### PR TITLE
Conform RCPurchasesDelegate to NSObject

### DIFF
--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -191,7 +191,7 @@ typedef NS_ENUM(NSInteger, RCAttributionNetwork) {
 
  @note Delegate methods can be called at any time after the `delegate` is set, not just in response to `makePurchase:` calls. Ensure your app is capable of handling completed transactions anytime `delegate` is set.
  */
-@protocol RCPurchasesDelegate
+@protocol RCPurchasesDelegate <NSObject>
 @required
 
 /**

--- a/Purchases/Classes/Public/RCPurchases.m
+++ b/Purchases/Classes/Public/RCPurchases.m
@@ -387,7 +387,7 @@ NSString * RCPurchaserInfoAppUserDefaultsKeyBase = @"com.revenuecat.userdefaults
         self.productsByIdentifier[product.productIdentifier] = product;
     }
     
-    if ([(id<NSObject>)self.delegate respondsToSelector:@selector(purchases:shouldPurchasePromoProduct:defermentBlock:)]) {
+    if ([self.delegate respondsToSelector:@selector(purchases:shouldPurchasePromoProduct:defermentBlock:)]) {
         return [self.delegate purchases:self shouldPurchasePromoProduct:product defermentBlock:^{
             [self.storeKitWrapper addPayment:payment];
         }];

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -209,7 +209,7 @@ class PurchasesTests: XCTestCase {
         }
     }
 
-    class PurchasesDelegate: RCPurchasesDelegate {
+    class PurchasesDelegate: NSObject, RCPurchasesDelegate {
         var completedTransaction: SKPaymentTransaction?
         var purchaserInfo: RCPurchaserInfo?
         func purchases(_ purchases: RCPurchases, completedTransaction transaction: SKPaymentTransaction, withUpdatedInfo purchaserInfo: RCPurchaserInfo) {


### PR DESCRIPTION
This is necessary to have optional protocol requirements. I saw that it was previously casting `self.delegate` to `id<NSObject>` but that isn't the best way to do it.