### PR TITLE
Adds observer_mode to postReceipt calls

### DIFF
--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -579,8 +579,8 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                     subscriptionGroup:nil
                             discounts:nil
           presentedOfferingIdentifier:nil
-                           completion:^(RCPurchaserInfo *_Nullable info,
-                                   NSError *_Nullable error) {
+                         observerMode:!self.finishTransactions
+                           completion:^(RCPurchaserInfo *_Nullable info, NSError *_Nullable error) {
                                [self dispatch:^{
                                    if (error) {
                                        CALL_AND_DISPATCH_IF_SET(completion, nil, error);
@@ -996,6 +996,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                                               subscriptionGroup:subscriptionGroup
                                                       discounts:discounts
                                     presentedOfferingIdentifier:presentedOffering
+                                                   observerMode:!self.finishTransactions
                                                      completion:^(RCPurchaserInfo * _Nullable info,
                                                              NSError * _Nullable error) {
                                                          [self handleReceiptPostWithTransaction:transaction
@@ -1014,6 +1015,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                                               subscriptionGroup:nil
                                                       discounts:nil
                                     presentedOfferingIdentifier:nil
+                                                   observerMode:!self.finishTransactions
                                                      completion:^(RCPurchaserInfo * _Nullable info,
                                                              NSError * _Nullable error) {
                                                          [self handleReceiptPostWithTransaction:transaction

--- a/Purchases/RCBackend.h
+++ b/Purchases/RCBackend.h
@@ -57,6 +57,7 @@ typedef void(^RCOfferSigningResponseHandler)(NSString * _Nullable signature,
           subscriptionGroup:(nullable NSString *)subscriptionGroup
                   discounts:(nullable NSArray<RCPromotionalOffer *> *)discounts
 presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
+               observerMode:(BOOL)observerMode
                  completion:(RCBackendPurchaserInfoResponseHandler)completion;
 
 - (void)getSubscriberDataWithAppUserID:(NSString *)appUserID

--- a/Purchases/RCBackend.m
+++ b/Purchases/RCBackend.m
@@ -215,7 +215,7 @@ presentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
     }
 
     if (paymentMode != RCPaymentModeNone) {
-        body[@"payment_mode"] = @((NSUInteger) paymentMode);
+        body[@"payment_mode"] = @((NSUInteger)paymentMode);
     }
 
     if (introductoryPrice) {

--- a/Purchases/RCBackend.m
+++ b/Purchases/RCBackend.m
@@ -167,6 +167,7 @@ RCPaymentMode RCPaymentModeFromSKProductDiscountPaymentMode(SKProductDiscountPay
           subscriptionGroup:(nullable NSString *)subscriptionGroup
                   discounts:(nullable NSArray<RCPromotionalOffer *> *)discounts
 presentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
+               observerMode:(BOOL)observerMode
                  completion:(RCBackendPurchaserInfoResponseHandler)completion
 {
     NSString *fetchToken = [data base64EncodedStringWithOptions:0];
@@ -174,10 +175,11 @@ presentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
                                  @{
                                    @"fetch_token": fetchToken,
                                    @"app_user_id": appUserID,
-                                   @"is_restore": @(isRestore)
-                                   }];
+                                   @"is_restore": @(isRestore),
+                                   @"observer_mode": @(observerMode)
+                                 }];
 
-    NSString *cacheKey = [NSString stringWithFormat:@"%@-%@-%@-%@-%@-%@-%@-%@-%@-%@",
+    NSString *cacheKey = [NSString stringWithFormat:@"%@-%@-%@-%@-%@-%@-%@-%@-%@-%@-%@",
                           appUserID,
                           @(isRestore),
                           fetchToken,
@@ -187,7 +189,8 @@ presentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
                           @((NSUInteger)paymentMode),
                           introductoryPrice,
                           subscriptionGroup,
-                          presentedOfferingIdentifier];
+                          presentedOfferingIdentifier,
+                          @(observerMode)];
 
     if (@available(iOS 12.2, macOS 10.14.4, *)) {
         for (RCPromotionalOffer *discount in discounts) {
@@ -212,13 +215,13 @@ presentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
     }
 
     if (paymentMode != RCPaymentModeNone) {
-        body[@"payment_mode"] = @((NSUInteger)paymentMode);
+        body[@"payment_mode"] = @((NSUInteger) paymentMode);
     }
 
     if (introductoryPrice) {
         body[@"introductory_price"] = introductoryPrice;
     }
-    
+
     if (subscriptionGroup) {
         body[@"subscription_group_id"] = subscriptionGroup;
     }

--- a/PurchasesTests/BackendTests.swift
+++ b/PurchasesTests/BackendTests.swift
@@ -90,15 +90,20 @@ class BackendTests: XCTestCase {
         var completionCalled = false
 
         let isRestore = arc4random_uniform(2) == 0
+        let observerMode = arc4random_uniform(2) == 0
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, completion: { (purchaserInfo, error) in
-            completionCalled = true
-        })
+        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil,
+                price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil,
+                subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
+                completion: { (purchaserInfo, error) in
+                    completionCalled = true
+                })
 
         let expectedCall = HTTPRequest(HTTPMethod: "POST", path: "/receipts", body: [
             "app_user_id": userID,
             "fetch_token": receiptData.base64EncodedString(),
-            "is_restore": isRestore
+            "is_restore": isRestore,
+            "observer_mode": observerMode
             ], headers: ["Authorization": "Bearer " + apiKey])
 
         expect(self.httpClient.calls.count).to(equal(1))
@@ -123,14 +128,21 @@ class BackendTests: XCTestCase {
         var completionCalled = 0
 
         let isRestore = arc4random_uniform(2) == 0
+        let observerMode = arc4random_uniform(2) == 0
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, completion: { (purchaserInfo, error) in
-            completionCalled += 1
-        })
+        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
+                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
+                discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
+                completion: { (purchaserInfo, error) in
+                    completionCalled += 1
+                })
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, completion: { (purchaserInfo, error) in
-            completionCalled += 1
-        })
+        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
+                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
+                discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
+                completion: { (purchaserInfo, error) in
+                    completionCalled += 1
+                })
 
         expect(self.httpClient.calls.count).to(equal(1))
         expect(completionCalled).toEventually(equal(2))
@@ -143,14 +155,21 @@ class BackendTests: XCTestCase {
         var completionCalled = 0
 
         let isRestore = arc4random_uniform(2) == 0
+        let observerMode = arc4random_uniform(2) == 0
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, completion: { (purchaserInfo, error) in
-            completionCalled += 1
-        })
+        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
+                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
+                discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
+                completion: { (purchaserInfo, error) in
+                    completionCalled += 1
+                })
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: !isRestore, productIdentifier: nil, price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, completion: { (purchaserInfo, error) in
-            completionCalled += 1
-        })
+        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: !isRestore, productIdentifier: nil, price: nil,
+                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
+                discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
+                completion: { (purchaserInfo, error) in
+                    completionCalled += 1
+                })
 
         expect(self.httpClient.calls.count).to(equal(2))
         expect(completionCalled).toEventually(equal(2))
@@ -163,14 +182,21 @@ class BackendTests: XCTestCase {
         var completionCalled = 0
 
         let isRestore = arc4random_uniform(2) == 0
+        let observerMode = arc4random_uniform(2) == 0
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, completion: { (purchaserInfo, error) in
-            completionCalled += 1
-        })
+        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
+                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
+                discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
+                completion: { (purchaserInfo, error) in
+                    completionCalled += 1
+                })
 
-        backend?.postReceiptData(receiptData2, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, completion: { (purchaserInfo, error) in
-            completionCalled += 1
-        })
+        backend?.postReceiptData(receiptData2, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
+                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
+                discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
+                completion: { (purchaserInfo, error) in
+                    completionCalled += 1
+                })
 
         expect(self.httpClient.calls.count).to(equal(2))
         expect(completionCalled).toEventually(equal(2))
@@ -183,14 +209,21 @@ class BackendTests: XCTestCase {
         var completionCalled = 0
 
         let isRestore = arc4random_uniform(2) == 0
+        let observerMode = arc4random_uniform(2) == 0
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, completion: { (purchaserInfo, error) in
-            completionCalled += 1
-        })
+        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
+                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
+                discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
+                completion: { (purchaserInfo, error) in
+                    completionCalled += 1
+                })
 
-        backend?.postReceiptData(receiptData2, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: "USD", subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, completion: { (purchaserInfo, error) in
-            completionCalled += 1
-        })
+        backend?.postReceiptData(receiptData2, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
+                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: "USD", subscriptionGroup: nil,
+                discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
+                completion: { (purchaserInfo, error) in
+                    completionCalled += 1
+                })
 
         expect(self.httpClient.calls.count).to(equal(2))
         expect(completionCalled).toEventually(equal(2))
@@ -203,14 +236,21 @@ class BackendTests: XCTestCase {
         var completionCalled = 0
 
         let isRestore = arc4random_uniform(2) == 0
+        let observerMode = arc4random_uniform(2) == 0
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: "offering_a", completion: { (purchaserInfo, error) in
-            completionCalled += 1
-        })
+        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
+                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
+                discounts: nil, presentedOfferingIdentifier: "offering_a", observerMode: observerMode,
+                completion: { (purchaserInfo, error) in
+                    completionCalled += 1
+                })
 
