### PR TITLE
[FINAL] Caching Purchaser Info

### DIFF
--- a/Purchases/Classes/Public/RCPurchaserInfo.m
+++ b/Purchases/Classes/Public/RCPurchaserInfo.m
@@ -14,6 +14,8 @@
 @property (nonatomic) NSSet<NSString *> *nonConsumablePurchases;
 @property (nonatomic) NSString *originalApplicationVersion;
 
+@property (nonatomic) NSDictionary *originalData;
+
 @end
 
 static NSDateFormatter *dateFormatter;
@@ -27,6 +29,8 @@ static dispatch_once_t onceToken;
         if (data[@"subscriber"] == nil) {
             return nil;
         }
+
+        self.originalData = data;
 
         NSDictionary *subscriberData = data[@"subscriber"];
 
@@ -100,6 +104,10 @@ static dispatch_once_t onceToken;
 - (NSDate *)expirationDateForProductIdentifier:(NSString *)productIdentifier
 {
     return self.expirationDates[productIdentifier];
+}
+
+- (NSDictionary * _Nonnull)JSONObject {
+    return self.originalData;
 }
 
 @end

--- a/Purchases/Classes/RCPurchaserInfo+Protected.h
+++ b/Purchases/Classes/RCPurchaserInfo+Protected.h
@@ -12,4 +12,6 @@
 
 - (instancetype _Nullable)initWithData:(NSDictionary * _Nonnull)data;
 
+- (NSDictionary * _Nonnull)JSONObject;
+
 @end

--- a/PurchasesTests/PurchaserInfoTests.swift
+++ b/PurchasesTests/PurchaserInfoTests.swift
@@ -94,4 +94,10 @@ class BasicPurchaerInfoTests: XCTestCase {
             ]])
         expect(purchaserInfo!.originalApplicationVersion).to(equal("1.0"))
     }
+
+    func testPreservesOriginalJSONSerializableObject() {
+        let json = purchaserInfo?.jsonObject()
+        let newInfo = RCPurchaserInfo(data: json!)
+        expect(newInfo).toNot(beNil())
+    }
 }

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -156,23 +156,21 @@ class PurchasesTests: XCTestCase {
         let purchaserInfoCachePrefix = "com.revenuecat.userdefaults.purchaserInfo"
 
         var appUserID: String?
-        var cachedUserInfo = [String : String]()
+        var cachedUserInfo = [String : Data]()
 
         override func string(forKey defaultName: String) -> String? {
-            if (defaultName == appUserIDKey) {
-                return appUserID
-            } else if (defaultName.starts(with: purchaserInfoCachePrefix)) {
-                return cachedUserInfo[defaultName];
-            } else {
-                return nil
-            }
+            return appUserID;
+        }
+
+        override func data(forKey defaultName: String) -> Data? {
+            return cachedUserInfo[defaultName];
         }
 
         override func set(_ value: Any?, forKey defaultName: String) {
             if (defaultName == appUserIDKey) {
                 appUserID = value as! String?
             } else if (defaultName.starts(with: purchaserInfoCachePrefix)){
-                cachedUserInfo[defaultName] = value as! String?
+                cachedUserInfo[defaultName] = value as! Data?
             }
         }
     }
@@ -598,9 +596,7 @@ class PurchasesTests: XCTestCase {
         setupPurchases()
         let purchaserInfo = RCPurchaserInfo()
         self.backend.postReceiptPurchaserInfo = purchaserInfo
-
-
-
+        
         purchases!.restoreTransactionsForAppStoreAccount()
 
         expect(self.purchasesDelegate.purchaserInfo).toEventually(equal(purchaserInfo))
@@ -755,12 +751,12 @@ class PurchasesTests: XCTestCase {
         expect(self.purchasesDelegate.purchaserInfo).toEventuallyNot(beNil())
 
         expect(self.userDefaults.cachedUserInfo.count).to(equal(1))
-        let purchaserInfo = userDefaults.cachedUserInfo["com.revenuecat.userdefaults.purchaserInfo"]
+        let purchaserInfo = userDefaults.cachedUserInfo["com.revenuecat.userdefaults.purchaserInfo." + self.purchases!.appUserID]
         expect(purchaserInfo).toNot(beNil())
 
         do {
             if (purchaserInfo != nil) {
-                try JSONSerialization.jsonObject(with: (purchaserInfo?.data(using: String.Encoding.utf8)!)!, options: [])
+                try JSONSerialization.jsonObject(with: purchaserInfo!, options: [])
             }
         } catch {
             fail()


### PR DESCRIPTION
The latest RCPurchaserInfo will now be cached by RevenueCat so the client apps don't have to worry about caching it themselves.