### PR TITLE
Changes swift names to start with "Purchases."

### DIFF
--- a/Purchases/Public/RCEntitlementInfo.h
+++ b/Purchases/Public/RCEntitlementInfo.h
@@ -23,7 +23,7 @@ typedef NS_ENUM(NSInteger, RCStore) {
     RCPromotional,
     /// For entitlements granted via an unknown store.
     RCUnknownStore,
-} NS_SWIFT_NAME(Store);
+} NS_SWIFT_NAME(Purchases.Store);
 
 /**
  Enum of supported period types for an entitlement.
@@ -35,12 +35,12 @@ typedef NS_ENUM(NSInteger, RCPeriodType) {
     RCIntro,
     /// If the entitlement is under a trial period.
     RCTrial,
-} NS_SWIFT_NAME(PeriodType);
+} NS_SWIFT_NAME(Purchases.PeriodType);
 
 /**
  The EntitlementInfo object gives you access to all of the information about the status of a user entitlement.
  */
-NS_SWIFT_NAME(EntitlementInfo)
+NS_SWIFT_NAME(Purchases.EntitlementInfo)
 @interface RCEntitlementInfo : NSObject
 
 /**

--- a/Purchases/Public/RCEntitlementInfos.h
+++ b/Purchases/Public/RCEntitlementInfos.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  This class contains all the entitlements associated to the user.
  */
-NS_SWIFT_NAME(EntitlementInfos)
+NS_SWIFT_NAME(Purchases.EntitlementInfos)
 @interface RCEntitlementInfos : NSObject
 
 /**

--- a/Purchases/Public/RCOffering.h
+++ b/Purchases/Public/RCOffering.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  An offering is a collection of Packages (`RCPackage`) available for the user to purchase. For more info see https://docs.revenuecat.com/docs/entitlements
  */
-NS_SWIFT_NAME(Offering)
+NS_SWIFT_NAME(Purchases.Offering)
 @interface RCOffering : NSObject
 
 /**

--- a/Purchases/Public/RCOfferings.h
+++ b/Purchases/Public/RCOfferings.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  This class contains all the offerings configured in RevenueCat dashboard. For more info see https://docs.revenuecat.com/docs/entitlements
 */
-NS_SWIFT_NAME(Offerings)
+NS_SWIFT_NAME(Purchases.Offerings)
 @interface RCOfferings : NSObject
 
 /**

--- a/Purchases/Public/RCPackage.h
+++ b/Purchases/Public/RCPackage.h
@@ -34,12 +34,12 @@ typedef NS_ENUM(NSInteger, RCPackageType) {
     RCPackageTypeMonthly,
     /// A package configured with the predefined weekly identifier.
     RCPackageTypeWeekly
-} NS_SWIFT_NAME(PackageType);
+} NS_SWIFT_NAME(Purchases.PackageType);
 
 /**
  Contains information about the product available for the user to purchase. For more info see https://docs.revenuecat.com/docs/entitlements
 */
-NS_SWIFT_NAME(Package)
+NS_SWIFT_NAME(Purchases.Package)
 @interface RCPackage : NSObject
 
 /**

--- a/Purchases/Public/RCPurchaserInfo.h
+++ b/Purchases/Public/RCPurchaserInfo.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  A container for the most recent purchaser info returned from `RCPurchases`. These objects are non-mutable and do not update automatically.
  */
-NS_SWIFT_NAME(PurchaserInfo)
+NS_SWIFT_NAME(Purchases.PurchaserInfo)
 @interface RCPurchaserInfo : NSObject
 
 /// Entitlements attached to this purchaser info

--- a/Purchases/Public/RCPurchasesErrorUtils.h
+++ b/Purchases/Public/RCPurchasesErrorUtils.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Utility class used to construct [NSError] instances.
  */
-NS_SWIFT_NAME(PurchasesErrorUtils)
+NS_SWIFT_NAME(Purchases.ErrorUtils)
 @interface RCPurchasesErrorUtils : NSObject
 
 /**

--- a/Purchases/Public/RCPurchasesErrors.h
+++ b/Purchases/Public/RCPurchasesErrors.h
@@ -9,22 +9,22 @@
 #import <Foundation/Foundation.h>
 
 
-NS_SWIFT_NAME(PurchasesErrors)
+NS_SWIFT_NAME(Purchases.Errors)
 @interface RCPurchasesErrors
 
 /**
  `NSErrorDomain` for errors occurring within the scope of the Purchases SDK.
  */
-extern NSErrorDomain const RCPurchasesErrorDomain NS_SWIFT_NAME(PurchasesErrorDomain);
+extern NSErrorDomain const RCPurchasesErrorDomain NS_SWIFT_NAME(Purchases.ErrorDomain);
 
 /**
  `NSErrorDomain` for errors occurring within the scope of the RevenueCat Backend.
  */
-extern NSErrorDomain const RCBackendErrorDomain NS_SWIFT_NAME(RevenueCatBackendErrorDomain);
+extern NSErrorDomain const RCBackendErrorDomain NS_SWIFT_NAME(Purchases.RevenueCatBackendErrorDomain);
 
-extern NSErrorUserInfoKey const RCFinishableKey NS_SWIFT_NAME(FinishableKey);
+extern NSErrorUserInfoKey const RCFinishableKey NS_SWIFT_NAME(Purchases.FinishableKey);
 
