### PR TITLE
[FINAL] Entitlements Don't Fail if Product Missing

### DIFF
--- a/Purchases/Classes/Public/RCOffering.h
+++ b/Purchases/Classes/Public/RCOffering.h
@@ -12,6 +12,8 @@
 
 @interface RCOffering : NSObject
 
-@property (readonly) SKProduct *activeProduct;
+// The active product, this will be null if the product is not available, usually because it has not been approved
+// for sale
+@property (readonly) SKProduct * _Nullable activeProduct;
 
 @end

--- a/Purchases/Classes/Public/RCPurchases.m
+++ b/Purchases/Classes/Public/RCPurchases.m
@@ -241,17 +241,9 @@ NSString * RCPurchaserInfoAppUserDefaultsKeyBase = @"com.revenuecat.userdefaults
                                                productsById[p.productIdentifier] = p;
                                            }
 
-                                           __block BOOL productMissing = NO;
-
                                            [self performOnEachOfferingInEntitlements:entitlements block:^(RCOffering *offering) {
                                                offering.activeProduct = productsById[offering.activeProductIdentifier];
-                                               productMissing |= (offering.activeProduct == nil);
                                            }];
-
-                                           if (productMissing) {
-                                               completion(nil);
-                                               return;
-                                           }
 
                                            if (entitlements != nil) {
                                                self.cachedEntitlements = entitlements;

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -889,7 +889,7 @@ class PurchasesTests: XCTestCase {
             entitlements = newEntitlements
         })
 
-        expect(entitlements).toEventually(beNil());
-
+        expect(entitlements).toEventuallyNot(beNil());
+        expect(entitlements).toEventually(haveCount(1))
     }
 }


### PR DESCRIPTION
Now, if a product is missing, it is nil, rather than nuking the whole entitlement.

This should be a more graceful failure mode.