### PR TITLE
Error overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+- Adds userCancelled as a parameter to the completion block of the makePurchase function.
+- Better error codes.
+
 ## 2.0.0
 - Refactor to all block based methods
 - Optional delegate method to receive changes in Purchaser Info

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "AliSoftware/OHHTTPStubs" "6.1.0"
-github "Quick/Nimble" "v7.3.1"
+github "Quick/Nimble" "v8.0.0"

--- a/Examples/SwiftExample/Podfile.lock
+++ b/Examples/SwiftExample/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Purchases (2.0.0-SNAPSHOT)
+  - Purchases (2.1.0-SNAPSHOT)
 
 DEPENDENCIES:
   - Purchases (from `../../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  Purchases: 28be1135e21907b502f6d0e3e253cd38cf911bed
+  Purchases: 6c7eccda28eb0c45918fe490e0c36557b0d87d9f
 
 PODFILE CHECKSUM: b6ad00ca1e6fc400e0898ad2ac4a293958616d2e
 

--- a/Examples/SwiftExample/SwiftExample.xcodeproj/project.pbxproj
+++ b/Examples/SwiftExample/SwiftExample.xcodeproj/project.pbxproj
@@ -83,7 +83,6 @@
 				F47D44DA0C1FBE5A9FCA7E55 /* Pods-SwiftExample.debug.xcconfig */,
 				164A5AED2A65F70448049504 /* Pods-SwiftExample.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -343,7 +342,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = YH39SE59AQ;
+				DEVELOPMENT_TEAM = 4V25WUJBS4;
 				INFOPLIST_FILE = SwiftExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -362,7 +361,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = YH39SE59AQ;
+				DEVELOPMENT_TEAM = 4V25WUJBS4;
 				INFOPLIST_FILE = SwiftExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Examples/SwiftExample/SwiftExample/AppDelegate.swift
+++ b/Examples/SwiftExample/SwiftExample/AppDelegate.swift
@@ -10,30 +10,17 @@ import UIKit
 import Purchases
 
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate, PurchasesDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
-    var deferment: RCDeferredPromotionalPurchaseBlock? = nil
+
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        
         Purchases.debugLogsEnabled = true
         Purchases.configure(withAPIKey: "AahhcxDdDwYNehVmpLnaKbzhEnwErcZm", appUserID: nil)
-        Purchases.shared.delegate = self
+        
         return true
     }
-    
-    func purchases(_ purchases: Purchases,
-                            shouldPurchasePromoProduct product: SKProduct,
-                            defermentBlock makeDeferredPurchase: @escaping RCDeferredPromotionalPurchaseBlock) {
-        makeDeferredPurchase { (transaction, purchaserInfo, error, userCancelled) in
-            if let e = error {
-                print("PURCHASE ERROR: - \(e.localizedDescription)")
-
-            } else if purchaserInfo?.activeEntitlements.contains("pro_cat") ?? false {
-                print("Purchased Pro Cats 🎉")
-            }
-        }
-    }
-
 }
 

--- a/Examples/SwiftExample/SwiftExample/AppDelegate.swift
+++ b/Examples/SwiftExample/SwiftExample/AppDelegate.swift
@@ -10,17 +10,30 @@ import UIKit
 import Purchases
 
 @UIApplicationMain
-class AppDelegate: UIResponder, UIApplicationDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate, PurchasesDelegate {
 
     var window: UIWindow?
-
+    var deferment: RCDeferredPromotionalPurchaseBlock? = nil
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        
         Purchases.debugLogsEnabled = true
         Purchases.configure(withAPIKey: "AahhcxDdDwYNehVmpLnaKbzhEnwErcZm", appUserID: nil)
-        
+        Purchases.shared.delegate = self
         return true
     }
+    
+    func purchases(_ purchases: Purchases,
+                            shouldPurchasePromoProduct product: SKProduct,
+                            defermentBlock makeDeferredPurchase: @escaping RCDeferredPromotionalPurchaseBlock) {
+        makeDeferredPurchase { (transaction, purchaserInfo, error, userCancelled) in
+            if let e = error {
+                print("PURCHASE ERROR: - \(e.localizedDescription)")
+
+            } else if purchaserInfo?.activeEntitlements.contains("pro_cat") ?? false {
+                print("Purchased Pro Cats 🎉")
+            }
+        }
+    }
+
 }
 

--- a/Examples/SwiftExample/SwiftExample/AppDelegate.swift
+++ b/Examples/SwiftExample/SwiftExample/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
         Purchases.debugLogsEnabled = true
-        Purchases.configure(withAPIKey: "AahhcxDdDwYNehVmpLnaKbzhEnwErcZm", appUserID: nil)
+        Purchases.configure(withAPIKey: "my_api_key", appUserID: nil)
         
         return true
     }

--- a/Examples/SwiftExample/SwiftExample/AppDelegate.swift
+++ b/Examples/SwiftExample/SwiftExample/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
         Purchases.debugLogsEnabled = true
-        Purchases.configure(withAPIKey: "my_api_key", appUserID: nil)
+        Purchases.configure(withAPIKey: "AahhcxDdDwYNehVmpLnaKbzhEnwErcZm", appUserID: nil)
         
         return true
     }

--- a/Examples/SwiftExample/SwiftExample/UpsellViewController.swift
+++ b/Examples/SwiftExample/SwiftExample/UpsellViewController.swift
@@ -80,7 +80,7 @@ class UpsellViewController: UIViewController {
     func makePurchase(catProduct: SKProduct) {
         
         setState(loading: true)
-        Purchases.shared.makePurchase(catProduct) { (transaction, purchaserInfo, error) in
+        Purchases.shared.makePurchase(catProduct) { (transaction, purchaserInfo, error, userCancelled) in
             if let e = error {
                 print("PURCHASE ERROR: - \(e.localizedDescription)")
                 

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Purchases"
-  s.version          = "2.1.0-SNAPSHOT"
+  s.version          = "2.1.0-rc1"
   s.summary          = "Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -29,7 +29,12 @@
 		35262A2D1F7D783F00C04F2C /* RCHTTPClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 35262A2B1F7D783F00C04F2C /* RCHTTPClient.m */; };
 		35262A301F7D78C600C04F2C /* HTTPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35262A2F1F7D78C600C04F2C /* HTTPClientTests.swift */; };
 		352C36BF1F9D372D00A15783 /* RCPurchaserInfo+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 352C36BE1F9D372D00A15783 /* RCPurchaserInfo+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		352E88442229B1A70046A10A /* RCPurchasesErrorUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 352E88422229B1A60046A10A /* RCPurchasesErrorUtils.m */; };
 		35395CB421B9F59E00286D13 /* RCIntroEligibility+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 35395CB321B9EB1000286D13 /* RCIntroEligibility+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		353AB5E4222F624E003754E6 /* RCPurchasesErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 353AB5E3222F624E003754E6 /* RCPurchasesErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		353AB5E6222F633D003754E6 /* RCPurchasesErrorUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 353AB5E5222F633D003754E6 /* RCPurchasesErrorUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		353AB5E92230A239003754E6 /* RCReceiptFetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 353AB5E82230A239003754E6 /* RCReceiptFetcher.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		353AB5F92230AAE2003754E6 /* RCReceiptFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 353AB5F82230AAE2003754E6 /* RCReceiptFetcher.m */; };
 		356D65F620B873AF00576D45 /* Purchases.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 352629FE1F7C4B9100C04F2C /* Purchases.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		359A0EA12003C8CD002D8C7F /* NSLocale+RCExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 359A0E9F2003C8CD002D8C7F /* NSLocale+RCExtensions.h */; };
 		359A0EA22003C8CD002D8C7F /* NSLocale+RCExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 359A0EA02003C8CD002D8C7F /* NSLocale+RCExtensions.m */; };
@@ -101,7 +106,12 @@
 		35262A2B1F7D783F00C04F2C /* RCHTTPClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCHTTPClient.m; sourceTree = "<group>"; };
 		35262A2F1F7D78C600C04F2C /* HTTPClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClientTests.swift; sourceTree = "<group>"; };
 		352C36BE1F9D372D00A15783 /* RCPurchaserInfo+Protected.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCPurchaserInfo+Protected.h"; sourceTree = "<group>"; };
+		352E88422229B1A60046A10A /* RCPurchasesErrorUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCPurchasesErrorUtils.m; sourceTree = "<group>"; };
 		35395CB321B9EB1000286D13 /* RCIntroEligibility+Protected.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCIntroEligibility+Protected.h"; sourceTree = "<group>"; };
+		353AB5E3222F624E003754E6 /* RCPurchasesErrors.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCPurchasesErrors.h; sourceTree = "<group>"; };
+		353AB5E5222F633D003754E6 /* RCPurchasesErrorUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCPurchasesErrorUtils.h; sourceTree = "<group>"; };
+		353AB5E82230A239003754E6 /* RCReceiptFetcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCReceiptFetcher.h; sourceTree = "<group>"; };
+		353AB5F82230AAE2003754E6 /* RCReceiptFetcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCReceiptFetcher.m; sourceTree = "<group>"; };
 		359A0E9F2003C8CD002D8C7F /* NSLocale+RCExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSLocale+RCExtensions.h"; sourceTree = "<group>"; };
 		359A0EA02003C8CD002D8C7F /* NSLocale+RCExtensions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSLocale+RCExtensions.m"; sourceTree = "<group>"; };
 		35A60EA81F82993E00D2FAE8 /* RCPurchases+Protected.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCPurchases+Protected.h"; sourceTree = "<group>"; };
@@ -150,6 +160,9 @@
 		350FBDE61F7EEEDF0065833D /* Public */ = {
 			isa = PBXGroup;
 			children = (
+				353AB5E5222F633D003754E6 /* RCPurchasesErrorUtils.h */,
+				352E88422229B1A60046A10A /* RCPurchasesErrorUtils.m */,
+				353AB5E3222F624E003754E6 /* RCPurchasesErrors.h */,
 				35262A011F7C4B9100C04F2C /* Purchases.h */,
 				350FBDE71F7EEF070065833D /* RCPurchases.h */,
 				350FBDE81F7EEF070065833D /* RCPurchases.m */,
@@ -206,6 +219,8 @@
 				359A0EA02003C8CD002D8C7F /* NSLocale+RCExtensions.m */,
 				35C98D9420B7306A006DCBB5 /* RCCrossPlatformSupport.h */,
 				35262A021F7C4B9100C04F2C /* Info.plist */,
+				353AB5E82230A239003754E6 /* RCReceiptFetcher.h */,
+				353AB5F82230AAE2003754E6 /* RCReceiptFetcher.m */,
 			);
 			path = Purchases;
 			sourceTree = "<group>";
@@ -239,8 +254,11 @@
 				350FBDED1F7EFB950065833D /* RCStoreKitRequestFetcher.h in Headers */,
 				35CE74F420C389E000CE09D8 /* RCEntitlement.h in Headers */,
 				35CE74FB20C38A7100CE09D8 /* RCOffering.h in Headers */,
+				353AB5E4222F624E003754E6 /* RCPurchasesErrors.h in Headers */,
+				353AB5E6222F633D003754E6 /* RCPurchasesErrorUtils.h in Headers */,
 				359A0EA12003C8CD002D8C7F /* NSLocale+RCExtensions.h in Headers */,
 				351F4FAB1F80190700F245F4 /* RCBackend.h in Headers */,
+				353AB5E92230A239003754E6 /* RCReceiptFetcher.h in Headers */,
 				352C36BF1F9D372D00A15783 /* RCPurchaserInfo+Protected.h in Headers */,
 				35395CB421B9F59E00286D13 /* RCIntroEligibility+Protected.h in Headers */,
 				350FBDE91F7EEF070065833D /* RCPurchases.h in Headers */,
@@ -377,8 +395,10 @@
 			files = (
 				350FBDEE1F7EFB950065833D /* RCStoreKitRequestFetcher.m in Sources */,
 				351F4FAC1F80190700F245F4 /* RCBackend.m in Sources */,
+				353AB5F92230AAE2003754E6 /* RCReceiptFetcher.m in Sources */,
 				350FBDE01F7EE8F20065833D /* RCUtils.m in Sources */,
 				35D3AB442030B4C600DE42C5 /* RCIntroEligibility.m in Sources */,
+				352E88442229B1A70046A10A /* RCPurchasesErrorUtils.m in Sources */,
 				359A0EA22003C8CD002D8C7F /* NSLocale+RCExtensions.m in Sources */,
 				351F4FB01F803D0700F245F4 /* RCPurchaserInfo.m in Sources */,
 				35CE74F620C389E000CE09D8 /* RCEntitlement.m in Sources */,

--- a/Purchases.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Purchases.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Purchases/Info.plist
+++ b/Purchases/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.0-SNAPSHOT</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Purchases/Public/Purchases.h
+++ b/Purchases/Public/Purchases.h
@@ -22,3 +22,5 @@ FOUNDATION_EXPORT const unsigned char PurchasesVersionString[];
 #import "RCIntroEligibility.h"
 #import "RCEntitlement.h"
 #import "RCOffering.h"
+#import "RCPurchasesErrorUtils.h"
+#import "RCPurchasesErrors.h"

--- a/Purchases/Public/RCIntroEligibility.m
+++ b/Purchases/Public/RCIntroEligibility.m
@@ -33,7 +33,7 @@
             return @"Not eligible for trial or introductory price.";
         case RCIntroEligibilityStatusUnknown:
         default:
-            return @"Status indeterminate. You may need to assign the subscription group in the RevenueCat web interface.";
+            return @"Status indeterminate.";
     }
 }
 

--- a/Purchases/Public/RCOffering.h
+++ b/Purchases/Public/RCOffering.h
@@ -24,11 +24,11 @@ NS_SWIFT_NAME(Offering)
 /**
  @return A String containing the localized price
  */
-- (NSString *)localizedPriceString;
+- (NSString * _Nonnull)localizedPriceString;
 
 /**
  @return A String containing the localized introductory price
  */
-- (NSString *)localizedIntroductoryPriceString;
+- (NSString * _Nonnull)localizedIntroductoryPriceString;
 
 @end

--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -38,25 +38,7 @@ typedef void (^RCReceiveProductsBlock)(NSArray<SKProduct *> *) NS_SWIFT_NAME(Pur
 /**
  Completion block for `makePurchase:withCompletionBlock:`
  */
-typedef void (^RCPurchaseCompletedBlock)(SKPaymentTransaction * _Nullable, RCPurchaserInfo * _Nullable, NSError * _Nullable) NS_SWIFT_NAME(Purchases.PurchaseCompletedBlock);
-
-/**
- NSErrorDomain for errors occuring within the scope of the Purchases SDK
- */
-FOUNDATION_EXPORT NSErrorDomain const RCPurchasesAPIErrorDomain;
-
-/**
- @typedef RCPurchasesAPIErrorDomain
- @brief Enum of SDK API errors
- @constant RCDuplicateMakePurchaseCallsError Error triggered when calling make purchase multiple times
- */
-typedef NS_ERROR_ENUM(RCPurchasesAPIErrorDomain, RCPurchasesAPIErrorEnum) {
-    /**
-    Error triggered when calling make purchase multiple times
-     */
-    RCDuplicateMakePurchaseCallsError = 0
-};
-
+typedef void (^RCPurchaseCompletedBlock)(SKPaymentTransaction * _Nullable, RCPurchaserInfo * _Nullable, NSError * _Nullable, BOOL userCancelled) NS_SWIFT_NAME(Purchases.PurchaseCompletedBlock);
 
 /**
  Deferred block for `shouldPurchasePromoProduct:defermentBlock`

--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -43,7 +43,7 @@ typedef void (^RCPurchaseCompletedBlock)(SKPaymentTransaction * _Nullable, RCPur
 /**
  Deferred block for `shouldPurchasePromoProduct:defermentBlock`
  */
-typedef void (^RCDeferredPromotionalPurchaseBlock)(void);
+typedef void (^RCDeferredPromotionalPurchaseBlock)(RCPurchaseCompletedBlock);
 
 
 /**
@@ -284,11 +284,11 @@ NS_SWIFT_NAME(PurchasesDelegate)
 NS_SWIFT_NAME(purchases(_:didReceiveUpdated:));
 
 /**
- Called when a user initiates a promotional in-app purchase from the App Store. Use this method to tell `RCPurchases` if your app is able to handle a purchase at the current time. If yes, return true and `RCPurchases` will initiate a purchase and will finish with one of the appropriate `RCPurchasesDelegate` methods. If the app is not in a state to make a purchase: cache the defermentBlock, return no, then call the defermentBlock when the app is ready to make the promotional purchase. If the purchase should never be made, do not cache the defermentBlock and return `NO`. The default return value is `NO`, if you don't override this delegate method, `RCPurchases` will not proceed with promotional purchases.
+ Called when a user initiates a promotional in-app purchase from the App Store. If your app is able to handle a purchase at the current time, run the deferment block in this method. If the app is not in a state to make a purchase: cache the defermentBlock, then call the defermentBlock when the app is ready to make the promotional purchase. If the purchase should never be made, you don't need to ever call the defermentBlock and `RCPurchases` will not proceed with promotional purchases.
  
  @param product `SKProduct` the product that was selected from the app store
  */
-- (BOOL)purchases:(RCPurchases *)purchases shouldPurchasePromoProduct:(SKProduct *)product defermentBlock:(RCDeferredPromotionalPurchaseBlock)makeDeferredPurchase;
+- (void)purchases:(RCPurchases *)purchases shouldPurchasePromoProduct:(SKProduct *)product defermentBlock:(RCDeferredPromotionalPurchaseBlock)makeDeferredPurchase;
 
 @end
 

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -350,7 +350,7 @@ static RCPurchases *_sharedPurchases = nil;
 {
     // Refresh the receipt and post to backend, this will allow the transactions to be transferred.
     // https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/StoreKitGuide/Chapters/Restoring.html
-    [self receiptData:^(NSData * _Nonnull data) {
+    [self refreshReceipt:^(NSData *_Nonnull data) {
         if (data.length == 0) {
             if (RCIsSandbox()) {
                 RCLog(@"App running on sandbox without a receipt file. Restoring transactions won't work unless you've purchased before and there is a receipt available.");
@@ -367,8 +367,8 @@ static RCPurchases *_sharedPurchases = nil;
                     introductoryPrice:nil
                          currencyCode:nil
                     subscriptionGroup:nil
-                           completion:^(RCPurchaserInfo * _Nullable info,
-                                        NSError * _Nullable error) {
+                           completion:^(RCPurchaserInfo *_Nullable info,
+                                   NSError *_Nullable error) {
                                [self dispatch:^{
                                    if (error) {
                                        CALL_AND_DISPATCH_IF_SET(completion, nil, error);

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -553,16 +553,21 @@ static RCPurchases *_sharedPurchases = nil;
     NSData *receiptData = [self.receiptFetcher receiptData];
     if (receiptData == nil) {
         RCDebugLog(@"Receipt empty, fetching");
-        [self.requestFetcher fetchReceiptData:^{
-            NSData *newReceiptData = [self.receiptFetcher receiptData];
-            if (newReceiptData == nil) {
-                RCLog(@"Unable to load receipt, ensure you are logged in to a Sandbox account");
-            }
-            completion(newReceiptData ?: [NSData data]);
-        }];
+        [self refreshReceipt:completion];
     } else {
         completion(receiptData);
     }
+}
+
+- (void)refreshReceipt:(void (^ _Nonnull)(NSData * _Nonnull data))completion
+{
+    [self.requestFetcher fetchReceiptData:^{
+        NSData *newReceiptData = [self.receiptFetcher receiptData];
+        if (newReceiptData == nil) {
+            RCLog(@"Unable to load receipt, ensure you are logged in to a Sandbox account");
+        }
+        completion(newReceiptData ?: [NSData data]);
+    }];
 }
 
 - (void)handleReceiptPostWithTransaction:(SKPaymentTransaction *)transaction

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -678,12 +678,15 @@ static RCPurchases *_sharedPurchases = nil;
     }
 
     if ([self.delegate respondsToSelector:@selector(purchases:shouldPurchasePromoProduct:defermentBlock:)]) {
-        return [self.delegate purchases:self shouldPurchasePromoProduct:product defermentBlock:^{
-            [self.storeKitWrapper addPayment:payment];
-        }];
-    } else {
-        return NO;
+        [self.delegate purchases:self
+      shouldPurchasePromoProduct:product
+                  defermentBlock:^(RCPurchaseCompletedBlock completion) {
+                      self.purchaseCompleteCallbacks[product.productIdentifier] = [completion copy];
+                      [self.storeKitWrapper addPayment:payment];
+                  }];
     }
+
+    return NO;
 }
 
 - (NSString *)purchaserInfoUserDefaultCacheKeyForAppUserID:(NSString *)appUserID {

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -350,7 +350,7 @@ static RCPurchases *_sharedPurchases = nil;
 {
     // Refresh the receipt and post to backend, this will allow the transactions to be transferred.
     // https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/StoreKitGuide/Chapters/Restoring.html
-    [self refreshReceipt:^(NSData *_Nonnull data) {
+    [self refreshReceipt:^(NSData * _Nonnull data) {
         if (data.length == 0) {
             if (RCIsSandbox()) {
                 RCLog(@"App running on sandbox without a receipt file. Restoring transactions won't work unless you've purchased before and there is a receipt available.");
@@ -367,8 +367,8 @@ static RCPurchases *_sharedPurchases = nil;
                     introductoryPrice:nil
                          currencyCode:nil
                     subscriptionGroup:nil
-                           completion:^(RCPurchaserInfo *_Nullable info,
-                                   NSError *_Nullable error) {
+                           completion:^(RCPurchaserInfo * _Nullable info,
+                                   NSError * _Nullable error) {
                                [self dispatch:^{
                                    if (error) {
                                        CALL_AND_DISPATCH_IF_SET(completion, nil, error);
@@ -564,7 +564,7 @@ static RCPurchases *_sharedPurchases = nil;
     [self.requestFetcher fetchReceiptData:^{
         NSData *newReceiptData = [self.receiptFetcher receiptData];
         if (newReceiptData == nil) {
-            RCLog(@"Unable to load receipt, ensure you are logged in to a Sandbox account");
+            RCLog(@"Unable to load receipt, ensure you are logged in to the correct iTunes account.");
         }
         completion(newReceiptData ?: [NSData data]);
     }];
@@ -743,7 +743,7 @@ static RCPurchases *_sharedPurchases = nil;
                                           introductoryPrice:introPrice
                                                currencyCode:currencyCode
                                           subscriptionGroup:subscriptionGroup
-                                                 completion:^(RCPurchaserInfo *_Nullable info,
+                                                 completion:^(RCPurchaserInfo * _Nullable info,
                                                              NSError * _Nullable error) {
                                                      [self handleReceiptPostWithTransaction:transaction
                                                                               purchaserInfo:info

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -62,7 +62,7 @@ static RCPurchases *_sharedPurchases = nil;
 }
 
 + (NSString *)frameworkVersion {
-    return @"2.1.0-SNAPSHOT";
+    return @"2.1.0-rc1";
 }
 
 + (instancetype)sharedPurchases {

--- a/Purchases/Public/RCPurchasesErrorUtils.h
+++ b/Purchases/Public/RCPurchasesErrorUtils.h
@@ -11,75 +11,72 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * @class RCPurchasesErrorUtils
- *
- * @brief Utility class used to construct @c NSError instances.
- *
+ * Utility class used to construct [NSError] instances.
  */
 NS_SWIFT_NAME(PurchasesErrorUtils)
 @interface RCPurchasesErrorUtils : NSObject
 
 /**
- * @brief Constructs an NSError with the @c RCNetworkError code and a populated @c RCUnderlyingErrorKey in
- * the @c NSError.userInfo dictionary.
+ * Constructs an NSError with the [RCNetworkError] code and a populated [RCUnderlyingErrorKey] in
+ * the [NSError.userInfo] dictionary.
  *
- * @param underlyingError The value of the @c NSUnderlyingErrorKey key.
+ * @param underlyingError The value of the [NSUnderlyingErrorKey] key.
  *
- * @remarks This error is used when there is an error performing network request returns an error or when there
- * is an @c NSJSONSerialization error.
+ * @note This error is used when there is an error performing network request returns an error or when there
+ * is an [NSJSONSerialization] error.
  */
 + (NSError *)networkErrorWithUnderlyingError:(NSError *)underlyingError;
 
 /**
- * @brief Maps an RCBackendError code to a RCPurchasesErrorCode code. Constructs an NSError with the mapped code and adds a
- * @c RCUnderlyingErrorKey in the @c NSError.userInfo dictionary. The backend error code will be mapped using
- * @c [RCPurchasesErrorCodeFromRCBackendErrorCode].
+ * Maps an RCBackendError code to a RCPurchasesErrorCode code. Constructs an NSError with the mapped code and adds a
+ * [RCUnderlyingErrorKey] in the [NSError.userInfo] dictionary. The backend error code will be mapped using
+ * [RCPurchasesErrorCodeFromRCBackendErrorCode].
  *
  * @param backendCode The value of the error key.
- * @param backendMessage The value of the @c NSUnderlyingErrorKey key.
+ * @param backendMessage The value of the [NSUnderlyingErrorKey] key.
  *
- * @remarks This error is used when an network request returns an error. The backend error returned is wrapped in
+ * @note This error is used when an network request returns an error. The backend error returned is wrapped in
  * this internal error code.
  */
-+ (NSError *)backendErrorWithBackendCode:(NSNumber *_Nullable)backendCode backendMessage:(NSString *_Nullable)backendMessage;
++ (NSError *)backendErrorWithBackendCode:(NSNumber * _Nullable)backendCode backendMessage:(NSString * _Nullable)backendMessage;
 
 
 /**
- * @brief Maps an RCBackendError code to a RCPurchasesErrorCode code. Constructs an NSError with the mapped code and adds a
- * @c RCUnderlyingErrorKey in the @c NSError.userInfo dictionary. The backend error code will be mapped using
- * @c [RCPurchasesErrorCodeFromRCBackendErrorCode].
+ * Maps an RCBackendError code to a [RCPurchasesErrorCode] code. Constructs an NSError with the mapped code and adds a
+ * [RCUnderlyingErrorKey] in the [NSError.userInfo] dictionary. The backend error code will be mapped using
+ * [RCPurchasesErrorCodeFromRCBackendErrorCode].
  *
  * @param backendCode The value of the error key.
- * @param backendMessage The value of the @c NSUnderlyingErrorKey key.
- * @param finishable Will be added to the UserInfo dictionary under the @c RCFinishableKey to indicate if the transaction
+ * @param backendMessage The value of the [NSUnderlyingErrorKey] key.
+ * @param finishable Will be added to the UserInfo dictionary under the [RCFinishableKey] to indicate if the transaction
  * should be finished after this error.
  *
- * @remarks This error is used when an network request returns an error. The backend error returned is wrapped in
+ * @note This error is used when an network request returns an error. The backend error returned is wrapped in
  * this internal error code.
  */
-+ (NSError *)backendErrorWithBackendCode:(NSNumber *_Nullable)backendCode backendMessage:(NSString *_Nullable)backendMessage finishable:(BOOL)finishable;
++ (NSError *)backendErrorWithBackendCode:(NSNumber * _Nullable)backendCode backendMessage:(NSString * _Nullable)backendMessage finishable:(BOOL)finishable;
 
 /**
- * @brief Constructs an NSError with the @c [RCUnexpectedBackendResponseError] code.
+ * Constructs an NSError with the [RCUnexpectedBackendResponseError] code.
  *
- * @remarks This error is used when an network request returns an unexpected response.
+ * @note This error is used when an network request returns an unexpected response.
  */
 + (NSError *)unexpectedBackendResponseError;
 
 /**
- * @brief Constructs an NSError with the @c [RCMissingReceiptFileError] code.
+ * Constructs an NSError with the [RCMissingReceiptFileError] code.
  *
- * @remarks This error is used when the receipt is missing in the device. This can happen if the user is in sandbox or
+ * @note This error is used when the receipt is missing in the device. This can happen if the user is in sandbox or
  * if there are no previous purchases.
  */
 + (NSError *)missingReceiptFileError;
 
 /**
- * @brief Maps an SKErrorCode code to a RCPurchasesErrorCode code. Constructs an NSError with the mapped code and adds a
- * @c RCUnderlyingErrorKey in the @c NSError.userInfo dictionary. The SKErrorCode code will be mapped using
- * @c [RCPurchasesErrorCodeFromSKError].
+ * Maps an SKErrorCode code to a RCPurchasesErrorCode code. Constructs an NSError with the mapped code and adds a
+ * [RCUnderlyingErrorKey] in the NSError.userInfo dictionary. The SKErrorCode code will be mapped using
+ * [RCPurchasesErrorCodeFromSKError].
  *
- * @param skError The originating @c [SKError].
+ * @param skError The originating [SKError].
  */
 + (NSError *)purchasesErrorWithSKError:(NSError *)skError;
 @end

--- a/Purchases/Public/RCPurchasesErrorUtils.h
+++ b/Purchases/Public/RCPurchasesErrorUtils.h
@@ -1,0 +1,87 @@
+//
+//  RCPurchasesErrorUtils.h
+//  Purchases
+//
+//  Created by César de la Vega  on 3/5/19.
+//  Copyright © 2019 RevenueCat. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * @class RCPurchasesErrorUtils
+ *
+ * @brief Utility class used to construct @c NSError instances.
+ *
+ */
+NS_SWIFT_NAME(PurchasesErrorUtils)
+@interface RCPurchasesErrorUtils : NSObject
+
+/**
+ * @brief Constructs an NSError with the @c RCNetworkError code and a populated @c RCUnderlyingErrorKey in
+ * the @c NSError.userInfo dictionary.
+ *
+ * @param underlyingError The value of the @c NSUnderlyingErrorKey key.
+ *
+ * @remarks This error is used when there is an error performing network request returns an error or when there
+ * is an @c NSJSONSerialization error.
+ */
++ (NSError *)networkErrorWithUnderlyingError:(NSError *)underlyingError;
+
+/**
+ * @brief Maps an RCBackendError code to a RCPurchasesErrorCode code. Constructs an NSError with the mapped code and adds a
+ * @c RCUnderlyingErrorKey in the @c NSError.userInfo dictionary. The backend error code will be mapped using
+ * @c [RCPurchasesErrorCodeFromRCBackendErrorCode].
+ *
+ * @param backendCode The value of the error key.
+ * @param backendMessage The value of the @c NSUnderlyingErrorKey key.
+ *
+ * @remarks This error is used when an network request returns an error. The backend error returned is wrapped in
+ * this internal error code.
+ */
++ (NSError *)backendErrorWithBackendCode:(NSNumber *_Nullable)backendCode backendMessage:(NSString *_Nullable)backendMessage;
+
+
+/**
+ * @brief Maps an RCBackendError code to a RCPurchasesErrorCode code. Constructs an NSError with the mapped code and adds a
+ * @c RCUnderlyingErrorKey in the @c NSError.userInfo dictionary. The backend error code will be mapped using
+ * @c [RCPurchasesErrorCodeFromRCBackendErrorCode].
+ *
+ * @param backendCode The value of the error key.
+ * @param backendMessage The value of the @c NSUnderlyingErrorKey key.
+ * @param finishable Will be added to the UserInfo dictionary under the @c RCFinishableKey to indicate if the transaction
+ * should be finished after this error.
+ *
+ * @remarks This error is used when an network request returns an error. The backend error returned is wrapped in
+ * this internal error code.
+ */
++ (NSError *)backendErrorWithBackendCode:(NSNumber *_Nullable)backendCode backendMessage:(NSString *_Nullable)backendMessage finishable:(BOOL)finishable;
+
+/**
+ * @brief Constructs an NSError with the @c [RCUnexpectedBackendResponseError] code.
+ *
+ * @remarks This error is used when an network request returns an unexpected response.
+ */
++ (NSError *)unexpectedBackendResponseError;
+
+/**
+ * @brief Constructs an NSError with the @c [RCMissingReceiptFileError] code.
+ *
+ * @remarks This error is used when the receipt is missing in the device. This can happen if the user is in sandbox or
+ * if there are no previous purchases.
+ */
++ (NSError *)missingReceiptFileError;
+
+/**
+ * @brief Maps an SKErrorCode code to a RCPurchasesErrorCode code. Constructs an NSError with the mapped code and adds a
+ * @c RCUnderlyingErrorKey in the @c NSError.userInfo dictionary. The SKErrorCode code will be mapped using
+ * @c [RCPurchasesErrorCodeFromSKError].
+ *
+ * @param skError The originating @c [SKError].
+ */
++ (NSError *)purchasesErrorWithSKError:(NSError *)skError;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -107,11 +107,14 @@ static NSString *const RCPurchasesErrorCodeString(RCPurchasesErrorCode code) {
     return @"UNRECOGNIZED_ERROR";
 }
 
-static RCPurchasesErrorCode RCPurchasesErrorCodeFromRCBackendErrorCode(NSInteger code) {
+static RCPurchasesErrorCode RCPurchasesErrorCodeFromRCBackendErrorCode(RCBackendErrorCode code) {
     switch (code) {
         case RCBackendInvalidPlatform:
             return RCUnknownError;
         case RCBackendStoreProblem:
+        case RCBackendPlayStoreQuotaExceeded:
+        case RCBackendPlayStoreInvalidPackageName:
+        case RCBackendPlayStoreGenericError:
             return RCStoreProblemError;
         case RCBackendCannotTransferPurchase:
             return RCReceiptAlreadyInUseError;
@@ -127,9 +130,8 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromRCBackendErrorCode(NSInteger
             return RCPurchaseInvalidError;
         case RCBackendEmptyAppUserId:
             return RCInvalidAppUserIdError;
-        default:
-            return RCUnknownError;
     }
+    return RCUnknownError;
 }
 
 static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
@@ -249,7 +251,7 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
 {
     RCPurchasesErrorCode errorCode;
     if (backendCode != nil) {
-        errorCode = RCPurchasesErrorCodeFromRCBackendErrorCode([backendCode integerValue]);
+        errorCode = RCPurchasesErrorCodeFromRCBackendErrorCode((RCBackendErrorCode) [backendCode integerValue]);
     } else {
         errorCode = RCUnknownBackendError;
     }

--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -136,7 +136,7 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
     if ([[skError domain] isEqualToString:SKErrorDomain]) {
         switch ((SKErrorCode) skError.code) {
             case SKErrorUnknown:
-                return RCUnknownError;
+                return RCStoreProblemError;
             case SKErrorClientInvalid:
                 return RCPurchaseNotAllowedError;
             case SKErrorPaymentCancelled:

--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -53,8 +53,6 @@ static NSString *RCPurchasesErrorDescription(RCPurchasesErrorCode code) {
             return @"Received malformed response from the backend.";
         case RCInvalidReceiptError:
             return @"The receipt is not valid.";
-        case RCReceiptInUseByOtherSubscriberError:
-            return @"The receipt is in use by other subscriber.";
         case RCInvalidAppUserIdError:
             return @"The app user id is not valid.";
         case RCOperationAlreadyInProgressError:
@@ -98,8 +96,6 @@ static NSString *const RCPurchasesErrorCodeString(RCPurchasesErrorCode code) {
             return @"UNEXPECTED_BACKEND_RESPONSE_ERROR";
         case RCInvalidReceiptError:
             return @"INVALID_RECEIPT";
-        case RCReceiptInUseByOtherSubscriberError:
-            return @"RECEIPT_IN_USE_BY_OTHER_SUBSCRIBER_ERROR";
         case RCInvalidAppUserIdError:
             return @"INVALID_APP_USER_ID";
         case RCOperationAlreadyInProgressError:
@@ -117,7 +113,7 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromRCBackendErrorCode(NSInteger
         case RCBackendStoreProblem:
             return RCStoreProblemError;
         case RCBackendCannotTransferPurchase:
-            return RCReceiptInUseByOtherSubscriberError;
+            return RCReceiptAlreadyInUseError;
         case RCBackendInvalidReceiptToken:
             return RCInvalidReceiptError;
         case RCBackendInvalidAppStoreSharedSecret:
@@ -148,6 +144,7 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
                 return RCPurchaseInvalidError;
             case SKErrorPaymentNotAllowed:
                 return RCPurchaseNotAllowedError;
+            #if !TARGET_OS_MAC
             case SKErrorStoreProductNotAvailable:
                 return RCProductNotAvailableForPurchaseError;
             case SKErrorCloudServicePermissionDenied: // Available on iOS 9.3
@@ -156,6 +153,7 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
                 return RCStoreProblemError;
             case SKErrorCloudServiceRevoked: // Available on iOS 10.3
                 return RCStoreProblemError;
+            #endif
         }
     }
     return RCUnknownError;

--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -22,9 +22,9 @@ NSErrorUserInfoKey const RCReadableErrorCodeKey = @"readable_error_code";
 
 #pragma mark - Standard Error Messages
 
-/** @var RCPurchasesErrorDescription
-    @brief The error description, based on the error code.
-    @remarks No default case so that we get a compiler warning if a new value was added to the enum.
+/**
+ * The error description, based on the error code.
+ * @note No default case so that we get a compiler warning if a new value was added to the enum.
  */
 static NSString *RCPurchasesErrorDescription(RCPurchasesErrorCode code) {
     switch (code) {
@@ -65,9 +65,9 @@ static NSString *RCPurchasesErrorDescription(RCPurchasesErrorCode code) {
 }
 
 
-/** @var RCPurchasesErrorCodeString
-    @brief The the error short string, based on the error code.
-    @remarks No default case so that we get a compiler warning if a new value was added to the enum.
+/**
+ * The error short string, based on the error code.
+ * @note No default case so that we get a compiler warning if a new value was added to the enum.
  */
 static NSString *const RCPurchasesErrorCodeString(RCPurchasesErrorCode code) {
     switch (code) {

--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -9,6 +9,7 @@
 #import <StoreKit/StoreKit.h>
 #import "RCPurchasesErrors.h"
 #import "RCPurchasesErrorUtils.h"
+#import "RCUtils.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -204,6 +205,7 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
 + (NSError *)errorWithCode:(RCPurchasesErrorCode)code
                   userInfo:(NSDictionary *)userInfo
 {
+    RCErrorLog(@"%@", RCPurchasesErrorDescription(code));
     return [NSError errorWithDomain:RCPurchasesErrorDomain code:code userInfo:userInfo];
 }
 

--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -1,0 +1,284 @@
+//
+//  RCPurchasesErrorUtils.m
+//  Purchases
+//
+//  Created by César de la Vega  on 3/5/19.
+//  Copyright © 2019 RevenueCat. All rights reserved.
+//
+
+#import <StoreKit/StoreKit.h>
+#import "RCPurchasesErrors.h"
+#import "RCPurchasesErrorUtils.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark - Error Domains and UserInfo keys
+
+NSErrorDomain const RCPurchasesErrorDomain = @"RCPurchasesErrorDomain";
+NSErrorDomain const RCBackendErrorDomain = @"RCBackendErrorDomain";
+NSErrorUserInfoKey const RCFinishableKey = @"finishable";
+NSErrorUserInfoKey const RCReadableErrorCodeKey = @"readable_error_code";
+
+#pragma mark - Standard Error Messages
+
+/** @var RCPurchasesErrorDescription
+    @brief The error description, based on the error code.
+    @remarks No default case so that we get a compiler warning if a new value was added to the enum.
+ */
+static NSString *RCPurchasesErrorDescription(RCPurchasesErrorCode code) {
+    switch (code) {
+        case RCNetworkError:
+            return @"Error performing request.";
+        case RCUnknownError:
+            return @"Unknown error.";
+        case RCPurchaseCancelledError:
+            return @"Purchase was cancelled.";
+        case RCStoreProblemError:
+            return @"There was a problem with the App Store.";
+        case RCPurchaseNotAllowedError:
+            return @"The device or user is not allowed to make the purchase.";
+        case RCPurchaseInvalidError:
+            return @"One or more of the arguments provided are invalid.";
+        case RCProductNotAvailableForPurchaseError:
+            return @"The product is not available for purchase.";
+        case RCProductAlreadyPurchasedError:
+            return @"This product is already active for the user.";
+        case RCReceiptAlreadyInUseError:
+            return @"There is already another active subscriber using the same receipt.";
+        case RCMissingReceiptFileError:
+            return @"The receipt is missing.";
+        case RCInvalidCredentialsError:
+            return @"There was a credentials issue. Check the underlying error for more details.";
+        case RCUnexpectedBackendResponseError:
+            return @"Received malformed response from the backend.";
+        case RCInvalidReceiptError:
+            return @"The receipt is not valid.";
+        case RCReceiptInUseByOtherSubscriberError:
+            return @"The receipt is in use by other subscriber.";
+        case RCInvalidAppUserIdError:
+            return @"The app user id is not valid.";
+        case RCOperationAlreadyInProgressError:
+            return @"The operation is already in progress.";
+        case RCUnknownBackendError:
+            return @"There was an unknown backend error.";
+    }
+    return @"Something went wrong.";
+}
+
+
+/** @var RCPurchasesErrorCodeString
+    @brief The the error short string, based on the error code.
+    @remarks No default case so that we get a compiler warning if a new value was added to the enum.
+ */
+static NSString *const RCPurchasesErrorCodeString(RCPurchasesErrorCode code) {
+    switch (code) {
+        case RCNetworkError:
+            return @"NETWORK_ERROR";
+        case RCUnknownError:
+            return @"UNKNOWN";
+        case RCPurchaseCancelledError:
+            return @"PURCHASE_CANCELLED";
+        case RCStoreProblemError:
+            return @"STORE_PROBLEM";
+        case RCPurchaseNotAllowedError:
+            return @"PURCHASE_NOT_ALLOWED";
+        case RCPurchaseInvalidError:
+            return @"PURCHASE_INVALID";
+        case RCProductNotAvailableForPurchaseError:
+            return @"PRODUCT_NOT_AVAILABLE_FOR_PURCHASE";
+        case RCProductAlreadyPurchasedError:
+            return @"PRODUCT_ALREADY_PURCHASED";
+        case RCReceiptAlreadyInUseError:
+            return @"RECEIPT_ALREADY_IN_USE";
+        case RCMissingReceiptFileError:
+            return @"MISSING_RECEIPT_FILE";
+        case RCInvalidCredentialsError:
+            return @"INVALID_CREDENTIALS";
+        case RCUnexpectedBackendResponseError:
+            return @"UNEXPECTED_BACKEND_RESPONSE_ERROR";
+        case RCInvalidReceiptError:
+            return @"INVALID_RECEIPT";
+        case RCReceiptInUseByOtherSubscriberError:
+            return @"RECEIPT_IN_USE_BY_OTHER_SUBSCRIBER_ERROR";
+        case RCInvalidAppUserIdError:
+            return @"INVALID_APP_USER_ID";
+        case RCOperationAlreadyInProgressError:
+            return @"OPERATION_ALREADY_IN_PROGRESS";
+        case RCUnknownBackendError:
+            return @"UNKNOWN_BACKEND_ERROR";
+    }
+    return @"UNRECOGNIZED_ERROR";
+}
+
+static RCPurchasesErrorCode RCPurchasesErrorCodeFromRCBackendErrorCode(NSInteger code) {
+    switch (code) {
+        case RCBackendInvalidPlatform:
+            return RCUnknownError;
+        case RCBackendStoreProblem:
+            return RCStoreProblemError;
+        case RCBackendCannotTransferPurchase:
+            return RCReceiptInUseByOtherSubscriberError;
+        case RCBackendInvalidReceiptToken:
+            return RCInvalidReceiptError;
+        case RCBackendInvalidAppStoreSharedSecret:
+        case RCBackendInvalidPlayStoreCredentials:
+        case RCBackendInvalidAuthToken:
+        case RCBackendInvalidAPIKey:
+            return RCInvalidCredentialsError;
+        case RCBackendInvalidPaymentModeOrIntroPriceNotProvided:
+        case RCBackendProductIdForGoogleReceiptNotProvided:
+            return RCPurchaseInvalidError;
+        case RCBackendEmptyAppUserId:
+            return RCInvalidAppUserIdError;
+        default:
+            return RCUnknownError;
+    }
+}
+
+static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
+    if ([[skError domain] isEqualToString:SKErrorDomain]) {
+        switch ((SKErrorCode) skError.code) {
+            case SKErrorUnknown:
+                return RCUnknownError;
+            case SKErrorClientInvalid:
+                return RCPurchaseNotAllowedError;
+            case SKErrorPaymentCancelled:
+                return RCPurchaseCancelledError;
+            case SKErrorPaymentInvalid:
+                return RCPurchaseInvalidError;
+            case SKErrorPaymentNotAllowed:
+                return RCPurchaseNotAllowedError;
+            case SKErrorStoreProductNotAvailable:
+                return RCProductNotAvailableForPurchaseError;
+            case SKErrorCloudServicePermissionDenied: // Available on iOS 9.3
+                return RCPurchaseNotAllowedError;
+            case SKErrorCloudServiceNetworkConnectionFailed: // Available on iOS 9.3
+                return RCStoreProblemError;
+            case SKErrorCloudServiceRevoked: // Available on iOS 10.3
+                return RCStoreProblemError;
+        }
+    }
+    return RCUnknownError;
+}
+
+@implementation RCPurchasesErrorUtils
+
++ (NSError *)errorWithCode:(RCPurchasesErrorCode)code
+{
+    return [self errorWithCode:code message:nil];
+}
+
++ (NSError *)errorWithCode:(RCPurchasesErrorCode)code
+                   message:(NSString *_Nullable)message
+{
+    return [self errorWithCode:code message:message underlyingError:nil];
+}
+
+
++ (NSError *)errorWithCode:(RCPurchasesErrorCode)code
+           underlyingError:(NSError *_Nullable)underlyingError
+{
+    return [self errorWithCode:code message:nil underlyingError:underlyingError extraUserInfo:nil];
+}
+
++ (NSError *)errorWithCode:(RCPurchasesErrorCode)code
+                   message:(NSString *_Nullable)message
+           underlyingError:(NSError *_Nullable)underlyingError
+{
+    return [self errorWithCode:code message:message underlyingError:underlyingError extraUserInfo:nil];
+}
+
++ (NSError *)errorWithCode:(RCPurchasesErrorCode)code
+                   message:(NSString *_Nullable)message
+           underlyingError:(NSError *_Nullable)underlyingError
+             extraUserInfo:(NSDictionary *_Nullable)extraUserInfo
+{
+
+    NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:extraUserInfo];
+    userInfo[NSLocalizedDescriptionKey] = message ?: RCPurchasesErrorDescription(code);
+    if (underlyingError) {
+        userInfo[NSUnderlyingErrorKey] = underlyingError;
+    }
+    userInfo[RCReadableErrorCodeKey] = RCPurchasesErrorCodeString(code);
+    return [self errorWithCode:code userInfo:userInfo];
+}
+
++ (NSError *)errorWithCode:(RCPurchasesErrorCode)code
+                  userInfo:(NSDictionary *)userInfo
+{
+    return [NSError errorWithDomain:RCPurchasesErrorDomain code:code userInfo:userInfo];
+}
+
++ (NSError *)networkErrorWithUnderlyingError:(NSError *)underlyingError
+{
+    return [self errorWithCode:RCNetworkError
+               underlyingError:underlyingError];
+}
+
++ (NSError *)backendUnderlyingError:(NSNumber *_Nullable)backendCode
+                     backendMessage:(NSString *_Nullable)backendMessage
+{
+
+    return [NSError errorWithDomain:RCBackendErrorDomain
+                               code:[backendCode integerValue] ?: RCUnknownError
+                           userInfo:@{
+                                   NSLocalizedDescriptionKey: backendMessage ?: @""
+                           }];
+}
+
++ (NSError *)backendErrorWithBackendCode:(NSNumber *_Nullable)backendCode
+                          backendMessage:(NSString *_Nullable)backendMessage
+{
+    return [self backendErrorWithBackendCode:backendCode backendMessage:backendMessage extraUserInfo:nil];
+}
+
++ (NSError *)backendErrorWithBackendCode:(NSNumber *_Nullable)backendCode
+                          backendMessage:(NSString *_Nullable)backendMessage
+                              finishable:(BOOL)finishable
+{
+    return [self backendErrorWithBackendCode:backendCode
+                              backendMessage:backendMessage
+                               extraUserInfo:@{
+                                       RCFinishableKey: @(finishable)
+                               }];
+}
+
++ (NSError *)backendErrorWithBackendCode:(NSNumber *_Nullable)backendCode
+                          backendMessage:(NSString *_Nullable)backendMessage
+                           extraUserInfo:(NSDictionary *_Nullable)extraUserInfo
+{
+    RCPurchasesErrorCode errorCode;
+    if (backendCode != nil) {
+        errorCode = RCPurchasesErrorCodeFromRCBackendErrorCode([backendCode integerValue]);
+    } else {
+        errorCode = RCUnknownBackendError;
+    }
+
+    return [self errorWithCode:errorCode
+                       message:RCPurchasesErrorDescription(errorCode)
+               underlyingError:[self backendUnderlyingError:backendCode backendMessage:backendMessage]
+                 extraUserInfo:extraUserInfo];
+}
+
++ (NSError *)unexpectedBackendResponseError
+{
+    return [self errorWithCode:RCUnexpectedBackendResponseError];
+}
+
++ (NSError *)missingReceiptFileError
+{
+    return [self errorWithCode:RCMissingReceiptFileError];
+}
+
++ (NSError *)purchasesErrorWithSKError:(NSError *)skError
+{
+
+    RCPurchasesErrorCode errorCode = RCPurchasesErrorCodeFromSKError(skError);
+    return [self errorWithCode:errorCode
+                       message:RCPurchasesErrorDescription(errorCode)
+               underlyingError:skError];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -168,29 +168,29 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
 }
 
 + (NSError *)errorWithCode:(RCPurchasesErrorCode)code
-                   message:(NSString *_Nullable)message
+                   message:(NSString * _Nullable)message
 {
     return [self errorWithCode:code message:message underlyingError:nil];
 }
 
 
 + (NSError *)errorWithCode:(RCPurchasesErrorCode)code
-           underlyingError:(NSError *_Nullable)underlyingError
+           underlyingError:(NSError * _Nullable)underlyingError
 {
     return [self errorWithCode:code message:nil underlyingError:underlyingError extraUserInfo:nil];
 }
 
 + (NSError *)errorWithCode:(RCPurchasesErrorCode)code
-                   message:(NSString *_Nullable)message
-           underlyingError:(NSError *_Nullable)underlyingError
+                   message:(NSString * _Nullable)message
+           underlyingError:(NSError * _Nullable)underlyingError
 {
     return [self errorWithCode:code message:message underlyingError:underlyingError extraUserInfo:nil];
 }
 
 + (NSError *)errorWithCode:(RCPurchasesErrorCode)code
-                   message:(NSString *_Nullable)message
-           underlyingError:(NSError *_Nullable)underlyingError
-             extraUserInfo:(NSDictionary *_Nullable)extraUserInfo
+                   message:(NSString * _Nullable)message
+           underlyingError:(NSError * _Nullable)underlyingError
+             extraUserInfo:(NSDictionary * _Nullable)extraUserInfo
 {
 
     NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:extraUserInfo];
@@ -215,8 +215,8 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
                underlyingError:underlyingError];
 }
 
-+ (NSError *)backendUnderlyingError:(NSNumber *_Nullable)backendCode
-                     backendMessage:(NSString *_Nullable)backendMessage
++ (NSError *)backendUnderlyingError:(NSNumber * _Nullable)backendCode
+                     backendMessage:(NSString * _Nullable)backendMessage
 {
 
     return [NSError errorWithDomain:RCBackendErrorDomain
@@ -226,14 +226,14 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
                            }];
 }
 
-+ (NSError *)backendErrorWithBackendCode:(NSNumber *_Nullable)backendCode
-                          backendMessage:(NSString *_Nullable)backendMessage
++ (NSError *)backendErrorWithBackendCode:(NSNumber * _Nullable)backendCode
+                          backendMessage:(NSString * _Nullable)backendMessage
 {
     return [self backendErrorWithBackendCode:backendCode backendMessage:backendMessage extraUserInfo:nil];
 }
 
-+ (NSError *)backendErrorWithBackendCode:(NSNumber *_Nullable)backendCode
-                          backendMessage:(NSString *_Nullable)backendMessage
++ (NSError *)backendErrorWithBackendCode:(NSNumber * _Nullable)backendCode
+                          backendMessage:(NSString * _Nullable)backendMessage
                               finishable:(BOOL)finishable
 {
     return [self backendErrorWithBackendCode:backendCode
@@ -243,9 +243,9 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
                                }];
 }
 
-+ (NSError *)backendErrorWithBackendCode:(NSNumber *_Nullable)backendCode
-                          backendMessage:(NSString *_Nullable)backendMessage
-                           extraUserInfo:(NSDictionary *_Nullable)extraUserInfo
++ (NSError *)backendErrorWithBackendCode:(NSNumber * _Nullable)backendCode
+                          backendMessage:(NSString * _Nullable)backendMessage
+                           extraUserInfo:(NSDictionary * _Nullable)extraUserInfo
 {
     RCPurchasesErrorCode errorCode;
     if (backendCode != nil) {

--- a/Purchases/Public/RCPurchasesErrors.h
+++ b/Purchases/Public/RCPurchasesErrors.h
@@ -1,0 +1,65 @@
+//
+//  NSError+Purchases.h
+//  Purchases
+//
+//  Created by César de la Vega  on 3/5/19.
+//  Copyright © 2019 RevenueCat. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+
+NS_SWIFT_NAME(PurchasesErrors)
+@interface RCPurchasesErrors
+
+/**
+ * NSErrorDomain for errors occurring within the scope of the Purchases SDK
+ */
+extern NSErrorDomain const RCPurchasesErrorDomain NS_SWIFT_NAME(PurchasesErrorDomain);
+extern NSErrorDomain const RCBackendErrorDomain NS_SWIFT_NAME(RevenueCatBackendErrorDomain);
+
+extern NSErrorUserInfoKey const RCFinishableKey NS_SWIFT_NAME(FinishableKey);
+extern NSErrorUserInfoKey const RCReadableErrorCodeKey NS_SWIFT_NAME(ReadableErrorCodeKey);
+
+
+/**
+ * @brief Error codes used by the Purchases SDK
+ */
+typedef NS_ERROR_ENUM(RCPurchasesErrorDomain, RCPurchasesErrorCode) {
+    RCUnknownError = 0,
+    RCPurchaseCancelledError,
+    RCStoreProblemError,
+    RCPurchaseNotAllowedError,
+    RCPurchaseInvalidError,
+    RCProductNotAvailableForPurchaseError,
+    RCProductAlreadyPurchasedError,
+    RCReceiptAlreadyInUseError,
+    RCInvalidReceiptError,
+    RCMissingReceiptFileError,
+    RCNetworkError,
+    RCInvalidCredentialsError,
+    RCUnexpectedBackendResponseError,
+    RCReceiptInUseByOtherSubscriberError,
+    RCInvalidAppUserIdError,
+    RCOperationAlreadyInProgressError,
+    RCUnknownBackendError,
+} NS_SWIFT_NAME(PurchasesErrorCode);
+
+/**
+ * @brief Error codes sent by the RevenueCat backend. This only includes the errors that matter to the SDK
+ */
+typedef NS_ENUM(NSInteger, RCBackendErrorCode) {
+    RCBackendInvalidPlatform = 7000,
+    RCBackendStoreProblem = 7101,
+    RCBackendCannotTransferPurchase = 7102,
+    RCBackendInvalidReceiptToken = 7103,
+    RCBackendInvalidAppStoreSharedSecret = 7104,
+    RCBackendInvalidPaymentModeOrIntroPriceNotProvided = 7105,
+    RCBackendProductIdForGoogleReceiptNotProvided = 7106,
+    RCBackendInvalidPlayStoreCredentials = 7107,
+    RCBackendEmptyAppUserId = 7220,
+    RCBackendInvalidAuthToken = 7224,
+    RCBackendInvalidAPIKey = 7225,
+} NS_SWIFT_NAME(RevenueCatBackendErrorCode);
+
+@end

--- a/Purchases/Public/RCPurchasesErrors.h
+++ b/Purchases/Public/RCPurchasesErrors.h
@@ -23,7 +23,7 @@ extern NSErrorUserInfoKey const RCReadableErrorCodeKey NS_SWIFT_NAME(ReadableErr
 
 
 /**
- * @brief Error codes used by the Purchases SDK
+ * Error codes used by the Purchases SDK
  */
 typedef NS_ERROR_ENUM(RCPurchasesErrorDomain, RCPurchasesErrorCode) {
     RCUnknownError = 0,
@@ -45,7 +45,7 @@ typedef NS_ERROR_ENUM(RCPurchasesErrorDomain, RCPurchasesErrorCode) {
 } NS_SWIFT_NAME(PurchasesErrorCode);
 
 /**
- * @brief Error codes sent by the RevenueCat backend. This only includes the errors that matter to the SDK
+ * Error codes sent by the RevenueCat backend. This only includes the errors that matter to the SDK
  */
 typedef NS_ENUM(NSInteger, RCBackendErrorCode) {
     RCBackendInvalidPlatform = 7000,

--- a/Purchases/Public/RCPurchasesErrors.h
+++ b/Purchases/Public/RCPurchasesErrors.h
@@ -39,7 +39,6 @@ typedef NS_ERROR_ENUM(RCPurchasesErrorDomain, RCPurchasesErrorCode) {
     RCNetworkError,
     RCInvalidCredentialsError,
     RCUnexpectedBackendResponseError,
-    RCReceiptInUseByOtherSubscriberError,
     RCInvalidAppUserIdError,
     RCOperationAlreadyInProgressError,
     RCUnknownBackendError,

--- a/Purchases/Public/RCPurchasesErrors.h
+++ b/Purchases/Public/RCPurchasesErrors.h
@@ -59,6 +59,9 @@ typedef NS_ENUM(NSInteger, RCBackendErrorCode) {
     RCBackendEmptyAppUserId = 7220,
     RCBackendInvalidAuthToken = 7224,
     RCBackendInvalidAPIKey = 7225,
+    RCBackendPlayStoreQuotaExceeded = 7229,
+    RCBackendPlayStoreInvalidPackageName = 7230,
+    RCBackendPlayStoreGenericError = 7231,
 } NS_SWIFT_NAME(RevenueCatBackendErrorCode);
 
 @end

--- a/Purchases/RCBackend.h
+++ b/Purchases/RCBackend.h
@@ -16,14 +16,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class RCPurchaserInfo, RCHTTPClient, RCIntroEligibility, RCEntitlement;
 
-FOUNDATION_EXPORT NSErrorDomain const RCBackendErrorDomain;
-
-NS_ERROR_ENUM(RCBackendErrorDomain) {
-    RCFinishableError = 0,
-    RCUnfinishableError,
-    RCUnexpectedBackendResponse 
-};
-
 typedef NS_ENUM(NSInteger, RCPaymentMode) {
     RCPaymentModeNone = -1,
     RCPaymentModePayAsYouGo = 0,
@@ -34,7 +26,7 @@ typedef NS_ENUM(NSInteger, RCPaymentMode) {
 API_AVAILABLE(ios(11.2), macos(10.13.2))
 RCPaymentMode RCPaymentModeFromSKProductDiscountPaymentMode(SKProductDiscountPaymentMode paymentMode);
 
-typedef void(^RCBackendResponseHandler)(RCPurchaserInfo * _Nullable,
+typedef void(^RCBackendPurchaserInfoResponseHandler)(RCPurchaserInfo * _Nullable,
                                         NSError * _Nullable);
 
 typedef void(^RCIntroEligibilityResponseHandler)(NSDictionary<NSString *,
@@ -58,10 +50,10 @@ typedef void(^RCEntitlementResponseHandler)(RCEntitlements * _Nullable, NSError 
       introductoryPrice:(NSDecimalNumber * _Nullable)introductoryPrice
            currencyCode:(NSString * _Nullable)currencyCode
       subscriptionGroup:(NSString * _Nullable)subscriptionGroup
-             completion:(RCBackendResponseHandler)completion;
+             completion:(RCBackendPurchaserInfoResponseHandler)completion;
 
 - (void)getSubscriberDataWithAppUserID:(NSString *)appUserID
-                            completion:(RCBackendResponseHandler)completion;
+                            completion:(RCBackendPurchaserInfoResponseHandler)completion;
 
 - (void)getIntroEligibilityForAppUserID:(NSString *)appUserID
                             receiptData:(NSData *)receiptData

--- a/Purchases/RCBackend.m
+++ b/Purchases/RCBackend.m
@@ -72,8 +72,8 @@ RCPaymentMode RCPaymentModeFromSKProductDiscountPaymentMode(SKProductDiscountPay
 }
 
 - (void)handle:(NSInteger)statusCode
-  withResponse:(NSDictionary *_Nullable)response
-         error:(NSError *_Nullable)error
+  withResponse:(NSDictionary * _Nullable)response
+         error:(NSError * _Nullable)error
     completion:(RCBackendPurchaserInfoResponseHandler)completion
 {
     if (error != nil) {

--- a/Purchases/RCPurchases+Protected.h
+++ b/Purchases/RCPurchases+Protected.h
@@ -7,7 +7,7 @@
 //
 
 
-@class RCPurchases, RCStoreKitRequestFetcher, RCBackend, RCStoreKitWrapper;
+@class RCPurchases, RCStoreKitRequestFetcher, RCBackend, RCStoreKitWrapper, RCReceiptFetcher;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -15,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype _Nullable)initWithAppUserID:(NSString * _Nullable)appUserID
                              requestFetcher:(RCStoreKitRequestFetcher *)requestFetcher
+                             receiptFetcher:(RCReceiptFetcher *)receiptFetcher
                                     backend:(RCBackend *)backend
                             storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper
                          notificationCenter:(NSNotificationCenter *)notificationCenter

--- a/Purchases/RCReceiptFetcher.h
+++ b/Purchases/RCReceiptFetcher.h
@@ -1,0 +1,16 @@
+//
+//  RCReceiptFetcher.h
+//  Purchases
+//
+//  Created by César de la Vega  on 3/6/19.
+//  Copyright © 2019 RevenueCat. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <StoreKit/StoreKit.h>
+
+@interface RCReceiptFetcher : NSObject
+
+- (NSData *)receiptData;
+
+@end

--- a/Purchases/RCReceiptFetcher.m
+++ b/Purchases/RCReceiptFetcher.m
@@ -1,0 +1,23 @@
+//
+//  RCReceiptFetcher.m
+//  Purchases
+//
+//  Created by César de la Vega  on 3/6/19.
+//  Copyright © 2019 Purchases. All rights reserved.
+//
+
+#import "RCReceiptFetcher.h"
+#import "RCUtils.h"
+
+@implementation RCReceiptFetcher : NSObject
+
+- (NSData *)receiptData
+{
+    NSURL *receiptURL = [[NSBundle mainBundle] appStoreReceiptURL];
+    NSData *data = [NSData dataWithContentsOfURL:receiptURL];
+    RCDebugLog(@"Loaded receipt from %@", receiptURL);
+    return data;
+}
+
+@end
+

--- a/Purchases/RCUtils.h
+++ b/Purchases/RCUtils.h
@@ -13,6 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 void RCSetShowDebugLogs(BOOL showDebugLogs);
 BOOL RCShowDebugLogs(void);
 void RCDebugLog(NSString *format, ...);
+void RCErrorLog(NSString *format, ...);
 void RCLog(NSString *format, ...);
 BOOL RCIsSandbox(void);
 

--- a/Purchases/RCUtils.h
+++ b/Purchases/RCUtils.h
@@ -14,5 +14,6 @@ void RCSetShowDebugLogs(BOOL showDebugLogs);
 BOOL RCShowDebugLogs(void);
 void RCDebugLog(NSString *format, ...);
 void RCLog(NSString *format, ...);
+BOOL RCIsSandbox(void);
 
 NS_ASSUME_NONNULL_END

--- a/Purchases/RCUtils.m
+++ b/Purchases/RCUtils.m
@@ -34,6 +34,20 @@ void RCDebugLog(NSString *format, ...)
     va_end(args);
 }
 
+void RCErrorLog(NSString *format, ...)
+{
+    if (!RCShouldShowLogs)
+        return;
+
+    va_list args;
+    va_start(args, format);
+
+    format = [NSString stringWithFormat:@"[Purchases] - ERROR: %@", format];
+
+    NSLogv(format, args);
+    va_end(args);
+}
+
 void RCLog(NSString *format, ...)
 {
     va_list args;

--- a/Purchases/RCUtils.m
+++ b/Purchases/RCUtils.m
@@ -43,3 +43,10 @@ void RCLog(NSString *format, ...)
     NSLogv(format, args);
     va_end(args);
 }
+
+BOOL RCIsSandbox()
+{
+    NSURL *url = [[NSBundle mainBundle] appStoreReceiptURL];
+    NSString *receiptURLString = [url path];
+    return ([receiptURLString rangeOfString:@"sandboxReceipt"].location != NSNotFound);
+}

--- a/PurchasesTests/PurchaserInfoTests.swift
+++ b/PurchasesTests/PurchaserInfoTests.swift
@@ -126,7 +126,6 @@ class BasicPurchaserInfoTests: XCTestCase {
         expect(newInfo).toNot(beNil())
     }
 
-
     func testTwoProductJson() {
         let json = try! JSONSerialization.jsonObject(with: validTwoProductsJSON.data(using: String.Encoding.utf8)!, options: [])
         let info = PurchaserInfo(data: json as! [AnyHashable : Any])

--- a/PurchasesTests/PurchasesTests-Bridging-Header.h
+++ b/PurchasesTests/PurchasesTests-Bridging-Header.h
@@ -5,6 +5,7 @@
 #include <Purchases/RCHTTPClient.h>
 #include <Purchases/RCPurchases+Protected.h>
 #include <Purchases/RCStoreKitRequestFetcher.h>
+#include <Purchases/RCReceiptFetcher.h>
 #include <Purchases/RCStoreKitWrapper.h>
 #include <Purchases/RCBackend.h>
 #include <Purchases/RCPurchaserInfo.h>

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -891,11 +891,12 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.postReceiptDataCalled).to(beTrue())
     }
 
-    func testRestoringPurchasesRefreshesAndPostsTheReceipt() {
+    func testRestoringPurchasesAlwaysRefreshesAndPostsTheReceipt() {
         setupPurchases()
+        self.receiptFetcher.shouldReturnReceipt = true
         purchases!.restoreTransactions()
 
-        expect(self.receiptFetcher.receiptDataTimesCalled).to(be(2))
+        expect(self.receiptFetcher.receiptDataTimesCalled).to(equal(1))
         expect(self.requestFetcher.refreshReceiptCalled).to(beTrue())
     }
 

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -44,7 +44,7 @@ class PurchasesTests: XCTestCase {
 
         override func receiptData() -> Data? {
             receiptDataCalled = true
-            receiptDataTimesCalled++
+            receiptDataTimesCalled += 1
             if (shouldReturnReceipt) {
                 return Data(1...3)
             } else {

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -40,9 +40,11 @@ class PurchasesTests: XCTestCase {
     class MockReceiptFetcher: RCReceiptFetcher {
         var receiptDataCalled = false
         var shouldReturnReceipt = true
+        var receiptDataTimesCalled = 0
 
         override func receiptData() -> Data? {
             receiptDataCalled = true
+            receiptDataTimesCalled++
             if (shouldReturnReceipt) {
                 return Data(1...3)
             } else {
@@ -891,9 +893,9 @@ class PurchasesTests: XCTestCase {
 
     func testRestoringPurchasesRefreshesAndPostsTheReceipt() {
         setupPurchases()
-        self.receiptFetcher.shouldReturnReceipt = false
         purchases!.restoreTransactions()
 
+        expect(self.receiptFetcher.receiptDataTimesCalled).to(be(2))
         expect(self.requestFetcher.refreshReceiptCalled).to(beTrue())
     }
 

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -37,6 +37,21 @@ class MockTransaction: SKPaymentTransaction {
 
 class PurchasesTests: XCTestCase {
 
+    class MockReceiptFetcher: RCReceiptFetcher {
+        var receiptDataCalled = false
+        var shouldReturnReceipt = true
+
+        override func receiptData() -> Data? {
+            receiptDataCalled = true
+            if (shouldReturnReceipt) {
+                return Data(1...3)
+            } else {
+                return nil
+            }
+        }
+
+    }
+
     class MockRequestFetcher: RCStoreKitRequestFetcher {
         var refreshReceiptCalled = false
         var failProducts = false
@@ -72,7 +87,7 @@ class PurchasesTests: XCTestCase {
                 "other_purchases": [:]
             ]])
         
-        override func getSubscriberData(withAppUserID appUserID: String, completion: @escaping RCBackendResponseHandler) {
+        override func getSubscriberData(withAppUserID appUserID: String, completion: @escaping RCBackendPurchaserInfoResponseHandler) {
             getSubscriberCallCount += 1
             userID = appUserID
             
@@ -98,7 +113,7 @@ class PurchasesTests: XCTestCase {
         var aliasError: Error?
         var aliasCalled = false
 
-        override func postReceiptData(_ data: Data, appUserID: String, isRestore: Bool, productIdentifier: String?, price: NSDecimalNumber?, paymentMode: RCPaymentMode, introductoryPrice: NSDecimalNumber?, currencyCode: String?, subscriptionGroup: String?, completion: @escaping RCBackendResponseHandler) {
+        override func postReceiptData(_ data: Data, appUserID: String, isRestore: Bool, productIdentifier: String?, price: NSDecimalNumber?, paymentMode: RCPaymentMode, introductoryPrice: NSDecimalNumber?, currencyCode: String?, subscriptionGroup: String?, completion: @escaping RCBackendPurchaserInfoResponseHandler) {
             postReceiptDataCalled = true
             postedIsRestore = isRestore
 
@@ -131,7 +146,7 @@ class PurchasesTests: XCTestCase {
         override func getEntitlementsForAppUserID(_ appUserID: String, completion: @escaping RCEntitlementResponseHandler) {
             gotEntitlements += 1
             if (failEntitlements) {
-                completion(nil, NSError.init(domain: RCBackendErrorDomain, code: 0, userInfo:nil))
+                completion(nil, PurchasesErrorUtils.unexpectedBackendResponseError())
                 return
             }
 
@@ -254,6 +269,7 @@ class PurchasesTests: XCTestCase {
         }
     }
 
+    let receiptFetcher = MockReceiptFetcher()
     let requestFetcher = MockRequestFetcher()
     let backend = MockBackend()
     let storeKitWrapper = MockStoreKitWrapper()
@@ -269,6 +285,7 @@ class PurchasesTests: XCTestCase {
     func setupPurchases() {
         purchases = Purchases(appUserID: appUserID,
                                 requestFetcher: requestFetcher,
+                                receiptFetcher: receiptFetcher,
                                 backend:backend,
                                 storeKitWrapper: storeKitWrapper,
                                 notificationCenter:notificationCenter,
@@ -280,6 +297,7 @@ class PurchasesTests: XCTestCase {
     func setupAnonPurchases() {
         purchases = Purchases(appUserID: nil,
                                 requestFetcher: requestFetcher,
+                                receiptFetcher: receiptFetcher,
                                 backend:backend,
                                 storeKitWrapper: storeKitWrapper,
                                 notificationCenter:notificationCenter,
@@ -322,7 +340,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
         
-        expect(self.backend.postReceiptDataCalled).to(equal(true))
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
         expect(self.purchasesDelegate.purchaserInfoReceivedCount).toEventually(equal(2))
     }
     
@@ -357,7 +375,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
         
-        expect(self.backend.postReceiptDataCalled).to(equal(true))
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
         expect(self.purchasesDelegate.purchaserInfoReceivedCount).toEventually(equal(2))
     }
     
@@ -398,14 +416,14 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
         
-        expect(self.backend.postReceiptDataCalled).to(equal(true))
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
         expect(self.purchasesDelegate.purchaserInfoReceivedCount).toEventually(equal(3))
     }
     
     func testDelegateIsNotCalledIfBlockPassed() {
         setupPurchases()
         let product = MockProduct(mockProductIdentifier: "com.product.id1")
-        self.purchases?.makePurchase(product) { (tx, info, error) in
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
             
         }
         
@@ -418,8 +436,8 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
         
-        expect(self.backend.postReceiptDataCalled).to(equal(true))
-        expect(self.backend.postedIsRestore).to(equal(false))
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
+        expect(self.backend.postedIsRestore).to(beFalse())
         expect(self.purchasesDelegate.purchaserInfoReceivedCount).toEventually(equal(1))
     }
 
@@ -443,7 +461,7 @@ class PurchasesTests: XCTestCase {
     func testAddsPaymentToWrapper() {
         setupPurchases()
         let product = MockProduct(mockProductIdentifier: "com.product.id1")
-        self.purchases?.makePurchase(product) { (tx, info, error) in
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
             
         }
 
@@ -454,7 +472,7 @@ class PurchasesTests: XCTestCase {
     func testTransitioningToPurchasing() {
         setupPurchases()
         let product = MockProduct(mockProductIdentifier: "com.product.id1")
-        self.purchases?.makePurchase(product) { (tx, info, error) in
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
             
         }
 
@@ -464,13 +482,13 @@ class PurchasesTests: XCTestCase {
 
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        expect(self.backend.postReceiptDataCalled).to(equal(false))
+        expect(self.backend.postReceiptDataCalled).to(beFalse())
     }
 
     func testTransitioningToPurchasedSendsToBackend() {
         setupPurchases()
         let product = MockProduct(mockProductIdentifier: "com.product.id1")
-        self.purchases?.makePurchase(product) { (tx, info, error) in
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
             
         }
 
@@ -483,14 +501,14 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        expect(self.backend.postReceiptDataCalled).to(equal(true))
-        expect(self.backend.postedIsRestore).to(equal(false))
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
+        expect(self.backend.postedIsRestore).to(beFalse())
     }
 
     func testReceiptsSendsAsRestoreWhenAnon() {
         setupAnonPurchases()
         let product = MockProduct(mockProductIdentifier: "com.product.id1")
-        self.purchases?.makePurchase(product) { (tx, info, error) in
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
             
         }
 
@@ -503,14 +521,14 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        expect(self.backend.postReceiptDataCalled).to(equal(true))
-        expect(self.backend.postedIsRestore).to(equal(true))
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
+        expect(self.backend.postedIsRestore).to(beTrue())
     }
 
     func testFinishesTransactionsIfSentToBackendCorrectly() {
         setupPurchases()
         let product = MockProduct(mockProductIdentifier: "com.product.id1")
-        self.purchases?.makePurchase(product) { (tx, info, error) in
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
             
         }
 
@@ -525,15 +543,15 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        expect(self.backend.postReceiptDataCalled).to(equal(true))
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
         expect(self.storeKitWrapper.finishCalled).toEventually(beTrue())
     }
 
-    func testDoesntFinishTransactionsIfFinishingDisbaled() {
+    func testDoesntFinishTransactionsIfFinishingDisabled() {
         setupPurchases()
         self.purchases?.finishTransactions = false
         let product = MockProduct(mockProductIdentifier: "com.product.id1")
-        self.purchases?.makePurchase(product) { (tx, info, error) in
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
             
         }
 
@@ -548,7 +566,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        expect(self.backend.postReceiptDataCalled).to(equal(true))
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
         expect(self.storeKitWrapper.finishCalled).toEventually(beFalse())
     }
     
@@ -558,7 +576,7 @@ class PurchasesTests: XCTestCase {
         let productIdentifiers = ["com.product.id1", "com.product.id2"]
         purchases!.products(productIdentifiers) { (newProducts) in
             let product = newProducts[0];
-            self.purchases?.makePurchase(product) { (tx, info, error) in
+            self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
                 
             }
             
@@ -573,7 +591,7 @@ class PurchasesTests: XCTestCase {
             transaction.mockState = SKPaymentTransactionState.purchased
             self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
             
-            expect(self.backend.postReceiptDataCalled).to(equal(true))
+            expect(self.backend.postReceiptDataCalled).to(beTrue())
             expect(self.backend.postReceiptData).toNot(beNil())
 
             expect(self.backend.postedProductID).to(equal(product.productIdentifier))
@@ -628,57 +646,56 @@ class PurchasesTests: XCTestCase {
     func testAfterSendingDoesntFinishTransactionIfBackendError() {
         setupPurchases()
         let product = MockProduct(mockProductIdentifier: "com.product.id1")
-        self.purchases?.makePurchase(product) { (tx, info, error) in
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
             
         }
 
         let transaction = MockTransaction()
         transaction.mockPayment = self.storeKitWrapper.payment!
-
-        self.backend.postReceiptError = NSError(domain: "error_domain", code: RCUnfinishableError, userInfo: nil)
+        self.backend.postReceiptError = PurchasesErrorUtils.backendError(withBackendCode: RevenueCatBackendErrorCode.invalidAPIKey.rawValue as NSNumber, backendMessage: "Invalid credentials", finishable: false)
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        expect(self.backend.postReceiptDataCalled).to(equal(true))
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
         expect(self.storeKitWrapper.finishCalled).to(beFalse())
     }
 
     func testAfterSendingFinishesFromBackendErrorIfAppropriate() {
         setupPurchases()
         let product = MockProduct(mockProductIdentifier: "com.product.id1")
-        self.purchases?.makePurchase(product) { (tx, info, error) in
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
             
         }
 
         let transaction = MockTransaction()
         transaction.mockPayment = self.storeKitWrapper.payment!
 
-        self.backend.postReceiptError = NSError(domain: "error_domain", code: RCFinishableError, userInfo: nil)
+        self.backend.postReceiptError = PurchasesErrorUtils.backendError(withBackendCode: RevenueCatBackendErrorCode.invalidAPIKey.rawValue as NSNumber, backendMessage: "Invalid credentials", finishable: true)
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        expect(self.backend.postReceiptDataCalled).to(equal(true))
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
         expect(self.storeKitWrapper.finishCalled).toEventually(beTrue())
     }
 
     func testNotifiesIfTransactionFailsFromBackend() {
         setupPurchases()
         let product = MockProduct(mockProductIdentifier: "com.product.id1")
-        self.purchases?.makePurchase(product) { (tx, info, error) in
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
             
         }
 
         let transaction = MockTransaction()
         transaction.mockPayment = self.storeKitWrapper.payment!
 
-        self.backend.postReceiptError = NSError(domain: "error_domain", code: RCUnfinishableError, userInfo: nil)
+        self.backend.postReceiptError = PurchasesErrorUtils.backendError(withBackendCode: PurchasesErrorCode.invalidCredentialsError.rawValue as NSNumber, backendMessage: "Invalid credentials", finishable: false)
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        expect(self.backend.postReceiptDataCalled).to(equal(true))
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
         expect(self.storeKitWrapper.finishCalled).to(beFalse())
     }
 
@@ -686,7 +703,7 @@ class PurchasesTests: XCTestCase {
         setupPurchases()
         let product = MockProduct(mockProductIdentifier: "com.product.id1")
         var receivedError: Error?
-        self.purchases?.makePurchase(product) { (tx, info, error) in
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
             receivedError = error
         }
 
@@ -699,7 +716,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.failed
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        expect(self.backend.postReceiptDataCalled).to(equal(false))
+        expect(self.backend.postReceiptDataCalled).to(beFalse())
         expect(self.storeKitWrapper.finishCalled).to(beTrue())
         expect(receivedError).toEventuallyNot(beNil())
     }
@@ -710,10 +727,12 @@ class PurchasesTests: XCTestCase {
         
         var purchaserInfo: PurchaserInfo?
         var receivedError: Error?
+        var receivedUserCancelled: Bool?
         
-        self.purchases?.makePurchase(product) { (tx, info, error) in
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
             purchaserInfo = info
             receivedError = error
+            receivedUserCancelled = userCancelled
         }
 
         let transaction = MockTransaction()
@@ -727,6 +746,7 @@ class PurchasesTests: XCTestCase {
         expect(purchaserInfo).toEventually(be(self.backend.postReceiptPurchaserInfo))
         expect(receivedError).toEventually(beNil())
         expect(self.purchasesDelegate.purchaserInfoReceivedCount).to(equal(2))
+        expect(receivedUserCancelled).toEventually(beFalse())
     }
     
     func testCompletionBlockOnlyCalledOnce() {
@@ -735,7 +755,7 @@ class PurchasesTests: XCTestCase {
         
         var callCount = 0
         
-        self.purchases?.makePurchase(product) { (tx, info, error) in
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
             callCount += 1
         }
         
@@ -759,7 +779,7 @@ class PurchasesTests: XCTestCase {
         
         var callCount = 0
         
-        self.purchases?.makePurchase(product) { (tx, info, error) in
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
             callCount += 1
         }
         
@@ -780,20 +800,25 @@ class PurchasesTests: XCTestCase {
         let product = MockProduct(mockProductIdentifier: "com.product.id1")
         
         // First one "works"
-        self.purchases?.makePurchase(product) { (tx, info, error) in }
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in }
         
         var receivedInfo: PurchaserInfo?
-        var receivedError: Error?
+        var receivedError: NSError?
+        var receivedUserCancelled: Bool?
         
         // Second one issues an error
-        self.purchases?.makePurchase(product) { (tx, info, error) in
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
             receivedInfo = info
-            receivedError = error
+            receivedError = error as NSError?
+            receivedUserCancelled = userCancelled
         }
         
         expect(receivedInfo).toEventually(beNil())
         expect(receivedError).toEventuallyNot(beNil())
+        expect(receivedError?.domain).toEventually(equal(PurchasesErrorDomain))
+        expect(receivedError?.code).toEventually(equal(PurchasesErrorCode.operationAlreadyInProgressError.rawValue))
         expect(self.storeKitWrapper.addPaymentCallCount).to(equal(1))
+        expect(receivedUserCancelled).toEventually(beFalse())
     }
 
     func testDoesntIgnorePurchasesThatDoNotHaveApplicationUserNames() {
@@ -810,7 +835,7 @@ class PurchasesTests: XCTestCase {
 
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        expect(self.backend.postReceiptDataCalled).to(equal(true))
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
     }
 
     func testDoesntSetWrapperDelegateToNilIfDelegateNil() {
@@ -861,27 +886,28 @@ class PurchasesTests: XCTestCase {
     func testRestoringPurchasesPostsTheReceipt() {
         setupPurchases()
         purchases!.restoreTransactions()
-        expect(self.backend.postReceiptDataCalled).to(equal(true))
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
     }
 
     func testRestoringPurchasesRefreshesAndPostsTheReceipt() {
         setupPurchases()
+        self.receiptFetcher.shouldReturnReceipt = false
         purchases!.restoreTransactions()
 
-        expect(self.requestFetcher.refreshReceiptCalled).to(equal(true))
+        expect(self.requestFetcher.refreshReceiptCalled).to(beTrue())
     }
 
     func testRestoringPurchasesSetsIsRestore() {
         setupPurchases()
         purchases!.restoreTransactions(nil)
-        expect(self.backend.postedIsRestore!).to(equal(true))
+        expect(self.backend.postedIsRestore!).to(beTrue())
     }
 
     func testRestoringPurchasesSetsIsRestoreForAnon() {
         setupAnonPurchases()
         purchases!.restoreTransactions(nil)
 
-        expect(self.backend.postedIsRestore!).to(equal(true))
+        expect(self.backend.postedIsRestore!).to(beTrue())
     }
 
     func testRestoringPurchasesCallsSuccessDelegateMethod() {
@@ -902,7 +928,8 @@ class PurchasesTests: XCTestCase {
     func testRestorePurchasesPassesErrorOnFailure() {
         setupPurchases()
         
-        let error = NSError(domain: "error_domain", code: RCFinishableError, userInfo: nil)
+        let error = PurchasesErrorUtils.backendError(withBackendCode: RevenueCatBackendErrorCode.invalidAPIKey.rawValue as NSNumber, backendMessage: "Invalid credentials", finishable:true)
+        
         self.backend.postReceiptError = error
         self.purchasesDelegate.purchaserInfo = nil
         
@@ -954,7 +981,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
         
-        expect(self.backend.postReceiptDataCalled).to(equal(true))
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
         expect(self.backend.postedProductID).to(equal(product.productIdentifier))
         expect(self.backend.postedPrice).to(equal(product.price))
     }
@@ -1004,7 +1031,7 @@ class PurchasesTests: XCTestCase {
         setupPurchases()
         purchases!.checkTrialOrIntroductoryPriceEligibility([]) { (eligibilities) in}
 
-        expect(self.requestFetcher.refreshReceiptCalled).to(beTrue())
+        expect(self.receiptFetcher.receiptDataCalled).to(beTrue())
     }
 
     func testFetchVersionSendsAReceiptIfNoVersion() {
@@ -1058,7 +1085,7 @@ class PurchasesTests: XCTestCase {
             ]]);
 
         let product = MockProduct(mockProductIdentifier: "com.product.id1")
-        self.purchases?.makePurchase(product) { (tx, info, error) in
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
             
         }
 
@@ -1071,7 +1098,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        expect(self.backend.postReceiptDataCalled).to(equal(true))
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
 
         expect(self.userDefaults.cachedUserInfoCount).toEventually(equal(2))
     }
@@ -1135,7 +1162,7 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.gotEntitlements).toEventually(equal(1))
         self.purchases?.entitlements { (newEntitlements, _) in
             let product = (newEntitlements?["pro"]?.offerings["monthly"]?.activeProduct)!;
-            self.purchases?.makePurchase(product) { (tx, info, error) in
+            self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
                 
             }
             
@@ -1150,7 +1177,7 @@ class PurchasesTests: XCTestCase {
             transaction.mockState = SKPaymentTransactionState.purchased
             self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
             
-            expect(self.backend.postReceiptDataCalled).to(equal(true))
+            expect(self.backend.postReceiptDataCalled).to(beTrue())
             expect(self.backend.postReceiptData).toNot(beNil())
             
             expect(self.backend.postedProductID).to(equal(product.productIdentifier))
@@ -1232,7 +1259,7 @@ class PurchasesTests: XCTestCase {
         
         expect(completionCalled).toEventually(beTrue())
         
-        self.backend.aliasError = NSError(domain: "error_domain", code: RCFinishableError, userInfo: nil)
+        self.backend.aliasError = PurchasesErrorUtils.backendError(withBackendCode: RevenueCatBackendErrorCode.invalidAPIKey.rawValue as NSNumber, backendMessage: "Invalid credentials", finishable:true)
         
         self.purchases?.createAlias("cesardro") { (info, error) in
             completionCalled = error == nil
@@ -1262,7 +1289,7 @@ class PurchasesTests: XCTestCase {
         let newAppUserID = "cesarPedro"
         
         self.purchases?.identify(newAppUserID)
-        identifiedSuccesfully(appUserID: newAppUserID)
+        identifiedSuccessfully(appUserID: newAppUserID)
         expect(self.userDefaults.cachedUserInfo.count).toEventually(equal(2))
         expect(self.purchasesDelegate.purchaserInfoReceivedCount).toEventually(equal(2))
     }
@@ -1273,13 +1300,13 @@ class PurchasesTests: XCTestCase {
         
         let newAppUserID = "cesarPedro"
         self.purchases?.createAlias(newAppUserID) { (info, error) in
-            self.identifiedSuccesfully(appUserID: newAppUserID)
+            self.identifiedSuccessfully(appUserID: newAppUserID)
         }
     }
     
     func testInitCallsIdentifies() {
         setupPurchases()
-        self.identifiedSuccesfully(appUserID: appUserID)
+        self.identifiedSuccessfully(appUserID: appUserID)
         expect(self.purchasesDelegate.purchaserInfoReceivedCount).toEventually(equal(1))
     }
     
@@ -1396,7 +1423,95 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.getSubscriberCallCount).toEventually(equal(1));
     }
 
-    private func identifiedSuccesfully(appUserID: String) {
+    func testWhenNoReceiptDataReceiptIsRefreshed() {
+        setupPurchases()
+        self.receiptFetcher.shouldReturnReceipt = false
+        self.purchases?.restoreTransactions()
+        expect(self.requestFetcher.refreshReceiptCalled).to(beTrue())
+    }
+
+    func testRestoresDontPostMissingReceipts() {
+        setupPurchases()
+        self.receiptFetcher.shouldReturnReceipt = false
+        var receivedError: NSError?
+        self.purchases?.restoreTransactions() { (info, error) in
+            receivedError = error as NSError?
+        }
+
+        expect(receivedError?.code).toEventually(be(PurchasesErrorCode.missingReceiptFileError.rawValue))
+    }
+
+    func testUserCancelledFalseIfPurchaseSuccessful() {
+        setupPurchases()
+        let product = MockProduct(mockProductIdentifier: "com.product.id1")
+        var receivedUserCancelled: Bool?
+
+        // Second one issues an error
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
+            receivedUserCancelled = userCancelled
+        }
+
+        let transaction = MockTransaction()
+        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockState = SKPaymentTransactionState.purchased
+        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+
+        expect(receivedUserCancelled).toEventually(beFalse())
+    }
+
+    func testUserCancelledTrueIfPurchaseCancelled() {
+        setupPurchases()
+        let product = MockProduct(mockProductIdentifier: "com.product.id1")
+        var receivedUserCancelled: Bool?
+        var receivedError: NSError?
+        var receivedUnderlyingError: NSError?
+
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
+            receivedError = error as NSError?
+            receivedUserCancelled = userCancelled
+            receivedUnderlyingError = receivedError?.userInfo[NSUnderlyingErrorKey] as! NSError?
+        }
+
+        let transaction = MockTransaction()
+        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockState = SKPaymentTransactionState.failed
+        transaction.mockError = NSError.init(domain: SKErrorDomain, code: SKError.Code.paymentCancelled.rawValue)
+        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+
+        expect(receivedUserCancelled).toEventually(beTrue())
+        expect(receivedError).toEventuallyNot(beNil())
+        expect(receivedError?.domain).toEventually(be(PurchasesErrorDomain))
+        expect(receivedError?.code).toEventually(be(PurchasesErrorCode.purchaseCancelledError.rawValue))
+        expect(receivedUnderlyingError?.domain).toEventually(be(SKErrorDomain))
+        expect(receivedUnderlyingError?.code).toEventually(equal(SKError.Code.paymentCancelled.rawValue))
+    }
+
+    func testDoNotSendEmptyReceiptWhenMakingPurchase() {
+        setupPurchases()
+        self.receiptFetcher.shouldReturnReceipt = false
+
+        let product = MockProduct(mockProductIdentifier: "com.product.id1")
+        var receivedUserCancelled: Bool?
+        var receivedError: NSError?
+        var receivedUnderlyingError: NSError?
+
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
+            receivedError = error as NSError?
+            receivedUserCancelled = userCancelled
+            receivedUnderlyingError = receivedError?.userInfo[NSUnderlyingErrorKey] as! NSError?
+        }
+
+        let transaction = MockTransaction()
+        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockState = SKPaymentTransactionState.purchased
+        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+
+        expect(receivedUserCancelled).toEventually(beFalse())
+        expect(receivedError?.code).toEventually(be(PurchasesErrorCode.missingReceiptFileError.rawValue))
+        expect(self.backend.postReceiptDataCalled).toEventually(beFalse())
+    }
+
+    private func identifiedSuccessfully(appUserID: String) {
         expect(self.userDefaults.cachedUserInfo[self.userDefaults.appUserIDKey]).to(beNil())
         expect(self.purchases?.appUserID).to(equal(appUserID))
         expect(self.purchases?.allowSharingAppStoreAccount).to(beFalse())


### PR DESCRIPTION
Easier way to detect if user cancelled purchase
---
- Adds `userCancelled` as a parameter to the completion block of the makePurchase function

Avoid sending empty receipts to the backend
---
- Avoids posting empty receipts when restoring transactions and when making a purchase.  It will return a `RCMissingReceiptFileError` instead. 
- Avoid sending receipt when get intro eligibility if no receipt. It will just return an `RCIntroEligibilityStatusUnknown`.

Better error codes
---
- Creates `NSError+Purchases.h` that contain `RCPurchasesErrorCode`, `RCBackendErrorCode` and the UserInfo dictionary keys
- Unifies the Error domain to a single `RCPurchasesErrorDomain`. There is a `RCBackendErrorDomain` used in underlying backend errors.
- If there is an SKError it maps the error code to our own set of errors and adds the SKError as an underlying error in the UserInfo dictionary
- For network connectivity errors it returns a `RCNetworkError` with the underlying error in the user info dictionary.
- For backend erorrs, it maps the error code to our own errors and adds the backend response as the originating error.

Other
---
- Fixes Eligibility typo

