### PR TITLE
[final] fix tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Carthage Update
-          command: carthage update
+          name: Carthage Bootstrap
+          command: carthage bootstrap
       - run: bundle install
       - run:
           name: Run tests


### PR DESCRIPTION
follow-up to https://github.com/RevenueCat/purchases-ios/pull/166, updates 
`carthage update` -> `carthage bootstrap`, since `update` actually upgrades libraries and was causing tests to fail because it was using a different version of `OHHTTPStubs` than what the code uses. 