### PR TITLE
[final] Feature/fastlane bump

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,4 +1,5 @@
-1. Update the version number in `RCPurchases.m`, `Purchases.podspec` and in `Purchases/Info.plist`
+1. Update the version number in `RCPurchases.m`
+1. Update the version number in `Purchases.podspec` and in `Purchases/Info.plist` by running `fastlane bump version:x.y.z`
 1. Update CHANGELOG.md for the new release
 1. Commit the changes `git commit -am "Version x.y.z"`
 1. `git tag -a x.y.z -m "Version x.y.z"`

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,4 +26,11 @@ platform :ios do
     snapshot
   end
 
+  desc "Increment build number"
+  lane :bump do |options|
+    version_number = options[:version]
+    increment_version_number(version_number: version_number)
+    version_bump_podspec(version_number: version_number)
+  end
+
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -1,0 +1,34 @@
+fastlane documentation
+================
+# Installation
+
+Make sure you have the latest version of the Xcode command line tools installed:
+
+```
+xcode-select --install
+```
+
+Install _fastlane_ using
+```
+[sudo] gem install fastlane -NV
+```
+or alternatively using `brew cask install fastlane`
+
+# Available Actions
+## iOS
+### ios test
+```
+fastlane ios test
+```
+Runs all the tests
+### ios bump
+```
+fastlane ios bump
+```
+Increment build number
+
+----
+
+This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
+More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
+The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).


### PR DESCRIPTION
Adds a quick lane to the fastfile to quickly bump versions. Will bump in the project file + podspec. 
I _think_ it can be expanded to also update RCPurchases... but we may have to do it manually.  

usage: 

```bash
fastlane bump version:x.y.z
```