### PR TITLE
[FINAL] Rename shared secret to API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.0
+- Rename shared secret to API key
+
 ## 0.1.0
 
 - Initial version

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -12,6 +12,8 @@ Pod::Spec.new do |s|
   s.author           = { "Revenue Cat, Inc." => "jacob@revenuecat.com" }
   s.source           = { :git => "https://github.com/revenuecat/purchases-ios.git", :tag => s.version.to_s }
 
+  s.framework      = 'StoreKit'
+
   s.ios.deployment_target = '9.0'
 
   s.source_files = [

--- a/Purchases/Classes/Public/Purchases.h
+++ b/Purchases/Classes/Public/Purchases.h
@@ -6,7 +6,7 @@
 //  Copyright © 2017 RevenueCat, Inc. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+#import <StoreKit/StoreKit.h>
 
 FOUNDATION_EXPORT double PurchasesVersionNumber;
 FOUNDATION_EXPORT const unsigned char PurchasesVersionString[];

--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -33,14 +33,14 @@ NS_ASSUME_NONNULL_BEGIN
 
  @warning If you don't pass a *unique* identifier per user or install every purchases shared with all users. If you do not have an account system you can use an `NSUUID` and persist it using `NSUserDefaults`.
 
- @param sharedSecret The shared secret generated for your app from https://www.revenuecat.com/
+ @param APIKey The API Key generated for your app from https://www.revenuecat.com/
 
  @param appUserID The unique app user id for this user. This user id will allow users to share their purchases and subscriptions across devices.
 
  @return An instantiated `RCPurchases` object
  */
-- (instancetype _Nullable)initWithSharedSecret:(NSString *)sharedSecret
-                                     appUserID:(NSString *)appUserID;
+- (instancetype _Nullable)initWithAPIKey:(NSString * _Nonnull)APIKey
+                               appUserID:(NSString *)appUserID;
 
 /**
  Delegate for `RCPurchases` instance. Object is responsible for handling completed purchases and updated subscription information.

--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -18,8 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 
  ```
  - (void)setupPurchases {
-     self.purchases = [[Purchases alloc] initWithSharedSecret:@"myappsharedsecret"
-                                                    appUserId:@"a-user-identifier"];
+     self.purchases = [[Purchases alloc] initWithAPIKey:@"myappapikey"
+                                              appUserId:@"a-user-identifier"];
      self.purcahses.delegate = self;
  }
  ```
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return An instantiated `RCPurchases` object
  */
-- (instancetype _Nullable)initWithAPIKey:(NSString * _Nonnull)APIKey
+- (instancetype _Nullable)initWithAPIKey:(NSString *)APIKey
                                appUserID:(NSString *)appUserID;
 
 /**

--- a/Purchases/Classes/Public/RCPurchases.m
+++ b/Purchases/Classes/Public/RCPurchases.m
@@ -26,13 +26,12 @@
 
 @implementation RCPurchases
 
-- (instancetype _Nullable)initWithSharedSecret:(NSString * _Nonnull)sharedSecret appUserID:(NSString *)appUserID
+- (instancetype _Nullable)initWithAPIKey:(NSString * _Nonnull)APIKey appUserID:(NSString *)appUserID
 {
     RCProductFetcher *fetcher = [[RCProductFetcher alloc] init];
-    RCBackend *backend = [[RCBackend alloc] initWithSharedSecret:sharedSecret];
+    RCBackend *backend = [[RCBackend alloc] initWithAPIKey:APIKey];
     RCStoreKitWrapper *storeKitWrapper = [[RCStoreKitWrapper alloc] init];
-    return [self initWithSharedSecret:sharedSecret
-                            appUserID:appUserID
+    return [self initWithAppUserID:appUserID
                        productFetcher:fetcher
                               backend:backend
                       storeKitWrapper:storeKitWrapper];
@@ -41,11 +40,10 @@
     return @"0.2.0-SNAPSHOT";
 }
 
-- (instancetype _Nullable)initWithSharedSecret:(NSString *)sharedSecret
-                                     appUserID:(NSString *)appUserID
-                                productFetcher:(RCProductFetcher *)productFetcher
-                                       backend:(RCBackend *)backend
-                               storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper
+- (instancetype _Nullable)initWithAppUserID:(NSString *)appUserID
+                          productFetcher:(RCProductFetcher *)productFetcher
+                                 backend:(RCBackend *)backend
+                         storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper
 {
     if (self = [super init])
     {

--- a/Purchases/Classes/Public/RCPurchases.m
+++ b/Purchases/Classes/Public/RCPurchases.m
@@ -26,24 +26,24 @@
 
 @implementation RCPurchases
 
-- (instancetype _Nullable)initWithAPIKey:(NSString * _Nonnull)APIKey appUserID:(NSString *)appUserID
+- (instancetype _Nullable)initWithAPIKey:(NSString *)APIKey appUserID:(NSString *)appUserID
 {
     RCProductFetcher *fetcher = [[RCProductFetcher alloc] init];
     RCBackend *backend = [[RCBackend alloc] initWithAPIKey:APIKey];
     RCStoreKitWrapper *storeKitWrapper = [[RCStoreKitWrapper alloc] init];
     return [self initWithAppUserID:appUserID
-                       productFetcher:fetcher
-                              backend:backend
-                      storeKitWrapper:storeKitWrapper];
+                    productFetcher:fetcher
+                           backend:backend
+                   storeKitWrapper:storeKitWrapper];
 }
 + (NSString *)frameworkVersion {
     return @"0.2.0-SNAPSHOT";
 }
 
 - (instancetype _Nullable)initWithAppUserID:(NSString *)appUserID
-                          productFetcher:(RCProductFetcher *)productFetcher
-                                 backend:(RCBackend *)backend
-                         storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper
+                             productFetcher:(RCProductFetcher *)productFetcher
+                                    backend:(RCBackend *)backend
+                            storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper
 {
     if (self = [super init])
     {

--- a/Purchases/Classes/RCBackend.h
+++ b/Purchases/Classes/RCBackend.h
@@ -24,10 +24,10 @@ typedef void(^RCBackendResponseHandler)(RCPurchaserInfo * _Nullable,
 
 @interface RCBackend : NSObject
 
-- (instancetype _Nullable)initWithSharedSecret:(NSString *)sharedSecret;
+- (instancetype _Nullable)initWithAPIKey:(NSString *)APIKey;
 
 - (instancetype _Nullable)initWithHTTPClient:(RCHTTPClient *)client
-                                sharedSecret:(NSString *)sharedSecret;
+                                      APIKey:(NSString *)APIKey;
 
 - (void)postReceiptData:(NSData *)data
               appUserID:(NSString *)appUserID

--- a/Purchases/Classes/RCBackend.m
+++ b/Purchases/Classes/RCBackend.m
@@ -16,7 +16,7 @@ NSErrorDomain const RCBackendErrorDomain = @"RCBackendErrorDomain";
 @interface RCBackend ()
 
 @property (nonatomic) RCHTTPClient *httpClient;
-@property (nonatomic) NSString *sharedSecret;
+@property (nonatomic) NSString *APIKey;
 
 @property (nonatomic) NSUInteger purchaseRequestsCount;
 
@@ -24,19 +24,19 @@ NSErrorDomain const RCBackendErrorDomain = @"RCBackendErrorDomain";
 
 @implementation RCBackend
 
-- (instancetype _Nullable)initWithSharedSecret:(NSString *)sharedSecret
+- (instancetype _Nullable)initWithAPIKey:(NSString *)APIKey
 {
     RCHTTPClient *client = [[RCHTTPClient alloc] init];
     return [self initWithHTTPClient:client
-                       sharedSecret:sharedSecret];
+                             APIKey:APIKey];
 }
 
 - (instancetype _Nullable)initWithHTTPClient:(RCHTTPClient *)client
-                                sharedSecret:(NSString *)sharedSecret
+                                      APIKey:(NSString *)APIKey
 {
     if (self = [super init]) {
         self.httpClient = client;
-        self.sharedSecret = sharedSecret;
+        self.APIKey = APIKey;
     }
     return self;
 }
@@ -45,7 +45,7 @@ NSErrorDomain const RCBackendErrorDomain = @"RCBackendErrorDomain";
 {
     return @{
              @"Authorization":
-                 [NSString stringWithFormat:@"Basic %@", self.sharedSecret]
+                 [NSString stringWithFormat:@"Basic %@", self.APIKey]
              };
 }
 

--- a/Purchases/Classes/RCPurchases+Protected.h
+++ b/Purchases/Classes/RCPurchases+Protected.h
@@ -14,11 +14,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RCPurchases (Protected)
 
-- (instancetype _Nullable)initWithSharedSecret:(NSString *)sharedSecret
-                                     appUserID:(NSString *)appUserID
-                                productFetcher:(RCProductFetcher *)productFetcher
-                                       backend:(RCBackend *)backend
-                               storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper;
+- (instancetype _Nullable)initWithAppUserID:(NSString *)appUserID
+                             productFetcher:(RCProductFetcher *)productFetcher
+                                    backend:(RCBackend *)backend
+                            storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper;
 
 @end
 

--- a/PurchasesTests/BackendTests.swift
+++ b/PurchasesTests/BackendTests.swift
@@ -50,7 +50,7 @@ class BackendTests: XCTestCase {
     }
 
     let httpClient = MockHTTPClient()
-    let sharedSecret = "asharedsecret"
+    let apiKey = "asharedsecret"
     let bundleID = "com.bundle.id"
     let userID = "user"
     let receiptData = "an awesome receipt".data(using: String.Encoding.utf8)!
@@ -73,7 +73,7 @@ class BackendTests: XCTestCase {
 
     override func setUp() {
         backend = RCBackend.init(httpClient: httpClient,
-                                  sharedSecret: sharedSecret)
+                                 apiKey: apiKey)
     }
 
     func testPostsReceiptDataCorrectly() {
@@ -91,7 +91,7 @@ class BackendTests: XCTestCase {
         let expectedCall = HTTPRequest(HTTPMethod: "POST", path: "/receipts", body: [
             "app_user_id": userID,
             "fetch_token": receiptData.base64EncodedString()
-            ], headers: ["Authorization": "Basic " + sharedSecret])
+            ], headers: ["Authorization": "Basic " + apiKey])
 
         expect(self.httpClient.calls.count).to(equal(1))
         if self.httpClient.calls.count > 0 {
@@ -170,7 +170,7 @@ class BackendTests: XCTestCase {
             XCTAssertEqual(call.HTTPMethod, "GET")
             XCTAssertNil(call.body)
             XCTAssertNotNil(call.headers?["Authorization"])
-            XCTAssertEqual(call.headers?["Authorization"], "Basic " + sharedSecret)
+            XCTAssertEqual(call.headers?["Authorization"], "Basic " + apiKey)
         }
     }
 

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -134,11 +134,10 @@ class PurchasesTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        purchases = RCPurchases.init(sharedSecret: sharedSecret,
-                                      appUserID: appUserID,
-                                      productFetcher: productFetcher,
-                                      backend:backend,
-                                      storeKitWrapper: storeKitWrapper)
+        purchases = RCPurchases.init(appUserID: appUserID,
+                                     productFetcher: productFetcher,
+                                     backend:backend,
+                                     storeKitWrapper: storeKitWrapper)
 
         purchases!.delegate = purchasesDelegate
     }

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -126,8 +126,7 @@ class PurchasesTests: XCTestCase {
     let storeKitWrapper = MockStoreKitWrapper()
 
     let purchasesDelegate = PurchasesDelegate()
-
-    let sharedSecret = "thisisasecret"
+    
     let appUserID = "app_user"
 
     var purchases: RCPurchases?
@@ -142,7 +141,7 @@ class PurchasesTests: XCTestCase {
         purchases!.delegate = purchasesDelegate
     }
     
-    func testIsAbleToBeIntializedWithASharedSecret() {
+    func testIsAbleToBeIntialized() {
         expect(self.purchases).toNot(beNil())
     }
 

--- a/README.md
+++ b/README.md
@@ -26,22 +26,22 @@ github "revenuecat/purchases-ios"
 
 #### 1. Create a RevenueCat Account
 
-Go to [RevenueCat](http://www.revenuecat.com), create an account, and obtain a shared secret for your application.
+Go to [RevenueCat](http://www.revenuecat.com), create an account, and obtain an API key for your application.
 
 #### 2. In your app instantiate an `RCPurchases` object with your secret.
 
 ```swift
 import Purchases
 
-self.purchases = RCPurchases.init(sharedSecret: "myappsharedsecret",
-                                     appUserID: "uniqueidforuser")!
+self.purchases = RCPurchases.init(apiKey: "myappapikey",
+                                  appUserID: "uniqueidforuser")!
 ```
 
 ```obj-c
 #import <Purchases/Purchases.h>
 
-RCPurchases *purchases = [[RCPurchases alloc] initWithSharedSecret:@"myappsharedsecret"
-                                                         appUserID:@"uniqueidforuser"];
+RCPurchases *purchases = [[RCPurchases alloc] initWithAPIKey:@"myappAPIKey"
+                                                   appUserID:@"uniqueidforuser"];
 ```
 
 #### 3. Create a delegate to handle new purchases


### PR DESCRIPTION
API key helps to disambiguate from the App-Specific Shared Secret in iTunesConnect.

Note: This is not compatible with the current version of the backend. The backend will be updated when 0.2.0 is ready.