### PR TITLE
[Final] Fix automaticAppleSearchAdsAttributionCollection on iOS SDK

### DIFF
--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -249,7 +249,9 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
             if (latestNetworkIdAndAdvertisingIdSentToAppleSearchAds == nil) {
                 [attributionFetcher adClientAttributionDetailsWithCompletionBlock:^(NSDictionary<NSString *, NSObject *> *_Nullable attributionDetails, NSError *_Nullable error) {
                     NSArray *values = [attributionDetails allValues];
-                    if (values.count != 0 && values[0][@"iad-attribution"]) {
+                    
+                    bool hasIadAttribution = values.count != 0 && [values[0][@"iad-attribution"] boolValue];
+                    if (hasIadAttribution) {
                         [self postAttributionData:attributionDetails fromNetwork:RCAttributionNetworkAppleSearchAds forNetworkUserId:nil];
                     }
                 }];


### PR DESCRIPTION
Addresses https://trello.com/c/HlJygO8w, an issue where we would send apple search ads attribution info even if the value of `@"iad-attribution"` was false. 

The issue was that we were assuming that the value would come in as a boolean, but since it's part of a dictionary of NSString * -> NSObject *, it actually comes in as a string. 

using `boolValue` should address it and make the correct conversion back to bool. 