### PR TITLE
[final] automate GitHub release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ Carthage
 CarthageUploads
 *.bck
 fastlane/report.xml
+CHANGELOG.latest.md

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,8 @@
 1. Create a branch bump/x.y.z
 1. Update the version number in `RCPurchases.m`, `Purchases.podspec` and in 
 `Purchases/Info.plist` by running `fastlane bump version:x.y.z`
-1. Update CHANGELOG.md for the new release
+1. Update CHANGELOG.md for the new release and create a CHANGELOG.latest.md with the changes for the current 
+version (to be used by Fastlane for the github release notes)
 1. Commit the changes `git commit -am "Version x.y.z"`
 1. Make a PR, merge when approved
 1. `cd bin`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,8 +9,6 @@
 1. `./release_version.sh -c x.y.z -n a.b.c`, where a.b.c will be the next release after this one. 
 If you're releasing version 3.0.2, for example, this would be `./release_version.sh -c 3.0.2 -n 3.1.0`. 
 This will do all of the other steps in the manual process.
-1. Create a [new github release](https://github.com/revenuecat/purchases-ios/releases)
-1. Upload the contents of `CarthageUploads/` to the new release.   
 1. Make a PR for the snapshot bump, merge when approved
 
 #### Manual process:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,10 +1,9 @@
 #### (Somewhat) automated process: 
 1. Create a branch bump/x.y.z
-1. Update the version number in `RCPurchases.m`, `Purchases.podspec` and in 
-`Purchases/Info.plist` by running `fastlane bump version:x.y.z`
 1. Create a CHANGELOG.latest.md with the changes for the current 
 version (to be used by Fastlane for the github release notes)
-1. `cat CHANGELOG.latest.md >> CHANGELOG.md`
+1. Update the version number in `RCPurchases.m`, `Purchases.podspec` and in 
+`Purchases/Info.plist` by running `fastlane bump_and_update_changelog version:x.y.z`
 1. Commit the changes `git commit -am "Version x.y.z"`
 1. Make a PR, merge when approved
 1. `cd bin`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,8 +2,9 @@
 1. Create a branch bump/x.y.z
 1. Update the version number in `RCPurchases.m`, `Purchases.podspec` and in 
 `Purchases/Info.plist` by running `fastlane bump version:x.y.z`
-1. Update CHANGELOG.md for the new release and create a CHANGELOG.latest.md with the changes for the current 
+1. Create a CHANGELOG.latest.md with the changes for the current 
 version (to be used by Fastlane for the github release notes)
+1. `cat CHANGELOG.latest.md >> CHANGELOG.md`
 1. Commit the changes `git commit -am "Version x.y.z"`
 1. Make a PR, merge when approved
 1. `cd bin`

--- a/bin/release_version.sh
+++ b/bin/release_version.sh
@@ -61,7 +61,7 @@ FRAMEWORK_NAME=Purchases.framework
 
 mv $FRAMEWORK_NAME.zip $CARTHAGE_UPLOADS_PATH
 
-echo "Don't forget to create a release in GitHub and upload them!"
+fastlane github_release $CURRENT_VERSION
 
 echo "Preparing next version"
 
@@ -75,5 +75,3 @@ fastlane bump version:$NEXT_VERSION
 echo "committing and pushing"
 git commit -am "Preparing for next version"
 git push origin $BRANCH_NAME
-
-echo "All set! Don't forget to create the new release in GitHub and upload the files in $CARTHAGE_UPLOADS_PATH!"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,24 +29,30 @@ platform :ios do
   desc "Increment build number"
   lane :bump do |options|
     new_version_number = options[:version]
-    fail ArgumentError, "missing version" unless release_version
+    fail ArgumentError, "missing version" unless new_version_number
     previous_version_number = get_version_number
     increment_version_number(version_number: new_version_number)
     version_bump_podspec(version_number: new_version_number)
     increment_build_number_in_rc_purchases(previous_version_number, new_version_number)
   end
 
+  desc "Increment build number and update changelog"
+  lane :bump_and_update_changelog do |options|
+    bump(options)
+    attach_changelog_to_master
+  end
+
   desc "Make github release"
   lane :github_release do |options|
     release_version = options[:version]
     fail ArgumentError, "missing version" unless release_version
-    
+
     begin
       changelog = File.read("../CHANGELOG.latest.md")
     rescue
-      fail "please add a CHANGELOG.latest.md file before calling this lane" 
+      fail "please add a CHANGELOG.latest.md file before calling this lane"
     end
-    
+
     set_github_release(
       repository_name: "revenuecat/purchases-ios",
       api_token: ENV["GITHUB_TOKEN"],
@@ -65,5 +71,22 @@ def increment_build_number_in_rc_purchases(previous_version_number, new_version_
   rc_purchases_path = '../Purchases/Public/RCPurchases.m'
   sed_regex = 's|' + previous_version_number + '|' + new_version_number + '|'
   backup_extension = '.bck'
-  sh("sed", '-i', backup_extension, sed_regex, rc_purchases_path)
+end
+
+def attach_changelog_to_master
+  current_changelog = File.open("../CHANGELOG.latest.md", 'r')
+  master_changelog = File.open("../CHANGELOG.md", 'r')
+
+  current_changelog_data = current_changelog.read
+  master_changelog_data = master_changelog.read
+
+  current_changelog.close  
+  master_changelog.close
+
+  File.open("../CHANGELOG.md", 'w') { |master_changelog_write_mode|
+    whole_file_data = "#{current_changelog_data}\n#{master_changelog_data}"
+    puts "going to save. Contents - #{whole_file_data}"
+    
+    master_changelog_write_mode.write(whole_file_data)
+  }
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,10 +29,34 @@ platform :ios do
   desc "Increment build number"
   lane :bump do |options|
     new_version_number = options[:version]
+    fail ArgumentError, "missing version" unless release_version
     previous_version_number = get_version_number
     increment_version_number(version_number: new_version_number)
     version_bump_podspec(version_number: new_version_number)
     increment_build_number_in_rc_purchases(previous_version_number, new_version_number)
+  end
+
+  desc "Make github release"
+  lane :github_release do |options|
+    release_version = options[:version]
+    fail ArgumentError, "missing version" unless release_version
+    
+    begin
+      changelog = File.read("../CHANGELOG.latest.md")
+    rescue
+      fail "please add a CHANGELOG.latest.md file before calling this lane" 
+    end
+    
+    set_github_release(
+      repository_name: "revenuecat/purchases-ios",
+      api_token: ENV["GITHUB_TOKEN"],
+      name: release_version,
+      tag_name: "v#{release_version}",
+      description: changelog,
+      commitish: "master",
+      upload_assets: ["CarthageUploads/Purchases.framework.zip"],
+      is_draft: true
+  )
   end
 
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -26,6 +26,11 @@ Runs all the tests
 fastlane ios bump
 ```
 Increment build number
+### ios github_release
+```
+fastlane ios github_release
+```
+Make github release
 
 ----
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -26,6 +26,11 @@ Runs all the tests
 fastlane ios bump
 ```
 Increment build number
+### ios bump_and_update_changelog
+```
+fastlane ios bump_and_update_changelog
+```
+Increment build number and update changelog
 ### ios github_release
 ```
 fastlane ios github_release


### PR DESCRIPTION
### Requirements

- [x] ~based on #163~

### Description

* Added fastlane lane that creates a github release and uploads the files. 
* Added a step to concatenate `CHANGELOG.latest.md` into `CHANGELOG.md`. The separate file makes it easy to use for the github release as well 