-        backend?.postReceiptData(receiptData2, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: "offering_b", completion: { (purchaserInfo, error) in
-            completionCalled += 1
-        })
+        backend?.postReceiptData(receiptData2, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
+                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
+                discounts: nil, presentedOfferingIdentifier: "offering_b", observerMode: observerMode,
+                completion: { (purchaserInfo, error) in
+                    completionCalled += 1
+                })
 
         expect(self.httpClient.calls.count).to(equal(2))
         expect(completionCalled).toEventually(equal(2))
@@ -259,9 +299,12 @@ class BackendTests: XCTestCase {
 
         var completionCalled = false
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: productIdentifier, price: price, paymentMode: paymentMode, introductoryPrice: nil, currencyCode: currencyCode, subscriptionGroup: group, discounts: nil, presentedOfferingIdentifier: offeringIdentifier, completion: { (purchaserInfo, error) in
-completionCalled = true
-})
+        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: productIdentifier,
+                price: price, paymentMode: paymentMode, introductoryPrice: nil, currencyCode: currencyCode,
+                subscriptionGroup: group, discounts: nil, presentedOfferingIdentifier: offeringIdentifier,
+                observerMode: false, completion: { (purchaserInfo, error) in
+            completionCalled = true
+        })
 
         let body: [String: Any] = [
             "app_user_id": userID,
@@ -271,7 +314,8 @@ completionCalled = true
             "price": price,
             "currency": currencyCode,
             "subscription_group_id": group,
-            "presented_offering_identifier": offeringIdentifier
+            "presented_offering_identifier": offeringIdentifier,
+            "observer_mode": false
         ]
 
         let expectedCall = HTTPRequest(HTTPMethod: "POST", path: "/receipts",
@@ -299,9 +343,12 @@ completionCalled = true
 
         var completionCalled = false
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: "product_id", price: 9.99, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, completion: { (purchaserInfo, error) in
-            completionCalled = true
-        })
+        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: "product_id",
+                price: 9.99, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil,
+                subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, observerMode: false,
+                completion: { (purchaserInfo, error) in
+                    completionCalled = true
+                })
 
         expect(self.httpClient.calls.count).to(equal(1))
         expect(completionCalled).toEventually(beTrue())
