### PR TITLE
[MISSING TESTS] Adds manageSubscriptionURLForProduct

### DIFF
--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -375,6 +375,9 @@ NS_SWIFT_NAME(restoreTransactions(_:));
            withDiscount:(SKPaymentDiscount *)discount
         completionBlock:(RCPurchaseCompletedBlock)completion NS_SWIFT_NAME(purchasePackage(_:discount:_:)) API_AVAILABLE(ios(12.2), macosx(10.14.4));
 
+- (void)manageSubscriptionURLForProduct:(SKProduct *)product
+                    withCompletionBlock:(void (^)(NSURL *))completion;
+
 #pragma mark Unavailable Methods
 #define RC_UNAVAILABLE(msg) __attribute__((unavailable(msg)));
 /// :nodoc:

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -632,6 +632,18 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
     }];
 }
 
+- (void)manageSubscriptionURLForProduct:(SKProduct *)product
+                    withCompletionBlock:(void (^)(NSURL *))completion
+{
+    [self.backend manageSubscriptionsURLForProductID:product.productIdentifier withAppUserID:self.appUserID completion:^(NSURL * _Nullable url, NSError * _Nullable error) {
+        if (error) {
+            RCDebugLog(@"There was an error fetching URL, using default.");
+            url = [NSURL URLWithString:@"itms-apps://apps.apple.com/account/subscriptions"];
+        }
+        CALL_AND_DISPATCH_IF_SET(completion, url);
+    }];
+}
+
 #pragma mark - Private Methods
 
 - (void)applicationDidBecomeActive:(__unused NSNotification *)notif

--- a/Purchases/RCBackend.h
+++ b/Purchases/RCBackend.h
@@ -87,6 +87,10 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
                   appUserID:(NSString *)applicationUsername
                  completion:(RCOfferSigningResponseHandler)completion;
 
+- (void)manageSubscriptionsURLForProductID:(NSString *)productID
+                             withAppUserID:(NSString *)appUserID
+                                completion:(nullable void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Purchases/RCBackend.m
+++ b/Purchases/RCBackend.m
@@ -403,7 +403,6 @@ presentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
                   }];
 }
 
-
 - (void)postOfferForSigning:(NSString *)offerIdentifier
       withProductIdentifier:(NSString *)productIdentifier
           subscriptionGroup:(NSString *)subscriptionGroup
@@ -456,6 +455,32 @@ presentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
                       }
 
                       completion(nil, nil, nil, nil, error);
+                  }];
+}
+
+- (void)manageSubscriptionsURLForProductID:(NSString *)productID
+                             withAppUserID:(NSString *)appUserID
+                                completion:(nullable void (^)(NSURL * _Nullable url, NSError * _Nullable error))completion
+{
+    NSString *escapedAppUserID = [self escapedAppUserID:appUserID];
+    NSString *path = [NSString stringWithFormat:@"/subscribers/%@/subscriptions/%@/manage", escapedAppUserID, productID];
+    [self.httpClient performRequest:@"GET"
+                               path:path
+                               body:nil
+                            headers:self.headers
+                  completionHandler:^(NSInteger statusCode, NSDictionary *_Nullable response, NSError *_Nullable error) {
+                        if (error == nil && statusCode < 300) {
+                            completion([NSURL URLWithString:response[@"url"]], nil);
+                            return;
+                        }
+
+                        if (error != nil) {
+                            error = [RCPurchasesErrorUtils networkErrorWithUnderlyingError:error];
+                        } else if (statusCode > 300) {
+                            error = [RCPurchasesErrorUtils backendErrorWithBackendCode:response[@"code"]
+                                                                        backendMessage:response[@"message"]];
+                        }
+                        completion(nil, error);
                   }];
 }
 


### PR DESCRIPTION
Adds a function `- (void)manageSubscriptionURLForProduct:(SKProduct *)product withCompletionBlock:(void (^)(NSURL *))completion;` that returns a NSURL that can be opened to manage the account subscriptions. 
