### PR TITLE
Fetches SKProduct if we don't have it in cache before posting the receipt

### DIFF
--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -328,7 +328,9 @@ static RCPurchases *_sharedPurchases = nil;
                                             self.productsByIdentifier[p.productIdentifier] = p;
                                         }
                                     }
-                                    completion([products arrayByAddingObjectsFromArray:newProducts]);
+                                    [self dispatch:^{
+                                        completion([products arrayByAddingObjectsFromArray:newProducts]);
+                                    }];
                                 }];
     } else {
         completion(products);


### PR DESCRIPTION
If someone is making purchases without fetching products before, we will send a nil price and currency code. This PR makes sure we never send nil and we fetch the products before posting the receipt if we haven't fetched that product before.

We already included this change in https://github.com/RevenueCat/purchases-ios/pull/70/ but since it will take time until everyone updates to `2.0.0` we should patch `1.x.x` so that we stop sending `nil` prices.