### PR TITLE
[final] fastlane create_sandbox_user

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -65,6 +65,20 @@ platform :ios do
   )
   end
 
+  desc "Create sandbox account"
+  lane :create_sandbox_account do |options|
+    email = options[:email]
+    fail ArgumentError, "missing email" unless email
+
+    password = options[:password]
+    fail ArgumentError, "missing password" unless password
+    require 'Spaceship'
+
+    Spaceship::Tunes.login()
+    
+    Spaceship::Tunes::SandboxTester.create!(email: email, password: password)
+  end
+
 end
 
 def increment_build_number_in_rc_purchases(previous_version_number, new_version_number)

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -36,6 +36,11 @@ Increment build number and update changelog
 fastlane ios github_release
 ```
 Make github release
+### ios create_sandbox_account
+```
+fastlane ios create_sandbox_account
+```
+Create sandbox account
 
 ----
 


### PR DESCRIPTION
Added a convenience method for creating sandbox users, since going through app store connect is a giant PITA and sometimes you need multiple accounts. 

usage: 

```bash
fastlane create_sandbox_account email:<email> password:<password>
```

This will prompt for your developer portal credentials, 2fa code (if enabled). 

**Note:** if you get an error, make sure to follow the password requirements: at least one capital letter, one punctuation mark and one number. Also, the email can't take `+` signs. 
