### PR TITLE
Enable base internationalisation

### DIFF
--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -404,6 +404,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 352629F41F7C4B9100C04F2C;
 			productRefGroup = 352629FF1F7C4B9100C04F2C /* Products */;


### PR DESCRIPTION
This silences a warning from Xcode and has no impact because this framework has no localised resources.

<img width="271" alt="Screenshot 2019-08-20 at 15 12 34" src="https://user-images.githubusercontent.com/2149061/63356002-f9650480-c35e-11e9-85f0-f18521da2a78.png">
