### PR TITLE
Adds requestDate to the purchaser info to avoid edge cases

### DIFF
--- a/Purchases/Classes/Public/RCPurchaserInfo.h
+++ b/Purchases/Classes/Public/RCPurchaserInfo.h
@@ -56,6 +56,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (NSDate * _Nullable)expirationDateForProductIdentifier:(NSString *)productIdentifier;
 
+/**
+ Returns the fetch date of this Purchaser info.
+ @note Can be nil if was cached before we added this
+*/
+@property (readonly) NSDate * _Nullable requestDate;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Purchases/Classes/Public/RCPurchaserInfo.m
+++ b/Purchases/Classes/Public/RCPurchaserInfo.m
@@ -94,9 +94,7 @@ static dispatch_once_t onceToken;
 
     for (NSString *identifier in dates) {
         NSDate *dateOrNull = (NSDate *)dates[identifier];
-        if ([dateOrNull isKindOfClass:NSNull.class] || [self isActive:dateOrNull]) {
-            // If the expiration date is not null and the day we fetched this is before the expiration,
-            // then this is an active subscription
+        if ([dateOrNull isKindOfClass:NSNull.class] || [self isAfterReferenceDate:dateOrNull]) {
             [activeSubscriptions addObject:identifier];
         }
     }
@@ -104,14 +102,9 @@ static dispatch_once_t onceToken;
     return [NSSet setWithSet:activeSubscriptions];
 }
 
-- (BOOL)isActive:(NSDate *)dateOrNull {
-    // Check if the date this purchaser info was fetched is before this products expiration date
-    // We need to check against the fetched date since this object could be cached
-    if (self.requestDate) {
-        return [self.requestDate compare:dateOrNull] == NSOrderedAscending;
-    } else { // The date this purchaser info was fetched can be nil if it is an old cached version
-        return dateOrNull.timeIntervalSinceNow > 0;
-    }
+- (BOOL)isAfterReferenceDate:(NSDate *)date {
+    NSDate *referenceDate = self.requestDate ?: [NSDate date];
+    return [date timeIntervalSinceDate:referenceDate] > 0;
 }
 
 - (NSSet<NSString *> *)activeSubscriptions

--- a/PurchasesTests/PurchaserInfoTests.swift
+++ b/PurchasesTests/PurchaserInfoTests.swift
@@ -20,8 +20,9 @@ class EmptyPurchaserInfoTests: XCTestCase {
     }
 }
 
-class BasicPurchaerInfoTests: XCTestCase {
+class BasicPurchaserInfoTests: XCTestCase {
     let validSubscriberResponse = [
+        "request_date": "2018-10-19T02:40:36Z",
         "subscriber": [
             "other_purchases": [
                 "onetime_purchase": [
@@ -48,9 +49,17 @@ class BasicPurchaerInfoTests: XCTestCase {
                 ],
             ]
         ]
-    ]
+    ] as [String : Any]
 
-    let validTwoProductsJSON = "{\"subscriber\": {\"original_application_version\": \"1.0\",\"other_purchases\": {},\"subscriptions\":{\"product_a\": {\"expires_date\": \"2018-05-27T06:24:50Z\",\"period_type\": \"normal\"},\"product_b\": {\"expires_date\": \"2018-05-27T05:24:50Z\",\"period_type\": \"normal\"}}}}";
+    let validTwoProductsJSON = "{" +
+            "\"request_date\": \"2018-05-20T06:24:50Z\"," +
+            "\"subscriber\": {" +
+            "\"original_application_version\": \"1.0\"," +
+            "\"other_purchases\": {}," +
+            "\"subscriptions\":{" +
+                "\"product_a\": {\"expires_date\": \"2018-05-27T06:24:50Z\",\"period_type\": \"normal\"}," +
+                "\"product_b\": {\"expires_date\": \"2018-05-27T05:24:50Z\",\"period_type\": \"normal\"}" +
+            "}}}";
 
     var purchaserInfo: RCPurchaserInfo?
 
@@ -145,4 +154,46 @@ class BasicPurchaerInfoTests: XCTestCase {
     func testExpirationLifetime() {
         expect(self.purchaserInfo!.expirationDate(forEntitlement: "forever_pro")).to(beNil())
     }
+
+    func testRequestDate() {
+        expect(self.purchaserInfo!.requestDate).toNot(beNil())
+    }
+
+    func testIfRequestDateIsNilUsesCurrentTime() {
+        let response = [
+            "subscriber": [
+                "other_purchases": [
+                    "onetime_purchase": [
+                        "purchase_date": "1990-08-30T02:40:36Z"
+                    ]
+                ],
+                "subscriptions": [
+                    "onemonth_freetrial": [
+                        "expires_date": "2100-08-30T02:40:36Z"
+                    ],
+                    "threemonth_freetrial": [
+                        "expires_date": "1990-08-30T02:40:36Z"
+                    ]
+                ],
+                "entitlements": [
+                    "pro" : [
+                        "expires_date" : "2100-08-30T02:40:36Z"
+                    ],
+                    "old_pro" : [
+                        "expires_date" : "1990-08-30T02:40:36Z"
+                    ],
+                    "forever_pro" : [
+                        "expires_date" : nil
+                    ],
+                ]
+            ]
+            ] as [String : Any]
+        let purchaserInfoWithoutRequestData = RCPurchaserInfo.init(data: response)
+
+        let entitlements = purchaserInfoWithoutRequestData!.activeEntitlements
+        expect(entitlements).to(contain("pro"));
+        expect(entitlements).toNot(contain("old_pro"));
+    }
+    
+    
 }


### PR DESCRIPTION
Before this PR, we are checking the validity of a subscription by comparing the current timestamp with the expiration date of the subscription.

It turns out that if we check that against a cached subscription, we could get into the edge case that the user could have renewed (extending the expiration date) and we would be checking against an older expiration date, which will lead to a returning subscription.

This PR makes a change in the way we check if a subscription is valid. We check now the expiration date against the date the version of the purchaser information we have available (remember, if it's a cached version, it could be really old, even older than a renewal date).

To avoid problems with older cached versions that use the next version of the SDK, if the request_date is not cached, we keep checking against the current time.