### PR TITLE
[FINAL] Request Caching

### DIFF
--- a/PurchasesTests/BackendTests.swift
+++ b/PurchasesTests/BackendTests.swift
@@ -41,7 +41,9 @@ class BackendTests: XCTestCase {
             calls.append(HTTPRequest(HTTPMethod: HTTPMethod, path: path, body: requestBody, headers: headers))
 
             if shouldFinish {
-                completionHandler!(response.statusCode, response.response, response.error)
+                DispatchQueue.main.async {
+                    completionHandler!(response.statusCode, response.response, response.error)
+                }
             }
         }
 


### PR DESCRIPTION
If we request to send the same receipt while a previous send is in flight, we don't initiate a request but just attach the completion block to the current request.