@@ -313,9 +360,12 @@ completionCalled = true
     func postPaymentMode(paymentMode: RCPaymentMode) {
         var completionCalled = false
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: "product", price: 2.99, paymentMode: paymentMode, introductoryPrice: 1.99, currencyCode: "USD", subscriptionGroup: "group", discounts: nil, presentedOfferingIdentifier: nil, completion: { (purchaserInfo, error) in
-           completionCalled = true
-})
+        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: "product",
+                price: 2.99, paymentMode: paymentMode, introductoryPrice: 1.99, currencyCode: "USD",
+                subscriptionGroup: "group", discounts: nil, presentedOfferingIdentifier: nil, observerMode: false,
+                completion: { (purchaserInfo, error) in
+                    completionCalled = true
+                })
 
         expect(completionCalled).toEventually(beTrue())
     }
@@ -357,10 +407,13 @@ completionCalled = true
 
         var error: NSError?
         var underlyingError: NSError?
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: nil, price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, completion: { (purchaserInfo, newError) in
-error = newError as NSError?
-underlyingError = error?.userInfo[NSUnderlyingErrorKey] as! NSError?
-})
+        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: nil,
+                price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil,
+                subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, observerMode: false,
+                completion: { (purchaserInfo, newError) in
+                    error = newError as NSError?
+                    underlyingError = error?.userInfo[NSUnderlyingErrorKey] as! NSError?
+                })
 
         expect(error).toEventuallyNot(beNil())
         expect(error?.code).toEventually(be(Purchases.ErrorCode.invalidCredentialsError.rawValue))
@@ -377,9 +430,12 @@ underlyingError = error?.userInfo[NSUnderlyingErrorKey] as! NSError?
         var error: Error?
         var underlyingError: Error?
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: nil, price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, completion: { (purchaserInfo, newError) in
-error = newError
-})
+        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: nil, price: nil,
+                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
+                discounts: nil, presentedOfferingIdentifier: nil, observerMode: false,
+                completion: { (purchaserInfo, newError) in
+                    error = newError
+                })
 
         expect(error).toEventuallyNot(beNil())
         expect((error as NSError?)?.code).toEventually(be(Purchases.ErrorCode.invalidCredentialsError.rawValue))
