### PR TITLE
[FINAL] Eligibility Checking Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
+## 0.9.0
+- Add support of checking eligibilty of introductory prices. RevenueCat will now be able to tell you definitively what version of a product you should present in your UI.
+
 ## 0.8.0
 - Add support of initializing without an `appUserID`. This standardizes and simplifies behavior for apps without account systems.
-- Add support of checking eligibilty of introductory prices. RevenueCat will now be able to tell you definitively what version of a product you should present in your UI.
 
 ## 0.7.0
 - Change `restoreTransactionsForAppStoreAccount:` to take a completion block since it no long relies on the app store queue. Removed delegate methods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.8.0
 - Add support of initializing without an `appUserID`. This standardizes and simplifies behavior for apps without account systems.
+- Add support of checking eligibilty of introductory prices. RevenueCat will now be able to tell you definitively what version of a product you should present in your UI.
 
 ## 0.7.0
 - Change `restoreTransactionsForAppStoreAccount:` to take a completion block since it no long relies on the app store queue. Removed delegate methods.

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -37,9 +37,8 @@
 		359A0EA12003C8CD002D8C7F /* NSLocale+RCExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 359A0E9F2003C8CD002D8C7F /* NSLocale+RCExtensions.h */; };
 		359A0EA22003C8CD002D8C7F /* NSLocale+RCExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 359A0EA02003C8CD002D8C7F /* NSLocale+RCExtensions.m */; };
 		35A60EAA1F82993E00D2FAE8 /* RCPurchases+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 35A60EA81F82993E00D2FAE8 /* RCPurchases+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		35D3AB432030B4C600DE42C5 /* RCIntroEligibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D3AB412030B4C600DE42C5 /* RCIntroEligibility.h */; };
+		35D3AB432030B4C600DE42C5 /* RCIntroEligibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D3AB412030B4C600DE42C5 /* RCIntroEligibility.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		35D3AB442030B4C600DE42C5 /* RCIntroEligibility.m in Sources */ = {isa = PBXBuildFile; fileRef = 35D3AB422030B4C600DE42C5 /* RCIntroEligibility.m */; };
-		35D3AB452030B4C600DE42C5 /* RCIntroEligibility.m in Sources */ = {isa = PBXBuildFile; fileRef = 35D3AB422030B4C600DE42C5 /* RCIntroEligibility.m */; };
 		35E5B1DC1F80026C00B2537C /* StoreKitWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E5B1DB1F80026C00B2537C /* StoreKitWrapperTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -359,7 +358,6 @@
 				35262A211F7D77E600C04F2C /* PurchasesTests.swift in Sources */,
 				351F4FB21F803D9C00F245F4 /* BackendTests.swift in Sources */,
 				35262A301F7D78C600C04F2C /* HTTPClientTests.swift in Sources */,
-				35D3AB452030B4C600DE42C5 /* RCIntroEligibility.m in Sources */,
 				35E5B1DC1F80026C00B2537C /* StoreKitWrapperTests.swift in Sources */,
 				350FBDF01F7EFC410065833D /* StoreKitRequestFetcherTests.swift in Sources */,
 				351703CD1F805E5D00EEE27A /* PurchaserInfoTests.swift in Sources */,

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -37,6 +37,9 @@
 		359A0EA12003C8CD002D8C7F /* NSLocale+RCExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 359A0E9F2003C8CD002D8C7F /* NSLocale+RCExtensions.h */; };
 		359A0EA22003C8CD002D8C7F /* NSLocale+RCExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 359A0EA02003C8CD002D8C7F /* NSLocale+RCExtensions.m */; };
 		35A60EAA1F82993E00D2FAE8 /* RCPurchases+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 35A60EA81F82993E00D2FAE8 /* RCPurchases+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		35D3AB432030B4C600DE42C5 /* RCIntroEligibility.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D3AB412030B4C600DE42C5 /* RCIntroEligibility.h */; };
