### PR TITLE
Add originalAppUserID to PurchaserInfo - DO NOT MERGE THIS PR, REVIEW ONLY

### DIFF
--- a/Purchases/Public/RCPurchaserInfo.h
+++ b/Purchases/Public/RCPurchaserInfo.h
@@ -40,6 +40,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly) NSString * _Nullable originalApplicationVersion;
 
 /**
+ Returns the AppUserID originally associated with the app store account, which should
+ provide a unique user identifier spanning devices when anonymous authentication is used.
+ */
+@property (readonly) NSString * _Nullable originalAppUserID;
+
+/**
  Get the expiration date for a given product identifier. You should use Entitlements though!
  
  @param productIdentifier Product identifier for product

--- a/Purchases/Public/RCPurchaserInfo.m
+++ b/Purchases/Public/RCPurchaserInfo.m
@@ -16,6 +16,7 @@
 @property (nonatomic) NSDictionary<NSString *, NSObject *> *purchaseDateByEntitlement;
 @property (nonatomic) NSSet<NSString *> *nonConsumablePurchases;
 @property (nonatomic) NSString *originalApplicationVersion;
+@property (nonatomic) NSString *originalAppUserID;
 @property (nonatomic) NSDictionary *originalData;
 @property (nonatomic) NSDate * _Nullable requestDate;
 @end
@@ -66,6 +67,8 @@ static dispatch_once_t onceToken;
         NSString *originalApplicationVersion = subscriberData[@"original_application_version"];
         self.originalApplicationVersion = [originalApplicationVersion isKindOfClass:[NSNull class]] ? nil : originalApplicationVersion;
         
+        NSString *originalAppUserID = subscriberData[@"original_app_user_id"];
+        self.originalAppUserID = [originalAppUserID isKindOfClass:[NSNull class]] ? nil : originalAppUserID;
     }
     return self;
 }


### PR DESCRIPTION
DO NOT MERGE THIS PR, for review only.

Add originalAppUserID to PurchaserInfo, garnered from the backend payload field original_app_user_id.  Upon investigation, it appears that all PurchaserInfo properties are sent to the UserDefaults cache in RCPurchases cachePurchaserInfo with no further modifications.