### PR TITLE
Adds test for Purchase Date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,6 @@ DerivedData/
 !default.mode2v3
 *.perspectivev3
 !default.perspectivev3
-
+.idea/
 
 Carthage

--- a/Purchases/Classes/Public/RCPurchaserInfo.m
+++ b/Purchases/Classes/Public/RCPurchaserInfo.m
@@ -72,44 +72,34 @@ static dispatch_once_t onceToken;
 
 - (NSDictionary<NSString *, NSDate *> *)parseExpirationDate:(NSDictionary<NSString *, NSDictionary *> *)expirationDates
 {
-    NSMutableDictionary<NSString *, NSObject *> *dates = [NSMutableDictionary new];
-    
-    for (NSString *identifier in expirationDates) {
-        id dateString = expirationDates[identifier][@"expires_date"];
-        
-        if ([dateString isKindOfClass:NSString.class]) {
-            NSDate *date = [dateFormatter dateFromString:(NSString *)dateString];
-            
-            if (date != nil) {
-                dates[identifier] = date;
-            }
-        } else {
-            dates[identifier] = [NSNull null];
-        }
-    }
-    
-    return [NSDictionary dictionaryWithDictionary:dates];
+    return [self parseDatesIn:expirationDates withLabel:@"expires_date"];
 }
 
 - (NSDictionary<NSString *, NSDate *> *)parsePurchaseDate:(NSDictionary<NSString *, NSDictionary *> *)purchaseDates
 {
-    NSMutableDictionary<NSString *, NSObject *> *dates = [NSMutableDictionary new];
-    
-    for (NSString *identifier in purchaseDates) {
-        id dateString = purchaseDates[identifier][@"purchase_date"];
-        
+    return [self parseDatesIn:purchaseDates withLabel:@"purchase_date"];
+}
+
+- (NSDictionary<NSString *, NSDate *> *)parseDatesIn:(NSDictionary<NSString *, NSDictionary *> *)dates
+                                           withLabel:(NSString *)label
+{
+    NSMutableDictionary<NSString *, NSObject *> *parsedDates = [NSMutableDictionary new];
+
+    for (NSString *identifier in dates) {
+        id dateString = dates[identifier][label];
+
         if ([dateString isKindOfClass:NSString.class]) {
             NSDate *date = [dateFormatter dateFromString:(NSString *)dateString];
-            
+
             if (date != nil) {
-                dates[identifier] = date;
+                parsedDates[identifier] = date;
             }
         } else {
-            dates[identifier] = [NSNull null];
+            parsedDates[identifier] = [NSNull null];
         }
     }
-    
-    return [NSDictionary dictionaryWithDictionary:dates];
+
+    return [NSDictionary dictionaryWithDictionary:parsedDates];
 }
 
 - (NSSet<NSString *> *)allPurchasedProductIdentifiers

--- a/PurchasesTests/PurchaserInfoTests.swift
+++ b/PurchasesTests/PurchaserInfoTests.swift
@@ -31,7 +31,8 @@ class BasicPurchaserInfoTests: XCTestCase {
             ],
             "subscriptions": [
                 "onemonth_freetrial": [
-                    "expires_date": "2100-08-30T02:40:36Z"
+                    "expires_date": "2100-08-30T02:40:36Z",
+                    "period_type": "normal"
                 ],
                 "threemonth_freetrial": [
                     "expires_date": "1990-08-30T02:40:36Z"
@@ -39,7 +40,9 @@ class BasicPurchaserInfoTests: XCTestCase {
             ],
             "entitlements": [
                 "pro" : [
-                    "expires_date" : "2100-08-30T02:40:36Z"
+                    "expires_date" : "2100-08-30T02:40:36Z",
+                    "product_identifier": "onemonth_freetrial",
+                    "purchase_date": "2018-10-26T23:17:53Z"
                 ],
                 "old_pro" : [
                     "expires_date" : "1990-08-30T02:40:36Z"
@@ -194,6 +197,10 @@ class BasicPurchaserInfoTests: XCTestCase {
         expect(entitlements).to(contain("pro"));
         expect(entitlements).toNot(contain("old_pro"));
     }
-    
-    
+
+    func testPurchaseDate() {
+        let purchaseDate = self.purchaserInfo!.purchaseDate(forEntitlement: "pro")
+        expect(purchaseDate).to(equal(Date(timeIntervalSinceReferenceDate: 562288673)))
+    }
+
 }

--- a/PurchasesTests/PurchaserInfoTests.swift
+++ b/PurchasesTests/PurchaserInfoTests.swift
@@ -203,4 +203,39 @@ class BasicPurchaserInfoTests: XCTestCase {
         expect(purchaseDate).to(equal(Date(timeIntervalSinceReferenceDate: 562288673)))
     }
 
+    func testPurchaseDateEmpty() {
+
+        let response = [
+            "subscriber": [
+                "other_purchases": [
+                    "onetime_purchase": [
+                        "expires_date": "1990-08-30T02:40:36Z"
+                    ]
+                ],
+                "subscriptions": [
+                    "onemonth_freetrial": [
+                        "expires_date": "2100-08-30T02:40:36Z"
+                    ],
+                    "threemonth_freetrial": [
+                        "expires_date": "1990-08-30T02:40:36Z"
+                    ]
+                ],
+                "entitlements": [
+                    "pro" : [
+                        "expires_date" : "2100-08-30T02:40:36Z"
+                    ],
+                    "old_pro" : [
+                        "expires_date" : "1990-08-30T02:40:36Z"
+                    ],
+                    "forever_pro" : [
+                        "expires_date" : nil
+                    ],
+                ]
+            ]
+        ] as [String : Any]
+        let purchaserInfoWithoutRequestData = RCPurchaserInfo.init(data: response)
+        let purchaseDate = purchaserInfoWithoutRequestData!.purchaseDate(forEntitlement: "pro")
+        expect(purchaseDate).to(beNil())
+    }
+
 }


### PR DESCRIPTION
This is a followup of https://github.com/RevenueCat/purchases-ios/pull/56

I added a couple tests and extracted common logic into a method.