### PR TITLE
Forces update of caches on reset and identify

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "AliSoftware/OHHTTPStubs" "6.1.0"
-github "Quick/Nimble" "v7.1.1"
+github "Quick/Nimble" "v7.3.1"

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -561,7 +561,7 @@ static RCPurchases *_sharedPurchases = nil;
 
 - (void)createAlias:(NSString *)alias
 {
-    [self createAlias:self.appUserID completion:^(NSError * _Nullable error) {}];
+    [self createAlias:alias completion:^(NSError * _Nullable error) {}];
 }
 
 - (void)createAlias:(NSString *)alias completion:(void (^)(NSError * _Nullable error))completion

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -580,12 +580,20 @@ static RCPurchases *_sharedPurchases = nil;
 {
     [self.userDefaults removeObjectForKey:RCAppUserDefaultsKey];
     self.appUserID = appUserID;
+    self.cachesLastUpdated = nil;
+    if (self.delegate != nil) {
+        [self updateCaches];
+    }
 }
 
 - (void)reset
 {
     self.appUserID = [self generateAndCacheID];
     self.isUsingAnonymousID = YES;
+    self.cachesLastUpdated = nil;
+    if (self.delegate != nil) {
+        [self updateCaches];
+    }
 }
 
 - (NSString *)generateAndCacheID

--- a/Purchases/RCBackend.m
+++ b/Purchases/RCBackend.m
@@ -148,7 +148,8 @@ RCPaymentMode RCPaymentModeFromSKProductDiscountPaymentMode(SKProductDiscountPay
                                    @"is_restore": @(isRestore)
                                    }];
 
-    NSString *cacheKey = [NSString stringWithFormat:@"%@-%@-%@-%@-%@-%@-%@",
+    NSString *cacheKey = [NSString stringWithFormat:@"%@-%@-%@-%@-%@-%@-%@-%@",
+                          appUserID,
                           @(isRestore),
                           fetchToken,
                           productIdentifier,

--- a/PurchasesTests/Info.plist
+++ b/PurchasesTests/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Purchases</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -1026,6 +1026,7 @@ class PurchasesTests: XCTestCase {
         let newAppUserID = "cesarPedro"
         self.purchases?.identify(newAppUserID)
         identifiedSuccesfully(appUserID: newAppUserID)
+        expect(self.userDefaults.cachedUserInfo.count).to(equal(2))
     }
 
     func testCreateAliasIdentifies() {
@@ -1048,6 +1049,21 @@ class PurchasesTests: XCTestCase {
         setupPurchases()
         self.purchases?.reset()
         expect(self.userDefaults.appUserID).toNot(beNil())
+    }
+    
+    func testIdentifyForcesCache() {
+        setupPurchases()
+        self.purchases?.identify("new")
+        expect(self.userDefaults.cachedUserInfo.count).to(equal(2))
+        let purchaserInfo = userDefaults.cachedUserInfo["com.revenuecat.userdefaults.purchaserInfo.new"]
+        expect(purchaserInfo).toNot(beNil())
+
+    }
+    
+    func testResetForcesCache() {
+        setupPurchases()
+        self.purchases?.reset()
+        expect(self.userDefaults.cachedUserInfo.count).to(equal(2))
     }
     
     private func identifiedSuccesfully(appUserID: String) {

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -88,6 +88,7 @@ class PurchasesTests: XCTestCase {
         var postReceiptPurchaserInfo: RCPurchaserInfo?
         var postReceiptError: Error?
         var aliasError: Error?
+        var aliasCalled = false
 
         override func postReceiptData(_ data: Data, appUserID: String, isRestore: Bool, productIdentifier: String?, price: NSDecimalNumber?, paymentMode: RCPaymentMode, introductoryPrice: NSDecimalNumber?, currencyCode: String?, completion: @escaping RCBackendResponseHandler) {
             postReceiptDataCalled = true
@@ -132,9 +133,11 @@ class PurchasesTests: XCTestCase {
         }
         
         override func createAlias(forAppUserID appUserID: String, withNewAppUserID newAppUserID: String, completion: ((Error?) -> Void)? = nil) {
+            aliasCalled = true
             if (aliasError != nil) {
                 completion!(aliasError)
             } else {
+                userID = newAppUserID
                 completion!(nil)
             }
         }
@@ -1000,7 +1003,7 @@ class PurchasesTests: XCTestCase {
         expect(RCPurchases.shared()).toEventually(equal(purchases))
     }
     
-    func testCreateAliasCallsBackend() {
+    func testCreateAliasWithCompletionCallsBackend() {
         setupPurchases()
 
         var completionCalled = false
@@ -1018,6 +1021,14 @@ class PurchasesTests: XCTestCase {
         })
         
         expect(completionCalled).toEventually(beFalse())
+    }
+    
+    func testCreateAliasCallsBackend() {
+        setupPurchases()
+        self.backend.aliasCalled = false
+        self.purchases?.createAlias("cesarpedro")
+        
+        expect(self.backend.aliasCalled).toEventually(beTrue())
     }
     
     func testIdentify() {
@@ -1064,6 +1075,28 @@ class PurchasesTests: XCTestCase {
         setupPurchases()
         self.purchases?.reset()
         expect(self.userDefaults.cachedUserInfo.count).to(equal(2))
+    }
+    
+    func testCreateAliasChangesAppUserId() {
+        setupPurchases()
+        
+        self.backend.aliasCalled = false
+        self.backend.aliasError = nil
+        self.purchases?.createAlias("cesarpedro")
+        
+        expect(self.backend.userID).to(be("cesarpedro"))
+    }
+    
+    func testCreateAliasWithCompletionChangesAppUserId() {
+        setupPurchases()
+        
+        self.backend.aliasCalled = false
+        self.backend.aliasError = nil
+        self.purchases?.createAlias("cesarpedro", completion: { (error) in
+            
+        })
+        
+        expect(self.backend.userID).to(be("cesarpedro"))
     }
     
     private func identifiedSuccesfully(appUserID: String) {


### PR DESCRIPTION
- Identify and reset were not updating the cached purchaser info
- I fixed a bug that made create alias not work if not passing a completion block
- I also added appuserid as part of the cache key of the backend post receipt handlers