### PR TITLE
[FINAL] Support for Non-consumable Purchases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Change `restoreTransactionsForAppStoreAccount:` to take a completion block since it no long relies on the app store queue. Removed delegate methods.
 - Added `updatedPurchaserInfo:` that allows force refreshing of `RCPurchaserInfo`. Useful if your app needs the latest purchaser info.
 - Removed `makePurchase:quantity:`.
+- Add `nonConsumablePurchases` on `RCPurchaserInfo`. Non-consumable purchases will now Just Work (tm). 
 
 ## 0.6.0
 - Add support for [promotional purchases](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/StoreKitGuide/PromotingIn-AppPurchases/PromotingIn-AppPurchases.html). 

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 		350FBDF01F7EFC410065833D /* StoreKitRequestFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 350FBDEF1F7EFC410065833D /* StoreKitRequestFetcherTests.swift */; };
 		350FBDF31F7FFD350065833D /* RCStoreKitWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 350FBDF11F7FFD340065833D /* RCStoreKitWrapper.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		350FBDF41F7FFD350065833D /* RCStoreKitWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 350FBDF21F7FFD340065833D /* RCStoreKitWrapper.m */; };
-		351703CD1F805E5D00EEE27A /* SubscriberInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351703CC1F805E5D00EEE27A /* SubscriberInfoTests.swift */; };
+		351703CD1F805E5D00EEE27A /* PurchaserInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351703CC1F805E5D00EEE27A /* PurchaserInfoTests.swift */; };
 		351F4FAB1F80190700F245F4 /* RCBackend.h in Headers */ = {isa = PBXBuildFile; fileRef = 351F4FA91F80190700F245F4 /* RCBackend.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		351F4FAC1F80190700F245F4 /* RCBackend.m in Sources */ = {isa = PBXBuildFile; fileRef = 351F4FAA1F80190700F245F4 /* RCBackend.m */; };
 		351F4FAF1F803D0700F245F4 /* RCPurchaserInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 351F4FAD1F803D0700F245F4 /* RCPurchaserInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -78,7 +78,7 @@
 		350FBDEF1F7EFC410065833D /* StoreKitRequestFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitRequestFetcherTests.swift; sourceTree = "<group>"; };
 		350FBDF11F7FFD340065833D /* RCStoreKitWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCStoreKitWrapper.h; sourceTree = "<group>"; };
 		350FBDF21F7FFD340065833D /* RCStoreKitWrapper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCStoreKitWrapper.m; sourceTree = "<group>"; };
-		351703CC1F805E5D00EEE27A /* SubscriberInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriberInfoTests.swift; sourceTree = "<group>"; };
+		351703CC1F805E5D00EEE27A /* PurchaserInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaserInfoTests.swift; sourceTree = "<group>"; };
 		351F4FA91F80190700F245F4 /* RCBackend.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCBackend.h; sourceTree = "<group>"; };
 		351F4FAA1F80190700F245F4 /* RCBackend.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCBackend.m; sourceTree = "<group>"; };
 		351F4FAD1F803D0700F245F4 /* RCPurchaserInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCPurchaserInfo.h; sourceTree = "<group>"; };
@@ -203,7 +203,7 @@
 				350FBDEF1F7EFC410065833D /* StoreKitRequestFetcherTests.swift */,
 				35E5B1DB1F80026C00B2537C /* StoreKitWrapperTests.swift */,
 				351F4FB11F803D9C00F245F4 /* BackendTests.swift */,
-				351703CC1F805E5D00EEE27A /* SubscriberInfoTests.swift */,
+				351703CC1F805E5D00EEE27A /* PurchaserInfoTests.swift */,
 				35262A221F7D77E600C04F2C /* Info.plist */,
 				350FBDD61F7DF1640065833D /* Frameworks */,
 			);
@@ -352,7 +352,7 @@
 				35262A301F7D78C600C04F2C /* HTTPClientTests.swift in Sources */,
 				35E5B1DC1F80026C00B2537C /* StoreKitWrapperTests.swift in Sources */,
 				350FBDF01F7EFC410065833D /* StoreKitRequestFetcherTests.swift in Sources */,
