### PR TITLE
Updates Catalyst conditionals

### DIFF
--- a/Purchases/RCCrossPlatformSupport.h
+++ b/Purchases/RCCrossPlatformSupport.h
@@ -12,7 +12,7 @@
 #import <AppKit/AppKit.h>
 #define APP_DID_BECOME_ACTIVE_NOTIFICATION_NAME NSApplicationDidBecomeActiveNotification
 #endif
-#if TARGET_OS_UIKITFORMAC
+#if TARGET_OS_MACCATALYST
 #define PLATFORM_HEADER @"uikitformac"
 #elif TARGET_OS_IPHONE
 #define PLATFORM_HEADER @"iOS"

--- a/Purchases/RCStoreKitWrapper.m
+++ b/Purchases/RCStoreKitWrapper.m
@@ -82,7 +82,7 @@
     }
 }
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE && !TARGET_OS_MACCATALYST
 - (BOOL)paymentQueue:(SKPaymentQueue *)queue shouldAddStorePayment:(SKPayment *)payment forProduct:(SKProduct *)product
 {
     return [self.delegate storeKitWrapper:self shouldAddStorePayment:payment forProduct:product];


### PR DESCRIPTION
- TARGET_OS_UIKITFORMAC has been replaced with TARGET_OS_MACCATALYST (although they kept TARGET_OS_UIKITFORMAC for compatibility)
- `paymentQueue:shouldAddStorePayment` is marked as unavailable for Catalyst apps