### PR TITLE
Crash when a removed product is still in a transaction in the queue

### DIFF
--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -2049,6 +2049,30 @@ class PurchasesTests: XCTestCase {
         }
     }
 
+    func testProductIsRemovedButPresentInReceipt() {
+        self.requestFetcher.failProducts = true
+        setupPurchases()
+
+        let purchaserInfo = Purchases.PurchaserInfo()
+        self.backend.postReceiptPurchaserInfo = purchaserInfo
+
+        let product = MockProduct(mockProductIdentifier: "product")
+        let payment = SKPayment(product: product)
+
+        let transaction = MockTransaction()
+
+        transaction.mockPayment = payment
+
+        transaction.mockState = SKPaymentTransactionState.purchasing
+        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+
+        transaction.mockState = SKPaymentTransactionState.purchased
+        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
+        expect(self.purchasesDelegate.purchaserInfoReceivedCount).toEventually(equal(2))
+    }
+
     private func identifiedSuccessfully(appUserID: String) {
         expect(self.userDefaults.cachedUserInfo[self.userDefaults.appUserIDKey]).to(beNil())
         expect(self.purchases?.appUserID).to(equal(appUserID))

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -2049,7 +2049,7 @@ class PurchasesTests: XCTestCase {
         }
     }
 
-    func testProductIsRemovedButPresentInReceipt() {
+    func testProductIsRemovedButPresentInTheQueuedTransaction() {
         self.requestFetcher.failProducts = true
         setupPurchases()
 


### PR DESCRIPTION
Fixes https://github.com/RevenueCat/purchases-ios/issues/135

We were assuming the array of products is not empty but it's possible to get an empty array of SKProducts if the product that's in the transaction has been removed from App Store Connect 