### PR TITLE
[Final] Fix: build issue in Swift Package Manager

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -5,9 +5,9 @@ objc: true
 sdk: iphonesimulator
 module: Purchases
 umbrella_header: Purchases/Public/Purchases.h
-module_version: 3.0.3
+module_version: 3.0.4
 github_url: https://github.com/revenuecat/purchases-ios
-github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.0.3
+github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.0.4
 output: docs
 # Leaving this commented out. We used to specify this before, but now it's working without it
 # xcodebuild_arguments: [--objc,Purchases/Public/Purchases.h,--,-x,objective-c,-isysroot,$(xcrun --show-sdk-path),-I,$(pwd)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.4
+- Fixed an issue where Swift Package Manager didn't pick up the new Caching group from 3.0.3 https://github.com/RevenueCat/purchases-ios/issues/176
+
 ## 3.0.3
 - Added new method to invalidate the purchaser info cache, useful when promotional purchases are granted from outside the app. https://github.com/RevenueCat/purchases-ios/pull/168
 - Made sure we dispatch offerings, and purchaser info https://github.com/RevenueCat/purchases-ios/pull/146

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
       xcodeproj (>= 1.8.1, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
+    ffi (1.12.2)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -142,8 +143,18 @@ GEM
     httpclient (2.8.3)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    jazzy (0.13.1)
+      cocoapods (~> 1.5)
+      mustache (~> 1.1)
+      open4
+      redcarpet (~> 3.4)
+      rouge (>= 2.0.6, < 4.0)
+      sassc (~> 2.1)
+      sqlite3 (~> 1.3)
+      xcinvoke (~> 0.3.0)
     json (2.2.0)
     jwt (2.1.0)
+    liferaft (0.0.6)
     memoist (0.16.0)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
@@ -154,13 +165,16 @@ GEM
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
+    mustache (1.1.1)
     nanaimo (0.2.6)
     nap (1.1.0)
     naturally (2.2.0)
     netrc (0.11.0)
+    open4 (1.3.4)
     os (1.0.1)
     plist (3.5.0)
     public_suffix (2.0.5)
+    redcarpet (3.5.0)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -169,6 +183,8 @@ GEM
     rouge (2.0.7)
     ruby-macho (1.4.0)
     rubyzip (1.3.0)
+    sassc (2.2.1)
+      ffi (~> 1.9)
     security (0.1.3)
     signet (0.11.0)
       addressable (~> 2.3)
@@ -179,6 +195,7 @@ GEM
       CFPropertyList
       naturally
     slack-notifier (2.3.2)
+    sqlite3 (1.4.2)
     terminal-notifier (2.0.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
@@ -195,6 +212,8 @@ GEM
     unf_ext (0.0.7.6)
     unicode-display_width (1.6.0)
     word_wrap (1.0.0)
+    xcinvoke (0.3.0)
+      liferaft (~> 0.0.6)
     xcodeproj (1.14.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
@@ -212,6 +231,7 @@ PLATFORMS
 DEPENDENCIES
   cocoapods
   fastlane
+  jazzy
 
 BUNDLED WITH
    1.17.3

--- a/Package.swift
+++ b/Package.swift
@@ -22,11 +22,12 @@ func resolveTargets() -> [Target] {
         .target(name: "Purchases",
                 dependencies: [],
                 path: ".",
-                sources: ["Purchases", "Purchases/Public"],
+                sources: ["Purchases", "Purchases/Public", "Purchases/Caching"],
                 publicHeadersPath: "Purchases/Public",
                 cSettings: [
                     .headerSearchPath("Purchases"),
                     .headerSearchPath("Purchases/Public")
+                    .headerSearchPath("Purchases/Caching")
                 ])]
 
     if shouldTest {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ func resolveTargets() -> [Target] {
                 publicHeadersPath: "Purchases/Public",
                 cSettings: [
                     .headerSearchPath("Purchases"),
-                    .headerSearchPath("Purchases/Public")
+                    .headerSearchPath("Purchases/Public"),
                     .headerSearchPath("Purchases/Caching")
                 ])]
 

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Purchases"
-  s.version          = "3.0.3"
+  s.version          = "3.0.4"
   s.summary          = "Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/Purchases/Info.plist
+++ b/Purchases/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.3</string>
+	<string>3.0.4</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -97,7 +97,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 }
 
 + (NSString *)frameworkVersion {
-    return @"3.0.3";
+    return @"3.0.4";
 }
 
 + (instancetype)sharedPurchases {

--- a/PurchasesTests/Info.plist
+++ b/PurchasesTests/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.3</string>
+	<string>3.0.4</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
The `Caching` group hadn't been added to package.swift spec for Swift Package Manager, so you'd get an error saying "'RCDeviceCache.h' file not found". 
This was reported here: https://github.com/RevenueCat/purchases-ios/issues/176

This fixes the issue and bumps the version number to 3.0.4. I confirmed it's working by setting the version rules to the branch under Swift Packages. 
