### PR TITLE
fix: missing nullability specifier makes pod trunk fail

### DIFF
--- a/Purchases/Caching/RCDeviceCache+Protected.h
+++ b/Purchases/Caching/RCDeviceCache+Protected.h
@@ -13,8 +13,8 @@
 
 @property (nonatomic, nullable) NSDate *purchaserInfoCachesLastUpdated;
 
-- (instancetype)initWith:(nullable NSUserDefaults *)userDefaults
-   offeringsCachedObject:(nullable RCInMemoryCachedObject<RCOfferings *> *)offeringsCachedObject;
+- (nullable instancetype)initWith:(nullable NSUserDefaults *)userDefaults
+            offeringsCachedObject:(nullable RCInMemoryCachedObject<RCOfferings *> *)offeringsCachedObject;
 
 @end
 


### PR DESCRIPTION
Adds a missing nullability specifier that's tripping up pod trunk. 

```bash
pod trunk push Purchases.podspec
```
is failing on master due to: 

```
Validating podspec
 -> Purchases (3.0.3)
    - NOTE  | xcodebuild:  note: Using new build system
    - NOTE  | xcodebuild:  note: Planning build
    - NOTE  | xcodebuild:  note: Constructing build description
    - NOTE  | [iOS] xcodebuild:  warning: Skipping code signing because the target does not have an Info.plist file and one is not being generated automatically. (in target 'App' from project 'App')
    - WARN  | xcodebuild:  Purchases/Purchases/Caching/RCDeviceCache+Protected.h:16:4: warning: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified) [-Wnullability-completeness]
    - NOTE  | xcodebuild:  Purchases/Purchases/Caching/RCDeviceCache+Protected.h:16:4: note: insert '_Nullable' if the pointer may be null
    - NOTE  | xcodebuild:  Purchases/Purchases/Caching/RCDeviceCache+Protected.h:16:4: note: insert '_Nonnull' if the pointer should never be null
    - NOTE  | xcodebuild:  note: Execution policy exception registration failed and was skipped: Error Domain=NSPOSIXErrorDomain Code=1 "Operation not permitted" (in target 'Purchases' from project 'Pods')
    - NOTE  | xcodebuild:  note: Execution policy exception registration failed and was skipped: Error Domain=NSPOSIXErrorDomain Code=1 "Operation not permitted" (in target 'Pods-App' from project 'Pods')
    - NOTE  | xcodebuild:  note: Execution policy exception registration failed and was skipped: Error Domain=NSPOSIXErrorDomain Code=1 "Operation not permitted" (in target 'App' from project 'App')
```