### PR TITLE
Adds access to "all" offerings

### DIFF
--- a/Examples/SwiftExample/SwiftExample/CatsViewController.swift
+++ b/Examples/SwiftExample/SwiftExample/CatsViewController.swift
@@ -29,7 +29,7 @@ class CatsViewController: UIViewController {
 
     }
     
-    func configureCatContentFor(purchaserInfo: PurchaserInfo?) {
+    func configureCatContentFor(purchaserInfo: Purchases.PurchaserInfo?) {
         
         // set the content based on the user subscription status
         if let purchaserInfo = purchaserInfo {

--- a/Examples/SwiftExample/SwiftExample/SwiftPaywall.swift
+++ b/Examples/SwiftExample/SwiftExample/SwiftPaywall.swift
@@ -16,9 +16,9 @@ enum PayWallEdgeStyle : String {
 }
 
 @objc protocol SwiftPaywallDelegate {
-    func purchaseCompleted(paywall: SwiftPaywall, transaction: SKPaymentTransaction, purchaserInfo: PurchaserInfo)
-    @objc optional func purchaseFailed(paywall: SwiftPaywall, purchaserInfo: PurchaserInfo?, error: Error, userCancelled: Bool)
-    @objc optional func purchaseRestored(paywall: SwiftPaywall, purchaserInfo: PurchaserInfo?, error: Error?)
+    func purchaseCompleted(paywall: SwiftPaywall, transaction: SKPaymentTransaction, purchaserInfo: Purchases.PurchaserInfo)
+    @objc optional func purchaseFailed(paywall: SwiftPaywall, purchaserInfo: Purchases.PurchaserInfo?, error: Error, userCancelled: Bool)
+    @objc optional func purchaseRestored(paywall: SwiftPaywall, purchaserInfo: Purchases.PurchaserInfo?, error: Error?)
 }
 
 class SwiftPaywall: UIViewController {
@@ -48,7 +48,7 @@ class SwiftPaywall: UIViewController {
     
     // Internal variables
     private var scrollView : UIScrollView!
-    private var offering : Offering?
+    private var offering : Purchases.Offering?
     private var offeringCollectionView : UICollectionView!
     private let maxItemsPerRow : CGFloat = 3
     private let aspectRatio : CGFloat = 1.3
@@ -268,13 +268,13 @@ class SwiftPaywall: UIViewController {
         }
     }
     
-    private func shouldShowDiscount(package: Package?) -> (Bool, Package?) {
+    private func shouldShowDiscount(package: Purchases.Package?) -> (Bool, Purchases.Package?) {
         return (showDiscountPercentage == true
             && mostAffordablePackages.count > 1
             && mostAffordablePackages.first?.product.productIdentifier == package?.product.productIdentifier, mostAffordablePackages.last)
     }
     
-    private var mostAffordablePackages : [Package] {
+    private var mostAffordablePackages : [Purchases.Package] {
         guard let sorted = offering?.availablePackages
             .filter({$0.packageType != .lifetime && $0.packageType != .custom})
             .sorted(by: { $1.annualCost() > $0.annualCost() }) else {
@@ -692,8 +692,8 @@ private class PackageCell : UICollectionViewCell {
     }
     
     func setupWith(
-        package: Package?,
-        discount: (Bool, Package?),
+        package: Purchases.Package?,
+        discount: (Bool, Purchases.Package?),
         edgeStyle: PayWallEdgeStyle = .round,
         productSelectedColor: UIColor? = nil,
         productDeselectedColor: UIColor? = nil) {
@@ -764,7 +764,7 @@ private class PackageCell : UICollectionViewCell {
         }
     }
     
-    func discountBetween(highest: Package, current: Package) -> NSNumber {
+    func discountBetween(highest: Purchases.Package, current: Purchases.Package) -> NSNumber {
         let highestAnnualCost : NSNumber!
         switch highest.packageType {
         case .annual:
@@ -853,7 +853,7 @@ private class PackageCell : UICollectionViewCell {
     }
 }
 
-fileprivate extension Package {
+fileprivate extension Purchases.Package {
     
     func annualCost() -> Double {
         switch self.packageType {

--- a/Purchases/Public/RCOfferings.h
+++ b/Purchases/Public/RCOfferings.h
@@ -24,6 +24,11 @@ NS_SWIFT_NAME(Purchases.Offerings)
 @property (readonly, nullable) RCOffering *current;
 
 /**
+ Dictionary of all Offerings (`RCOffering`) objects keyed by their identifier. This dictionary can also be accessed by using an index subscript on RCOfferings, e.g. `offerings[@"offering_id"]`. To access the current offering use `RCOfferings.current`.
+*/
+@property (readonly) NSDictionary<NSString *, RCOffering *> *all;
+
+/**
  Retrieves a specific offering by its identifier, use this to access additional offerings configured in the RevenueCat dashboard, e.g. `[offerings offeringWithIdentifier:@"offering_id"]` or `offerings[@"offering_id"]`. To access the current offering use `RCOfferings.current`.
 */
 - (nullable RCOffering *)offeringWithIdentifier:(nullable NSString *)identifier NS_SWIFT_NAME(offering(identifier:));

--- a/Purchases/Public/RCOfferings.m
+++ b/Purchases/Public/RCOfferings.m
@@ -11,7 +11,7 @@
 
 @interface RCOfferings ()
 @property (readwrite, nullable) NSString *currentOfferingID;
-@property (readwrite) NSDictionary<NSString *, RCOffering *> *offerings;
+@property (readwrite) NSDictionary<NSString *, RCOffering *> *all;
 @end
 
 @implementation RCOfferings
@@ -19,7 +19,7 @@
 {
     self = [super init];
     if (self) {
-        self.offerings = offerings;
+        self.all = offerings;
         self.currentOfferingID = currentOfferingID;
     }
 
@@ -28,7 +28,7 @@
 
 - (nullable RCOffering *)offeringWithIdentifier:(nullable NSString *)identifier
 {
-    return self.offerings[identifier];
+    return self.all[identifier];
 }
 
 - (nullable RCOffering *)objectForKeyedSubscript:(NSString *)key
@@ -39,7 +39,7 @@
 - (nullable RCOffering *)current
 {
     if (self.currentOfferingID) {
-        return self.offerings[self.currentOfferingID];
+        return self.all[self.currentOfferingID];
     }
     return nil;
 }
@@ -47,8 +47,8 @@
 - (NSString *)description
 {
     NSMutableString *description = [NSMutableString stringWithFormat:@"<Offerings {\n"];
-    for (NSString *offeringName in self.offerings) {
-        RCOffering *offering = self.offerings[offeringName];
+    for (NSString *offeringName in self.all) {
+        RCOffering *offering = self.all[offeringName];
         NSString *offeringDesc = [NSMutableString stringWithFormat:@"\t%@\n", offering];
         [description appendString:offeringDesc];
     }

--- a/Purchases/RCOfferings+Protected.h
+++ b/Purchases/RCOfferings+Protected.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RCOfferings (Protected)
 
-@property (readonly) NSDictionary<NSString *, RCOffering *> *offerings;
+@property (readonly) NSDictionary<NSString *, RCOffering *> *all;
 
 - (instancetype)initWithOfferings:(NSDictionary<NSString *, RCOffering *> *)offerings currentOfferingID:(NSString *)currentOfferingID;
 


### PR DESCRIPTION
- I added visibility to `all` offerings. We already had the property in the class, so I just added it to the header and renamed it.
- Updated the sample with the `Purchases.` prefix of the Swift classes.