### PR TITLE
Support removing current instance

### DIFF
--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -130,10 +130,21 @@ NS_SWIFT_NAME(Purchases)
 + (instancetype)configureWithAPIKey:(NSString *)APIKey
                           appUserID:(NSString * _Nullable)appUserID
                        userDefaults:(NSUserDefaults * _Nullable)userDefaults;
+
+/**
+ Removes the current configured instance.
+ */
++ (void)removeInstance;
+
 /**
  Indicates whether the user is allowed to make payments.
  */
 + (BOOL)canMakePayments;
+
+/**
+ Indicates if the default instance is configured.
+ */
++ (BOOL)isConfigured;
 
 /**
  @return A singleton `RCPurchases` object. Call this after a configure method to access the singleton.

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -82,9 +82,25 @@ static RCPurchases *_sharedPurchases = nil;
     }
 }
 
++ (void)removeInstance
+{
+    @synchronized([RCPurchases class]) {
+        if (!_sharedPurchases) {
+            RCLog(@"There is no configured instance to remove.");
+        }
+
+        _sharedPurchases = nil;
+    }
+}
+
 + (BOOL)canMakePayments
 {
     return [SKPaymentQueue canMakePayments];
+}
+
++ (BOOL)isConfigured
+{
+    return _sharedPurchases != nil;
 }
 
 + (instancetype)configureWithAPIKey:(NSString *)APIKey

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -1299,6 +1299,13 @@ class PurchasesTests: XCTestCase {
         let purchases = Purchases.configure(withAPIKey: "", appUserID: "", userDefaults: nil)
         expect(Purchases.shared).toEventually(equal(purchases))
     }
+
+    func testRemoveInstance() {
+        Purchases.configure(withAPIKey: "")
+        Purchases.removeInstance()
+
+        expect(Purchases.isConfigured()).toEventually(equal(false))
+    }
     
     func testCreateAliasWithCompletionCallsBackend() {
         setupPurchases()


### PR DESCRIPTION
This PR adds support to allow removing the current configured instance of `Purchases`.

For example, this adds the possibility to developers to stop processing purchases if the users signs out and not create anonymous IDs.

Issue: #102