### PR TITLE
Renames automaticAttributionCollection to automaticAppleSearchAdsAttributionCollection

### DIFF
--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -86,9 +86,14 @@ NS_SWIFT_NAME(Purchases)
 @interface RCPurchases : NSObject
 
 /**
- Enable automatic collection of Apple Search Ad attribution. Disabled by default
+ Enable automatic collection of Apple Search Ads attribution. Disabled by default
  */
-@property (class, nonatomic, assign) BOOL automaticAttributionCollection;
+@property (class, nonatomic, assign) BOOL automaticAttributionCollection DEPRECATED_MSG_ATTRIBUTE("Use automaticAppleSearchAdsAttributionCollection instead.");
+
+/**
+ Enable automatic collection of Apple Search Ads attribution. Disabled by default
+ */
+@property (class, nonatomic, assign) BOOL automaticAppleSearchAdsAttributionCollection;
 
 /**
  Enable debug logging. Useful for debugging issues with the lovely team @RevenueCat

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -58,26 +58,26 @@ NSMutableArray<RCAttributionData *> * _Nullable postponedAttributionData;
 #pragma mark - Configuration
 static RCPurchases *_sharedPurchases = nil;
 
-static BOOL _automaticAppleSearchAdAttributionCollection = NO;
+static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 
 + (void)setAutomaticAttributionCollection:(BOOL)automaticAttributionCollection
 {
-    _automaticAppleSearchAdAttributionCollection = automaticAttributionCollection;
+    _automaticAppleSearchAdsAttributionCollection = automaticAttributionCollection;
 }
 
 + (void)setAutomaticAppleSearchAdsAttributionCollection:(BOOL)automaticAppleSearchAdsAttributionCollection
 {
-    _automaticAppleSearchAdAttributionCollection = automaticAppleSearchAdsAttributionCollection;
+    _automaticAppleSearchAdsAttributionCollection = automaticAppleSearchAdsAttributionCollection;
 }
 
 + (BOOL)automaticAttributionCollection
 {
-    return _automaticAppleSearchAdAttributionCollection;
+    return _automaticAppleSearchAdsAttributionCollection;
 }
 
 + (BOOL)automaticAppleSearchAdsAttributionCollection
 {
-    return _automaticAppleSearchAdAttributionCollection;
+    return _automaticAppleSearchAdsAttributionCollection;
 }
 
 + (void)setDebugLogsEnabled:(BOOL)enabled
@@ -236,7 +236,7 @@ static BOOL _automaticAppleSearchAdAttributionCollection = NO;
         
         postponedAttributionData = nil;
         
-        if (_automaticAppleSearchAdAttributionCollection) {
+        if (_automaticAppleSearchAdsAttributionCollection) {
             NSString *latestNetworkIdAndAdvertisingIdSentToAppleSearchAds = [self latestNetworkIdAndAdvertisingIdentifierSentForNetwork:RCAttributionNetworkAppleSearchAds];
             if (latestNetworkIdAndAdvertisingIdSentToAppleSearchAds == nil) {
                 [attributionFetcher adClientAttributionDetailsWithCompletionBlock:^(NSDictionary<NSString *, NSObject *> * _Nullable attributionDetails, NSError * _Nullable error) {

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -58,16 +58,26 @@ NSMutableArray<RCAttributionData *> * _Nullable postponedAttributionData;
 #pragma mark - Configuration
 static RCPurchases *_sharedPurchases = nil;
 
-static BOOL _automaticAttributionCollection = NO;
+static BOOL _automaticAppleSearchAdAttributionCollection = NO;
 
 + (void)setAutomaticAttributionCollection:(BOOL)automaticAttributionCollection
 {
-    _automaticAttributionCollection = automaticAttributionCollection;
+    _automaticAppleSearchAdAttributionCollection = automaticAttributionCollection;
+}
+
++ (void)setAutomaticAppleSearchAdsAttributionCollection:(BOOL)automaticAppleSearchAdsAttributionCollection
+{
+    _automaticAppleSearchAdAttributionCollection = automaticAppleSearchAdsAttributionCollection;
 }
 
 + (BOOL)automaticAttributionCollection
 {
-    return _automaticAttributionCollection;
+    return _automaticAppleSearchAdAttributionCollection;
+}
+
++ (BOOL)automaticAppleSearchAdsAttributionCollection
+{
+    return _automaticAppleSearchAdAttributionCollection;
 }
 
 + (void)setDebugLogsEnabled:(BOOL)enabled
@@ -226,7 +236,7 @@ static BOOL _automaticAttributionCollection = NO;
         
         postponedAttributionData = nil;
         
-        if (_automaticAttributionCollection) {
+        if (_automaticAppleSearchAdAttributionCollection) {
             NSString *latestNetworkIdAndAdvertisingIdSentToAppleSearchAds = [self latestNetworkIdAndAdvertisingIdentifierSentForNetwork:RCAttributionNetworkAppleSearchAds];
             if (latestNetworkIdAndAdvertisingIdSentToAppleSearchAds == nil) {
                 [attributionFetcher adClientAttributionDetailsWithCompletionBlock:^(NSDictionary<NSString *, NSObject *> * _Nullable attributionDetails, NSError * _Nullable error) {

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -355,7 +355,7 @@ class PurchasesTests: XCTestCase {
     var purchases: Purchases?
     
     func setupPurchases(automaticCollection: Bool = false) {
-        Purchases.automaticAttributionCollection = automaticCollection
+        Purchases.automaticAppleSearchAdsAttributionCollection = automaticCollection
         purchases = Purchases(appUserID: appUserID,
                                 requestFetcher: requestFetcher,
                                 receiptFetcher: receiptFetcher,
@@ -370,7 +370,7 @@ class PurchasesTests: XCTestCase {
     }
 
     func setupAnonPurchases() {
-        Purchases.automaticAttributionCollection = false
+        Purchases.automaticAppleSearchAdsAttributionCollection = false
 
         purchases = Purchases(appUserID: nil,
                 requestFetcher: requestFetcher,


### PR DESCRIPTION
I deprecated `automaticAttributionCollection` to avoid breaking people's compilation and I created a new  `automaticAppleSearchAdsAttributionCollection` that has the same effect.