### PR TITLE
[WIP] universal purchases

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -5,9 +5,9 @@ objc: true
 sdk: iphonesimulator
 module: Purchases
 umbrella_header: Purchases/Public/Purchases.h
-module_version: 3.0.3
+module_version: 3.0.4
 github_url: https://github.com/revenuecat/purchases-ios
-github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.0.3
+github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.0.4
 output: docs
 # Leaving this commented out. We used to specify this before, but now it's working without it
 # xcodebuild_arguments: [--objc,Purchases/Public/Purchases.h,--,-x,objective-c,-isysroot,$(xcrun --show-sdk-path),-I,$(pwd)]

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -5,9 +5,9 @@ objc: true
 sdk: iphonesimulator
 module: Purchases
 umbrella_header: Purchases/Public/Purchases.h
-module_version: 3.0.4
+module_version: 3.1.0-SNAPSHOT
 github_url: https://github.com/revenuecat/purchases-ios
-github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.0.4
+github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.1.0-SNAPSHOT
 output: docs
 # Leaving this commented out. We used to specify this before, but now it's working without it
 # xcodebuild_arguments: [--objc,Purchases/Public/Purchases.h,--,-x,objective-c,-isysroot,$(xcrun --show-sdk-path),-I,$(pwd)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.4
+- Fixed an issue where Swift Package Manager didn't pick up the new Caching group from 3.0.3 https://github.com/RevenueCat/purchases-ios/issues/176
+
 ## 3.0.3
 - Added new method to invalidate the purchaser info cache, useful when promotional purchases are granted from outside the app. https://github.com/RevenueCat/purchases-ios/pull/168
 - Made sure we dispatch offerings, and purchaser info https://github.com/RevenueCat/purchases-ios/pull/146

--- a/Examples/SwiftExample/Podfile.lock
+++ b/Examples/SwiftExample/Podfile.lock
@@ -1,3 +1,16 @@
-PODFILE CHECKSUM: b4d1fa385624aae137b02b01f594f56927c94307
+PODS:
+  - Purchases (3.0.4)
 
