### PR TITLE
[FINAL] API Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.0
+- Change `restoreTransactionsForAppStoreAccount:` to take a completion block since it no long relies on the app store queue. Removed delegate methods.
+- Added `updatedPurchaserInfo:` that allows force refreshing of `RCPurchaserInfo`. Useful if your app needs the latest purchaser info.
+- Removed `makePurchase:quantity:`.
+
 ## 0.6.0
 - Add support for [promotional purchases](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/StoreKitGuide/PromotingIn-AppPurchases/PromotingIn-AppPurchases.html). 
 - Adds support for `appUserId`s with non-url compatable characters

--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -71,12 +71,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)makePurchase:(SKProduct *)product;
 
 /**
- Same as `makePurchase:` but allows you to set the quantity. Only valid for consumable products.
- */
-- (void)makePurchase:(SKProduct *)product
-            quantity:(NSInteger)quantity;
-
-/**
  This method will post all purchases associated with the current App Store account to RevenueCat and become associated with the current `appUserID`. If the receipt is being used by an existing user, the current `appUserID` will be aliased together with the `appUserID` of the existing user. Going forward, either `appUserID` will be able to reference the same user.
 
  @note This may force your users to enter the App Store password so should only be performed on request of the user. Typically with a button in settings or near your purchase UI.

--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -132,22 +132,6 @@ NS_ASSUME_NONNULL_BEGIN
 @optional
 
 /**
- Called when `RCPurchases` completes a restoration that was initiated with `restoreTransactionsForAppStoreAccount`;
-
- @param purchases Related `RCPurchases` object
- @param purchaserInfo Updated `RCPurchaserInfo`
- */
-- (void)purchases:(RCPurchases *)purchases restoredTransactionsWithPurchaserInfo:(RCPurchaserInfo *)purchaserInfo;
-
-/**
- Called when restoring a transaction fails.
-
- @param purchases Related `RCPurchases` object
- @param failureReason `NSError` containing the reason for the failure
- */
-- (void)purchases:(RCPurchases *)purchases failedToRestoreTransactionsWithReason:(NSError *)failureReason;
-
-/**
  Called when a user initiates a promotional in-app purchase from the App Store. Use this method to tell `RCPurchases` if your app is able to handle a purchase at the current time. If yes, return true and `RCPurchases` will initiate a purchase and will finish with one of the appropriate `RCPurchasesDelegate` methods. If the app is not in a state to make a purchase: cache the defermentBlock, return no, then call the defermentBlock when the app is ready to make the promotional purchase. If the purchase should never be made, do not cache the defermentBlock and return `NO`. The default return value is `NO`, if you don't override this delegate method, `RCPurchases` will not proceed with promotional purchases.
  
  @param product `SKProduct` the product that was selected from the app store

--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -80,6 +80,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)restoreTransactionsForAppStoreAccount:(RCReceivePurchaserInfoBlock)receivePurchaserInfo;
 
 /**
+ Fetches the latest purchaser info from the backend. This will happen periodically on `applicationDidResumeActive:` and will trigger the delegate method `purchases:receivedUpdatedPurchaserInfo:`. You can use this method if you'd like to refresh the purchaser info manually.
+ */
+- (void)updatedPurchaserInfo:(RCReceivePurchaserInfoBlock)receivePurchaserInfo;
+
+/**
  This version of the Purchases framework
 */
 + (NSString *)frameworkVersion;

--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -12,6 +12,7 @@
 @protocol RCPurchasesDelegate;
 
 typedef void (^RCDeferredPromotionalPurchaseBlock)(void);
+typedef void (^RCReceivePurchaserInfoBlock)(RCPurchaserInfo * _Nullable, NSError * _Nullable);
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -82,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @warning Calling this method requires that the optional delegate methods `purchases:restoredTransactionsWithPurchaserInfo:` and `purchases:failedToRestoreTransactionsWithReason:` are implemented.
  */