@@ -396,9 +452,12 @@ error = newError
 
         var purchaserInfo: Purchases.PurchaserInfo?
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: nil, price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, completion: { (newPurchaserInfo, newError) in
-purchaserInfo = newPurchaserInfo
-})
+        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: nil, price: nil,
+                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
+                discounts: nil, presentedOfferingIdentifier: nil, observerMode: false,
+                completion: { (newPurchaserInfo, newError) in
+                    purchaserInfo = newPurchaserInfo
+                })
 
         expect(purchaserInfo).toEventuallyNot(beNil())
         if purchaserInfo != nil {
@@ -723,10 +782,13 @@ purchaserInfo = newPurchaserInfo
         httpClient.mock(requestPath: "/receipts", response: response)
         var receivedError : NSError?
         var receivedUnderlyingError : NSError?
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: true, productIdentifier: nil, price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, completion: { (purchaserInfo, error) in
-            receivedError = error as NSError?
-            receivedUnderlyingError = receivedError?.userInfo[NSUnderlyingErrorKey] as! NSError?
-        })
+        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: true, productIdentifier: nil, price: nil,
+                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
+                discounts: nil, presentedOfferingIdentifier: nil, observerMode: false,
+                completion: { (purchaserInfo, error) in
+                    receivedError = error as NSError?
+                    receivedUnderlyingError = receivedError?.userInfo[NSUnderlyingErrorKey] as! NSError?
+                })
 
         expect(receivedError).toEventuallyNot(beNil())
         expect(receivedError?.domain).toEventually(equal(Purchases.ErrorDomain))
@@ -833,19 +895,26 @@ purchaserInfo = newPurchaserInfo
         var completionCalled = 0
         
         let isRestore = arc4random_uniform(2) == 0
+        let observerMode = arc4random_uniform(2) == 0
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, completion: { (purchaserInfo, error) in
-            completionCalled += 1
-        })
+        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
+                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
+                discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
+                completion: { (purchaserInfo, error) in
+                    completionCalled += 1
+                })
         
         let discount = RCPromotionalOffer.init()
         discount.offerIdentifier = "offerid"
         discount.paymentMode = RCPaymentMode.payAsYouGo
         discount.price = 12
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil, discounts: [discount], presentedOfferingIdentifier: nil, completion: { (purchaserInfo, error) in
-            completionCalled += 1
-        })
+        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
+                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
+                discounts: [discount], presentedOfferingIdentifier: nil, observerMode: observerMode,
+                completion: { (purchaserInfo, error) in
+                    completionCalled += 1
+                })
         
         expect(self.httpClient.calls.count).to(equal(2))
         expect(completionCalled).toEventually(equal(2))
@@ -870,14 +939,18 @@ purchaserInfo = newPurchaserInfo
         discount.paymentMode = RCPaymentMode.payAsYouGo
         discount.price = 12
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: productIdentifier, price: price, paymentMode: paymentMode, introductoryPrice: nil, currencyCode: currencyCode, subscriptionGroup: group, discounts: [discount], presentedOfferingIdentifier: nil, completion: { (purchaserInfo, error) in
-            completionCalled = true
-        })
+        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: productIdentifier,
+                price: price, paymentMode: paymentMode, introductoryPrice: nil, currencyCode: currencyCode,
+                subscriptionGroup: group, discounts: [discount], presentedOfferingIdentifier: nil, observerMode: false,
+                completion: { (purchaserInfo, error) in
+                    completionCalled = true
+                })
         
         let body: [String: Any] = [
             "app_user_id": userID,
             "fetch_token": receiptData.base64EncodedString(),
             "is_restore": false,
+            "observer_mode": false,
             "product_id": productIdentifier,
             "price": price,
             "currency": currencyCode,
@@ -1154,19 +1227,26 @@ purchaserInfo = newPurchaserInfo
         var completionCalled = 0
         
         let isRestore = arc4random_uniform(2) == 0
-        
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, completion: { (purchaserInfo, error) in
-            completionCalled += 1
-        })
+        let observerMode = arc4random_uniform(2) == 0
+
+        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
+                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
+                discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
+                completion: { (purchaserInfo, error) in
+                    completionCalled += 1
+                })
         
         let discount = RCPromotionalOffer.init()
         discount.offerIdentifier = "offerid"
         discount.paymentMode = RCPaymentMode.payAsYouGo
         discount.price = 12
-        
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: "offering_a", completion: { (purchaserInfo, error) in
-            completionCalled += 1
-        })
+
+        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
+                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
+                discounts: nil, presentedOfferingIdentifier: "offering_a", observerMode: observerMode,
+                completion: { (purchaserInfo, error) in
+                    completionCalled += 1
+                })
         
         expect(self.httpClient.calls.count).to(equal(2))
         expect(completionCalled).toEventually(equal(2))


### PR DESCRIPTION
Adds a new `observer_mode` parameter that will help us know if deverlopers have observer mode on or not.