+		35D3AB442030B4C600DE42C5 /* RCIntroEligibility.m in Sources */ = {isa = PBXBuildFile; fileRef = 35D3AB422030B4C600DE42C5 /* RCIntroEligibility.m */; };
+		35D3AB452030B4C600DE42C5 /* RCIntroEligibility.m in Sources */ = {isa = PBXBuildFile; fileRef = 35D3AB422030B4C600DE42C5 /* RCIntroEligibility.m */; };
 		35E5B1DC1F80026C00B2537C /* StoreKitWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E5B1DB1F80026C00B2537C /* StoreKitWrapperTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -99,6 +102,8 @@
 		359A0E9F2003C8CD002D8C7F /* NSLocale+RCExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSLocale+RCExtensions.h"; sourceTree = "<group>"; };
 		359A0EA02003C8CD002D8C7F /* NSLocale+RCExtensions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSLocale+RCExtensions.m"; sourceTree = "<group>"; };
 		35A60EA81F82993E00D2FAE8 /* RCPurchases+Protected.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCPurchases+Protected.h"; sourceTree = "<group>"; };
+		35D3AB412030B4C600DE42C5 /* RCIntroEligibility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCIntroEligibility.h; sourceTree = "<group>"; };
+		35D3AB422030B4C600DE42C5 /* RCIntroEligibility.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCIntroEligibility.m; sourceTree = "<group>"; };
 		35E5B1DB1F80026C00B2537C /* StoreKitWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitWrapperTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -140,6 +145,8 @@
 				350FBDE81F7EEF070065833D /* RCPurchases.m */,
 				351F4FAD1F803D0700F245F4 /* RCPurchaserInfo.h */,
 				351F4FAE1F803D0700F245F4 /* RCPurchaserInfo.m */,
+				35D3AB412030B4C600DE42C5 /* RCIntroEligibility.h */,
+				35D3AB422030B4C600DE42C5 /* RCIntroEligibility.m */,
 			);
 			path = Public;
 			sourceTree = "<group>";
@@ -219,6 +226,7 @@
 			files = (
 				350FBDE31F7EECAA0065833D /* RCUtils.h in Headers */,
 				35262A2C1F7D783F00C04F2C /* RCHTTPClient.h in Headers */,
+				35D3AB432030B4C600DE42C5 /* RCIntroEligibility.h in Headers */,
 				350FBDED1F7EFB950065833D /* RCStoreKitRequestFetcher.h in Headers */,
 				359A0EA12003C8CD002D8C7F /* NSLocale+RCExtensions.h in Headers */,
 				351F4FAB1F80190700F245F4 /* RCBackend.h in Headers */,
@@ -335,6 +343,7 @@
 				350FBDEE1F7EFB950065833D /* RCStoreKitRequestFetcher.m in Sources */,
 				351F4FAC1F80190700F245F4 /* RCBackend.m in Sources */,
 				350FBDE01F7EE8F20065833D /* RCUtils.m in Sources */,
+				35D3AB442030B4C600DE42C5 /* RCIntroEligibility.m in Sources */,
 				359A0EA22003C8CD002D8C7F /* NSLocale+RCExtensions.m in Sources */,
 				351F4FB01F803D0700F245F4 /* RCPurchaserInfo.m in Sources */,
 				350FBDEA1F7EEF070065833D /* RCPurchases.m in Sources */,
@@ -350,6 +359,7 @@
 				35262A211F7D77E600C04F2C /* PurchasesTests.swift in Sources */,
 				351F4FB21F803D9C00F245F4 /* BackendTests.swift in Sources */,
 				35262A301F7D78C600C04F2C /* HTTPClientTests.swift in Sources */,
+				35D3AB452030B4C600DE42C5 /* RCIntroEligibility.m in Sources */,
 				35E5B1DC1F80026C00B2537C /* StoreKitWrapperTests.swift in Sources */,
 				350FBDF01F7EFC410065833D /* StoreKitRequestFetcherTests.swift in Sources */,
 				351703CD1F805E5D00EEE27A /* PurchaserInfoTests.swift in Sources */,

--- a/Purchases/Classes/Public/Purchases.h
+++ b/Purchases/Classes/Public/Purchases.h
@@ -13,3 +13,4 @@ FOUNDATION_EXPORT const unsigned char PurchasesVersionString[];
 
 #import <Purchases/RCPurchases.h>
 #import <Purchases/RCPurchaserInfo.h>
+#import <Purchases/RCIntroEligibility.h>

--- a/Purchases/Classes/Public/RCIntroEligibility.h
+++ b/Purchases/Classes/Public/RCIntroEligibility.h
@@ -8,6 +8,13 @@
 
 #import <Foundation/Foundation.h>
 
+/**
+ @typedef RCIntroEligibityStatus
+ @brief Enum of different possible states for intro price eligibility status.
+ @constant RCIntroEligibityStatusUnknown RevenueCat doesn't have enough information to determine eligibility.
+ @constant RCIntroEligibityStatusIneligible The user is not eligible for a free trial or intro pricing for this product.
+ @constant RCIntroEligibityStatusEligible The user is eligible for a free trial or intro pricing for this product.
+ */
 typedef NS_ENUM(NSInteger, RCIntroEligibityStatus) {
     RCIntroEligibityStatusUnknown = 0,
     RCIntroEligibityStatusIneligible,

--- a/Purchases/Classes/Public/RCIntroEligibility.h
+++ b/Purchases/Classes/Public/RCIntroEligibility.h
@@ -1,0 +1,23 @@
+//
+//  RCIntroEligibility.h
+//  Purchases
+//
+//  Created by Jacob Eiting on 2/11/18.
+//  Copyright © 2018 Purchases. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSInteger, RCIntroEligibityStatus) {
+    RCIntroEligibityStatusUnknown = 0,
+    RCIntroEligibityStatusIneligible,
+    RCIntroEligibityStatusEligible
+};
+
+@interface RCIntroEligibility : NSObject
+
+- (instancetype)initWithEligibilityStatus:(RCIntroEligibityStatus)status;
+
+@property (readonly) RCIntroEligibityStatus status;
+
+@end

--- a/Purchases/Classes/Public/RCIntroEligibility.m
+++ b/Purchases/Classes/Public/RCIntroEligibility.m
@@ -1,0 +1,27 @@
+//
+//  RCIntroEligibility.m
+//  Purchases
+//
+//  Created by Jacob Eiting on 2/11/18.
+//  Copyright © 2018 Purchases. All rights reserved.
+//
+
+#import "RCIntroEligibility.h"
+
+@interface RCIntroEligibility ()
+
+@property (nonatomic) RCIntroEligibityStatus status;
+
+@end
+
+@implementation RCIntroEligibility
+
+- (instancetype)initWithEligibilityStatus:(RCIntroEligibityStatus)status
+{
+    if (self = [super init]) {
+        self.status = status;
+    }
+    return self;
+}
+
+@end

--- a/Purchases/Classes/Public/RCIntroEligibility.m
+++ b/Purchases/Classes/Public/RCIntroEligibility.m
@@ -24,4 +24,17 @@
     return self;
 }
 
