### PR TITLE
Adds platform flavor private configure method

### DIFF
--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -143,25 +143,35 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                        observerMode:(BOOL)observerMode
                        userDefaults:(nullable NSUserDefaults *)userDefaults
 {
-    RCPurchases *purchases = [[self alloc] initWithAPIKey:APIKey appUserID:appUserID userDefaults:userDefaults observerMode:observerMode];
+    return [self configureWithAPIKey:APIKey appUserID:appUserID observerMode:observerMode userDefaults:userDefaults platformFlavor:nil];
+}
+
++ (instancetype)configureWithAPIKey:(NSString *)APIKey
+                          appUserID:(nullable NSString *)appUserID
+                       observerMode:(BOOL)observerMode
+                       userDefaults:(nullable NSUserDefaults *)userDefaults
+                     platformFlavor:(NSString *)platformFlavor
+{
+    RCPurchases *purchases = [[self alloc] initWithAPIKey:APIKey appUserID:appUserID userDefaults:userDefaults observerMode:observerMode platformFlavor:platformFlavor];
     [self setDefaultInstance:purchases];
     return purchases;
 }
 
 - (instancetype)initWithAPIKey:(NSString *)APIKey appUserID:(nullable NSString *)appUserID
 {
-    return [self initWithAPIKey:APIKey appUserID:appUserID userDefaults:nil observerMode:false];
+    return [self initWithAPIKey:APIKey appUserID:appUserID userDefaults:nil observerMode:false platformFlavor:nil];
 }
 
 - (instancetype)initWithAPIKey:(NSString *)APIKey
                      appUserID:(nullable NSString *)appUserID
                   userDefaults:(nullable NSUserDefaults *)userDefaults
                   observerMode:(BOOL)observerMode
+                platformFlavor:(nullable NSString *)platformFlavor
 {
     RCStoreKitRequestFetcher *fetcher = [[RCStoreKitRequestFetcher alloc] init];
     RCReceiptFetcher *receiptFetcher = [[RCReceiptFetcher alloc] init];
     RCAttributionFetcher *attributionFetcher = [[RCAttributionFetcher alloc] init];
-    RCBackend *backend = [[RCBackend alloc] initWithAPIKey:APIKey];
+    RCBackend *backend = [[RCBackend alloc] initWithAPIKey:APIKey platformFlavor:platformFlavor];
     RCStoreKitWrapper *storeKitWrapper = [[RCStoreKitWrapper alloc] init];
     RCOfferingsFactory *offeringsFactory = [[RCOfferingsFactory alloc] init];
 

--- a/Purchases/RCBackend.h
+++ b/Purchases/RCBackend.h
@@ -41,7 +41,7 @@ typedef void(^RCOfferSigningResponseHandler)(NSString * _Nullable signature,
 
 @interface RCBackend : NSObject
 
-- (nullable instancetype)initWithAPIKey:(NSString *)APIKey;
+- (nullable instancetype)initWithAPIKey:(NSString *)APIKey platformFlavor:(NSString *)platformFlavor;
 
 - (nullable instancetype)initWithHTTPClient:(RCHTTPClient *)client
                                      APIKey:(NSString *)APIKey;

--- a/Purchases/RCBackend.m
+++ b/Purchases/RCBackend.m
@@ -44,9 +44,9 @@ RCPaymentMode RCPaymentModeFromSKProductDiscountPaymentMode(SKProductDiscountPay
 
 @implementation RCBackend
 
-- (nullable instancetype)initWithAPIKey:(NSString *)APIKey
+- (nullable instancetype)initWithAPIKey:(NSString *)APIKey platformFlavor:(NSString *)platformFlavor
 {
-    RCHTTPClient *client = [[RCHTTPClient alloc] init];
+    RCHTTPClient *client = [[RCHTTPClient alloc] initWithPlatformFlavor:platformFlavor];
     return [self initWithHTTPClient:client
                              APIKey:APIKey];
 }

--- a/Purchases/RCHTTPClient.h
+++ b/Purchases/RCHTTPClient.h
@@ -16,6 +16,7 @@ typedef void(^RCHTTPClientResponseHandler)(NSInteger statusCode,
 
 @interface RCHTTPClient : NSObject
 
+- (instancetype)initWithPlatformFlavor:(nullable NSString *)platformFlavor;
 
 + (NSString *)serverHostName;
 

--- a/Purchases/RCHTTPClient.m
+++ b/Purchases/RCHTTPClient.m
@@ -21,6 +21,7 @@ void RCOverrideServerHost(NSString *hostname)
 @interface RCHTTPClient ()
 
 @property (nonatomic) NSURLSession *session;
+@property (nonatomic) NSString *platformFlavor;
 
 @end
 
@@ -31,12 +32,13 @@ void RCOverrideServerHost(NSString *hostname)
     return  (overrideHostName) ? overrideHostName : @"api.revenuecat.com";
 }
 
-- (instancetype)init
+- (instancetype)initWithPlatformFlavor:(nullable NSString *)platformFlavor
 {
     if (self = [super init]) {
         NSURLSessionConfiguration *config = [NSURLSessionConfiguration ephemeralSessionConfiguration];
         config.HTTPMaximumConnectionsPerHost = 1;
         self.session = [NSURLSession sessionWithConfiguration:config];
+        self.platformFlavor = platformFlavor;
     }
     return self;
 }
@@ -71,7 +73,11 @@ void RCOverrideServerHost(NSString *hostname)
                                                                       @"X-Version": [RCPurchases frameworkVersion],
                                                                       @"X-Platform": PLATFORM_HEADER,
                                                                       @"X-Platform-Version": [self.class systemVersion],
+                                                                      @"X-Platform-Flavor": self.platformFlavor ? self.platformFlavor : @"native",
                                                                       @"X-Client-Version": [self.class appVersion]}];
+
+    RCDebugLog(@"Platform header - %@", defaultHeaders[@"X-Platform-Flavor"]);
+
     [defaultHeaders addEntriesFromDictionary:headers];
 
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:urlString]];

