### PR TITLE
Adds observer mode as a boolean in configuration function

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "AliSoftware/OHHTTPStubs" "6.1.0"
-github "Quick/Nimble" "v8.0.0"
+github "AliSoftware/OHHTTPStubs" "8.0.0"
+github "Quick/Nimble" "v8.0.1"

--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -133,7 +133,7 @@ NS_SWIFT_NAME(Purchases)
 
 
 /**
- Configures an instance of the Purchases SDK with object with a custom userDefaults. Use this constructor if you want to sync status across a shared container, such as between a host app and an extension. The instance of the Purchases SDK will be set as a singleton. You should access the singleton instance using [RCPurchases sharedPurchases]
+ Configures an instance of the Purchases SDK with a custom userDefaults. Use this constructor if you want to sync status across a shared container, such as between a host app and an extension. The instance of the Purchases SDK will be set as a singleton. You should access the singleton instance using [RCPurchases sharedPurchases]
  
  @param APIKey The API Key generated for your app from https://app.revenuecat.com/
  
@@ -141,7 +141,7 @@ NS_SWIFT_NAME(Purchases)
  
  @param userDefaults Custom userDefaults to use
  
- @param observerMode Set this to TRUE if you have your own subscription system and want to use only RevenueCat's backend. Default is FALSE.
+ @param observerMode Set this to TRUE if you have your own IAP implementation and want to use only RevenueCat's backend. Default is FALSE.
  
  @return An instantiated `RCPurchases` object that has been set as a singleton.
  */

--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -148,7 +148,7 @@ NS_SWIFT_NAME(Purchases)
 + (instancetype)configureWithAPIKey:(NSString *)APIKey
                           appUserID:(NSString * _Nullable)appUserID
                        userDefaults:(NSUserDefaults * _Nullable)userDefaults
-                       observerMode:(Boolean)observerMode;
+                       observerMode:(BOOL)observerMode;
 
 /**
  Indicates whether the user is allowed to make payments.

--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -130,6 +130,26 @@ NS_SWIFT_NAME(Purchases)
 + (instancetype)configureWithAPIKey:(NSString *)APIKey
                           appUserID:(NSString * _Nullable)appUserID
                        userDefaults:(NSUserDefaults * _Nullable)userDefaults;
+
+
+/**
+ Configures an instance of the Purchases SDK with object with a custom userDefaults. Use this constructor if you want to sync status across a shared container, such as between a host app and an extension. The instance of the Purchases SDK will be set as a singleton. You should access the singleton instance using [RCPurchases sharedPurchases]
+ 
+ @param APIKey The API Key generated for your app from https://app.revenuecat.com/
+ 
+ @param appUserID The unique app user id for this user. This user id will allow users to share their purchases and subscriptions across devices. Pass nil if you want `RCPurchases` to generate this for you.
+ 
+ @param userDefaults Custom userDefaults to use
+ 
+ @param observerMode Set this to TRUE if you have your own subscription system and want to use only RevenueCat's backend. Default is FALSE.
+ 
+ @return An instantiated `RCPurchases` object that has been set as a singleton.
+ */
++ (instancetype)configureWithAPIKey:(NSString *)APIKey
+                          appUserID:(NSString * _Nullable)appUserID
+                       userDefaults:(NSUserDefaults * _Nullable)userDefaults
+                       observerMode:(Boolean)observerMode;
+
 /**
  Indicates whether the user is allowed to make payments.
  */