+- (NSString *)description
+{
+    switch (self.status) {
+        case RCIntroEligibityStatusEligible:
+            return @"Eligible for trial or introductory price.";
+        case RCIntroEligibityStatusIneligible:
+            return @"Not eligible for trial or introductory price.";
+        case RCIntroEligibityStatusUnknown:
+        default:
+            return @"Status indeterminate. You may need to assign the subscription group in the RevenueCat web interface.";
+    }
+}
+
 @end

--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -69,7 +69,7 @@ typedef void (^RCReceiveIntroEligibilityBlock)(NSDictionary<NSString *, RCIntroE
  @param productIdentifiers A set of product identifiers for in app purchases setup via iTunesConnect. This should be either hard coded in your application, from a file, or from a custom endpoint if you want to be able to deploy new IAPs without an app update.
  @param completion An @escaping callback that is called with the loaded products. If the fetch fails for any reason it will return an empty array.
  */
-- (void)productsWithIdentifiers:(NSSet<NSString *> *)productIdentifiers
+- (void)productsWithIdentifiers:(NSArray<NSString *> *)productIdentifiers
                      completion:(void (^)(NSArray<SKProduct *>* products))completion;
 
 /**
@@ -102,7 +102,7 @@ typedef void (^RCReceiveIntroEligibilityBlock)(NSDictionary<NSString *, RCIntroE
 /**
  Computes whether or not a user is eligible for the introductory pricing period of a given product. You should use this method to determine whether or not you show the user the normal product price or the introductory price. This also applies to trials (trials are considered a type of introductory pricing).
 
- @note If you have multiple subscription groups you will need to specify which products belong to which subscription groups on https://app.revenuecat.com/. If RevenueCat can't definitively compute the eligibilty, most like because of missing group information, it will return `RCIntroEligibilityStatusUnknown`. The best course of action on unknown status is to display the non-intro pricing, to not create a misleading situation.
+ @note If you have multiple subscription groups you will need to specify which products belong to which subscription groups on https://app.revenuecat.com/. If RevenueCat can't definitively compute the eligibilty, most likely because of missing group information, it will return `RCIntroEligibilityStatusUnknown`. The best course of action on unknown status is to display the non-intro pricing, to not create a misleading situation.
 
  @param productIdentifiers Array of product identifiers for which you want to compute eligibility
  @param receiveEligibility A block that receives a dictionary of product_id -> eligibility. Will always have keys for every product passed in via `productIdentifiers`.

--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -8,13 +8,14 @@
 
 #import <Foundation/Foundation.h>
 
-@class SKProduct, SKPayment, SKPaymentTransaction, RCPurchaserInfo, RCPurchases;
+@class SKProduct, SKPayment, SKPaymentTransaction, RCPurchaserInfo, RCIntroEligibility;
 @protocol RCPurchasesDelegate;
+
+NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^RCDeferredPromotionalPurchaseBlock)(void);
 typedef void (^RCReceivePurchaserInfoBlock)(RCPurchaserInfo * _Nullable, NSError * _Nullable);
-
-NS_ASSUME_NONNULL_BEGIN
+typedef void (^RCReceiveIntroEligibilityBlock)(NSDictionary<NSString *, RCIntroEligibility *> *);
 
 /**
  `RCPurchases` is the entry point for Purchases.framework. It should be instantiated as soon as your app has a unique user id for your user. This can be when a user logs in if you have accounts or on launch if you can generate a random user identifier.
@@ -97,6 +98,18 @@ NS_ASSUME_NONNULL_BEGIN
  Fetches the latest purchaser info from the backend. This will happen periodically on `applicationDidResumeActive:` and will trigger the delegate method `purchases:receivedUpdatedPurchaserInfo:`. You can use this method if you'd like to refresh the purchaser info manually.
  */
 - (void)updatedPurchaserInfo:(RCReceivePurchaserInfoBlock)receivePurchaserInfo;
+
+/**
+ Computes whether or not a user is eligible for the introductory pricing period of a given product. You should use this method to determine whether or not you show the user the normal product price or the introductory price. This also applies to trials (trials are considered a type of introductory pricing).
+
+ @note If you have multiple subscription groups you will need to specify which products belong to which subscription groups on https://app.revenuecat.com/. If RevenueCat can't definitively compute the eligibilty, most like because of missing group information, it will return `RCIntroEligibilityStatusUnknown`. The best course of action on unknown status is to display the non-intro pricing, to not create a misleading situation.
+
+ @param productIdentifiers Array of product identifiers for which you want to compute eligibility
+ @param receiveEligibility A block that receives a dictionary of product_id -> eligibility. Will always have keys for every product passed in via `productIdentifiers`.
+*/
+- (void)checkTrialOrIntroductoryPriceEligibility:(NSArray<NSString *> *)productIdentifiers
+                                      completion:(RCReceiveIntroEligibilityBlock)receiveEligibility;
+
 
 /**
  This version of the Purchases framework

--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -105,7 +105,7 @@ typedef void (^RCReceiveIntroEligibilityBlock)(NSDictionary<NSString *, RCIntroE
  @note If you have multiple subscription groups you will need to specify which products belong to which subscription groups on https://app.revenuecat.com/. If RevenueCat can't definitively compute the eligibilty, most likely because of missing group information, it will return `RCIntroEligibilityStatusUnknown`. The best course of action on unknown status is to display the non-intro pricing, to not create a misleading situation.
 
  @param productIdentifiers Array of product identifiers for which you want to compute eligibility
- @param receiveEligibility A block that receives a dictionary of product_id -> eligibility. Will always have keys for every product passed in via `productIdentifiers`.
+ @param receiveEligibility A block that receives a dictionary of product_id -> `RCIntroEligibility`.
 */
 - (void)checkTrialOrIntroductoryPriceEligibility:(NSArray<NSString *> *)productIdentifiers
                                       completion:(RCReceiveIntroEligibilityBlock)receiveEligibility;

--- a/Purchases/Classes/Public/RCPurchases.m
+++ b/Purchases/Classes/Public/RCPurchases.m
@@ -170,7 +170,12 @@ NSString * RCAppUserDefaultsKey = @"com.revenuecat.userdefaults.appUserID";
 - (void)checkTrialOrIntroductoryPriceEligibility:(NSArray<NSString *> *)productIdentifiers
                                       completion:(RCReceiveIntroEligibilityBlock)receiveEligibility
 {
-    
+    [self receiptData:^(NSData * _Nonnull data) {
+        [self.backend getIntroElgibilityForAppUserID:self.appUserID
+                                         receiptData:data
+                                  productIdentifiers:productIdentifiers
+                                          completion:receiveEligibility];
+    }];
 }
 
 - (void)makePurchase:(SKProduct *)product

--- a/Purchases/Classes/Public/RCPurchases.m
+++ b/Purchases/Classes/Public/RCPurchases.m
@@ -167,6 +167,12 @@ NSString * RCAppUserDefaultsKey = @"com.revenuecat.userdefaults.appUserID";
     }];
 }
 
