### PR TITLE
Creates a configuration method that creates a singleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,5 @@ DerivedData/
 *.perspectivev3
 !default.perspectivev3
 
-
+.idea/
 Carthage

--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -39,7 +39,7 @@ typedef NS_ENUM(NSInteger, RCAttributionNetwork) {
 @interface RCPurchases : NSObject
 
 /**
- Configures an instance of the Purchases SDK with an specified API key. The instance will be set as a singleton. You should access the singleton instance using [RCPurchases defaultInstance]
+ Configures an instance of the Purchases SDK with an specified API key. The instance will be set as a singleton. You should access the singleton instance using [RCPurchases sharedPurchases]
 
  @note Use this initializer if your app does not have an account system.`RCPurchases` will generate a unique identifier for the current device and persist it to `NSUserDefaults`. This also affects the behavior of `restoreTransactionsForAppStoreAccount`.
 
@@ -50,7 +50,7 @@ typedef NS_ENUM(NSInteger, RCAttributionNetwork) {
 + (instancetype)configureWithAPIKey:(NSString *)APIKey;
 
 /**
- Configures an instance of the Purchases SDK with an specified API key and app user ID. The instance will be set as a singleton. You should access the singleton instance using [RCPurchases defaultInstance]
+ Configures an instance of the Purchases SDK with an specified API key and app user ID. The instance will be set as a singleton. You should access the singleton instance using [RCPurchases sharedPurchases]
 
  @note Best practice is to use a salted hash of your unique app user ids.
 
@@ -65,7 +65,7 @@ typedef NS_ENUM(NSInteger, RCAttributionNetwork) {
 + (instancetype)configureWithAPIKey:(NSString *)APIKey appUserID:(NSString * _Nullable)appUserID;
 
 /**
- Configures an instance of the Purchases SDK with object with a custom userDefaults. Use this constructor if you want to sync status across a shared container, such as between a host app and an extension. The instance of the Purchases SDK will be set as a singleton. You should access the singleton instance using [RCPurchases defaultInstance]
+ Configures an instance of the Purchases SDK with object with a custom userDefaults. Use this constructor if you want to sync status across a shared container, such as between a host app and an extension. The instance of the Purchases SDK will be set as a singleton. You should access the singleton instance using [RCPurchases sharedPurchases]
 
  @param APIKey The API Key generated for your app from https://app.revenuecat.com/
 
@@ -82,7 +82,7 @@ typedef NS_ENUM(NSInteger, RCAttributionNetwork) {
 /**
  @return A singleton `RCPurchases` object. Call this after a configure method to access the singleton.
  */
-+ (instancetype)defaultInstance;
++ (instancetype)sharedPurchases;
 
 /**
  Configures an instance of the Purchases SDK as a singleton. The configure methods call this internally so it's preferably to set the default instance through a configure method. Use this method only if you want to override what the configure methods are doing.

--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -38,6 +38,15 @@ typedef NS_ENUM(NSInteger, RCAttributionNetwork) {
  */
 @interface RCPurchases : NSObject
 
++ (instancetype)configureWithAPIKey:(NSString *)APIKey;
++ (instancetype)configureWithAPIKey:(NSString *)APIKey appUserID:(NSString * _Nullable)appUserID;
++ (instancetype)configureWithAPIKey:(NSString *)APIKey
+                          appUserID:(NSString * _Nullable)appUserID
+                       userDefaults:(NSUserDefaults * _Nullable)userDefaults;
+
++ (instancetype)defaultInstance;
++ (void)setDefaultInstance:(RCPurchases *)instance;
+
 /**
  Initializes an `RCPurchases` object with specified API key.
 

--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -39,9 +39,9 @@ typedef NS_ENUM(NSInteger, RCAttributionNetwork) {
 @interface RCPurchases : NSObject
 
 /**
- Configures an instance of the Purchases SDK with an specified API key. The instance will be set as a singleton. You should access the singleton instance using [RCPurchases sharedPurchases]
+ Configures an instance of the Purchases SDK with a specified API key. The instance will be set as a singleton. You should access the singleton instance using [RCPurchases sharedPurchases]
 
- @note Use this initializer if your app does not have an account system.`RCPurchases` will generate a unique identifier for the current device and persist it to `NSUserDefaults`. This also affects the behavior of `restoreTransactionsForAppStoreAccount`.
+ @note Use this initializer if your app does not have an account system. `RCPurchases` will generate a unique identifier for the current device and persist it to `NSUserDefaults`. This also affects the behavior of `restoreTransactionsForAppStoreAccount`.
 
  @param APIKey The API Key generated for your app from https://app.revenuecat.com/
 
@@ -50,7 +50,7 @@ typedef NS_ENUM(NSInteger, RCAttributionNetwork) {
 + (instancetype)configureWithAPIKey:(NSString *)APIKey;
 
 /**
- Configures an instance of the Purchases SDK with an specified API key and app user ID. The instance will be set as a singleton. You should access the singleton instance using [RCPurchases sharedPurchases]
+ Configures an instance of the Purchases SDK with a specified API key and app user ID. The instance will be set as a singleton. You should access the singleton instance using [RCPurchases sharedPurchases]
 
  @note Best practice is to use a salted hash of your unique app user ids.
 
@@ -85,7 +85,7 @@ typedef NS_ENUM(NSInteger, RCAttributionNetwork) {
 + (instancetype)sharedPurchases;
 
 /**
- Configures an instance of the Purchases SDK as a singleton. The configure methods call this internally so it's preferably to set the default instance through a configure method. Use this method only if you want to override what the configure methods are doing.
+ Sets an instance of the Purchases SDK as a singleton. The configure methods call this internally so it's preferably to set the default instance through a configure method. Use this method only if you want to override what the configure methods are doing.
  */
 + (void)setDefaultInstance:(RCPurchases *)instance;
 

--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -178,7 +178,7 @@ typedef NS_ENUM(NSInteger, RCAttributionNetwork) {
  @param productIdentifiers A set of product identifiers for in app purchases setup via iTunesConnect. This should be either hard coded in your application, from a file, or from a custom endpoint if you want to be able to deploy new IAPs without an app update.
  @param completion An @escaping callback that is called with the loaded products. If the fetch fails for any reason it will return an empty array.
  */
-- (void)productsWithIdentifiers:(NSSet<NSString *> *)productIdentifiers
+- (void)productsWithIdentifiers:(NSArray<NSString *> *)productIdentifiers
                      completion:(void (^)(NSArray<SKProduct *>* products))completion;
 
 /**

--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -34,17 +34,59 @@ typedef NS_ENUM(NSInteger, RCAttributionNetwork) {
 /**
  `RCPurchases` is the entry point for Purchases.framework. It should be instantiated as soon as your app has a unique user id for your user. This can be when a user logs in if you have accounts or on launch if you can generate a random user identifier.
 
- @warning Only one instance of RCPurchases should be instantiated at a time!
+ @warning Only one instance of RCPurchases should be instantiated at a time! Use a configure method to let the framework handle the singleton instance for you.
  */
 @interface RCPurchases : NSObject
 
+/**
+ Configures an instance of the Purchases SDK with an specified API key. The instance will be set as a singleton. You should access the singleton instance using [RCPurchases defaultInstance]
+
+ @note Use this initializer if your app does not have an account system.`RCPurchases` will generate a unique identifier for the current device and persist it to `NSUserDefaults`. This also affects the behavior of `restoreTransactionsForAppStoreAccount`.
+
+ @param APIKey The API Key generated for your app from https://app.revenuecat.com/
+
+ @return An instantiated `RCPurchases` object that has been set as a singleton.
+ */
 + (instancetype)configureWithAPIKey:(NSString *)APIKey;
+
+/**
+ Configures an instance of the Purchases SDK with an specified API key and app user ID. The instance will be set as a singleton. You should access the singleton instance using [RCPurchases defaultInstance]
+
+ @note Best practice is to use a salted hash of your unique app user ids.
+
+ @warning Use this initializer if you have your own user identifiers that you manage.
+
+ @param APIKey The API Key generated for your app from https://app.revenuecat.com/
+
+ @param appUserID The unique app user id for this user. This user id will allow users to share their purchases and subscriptions across devices. Pass nil if you want `RCPurchases` to generate this for you.
+
+ @return An instantiated `RCPurchases` object that has been set as a singleton.
+ */
 + (instancetype)configureWithAPIKey:(NSString *)APIKey appUserID:(NSString * _Nullable)appUserID;
+
+/**
+ Configures an instance of the Purchases SDK with object with a custom userDefaults. Use this constructor if you want to sync status across a shared container, such as between a host app and an extension. The instance of the Purchases SDK will be set as a singleton. You should access the singleton instance using [RCPurchases defaultInstance]
+
+ @param APIKey The API Key generated for your app from https://app.revenuecat.com/
+
+ @param appUserID The unique app user id for this user. This user id will allow users to share their purchases and subscriptions across devices. Pass nil if you want `RCPurchases` to generate this for you.
+
+ @param userDefaults Custom userDefaults to use
+
+ @return An instantiated `RCPurchases` object that has been set as a singleton.
+ */
 + (instancetype)configureWithAPIKey:(NSString *)APIKey
                           appUserID:(NSString * _Nullable)appUserID
                        userDefaults:(NSUserDefaults * _Nullable)userDefaults;
 
+/**
+ @return A singleton `RCPurchases` object. Call this after a configure method to access the singleton.
+ */
 + (instancetype)defaultInstance;
+
+/**
+ Configures an instance of the Purchases SDK as a singleton. The configure methods call this internally so it's preferably to set the default instance through a configure method. Use this method only if you want to override what the configure methods are doing.
+ */
 + (void)setDefaultInstance:(RCPurchases *)instance;
 
 /**
@@ -75,16 +117,16 @@ typedef NS_ENUM(NSInteger, RCAttributionNetwork) {
                      appUserID:(NSString * _Nullable)appUserID;
 
 /**
- Initializes an `RCPurchases` object with a custom userDefaults. Use this constructor if you want to sync status across
- a shared container, such as between a host app and an extension.
+ Initializes an `RCPurchases` object with a custom userDefaults. Use this constructor if you want to sync status across a shared container, such as between a host app and an extension.
 
  @param APIKey The API Key generated for your app from https://app.revenuecat.com/
 
  @param appUserID The unique app user id for this user. This user id will allow users to share their purchases and subscriptions across devices. Pass nil if you want `RCPurchases` to generate this for you.
 
+ @param userDefaults Custom userDefaults to use
+
  @return An instantiated `RCPurchases` object
  */
-
 - (instancetype)initWithAPIKey:(NSString *)APIKey
                      appUserID:(NSString * _Nullable)appUserID
                   userDefaults:(NSUserDefaults * _Nullable)userDefaults;

--- a/Purchases/Classes/Public/RCPurchases.h
+++ b/Purchases/Classes/Public/RCPurchases.h
@@ -178,7 +178,7 @@ typedef NS_ENUM(NSInteger, RCAttributionNetwork) {
  @param productIdentifiers A set of product identifiers for in app purchases setup via iTunesConnect. This should be either hard coded in your application, from a file, or from a custom endpoint if you want to be able to deploy new IAPs without an app update.
  @param completion An @escaping callback that is called with the loaded products. If the fetch fails for any reason it will return an empty array.
  */
-- (void)productsWithIdentifiers:(NSArray<NSString *> *)productIdentifiers
+- (void)productsWithIdentifiers:(NSSet<NSString *> *)productIdentifiers
                      completion:(void (^)(NSArray<SKProduct *>* products))completion;
 
 /**

--- a/Purchases/Classes/Public/RCPurchases.m
+++ b/Purchases/Classes/Public/RCPurchases.m
@@ -41,24 +41,23 @@ NSString * RCPurchaserInfoAppUserDefaultsKeyBase = @"com.revenuecat.userdefaults
 
 @implementation RCPurchases
 
-static RCPurchases *_singleton = nil;
-
+static RCPurchases *_sharedPurchases = nil;
 @synthesize delegate=_delegate;
 
 + (NSString *)frameworkVersion {
     return @"1.2.0-SNAPSHOT";
 }
 
-+ (instancetype)defaultInstance {
-    if (!_singleton) {
-        RCLog(@"There is no default instance. Make sure you configure Purchases before trying to get the default instance.");
++ (instancetype)sharedPurchases {
+    if (!_sharedPurchases) {
+        RCLog(@"There is no singleton instance. Make sure you configure Purchases before trying to get the default instance.");
     }
-    return _singleton;
+    return _sharedPurchases;
 }
 
 + (void)setDefaultInstance:(RCPurchases *)instance {
-    @synchronized(_singleton) {
-        _singleton = instance;
+    @synchronized(_sharedPurchases) {
+        _sharedPurchases = instance;
     }
 }
 

--- a/Purchases/Classes/Public/RCPurchases.m
+++ b/Purchases/Classes/Public/RCPurchases.m
@@ -56,7 +56,7 @@ static RCPurchases *_sharedPurchases = nil;
 }
 
 + (void)setDefaultInstance:(RCPurchases *)instance {
-    @synchronized(_sharedPurchases) {
+    @synchronized([RCPurchases class]) {
         _sharedPurchases = instance;
     }
 }

--- a/Purchases/Classes/Public/RCPurchases.m
+++ b/Purchases/Classes/Public/RCPurchases.m
@@ -41,14 +41,58 @@ NSString * RCPurchaserInfoAppUserDefaultsKeyBase = @"com.revenuecat.userdefaults
 
 @implementation RCPurchases
 
+static RCPurchases *_singleton = nil;
+
+@synthesize delegate=_delegate;
+
++ (NSString *)frameworkVersion {
+    return @"1.2.0-SNAPSHOT";
+}
+
++ (instancetype)defaultInstance {
+    if (!_singleton) {
+        RCLog(@"There is no default instance. Make sure you configure Purchases before trying to get the default instance.");
+    }
+    return _singleton;
+}
+
++ (void)setDefaultInstance:(RCPurchases *)instance {
+    @synchronized(_singleton) {
+        _singleton = instance;
+    }
+}
+
++ (instancetype)configureWithAPIKey:(NSString *)APIKey
+{
+    RCPurchases *purchases = [[RCPurchases alloc] initWithAPIKey:APIKey];
+    [RCPurchases setDefaultInstance:purchases];
+    return purchases;
+}
+
 - (instancetype)initWithAPIKey:(NSString *)APIKey
 {
     return [self initWithAPIKey:APIKey appUserID:nil];
 }
 
++ (instancetype)configureWithAPIKey:(NSString *)APIKey appUserID:(NSString * _Nullable)appUserID
+{
+    RCPurchases *purchases = [[RCPurchases alloc] initWithAPIKey:APIKey appUserID:appUserID];
+    [RCPurchases setDefaultInstance:purchases];
+    return purchases;
+}
+
 - (instancetype)initWithAPIKey:(NSString *)APIKey appUserID:(NSString * _Nullable)appUserID
 {
     return [self initWithAPIKey:APIKey appUserID:appUserID userDefaults:nil];
+}
+
++ (instancetype)configureWithAPIKey:(NSString *)APIKey
+                          appUserID:(NSString * _Nullable)appUserID
+                       userDefaults:(NSUserDefaults * _Nullable)userDefaults
+{
+    RCPurchases *purchases = [[RCPurchases alloc] initWithAPIKey:APIKey appUserID:appUserID userDefaults:userDefaults];
+    [RCPurchases setDefaultInstance:purchases];
+    return purchases;
 }
 
 - (instancetype)initWithAPIKey:(NSString *)APIKey
@@ -69,10 +113,6 @@ NSString * RCPurchaserInfoAppUserDefaultsKeyBase = @"com.revenuecat.userdefaults
                    storeKitWrapper:storeKitWrapper
                 notificationCenter:[NSNotificationCenter defaultCenter]
                       userDefaults:userDefaults];
-}
-
-+ (NSString *)frameworkVersion {
-    return @"1.2.0-SNAPSHOT";
 }
 
 - (instancetype)initWithAppUserID:(NSString *)appUserID
@@ -124,9 +164,6 @@ NSString * RCPurchaserInfoAppUserDefaultsKeyBase = @"com.revenuecat.userdefaults
                              forAppUserID:self.appUserID];
     }
 }
-
-
-@synthesize delegate=_delegate;
 
 - (void)setDelegate:(id<RCPurchasesDelegate>)delegate
 {
@@ -292,10 +329,10 @@ NSString * RCPurchaserInfoAppUserDefaultsKeyBase = @"com.revenuecat.userdefaults
                                       completion:(RCReceiveIntroEligibilityBlock)receiveEligibility
 {
     [self receiptData:^(NSData * _Nonnull data) {
-        [self.backend getIntroElgibilityForAppUserID:self.appUserID
-                                         receiptData:data
-                                  productIdentifiers:productIdentifiers
-                                          completion:receiveEligibility];
+        [self.backend getIntroEligibilityForAppUserID:self.appUserID
+                                          receiptData:data
+                                   productIdentifiers:productIdentifiers
+                                           completion:receiveEligibility];
     }];
 }
 

--- a/Purchases/Classes/Public/RCPurchases.m
+++ b/Purchases/Classes/Public/RCPurchases.m
@@ -303,10 +303,10 @@ static RCPurchases *_sharedPurchases = nil;
     }];
 }
 
-- (void)productsWithIdentifiers:(NSSet<NSString *> *)productIdentifiers
+- (void)productsWithIdentifiers:(NSArray<NSString *> *)productIdentifiers
                      completion:(void (^)(NSArray<SKProduct *>* products))completion
 {
-    [self.requestFetcher fetchProducts:productIdentifiers completion:^(NSArray<SKProduct *> * _Nonnull products) {
+    [self.requestFetcher fetchProducts:[NSSet setWithArray:productIdentifiers] completion:^(NSArray<SKProduct *> * _Nonnull products) {
         @synchronized(self) {
             for (SKProduct *product in products) {
                 self.productsByIdentifier[product.productIdentifier] = product;

--- a/Purchases/Classes/RCBackend.h
+++ b/Purchases/Classes/RCBackend.h
@@ -61,10 +61,10 @@ typedef void(^RCEntitlementResponseHandler)(NSDictionary<NSString *, RCEntitleme
 - (void)getSubscriberDataWithAppUserID:(NSString *)appUserID
                             completion:(RCBackendResponseHandler)completion;
 
-- (void)getIntroElgibilityForAppUserID:(NSString *)appUserID
-                           receiptData:(NSData * _Nullable)receiptData
-                    productIdentifiers:(NSArray<NSString *> *)productIdentifiers
-                            completion:(RCIntroEligibilityResponseHandler)completion;
+- (void)getIntroEligibilityForAppUserID:(NSString *)appUserID
+                            receiptData:(NSData *)receiptData
+                     productIdentifiers:(NSArray<NSString *> *)productIdentifiers
+                             completion:(RCIntroEligibilityResponseHandler)completion;
 
 - (void)getEntitlementsForAppUserID:(NSString *)appUserID
                          completion:(RCEntitlementResponseHandler)completion;

--- a/Purchases/Classes/RCBackend.m
+++ b/Purchases/Classes/RCBackend.m
@@ -209,10 +209,10 @@ RCPaymentMode RCPaymentModeFromSKProductDiscountPaymentMode(SKProductDiscountPay
                   }];
 }
 
-- (void)getIntroElgibilityForAppUserID:(NSString *)appUserID
-                           receiptData:(NSData *)receiptData
-                    productIdentifiers:(NSArray<NSString *> *)productIdentifiers
-                            completion:(RCIntroEligibilityResponseHandler)completion
+- (void)getIntroEligibilityForAppUserID:(NSString *)appUserID
+                            receiptData:(NSData *)receiptData
+                     productIdentifiers:(NSArray<NSString *> *)productIdentifiers
+                             completion:(RCIntroEligibilityResponseHandler)completion
 {
     if (productIdentifiers.count == 0) {
         completion(@{});

--- a/PurchasesTests/BackendTests.swift
+++ b/PurchasesTests/BackendTests.swift
@@ -442,7 +442,7 @@ class BackendTests: XCTestCase {
     }
 
     func testEmptyEligibiltyCheckDoesNothing() {
-        backend?.getIntroElgibility(forAppUserID: userID, receiptData: Data(), productIdentifiers: [], completion: { (eligibilities) in
+        backend?.getIntroEligibility(forAppUserID: userID, receiptData: Data(), productIdentifiers: [], completion: { (eligibilities) in
 
         })
         expect(self.httpClient.calls.count).to(equal(0))
@@ -456,7 +456,7 @@ class BackendTests: XCTestCase {
         var eligibility: [String: RCIntroEligibility]?
 
         let products = ["producta", "productb", "productc", "productd"]
-        backend?.getIntroElgibility(forAppUserID: userID, receiptData: Data(), productIdentifiers: products, completion: {(productEligbility) in
+        backend?.getIntroEligibility(forAppUserID: userID, receiptData: Data(), productIdentifiers: products, completion: {(productEligbility) in
             eligibility = productEligbility
         })
 
@@ -490,7 +490,7 @@ class BackendTests: XCTestCase {
         var eligibility: [String: RCIntroEligibility]?
 
         let products = ["producta", "productb", "productc"]
-        backend?.getIntroElgibility(forAppUserID: userID, receiptData: Data(), productIdentifiers: products, completion: {(productEligbility) in
+        backend?.getIntroEligibility(forAppUserID: userID, receiptData: Data(), productIdentifiers: products, completion: {(productEligbility) in
             eligibility = productEligbility
         })
 
@@ -508,7 +508,7 @@ class BackendTests: XCTestCase {
         var eligibility: [String: RCIntroEligibility]?
 
         let products = ["producta", "productb", "productc"]
-        backend?.getIntroElgibility(forAppUserID: userID, receiptData: Data(), productIdentifiers: products, completion: {(productEligbility) in
+        backend?.getIntroEligibility(forAppUserID: userID, receiptData: Data(), productIdentifiers: products, completion: {(productEligbility) in
             eligibility = productEligbility
         })
 

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -104,7 +104,7 @@ class PurchasesTests: XCTestCase {
         }
 
         var postedProductIdentifiers: [String]?
-        override func getIntroElgibility(forAppUserID appUserID: String, receiptData: Data?, productIdentifiers: [String], completion: @escaping RCIntroEligibilityResponseHandler) {
+        override func getIntroEligibility(forAppUserID appUserID: String, receiptData: Data?, productIdentifiers: [String], completion: @escaping RCIntroEligibilityResponseHandler) {
             postedProductIdentifiers = productIdentifiers
 
             var eligibilities = [String: RCIntroEligibility]()
@@ -970,5 +970,20 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.postedAttributionData?.keys).toEventually(equal(data.keys))
         expect(self.backend.postedAttributionFromNetwork).toEventually(equal(RCAttributionNetwork.appleSearchAds))
         expect(self.backend.postedAttributionAppUserId).toEventually(equal(self.purchases?.appUserID))
+    }
+
+    func testSharedInstanceIsSetWhenConfiguring() {
+        let purchases = RCPurchases.configure(withAPIKey: "")
+        expect(RCPurchases.shared()).toEventually(equal(purchases))
+    }
+    
+    func testSharedInstanceIsSetWhenConfiguringWithAppUserID() {
+        let purchases = RCPurchases.configure(withAPIKey: "", appUserID:"")
+        expect(RCPurchases.shared()).toEventually(equal(purchases))
+    }
+    
+    func testSharedInstanceIsSetWhenConfiguringWithAppUserIDAndUserDefaults() {
+        let purchases = RCPurchases.configure(withAPIKey: "", appUserID: "", userDefaults: nil)
+        expect(RCPurchases.shared()).toEventually(equal(purchases))
     }
 }


### PR DESCRIPTION
This PR creates configuration methods that create a singleton instance of Purchases. This instance can be accessed through `defaultInstance`.

This will ensure there is a single instance created for purchases and the SDK is not recreated multiple times, which is what is recommended in the documentation