### PR TITLE
Removes fallback to appUserID when posting attribution

### DIFF
--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -311,7 +311,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
         NSMutableDictionary *newData = [NSMutableDictionary dictionaryWithDictionary:data];
         newData[@"rc_idfa"] = advertisingIdentifier;
         newData[@"rc_idfv"] = [self.attributionFetcher identifierForVendor];
-        newData[@"rc_attribution_network_id"] = networkUserId ?: self.appUserID;
+        newData[@"rc_attribution_network_id"] = networkUserId;
         
         if (newData.count > 0) {
             [self.backend postAttributionData:newData

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -1319,7 +1319,7 @@ class PurchasesTests: XCTestCase {
 
         Purchases.addAttributionData([:], from: RCAttributionNetwork.adjust)
 
-        expect(self.backend.postedAttributionData?[0].data.count).toEventually(equal(3))
+        expect(self.backend.postedAttributionData?[0].data.count).toEventually(equal(2))
         expect(self.backend.postedAttributionData?[0].data["rc_idfa"] as? String).toEventually(equal("rc_idfa"))
         expect(self.backend.postedAttributionData?[0].data["rc_idfv"] as? String).toEventually(equal("rc_idfv"))
     }
@@ -1743,6 +1743,24 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.postedAttributionData?[0].data.keys.contains("rc_idfv")).toEventually(beTrue())
         expect(self.backend.postedAttributionData?[0].data.keys.contains("rc_attribution_network_id")).toEventually(beTrue())
         expect(self.backend.postedAttributionData?[0].data["rc_attribution_network_id"] as? String).toEventually(equal("newuser"))
+        expect(self.backend.postedAttributionData?[0].network).toEventually(equal(RCAttributionNetwork.appleSearchAds))
+        expect(self.backend.postedAttributionData?[0].networkUserId).toEventually(equal(self.appUserID))
+    }
+    
+    func testAttributionDataDontSendNetworkAppUserIdIfNotProvided() {
+        let data = ["yo" : "dog", "what" : 45, "is" : ["up"]] as [AnyHashable : Any]
+        
+        Purchases.addAttributionData(data, from: RCAttributionNetwork.appleSearchAds)
+        
+        setupPurchases()
+        
+        for key in data.keys {
+            expect(self.backend.postedAttributionData?[0].data.keys.contains(key)).toEventually(beTrue())
+        }
+        
+        expect(self.backend.postedAttributionData?[0].data.keys.contains("rc_idfa")).toEventually(beTrue())
+        expect(self.backend.postedAttributionData?[0].data.keys.contains("rc_idfv")).toEventually(beTrue())
+        expect(self.backend.postedAttributionData?[0].data.keys.contains("rc_attribution_network_id")).toEventually(beFalse())
         expect(self.backend.postedAttributionData?[0].network).toEventually(equal(RCAttributionNetwork.appleSearchAds))
         expect(self.backend.postedAttributionData?[0].networkUserId).toEventually(equal(self.appUserID))
     }


### PR DESCRIPTION
Removes fallback to `appUserID` if `networkUserId` is not provided when posting attribution. This will match Android's behavior and let the backend decide