-COCOAPODS: 1.6.0.beta.2
+DEPENDENCIES:
+  - Purchases (from `../../`)
+
+EXTERNAL SOURCES:
+  Purchases:
+    :path: "../../"
+
+SPEC CHECKSUMS:
+  Purchases: 9325b85dd0b278ffd4c8a2cbcf2b9a74fa4f8248
+
+PODFILE CHECKSUM: b6ad00ca1e6fc400e0898ad2ac4a293958616d2e
+
+COCOAPODS: 1.8.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
       xcodeproj (>= 1.8.1, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
+    ffi (1.12.2)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -142,8 +143,18 @@ GEM
     httpclient (2.8.3)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    jazzy (0.13.1)
+      cocoapods (~> 1.5)
+      mustache (~> 1.1)
+      open4
+      redcarpet (~> 3.4)
+      rouge (>= 2.0.6, < 4.0)
+      sassc (~> 2.1)
+      sqlite3 (~> 1.3)
+      xcinvoke (~> 0.3.0)
     json (2.2.0)
     jwt (2.1.0)
+    liferaft (0.0.6)
     memoist (0.16.0)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
@@ -154,13 +165,16 @@ GEM
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
+    mustache (1.1.1)
     nanaimo (0.2.6)
     nap (1.1.0)
     naturally (2.2.0)
     netrc (0.11.0)
+    open4 (1.3.4)
     os (1.0.1)
     plist (3.5.0)
     public_suffix (2.0.5)
+    redcarpet (3.5.0)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -169,6 +183,8 @@ GEM
     rouge (2.0.7)
     ruby-macho (1.4.0)
     rubyzip (1.3.0)
+    sassc (2.2.1)
+      ffi (~> 1.9)
     security (0.1.3)
     signet (0.11.0)
       addressable (~> 2.3)
@@ -179,6 +195,7 @@ GEM
       CFPropertyList
       naturally
     slack-notifier (2.3.2)
+    sqlite3 (1.4.2)
     terminal-notifier (2.0.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
@@ -195,6 +212,8 @@ GEM
     unf_ext (0.0.7.6)
     unicode-display_width (1.6.0)
     word_wrap (1.0.0)
+    xcinvoke (0.3.0)
+      liferaft (~> 0.0.6)
     xcodeproj (1.14.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
@@ -212,6 +231,7 @@ PLATFORMS
 DEPENDENCIES
   cocoapods
   fastlane
+  jazzy
 
 BUNDLED WITH
    1.17.3

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ func resolveTargets() -> [Target] {
         .target(name: "Purchases",
                 dependencies: [],
                 path: ".",
-                sources: ["Purchases"],
+                sources: ["Purchases", "Purchases/Public"],
                 publicHeadersPath: "Purchases/Public",
                 cSettings: [
                     .headerSearchPath("Purchases"),

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ func resolveTargets() -> [Target] {
 let package = Package(
         name: "Purchases",
         platforms: [
-            .macOS(.v10_12), .iOS(.v9)
+            .macOS(.v10_12), .iOS(.v9), watchOS(.v6_2), tvOS(.v13_4)
         ],
         products: [
             .library(name: "Purchases",

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,6 @@ func resolveTargets() -> [Target] {
         .target(name: "Purchases",
                 dependencies: [],
                 path: ".",
-                sources: ["Purchases", "Purchases/Public"],
                 publicHeadersPath: "Purchases/Public",
                 cSettings: [
                     .headerSearchPath("Purchases"),

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ func resolveTargets() -> [Target] {
 let package = Package(
         name: "Purchases",
         platforms: [
-            .macOS(.v10_12), .iOS(.v9), watchOS(.v6_2), tvOS(.v13_4)
+            .macOS(.v10_12), .iOS(.v9), .watchOS("6.2"), .tvOS("13.4")
         ],
         products: [
             .library(name: "Purchases",

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ func resolveTargets() -> [Target] {
         .target(name: "Purchases",
                 dependencies: [],
                 path: ".",
-                sources: ["Purchases", "Purchases/Public", "Purchases/Caching"],
+                sources: ["Purchases"],
                 publicHeadersPath: "Purchases/Public",
                 cSettings: [
                     .headerSearchPath("Purchases"),

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ func resolveTargets() -> [Target] {
         .target(name: "Purchases",
                 dependencies: [],
                 path: ".",
+                sources: ["Purchases", "Purchases/Public"],
                 publicHeadersPath: "Purchases/Public",
                 cSettings: [
                     .headerSearchPath("Purchases"),

--- a/Package.swift
+++ b/Package.swift
@@ -22,11 +22,12 @@ func resolveTargets() -> [Target] {
         .target(name: "Purchases",
                 dependencies: [],
                 path: ".",
-                sources: ["Purchases", "Purchases/Public"],
+                sources: ["Purchases", "Purchases/Public", "Purchases/Caching"],
                 publicHeadersPath: "Purchases/Public",
                 cSettings: [
                     .headerSearchPath("Purchases"),
-                    .headerSearchPath("Purchases/Public")
+                    .headerSearchPath("Purchases/Public"),
+                    .headerSearchPath("Purchases/Caching")
                 ])]
 
     if shouldTest {

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -17,6 +17,8 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.12'
+  s.watchos.deployment_target = '6.2'
+  s.tvos.deployment_target = '13.4'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Purchases"
-  s.version          = "3.0.4"
+  s.version          = "3.1.0-SNAPSHOT"
   s.summary          = "Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Purchases"
-  s.version          = "3.0.3"
+  s.version          = "3.0.4"
   s.summary          = "Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -747,7 +747,7 @@
 				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 			};
 			name = Debug;
 		};
@@ -775,7 +775,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 			};
 			name = Release;
 		};

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -483,6 +483,7 @@
 				TargetAttributes = {
 					352629FD1F7C4B9100C04F2C = {
 						CreatedOnToolsVersion = 9.0;
+						LastSwiftMigration = 1140;
 						ProvisioningStyle = Automatic;
 					};
 					35262A1D1F7D77E600C04F2C = {
@@ -724,6 +725,7 @@
 		35262A131F7C4B9100C04F2C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -743,6 +745,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -750,6 +754,7 @@
 		35262A141F7C4B9100C04F2C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -769,6 +774,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -742,7 +742,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.purchases.Purchases;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -768,7 +768,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.purchases.Purchases;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Purchases/Info.plist
+++ b/Purchases/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.3</string>
+	<string>3.0.4</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Purchases/Info.plist
+++ b/Purchases/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.4</string>
+	<string>3.1.0-SNAPSHOT</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -399,6 +399,14 @@ NS_SWIFT_NAME(entitlements(_:)) RC_UNAVAILABLE("entitlements: has been replaced 
  */
 - (void)invalidatePurchaserInfoCache;
 
+#if TARGET_OS_WATCH
+/**
+ Used to notify Purchses that the app has become active. WatchOS doesn't implement the ApplicationDidBecomeActive
+ notification, so this should be called instead, from the app's WKExtensionDelegate's applicationDidBecomeActive.
+ */
+- (void)watchAppDidBecomeActive;
+#endif
+
 @end
 
 /**

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -246,7 +246,6 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
         [self.notificationCenter addObserver:self
                                     selector:@selector(applicationDidBecomeActive:)
                                         name:APP_DID_BECOME_ACTIVE_NOTIFICATION_NAME object:nil];
-
 #endif
         if (postponedAttributionData) {
             for (RCAttributionData *attributionData in postponedAttributionData) {
@@ -653,6 +652,12 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
     RCDebugLog(@"Purchaser info cache is invalidated");
     [self.deviceCache clearPurchaserInfoCacheTimestamp];
 }
+
+#if TARGET_OS_WATCH
+- (void)watchAppDidBecomeActive {
+    [self applicationDidBecomeActive:nil];
+}
+#endif
 
 #pragma mark - Private Methods
 

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -97,7 +97,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 }
 
 + (NSString *)frameworkVersion {
-    return @"3.0.4";
+    return @"3.1.0-SNAPSHOT";
 }
 
 + (instancetype)sharedPurchases {

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -242,10 +242,12 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
         [self updateAllCachesWithCompletionBlock:callDelegate];
 
         self.storeKitWrapper.delegate = self;
+#if !TARGET_OS_WATCH
         [self.notificationCenter addObserver:self
                                     selector:@selector(applicationDidBecomeActive:)
                                         name:APP_DID_BECOME_ACTIVE_NOTIFICATION_NAME object:nil];
 
+#endif
         if (postponedAttributionData) {
             for (RCAttributionData *attributionData in postponedAttributionData) {
                 [self postAttributionData:attributionData.data fromNetwork:attributionData.network forNetworkUserId:attributionData.networkUserId];
@@ -275,9 +277,11 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 - (void)dealloc
 {
     self.storeKitWrapper.delegate = nil;
+#if !TARGET_OS_WATCH
     [self.notificationCenter removeObserver:self
                                        name:APP_DID_BECOME_ACTIVE_NOTIFICATION_NAME
                                      object:nil];
+#endif
     self.delegate = nil;
 }
 

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -657,20 +657,12 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
     RCDebugLog(@"applicationDidBecomeActive");
     if ([self.deviceCache isPurchaserInfoCacheStale]) {
         RCDebugLog(@"PurchaserInfo cache is stale, updating caches");
-        [self updateCacheAndSendUpdatedPurchaserInfoIfChanged];
+        [self fetchAndCachePurchaserInfoWithCompletion:nil];
     }
     if ([self.deviceCache isOfferingsCacheStale]) {
         RCDebugLog(@"Offerings cache is stale, updating caches");
         [self updateOfferingsCache:nil];
     }
-}
-
-- (void)updateCacheAndSendUpdatedPurchaserInfoIfChanged {
-    [self fetchAndCachePurchaserInfoWithCompletion:^(RCPurchaserInfo *info, NSError *error) {
-        if (info) {
-            [self sendUpdatedPurchaserInfoToDelegateIfChanged:info];
-        }
-    }];
 }
 
 - (RCPurchaserInfo *)readPurchaserInfoFromCache {
@@ -748,7 +740,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
         CALL_IF_SET_ON_MAIN_THREAD(completion, self.deviceCache.cachedOfferings, nil);
         if (self.deviceCache.isOfferingsCacheStale) {
             RCDebugLog(@"Offerings cache is stale, updating cache");
-            [self updateOfferingsCache:completion];
+            [self updateOfferingsCache:nil];
         }
     } else {
         RCDebugLog(@"No cached offerings, fetching");
@@ -803,9 +795,8 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 
             CALL_IF_SET_ON_MAIN_THREAD(completion, offerings, nil);
         } else {
-            CALL_IF_SET_ON_MAIN_THREAD(completion, nil, [RCPurchasesErrorUtils unexpectedBackendResponseError]);
+            [self handleOfferingsUpdateError:RCPurchasesErrorUtils.unexpectedBackendResponseError completion:completion];
         }
-
     }];
 }
 

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -97,7 +97,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 }
 
 + (NSString *)frameworkVersion {
-    return @"3.0.3";
+    return @"3.0.4";
 }
 
 + (instancetype)sharedPurchases {

--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -150,7 +150,7 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromRCBackendErrorCode(RCBackend
     return RCUnknownError;
 }
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
     #define CODE_IF_TARGET_IPHONE(code, value) code
 #else
     #define CODE_IF_TARGET_IPHONE(code, value) ((SKErrorCode) value)

--- a/Purchases/RCAttributionFetcher.m
+++ b/Purchases/RCAttributionFetcher.m
@@ -9,7 +9,7 @@
 #import "RCAttributionFetcher.h"
 #import "RCUtils.h"
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
 #import <UIKit/UIKit.h>
 #endif
 
@@ -46,7 +46,7 @@
 
 - (nullable NSString *)identifierForVendor
 {
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
     if ([UIDevice class]) {
         return UIDevice.currentDevice.identifierForVendor.UUIDString;
     }
@@ -56,7 +56,7 @@
 
 - (void)adClientAttributionDetailsWithCompletionBlock:(void (^)(NSDictionary<NSString *, NSObject *> * _Nullable attributionDetails, NSError * _Nullable error))completionHandler
 {
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
     id<FakeAdClient> adClientClass = (id<FakeAdClient>)NSClassFromString(@"ADClient");
     
     if (adClientClass) {

--- a/Purchases/RCCrossPlatformSupport.h
+++ b/Purchases/RCCrossPlatformSupport.h
@@ -25,7 +25,7 @@
 #elif TARGET_OS_OSX
 #define PLATFORM_HEADER @"macOS"
 #elif TARGET_OS_WATCH
-#define PLATFORM_HEADER @"watchOS"
+#define PLATFORM_HEADER @"iOS"
 #elif TARGET_OS_TV
 #define PLATFORM_HEADER @"tvOS"
 #endif

--- a/Purchases/RCCrossPlatformSupport.h
+++ b/Purchases/RCCrossPlatformSupport.h
@@ -9,14 +9,18 @@
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 #define APP_DID_BECOME_ACTIVE_NOTIFICATION_NAME UIApplicationDidBecomeActiveNotification
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 #import <AppKit/AppKit.h>
 #define APP_DID_BECOME_ACTIVE_NOTIFICATION_NAME NSApplicationDidBecomeActiveNotification
 #endif
 #if TARGET_OS_MACCATALYST
 #define PLATFORM_HEADER @"uikitformac"
-#elif TARGET_OS_IPHONE
+#elif TARGET_OS_IOS
 #define PLATFORM_HEADER @"iOS"
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
 #define PLATFORM_HEADER @"macOS"
+#elif TARGET_OS_WATCHOS
+#define PLATFORM_HEADER @"watchOS"
+#elif TARGET_OS_TVOS
+#define PLATFORM_HEADER @"tvOS"
 #endif

--- a/Purchases/RCCrossPlatformSupport.h
+++ b/Purchases/RCCrossPlatformSupport.h
@@ -25,7 +25,7 @@
 #elif TARGET_OS_OSX
 #define PLATFORM_HEADER @"macOS"
 #elif TARGET_OS_WATCH
-#define PLATFORM_HEADER @"iOS"
+#define PLATFORM_HEADER @"iOS" // temporarily until backend support is added for watchOS platform
 #elif TARGET_OS_TV
-#define PLATFORM_HEADER @"tvOS"
+#define PLATFORM_HEADER @"iOS" // temporarily until backend support is added for watchOS platform
 #endif

--- a/Purchases/RCCrossPlatformSupport.h
+++ b/Purchases/RCCrossPlatformSupport.h
@@ -6,21 +6,26 @@
 //  Copyright © 2019 RevenueCat. All rights reserved.
 //
 
-#if TARGET_OS_IPHONE
-#import <UIKit/UIKit.h>
+#if TARGET_OS_IOS || TARGET_OS_TV
 #define APP_DID_BECOME_ACTIVE_NOTIFICATION_NAME UIApplicationDidBecomeActiveNotification
 #elif TARGET_OS_OSX
-#import <AppKit/AppKit.h>
 #define APP_DID_BECOME_ACTIVE_NOTIFICATION_NAME NSApplicationDidBecomeActiveNotification
 #endif
+
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#elif TARGET_OS_OSX
+#import <AppKit/AppKit.h>
+#endif
+
 #if TARGET_OS_MACCATALYST
 #define PLATFORM_HEADER @"uikitformac"
 #elif TARGET_OS_IOS
 #define PLATFORM_HEADER @"iOS"
 #elif TARGET_OS_OSX
 #define PLATFORM_HEADER @"macOS"
-#elif TARGET_OS_WATCHOS
+#elif TARGET_OS_WATCH
 #define PLATFORM_HEADER @"watchOS"
-#elif TARGET_OS_TVOS
+#elif TARGET_OS_TV
 #define PLATFORM_HEADER @"tvOS"
 #endif

--- a/Purchases/RCStoreKitWrapper.m
+++ b/Purchases/RCStoreKitWrapper.m
@@ -82,7 +82,7 @@
     }
 }
 
-#if TARGET_OS_IPHONE && !TARGET_OS_MACCATALYST
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 - (BOOL)paymentQueue:(SKPaymentQueue *)queue shouldAddStorePayment:(SKPayment *)payment forProduct:(SKProduct *)product
 {
     return [self.delegate storeKitWrapper:self shouldAddStorePayment:payment forProduct:product];

--- a/PurchasesTests/Info.plist
+++ b/PurchasesTests/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.3</string>
+	<string>3.0.4</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/PurchasesTests/Info.plist
+++ b/PurchasesTests/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.4</string>
+	<string>3.1.0-SNAPSHOT</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/bin/release_version.sh
+++ b/bin/release_version.sh
@@ -41,15 +41,6 @@ bundle install
 echo "Pushing release to Cocoapods..."
 pod trunk push Purchases.podspec
 
-COCOAPODS_RESULT=$
-
-if [ $COCOAPODS_RESULT == 0 ]; then
-  echo "Successfully pushed $CURRENT_VERSION to Cocoapods!"
-else
-  echo "Error pushing to Cocoapods, aborting"
-  exit $COCOAPODS_RESULT
-fi
-
 echo "Preparing Carthage release"
 echo "building..."
 carthage build --archive
@@ -61,7 +52,7 @@ FRAMEWORK_NAME=Purchases.framework
 
 mv $FRAMEWORK_NAME.zip $CARTHAGE_UPLOADS_PATH
 
-fastlane github_release $CURRENT_VERSION
+fastlane ios github_release version:$CURRENT_VERSION
 
 echo "Preparing next version"
 

--- a/bin/release_version.sh
+++ b/bin/release_version.sh
@@ -52,7 +52,7 @@ FRAMEWORK_NAME=Purchases.framework
 
 mv $FRAMEWORK_NAME.zip $CARTHAGE_UPLOADS_PATH
 
-fastlane ios github_release version:$CURRENT_VERSION
+fastlane github_release $CURRENT_VERSION
 
 echo "Preparing next version"
 


### PR DESCRIPTION
Adds support for tvOS and watchOS. 

### To do: 
Platforms: 
- [X] Cocoapods support
- [ ] Carthage support (Mac version won't be supported until Carthage supports XCFrameworks)
- [ ] Swift Package Manager support: it compiles correctly on Xcode < 11.4, but 11.4 raises some linking issues. I've been trying to get around them but couldn't. Maybe the next beta will fix them. 

Other: 
- [x] (watchOS only) Add a public method for the app to notify when it has become active, since didBecomeActive notification isn't available on watchOS. 
- [ ] Update platform string for watch and tv, once backend support for them is added. 