--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -117,7 +117,7 @@ NS_SWIFT_NAME(Purchases)
 + (instancetype)configureWithAPIKey:(NSString *)APIKey appUserID:(NSString * _Nullable)appUserID;
 
 /**
- Configures an instance of the Purchases SDK with object with a custom userDefaults. Use this constructor if you want to sync status across a shared container, such as between a host app and an extension. The instance of the Purchases SDK will be set as a singleton. You should access the singleton instance using [RCPurchases sharedPurchases]
+ Configures an instance of the Purchases SDK with a custom userDefaults. Use this constructor if you want to sync status across a shared container, such as between a host app and an extension. The instance of the Purchases SDK will be set as a singleton. You should access the singleton instance using [RCPurchases sharedPurchases]
 
  @param APIKey The API Key generated for your app from https://app.revenuecat.com/
 

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -107,7 +107,7 @@ static RCPurchases *_sharedPurchases = nil;
 + (instancetype)configureWithAPIKey:(NSString *)APIKey
                           appUserID:(NSString *)appUserID
                        userDefaults:(NSUserDefaults * _Nullable)userDefaults
-                       observerMode:(Boolean)observerMode
+                       observerMode:(BOOL)observerMode
 {
     RCPurchases *purchases = [[RCPurchases alloc] initWithAPIKey:APIKey appUserID:appUserID userDefaults:userDefaults observerMode:observerMode];
     [RCPurchases setDefaultInstance:purchases];
@@ -122,7 +122,7 @@ static RCPurchases *_sharedPurchases = nil;
 - (instancetype)initWithAPIKey:(NSString *)APIKey
                      appUserID:(NSString * _Nullable)appUserID
                   userDefaults:(NSUserDefaults * _Nullable)userDefaults
-                  observerMode:(Boolean)observerMode
+                  observerMode:(BOOL)observerMode
 {
     RCStoreKitRequestFetcher *fetcher = [[RCStoreKitRequestFetcher alloc] init];
     RCReceiptFetcher *receiptFetcher = [[RCReceiptFetcher alloc] init];
@@ -150,7 +150,7 @@ static RCPurchases *_sharedPurchases = nil;
                   storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper
                notificationCenter:(NSNotificationCenter *)notificationCenter
                      userDefaults:(NSUserDefaults *)userDefaults
-                     observerMode:(Boolean)observerMode
+                     observerMode:(BOOL)observerMode
 {
     if (self = [super init]) {
         RCDebugLog(@"Debug logging enabled.");

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -693,6 +693,7 @@ static RCPurchases *_sharedPurchases = nil;
      updatedTransaction:(SKPaymentTransaction *)transaction
 {
     switch (transaction.transactionState) {
+        case SKPaymentTransactionStateRestored: // For observer mode
         case SKPaymentTransactionStatePurchased: {
             [self handlePurchasedTransaction:transaction];
             break;
@@ -721,7 +722,6 @@ static RCPurchases *_sharedPurchases = nil;
         }
         case SKPaymentTransactionStateDeferred:
         case SKPaymentTransactionStatePurchasing:
-        case SKPaymentTransactionStateRestored:
             break;
     }
 }

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -89,19 +89,19 @@ static RCPurchases *_sharedPurchases = nil;
 
 + (instancetype)configureWithAPIKey:(NSString *)APIKey
 {
-    return [RCPurchases configureWithAPIKey:APIKey appUserID:nil];
+    return [self configureWithAPIKey:APIKey appUserID:nil];
 }
 
 + (instancetype)configureWithAPIKey:(NSString *)APIKey appUserID:(NSString * _Nullable)appUserID
 {
-    return [RCPurchases configureWithAPIKey:APIKey appUserID:appUserID userDefaults:nil];
+    return [self configureWithAPIKey:APIKey appUserID:appUserID userDefaults:nil];
 }
 
 + (instancetype)configureWithAPIKey:(NSString *)APIKey
                           appUserID:(NSString * _Nullable)appUserID
                        userDefaults:(NSUserDefaults * _Nullable)userDefaults
 {
-    return [RCPurchases configureWithAPIKey:APIKey appUserID:appUserID userDefaults:nil observerMode:false];
+    return [self configureWithAPIKey:APIKey appUserID:appUserID userDefaults:nil observerMode:false];
 }
 
 + (instancetype)configureWithAPIKey:(NSString *)APIKey
@@ -109,8 +109,8 @@ static RCPurchases *_sharedPurchases = nil;
                        userDefaults:(NSUserDefaults * _Nullable)userDefaults
                        observerMode:(BOOL)observerMode
 {
-    RCPurchases *purchases = [[RCPurchases alloc] initWithAPIKey:APIKey appUserID:appUserID userDefaults:userDefaults observerMode:observerMode];
-    [RCPurchases setDefaultInstance:purchases];
+    RCPurchases *purchases = [[self alloc] initWithAPIKey:APIKey appUserID:appUserID userDefaults:userDefaults observerMode:observerMode];
+    [self setDefaultInstance:purchases];
     return purchases;
 }
 

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -344,6 +344,9 @@ static RCPurchases *_sharedPurchases = nil;
             withPayment:(SKMutablePayment *)payment
              completion:(RCPurchaseCompletedBlock)completion
 {
+    if (!self.finishTransactions) {
+        RCDebugLog(@"Observer mode is active (finishTransactions is set to false) and makePurchase has been called. Are you sure you want to do this?");
+    }
     payment.applicationUsername = self.appUserID;
 
     // This is to prevent the UIApplicationDidBecomeActive call from the purchase popup
@@ -374,6 +377,9 @@ static RCPurchases *_sharedPurchases = nil;
 
 - (void)restoreTransactionsWithCompletionBlock:(RCReceivePurchaserInfoBlock)completion
 {
+    if (!self.allowSharingAppStoreAccount) {
+        RCDebugLog(@"allowSharingAppStoreAccount is set to false and restoreTransactions has been called. Are you sure you want to do this?");
+    }
     // Refresh the receipt and post to backend, this will allow the transactions to be transferred.
     // https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/StoreKitGuide/Chapters/Restoring.html
     [self receiptData:^(NSData * _Nonnull data) {

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -89,40 +89,40 @@ static RCPurchases *_sharedPurchases = nil;
 
 + (instancetype)configureWithAPIKey:(NSString *)APIKey
 {
-    RCPurchases *purchases = [[RCPurchases alloc] initWithAPIKey:APIKey];
-    [RCPurchases setDefaultInstance:purchases];
-    return purchases;
-}
-
-- (instancetype)initWithAPIKey:(NSString *)APIKey
-{
-    return [self initWithAPIKey:APIKey appUserID:nil];
+    return [RCPurchases configureWithAPIKey:APIKey appUserID:nil];
 }
 
 + (instancetype)configureWithAPIKey:(NSString *)APIKey appUserID:(NSString * _Nullable)appUserID
 {
-    RCPurchases *purchases = [[RCPurchases alloc] initWithAPIKey:APIKey appUserID:appUserID];
-    [RCPurchases setDefaultInstance:purchases];
-    return purchases;
-}
-
-- (instancetype)initWithAPIKey:(NSString *)APIKey appUserID:(NSString * _Nullable)appUserID
-{
-    return [self initWithAPIKey:APIKey appUserID:appUserID userDefaults:nil];
+    return [RCPurchases configureWithAPIKey:APIKey appUserID:appUserID userDefaults:nil];
 }
 
 + (instancetype)configureWithAPIKey:(NSString *)APIKey
                           appUserID:(NSString * _Nullable)appUserID
                        userDefaults:(NSUserDefaults * _Nullable)userDefaults
 {
-    RCPurchases *purchases = [[RCPurchases alloc] initWithAPIKey:APIKey appUserID:appUserID userDefaults:userDefaults];
+    return [RCPurchases configureWithAPIKey:APIKey appUserID:appUserID userDefaults:nil observerMode:false];
+}
+
++ (instancetype)configureWithAPIKey:(NSString *)APIKey
+                          appUserID:(NSString *)appUserID
+                       userDefaults:(NSUserDefaults * _Nullable)userDefaults
+                       observerMode:(Boolean)observerMode
+{
+    RCPurchases *purchases = [[RCPurchases alloc] initWithAPIKey:APIKey appUserID:appUserID userDefaults:userDefaults observerMode:observerMode];
     [RCPurchases setDefaultInstance:purchases];
     return purchases;
+}
+
+- (instancetype)initWithAPIKey:(NSString *)APIKey appUserID:(NSString * _Nullable)appUserID
+{
+    return [self initWithAPIKey:APIKey appUserID:appUserID userDefaults:nil observerMode:false];
 }
 
 - (instancetype)initWithAPIKey:(NSString *)APIKey
                      appUserID:(NSString * _Nullable)appUserID
                   userDefaults:(NSUserDefaults * _Nullable)userDefaults
+                  observerMode:(Boolean)observerMode
 {
     RCStoreKitRequestFetcher *fetcher = [[RCStoreKitRequestFetcher alloc] init];
     RCReceiptFetcher *receiptFetcher = [[RCReceiptFetcher alloc] init];
@@ -139,7 +139,8 @@ static RCPurchases *_sharedPurchases = nil;
                            backend:backend
                    storeKitWrapper:storeKitWrapper
                 notificationCenter:[NSNotificationCenter defaultCenter]
-                      userDefaults:userDefaults];
+                      userDefaults:userDefaults
+                      observerMode:observerMode];
 }
 
 - (instancetype)initWithAppUserID:(NSString *)appUserID
@@ -149,6 +150,7 @@ static RCPurchases *_sharedPurchases = nil;
                   storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper
                notificationCenter:(NSNotificationCenter *)notificationCenter
                      userDefaults:(NSUserDefaults *)userDefaults
+                     observerMode:(Boolean)observerMode
 {
     if (self = [super init]) {
         RCDebugLog(@"Debug logging enabled.");
@@ -166,7 +168,7 @@ static RCPurchases *_sharedPurchases = nil;
         self.productsByIdentifier = [NSMutableDictionary new];
         self.purchaseCompleteCallbacks = [NSMutableDictionary new];
 
-        self.finishTransactions = YES;
+        self.finishTransactions = !observerMode;
         
         RCReceivePurchaserInfoBlock callDelegate = ^void(RCPurchaserInfo *info, NSError *error) {
             if (info) {

--- a/Purchases/RCPurchases+Protected.h
+++ b/Purchases/RCPurchases+Protected.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
                             storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper
                          notificationCenter:(NSNotificationCenter *)notificationCenter
                                userDefaults:(NSUserDefaults *)userDefaults
-                               observerMode:(Boolean)observerMode;
+                               observerMode:(BOOL)observerMode;
 
 @end
 

--- a/Purchases/RCPurchases+Protected.h
+++ b/Purchases/RCPurchases+Protected.h
@@ -19,7 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
                                     backend:(RCBackend *)backend
                             storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper
                          notificationCenter:(NSNotificationCenter *)notificationCenter
-                               userDefaults:(NSUserDefaults *)userDefaults;
+                               userDefaults:(NSUserDefaults *)userDefaults
+                               observerMode:(Boolean)observerMode;
 
 @end
 

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -330,44 +330,44 @@ class PurchasesTests: XCTestCase {
 
     func setupPurchases() {
         purchases = Purchases(appUserID: appUserID,
-                                requestFetcher: requestFetcher,
-                                receiptFetcher: receiptFetcher,
-                                backend:backend,
-                                storeKitWrapper: storeKitWrapper,
-                                notificationCenter:notificationCenter,
-                                userDefaults:userDefaults,
-                                observerMode:false)
+                requestFetcher: requestFetcher,
+                receiptFetcher: receiptFetcher,
+                backend: backend,
+                storeKitWrapper: storeKitWrapper,
+                notificationCenter: notificationCenter,
+                userDefaults: userDefaults,
+                observerMode: false)
 
         purchases!.delegate = purchasesDelegate
     }
 
     func setupAnonPurchases() {
         purchases = Purchases(appUserID: nil,
-                                requestFetcher: requestFetcher,
-                                receiptFetcher: receiptFetcher,
-                                backend:backend,
-                                storeKitWrapper: storeKitWrapper,
-                                notificationCenter:notificationCenter,
-                                userDefaults:userDefaults,
-                                observerMode: false)
+                requestFetcher: requestFetcher,
+                receiptFetcher: receiptFetcher,
+                backend: backend,
+                storeKitWrapper: storeKitWrapper,
+                notificationCenter: notificationCenter,
+                userDefaults: userDefaults,
+                observerMode: false)
+
+        purchases!.delegate = purchasesDelegate
+    }
+
+    func setupPurchasesObserverModeOn() {
+        purchases = Purchases(appUserID: nil,
+                requestFetcher: requestFetcher,
+                receiptFetcher: receiptFetcher,
+                backend: backend,
+                storeKitWrapper: storeKitWrapper,
+                notificationCenter: notificationCenter,
+                userDefaults: userDefaults,
+                observerMode: true)
 
         purchases!.delegate = purchasesDelegate
     }
     
-    func setupPurchasesObserverModeOn() {
-        purchases = Purchases(appUserID: nil,
-                              requestFetcher: requestFetcher,
-                              receiptFetcher: receiptFetcher,
-                              backend:backend,
-                              storeKitWrapper: storeKitWrapper,
-                              notificationCenter:notificationCenter,
-                              userDefaults:userDefaults,
-                              observerMode: true)
-        
-        purchases!.delegate = purchasesDelegate
-    }
-    
-    func testIsAbleToBeIntialized() {
+    func testIsAbleToBeInitialized() {
         setupPurchases()
         expect(self.purchases).toNot(beNil())
     }

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -335,7 +335,8 @@ class PurchasesTests: XCTestCase {
                                 backend:backend,
                                 storeKitWrapper: storeKitWrapper,
                                 notificationCenter:notificationCenter,
-                                userDefaults:userDefaults)
+                                userDefaults:userDefaults,
+                                observerMode:false)
 
         purchases!.delegate = purchasesDelegate
     }
@@ -347,8 +348,22 @@ class PurchasesTests: XCTestCase {
                                 backend:backend,
                                 storeKitWrapper: storeKitWrapper,
                                 notificationCenter:notificationCenter,
-                                userDefaults:userDefaults)
+                                userDefaults:userDefaults,
+                                observerMode: false)
 
+        purchases!.delegate = purchasesDelegate
+    }
+    
+    func setupPurchasesObserverModeOn() {
+        purchases = Purchases(appUserID: nil,
+                              requestFetcher: requestFetcher,
+                              receiptFetcher: receiptFetcher,
+                              backend:backend,
+                              storeKitWrapper: storeKitWrapper,
+                              notificationCenter:notificationCenter,
+                              userDefaults:userDefaults,
+                              observerMode: true)
+        
         purchases!.delegate = purchasesDelegate
     }
     
@@ -1637,6 +1652,50 @@ class PurchasesTests: XCTestCase {
         }
     }
 
+    func testObserverModeSetToFalseSetFinishTransactions() {
+        setupPurchases()
+        let product = MockProduct(mockProductIdentifier: "com.product.id1")
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
+            
+        }
+        
+        let transaction = MockTransaction()
+        transaction.mockPayment = self.storeKitWrapper.payment!
+        
+        transaction.mockState = SKPaymentTransactionState.purchasing
+        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        
+        self.backend.postReceiptPurchaserInfo = PurchaserInfo()
+        
+        transaction.mockState = SKPaymentTransactionState.purchased
+        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
+        expect(self.storeKitWrapper.finishCalled).toEventually(beTrue())
+    }
+    
+    func testDoesntFinishTransactionsIfObserverModeIsSet() {
+        setupPurchasesObserverModeOn()
+        let product = MockProduct(mockProductIdentifier: "com.product.id1")
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
+            
+        }
+        
+        let transaction = MockTransaction()
+        transaction.mockPayment = self.storeKitWrapper.payment!
+        
+        transaction.mockState = SKPaymentTransactionState.purchasing
+        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        
+        self.backend.postReceiptPurchaserInfo = PurchaserInfo()
+        
+        transaction.mockState = SKPaymentTransactionState.purchased
+        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
+        expect(self.storeKitWrapper.finishCalled).toEventually(beFalse())
+    }
+    
     private func identifiedSuccessfully(appUserID: String) {
         expect(self.userDefaults.cachedUserInfo[self.userDefaults.appUserIDKey]).to(beNil())
         expect(self.purchases?.appUserID).to(equal(appUserID))

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -1696,6 +1696,23 @@ class PurchasesTests: XCTestCase {
         expect(self.storeKitWrapper.finishCalled).toEventually(beFalse())
     }
     
+    func testRestoredPurchasesArePosted() {
+        setupPurchasesObserverModeOn()
+        let product = MockProduct(mockProductIdentifier: "com.product.id1")
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
+            
+        }
+        
+        let transaction = MockTransaction()
+        transaction.mockPayment = self.storeKitWrapper.payment!
+        
+        transaction.mockState = SKPaymentTransactionState.restored
+        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
+        expect(self.storeKitWrapper.finishCalled).toEventually(beFalse())
+    }
+    
     private func identifiedSuccessfully(appUserID: String) {
         expect(self.userDefaults.cachedUserInfo[self.userDefaults.appUserIDKey]).to(beNil())
         expect(self.purchases?.appUserID).to(equal(appUserID))


### PR DESCRIPTION
- Adds an optional `observerMode` to configure function
- Treats SKPaymentTransactionStateRestored transactions same as purchases to offer observer mode for restores too