-				351703CD1F805E5D00EEE27A /* SubscriberInfoTests.swift in Sources */,
+				351703CD1F805E5D00EEE27A /* PurchaserInfoTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Purchases/Classes/Public/RCPurchaserInfo.h
+++ b/Purchases/Classes/Public/RCPurchaserInfo.h
@@ -25,6 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Returns the latest expiration date of all products, nil if there are none
 @property (readonly) NSDate * _Nullable latestExpirationDate;
 
+/// Returns all the non-consumable purchases a user has made.
+@property (readonly) NSSet<NSString *> *nonConsumablePurchases;
+
 /**
  Get the expiration date for a given product identifier.
 

--- a/Purchases/Classes/Public/RCPurchaserInfo.m
+++ b/Purchases/Classes/Public/RCPurchaserInfo.m
@@ -64,7 +64,7 @@ static dispatch_once_t onceToken;
 
 - (NSSet<NSString *> *)allPurchasedProductIdentifiers
 {
-    return [NSSet setWithArray:self.expirationDates.allKeys];
+    return [self.nonConsumablePurchases setByAddingObjectsFromArray:self.expirationDates.allKeys];
 }
 
 - (NSSet<NSString *> *)activeSubscriptions

--- a/Purchases/Classes/Public/RCPurchaserInfo.m
+++ b/Purchases/Classes/Public/RCPurchaserInfo.m
@@ -11,6 +11,7 @@
 @interface RCPurchaserInfo ()
 
 @property (nonatomic) NSDictionary<NSString *, NSDate *> *expirationDates;
+@property (nonatomic) NSSet<NSString *> *nonConsumablePurchases;
 
 @end
 
@@ -53,6 +54,10 @@ static dispatch_once_t onceToken;
         }
 
         self.expirationDates = [NSDictionary dictionaryWithDictionary:dates];
+
+        NSDictionary<NSString *, id> *otherPurchases = subscriberData[@"other_purchases"];
+        self.nonConsumablePurchases = [NSSet setWithArray:[otherPurchases allKeys]];
+
     }
     return self;
 }

--- a/PurchasesTests/PurchaserInfoTests.swift
+++ b/PurchasesTests/PurchaserInfoTests.swift
@@ -1,5 +1,5 @@
 //
-//  SubscriberInfoTests.swift
+//  PurchaserInfoTests.swift
 //  PurchasesTests
 //
 //  Created by Jacob Eiting on 9/30/17.
@@ -12,15 +12,15 @@ import Nimble
 
 import Purchases
 
-class EmptySubscriberInfoTests: XCTestCase {
-    let subscriberInfo = RCPurchaserInfo.init(data: [AnyHashable : Any]())
+class EmptyPurchaserInfoTests: XCTestCase {
+    let purchaserInfo = RCPurchaserInfo.init(data: [AnyHashable : Any]())
 
     func testEmptyDataYieldsANilInfo() {
-        expect(RCPurchaserInfo.init(data: [AnyHashable : Any]())).to(beNil())
+        expect(self.purchaserInfo).to(beNil())
     }
 }
 
-class BasicSubscriberInfoTests: XCTestCase {
+class BasicPurchaerInfoTests: XCTestCase {
     let validSubscriberResponse = [
         "subscriber": [
             "subscriptions": [
@@ -34,38 +34,38 @@ class BasicSubscriberInfoTests: XCTestCase {
         ]
     ]
 
-    var subscriberInfo: RCPurchaserInfo?
+    var purchaserInfo: RCPurchaserInfo?
 
     override func setUp() {
         super.setUp()
 
-        subscriberInfo = RCPurchaserInfo.init(data: validSubscriberResponse)
+        purchaserInfo = RCPurchaserInfo.init(data: validSubscriberResponse)
     }
 
     func testParsesSubscriptions() {
-        expect(self.subscriberInfo).toNot(beNil())
+        expect(self.purchaserInfo).toNot(beNil())
     }
 
     func testParsesExpirationDate() {
-        let expireDate = subscriberInfo!.expirationDate(forProductIdentifier: "onemonth_freetrial")!
+        let expireDate = purchaserInfo!.expirationDate(forProductIdentifier: "onemonth_freetrial")!
         expect(expireDate.timeIntervalSince1970).to(equal(4123276836))
     }
 
     func testListActiveSubscriptions() {
-        XCTAssertEqual(Set(["onemonth_freetrial"]), subscriberInfo!.activeSubscriptions)
+        XCTAssertEqual(Set(["onemonth_freetrial"]), purchaserInfo!.activeSubscriptions)
     }
 
     func testAllPurchasedProductIdentifier() {
-        let allPurchased = subscriberInfo!.allPurchasedProductIdentifiers
+        let allPurchased = purchaserInfo!.allPurchasedProductIdentifiers
 
         expect(allPurchased).to(equal(Set(["onemonth_freetrial", "threemonth_freetrial"])))
     }
 
     func testLatestExpirationDateHelper() {
-        let latestExpiration = subscriberInfo!.latestExpirationDate
+        let latestExpiration = purchaserInfo!.latestExpirationDate
 
         expect(latestExpiration).toNot(beNil())
 
-        expect(latestExpiration).to(equal(subscriberInfo!.expirationDate(forProductIdentifier: "onemonth_freetrial")))
+        expect(latestExpiration).to(equal(purchaserInfo!.expirationDate(forProductIdentifier: "onemonth_freetrial")))
     }
 }

--- a/PurchasesTests/PurchaserInfoTests.swift
+++ b/PurchasesTests/PurchaserInfoTests.swift
@@ -23,6 +23,11 @@ class EmptyPurchaserInfoTests: XCTestCase {
 class BasicPurchaerInfoTests: XCTestCase {
     let validSubscriberResponse = [
         "subscriber": [
+            "other_purchases": [
+                "onetime_purchase": [
+                    "purchase_date": "1990-08-30T02:40:36Z"
+                ]
+            ],
             "subscriptions": [
                 "onemonth_freetrial": [
                     "expires_date": "2100-08-30T02:40:36Z"
@@ -67,5 +72,12 @@ class BasicPurchaerInfoTests: XCTestCase {
         expect(latestExpiration).toNot(beNil())
 
         expect(latestExpiration).to(equal(purchaserInfo!.expirationDate(forProductIdentifier: "onemonth_freetrial")))
+    }
+
+    func testParsesOtherPurchases() {
+        let nonConsumables = purchaserInfo!.nonConsumablePurchases
+        expect(nonConsumables.count).to(equal(1))
+
+        expect(nonConsumables).to(contain(["onetime_purchase"]))
     }
 }


### PR DESCRIPTION
- Add `nonConsumablePurchases` on `RCPurchaserInfo`. Non-consumable purchases will now Just Work (tm). 