+- (void)checkTrialOrIntroductoryPriceEligibility:(NSArray<NSString *> *)productIdentifiers
+                                      completion:(RCReceiveIntroEligibilityBlock)receiveEligibility
+{
+    
+}
+
 - (void)makePurchase:(SKProduct *)product
 {
     SKMutablePayment *payment = [SKMutablePayment paymentWithProduct:product];

--- a/Purchases/Classes/RCBackend.h
+++ b/Purchases/Classes/RCBackend.h
@@ -11,7 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class RCPurchaserInfo, RCHTTPClient;
+@class RCPurchaserInfo, RCHTTPClient, RCIntroEligibility;
 
 FOUNDATION_EXPORT NSErrorDomain const RCBackendErrorDomain;
 
@@ -33,6 +33,9 @@ RCPaymentMode RCPaymentModeFromSKProductDiscountPaymentMode(SKProductDiscountPay
 typedef void(^RCBackendResponseHandler)(RCPurchaserInfo * _Nullable,
                                         NSError * _Nullable);
 
+typedef void(^RCIntroEligibilityResponseHandler)(NSDictionary<NSString *,
+                                                 RCIntroEligibility *> *);
+
 @interface RCBackend : NSObject
 
 - (instancetype _Nullable)initWithAPIKey:(NSString *)APIKey;
@@ -52,6 +55,10 @@ typedef void(^RCBackendResponseHandler)(RCPurchaserInfo * _Nullable,
 
 - (void)getSubscriberDataWithAppUserID:(NSString *)appUserID
                             completion:(RCBackendResponseHandler)completion;
+
+- (void)getIntroElgibilityForAppUserID:(NSString *)appUserID
+                    productIdentifiers:(NSArray<NSString *> *)productIdentifiers
+                            completion:(RCIntroEligibilityResponseHandler)completion;
 
 @end
 

--- a/Purchases/Classes/RCBackend.h
+++ b/Purchases/Classes/RCBackend.h
@@ -57,6 +57,7 @@ typedef void(^RCIntroEligibilityResponseHandler)(NSDictionary<NSString *,
                             completion:(RCBackendResponseHandler)completion;
 
 - (void)getIntroElgibilityForAppUserID:(NSString *)appUserID
+                           receiptData:(NSData * _Nullable)receiptData
                     productIdentifiers:(NSArray<NSString *> *)productIdentifiers
                             completion:(RCIntroEligibilityResponseHandler)completion;
 

--- a/Purchases/Classes/RCBackend.m
+++ b/Purchases/Classes/RCBackend.m
@@ -164,6 +164,7 @@ RCPaymentMode RCPaymentModeFromSKProductDiscountPaymentMode(SKProductDiscountPay
 }
 
 - (void)getIntroElgibilityForAppUserID:(NSString *)appUserID
+                           receiptData:(NSData *)receiptData
                     productIdentifiers:(NSArray<NSString *> *)productIdentifiers
                             completion:(RCIntroEligibilityResponseHandler)completion
 {
@@ -172,11 +173,16 @@ RCPaymentMode RCPaymentModeFromSKProductDiscountPaymentMode(SKProductDiscountPay
         return;
     }
 
+    NSString *fetchToken = [receiptData base64EncodedStringWithOptions:0];
+
     NSString *escapedAppUserID = [appUserID stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
     NSString *path = [NSString stringWithFormat:@"/subscribers/%@/intro_eligibility", escapedAppUserID];
     [self.httpClient performRequest:@"POST"
                                path:path
-                               body:@{@"product_identifiers": productIdentifiers}
+                               body:@{
+                                      @"product_identifiers": productIdentifiers,
+                                      @"fetch_token": fetchToken
+                                      }
                             headers:self.headers
                   completionHandler:^(NSInteger statusCode, NSDictionary * _Nullable response, NSError * _Nullable error) {
                       if (statusCode >= 300) {

--- a/Purchases/Classes/RCBackend.m
+++ b/Purchases/Classes/RCBackend.m
@@ -193,7 +193,7 @@ RCPaymentMode RCPaymentModeFromSKProductDiscountPaymentMode(SKProductDiscountPay
                       for (NSString *productID in productIdentifiers) {
                           NSNumber *e = response[productID];
                           RCIntroEligibityStatus status;
-                          if (e == nil) {
+                          if (e == nil || [e isKindOfClass:[NSNull class]]) {
                               status = RCIntroEligibityStatusUnknown;
                           } else if ([e boolValue]) {
                               status = RCIntroEligibityStatusEligible;

--- a/Purchases/Classes/RCHTTPClient.m
+++ b/Purchases/Classes/RCHTTPClient.m
@@ -21,7 +21,7 @@
 
 + (NSString *)serverHostName
 {
-    return @"api.revenuecat.com";
+    return @"staging.revenuecat.com";
 }
 
 - (instancetype)init

--- a/Purchases/Classes/RCHTTPClient.m
+++ b/Purchases/Classes/RCHTTPClient.m
@@ -21,7 +21,7 @@
 
 + (NSString *)serverHostName
 {
-    return @"staging.revenuecat.com";
+    return @"api.revenuecat.com";
 }
 
 - (instancetype)init

--- a/PurchasesTests/BackendTests.swift
+++ b/PurchasesTests/BackendTests.swift
@@ -99,11 +99,11 @@ class BackendTests: XCTestCase {
         if self.httpClient.calls.count > 0 {
             let call = self.httpClient.calls[0]
 
-            XCTAssertEqual(call.path, expectedCall.path)
-            XCTAssertEqual(call.HTTPMethod, expectedCall.HTTPMethod)
+            expect(call.path).to(equal(expectedCall.path))
+            expect(call.HTTPMethod).to(equal(expectedCall.HTTPMethod))
             XCTAssertEqual(call.body!.keys, expectedCall.body!.keys)
-            XCTAssertNotNil(call.headers?["Authorization"])
-            XCTAssertEqual(call.headers?["Authorization"], expectedCall.headers?["Authorization"])
+            expect(call.headers?["Authorization"]).toNot(beNil())
+            expect(call.headers?["Authorization"]).to(equal(expectedCall.headers?["Authorization"]))
         }
 
         expect(completionCalled).toEventually(beTrue())
@@ -150,11 +150,12 @@ class BackendTests: XCTestCase {
         if self.httpClient.calls.count > 0 {
             let call = self.httpClient.calls[0]
 
-            XCTAssertEqual(call.path, expectedCall.path)
-            XCTAssertEqual(call.HTTPMethod, expectedCall.HTTPMethod)
+            expect(call.path).to(equal(expectedCall.path))
+            expect(call.HTTPMethod).to(equal(expectedCall.HTTPMethod))
             XCTAssert(call.body!.keys == expectedCall.body!.keys)
-            XCTAssertNotNil(call.headers?["Authorization"])
-            XCTAssertEqual(call.headers?["Authorization"], expectedCall.headers?["Authorization"])
+
+            expect(call.headers?["Authorization"]).toNot(beNil())
+            expect(call.headers?["Authorization"]).to(equal(expectedCall.headers?["Authorization"]))
         }
 
         expect(completionCalled).toEventually(beTrue())
@@ -339,7 +340,7 @@ class BackendTests: XCTestCase {
     }
 
     func testEmptyEligibiltyCheckDoesNothing() {
-        backend?.getIntroElgibility(forAppUserID: userID, productIdentifiers: [], completion: { (eligibilities) in
+        backend?.getIntroElgibility(forAppUserID: userID, receiptData: Data(), productIdentifiers: [], completion: { (eligibilities) in
 
         })
         expect(self.httpClient.calls.count).to(equal(0))
@@ -353,7 +354,7 @@ class BackendTests: XCTestCase {
         var eligibility: [String: RCIntroEligibility]?
 
         let products = ["producta", "productb", "productc"]
-        backend?.getIntroElgibility(forAppUserID: userID, productIdentifiers: products, completion: {(productEligbility) in
+        backend?.getIntroElgibility(forAppUserID: userID, receiptData: Data(), productIdentifiers: products, completion: {(productEligbility) in
             eligibility = productEligbility
         })
 
@@ -361,13 +362,14 @@ class BackendTests: XCTestCase {
         if httpClient.calls.count > 0 {
             let call = httpClient.calls[0]
 
-            XCTAssertEqual(path, "/subscribers/" + userID + "/intro_eligibility")
-            XCTAssertEqual(call.HTTPMethod, "POST")
-            XCTAssertNotNil(call.headers?["Authorization"])
-            XCTAssertEqual(call.headers?["Authorization"], "Basic " + apiKey)
+            expect(path).to(equal("/subscribers/" + userID + "/intro_eligibility"))
+            expect(call.HTTPMethod).to(equal("POST"))
+            expect(call.headers!["Authorization"]).toNot(beNil())
+            expect(call.headers!["Authorization"]).to(equal("Basic " + apiKey))
 
-            XCTAssertNotNil(call.body)
-            XCTAssertEqual(call.body!["product_identifiers"] as! [String], products)
+            expect(call.body).toNot(beNil())
+            expect(call.body!["product_identifiers"] as? [String]).to(equal(products))
+            expect(call.body!["fetch_token"]).toNot(beNil())
         }
 
         expect(eligibility).toEventuallyNot(beNil())
@@ -385,7 +387,7 @@ class BackendTests: XCTestCase {
         var eligibility: [String: RCIntroEligibility]?
 
         let products = ["producta", "productb", "productc"]
-        backend?.getIntroElgibility(forAppUserID: userID, productIdentifiers: products, completion: {(productEligbility) in
+        backend?.getIntroElgibility(forAppUserID: userID, receiptData: Data(), productIdentifiers: products, completion: {(productEligbility) in
             eligibility = productEligbility
         })
 
@@ -403,7 +405,7 @@ class BackendTests: XCTestCase {
         var eligibility: [String: RCIntroEligibility]?
 
         let products = ["producta", "productb", "productc"]
-        backend?.getIntroElgibility(forAppUserID: userID, productIdentifiers: products, completion: {(productEligbility) in
+        backend?.getIntroElgibility(forAppUserID: userID, receiptData: Data(), productIdentifiers: products, completion: {(productEligbility) in
             eligibility = productEligbility
         })
 

--- a/PurchasesTests/BackendTests.swift
+++ b/PurchasesTests/BackendTests.swift
@@ -347,13 +347,13 @@ class BackendTests: XCTestCase {
     }
 
     func testPostsProductIdentifiers() {
-        let response = HTTPResponse(statusCode: 200, response: ["producta": true, "productb": false], error: nil)
+        let response = HTTPResponse(statusCode: 200, response: ["producta": true, "productb": false, "productd": NSNull()], error: nil)
         let path = "/subscribers/" + userID + "/intro_eligibility"
         httpClient.mock(requestPath: path, response: response)
 
         var eligibility: [String: RCIntroEligibility]?
 
-        let products = ["producta", "productb", "productc"]
+        let products = ["producta", "productb", "productc", "productd"]
         backend?.getIntroElgibility(forAppUserID: userID, receiptData: Data(), productIdentifiers: products, completion: {(productEligbility) in
             eligibility = productEligbility
         })
@@ -377,6 +377,7 @@ class BackendTests: XCTestCase {
         expect(eligibility!["producta"]!.status).toEventually(equal(RCIntroEligibityStatus.eligible))
         expect(eligibility!["productb"]!.status).toEventually(equal(RCIntroEligibityStatus.ineligible))
         expect(eligibility!["productc"]!.status).toEventually(equal(RCIntroEligibityStatus.unknown))
+        expect(eligibility!["productd"]!.status).toEventually(equal(RCIntroEligibityStatus.unknown))
     }
 
     func testEligbilityUnknownIfError() {

--- a/PurchasesTests/BackendTests.swift
+++ b/PurchasesTests/BackendTests.swift
@@ -376,4 +376,39 @@ class BackendTests: XCTestCase {
         expect(eligibility!["productb"]!.status).toEventually(equal(RCIntroEligibityStatus.ineligible))
         expect(eligibility!["productc"]!.status).toEventually(equal(RCIntroEligibityStatus.unknown))
     }
+
+    func testEligbilityUnknownIfError() {
+        let response = HTTPResponse(statusCode: 499, response: serverErrorResponse, error: nil)
+        let path = "/subscribers/" + userID + "/intro_eligibility"
+        httpClient.mock(requestPath: path, response: response)
+
+        var eligibility: [String: RCIntroEligibility]?
+
+        let products = ["producta", "productb", "productc"]
+        backend?.getIntroElgibility(forAppUserID: userID, productIdentifiers: products, completion: {(productEligbility) in
+            eligibility = productEligbility
+        })
+
+        expect(eligibility!["producta"]!.status).toEventually(equal(RCIntroEligibityStatus.unknown))
+        expect(eligibility!["productb"]!.status).toEventually(equal(RCIntroEligibityStatus.unknown))
+        expect(eligibility!["productc"]!.status).toEventually(equal(RCIntroEligibityStatus.unknown))
+    }
+
+    func testEligbilityUnknownIfUnknownError() {
+        let error = NSError(domain: "myhouse", code: 12, userInfo: nil) as Error
+        let response = HTTPResponse(statusCode: 200, response: serverErrorResponse, error: error)
+        let path = "/subscribers/" + userID + "/intro_eligibility"
+        httpClient.mock(requestPath: path, response: response)
+
+        var eligibility: [String: RCIntroEligibility]?
+
+        let products = ["producta", "productb", "productc"]
+        backend?.getIntroElgibility(forAppUserID: userID, productIdentifiers: products, completion: {(productEligbility) in
+            eligibility = productEligbility
+        })
+
+        expect(eligibility!["producta"]!.status).toEventually(equal(RCIntroEligibityStatus.unknown))
+        expect(eligibility!["productb"]!.status).toEventually(equal(RCIntroEligibityStatus.unknown))
+        expect(eligibility!["productc"]!.status).toEventually(equal(RCIntroEligibityStatus.unknown))
+    }
 }

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -224,7 +224,7 @@ class PurchasesTests: XCTestCase {
         setupPurchases()
         var products: [SKProduct]?
         let productIdentifiers = ["com.product.id1", "com.product.id2"]
-        purchases!.products(withIdentifiers:Set(productIdentifiers)) { (newProducts) in
+        purchases!.products(withIdentifiers:productIdentifiers) { (newProducts) in
             products = newProducts
         }
 
@@ -320,7 +320,7 @@ class PurchasesTests: XCTestCase {
     func testSendsProductInfoIfProductIsCached() {
         setupPurchases()
         let productIdentifiers = ["com.product.id1", "com.product.id2"]
-        purchases!.products(withIdentifiers:Set(productIdentifiers)) { (newProducts) in
+        purchases!.products(withIdentifiers:productIdentifiers) { (newProducts) in
             let product = newProducts[0];
             self.purchases?.makePurchase(product)
             

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -77,6 +77,18 @@ class PurchasesTests: XCTestCase {
 
             completion(postReceiptPurchaserInfo, postReceiptError)
         }
+
+        var postedProductIdentifiers: [String]?
+        override func getIntroElgibility(forAppUserID appUserID: String, productIdentifiers: [String], completion: @escaping RCIntroEligibilityResponseHandler) {
+            postedProductIdentifiers = productIdentifiers
+
+            var eligibilities = [String: RCIntroEligibility]()
+            for productID in productIdentifiers {
+                eligibilities[productID] = RCIntroEligibility(eligibilityStatus: RCIntroEligibityStatus.eligible)
+            }
+
+            completion(eligibilities);
+        }
     }
 
     class MockStoreKitWrapper: RCStoreKitWrapper {
@@ -678,5 +690,9 @@ class PurchasesTests: XCTestCase {
         setupAnonPurchases()
 
         expect(self.purchases?.appUserID).to(equal(appUserID))
+    }
+    
+    func testGetEligibility() {
+        purchases!.checkTrialOrIntroductoryPriceEligibility([]) { (eligibilities) in}
     }
 }

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -701,16 +701,6 @@ class PurchasesTests: XCTestCase {
         setupPurchases()
         purchases!.checkTrialOrIntroductoryPriceEligibility([]) { (eligibilities) in}
 
-        expect(self.backend.postReceiptDataCalled).to(beTrue())
-    }
-
-    func testGetEligibilityRespectsAnonIDRules() {
-        setupPurchases()
-        purchases!.checkTrialOrIntroductoryPriceEligibility([]) { (eligibilities) in}
-        expect(self.backend.postedIsRestore).to(beFalse())
-
-        setupAnonPurchases()
-        purchases!.checkTrialOrIntroductoryPriceEligibility([]) { (eligibilities) in}
-        expect(self.backend.postedIsRestore).to(beTrue())
+        expect(self.requestFetcher.refreshReceiptCalled).to(beTrue())
     }
 }

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -79,7 +79,7 @@ class PurchasesTests: XCTestCase {
         }
 
         var postedProductIdentifiers: [String]?
-        override func getIntroElgibility(forAppUserID appUserID: String, productIdentifiers: [String], completion: @escaping RCIntroEligibilityResponseHandler) {
+        override func getIntroElgibility(forAppUserID appUserID: String, receiptData: Data?, productIdentifiers: [String], completion: @escaping RCIntroEligibilityResponseHandler) {
             postedProductIdentifiers = productIdentifiers
 
             var eligibilities = [String: RCIntroEligibility]()
@@ -693,6 +693,24 @@ class PurchasesTests: XCTestCase {
     }
     
     func testGetEligibility() {
+        setupPurchases()
         purchases!.checkTrialOrIntroductoryPriceEligibility([]) { (eligibilities) in}
+    }
+
+    func testGetEligibilitySendsAReceipt() {
+        setupPurchases()
+        purchases!.checkTrialOrIntroductoryPriceEligibility([]) { (eligibilities) in}
+
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
+    }
+
+    func testGetEligibilityRespectsAnonIDRules() {
+        setupPurchases()
+        purchases!.checkTrialOrIntroductoryPriceEligibility([]) { (eligibilities) in}
+        expect(self.backend.postedIsRestore).to(beFalse())
+
+        setupAnonPurchases()
+        purchases!.checkTrialOrIntroductoryPriceEligibility([]) { (eligibilities) in}
+        expect(self.backend.postedIsRestore).to(beTrue())
     }
 }


### PR DESCRIPTION
- Add support of checking eligibilty of introductory prices. RevenueCat will now be able to tell you definitively what version of a product you should present in your UI.