### PR TITLE
[FINAL] Promotional Purchases

### DIFF
--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -145,7 +145,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)purchases:(RCPurchases *)purchases failedToRestoreTransactionsWithReason:(NSError *)failureReason;
 
 /**
- Called when a user initiates an in-app purchase from the App Store. Use this method to determine if your app is able to handle a purchase at the current time. If yes, return true and `RCPurchases` will initiate a purchase and should finish with one of the appropriate delegate methods. If you are not ready, cache the product and pass it to `makePurchase:` as soon as the app is  ready. If you don't want to ever make the purchase, simply ignore the call. The default return value is `YES`, if you don't override this delegate method, `RCPurchases` will always initiate a purchase when a user taps a promo purchase from the App Store.
+ Called when a user initiates an in-app purchase from the App Store. Use this method to determine if your app is able to handle a purchase at the current time. If yes, return true and `RCPurchases` will initiate a purchase and should finish with one of the appropriate delegate methods. If you are not ready, cache the product and pass it to `makePurchase:` as soon as the app is  ready. If you don't want to ever make the purchase, simply ignore the call. The default return value is `NO`, if you don't override this delegate method, `RCPurchases` will not proceed with promotional purchases.
  
  @param product `SKProduct` the product that was selected from the app store
  */

--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -145,7 +145,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)purchases:(RCPurchases *)purchases failedToRestoreTransactionsWithReason:(NSError *)failureReason;
 
 /**
- Called when a user initiates an in-app purchase from the App Store. Use this method to determine if your app is able to handle a purchase at the current time. If yes, return true and Purchases will initiate a purchase and should finish with one of the appropriate delegate methods. If you are not ready, cache the product and pass it to `makePurchase:` as soon as the app is  ready. If you don't want to ever make the purchase, simply ignore the call.
+ Called when a user initiates an in-app purchase from the App Store. Use this method to determine if your app is able to handle a purchase at the current time. If yes, return true and `RCPurchases` will initiate a purchase and should finish with one of the appropriate delegate methods. If you are not ready, cache the product and pass it to `makePurchase:` as soon as the app is  ready. If you don't want to ever make the purchase, simply ignore the call. The default return value is `YES`, if you don't override this delegate method, `RCPurchases` will always initiate a purchase when a user taps a promo purchase from the App Store.
  
  @param product `SKProduct` the product that was selected from the app store
  */

--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class SKProduct, SKPaymentTransaction, RCPurchaserInfo, RCPurchases;
+@class SKProduct, SKPayment, SKPaymentTransaction, RCPurchaserInfo, RCPurchases;
 @protocol RCPurchasesDelegate;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -143,6 +143,13 @@ NS_ASSUME_NONNULL_BEGIN
  @param failureReason `NSError` containing the reason for the failure
  */
 - (void)purchases:(RCPurchases *)purchases failedToRestoreTransactionsWithReason:(NSError *)failureReason;
+
+/**
+ Called when a user initiates an in-app purchase from the App Store. Use this method to determine if your app is able to handle a purchase at the current time. If yes, return true and Purchases will initiate a purchase and should finish with one of the appropriate delegate methods. If you are not ready, cache the product and pass it to `makePurchase:` as soon as the app is  ready. If you don't want to ever make the purchase, simply ignore the call.
+ 
+ @param product `SKProduct` the product that was selected from the app store
+ */
+- (BOOL)purchases:(RCPurchases *)purchases shouldPurchasePromoProduct:(SKProduct *)product;
 
 @end
 

--- a/Purchases/Classes/Public/RCPurchases.m
+++ b/Purchases/Classes/Public/RCPurchases.m
@@ -233,6 +233,11 @@
     }
 }
 
+- (BOOL)storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper shouldAddStorePayment:(SKPayment *)payment
+{
+    return NO;
+}
+
 - (void)handlePurchasedTransaction:(SKPaymentTransaction *)transaction
 {
     [self receiptData:^(NSData * _Nonnull data) {

--- a/Purchases/Classes/Public/RCPurchases.m
+++ b/Purchases/Classes/Public/RCPurchases.m
@@ -235,7 +235,7 @@
     if ([(id<NSObject>)self.delegate respondsToSelector:@selector(purchases:shouldPurchasePromoProduct:)]) {
         return [self.delegate purchases:self shouldPurchasePromoProduct:product];
     } else {
-        return YES;
+        return NO;
     }
 }
 
@@ -245,11 +245,6 @@
     @synchronized(self) {
         return self.productsByIdentifier[productIdentifier];
     }
-}
-
-- (BOOL)storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper shouldAddStorePayment:(SKPayment *)payment
-{
-    return NO;
 }
 
 - (void)handlePurchasedTransaction:(SKPaymentTransaction *)transaction

--- a/Purchases/Classes/Public/RCPurchases.m
+++ b/Purchases/Classes/Public/RCPurchases.m
@@ -227,7 +227,16 @@
 }
 
 - (BOOL)storeKitWrapper:(nonnull RCStoreKitWrapper *)storeKitWrapper shouldAddStorePayment:(nonnull SKPayment *)payment forProduct:(nonnull SKProduct *)product {
-    return NO;
+    
+    @synchronized(self) {
+        self.productsByIdentifier[product.productIdentifier] = product;
+    }
+    
+    if ([(id<NSObject>)self.delegate respondsToSelector:@selector(purchases:shouldPurchasePromoProduct:)]) {
+        return [self.delegate purchases:self shouldPurchasePromoProduct:product];
+    } else {
+        return YES;
+    }
 }
 
 

--- a/Purchases/Classes/Public/RCPurchases.m
+++ b/Purchases/Classes/Public/RCPurchases.m
@@ -226,6 +226,11 @@
 
 }
 
