### PR TITLE
[FINAL] Add handling for deferring a promotional payment

### DIFF
--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -147,7 +147,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)purchases:(RCPurchases *)purchases failedToRestoreTransactionsWithReason:(NSError *)failureReason;
 
 /**
- Called when a user initiates an in-app purchase from the App Store. Use this method to determine if your app is able to handle a purchase at the current time. If yes, return true and `RCPurchases` will initiate a purchase and should finish with one of the appropriate delegate methods. If the app is not in a state to make a purchase, cache the defermentBlock and call it when your ready to make the promotional purchase. The default return value is `NO`, if you don't override this delegate method, `RCPurchases` will not proceed with promotional purchases.
+ Called when a user initiates an in-app purchase from the App Store. Use this method to determine if your app is able to handle a purchase at the current time. If yes, return true and `RCPurchases` will initiate a purchase and should finish with one of the appropriate delegate methods. If the app is not in a state to make a purchase, cache the defermentBlock and call it when your ready to make the promotional purchase. If the purchase should never be made, do not cache the defermentBlock. The default return value is `NO`, if you don't override this delegate method, `RCPurchases` will not proceed with promotional purchases.
  
  @param product `SKProduct` the product that was selected from the app store
  */

--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -11,7 +11,7 @@
 @class SKProduct, SKPayment, SKPaymentTransaction, RCPurchaserInfo, RCPurchases;
 @protocol RCPurchasesDelegate;
 
-typedef void (^RCDeferedPromotionalPurchase)(void);
+typedef void (^RCDeferredPromotionalPurchaseBlock)(void);
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -151,7 +151,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param product `SKProduct` the product that was selected from the app store
  */
-- (BOOL)purchases:(RCPurchases *)purchases shouldPurchasePromoProduct:(SKProduct *)product defermentBlock:(RCDeferedPromotionalPurchase)makeDeferredPurchase;
+- (BOOL)purchases:(RCPurchases *)purchases shouldPurchasePromoProduct:(SKProduct *)product defermentBlock:(RCDeferredPromotionalPurchaseBlock)makeDeferredPurchase;
 
 @end
 

--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -147,7 +147,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)purchases:(RCPurchases *)purchases failedToRestoreTransactionsWithReason:(NSError *)failureReason;
 
 /**
- Called when a user initiates an in-app purchase from the App Store. Use this method to determine if your app is able to handle a purchase at the current time. If yes, return true and `RCPurchases` will initiate a purchase and should finish with one of the appropriate delegate methods. If the app is not in a state to make a purchase, cache the defermentBlock and call it when your ready to make the promotional purchase. If the purchase should never be made, do not cache the defermentBlock. The default return value is `NO`, if you don't override this delegate method, `RCPurchases` will not proceed with promotional purchases.
+ Called when a user initiates a promotional in-app purchase from the App Store. Use this method to tell `RCPurchases` if your app is able to handle a purchase at the current time. If yes, return true and `RCPurchases` will initiate a purchase and will finish with one of the appropriate `RCPurchasesDelegate` methods. If the app is not in a state to make a purchase: cache the defermentBlock, return no, then call the defermentBlock when the app is ready to make the promotional purchase. If the purchase should never be made, do not cache the defermentBlock and return `NO`. The default return value is `NO`, if you don't override this delegate method, `RCPurchases` will not proceed with promotional purchases.
  
  @param product `SKProduct` the product that was selected from the app store
  */

--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -11,6 +11,8 @@
 @class SKProduct, SKPayment, SKPaymentTransaction, RCPurchaserInfo, RCPurchases;
 @protocol RCPurchasesDelegate;
 
+typedef void (^RCDeferedPromotionalPurchase)(void);
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -145,11 +147,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)purchases:(RCPurchases *)purchases failedToRestoreTransactionsWithReason:(NSError *)failureReason;
 
 /**
- Called when a user initiates an in-app purchase from the App Store. Use this method to determine if your app is able to handle a purchase at the current time. If yes, return true and `RCPurchases` will initiate a purchase and should finish with one of the appropriate delegate methods. If you are not ready, cache the product and pass it to `makePurchase:` as soon as the app is  ready. If you don't want to ever make the purchase, simply ignore the call. The default return value is `NO`, if you don't override this delegate method, `RCPurchases` will not proceed with promotional purchases.
+ Called when a user initiates an in-app purchase from the App Store. Use this method to determine if your app is able to handle a purchase at the current time. If yes, return true and `RCPurchases` will initiate a purchase and should finish with one of the appropriate delegate methods. If the app is not in a state to make a purchase, cache the defermentBlock and call it when your ready to make the promotional purchase. The default return value is `NO`, if you don't override this delegate method, `RCPurchases` will not proceed with promotional purchases.
  
  @param product `SKProduct` the product that was selected from the app store
  */
