### PR TITLE
Changes trigger of docs-deploy to deploy when tagging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,12 +49,10 @@ workflows:
       - runtest
   docs:
     jobs:
-      - docs-approval:
-          type: approval
-          filters:
-            branches:
-              only: master
       - docs-deploy:
-          requires:
-            - docs-approval
+          filters:
+            tags:
+              ignore: /^.*-SNAPSHOT/
+            branches:
+              ignore: /.*/
 


### PR DESCRIPTION
I didn't like that master had all CI tests without completing (due to the nature of the approval job we have right now for deploying docs).