### PR TITLE
[FIX] Encoding App User ID in the URL

### DIFF
--- a/Purchases/Classes/RCBackend.m
+++ b/Purchases/Classes/RCBackend.m
@@ -128,7 +128,8 @@ NSErrorDomain const RCBackendErrorDomain = @"RCBackendErrorDomain";
 - (void)getSubscriberDataWithAppUserID:(NSString *)appUserID
                             completion:(RCBackendResponseHandler)completion
 {
-    NSString *path = [NSString stringWithFormat:@"/subscribers/%@", appUserID];
+    NSString *escapedAppUserID = [appUserID stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
+    NSString *path = [NSString stringWithFormat:@"/subscribers/%@", escapedAppUserID];
 
     [self.httpClient performRequest:@"GET"
                                path:path

--- a/PurchasesTests/BackendTests.swift
+++ b/PurchasesTests/BackendTests.swift
@@ -242,6 +242,22 @@ class BackendTests: XCTestCase {
         expect(subscriberInfo).toEventuallyNot(beNil())
     }
 
+    func testEncodesSubscriberUserID() {
+        let encodeableUserID = "userid with spaces";
+        let encodedUserID = "userid%20with%20spaces";
+        let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
+        httpClient.mock(requestPath: "/subscribers/" + encodedUserID, response: response)
+        httpClient.mock(requestPath: "/subscribers/" + encodeableUserID, response: HTTPResponse(statusCode: 404, response: nil, error: nil))
+
+        var subscriberInfo: RCPurchaserInfo?
+
+        backend?.getSubscriberData(withAppUserID: encodeableUserID, completion: { (newSubscriberInfo, newError) in
+            subscriberInfo = newSubscriberInfo
+        })
+
+        expect(subscriberInfo).toEventuallyNot(beNil())
+    }
+
     func testHandlesGetSubscriberInfoErrors() {
         let response = HTTPResponse(statusCode: 404, response: nil, error: nil)
         httpClient.mock(requestPath: "/subscribers/" + userID, response: response)
@@ -271,6 +287,5 @@ class BackendTests: XCTestCase {
         expect((error as NSError?)?.domain).to(equal(RCBackendErrorDomain))
         expect((error as NSError?)?.code).to(equal(RCUnexpectedBackendResponse))
     }
-
 
 }


### PR DESCRIPTION
I realized that we were using `appUserID`s in the URL for getting a subscribers status. This would have crashed if someone ever used an `appUserID` that had any non URL friendly characters in it. 

This fixes it by encoding the appUserID first.