### PR TITLE
Makes sure we don't create alias or identify over the same app user id

### DIFF
--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -227,23 +227,31 @@ static RCPurchases *_sharedPurchases = nil;
 
 - (void)createAlias:(NSString *)alias completionBlock:(RCReceivePurchaserInfoBlock _Nullable)completion
 {
-    RCDebugLog(@"Creating an alias to %@ from %@", self.appUserID, alias);
-    [self.backend createAliasForAppUserID:self.appUserID withNewAppUserID:alias completion:^(NSError * _Nullable error) {
-        if (error == nil) {
-            RCDebugLog(@"Alias created");
-            [self identify:alias completionBlock:completion];
-        } else {
-            CALL_AND_DISPATCH_IF_SET(completion, nil, error);
-        }
-    }];
+    if ([alias isEqualToString:self.appUserID]) {
+        [self purchaserInfoWithCompletionBlock:completion];
+    } else {
+        RCDebugLog(@"Creating an alias to %@ from %@", self.appUserID, alias);
+        [self.backend createAliasForAppUserID:self.appUserID withNewAppUserID:alias completion:^(NSError * _Nullable error) {
+            if (error == nil) {
+                RCDebugLog(@"Alias created");
+                [self identify:alias completionBlock:completion];
+            } else {
+                CALL_AND_DISPATCH_IF_SET(completion, nil, error);
+            }
+        }];
+    }
 }
 
 - (void)identify:(NSString *)appUserID completionBlock:(RCReceivePurchaserInfoBlock)completion
 {
-    RCDebugLog(@"Changing App User ID: %@ -> %@", self.appUserID, appUserID);
-    [self clearCaches];
-    self.appUserID = appUserID;
-    [self updateCachesWithCompletionBlock:completion];
+    if ([appUserID isEqualToString:self.appUserID]) {
+        [self purchaserInfoWithCompletionBlock:completion];
+    } else {
+        RCDebugLog(@"Changing App User ID: %@ -> %@", self.appUserID, appUserID);
+        [self clearCaches];
+        self.appUserID = appUserID;
+        [self updateCachesWithCompletionBlock:completion];
+    }
 }
 
 - (void)resetWithCompletionBlock:(RCReceivePurchaserInfoBlock)completion

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -1234,7 +1234,7 @@ class PurchasesTests: XCTestCase {
         
         self.backend.aliasError = NSError(domain: "error_domain", code: RCFinishableError, userInfo: nil)
         
-        self.purchases?.createAlias("cesarpedro") { (info, error) in
+        self.purchases?.createAlias("cesardro") { (info, error) in
             completionCalled = error == nil
         }
         
@@ -1367,7 +1367,35 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.userID).to(be("cesarpedro"))
         expect(self.purchasesDelegate.purchaserInfoReceivedCount).toEventually(equal(2))
     }
-    
+
+    func testCreateAliasForTheSameUserID() {
+        setupPurchases()
+
+        self.backend.aliasCalled = false
+        self.backend.aliasError = nil
+
+        var completionCalled = false
+        self.purchases?.createAlias(appUserID) { (info, error) in
+            completionCalled = true
+        }
+
+        expect(self.backend.aliasCalled).to(be(false))
+        expect(self.backend.aliasError).to(beNil())
+        expect(completionCalled).toEventually(be(true))
+    }
+
+    func testIdentifyForTheSameUserID() {
+        setupPurchases()
+
+        expect(self.purchasesDelegate.purchaserInfoReceivedCount).toEventually(equal(1));
+        expect(self.backend.getSubscriberCallCount).toEventually(equal(1));
+
+        self.purchases?.identify(appUserID)
+
+        expect(self.purchasesDelegate.purchaserInfoReceivedCount).toEventually(equal(1));
+        expect(self.backend.getSubscriberCallCount).toEventually(equal(1));
+    }
+
     private func identifiedSuccesfully(appUserID: String) {
         expect(self.userDefaults.cachedUserInfo[self.userDefaults.appUserIDKey]).to(beNil())
         expect(self.purchases?.appUserID).to(equal(appUserID))


### PR DESCRIPTION
Looking at https://docs.revenuecat.com/discuss/5c479f9f9c2c64013f2836a2 

> I've been using the auto generated ID, what's the best way to retroactively add the UID to the account without having them to restore transactions?

The solution is:

>You can use the .createAlias method to attach your User ID to the purchase history of a previous randomly generated App User ID. After you get your account UID you can check to see if it equals the current App User Id for the Purchases instance - if not, call .createAlias.

To make things easier, I added this check in the code so that users that are calling `createAlias` are not triggering useless backend calls.