--- a/Purchases/RCHTTPClient.m
+++ b/Purchases/RCHTTPClient.m
@@ -75,9 +75,6 @@ void RCOverrideServerHost(NSString *hostname)
                                                                       @"X-Platform-Version": [self.class systemVersion],
                                                                       @"X-Platform-Flavor": self.platformFlavor ? self.platformFlavor : @"native",
                                                                       @"X-Client-Version": [self.class appVersion]}];
-
-    RCDebugLog(@"Platform header - %@", defaultHeaders[@"X-Platform-Flavor"]);
-
     [defaultHeaders addEntriesFromDictionary:headers];
 
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:urlString]];

--- a/PurchasesTests/HTTPClientTests.swift
+++ b/PurchasesTests/HTTPClientTests.swift
@@ -15,7 +15,7 @@ import Purchases
 
 class HTTPClientTests: XCTestCase {
 
-    let client = RCHTTPClient()
+    let client = RCHTTPClient(platformFlavor: nil)
 
     override func tearDown() {
         OHHTTPStubs.removeAllStubs()
@@ -302,6 +302,37 @@ class HTTPClientTests: XCTestCase {
         self.client.performRequest("POST", path: path, body: Dictionary.init(),
                                    headers: ["test_header": "value"], completionHandler:nil)
         
+        expect(headerPresent).toEventually(equal(true))
+    }
+
+    func testDefaultsPlatformFlavorToNative() {
+        let path = "/a_random_path"
+        var headerPresent = false
+
+        stub(condition: hasHeaderNamed("X-Platform-Flavor", value: "native")) { request in
+            headerPresent = true
+            return OHHTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
+        }
+
+        self.client.performRequest("POST", path: path, body: Dictionary.init(),
+                                   headers: ["test_header": "value"], completionHandler:nil)
+
+        expect(headerPresent).toEventually(equal(true))
+    }
+    
+    func testPassesPlatformFlavorHeader() {
+        let path = "/a_random_path"
+        var headerPresent = false
+
+        stub(condition: hasHeaderNamed("X-Platform-Flavor", value: "react-native")) { request in
+            headerPresent = true
+            return OHHTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
+        }
+        let client = RCHTTPClient(platformFlavor: "react-native")
+
+        client.performRequest("POST", path: path, body: Dictionary.init(),
+                                   headers: ["test_header": "value"], completionHandler:nil)
+
         expect(headerPresent).toEventually(equal(true))
     }
 }


### PR DESCRIPTION
This PR adds a function to `RCPurchases` that will be used by the hybrid SDKs to indicate the platform. We don't have a way right now to know if a http request is coming from Cordova, ReactNative, Unity, etc. and we only know if the underlying SDK is Android or iOS. We should start sending a new header in the HTTP requests that indicate the platform flavor.

The idea would be to add a header to the Cordova, ReactNative, etc. SDKs that will expose this function and to call it in every setup call. 