-extern NSErrorUserInfoKey const RCReadableErrorCodeKey NS_SWIFT_NAME(ReadableErrorCodeKey);
+extern NSErrorUserInfoKey const RCReadableErrorCodeKey NS_SWIFT_NAME(Purchases.ReadableErrorCodeKey);
 
 
 /**
@@ -50,7 +50,7 @@ typedef NS_ERROR_ENUM(RCPurchasesErrorDomain, RCPurchasesErrorCode) {
     RCUnknownBackendError,
     RCInvalidAppleSubscriptionKeyError,
     RCIneligibleError,
-} NS_SWIFT_NAME(PurchasesErrorCode);
+} NS_SWIFT_NAME(Purchases.ErrorCode);
 
 /**
  Error codes sent by the RevenueCat backend. This only includes the errors that matter to the SDK
@@ -72,6 +72,6 @@ typedef NS_ENUM(NSInteger, RCBackendErrorCode) {
     RCBackendPlayStoreGenericError = 7231,
     RCBackendUserIneligibleForPromoOffer = 7232,
     RCBackendInvalidAppleSubscriptionKey = 7234
-} NS_SWIFT_NAME(RevenueCatBackendErrorCode);
+} NS_SWIFT_NAME(Purchases.RevenueCatBackendErrorCode);
 
 @end

--- a/PurchasesTests/BackendTests.swift
+++ b/PurchasesTests/BackendTests.swift
@@ -363,7 +363,7 @@ underlyingError = error?.userInfo[NSUnderlyingErrorKey] as! NSError?
 })
 
         expect(error).toEventuallyNot(beNil())
-        expect(error?.code).toEventually(be(PurchasesErrorCode.invalidCredentialsError.rawValue))
+        expect(error?.code).toEventually(be(Purchases.ErrorCode.invalidCredentialsError.rawValue))
         expect(error?.userInfo["finishable"]).to(be(false))
 
         expect(underlyingError).toEventuallyNot(beNil())
@@ -382,7 +382,7 @@ error = newError
 })
 
         expect(error).toEventuallyNot(beNil())
-        expect((error as NSError?)?.code).toEventually(be(PurchasesErrorCode.invalidCredentialsError.rawValue))
+        expect((error as NSError?)?.code).toEventually(be(Purchases.ErrorCode.invalidCredentialsError.rawValue))
         expect((error as NSError?)?.userInfo["finishable"]).to(be(true))
 
         underlyingError = (error as NSError?)?.userInfo[NSUnderlyingErrorKey] as? Error
@@ -394,7 +394,7 @@ error = newError
         let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
         httpClient.mock(requestPath: "/receipts", response: response)
 
-        var purchaserInfo: PurchaserInfo?
+        var purchaserInfo: Purchases.PurchaserInfo?
 
         backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: nil, price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, completion: { (newPurchaserInfo, newError) in
 purchaserInfo = newPurchaserInfo
@@ -431,7 +431,7 @@ purchaserInfo = newPurchaserInfo
         let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
         httpClient.mock(requestPath: "/subscribers/" + userID, response: response)
 
-        var subscriberInfo: PurchaserInfo?
+        var subscriberInfo: Purchases.PurchaserInfo?
 
         backend?.getSubscriberData(withAppUserID: userID, completion: { (newSubscriberInfo, newError) in
             subscriberInfo = newSubscriberInfo
@@ -447,7 +447,7 @@ purchaserInfo = newPurchaserInfo
         httpClient.mock(requestPath: "/subscribers/" + encodedUserID, response: response)
         httpClient.mock(requestPath: "/subscribers/" + encodeableUserID, response: HTTPResponse(statusCode: 404, response: nil, error: nil))
 
-        var subscriberInfo: PurchaserInfo?
+        var subscriberInfo: Purchases.PurchaserInfo?
 
         backend?.getSubscriberData(withAppUserID: encodeableUserID, completion: { (newSubscriberInfo, newError) in
             subscriberInfo = newSubscriberInfo
@@ -467,10 +467,10 @@ purchaserInfo = newPurchaserInfo
         })
 
         expect(error).toEventuallyNot(beNil())
-        expect(error?.domain).to(equal(PurchasesErrorDomain))
+        expect(error?.domain).to(equal(Purchases.ErrorDomain))
         let underlyingError = (error?.userInfo[NSUnderlyingErrorKey]) as! NSError
         expect(underlyingError).toEventuallyNot(beNil())
-        expect(underlyingError.domain).to(equal(RevenueCatBackendErrorDomain))
+        expect(underlyingError.domain).to(equal(Purchases.RevenueCatBackendErrorDomain))
         expect(error?.userInfo["finishable"]).to(be(true))
     }
 
@@ -485,8 +485,8 @@ purchaserInfo = newPurchaserInfo
         })
 
         expect(error).toEventuallyNot(beNil())
-        expect(error?.domain).to(equal(PurchasesErrorDomain))
-        expect(error?.code).to(be(PurchasesErrorCode.unexpectedBackendResponseError.rawValue))
+        expect(error?.domain).to(equal(Purchases.ErrorDomain))
+        expect(error?.code).to(be(Purchases.ErrorCode.unexpectedBackendResponseError.rawValue))
     }
 
     func testEmptyEligibilityCheckDoesNothing() {
@@ -729,8 +729,8 @@ purchaserInfo = newPurchaserInfo
         })
 
         expect(receivedError).toEventuallyNot(beNil())
-        expect(receivedError?.domain).toEventually(equal(PurchasesErrorDomain))
-        expect(receivedError?.code).toEventually(equal(PurchasesErrorCode.networkError.rawValue))
+        expect(receivedError?.domain).toEventually(equal(Purchases.ErrorDomain))
+        expect(receivedError?.code).toEventually(equal(Purchases.ErrorCode.networkError.rawValue))
         expect(receivedUnderlyingError).toEventuallyNot(beNil())
         expect(receivedUnderlyingError?.domain).toEventually(equal(NSURLErrorDomain))
         expect(receivedUnderlyingError?.code).toEventually(equal(-1009))
@@ -747,8 +747,8 @@ purchaserInfo = newPurchaserInfo
         })
 
         expect(receivedError).toEventuallyNot(beNil())
-        expect(receivedError?.domain).toEventually(equal(PurchasesErrorDomain))
-        expect(receivedError?.code).toEventually(equal(PurchasesErrorCode.networkError.rawValue))
+        expect(receivedError?.domain).toEventually(equal(Purchases.ErrorDomain))
+        expect(receivedError?.code).toEventually(equal(Purchases.ErrorCode.networkError.rawValue))
         expect(receivedUnderlyingError).toEventuallyNot(beNil())
         expect(receivedUnderlyingError?.domain).toEventually(equal(NSURLErrorDomain))
         expect(receivedUnderlyingError?.code).toEventually(equal(-1009))
@@ -767,7 +767,7 @@ purchaserInfo = newPurchaserInfo
         })
 
         expect(receivedError).toEventuallyNot(beNil())
-        expect(receivedError?.code).toEventually(be(PurchasesErrorCode.invalidCredentialsError.rawValue))
+        expect(receivedError?.code).toEventually(be(Purchases.ErrorCode.invalidCredentialsError.rawValue))
 
         expect(receivedUnderlyingError).toEventuallyNot(beNil())
         expect(receivedUnderlyingError?.localizedDescription).to(equal(serverErrorResponse["message"]))
@@ -800,8 +800,8 @@ purchaserInfo = newPurchaserInfo
         })
 
         expect(receivedError).toEventuallyNot(beNil())
-        expect(receivedError?.domain).toEventually(equal(PurchasesErrorDomain))
-        expect(receivedError?.code).toEventually(equal(PurchasesErrorCode.networkError.rawValue))
+        expect(receivedError?.domain).toEventually(equal(Purchases.ErrorDomain))
+        expect(receivedError?.code).toEventually(equal(Purchases.ErrorCode.networkError.rawValue))
         expect(receivedUnderlyingError).toEventuallyNot(beNil())
         expect(receivedUnderlyingError?.domain).toEventually(equal(NSURLErrorDomain))
         expect(receivedUnderlyingError?.code).toEventually(equal(-1009))
@@ -820,7 +820,7 @@ purchaserInfo = newPurchaserInfo
         })
 
         expect(receivedError).toEventuallyNot(beNil())
-        expect(receivedError?.code).toEventually(be(PurchasesErrorCode.invalidCredentialsError.rawValue))
+        expect(receivedError?.code).toEventually(be(Purchases.ErrorCode.invalidCredentialsError.rawValue))
 
         expect(receivedUnderlyingError).toEventuallyNot(beNil())
         expect(receivedUnderlyingError?.localizedDescription).to(equal(serverErrorResponse["message"]))
@@ -994,8 +994,8 @@ purchaserInfo = newPurchaserInfo
         }
 
         expect(receivedError).toEventuallyNot(beNil())
-        expect(receivedError?.domain).toEventually(equal(PurchasesErrorDomain))
-        expect(receivedError?.code).toEventually(equal(PurchasesErrorCode.networkError.rawValue))
+        expect(receivedError?.domain).toEventually(equal(Purchases.ErrorDomain))
+        expect(receivedError?.code).toEventually(equal(Purchases.ErrorCode.networkError.rawValue))
         expect(receivedUnderlyingError).toEventuallyNot(beNil())
         expect(receivedUnderlyingError?.domain).toEventually(equal(NSURLErrorDomain))
         expect(receivedUnderlyingError?.code).toEventually(equal(-1009))
@@ -1028,8 +1028,8 @@ purchaserInfo = newPurchaserInfo
         }
 
         expect(receivedError).toEventuallyNot(beNil())
-        expect(receivedError?.domain).toEventually(equal(PurchasesErrorDomain))
-        expect(receivedError?.code).toEventually(equal(PurchasesErrorCode.unexpectedBackendResponseError.rawValue))
+        expect(receivedError?.domain).toEventually(equal(Purchases.ErrorDomain))
+        expect(receivedError?.code).toEventually(equal(Purchases.ErrorCode.unexpectedBackendResponseError.rawValue))
         expect(receivedUnderlyingError).toEventually(beNil())
     }
     
@@ -1071,11 +1071,11 @@ purchaserInfo = newPurchaserInfo
         }
         
         expect(receivedError).toEventuallyNot(beNil())
-        expect(receivedError?.domain).toEventually(equal(PurchasesErrorDomain))
-        expect(receivedError?.code).toEventually(equal(PurchasesErrorCode.invalidAppleSubscriptionKeyError.rawValue))
+        expect(receivedError?.domain).toEventually(equal(Purchases.ErrorDomain))
+        expect(receivedError?.code).toEventually(equal(Purchases.ErrorCode.invalidAppleSubscriptionKeyError.rawValue))
         expect(receivedUnderlyingError).toEventuallyNot(beNil())
         expect(receivedUnderlyingError?.code).toEventually(equal(7234))
-        expect(receivedUnderlyingError?.domain).toEventually(equal(RevenueCatBackendErrorDomain))
+        expect(receivedUnderlyingError?.domain).toEventually(equal(Purchases.RevenueCatBackendErrorDomain))
         expect(receivedUnderlyingError?.localizedDescription).toEventually(equal("Ineligible for some reason"))
     }
     
@@ -1114,8 +1114,8 @@ purchaserInfo = newPurchaserInfo
         }
 
         expect(receivedError).toEventuallyNot(beNil())
-        expect(receivedError?.domain).toEventually(equal(PurchasesErrorDomain))
-        expect(receivedError?.code).toEventually(equal(PurchasesErrorCode.unexpectedBackendResponseError.rawValue))
+        expect(receivedError?.domain).toEventually(equal(Purchases.ErrorDomain))
+        expect(receivedError?.code).toEventually(equal(Purchases.ErrorCode.unexpectedBackendResponseError.rawValue))
         expect(receivedUnderlyingError).toEventually(beNil())
 
     }
@@ -1141,7 +1141,7 @@ purchaserInfo = newPurchaserInfo
         }
 
         expect(receivedError).toEventuallyNot(beNil())
-        expect(receivedError?.code).toEventually(be(PurchasesErrorCode.invalidCredentialsError.rawValue))
+        expect(receivedError?.code).toEventually(be(Purchases.ErrorCode.invalidCredentialsError.rawValue))
 
         expect(receivedUnderlyingError).toEventuallyNot(beNil())
         expect(receivedUnderlyingError?.localizedDescription).to(equal(serverErrorResponse["message"]))

--- a/PurchasesTests/EntitlementInfosTests.swift
+++ b/PurchasesTests/EntitlementInfosTests.swift
@@ -85,7 +85,7 @@ class EntitlementInfosTests: XCTestCase {
             ]
         )
         
-        let subscriberInfo: PurchaserInfo = PurchaserInfo(data: response)!
+        let subscriberInfo: Purchases.PurchaserInfo = Purchases.PurchaserInfo(data: response)!
         expect(subscriberInfo.entitlements.all.count).to(equal(2))
         // The default is "pro_cat"
         verifySubscriberInfo()
@@ -98,8 +98,8 @@ class EntitlementInfosTests: XCTestCase {
         // Check for "lifetime_cat" entitlement
         verifyEntitlementActive(beTrue(), entitlement: "lifetime_cat")
         verifyRenewal(beTrue(), unsubscribeDetectedAt: beNil(), billingIssueDetectedAt: beNil(), entitlement: "lifetime_cat")
-        verifyPeriodType(equal(PeriodType.normal.rawValue), entitlement: "lifetime_cat")
-        verifyStore(equal(Store.appStore.rawValue), entitlement: "lifetime_cat")
+        verifyPeriodType(equal(Purchases.PeriodType.normal.rawValue), entitlement: "lifetime_cat")
+        verifyStore(equal(Purchases.Store.appStore.rawValue), entitlement: "lifetime_cat")
         verifySandbox(beFalse(), entitlement: "lifetime_cat")
         verifyProduct(identifier: equal("lifetime"),
                       latestPurchaseDate: equal(formatter.date(from: "2019-07-26T23:45:40Z")),
@@ -132,7 +132,7 @@ class EntitlementInfosTests: XCTestCase {
             ]
         )
         
-        let subscriberInfo: PurchaserInfo = PurchaserInfo(data: response)!
+        let subscriberInfo: Purchases.PurchaserInfo = Purchases.PurchaserInfo(data: response)!
         
         expect(subscriberInfo.entitlements["pro_cat"]).toNot(beNil())
         expect(subscriberInfo.entitlements.active["pro_cat"]).toNot(beNil())
@@ -192,7 +192,7 @@ class EntitlementInfosTests: XCTestCase {
 
     func testGetsEmptySubscriberInfo() {
         stubResponse()
-        let subscriberInfo = PurchaserInfo(data: response)
+        let subscriberInfo = Purchases.PurchaserInfo(data: response)
 
         expect(subscriberInfo?.firstSeen).toNot(beNil())
         expect(subscriberInfo?.originalAppUserId).to(equal("cesarsandbox1"))
@@ -505,7 +505,7 @@ class EntitlementInfosTests: XCTestCase {
                     ]
                 ])
 
-        verifyStore(equal(Store.appStore.rawValue))
+        verifyStore(equal(Purchases.Store.appStore.rawValue))
         
         stubResponse(
             entitlements: [
@@ -527,7 +527,7 @@ class EntitlementInfosTests: XCTestCase {
                     "unsubscribe_detected_at": nil
                 ]
             ])
-        verifyStore(equal(Store.macAppStore.rawValue))
+        verifyStore(equal(Purchases.Store.macAppStore.rawValue))
         
         stubResponse(
             entitlements: [
@@ -549,7 +549,7 @@ class EntitlementInfosTests: XCTestCase {
                     "unsubscribe_detected_at": nil
                 ]
             ])
-        verifyStore(equal(Store.playStore.rawValue))
+        verifyStore(equal(Purchases.Store.playStore.rawValue))
         
         stubResponse(
             entitlements: [
@@ -571,7 +571,7 @@ class EntitlementInfosTests: XCTestCase {
                     "unsubscribe_detected_at": nil
                 ]
             ])
-        verifyStore(equal(Store.promotional.rawValue))
+        verifyStore(equal(Purchases.Store.promotional.rawValue))
         
         stubResponse(
             entitlements: [
@@ -593,7 +593,7 @@ class EntitlementInfosTests: XCTestCase {
                     "unsubscribe_detected_at": nil
                 ]
             ])
-        verifyStore(equal(Store.stripe.rawValue))
+        verifyStore(equal(Purchases.Store.stripe.rawValue))
         
         stubResponse(
             entitlements: [
@@ -615,7 +615,7 @@ class EntitlementInfosTests: XCTestCase {
                     "unsubscribe_detected_at": nil
                 ]
             ])
-        verifyStore(equal(Store.unknownStore.rawValue))
+        verifyStore(equal(Purchases.Store.unknownStore.rawValue))
     }
 
     func testParseStoreFromNonSubscription() {
@@ -647,7 +647,7 @@ class EntitlementInfosTests: XCTestCase {
                 ],
                 subscriptions: [:]
         )
-        verifyStore(equal(Store.appStore.rawValue))
+        verifyStore(equal(Purchases.Store.appStore.rawValue))
 
         stubResponse(
                 entitlements: [
@@ -677,7 +677,7 @@ class EntitlementInfosTests: XCTestCase {
                 ],
                 subscriptions: [:]
         )
-        verifyStore(equal(Store.macAppStore.rawValue))
+        verifyStore(equal(Purchases.Store.macAppStore.rawValue))
 
         stubResponse(
                 entitlements: [
@@ -707,7 +707,7 @@ class EntitlementInfosTests: XCTestCase {
                 ],
                 subscriptions: [:]
         )
-        verifyStore(equal(Store.playStore.rawValue))
+        verifyStore(equal(Purchases.Store.playStore.rawValue))
 
         stubResponse(
                 entitlements: [
@@ -737,7 +737,7 @@ class EntitlementInfosTests: XCTestCase {
                 ],
                 subscriptions: [:]
         )
-        verifyStore(equal(Store.promotional.rawValue))
+        verifyStore(equal(Purchases.Store.promotional.rawValue))
 
         stubResponse(
                 entitlements: [
@@ -767,7 +767,7 @@ class EntitlementInfosTests: XCTestCase {
                 ],
                 subscriptions: [:]
         )
-        verifyStore(equal(Store.stripe.rawValue))
+        verifyStore(equal(Purchases.Store.stripe.rawValue))
 
         stubResponse(
                 entitlements: [
@@ -797,7 +797,7 @@ class EntitlementInfosTests: XCTestCase {
                 ],
                 subscriptions: [:]
         )
-        verifyStore(equal(Store.unknownStore.rawValue))
+        verifyStore(equal(Purchases.Store.unknownStore.rawValue))
     }
 
     func testParsePeriod() {
@@ -822,7 +822,7 @@ class EntitlementInfosTests: XCTestCase {
                     ]
                 ])
 
-        verifyPeriodType(equal(PeriodType.normal.rawValue))
+        verifyPeriodType(equal(Purchases.PeriodType.normal.rawValue))
 
         stubResponse(
                 entitlements: [
@@ -844,7 +844,7 @@ class EntitlementInfosTests: XCTestCase {
                         "unsubscribe_detected_at": nil
                     ]
                 ])
-        verifyPeriodType(equal(PeriodType.intro.rawValue))
+        verifyPeriodType(equal(Purchases.PeriodType.intro.rawValue))
 
         stubResponse(
                 entitlements: [
@@ -866,7 +866,7 @@ class EntitlementInfosTests: XCTestCase {
                         "unsubscribe_detected_at": nil
                     ]
                 ])
-        verifyPeriodType(equal(PeriodType.trial.rawValue))
+        verifyPeriodType(equal(Purchases.PeriodType.trial.rawValue))
 
         stubResponse(
                 entitlements: [
@@ -888,7 +888,7 @@ class EntitlementInfosTests: XCTestCase {
                         "unsubscribe_detected_at": nil
                     ]
                 ])
-        verifyPeriodType(equal(PeriodType.normal.rawValue))
+        verifyPeriodType(equal(Purchases.PeriodType.normal.rawValue))
     }
 
     func testParsePeriodForNonSubscription() {
@@ -920,11 +920,11 @@ class EntitlementInfosTests: XCTestCase {
             ],
             subscriptions: [:]
         )
-        verifyPeriodType(equal(PeriodType.normal.rawValue))
+        verifyPeriodType(equal(Purchases.PeriodType.normal.rawValue))
     }
 
     func verifySubscriberInfo() {
-        let subscriberInfo: PurchaserInfo = PurchaserInfo(data: response)!
+        let subscriberInfo: Purchases.PurchaserInfo = Purchases.PurchaserInfo(data: response)!
 
         expect(subscriberInfo).toNot(beNil())
         expect(subscriberInfo.firstSeen).to(equal(formatter.date(from: "2019-07-26T23:29:50Z")))
@@ -932,8 +932,8 @@ class EntitlementInfosTests: XCTestCase {
     }
 
     func verifyEntitlementActive(_ matcher: Predicate<Bool> = beTrue(), entitlement: String = "pro_cat") {
-        let subscriberInfo: PurchaserInfo = PurchaserInfo(data: response)!
-        let proCat: EntitlementInfo = subscriberInfo.entitlements[entitlement]!
+        let subscriberInfo: Purchases.PurchaserInfo = Purchases.PurchaserInfo(data: response)!
+        let proCat: Purchases.EntitlementInfo = subscriberInfo.entitlements[entitlement]!
 
         expect(proCat.identifier).to(equal(entitlement))
         expect(subscriberInfo.entitlements.all.keys.contains(entitlement)).to(beTrue())
@@ -945,31 +945,31 @@ class EntitlementInfosTests: XCTestCase {
                 unsubscribeDetectedAt: Predicate<Date> = beNil(),
                 billingIssueDetectedAt: Predicate<Date> = beNil(),
                 entitlement: String = "pro_cat") {
-        let subscriberInfo: PurchaserInfo = PurchaserInfo(data: response)!
-        let proCat: EntitlementInfo = subscriberInfo.entitlements[entitlement]!
+        let subscriberInfo: Purchases.PurchaserInfo = Purchases.PurchaserInfo(data: response)!
+        let proCat: Purchases.EntitlementInfo = subscriberInfo.entitlements[entitlement]!
 
         expect(proCat.willRenew).to(matcher)
         expect(proCat.unsubscribeDetectedAt).to(unsubscribeDetectedAt)
         expect(proCat.billingIssueDetectedAt).to(billingIssueDetectedAt)
     }
 
-    func verifyPeriodType(_ matcher: Predicate<Int> = equal(PeriodType.normal.rawValue), entitlement: String = "pro_cat") {
-        let subscriberInfo: PurchaserInfo = PurchaserInfo(data: response)!
-        let proCat: EntitlementInfo = subscriberInfo.entitlements[entitlement]!
+    func verifyPeriodType(_ matcher: Predicate<Int> = equal(Purchases.PeriodType.normal.rawValue), entitlement: String = "pro_cat") {
+        let subscriberInfo: Purchases.PurchaserInfo = Purchases.PurchaserInfo(data: response)!
+        let proCat: Purchases.EntitlementInfo = subscriberInfo.entitlements[entitlement]!
 
         expect(proCat.periodType.rawValue).to(matcher)
     }
 
-    func verifyStore(_ matcher: Predicate<Int> = equal(Store.appStore.rawValue), entitlement: String = "pro_cat") {
-        let subscriberInfo: PurchaserInfo = PurchaserInfo(data: response)!
-        let proCat: EntitlementInfo = subscriberInfo.entitlements[entitlement]!
+    func verifyStore(_ matcher: Predicate<Int> = equal(Purchases.Store.appStore.rawValue), entitlement: String = "pro_cat") {
+        let subscriberInfo: Purchases.PurchaserInfo = Purchases.PurchaserInfo(data: response)!
+        let proCat: Purchases.EntitlementInfo = subscriberInfo.entitlements[entitlement]!
 
         expect(proCat.store.rawValue).to(matcher)
     }
 
     func verifySandbox(_ matcher: Predicate<Bool> = beFalse(), entitlement: String = "pro_cat") {
-        let subscriberInfo: PurchaserInfo = PurchaserInfo(data: response)!
-        let proCat: EntitlementInfo = subscriberInfo.entitlements[entitlement]!
+        let subscriberInfo: Purchases.PurchaserInfo = Purchases.PurchaserInfo(data: response)!
+        let proCat: Purchases.EntitlementInfo = subscriberInfo.entitlements[entitlement]!
 
         expect(proCat.isSandbox).to(matcher)
     }
@@ -988,8 +988,8 @@ class EntitlementInfosTests: XCTestCase {
                        originalPurchaseDate: Predicate<Date>,
                        expirationDate: Predicate<Date>,
                        entitlement: String = "pro_cat") {
-        let subscriberInfo: PurchaserInfo = PurchaserInfo(data: response)!
-        let proCat: EntitlementInfo = subscriberInfo.entitlements[entitlement]!
+        let subscriberInfo: Purchases.PurchaserInfo = Purchases.PurchaserInfo(data: response)!
+        let proCat: Purchases.EntitlementInfo = subscriberInfo.entitlements[entitlement]!
 
         expect(proCat.latestPurchaseDate).to(latestPurchaseDate)
         expect(proCat.originalPurchaseDate).to(originalPurchaseDate)

--- a/PurchasesTests/OfferingsTests.swift
+++ b/PurchasesTests/OfferingsTests.swift
@@ -57,7 +57,7 @@ class OfferingsTests: XCTestCase {
         expect(package).toNot(beNil())
         expect(package?.product).to(equal(product))
         expect(package?.identifier).to(equal(packageIdentifier))
-        expect(package?.packageType).to(equal(PackageType.monthly))
+        expect(package?.packageType).to(equal(Purchases.PackageType.monthly))
     }
 
     func testOfferingIsNotCreatedIfNoValidPackage() {
@@ -167,39 +167,39 @@ class OfferingsTests: XCTestCase {
     }
 
     func testLifetimePackage() {
-        testPackageType(packageType: PackageType.lifetime)
+        testPackageType(packageType: Purchases.PackageType.lifetime)
     }
 
     func testAnnualPackage() {
-        testPackageType(packageType: PackageType.annual)
+        testPackageType(packageType: Purchases.PackageType.annual)
     }
 
     func testSixMonthPackage() {
-        testPackageType(packageType: PackageType.sixMonth)
+        testPackageType(packageType: Purchases.PackageType.sixMonth)
     }
 
     func testThreeMonthPackage() {
-        testPackageType(packageType: PackageType.threeMonth)
+        testPackageType(packageType: Purchases.PackageType.threeMonth)
     }
 
     func testTwoMonthPackage() {
-        testPackageType(packageType: PackageType.twoMonth)
+        testPackageType(packageType: Purchases.PackageType.twoMonth)
     }
 
     func testMonthlyPackage() {
-        testPackageType(packageType: PackageType.monthly)
+        testPackageType(packageType: Purchases.PackageType.monthly)
     }
 
     func testWeeklyPackage() {
-        testPackageType(packageType: PackageType.weekly)
+        testPackageType(packageType: Purchases.PackageType.weekly)
     }
 
     func testCustomPackage() {
-        testPackageType(packageType: PackageType.custom)
+        testPackageType(packageType: Purchases.PackageType.custom)
     }
     
     func testUnknownPackageType() {
-        testPackageType(packageType: PackageType.unknown)
+        testPackageType(packageType: Purchases.PackageType.unknown)
     }
     
     func testNoOfferings() {
@@ -231,10 +231,10 @@ class OfferingsTests: XCTestCase {
         expect(offerings).to(beNil())
     }
 
-    private func testPackageType(packageType: PackageType) {
-        var identifier = Package.string(from: packageType)
+    private func testPackageType(packageType: Purchases.PackageType) {
+        var identifier = Purchases.Package.string(from: packageType)
         if (identifier == nil) {
-            if (packageType == PackageType.unknown) {
+            if (packageType == Purchases.PackageType.unknown) {
                 identifier = "$rc_unknown_id_from_the_future"
             } else {
                 identifier = "custom"
@@ -260,37 +260,37 @@ class OfferingsTests: XCTestCase {
 
         expect(offerings).toNot(beNil())
         expect(offerings!.current).toNot(beNil())
-        if (packageType == PackageType.lifetime) {
+        if (packageType == Purchases.PackageType.lifetime) {
             expect(offerings!.current?.lifetime).toNot(beNil())
         } else {
             expect(offerings!.current?.lifetime).to(beNil())
         }
-        if (packageType == PackageType.annual) {
+        if (packageType == Purchases.PackageType.annual) {
             expect(offerings!.current?.annual).toNot(beNil())
         } else {
             expect(offerings!.current?.annual).to(beNil())
         }
-        if (packageType == PackageType.sixMonth) {
+        if (packageType == Purchases.PackageType.sixMonth) {
             expect(offerings!.current?.sixMonth).toNot(beNil())
         } else {
             expect(offerings!.current?.sixMonth).to(beNil())
         }
-        if (packageType == PackageType.threeMonth) {
+        if (packageType == Purchases.PackageType.threeMonth) {
             expect(offerings!.current?.threeMonth).toNot(beNil())
         } else {
             expect(offerings!.current?.threeMonth).to(beNil())
         }
-        if (packageType == PackageType.twoMonth) {
+        if (packageType == Purchases.PackageType.twoMonth) {
             expect(offerings!.current?.twoMonth).toNot(beNil())
         } else {
             expect(offerings!.current?.twoMonth).to(beNil())
         }
-        if (packageType == PackageType.monthly) {
+        if (packageType == Purchases.PackageType.monthly) {
             expect(offerings!.current?.monthly).toNot(beNil())
         } else {
             expect(offerings!.current?.monthly).to(beNil())
         }
-        if (packageType == PackageType.weekly) {
+        if (packageType == Purchases.PackageType.weekly) {
             expect(offerings!.current?.weekly).toNot(beNil())
         } else {
             expect(offerings!.current?.weekly).to(beNil())

--- a/PurchasesTests/PurchaserInfoTests.swift
+++ b/PurchasesTests/PurchaserInfoTests.swift
@@ -13,7 +13,7 @@ import Nimble
 import Purchases
 
 class EmptyPurchaserInfoTests: XCTestCase {
-    let purchaserInfo = PurchaserInfo.init(data: [AnyHashable : Any]())
+    let purchaserInfo = Purchases.PurchaserInfo.init(data: [AnyHashable : Any]())
 
     func testEmptyDataYieldsANilInfo() {
         expect(self.purchaserInfo).to(beNil())
@@ -75,12 +75,12 @@ class BasicPurchaserInfoTests: XCTestCase {
                 "\"product_b\": {\"expires_date\": \"2018-05-27T05:24:50Z\",\"period_type\": \"normal\"}" +
             "}}}";
 
-    var purchaserInfo: PurchaserInfo?
+    var purchaserInfo: Purchases.PurchaserInfo?
 
     override func setUp() {
         super.setUp()
 
-        purchaserInfo = PurchaserInfo(data: validSubscriberResponse)
+        purchaserInfo = Purchases.PurchaserInfo(data: validSubscriberResponse)
     }
 
     func testParsesSubscriptions() {
@@ -123,7 +123,7 @@ class BasicPurchaserInfoTests: XCTestCase {
     }
 
     func testOriginalApplicationVersion() {
-        let purchaserInfo = PurchaserInfo(data: [
+        let purchaserInfo = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "original_application_version": "1.0",
                 "subscriptions": [:],
@@ -134,13 +134,13 @@ class BasicPurchaserInfoTests: XCTestCase {
 
     func testPreservesOriginalJSONSerializableObject() {
         let json = purchaserInfo?.jsonObject()
-        let newInfo = PurchaserInfo(data: json!)
+        let newInfo = Purchases.PurchaserInfo(data: json!)
         expect(newInfo).toNot(beNil())
     }
 
     func testTwoProductJson() {
         let json = try! JSONSerialization.jsonObject(with: validTwoProductsJSON.data(using: String.Encoding.utf8)!, options: [])
-        let info = PurchaserInfo(data: json as! [AnyHashable : Any])
+        let info = Purchases.PurchaserInfo(data: json as! [AnyHashable : Any])
         expect(info?.latestExpirationDate).toNot(beNil())
     }
 
@@ -230,9 +230,9 @@ class BasicPurchaserInfoTests: XCTestCase {
                 ]
             ]
         ] as [String : Any]
-        let purchaserInfoWithoutRequestData = PurchaserInfo(data: response)
+        let purchaserInfoWithoutRequestData = Purchases.PurchaserInfo(data: response)
 
-        let entitlements: [String : EntitlementInfo] = purchaserInfoWithoutRequestData!.entitlements.active
+        let entitlements: [String : Purchases.EntitlementInfo] = purchaserInfoWithoutRequestData!.entitlements.active
         expect(entitlements["pro"]).toNot(beNil());
         expect(entitlements["old_pro"]).to(beNil());
     }
@@ -271,18 +271,18 @@ class BasicPurchaserInfoTests: XCTestCase {
                 ]
             ]
         ] as [String : Any]
-        let purchaserInfoWithoutRequestData = PurchaserInfo(data: response)
+        let purchaserInfoWithoutRequestData = Purchases.PurchaserInfo(data: response)
         let purchaseDate = purchaserInfoWithoutRequestData!.purchaseDate(forEntitlement: "pro")
         expect(purchaseDate).to(beNil())
     }
     
     func testEmptyInfosEqual() {
-        let info1 = PurchaserInfo(data: [
+        let info1 = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
                 "other_purchases": [:]
             ]])
-        let info2 = PurchaserInfo(data: [
+        let info2 = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
                 "other_purchases": [:]
@@ -291,13 +291,13 @@ class BasicPurchaserInfoTests: XCTestCase {
     }
     
     func testDifferentFetchDatesStillEqual() {
-        let info1 = PurchaserInfo(data: [
+        let info1 = Purchases.PurchaserInfo(data: [
             "request_date": "2018-12-19T02:40:36Z",
             "subscriber": [
                 "subscriptions": [:],
                 "other_purchases": [:]
             ]])
-        let info2 = PurchaserInfo(data: [
+        let info2 = Purchases.PurchaserInfo(data: [
             "request_date": "2018-11-19T02:40:36Z",
             "subscriber": [
                 "subscriptions": [:],
@@ -307,7 +307,7 @@ class BasicPurchaserInfoTests: XCTestCase {
     }
     
     func testDifferentActiveEntitlementsNotEqual() {
-        let info1 = PurchaserInfo(data: [
+        let info1 = Purchases.PurchaserInfo(data: [
             "request_date": "2018-12-20T02:40:36Z",
             "subscriber": [
                 "subscriptions": [
@@ -322,7 +322,7 @@ class BasicPurchaserInfoTests: XCTestCase {
                     ]
                 ]
             ]])
-        let info2 = PurchaserInfo(data: [
+        let info2 = Purchases.PurchaserInfo(data: [
             "request_date": "2018-11-19T02:40:36Z",
             "subscriber": [
                 "subscriptions": [
@@ -342,7 +342,7 @@ class BasicPurchaserInfoTests: XCTestCase {
     }
     
     func testDifferentEntitlementsNotEqual() {
-        let info1 = PurchaserInfo(data: [
+        let info1 = Purchases.PurchaserInfo(data: [
             "request_date": "2018-12-20T02:40:36Z",
             "subscriber": [
                 "subscriptions": [
@@ -366,7 +366,7 @@ class BasicPurchaserInfoTests: XCTestCase {
                     ]
                 ]
             ]])
-        let info2 = PurchaserInfo(data: [
+        let info2 = Purchases.PurchaserInfo(data: [
             "request_date": "2018-12-20T02:40:36Z",
             "subscriber": [
                 "subscriptions": [
@@ -394,7 +394,7 @@ class BasicPurchaserInfoTests: XCTestCase {
     }
     
     func testSameEntitlementsDifferentRequestDateEqual() {
-        let info1 = PurchaserInfo(data: [
+        let info1 = Purchases.PurchaserInfo(data: [
             "request_date": "2018-12-21T02:40:36Z",
             "subscriber": [
                 "subscriptions": [
@@ -418,7 +418,7 @@ class BasicPurchaserInfoTests: XCTestCase {
                     ]
                 ]
             ]])
-        let info2 = PurchaserInfo(data: [
+        let info2 = Purchases.PurchaserInfo(data: [
             "request_date": "2018-12-20T02:40:36Z",
             "subscriber": [
                 "subscriptions": [

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -126,7 +126,7 @@ class PurchasesTests: XCTestCase {
         var originalApplicationVersion: String?
         var timeout = false
         var getSubscriberCallCount = 0
-        var overridePurchaserInfo = PurchaserInfo(data: [
+        var overridePurchaserInfo = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
                 "other_purchases": [:]
@@ -155,7 +155,7 @@ class PurchasesTests: XCTestCase {
         var postedDiscounts: Array<RCPromotionalOffer>?
         var postedOfferingIdentifier: String?
 
-        var postReceiptPurchaserInfo: PurchaserInfo?
+        var postReceiptPurchaserInfo: Purchases.PurchaserInfo?
         var postReceiptError: Error?
         var aliasError: Error?
         var aliasCalled = false
@@ -196,7 +196,7 @@ class PurchasesTests: XCTestCase {
         override func getOfferingsForAppUserID(_ appUserID: String, completion: @escaping RCOfferingsResponseHandler) {
             gotOfferings += 1
             if (failOfferings) {
-                completion(nil, PurchasesErrorUtils.unexpectedBackendResponseError())
+                completion(nil, Purchases.ErrorUtils.unexpectedBackendResponseError())
                 return
             }
             if (badOfferingsResponse) {
@@ -347,20 +347,20 @@ class PurchasesTests: XCTestCase {
         var emptyOfferings = false
         var badOfferings = false
         
-        override func createOfferings(withProducts products: [String : SKProduct], data: [AnyHashable : Any]) -> Offerings? {
+        override func createOfferings(withProducts products: [String : SKProduct], data: [AnyHashable : Any]) -> Purchases.Offerings? {
             if (emptyOfferings) {
-                return Offerings(offerings: [:], currentOfferingID: "base")
+                return Purchases.Offerings(offerings: [:], currentOfferingID: "base")
             }
             if (badOfferings) {
                 return nil
             }
-            return Offerings(
+            return Purchases.Offerings(
                 offerings: [
-                    "base": Offering(
+                    "base": Purchases.Offering(
                         identifier: "base",
                         serverDescription: "This is the base offering",
                         availablePackages: [
-                            Package(identifier: "$rc_monthly", packageType: PackageType.monthly, product: MockProduct(mockProductIdentifier: "monthly_freetrial"), offeringIdentifier: "base")
+                            Purchases.Package(identifier: "$rc_monthly", packageType: Purchases.PackageType.monthly, product: MockProduct(mockProductIdentifier: "monthly_freetrial"), offeringIdentifier: "base")
                         ]
                     )],
                 currentOfferingID: "base")
@@ -369,9 +369,9 @@ class PurchasesTests: XCTestCase {
     }
 
     class Delegate: NSObject, PurchasesDelegate {
-        var purchaserInfo: PurchaserInfo?
+        var purchaserInfo: Purchases.PurchaserInfo?
         var purchaserInfoReceivedCount = 0
-        func purchases(_ purchases: Purchases, didReceiveUpdated purchaserInfo: PurchaserInfo) {
+        func purchases(_ purchases: Purchases, didReceiveUpdated purchaserInfo: Purchases.PurchaserInfo) {
             purchaserInfoReceivedCount += 1
             self.purchaserInfo = purchaserInfo
         }
@@ -466,7 +466,7 @@ class PurchasesTests: XCTestCase {
     func testDelegateIsCalledForRandomPurchaseSuccess() {
         setupPurchases()
         
-        let purchaserInfo = PurchaserInfo()
+        let purchaserInfo = Purchases.PurchaserInfo()
         self.backend.postReceiptPurchaserInfo = purchaserInfo
         
         let product = MockProduct(mockProductIdentifier: "product")
@@ -489,7 +489,7 @@ class PurchasesTests: XCTestCase {
     func testDelegateIsOnlyCalledOnceIfPurchaserInfoTheSame() {
         setupPurchases()
         
-        let purchaserInfo1 = PurchaserInfo(data: [
+        let purchaserInfo1 = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
                 "other_purchases": [:],
@@ -524,7 +524,7 @@ class PurchasesTests: XCTestCase {
     func testDelegateIsCalledTwiceIfPurchaserInfoTheDifferent() {
         setupPurchases()
         
-        let purchaserInfo1 = PurchaserInfo(data: [
+        let purchaserInfo1 = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
                 "other_purchases": [:],
@@ -532,7 +532,7 @@ class PurchasesTests: XCTestCase {
             ]
             ])
         
-        let purchaserInfo2 = PurchaserInfo(data: [
+        let purchaserInfo2 = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
                 "other_purchases": [:],
@@ -680,7 +680,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        self.backend.postReceiptPurchaserInfo = PurchaserInfo()
+        self.backend.postReceiptPurchaserInfo = Purchases.PurchaserInfo()
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -703,7 +703,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        self.backend.postReceiptPurchaserInfo = PurchaserInfo()
+        self.backend.postReceiptPurchaserInfo = Purchases.PurchaserInfo()
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -727,7 +727,7 @@ class PurchasesTests: XCTestCase {
             transaction.mockState = SKPaymentTransactionState.purchasing
             self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
             
-            self.backend.postReceiptPurchaserInfo = PurchaserInfo()
+            self.backend.postReceiptPurchaserInfo = Purchases.PurchaserInfo()
             
             transaction.mockState = SKPaymentTransactionState.purchased
             self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -774,7 +774,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
         
-        self.backend.postReceiptPurchaserInfo = PurchaserInfo()
+        self.backend.postReceiptPurchaserInfo = Purchases.PurchaserInfo()
         
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -800,7 +800,7 @@ class PurchasesTests: XCTestCase {
 
         let transaction = MockTransaction()
         transaction.mockPayment = self.storeKitWrapper.payment!
-        self.backend.postReceiptError = PurchasesErrorUtils.backendError(withBackendCode: RevenueCatBackendErrorCode.invalidAPIKey.rawValue as NSNumber, backendMessage: "Invalid credentials", finishable: false)
+        self.backend.postReceiptError = Purchases.ErrorUtils.backendError(withBackendCode: Purchases.RevenueCatBackendErrorCode.invalidAPIKey.rawValue as NSNumber, backendMessage: "Invalid credentials", finishable: false)
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -819,7 +819,7 @@ class PurchasesTests: XCTestCase {
         let transaction = MockTransaction()
         transaction.mockPayment = self.storeKitWrapper.payment!
 
-        self.backend.postReceiptError = PurchasesErrorUtils.backendError(withBackendCode: RevenueCatBackendErrorCode.invalidAPIKey.rawValue as NSNumber, backendMessage: "Invalid credentials", finishable: true)
+        self.backend.postReceiptError = Purchases.ErrorUtils.backendError(withBackendCode: Purchases.RevenueCatBackendErrorCode.invalidAPIKey.rawValue as NSNumber, backendMessage: "Invalid credentials", finishable: true)
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -838,7 +838,7 @@ class PurchasesTests: XCTestCase {
         let transaction = MockTransaction()
         transaction.mockPayment = self.storeKitWrapper.payment!
 
-        self.backend.postReceiptError = PurchasesErrorUtils.backendError(withBackendCode: PurchasesErrorCode.invalidCredentialsError.rawValue as NSNumber, backendMessage: "Invalid credentials", finishable: false)
+        self.backend.postReceiptError = Purchases.ErrorUtils.backendError(withBackendCode: Purchases.ErrorCode.invalidCredentialsError.rawValue as NSNumber, backendMessage: "Invalid credentials", finishable: false)
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -873,7 +873,7 @@ class PurchasesTests: XCTestCase {
         setupPurchases()
         let product = MockProduct(mockProductIdentifier: "com.product.id1")
         
-        var purchaserInfo: PurchaserInfo?
+        var purchaserInfo: Purchases.PurchaserInfo?
         var receivedError: Error?
         var receivedUserCancelled: Bool?
         
@@ -886,7 +886,7 @@ class PurchasesTests: XCTestCase {
         let transaction = MockTransaction()
         transaction.mockPayment = self.storeKitWrapper.payment!
 
-        self.backend.postReceiptPurchaserInfo = PurchaserInfo()
+        self.backend.postReceiptPurchaserInfo = Purchases.PurchaserInfo()
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -910,7 +910,7 @@ class PurchasesTests: XCTestCase {
         let transaction = MockTransaction()
         transaction.mockPayment = self.storeKitWrapper.payment!
         
-        self.backend.postReceiptPurchaserInfo = PurchaserInfo()
+        self.backend.postReceiptPurchaserInfo = Purchases.PurchaserInfo()
         
         transaction.mockState = SKPaymentTransactionState.purchased
         
@@ -934,7 +934,7 @@ class PurchasesTests: XCTestCase {
         let transaction = MockTransaction()
         transaction.mockPayment = SKPayment.init(product: otherProduct)
         
-        self.backend.postReceiptPurchaserInfo = PurchaserInfo()
+        self.backend.postReceiptPurchaserInfo = Purchases.PurchaserInfo()
         
         transaction.mockState = SKPaymentTransactionState.purchased
         
@@ -950,7 +950,7 @@ class PurchasesTests: XCTestCase {
         // First one "works"
         self.purchases?.purchaseProduct(product) { (tx, info, error, userCancelled) in }
         
-        var receivedInfo: PurchaserInfo?
+        var receivedInfo: Purchases.PurchaserInfo?
         var receivedError: NSError?
         var receivedUserCancelled: Bool?
         
@@ -963,8 +963,8 @@ class PurchasesTests: XCTestCase {
         
         expect(receivedInfo).toEventually(beNil())
         expect(receivedError).toEventuallyNot(beNil())
-        expect(receivedError?.domain).toEventually(equal(PurchasesErrorDomain))
-        expect(receivedError?.code).toEventually(equal(PurchasesErrorCode.operationAlreadyInProgressError.rawValue))
+        expect(receivedError?.domain).toEventually(equal(Purchases.ErrorDomain))
+        expect(receivedError?.code).toEventually(equal(Purchases.ErrorCode.operationAlreadyInProgressError.rawValue))
         expect(self.storeKitWrapper.addPaymentCallCount).to(equal(1))
         expect(receivedUserCancelled).toEventually(beFalse())
     }
@@ -1062,10 +1062,10 @@ class PurchasesTests: XCTestCase {
     func testRestoringPurchasesCallsSuccessDelegateMethod() {
         setupPurchases()
 
-        let purchaserInfo = PurchaserInfo()
+        let purchaserInfo = Purchases.PurchaserInfo()
         self.backend.postReceiptPurchaserInfo = purchaserInfo
         
-        var receivedPurchaserInfo: PurchaserInfo?
+        var receivedPurchaserInfo: Purchases.PurchaserInfo?
 
         purchases!.restoreTransactions { (info, error) in
             receivedPurchaserInfo = info
@@ -1077,7 +1077,7 @@ class PurchasesTests: XCTestCase {
     func testRestorePurchasesPassesErrorOnFailure() {
         setupPurchases()
         
-        let error = PurchasesErrorUtils.backendError(withBackendCode: RevenueCatBackendErrorCode.invalidAPIKey.rawValue as NSNumber, backendMessage: "Invalid credentials", finishable:true)
+        let error = Purchases.ErrorUtils.backendError(withBackendCode: Purchases.RevenueCatBackendErrorCode.invalidAPIKey.rawValue as NSNumber, backendMessage: "Invalid credentials", finishable:true)
         
         self.backend.postReceiptError = error
         self.purchasesDelegate.purchaserInfo = nil
@@ -1184,7 +1184,7 @@ class PurchasesTests: XCTestCase {
     func testFetchVersionSendsAReceiptIfNoVersion() {
         setupPurchases()
 
-        self.backend.postReceiptPurchaserInfo = PurchaserInfo(data: [
+        self.backend.postReceiptPurchaserInfo = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
                 "other_purchases": [:],
@@ -1192,7 +1192,7 @@ class PurchasesTests: XCTestCase {
             ]
         ])
         
-        var receivedPurchaserInfo: PurchaserInfo?
+        var receivedPurchaserInfo: Purchases.PurchaserInfo?
 
         purchases?.restoreTransactions { (info, error) in
             receivedPurchaserInfo = info
@@ -1225,7 +1225,7 @@ class PurchasesTests: XCTestCase {
 
         expect(self.userDefaults.cachedUserInfo.count).toEventually(equal(1))
 
-        self.backend.postReceiptPurchaserInfo = PurchaserInfo(data: [
+        self.backend.postReceiptPurchaserInfo = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
                 "other_purchases": [:]
@@ -1251,7 +1251,7 @@ class PurchasesTests: XCTestCase {
     }
 
     func testCachedPurchaserInfoHasSchemaVersion() {
-        let info = PurchaserInfo(data: [
+        let info = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
                 "other_purchases": [:]
@@ -1264,7 +1264,7 @@ class PurchasesTests: XCTestCase {
         
         setupPurchases()
         
-        var receivedInfo: PurchaserInfo?
+        var receivedInfo: Purchases.PurchaserInfo?
         
         purchases!.purchaserInfo { (info, error) in
             receivedInfo = info
@@ -1275,7 +1275,7 @@ class PurchasesTests: XCTestCase {
     }
     
     func testCachedPurchaserInfoHandlesNullSchema() {
-        let info = PurchaserInfo(data: [
+        let info = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
                 "other_purchases": [:]
@@ -1291,7 +1291,7 @@ class PurchasesTests: XCTestCase {
         
         setupPurchases()
         
-        var receivedInfo: PurchaserInfo?
+        var receivedInfo: Purchases.PurchaserInfo?
         
         purchases!.purchaserInfo { (info, error) in
             receivedInfo = info
@@ -1301,7 +1301,7 @@ class PurchasesTests: XCTestCase {
     }
 
     func testSendsCachedPurchaserInfoToGetter() {
-        let info = PurchaserInfo(data: [
+        let info = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
                 "other_purchases": [:]
@@ -1312,7 +1312,7 @@ class PurchasesTests: XCTestCase {
 
         setupPurchases()
         
-        var receivedInfo: PurchaserInfo?
+        var receivedInfo: Purchases.PurchaserInfo?
         
         purchases!.purchaserInfo { (info, error) in
             receivedInfo = info
@@ -1322,7 +1322,7 @@ class PurchasesTests: XCTestCase {
     }
     
     func testDoesntSendsCachedPurchaserInfoToGetterIfSchemaVersionDiffers() {
-        let info = PurchaserInfo(data: [
+        let info = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
                 "other_purchases": [:]
@@ -1336,7 +1336,7 @@ class PurchasesTests: XCTestCase {
         
         setupPurchases()
         
-        var receivedInfo: PurchaserInfo?
+        var receivedInfo: Purchases.PurchaserInfo?
         
         purchases!.purchaserInfo { (info, error) in
             receivedInfo = info
@@ -1346,7 +1346,7 @@ class PurchasesTests: XCTestCase {
     }
     
     func testDoesntSendsCachedPurchaserInfoToGetterIfNoSchemaVersionInCached() {
-        let info = PurchaserInfo(data: [
+        let info = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
                 "other_purchases": [:]
@@ -1360,7 +1360,7 @@ class PurchasesTests: XCTestCase {
         
         setupPurchases()
         
-        var receivedInfo: PurchaserInfo?
+        var receivedInfo: Purchases.PurchaserInfo?
         
         purchases!.purchaserInfo { (info, error) in
             receivedInfo = info
@@ -1386,7 +1386,7 @@ class PurchasesTests: XCTestCase {
         setupPurchases()
         expect(self.backend.gotOfferings).toEventually(equal(1))
 
-        var offerings: Offerings?
+        var offerings: Purchases.Offerings?
         self.purchases?.offerings { (newOfferings, _)  in
             offerings = newOfferings
         }
@@ -1412,7 +1412,7 @@ class PurchasesTests: XCTestCase {
             transaction.mockState = SKPaymentTransactionState.purchasing
             self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-            self.backend.postReceiptPurchaserInfo = PurchaserInfo()
+            self.backend.postReceiptPurchaserInfo = Purchases.PurchaserInfo()
 
             transaction.mockState = SKPaymentTransactionState.purchased
             self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -1432,7 +1432,7 @@ class PurchasesTests: XCTestCase {
         self.backend.failOfferings = true
         setupPurchases()
 
-        var offerings: Offerings?
+        var offerings: Purchases.Offerings?
         self.purchases?.offerings({ (newOfferings, _) in
             offerings = newOfferings
         })
@@ -1451,8 +1451,8 @@ class PurchasesTests: XCTestCase {
         })
 
         expect(receivedError).toEventuallyNot(beNil());
-        expect(receivedError?.domain).to(equal(PurchasesErrorDomain))
-        expect(receivedError?.code).to(be(PurchasesErrorCode.unexpectedBackendResponseError.rawValue))
+        expect(receivedError?.domain).to(equal(Purchases.ErrorDomain))
+        expect(receivedError?.code).to(be(Purchases.ErrorCode.unexpectedBackendResponseError.rawValue))
     }
 
     func testMissingProductDetailsReturnsNil() {
@@ -1460,7 +1460,7 @@ class PurchasesTests: XCTestCase {
         offeringsFactory.emptyOfferings = true
         setupPurchases()
 
-        var offerings: Offerings?
+        var offerings: Purchases.Offerings?
         self.purchases?.offerings({ (newOfferings, _) in
             offerings = newOfferings
         })
@@ -1528,7 +1528,7 @@ class PurchasesTests: XCTestCase {
         
         expect(completionCalled).toEventually(beTrue())
         
-        self.backend.aliasError = PurchasesErrorUtils.backendError(withBackendCode: RevenueCatBackendErrorCode.invalidAPIKey.rawValue as NSNumber, backendMessage: "Invalid credentials", finishable:true)
+        self.backend.aliasError = Purchases.ErrorUtils.backendError(withBackendCode: Purchases.RevenueCatBackendErrorCode.invalidAPIKey.rawValue as NSNumber, backendMessage: "Invalid credentials", finishable:true)
         
         self.purchases?.createAlias("cesardro") { (info, error) in
             completionCalled = error == nil
@@ -1538,6 +1538,7 @@ class PurchasesTests: XCTestCase {
     }
     
     func testCreateAliasCallsBackend() {
+        Purchases.ErrorDomain
         setupPurchases()
         self.backend.aliasCalled = false
         self.purchases?.createAlias("cesarpedro")
@@ -1548,7 +1549,7 @@ class PurchasesTests: XCTestCase {
     func testIdentify() {
         setupPurchases()
         
-        self.backend.overridePurchaserInfo = PurchaserInfo(data: [
+        self.backend.overridePurchaserInfo = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
                 "other_purchases": [:],
@@ -1571,7 +1572,7 @@ class PurchasesTests: XCTestCase {
         
         let newAppUserID = "cesarPedro"
         
-        var receivedInfo: PurchaserInfo?
+        var receivedInfo: Purchases.PurchaserInfo?
         self.purchases?.createAlias(newAppUserID) { (info, error) in
             receivedInfo = info
         }
@@ -1597,7 +1598,7 @@ class PurchasesTests: XCTestCase {
     
     func testResetGetsNewAppUserID() {
         setupPurchases()
-        var info: PurchaserInfo?
+        var info: Purchases.PurchaserInfo?
         
         self.purchases?.reset() { (newInfo, error) in
             info = newInfo
@@ -1609,7 +1610,7 @@ class PurchasesTests: XCTestCase {
     func testIdentifyForcesCache() {
         setupPurchases()
         
-        self.backend.overridePurchaserInfo = PurchaserInfo(data: [
+        self.backend.overridePurchaserInfo = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
                 "other_purchases": [:],
@@ -1627,7 +1628,7 @@ class PurchasesTests: XCTestCase {
     func testResetForcesCache() {
         setupPurchases()
         
-        self.backend.overridePurchaserInfo = PurchaserInfo(data: [
+        self.backend.overridePurchaserInfo = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
                 "other_purchases": [:],
@@ -1644,7 +1645,7 @@ class PurchasesTests: XCTestCase {
         
         self.backend.aliasCalled = false
         self.backend.aliasError = nil
-        self.backend.overridePurchaserInfo = PurchaserInfo(data: [
+        self.backend.overridePurchaserInfo = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
                 "other_purchases": [:],
@@ -1661,7 +1662,7 @@ class PurchasesTests: XCTestCase {
         
         self.backend.aliasCalled = false
         self.backend.aliasError = nil
-        self.backend.overridePurchaserInfo = PurchaserInfo(data: [
+        self.backend.overridePurchaserInfo = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
                 "other_purchases": [:],
@@ -1717,7 +1718,7 @@ class PurchasesTests: XCTestCase {
             receivedError = error as NSError?
         }
 
-        expect(receivedError?.code).toEventually(be(PurchasesErrorCode.missingReceiptFileError.rawValue))
+        expect(receivedError?.code).toEventually(be(Purchases.ErrorCode.missingReceiptFileError.rawValue))
     }
 
     func testUserCancelledFalseIfPurchaseSuccessful() {
@@ -1759,8 +1760,8 @@ class PurchasesTests: XCTestCase {
 
         expect(receivedUserCancelled).toEventually(beTrue())
         expect(receivedError).toEventuallyNot(beNil())
-        expect(receivedError?.domain).toEventually(be(PurchasesErrorDomain))
-        expect(receivedError?.code).toEventually(be(PurchasesErrorCode.purchaseCancelledError.rawValue))
+        expect(receivedError?.domain).toEventually(be(Purchases.ErrorDomain))
+        expect(receivedError?.code).toEventually(be(Purchases.ErrorCode.purchaseCancelledError.rawValue))
         expect(receivedUnderlyingError?.domain).toEventually(be(SKErrorDomain))
         expect(receivedUnderlyingError?.code).toEventually(equal(SKError.Code.paymentCancelled.rawValue))
     }
@@ -1784,7 +1785,7 @@ class PurchasesTests: XCTestCase {
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
         expect(receivedUserCancelled).toEventually(beFalse())
-        expect(receivedError?.code).toEventually(be(PurchasesErrorCode.missingReceiptFileError.rawValue))
+        expect(receivedError?.code).toEventually(be(Purchases.ErrorCode.missingReceiptFileError.rawValue))
         expect(self.backend.postReceiptDataCalled).toEventually(beFalse())
     }
     
@@ -1955,7 +1956,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
         
-        self.backend.postReceiptPurchaserInfo = PurchaserInfo()
+        self.backend.postReceiptPurchaserInfo = Purchases.PurchaserInfo()
         
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -1977,7 +1978,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
         
-        self.backend.postReceiptPurchaserInfo = PurchaserInfo()
+        self.backend.postReceiptPurchaserInfo = Purchases.PurchaserInfo()
         
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -2033,7 +2034,7 @@ class PurchasesTests: XCTestCase {
             transaction.mockState = SKPaymentTransactionState.purchasing
             self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-            self.backend.postReceiptPurchaserInfo = PurchaserInfo()
+            self.backend.postReceiptPurchaserInfo = Purchases.PurchaserInfo()
 
             transaction.mockState = SKPaymentTransactionState.purchased
             self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)


### PR DESCRIPTION
Related: https://github.com/RevenueCat/purchases-ios/issues/131

We might not want to update some of the ones I have updated. I didn't update `PurchasesDelegate` because it's probably extensively referenced.