+- (BOOL)storeKitWrapper:(nonnull RCStoreKitWrapper *)storeKitWrapper shouldAddStorePayment:(nonnull SKPayment *)payment forProduct:(nonnull SKProduct *)product {
+    return NO;
+}
+
+
 - (SKProduct * _Nullable)productForIdentifier:(NSString *)productIdentifier
 {
     @synchronized(self) {

--- a/Purchases/Classes/RCStoreKitWrapper.h
+++ b/Purchases/Classes/RCStoreKitWrapper.h
@@ -32,6 +32,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper
      removedTransaction:(SKPaymentTransaction *)transaction;
 
+- (BOOL)storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper
+  shouldAddStorePayment:(SKPayment *)payment
+             forProduct:(SKProduct *)product;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Purchases/Classes/RCStoreKitWrapper.m
+++ b/Purchases/Classes/RCStoreKitWrapper.m
@@ -80,4 +80,9 @@
     }
 }
 
+- (BOOL)paymentQueue:(SKPaymentQueue *)queue shouldAddStorePayment:(SKPayment *)payment forProduct:(SKProduct *)product
+{
+    return false;
+}
+
 @end

--- a/Purchases/Classes/RCStoreKitWrapper.m
+++ b/Purchases/Classes/RCStoreKitWrapper.m
@@ -82,7 +82,7 @@
 
 - (BOOL)paymentQueue:(SKPaymentQueue *)queue shouldAddStorePayment:(SKPayment *)payment forProduct:(SKProduct *)product
 {
-    return false;
+    return [self.delegate storeKitWrapper:self shouldAddStorePayment:payment forProduct:product];
 }
 
 @end

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -485,7 +485,7 @@ class PurchasesTests: XCTestCase {
     }
     
     func testCallsShouldAddPromoPaymentDelegateMethod() {
-        let product = SKProduct.init()
+        let product = MockProduct(mockProductIdentifier: "mock_product")
         let payment = SKPayment.init()
         
         storeKitWrapper.delegate?.storeKitWrapper(storeKitWrapper, shouldAddStore: payment, for: product)
@@ -494,10 +494,11 @@ class PurchasesTests: XCTestCase {
     }
     
     func testShouldAddPromoPaymentDelegateMethodPassesUpResult() {
-        let product = SKProduct.init()
+        let product = MockProduct(mockProductIdentifier: "mock_product")
         let payment = SKPayment.init()
         
         let randomBool = (arc4random() % 2 == 0) as Bool
+        purchasesDelegate.shouldAddPromo = randomBool
         
         let result = storeKitWrapper.delegate?.storeKitWrapper(storeKitWrapper, shouldAddStore: payment, for: product)
         

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -143,6 +143,13 @@ class PurchasesTests: XCTestCase {
         func purchases(_ purchases: RCPurchases, failedToRestoreTransactionsWithReason failureReason: Error) {
             restoredError = failureReason
         }
+        
+        var promoProduct: SKProduct?
+        var shouldAddPromo = false
+        func purchases(_ purchases: RCPurchases, shouldPurchasePromoProduct product: SKProduct) -> Bool {
+            promoProduct = product
+            return shouldAddPromo
+        }
     }
 
     let requestFetcher = MockRequestFetcher()
@@ -476,6 +483,46 @@ class PurchasesTests: XCTestCase {
         expect(self.purchasesDelegate.restoredPurchaserInfo).to(beNil())
         expect(self.purchasesDelegate.restoredError).toNot(beNil())
     }
-
-
+    
+    func testCallsShouldAddPromoPaymentDelegateMethod() {
+        let product = SKProduct.init()
+        let payment = SKPayment.init()
+        
+        storeKitWrapper.delegate?.storeKitWrapper(storeKitWrapper, shouldAddStore: payment, for: product)
+        
+        expect(self.purchasesDelegate.promoProduct).to(be(product))
+    }
+    
+    func testShouldAddPromoPaymentDelegateMethodPassesUpResult() {
+        let product = SKProduct.init()
+        let payment = SKPayment.init()
+        
+        let randomBool = (arc4random() % 2 == 0) as Bool
+        
+        let result = storeKitWrapper.delegate?.storeKitWrapper(storeKitWrapper, shouldAddStore: payment, for: product)
+        
+        expect(randomBool).to(equal(result))
+    }
+    
+    func testShouldCacheProductsFromPromoPaymentDelegateMethod() {
+        let product = MockProduct(mockProductIdentifier: "mock_product")
+        let payment = SKPayment.init(product: product)
+        
+        storeKitWrapper.delegate?.storeKitWrapper(storeKitWrapper, shouldAddStore: payment, for: product)
+        
+        purchases?.makePurchase(product)
+        
+        let transaction = MockTransaction()
+        transaction.mockPayment = self.storeKitWrapper.payment!
+        
+        transaction.mockState = SKPaymentTransactionState.purchasing
+        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        
+        transaction.mockState = SKPaymentTransactionState.purchased
+        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        
+        expect(self.backend.postReceiptDataCalled).to(equal(true))
+        expect(self.backend.postedProductID).to(equal(product.productIdentifier))
+        expect(self.backend.postedPrice).to(equal(product.price))
+    }
 }


### PR DESCRIPTION
Adds support for [promotional in-app purchases](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/StoreKitGuide/PromotingIn-AppPurchases/PromotingIn-AppPurchases.html).

By default, `RCPurchases` will not allow promotional purchases to proceed. Developers will need to implement the `purchases:shouldPurchasePromoProduct:` `RCPurchasesDelegate` method to override this behavior.