### PR TITLE
Protects agains nil products or productIdentifiers

### DIFF
--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -1946,6 +1946,17 @@ class PurchasesTests: XCTestCase {
         expect(self.storeKitWrapper.finishCalled).toEventually(beFalse())
     }
     
+    func testNilProductIdentifier() {
+        setupPurchases()
+        let product = SKProduct()
+        var receivedError: Error?
+        self.purchases?.makePurchase(product) { (tx, info, error, userCancelled) in
+            receivedError = error
+        }
+
+        expect(receivedError).toNot(beNil())
+    }
+
     private func identifiedSuccessfully(appUserID: String) {
         expect(self.userDefaults.cachedUserInfo[self.userDefaults.appUserIDKey]).to(beNil())
         expect(self.purchases?.appUserID).to(equal(appUserID))


### PR DESCRIPTION
We got a crash report that showed either the product, payment or productIdentifier was nil. I added some protective measures to avoid the crash. Can't really add unit tests since Swift is smart and can't really pass a nil product to makePurchase, but I passed a product without product identifier to reproduce the crash.