-- (void)restoreTransactionsForAppStoreAccount;
+- (void)restoreTransactionsForAppStoreAccount:(RCReceivePurchaserInfoBlock)receivePurchaserInfo;
 
 /**
  This version of the Purchases framework

--- a/Purchases/Classes/Public/RCPurchases.m
+++ b/Purchases/Classes/Public/RCPurchases.m
@@ -273,7 +273,7 @@
     }];
 }
 
-- (void)restoreTransactionsForAppStoreAccount
+- (void)restoreTransactionsForAppStoreAccount:(RCReceivePurchaserInfoBlock)receivePurchaserInfo
 {
     // Refresh the receipt and post to backend, this will allow the transactions to be transferred.
     // https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/StoreKitGuide/Chapters/Restoring.html
@@ -285,16 +285,7 @@
                                 price:nil
                     introductoryPrice:nil
                          currencyCode:nil
-                           completion:^(RCPurchaserInfo * _Nullable info,
-                                        NSError * _Nullable error) {
-                               if (info) {
-                                   [self.delegate purchases:self restoredTransactionsWithPurchaserInfo:info];
-                               } else if (error) {
-                                   [self.delegate purchases:self failedToRestoreTransactionsWithReason:error];
-                               } else {
-                                   RCLog(@"Unexpected error restoring transactions");
-                               }
-                           }];
+                           completion:receivePurchaserInfo];
     }];
 }
 

--- a/Purchases/Classes/Public/RCPurchases.m
+++ b/Purchases/Classes/Public/RCPurchases.m
@@ -133,7 +133,7 @@
     }];
 }
 
-- (void)purchaserInfoWithCompletion:(void (^)(RCPurchaserInfo * _Nullable purchaserInfo))completion
+- (void)updatedPurchaserInfo:(RCReceivePurchaserInfoBlock)receivePurchaserInfo
 {
     [self.backend getSubscriberDataWithAppUserID:self.appUserID completion:^(RCPurchaserInfo * _Nullable purchaserInfo, NSError * _Nullable error) {
 
@@ -141,20 +141,13 @@
             RCLog(@"Error fetching purchaser info: %@", error.localizedDescription);
         }
 
-        completion(purchaserInfo);
+        receivePurchaserInfo(purchaserInfo, error);
     }];
 }
 
 - (void)makePurchase:(SKProduct *)product
 {
-    [self makePurchase:product quantity:1];
-}
-
-- (void)makePurchase:(SKProduct *)product
-            quantity:(NSInteger)quantity
-{
     SKMutablePayment *payment = [SKMutablePayment paymentWithProduct:product];
-    payment.quantity = quantity;
     payment.applicationUsername = self.appUserID;
 
     [self.storeKitWrapper addPayment:payment];

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -558,4 +558,13 @@ class PurchasesTests: XCTestCase {
         
         expect(self.storeKitWrapper.payment).to(be(payment))
     }
+
+    func testGetUpdatedPurchaserInfo() {
+        var purchaserInfo: RCPurchaserInfo?
+        purchases!.updatedPurchaserInfo { (info, error) in
+            purchaserInfo = info
+        }
+        expect(self.backend.postReceiptDataCalled).to(beFalse());
+        expect(purchaserInfo).toEventuallyNot(beNil());
+    }
 }

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -453,17 +453,23 @@ class PurchasesTests: XCTestCase {
     }
 
     func testRestoringPurchasesPostsTheReceipt() {
-        purchases!.restoreTransactionsForAppStoreAccount()
+        purchases!.restoreTransactions { (_, _) in
+
+        }
         expect(self.backend.postReceiptDataCalled).to(equal(true))
     }
 
     func testRestoringPurchasesRefreshesAndPostsTheReceipt() {
-        purchases!.restoreTransactionsForAppStoreAccount()
+        purchases!.restoreTransactions { (_, _) in
+
+        }
         expect(self.requestFetcher.refreshReceiptCalled).to(equal(true))
     }
 
     func testRestoringPurchasesSetsIsRestore() {
-        purchases!.restoreTransactionsForAppStoreAccount()
+        purchases!.restoreTransactions { (_, _) in
+
+        }
         expect(self.backend.postedIsRestore!).to(equal(true))
     }
 
@@ -471,19 +477,29 @@ class PurchasesTests: XCTestCase {
         let purchaserInfo = RCPurchaserInfo()
         self.backend.postReceiptPurchaserInfo = purchaserInfo
 
-        purchases!.restoreTransactionsForAppStoreAccount()
+        var restoredPurchaserInfo: RCPurchaserInfo?
 
-        expect(self.purchasesDelegate.restoredPurchaserInfo).to(equal(purchaserInfo))
+        purchases!.restoreTransactions { (newPurchaserInfo, _) in
+            restoredPurchaserInfo = newPurchaserInfo
+        }
+
+        expect(restoredPurchaserInfo).toEventually(equal(purchaserInfo))
     }
 
     func testRestorePurchasesCallsFailureDelegateMethodOnFailure() {
         let error = NSError(domain: "error_domain", code: RCFinishableError, userInfo: nil)
         self.backend.postReceiptError = error
 
-        purchases!.restoreTransactionsForAppStoreAccount()
+        var restoredPurchaserInfo: RCPurchaserInfo?
+        var restoreError: Error?
 
-        expect(self.purchasesDelegate.restoredPurchaserInfo).to(beNil())
-        expect(self.purchasesDelegate.restoredError).toNot(beNil())
+        purchases!.restoreTransactions { (newPurchaserInfo, newError) in
+            restoredPurchaserInfo = newPurchaserInfo
+            restoreError = newError
+        }
+
+        expect(restoredPurchaserInfo).toEventually(beNil())
+        expect(restoreError).toEventuallyNot(beNil())
     }
     
     func testCallsShouldAddPromoPaymentDelegateMethod() {


### PR DESCRIPTION
Some API changes and clean up to make React Native integration a little easier.

- Change `restoreTransactionsForAppStoreAccount:` to take a completion block since it no long relies on the app store queue. Removed delegate methods.
- Added `updatedPurchaserInfo:` that allows force refreshing of `RCPurchaserInfo`. Useful if your app needs the latest purchaser info.
- Removed `makePurchase:quantity:`.
