### PR TITLE
[FINAL] Better Caching

### DIFF
--- a/Purchases/Classes/Public/RCPurchases.m
+++ b/Purchases/Classes/Public/RCPurchases.m
@@ -176,7 +176,10 @@ NSString * RCPurchaserInfoAppUserDefaultsKeyBase = @"com.revenuecat.userdefaults
 - (void)updateCaches
 {
     NSTimeInterval timeSinceLastCheck = -[self.cachesLastUpdated timeIntervalSinceNow];
-    if (self.cachesLastUpdated != nil && timeSinceLastCheck < 60.) return;
+    if (self.cachesLastUpdated != nil && timeSinceLastCheck < 60.) {
+        [self readPurchaserInfoFromCache];
+        return;
+    }
 
     self.cachesLastUpdated = [NSDate date];
 

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -203,7 +203,9 @@ class PurchasesTests: XCTestCase {
             self.failedTransaction = transaction
         }
 
+        var purchaserInfoReceivedCount = 0
         func purchases(_ purchases: RCPurchases, receivedUpdatedPurchaserInfo purchaserInfo: RCPurchaserInfo) {
+            purchaserInfoReceivedCount += 1
             self.purchaserInfo = purchaserInfo
         }
 
@@ -564,6 +566,15 @@ class PurchasesTests: XCTestCase {
         setupPurchases()
         notificationCenter.fireNotifications();
         expect(self.purchasesDelegate.purchaserInfo).toEventuallyNot(beNil());
+    }
+
+    func testBackToBackTriggersReemitCachedPurchaserInfo() {
+        setupPurchases()
+
+        notificationCenter.fireNotifications();
+        expect(self.purchasesDelegate.purchaserInfoReceivedCount).to(equal(2));
+        notificationCenter.fireNotifications();
+        expect(self.purchasesDelegate.purchaserInfoReceivedCount).to(equal(3));
     }
 
     func testRemovesObservationWhenDelegateNild() {


### PR DESCRIPTION
- Adds a test for caching on purchase
- SDK now emits the cached version of the purchaser info when activating within throttle limit