### PR TITLE
Error logs for AppsFlyer if missing networkUserID

### DIFF
--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -245,7 +245,7 @@ NS_SWIFT_NAME(reset(_:));
  */
 + (void)addAttributionData:(NSDictionary *)data
                fromNetwork:(RCAttributionNetwork)network
-          forNetworkUserId:(NSString * _Nullable)networkUserId NS_SWIFT_NAME(addAttributionData(_:from:forNeworkUserId:));
+          forNetworkUserId:(NSString * _Nullable)networkUserId NS_SWIFT_NAME(addAttributionData(_:from:forNetworkUserId:));
 
 #pragma mark Purchases
 

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -295,12 +295,11 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                fromNetwork:(RCAttributionNetwork)network
           forNetworkUserId:(NSString * _Nullable)networkUserId
 {
+    if (data[@"rc_appsflyer_id"]) {
+        RCErrorLog(@"⚠️ The parameter key rc_appsflyer_id is deprecated. Pass networkUserId to addAttribution instead. ⚠️");
+    }
     if (network == RCAttributionNetworkAppsFlyer && networkUserId == nil) {
-        if (data[@"rc_appsflyer_id"]) {
-            RCErrorLog(@"⚠️ The parameter key rc_appsflyer_id is deprecated. Pass networkUserId to addAttribution instead. ⚠️");
-        } else {
-            RCErrorLog(@"⚠️ The parameter networkUserId is REQUIRED for AppsFlyer. ⚠️");
-        }
+        RCErrorLog(@"⚠️ The parameter networkUserId is REQUIRED for AppsFlyer. ⚠️");
     }
     NSString *networkKey = [NSString stringWithFormat:@"%ld",(long)network];
     NSString *advertisingIdentifier = [self.attributionFetcher advertisingIdentifier];

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -295,6 +295,13 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                fromNetwork:(RCAttributionNetwork)network
           forNetworkUserId:(NSString * _Nullable)networkUserId
 {
+    if (network == RCAttributionNetworkAppsFlyer && networkUserId == nil) {
+        if (data[@"rc_appsflyer_id"]) {
+            RCErrorLog(@"⚠️ The parameter key rc_appsflyer_id is deprecated. Pass networkUserId to addAttribution instead. ⚠️");
+        } else {
+            RCErrorLog(@"⚠️ The parameter networkUserId is REQUIRED for AppsFlyer. ⚠️");
+        }
+    }
     NSString *networkKey = [NSString stringWithFormat:@"%ld",(long)network];
     NSString *advertisingIdentifier = [self.attributionFetcher advertisingIdentifier];
     NSString *cacheKey = [self attributionDataUserDefaultCacheKeyForAppUserID:self.appUserID];

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -1731,7 +1731,7 @@ class PurchasesTests: XCTestCase {
     func testAttributionDataSendsNetworkAppUserId() {
         let data = ["yo" : "dog", "what" : 45, "is" : ["up"]] as [AnyHashable : Any]
         
-        Purchases.addAttributionData(data, from: RCAttributionNetwork.appleSearchAds, forNeworkUserId: "newuser")
+        Purchases.addAttributionData(data, from: RCAttributionNetwork.appleSearchAds, forNetworkUserId: "newuser")
 
         setupPurchases()
         
@@ -1780,7 +1780,7 @@ class PurchasesTests: XCTestCase {
     func testAttributionDataPostponesMultiple() {
         let data = ["yo" : "dog", "what" : 45, "is" : ["up"]] as [AnyHashable : Any]
         
-        Purchases.addAttributionData(data, from: RCAttributionNetwork.appleSearchAds, forNeworkUserId: "newuser")
+        Purchases.addAttributionData(data, from: RCAttributionNetwork.appleSearchAds, forNetworkUserId: "newuser")
 
         setupPurchases(automaticCollection: true)
         expect(self.backend.postedAttributionData).toEventuallyNot(beNil())


### PR DESCRIPTION
- Added two error logs
- Fixed typo in the NS_SWIFT_NAME. This will break compilation but there's no way to deprecate it.