-- (BOOL)purchases:(RCPurchases *)purchases shouldPurchasePromoProduct:(SKProduct *)product;
+- (BOOL)purchases:(RCPurchases *)purchases shouldPurchasePromoProduct:(SKProduct *)product defermentBlock:(RCDeferedPromotionalPurchase)makeDeferredPurchase;
 
 @end
 

--- a/Purchases/Classes/Public/RCPurchases.m
+++ b/Purchases/Classes/Public/RCPurchases.m
@@ -232,8 +232,8 @@
         self.productsByIdentifier[product.productIdentifier] = product;
     }
     
-    if ([(id<NSObject>)self.delegate respondsToSelector:@selector(purchases:shouldPurchasePromoProduct:)]) {
-        return [self.delegate purchases:self shouldPurchasePromoProduct:product];
+    if ([(id<NSObject>)self.delegate respondsToSelector:@selector(purchases:shouldPurchasePromoProduct:defermentBlock:)]) {
+        return [self.delegate purchases:self shouldPurchasePromoProduct:product defermentBlock:^{}];
     } else {
         return NO;
     }

--- a/Purchases/Classes/Public/RCPurchases.m
+++ b/Purchases/Classes/Public/RCPurchases.m
@@ -233,7 +233,9 @@
     }
     
     if ([(id<NSObject>)self.delegate respondsToSelector:@selector(purchases:shouldPurchasePromoProduct:defermentBlock:)]) {
-        return [self.delegate purchases:self shouldPurchasePromoProduct:product defermentBlock:^{}];
+        return [self.delegate purchases:self shouldPurchasePromoProduct:product defermentBlock:^{
+            [self.storeKitWrapper addPayment:payment];
+        }];
     } else {
         return NO;
     }

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -146,8 +146,8 @@ class PurchasesTests: XCTestCase {
         
         var promoProduct: SKProduct?
         var shouldAddPromo = false
-        var makeDeferredPurchase: RCDeferedPromotionalPurchase?
-        func purchases(_ purchases: RCPurchases, shouldPurchasePromoProduct product: SKProduct, defermentBlock makeDeferredPurchase: @escaping RCDeferedPromotionalPurchase) -> Bool {
+        var makeDeferredPurchase: RCDeferredPromotionalPurchaseBlock?
+        func purchases(_ purchases: RCPurchases, shouldPurchasePromoProduct product: SKProduct, defermentBlock makeDeferredPurchase: @escaping RCDeferredPromotionalPurchaseBlock) -> Bool {
             promoProduct = product
             self.makeDeferredPurchase = makeDeferredPurchase
             return shouldAddPromo

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -146,8 +146,10 @@ class PurchasesTests: XCTestCase {
         
         var promoProduct: SKProduct?
         var shouldAddPromo = false
-        func purchases(_ purchases: RCPurchases, shouldPurchasePromoProduct product: SKProduct) -> Bool {
+        var makeDeferredPurchase: RCDeferedPromotionalPurchase?
+        func purchases(_ purchases: RCPurchases, shouldPurchasePromoProduct product: SKProduct, defermentBlock makeDeferredPurchase: @escaping RCDeferedPromotionalPurchase) -> Bool {
             promoProduct = product
+            self.makeDeferredPurchase = makeDeferredPurchase
             return shouldAddPromo
         }
     }
@@ -511,10 +513,8 @@ class PurchasesTests: XCTestCase {
         
         storeKitWrapper.delegate?.storeKitWrapper(storeKitWrapper, shouldAddStore: payment, for: product)
         
-        purchases?.makePurchase(product)
-        
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = payment
         
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -525,5 +525,21 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.postReceiptDataCalled).to(equal(true))
         expect(self.backend.postedProductID).to(equal(product.productIdentifier))
         expect(self.backend.postedPrice).to(equal(product.price))
+    }
+    
+    func testDeferBlockMakesPayment() {
+        let product = MockProduct(mockProductIdentifier: "mock_product")
+        let payment = SKPayment.init(product: product)
+        
+        purchasesDelegate.shouldAddPromo = false
+        storeKitWrapper.delegate?.storeKitWrapper(storeKitWrapper, shouldAddStore: payment, for: product)
+        
+        expect(self.purchasesDelegate.makeDeferredPurchase).toNot(beNil())
+        
+        expect(self.storeKitWrapper.payment).to(beNil())
+        
+        self.purchasesDelegate.makeDeferredPurchase!()
+        
+        expect(self.storeKitWrapper.payment).to(be(payment))
     }
 }


### PR DESCRIPTION
Apple is very specific about using the same payment object for deferring a promotional purchase:
<img width="1270" alt="screen shot 2018-01-22 at 9 54 27 am" src="https://user-images.githubusercontent.com/138742/35235874-44895328-ff5a-11e7-8fdb-57cc83219e48.png">

Since `RCPurchases` only has an API for adding products, and not payments, I'm passing a defermentBlock to the delegate that clients can save and call when they are ready.
