### PR TITLE
Renames isUsingAnonymousID to allowSharingAppStoreAccount

### DIFF
--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -138,7 +138,7 @@ typedef NS_ENUM(NSInteger, RCAttributionNetwork) {
  If a user tries to purchase a product that is active on the current app store account, we will treat it as a restore and alias
  the new ID with the previous id.
  */
-@property (nonatomic) BOOL isUsingAnonymousID;
+@property (nonatomic) BOOL allowSharingAppStoreAccount;
 
 /// Default to YES, set this to NO if you are finishing transactions with your own StoreKit queue listener
 @property (nonatomic) BOOL finishTransactions;

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -138,7 +138,7 @@ static RCPurchases *_sharedPurchases = nil;
             if (appUserID == nil) {
                 appUserID = [self generateAndCacheID];
             }
-            self.isUsingAnonymousID = YES;
+            self.allowSharingAppStoreAccount = YES;
             self.appUserID = appUserID;
         } else {
             [self identify:appUserID];
@@ -487,7 +487,7 @@ static RCPurchases *_sharedPurchases = nil;
 
         [self.backend postReceiptData:data
                             appUserID:self.appUserID
-                            isRestore:self.isUsingAnonymousID
+                            isRestore:self.allowSharingAppStoreAccount
                     productIdentifier:productIdentifier
                                 price:price
                           paymentMode:paymentMode
@@ -585,7 +585,7 @@ static RCPurchases *_sharedPurchases = nil;
 - (void)reset
 {
     self.appUserID = [self generateAndCacheID];
-    self.isUsingAnonymousID = YES;
+    self.allowSharingAppStoreAccount = YES;
 }
 
 - (NSString *)generateAndCacheID

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -1053,7 +1053,7 @@ class PurchasesTests: XCTestCase {
     private func identifiedSuccesfully(appUserID: String) {
         expect(self.userDefaults.cachedUserInfo[self.userDefaults.appUserIDKey]).to(beNil())
         expect(self.purchases?.appUserID).to(equal(appUserID))
-        expect(self.purchases?.isUsingAnonymousID).to(beFalse())
+        expect(self.purchases?.allowSharingAppStoreAccount).to(beFalse())
     }
     
 }


### PR DESCRIPTION
Name is confusing, so renaming