### PR TITLE
[Final] subscriber attributes part 1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,8 @@ func resolveTargets() -> [Target] {
                 cSettings: [
                     .headerSearchPath("Purchases"),
                     .headerSearchPath("Purchases/Public"),
-                    .headerSearchPath("Purchases/Caching")
+                    .headerSearchPath("Purchases/Caching"),
+                    .headerSearchPath("Purchases/SubscriberAttributes")
                 ])]
 
     if shouldTest {

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -28,6 +28,8 @@ Pod::Spec.new do |s|
     'Purchases/Public/*.m',
     'Purchases/Caching/*.h',
     'Purchases/Caching/*.m',
+    'Purchases/SubscriberAttributes/*.h',
+    'Purchases/SubscriberAttributes/*.m',
   ]
 
 

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2D5033242406E4E8009CAE61 /* RCSubscriberAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5033212406E4E8009CAE61 /* RCSubscriberAttribute.h */; };
+		2D5033252406E4E8009CAE61 /* RCSubscriberAttribute.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D5033222406E4E8009CAE61 /* RCSubscriberAttribute.m */; };
+		2D5033262406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5033232406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h */; };
 		35095A6C2351461E00ADF0B2 /* RCIdentityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 35095A6A2351461E00ADF0B2 /* RCIdentityManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		35095A6D2351461E00ADF0B2 /* RCIdentityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 35095A6B2351461E00ADF0B2 /* RCIdentityManager.m */; };
 		350A1B87226F937F00CCA10F /* RCAttributionData.h in Headers */ = {isa = PBXBuildFile; fileRef = 350A1B86226F937F00CCA10F /* RCAttributionData.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -114,6 +117,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2D5033212406E4E8009CAE61 /* RCSubscriberAttribute.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCSubscriberAttribute.h; path = Purchases/SubscriberAttributes/RCSubscriberAttribute.h; sourceTree = SOURCE_ROOT; };
+		2D5033222406E4E8009CAE61 /* RCSubscriberAttribute.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCSubscriberAttribute.m; path = Purchases/SubscriberAttributes/RCSubscriberAttribute.m; sourceTree = SOURCE_ROOT; };
+		2D5033232406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCSpecialSubscriberAttributes.h; path = Purchases/SubscriberAttributes/RCSpecialSubscriberAttributes.h; sourceTree = SOURCE_ROOT; };
 		35095A6A2351461E00ADF0B2 /* RCIdentityManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCIdentityManager.h; sourceTree = "<group>"; };
 		35095A6B2351461E00ADF0B2 /* RCIdentityManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCIdentityManager.m; sourceTree = "<group>"; };
 		350A1B84226E3E8700CCA10F /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -221,6 +227,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2D5033202406E4C7009CAE61 /* SubscriberAttributes */ = {
+			isa = PBXGroup;
+			children = (
+				2D5033232406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h */,
+				2D5033212406E4E8009CAE61 /* RCSubscriberAttribute.h */,
+				2D5033222406E4E8009CAE61 /* RCSubscriberAttribute.m */,
+			);
+			path = SubscriberAttributes;
+			sourceTree = "<group>";
+		};
 		350FBDD61F7DF1640065833D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -233,6 +249,7 @@
 		350FBDE61F7EEEDF0065833D /* Public */ = {
 			isa = PBXGroup;
 			children = (
+				2D5033202406E4C7009CAE61 /* SubscriberAttributes */,
 				353AB5E5222F633D003754E6 /* RCPurchasesErrorUtils.h */,
 				352E88422229B1A60046A10A /* RCPurchasesErrorUtils.m */,
 				353AB5E3222F624E003754E6 /* RCPurchasesErrors.h */,
@@ -401,6 +418,7 @@
 				35B54E4822EA6F4E005918B1 /* RCEntitlementInfo.h in Headers */,
 				353AB5E4222F624E003754E6 /* RCPurchasesErrors.h in Headers */,
 				35846AFF226A56AE00CC9E56 /* RCPromotionalOffer+Protected.h in Headers */,
+				2D5033262406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h in Headers */,
 				3585D6A322E680E30079E2C5 /* RCPackage.h in Headers */,
 				353AB5E6222F633D003754E6 /* RCPurchasesErrorUtils.h in Headers */,
 				351F4FAB1F80190700F245F4 /* RCBackend.h in Headers */,
@@ -408,6 +426,7 @@
 				352C36BF1F9D372D00A15783 /* RCPurchaserInfo+Protected.h in Headers */,
 				35A3F73323172D9900559FF9 /* RCOfferings+Protected.h in Headers */,
 				35395CB421B9F59E00286D13 /* RCIntroEligibility+Protected.h in Headers */,
+				2D5033242406E4E8009CAE61 /* RCSubscriberAttribute.h in Headers */,
 				350FBDE91F7EEF070065833D /* RCPurchases.h in Headers */,
 				35A60EAA1F82993E00D2FAE8 /* RCPurchases+Protected.h in Headers */,
 				354D50DF22E7D014009B870C /* RCOfferings.h in Headers */,
@@ -567,6 +586,7 @@
 				352E88442229B1A70046A10A /* RCPurchasesErrorUtils.m in Sources */,
 				359A0EA22003C8CD002D8C7F /* NSLocale+RCExtensions.m in Sources */,
 				351F4FB01F803D0700F245F4 /* RCPurchaserInfo.m in Sources */,
+				2D5033252406E4E8009CAE61 /* RCSubscriberAttribute.m in Sources */,
 				350FBDEA1F7EEF070065833D /* RCPurchases.m in Sources */,
 				35262A2D1F7D783F00C04F2C /* RCHTTPClient.m in Sources */,
 				350FBDF41F7FFD350065833D /* RCStoreKitWrapper.m in Sources */,

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		2D5033242406E4E8009CAE61 /* RCSubscriberAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5033212406E4E8009CAE61 /* RCSubscriberAttribute.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D5033252406E4E8009CAE61 /* RCSubscriberAttribute.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D5033222406E4E8009CAE61 /* RCSubscriberAttribute.m */; };
 		2D5033262406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5033232406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2D8DB34B24072AAE00BE3D31 /* SubscriberAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8DB34A24072AAE00BE3D31 /* SubscriberAttributeTests.swift */; };
 		35095A6C2351461E00ADF0B2 /* RCIdentityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 35095A6A2351461E00ADF0B2 /* RCIdentityManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		35095A6D2351461E00ADF0B2 /* RCIdentityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 35095A6B2351461E00ADF0B2 /* RCIdentityManager.m */; };
 		350A1B87226F937F00CCA10F /* RCAttributionData.h in Headers */ = {isa = PBXBuildFile; fileRef = 350A1B86226F937F00CCA10F /* RCAttributionData.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -88,6 +89,7 @@
 		37E356619BE46B3AA82A69E8 /* RCInMemoryCachedObject+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35483531C5A5E6BF09BBD /* RCInMemoryCachedObject+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E3585E0B39722838F235BD /* MockUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E357D16038F07915D7825D /* MockUserDefaults.swift */; };
 		37E3598A1AAA3D70EA01C82D /* RCInMemoryCachedObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35C6CBB3229AA53ECEB58 /* RCInMemoryCachedObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		37E35AE982974800FF079C14 /* RCSubscriberAttribute+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35C82A59C953A5F6017BB /* RCSubscriberAttribute+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E35AF213F2F79CB067FDC2 /* InMemoryCachedObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35E3250FBBB03D92E06EC /* InMemoryCachedObjectTests.swift */; };
 		37E35D4498633E73BF02BAE7 /* RCDeviceCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E356820F0AD560FA23F3BF /* RCDeviceCache.m */; };
 /* End PBXBuildFile section */
@@ -120,6 +122,7 @@
 		2D5033212406E4E8009CAE61 /* RCSubscriberAttribute.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCSubscriberAttribute.h; path = Purchases/SubscriberAttributes/RCSubscriberAttribute.h; sourceTree = SOURCE_ROOT; };
 		2D5033222406E4E8009CAE61 /* RCSubscriberAttribute.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCSubscriberAttribute.m; path = Purchases/SubscriberAttributes/RCSubscriberAttribute.m; sourceTree = SOURCE_ROOT; };
 		2D5033232406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCSpecialSubscriberAttributes.h; path = Purchases/SubscriberAttributes/RCSpecialSubscriberAttributes.h; sourceTree = SOURCE_ROOT; };
+		2D8DB34A24072AAE00BE3D31 /* SubscriberAttributeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriberAttributeTests.swift; sourceTree = "<group>"; };
 		35095A6A2351461E00ADF0B2 /* RCIdentityManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCIdentityManager.h; sourceTree = "<group>"; };
 		35095A6B2351461E00ADF0B2 /* RCIdentityManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCIdentityManager.m; sourceTree = "<group>"; };
 		350A1B84226E3E8700CCA10F /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -198,6 +201,7 @@
 		37E359893D3371FC3497D957 /* RCInMemoryCachedObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCInMemoryCachedObject.m; sourceTree = "<group>"; };
 		37E35C5A65AAF701DED59800 /* MockInMemoryCachedOfferings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockInMemoryCachedOfferings.swift; sourceTree = "<group>"; };
 		37E35C6CBB3229AA53ECEB58 /* RCInMemoryCachedObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCInMemoryCachedObject.h; sourceTree = "<group>"; };
+		37E35C82A59C953A5F6017BB /* RCSubscriberAttribute+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "RCSubscriberAttribute+Protected.h"; path = "Purchases/SubscriberAttributes/RCSubscriberAttribute+Protected.h"; sourceTree = SOURCE_ROOT; };
 		37E35D87B7E6F91E27E98F42 /* DeviceCacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceCacheTests.swift; sourceTree = "<group>"; };
 		37E35E3250FBBB03D92E06EC /* InMemoryCachedObjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InMemoryCachedObjectTests.swift; sourceTree = "<group>"; };
 		EF6FB66AA75A6EA23ACC0A9E /* RCPackage+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCPackage+Protected.h"; sourceTree = "<group>"; };
@@ -233,6 +237,7 @@
 				2D5033232406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h */,
 				2D5033212406E4E8009CAE61 /* RCSubscriberAttribute.h */,
 				2D5033222406E4E8009CAE61 /* RCSubscriberAttribute.m */,
+				37E35C82A59C953A5F6017BB /* RCSubscriberAttribute+Protected.h */,
 			);
 			name = SubscriberAttributes;
 			path = Public/SubscriberAttributes;
@@ -355,6 +360,7 @@
 				350FBDD61F7DF1640065833D /* Frameworks */,
 				37E35081077192045E3A8080 /* Mocks */,
 				37E35AE0CDC4C2AA8260FB58 /* Caching */,
+				37E35E77A60AC8D3F0E1A23D /* SubscriberAttributes */,
 			);
 			path = PurchasesTests;
 			sourceTree = "<group>";
@@ -401,6 +407,14 @@
 			path = Caching;
 			sourceTree = "<group>";
 		};
+		37E35E77A60AC8D3F0E1A23D /* SubscriberAttributes */ = {
+			isa = PBXGroup;
+			children = (
+				2D8DB34A24072AAE00BE3D31 /* SubscriberAttributeTests.swift */,
+			);
+			path = SubscriberAttributes;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -445,6 +459,7 @@
 				2D5033242406E4E8009CAE61 /* RCSubscriberAttribute.h in Headers */,
 				37E356619BE46B3AA82A69E8 /* RCInMemoryCachedObject+Protected.h in Headers */,
 				35846AFD226940F600CC9E56 /* RCPromotionalOffer.h in Headers */,
+				37E35AE982974800FF079C14 /* RCSubscriberAttribute+Protected.h in Headers */,
 				37E352F9B7505A398D578F53 /* RCDeviceCache+Protected.h in Headers */,
 				35C98D9520B7306A006DCBB5 /* RCCrossPlatformSupport.h in Headers */,
 			);
@@ -607,6 +622,7 @@
 				35262A211F7D77E600C04F2C /* PurchasesTests.swift in Sources */,
 				351F4FB21F803D9C00F245F4 /* BackendTests.swift in Sources */,
 				35262A301F7D78C600C04F2C /* HTTPClientTests.swift in Sources */,
+				2D8DB34B24072AAE00BE3D31 /* SubscriberAttributeTests.swift in Sources */,
 				35C514BE2321AC23000FFD78 /* OfferingsTests.swift in Sources */,
 				35E5B1DC1F80026C00B2537C /* StoreKitWrapperTests.swift in Sources */,
 				35B54E4E22ED1FA9005918B1 /* EntitlementInfosTests.swift in Sources */,

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -85,13 +85,16 @@
 		37E3526C938D7B291671BE8A /* RCInMemoryCachedObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E359893D3371FC3497D957 /* RCInMemoryCachedObject.m */; };
 		37E352F190E0E957E8D932F8 /* RCDeviceCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E3524E3032ABC72467AA43 /* RCDeviceCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E352F9B7505A398D578F53 /* RCDeviceCache+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E3555AC54BD10BE56F2B6B /* RCDeviceCache+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		37E353851D42047D5B0A57D0 /* MockDateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3578BD602C7B8E2274279 /* MockDateProvider.swift */; };
 		37E354BE25CE61E55E4FD89C /* MockDeviceCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E354BEB8FDE39CAB7C4D69 /* MockDeviceCache.swift */; };
 		37E356619BE46B3AA82A69E8 /* RCInMemoryCachedObject+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35483531C5A5E6BF09BBD /* RCInMemoryCachedObject+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E3585E0B39722838F235BD /* MockUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E357D16038F07915D7825D /* MockUserDefaults.swift */; };
+		37E358E75F7A3C75F2CA10BA /* RCDateProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E35642B1AD2A45A7152CD5 /* RCDateProvider.m */; };
 		37E3598A1AAA3D70EA01C82D /* RCInMemoryCachedObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35C6CBB3229AA53ECEB58 /* RCInMemoryCachedObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E35AE982974800FF079C14 /* RCSubscriberAttribute+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35C82A59C953A5F6017BB /* RCSubscriberAttribute+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E35AF213F2F79CB067FDC2 /* InMemoryCachedObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35E3250FBBB03D92E06EC /* InMemoryCachedObjectTests.swift */; };
 		37E35D4498633E73BF02BAE7 /* RCDeviceCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E356820F0AD560FA23F3BF /* RCDeviceCache.m */; };
+		37E35EC177759FE5350F53B3 /* RCDateProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35192068E91782835FA85 /* RCDateProvider.h */; settings = {ATTRIBUTES = (Private, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -192,11 +195,14 @@
 		35D3AB412030B4C600DE42C5 /* RCIntroEligibility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCIntroEligibility.h; sourceTree = "<group>"; };
 		35D3AB422030B4C600DE42C5 /* RCIntroEligibility.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCIntroEligibility.m; sourceTree = "<group>"; };
 		35E5B1DB1F80026C00B2537C /* StoreKitWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitWrapperTests.swift; sourceTree = "<group>"; };
+		37E35192068E91782835FA85 /* RCDateProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCDateProvider.h; sourceTree = "<group>"; };
 		37E3524E3032ABC72467AA43 /* RCDeviceCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCDeviceCache.h; sourceTree = "<group>"; };
 		37E35483531C5A5E6BF09BBD /* RCInMemoryCachedObject+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCInMemoryCachedObject+Protected.h"; sourceTree = "<group>"; };
 		37E354BEB8FDE39CAB7C4D69 /* MockDeviceCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDeviceCache.swift; sourceTree = "<group>"; };
 		37E3555AC54BD10BE56F2B6B /* RCDeviceCache+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCDeviceCache+Protected.h"; sourceTree = "<group>"; };
+		37E35642B1AD2A45A7152CD5 /* RCDateProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCDateProvider.m; sourceTree = "<group>"; };
 		37E356820F0AD560FA23F3BF /* RCDeviceCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCDeviceCache.m; sourceTree = "<group>"; };
+		37E3578BD602C7B8E2274279 /* MockDateProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDateProvider.swift; sourceTree = "<group>"; };
 		37E357D16038F07915D7825D /* MockUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockUserDefaults.swift; sourceTree = "<group>"; };
 		37E359893D3371FC3497D957 /* RCInMemoryCachedObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCInMemoryCachedObject.m; sourceTree = "<group>"; };
 		37E35C5A65AAF701DED59800 /* MockInMemoryCachedOfferings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockInMemoryCachedOfferings.swift; sourceTree = "<group>"; };
@@ -339,6 +345,8 @@
 				35095A6A2351461E00ADF0B2 /* RCIdentityManager.h */,
 				35095A6B2351461E00ADF0B2 /* RCIdentityManager.m */,
 				37E359927177DF24576FF361 /* Caching */,
+				37E35642B1AD2A45A7152CD5 /* RCDateProvider.m */,
+				37E35192068E91782835FA85 /* RCDateProvider.h */,
 			);
 			path = Purchases;
 			sourceTree = "<group>";
@@ -381,6 +389,7 @@
 				37E354BEB8FDE39CAB7C4D69 /* MockDeviceCache.swift */,
 				37E357D16038F07915D7825D /* MockUserDefaults.swift */,
 				37E35C5A65AAF701DED59800 /* MockInMemoryCachedOfferings.swift */,
+				37E3578BD602C7B8E2274279 /* MockDateProvider.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -460,6 +469,7 @@
 				37E356619BE46B3AA82A69E8 /* RCInMemoryCachedObject+Protected.h in Headers */,
 				35846AFD226940F600CC9E56 /* RCPromotionalOffer.h in Headers */,
 				37E35AE982974800FF079C14 /* RCSubscriberAttribute+Protected.h in Headers */,
+				37E35EC177759FE5350F53B3 /* RCDateProvider.h in Headers */,
 				37E352F9B7505A398D578F53 /* RCDeviceCache+Protected.h in Headers */,
 				35C98D9520B7306A006DCBB5 /* RCCrossPlatformSupport.h in Headers */,
 			);
@@ -611,6 +621,7 @@
 				35CE74FD20C38A7100CE09D8 /* RCOffering.m in Sources */,
 				37E35D4498633E73BF02BAE7 /* RCDeviceCache.m in Sources */,
 				37E3526C938D7B291671BE8A /* RCInMemoryCachedObject.m in Sources */,
+				37E358E75F7A3C75F2CA10BA /* RCDateProvider.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -635,6 +646,7 @@
 				37E351AB03EE37534CA10B59 /* MockInMemoryCachedOfferings.swift in Sources */,
 				37E351E3AC0B5F67305B4CB6 /* DeviceCacheTests.swift in Sources */,
 				37E35AF213F2F79CB067FDC2 /* InMemoryCachedObjectTests.swift in Sources */,
+				37E353851D42047D5B0A57D0 /* MockDateProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -7,9 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2D5033242406E4E8009CAE61 /* RCSubscriberAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5033212406E4E8009CAE61 /* RCSubscriberAttribute.h */; };
+		2D5033242406E4E8009CAE61 /* RCSubscriberAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5033212406E4E8009CAE61 /* RCSubscriberAttribute.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D5033252406E4E8009CAE61 /* RCSubscriberAttribute.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D5033222406E4E8009CAE61 /* RCSubscriberAttribute.m */; };
-		2D5033262406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5033232406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h */; };
+		2D5033262406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5033232406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		35095A6C2351461E00ADF0B2 /* RCIdentityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 35095A6A2351461E00ADF0B2 /* RCIdentityManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		35095A6D2351461E00ADF0B2 /* RCIdentityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 35095A6B2351461E00ADF0B2 /* RCIdentityManager.m */; };
 		350A1B87226F937F00CCA10F /* RCAttributionData.h in Headers */ = {isa = PBXBuildFile; fileRef = 350A1B86226F937F00CCA10F /* RCAttributionData.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -234,7 +234,8 @@
 				2D5033212406E4E8009CAE61 /* RCSubscriberAttribute.h */,
 				2D5033222406E4E8009CAE61 /* RCSubscriberAttribute.m */,
 			);
-			path = SubscriberAttributes;
+			name = SubscriberAttributes;
+			path = Public/SubscriberAttributes;
 			sourceTree = "<group>";
 		};
 		350FBDD61F7DF1640065833D /* Frameworks */ = {
@@ -249,7 +250,6 @@
 		350FBDE61F7EEEDF0065833D /* Public */ = {
 			isa = PBXGroup;
 			children = (
-				2D5033202406E4C7009CAE61 /* SubscriberAttributes */,
 				353AB5E5222F633D003754E6 /* RCPurchasesErrorUtils.h */,
 				352E88422229B1A60046A10A /* RCPurchasesErrorUtils.m */,
 				353AB5E3222F624E003754E6 /* RCPurchasesErrors.h */,
@@ -297,6 +297,7 @@
 			isa = PBXGroup;
 			children = (
 				350FBDE61F7EEEDF0065833D /* Public */,
+				2D5033202406E4C7009CAE61 /* SubscriberAttributes */,
 				35A60EA81F82993E00D2FAE8 /* RCPurchases+Protected.h */,
 				35395CB321B9EB1000286D13 /* RCIntroEligibility+Protected.h */,
 				352C36BE1F9D372D00A15783 /* RCPurchaserInfo+Protected.h */,
@@ -418,7 +419,6 @@
 				35B54E4822EA6F4E005918B1 /* RCEntitlementInfo.h in Headers */,
 				353AB5E4222F624E003754E6 /* RCPurchasesErrors.h in Headers */,
 				35846AFF226A56AE00CC9E56 /* RCPromotionalOffer+Protected.h in Headers */,
-				2D5033262406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h in Headers */,
 				3585D6A322E680E30079E2C5 /* RCPackage.h in Headers */,
 				353AB5E6222F633D003754E6 /* RCPurchasesErrorUtils.h in Headers */,
 				351F4FAB1F80190700F245F4 /* RCBackend.h in Headers */,
@@ -426,7 +426,6 @@
 				352C36BF1F9D372D00A15783 /* RCPurchaserInfo+Protected.h in Headers */,
 				35A3F73323172D9900559FF9 /* RCOfferings+Protected.h in Headers */,
 				35395CB421B9F59E00286D13 /* RCIntroEligibility+Protected.h in Headers */,
-				2D5033242406E4E8009CAE61 /* RCSubscriberAttribute.h in Headers */,
 				350FBDE91F7EEF070065833D /* RCPurchases.h in Headers */,
 				35A60EAA1F82993E00D2FAE8 /* RCPurchases+Protected.h in Headers */,
 				354D50DF22E7D014009B870C /* RCOfferings.h in Headers */,
@@ -437,15 +436,17 @@
 				35A3F7352318772500559FF9 /* RCOfferingsFactory.h in Headers */,
 				35B54E5022EF7F3A005918B1 /* RCEntitlementInfo+Protected.h in Headers */,
 				35B54E5222EF88CE005918B1 /* RCEntitlementInfos+Protected.h in Headers */,
-				35C98D9520B7306A006DCBB5 /* RCCrossPlatformSupport.h in Headers */,
 				35095A6C2351461E00ADF0B2 /* RCIdentityManager.h in Headers */,
 				35262A0F1F7C4B9100C04F2C /* Purchases.h in Headers */,
 				359A0EA12003C8CD002D8C7F /* NSLocale+RCExtensions.h in Headers */,
 				37E3598A1AAA3D70EA01C82D /* RCInMemoryCachedObject.h in Headers */,
 				37E352F190E0E957E8D932F8 /* RCDeviceCache.h in Headers */,
+				2D5033262406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h in Headers */,
+				2D5033242406E4E8009CAE61 /* RCSubscriberAttribute.h in Headers */,
 				37E356619BE46B3AA82A69E8 /* RCInMemoryCachedObject+Protected.h in Headers */,
 				35846AFD226940F600CC9E56 /* RCPromotionalOffer.h in Headers */,
 				37E352F9B7505A398D578F53 /* RCDeviceCache+Protected.h in Headers */,
+				35C98D9520B7306A006DCBB5 /* RCCrossPlatformSupport.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Purchases/RCDateProvider.h
+++ b/Purchases/RCDateProvider.h
@@ -1,0 +1,18 @@
+//
+// Created by RevenueCat on 2/27/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+@interface RCDateProvider : NSObject
+
+- (NSDate *)now;
+
+@end
+
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/RCDateProvider.m
+++ b/Purchases/RCDateProvider.m
@@ -1,0 +1,21 @@
+//
+// Created by RevenueCat on 2/27/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+#import "RCDateProvider.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+@implementation RCDateProvider
+
+- (NSDate *)now {
+    return NSDate.date;
+}
+
+
+@end
+
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/SubscriberAttributes/RCSpecialSubscriberAttributes.h
+++ b/Purchases/SubscriberAttributes/RCSpecialSubscriberAttributes.h
@@ -1,0 +1,15 @@
+//
+// Created by RevenueCat on 2/7/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+#define SPECIAL_ATTRIBUTE_EMAIL @"$email"
+#define SPECIAL_ATTRIBUTE_PHONE_NUMBER @"$phoneNumber"
+#define SPECIAL_ATTRIBUTE_DISPLAY_NAME @"$displayName"
+#define SPECIAL_ATTRIBUTE_PUSH_TOKEN @"$apnsTokens"
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/SubscriberAttributes/RCSubscriberAttribute+Protected.h
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttribute+Protected.h
@@ -8,6 +8,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class RCDateProvider;
+
 @interface RCSubscriberAttribute (Protected)
 
 - (instancetype)initWithKey:(NSString *)key
@@ -16,6 +18,12 @@ NS_ASSUME_NONNULL_BEGIN
                    isSynced:(BOOL)isSynced
                     setTime:(NSDate *)setTime;
 
+- (instancetype)initWithKey:(NSString *)key
+                      value:(NSString *)value
+                  appUserID:(NSString *)appUserID
+               dateProvider:(RCDateProvider *)dateProvider;
+
 @end
+
 
 NS_ASSUME_NONNULL_END

--- a/Purchases/SubscriberAttributes/RCSubscriberAttribute+Protected.h
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttribute+Protected.h
@@ -1,0 +1,21 @@
+//
+// Created by RevenueCat on 2/26/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "RCSubscriberAttribute.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCSubscriberAttribute (Protected)
+
+- (instancetype)initWithKey:(NSString *)key
+                      value:(NSString *)value
+                  appUserID:(NSString *)appUserID
+                   isSynced:(BOOL)isSynced
+                    setTime:(NSDate *)setTime;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/SubscriberAttributes/RCSubscriberAttribute+Protected.h
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttribute+Protected.h
@@ -14,13 +14,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithKey:(NSString *)key
                       value:(NSString *)value
-                  appUserID:(NSString *)appUserID
                    isSynced:(BOOL)isSynced
                     setTime:(NSDate *)setTime;
 
 - (instancetype)initWithKey:(NSString *)key
                       value:(NSString *)value
-                  appUserID:(NSString *)appUserID
                dateProvider:(RCDateProvider *)dateProvider;
 
 @end

--- a/Purchases/SubscriberAttributes/RCSubscriberAttribute.h
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttribute.h
@@ -1,5 +1,5 @@
 //
-// Created by Andrés Boedo on 2/17/20.
+// Created by RevenueCat on 2/17/20.
 // Copyright (c) 2020 Purchases. All rights reserved.
 //
 

--- a/Purchases/SubscriberAttributes/RCSubscriberAttribute.h
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttribute.h
@@ -12,11 +12,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy, readonly) NSString *key;
 @property (nonatomic, copy, readonly) NSString *value;
-@property (nonatomic, copy, readonly) NSString *appUserID;
 @property (nonatomic, readonly) NSDate *setTime;
 @property (nonatomic, assign) BOOL isSynced;
 
-- (instancetype)initWithKey:(NSString *)key value:(NSString *)value appUserID:(NSString *)appUserID;
+- (instancetype)initWithKey:(NSString *)key value:(NSString *)value;
 
 - (instancetype)initWithDictionary:(NSDictionary <NSString *, NSObject *> *)dict;
 

--- a/Purchases/SubscriberAttributes/RCSubscriberAttribute.h
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttribute.h
@@ -1,0 +1,34 @@
+//
+// Created by Andrés Boedo on 2/17/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+@interface RCSubscriberAttribute : NSObject
+
+@property (nonatomic, copy, readonly) NSString *key;
+@property (nonatomic, copy, readonly) NSString *value;
+@property (nonatomic, copy, readonly) NSString *appUserID;
+@property (nonatomic, readonly) NSDate *setTime;
+@property (nonatomic, assign) BOOL isSynced;
+
+- (instancetype)initWithKey:(NSString *)key value:(NSString *)value appUserID:(NSString *)appUserID;
+
+- (instancetype)initWithDictionary:(NSDictionary <NSString *, NSObject *> *)dict;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+- (NSDictionary <NSString *, NSObject *> *)asDictionary;
+
+- (NSDictionary <NSString *, NSObject *> *)asBackendDictionary;
+
+@end
+
+typedef NSMutableDictionary<NSString *, RCSubscriberAttribute *> *RCSubscriberAttributeMutableDict;
+typedef NSDictionary<NSString *, RCSubscriberAttribute *> *RCSubscriberAttributeDict;
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/SubscriberAttributes/RCSubscriberAttribute.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttribute.m
@@ -11,7 +11,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 #define KEY_KEY @"key"
 #define VALUE_KEY @"value"
-#define APP_USER_ID_KEY @"appUserID"
 #define SET_TIME_KEY @"setTime"
 #define IS_SYNCED_KEY @"isSynced"
 
@@ -23,7 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy) NSString *key;
 @property (nonatomic, copy) NSString *value;
-@property (nonatomic, copy) NSString *appUserID;
 @property (nonatomic) NSDate *setTime;
 
 @end
@@ -34,22 +32,19 @@ NS_ASSUME_NONNULL_END
 
 @implementation RCSubscriberAttribute
 
-- (instancetype)initWithKey:(NSString *)key value:(NSString *)value appUserID:(NSString *)appUserID {
+- (instancetype)initWithKey:(NSString *)key value:(NSString *)value {
     return [self initWithKey:key
                        value:value
-                   appUserID:appUserID
                 dateProvider:[[RCDateProvider alloc] init]];
 }
 
 - (instancetype)initWithKey:(NSString *)key
                       value:(NSString *)value
-                  appUserID:(NSString *)appUserID
                    isSynced:(BOOL)isSynced
                     setTime:(NSDate *)setTime {
     if (self = [super init]) {
         self.key = key;
         self.value = value;
-        self.appUserID = appUserID;
         self.isSynced = isSynced;
         self.setTime = setTime;
     }
@@ -58,11 +53,9 @@ NS_ASSUME_NONNULL_END
 
 - (instancetype)initWithKey:(NSString *)key
                       value:(NSString *)value
-                  appUserID:(NSString *)appUserID
                dateProvider:(RCDateProvider *)dateProvider {
     return [self initWithKey:key
                        value:value
-                   appUserID:appUserID
                     isSynced:NO
                      setTime:dateProvider.now];
 }
@@ -70,7 +63,6 @@ NS_ASSUME_NONNULL_END
 - (instancetype)initWithDictionary:(NSDictionary <NSString *, NSObject *> *)dict {
     return [self initWithKey:(NSString *) dict[KEY_KEY]
                        value:(NSString *) dict[VALUE_KEY]
-                   appUserID:(NSString *) dict[APP_USER_ID_KEY]
                     isSynced:((NSNumber *) dict[IS_SYNCED_KEY]).boolValue
                      setTime:(NSDate *) dict[SET_TIME_KEY]];
 }
@@ -79,7 +71,6 @@ NS_ASSUME_NONNULL_END
     return @{
         KEY_KEY: self.key,
         VALUE_KEY: self.value ?: @"",
-        APP_USER_ID_KEY: self.appUserID,
         IS_SYNCED_KEY: @(self.isSynced),
         SET_TIME_KEY: self.setTime,
     };
@@ -93,8 +84,8 @@ NS_ASSUME_NONNULL_END
 }
 
 - (NSString *)description {
-    return [NSString stringWithFormat:@"Subscriber attribute: key: %@ value: %@ appUserID: %@ setTime: %@",
-                                      self.key, self.value, self.appUserID, self.setTime];
+    return [NSString stringWithFormat:@"Subscriber attribute: key: %@ value: %@ setTime: %@",
+                                      self.key, self.value, self.setTime];
 }
 
 @end

--- a/Purchases/SubscriberAttributes/RCSubscriberAttribute.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttribute.m
@@ -1,5 +1,5 @@
 //
-// Created by Andrés Boedo on 2/17/20.
+// Created by RevenueCat on 2/17/20.
 // Copyright (c) 2020 Purchases. All rights reserved.
 //
 

--- a/Purchases/SubscriberAttributes/RCSubscriberAttribute.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttribute.m
@@ -5,6 +5,7 @@
 
 #import <Foundation/Foundation.h>
 #import "RCSubscriberAttribute.h"
+#import "RCDateProvider.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -37,8 +38,7 @@ NS_ASSUME_NONNULL_END
     return [self initWithKey:key
                        value:value
                    appUserID:appUserID
-                    isSynced:NO
-                     setTime:[NSDate date]];
+                dateProvider:[[RCDateProvider alloc] init]];
 }
 
 - (instancetype)initWithKey:(NSString *)key
@@ -54,6 +54,17 @@ NS_ASSUME_NONNULL_END
         self.setTime = setTime;
     }
     return self;
+}
+
+- (instancetype)initWithKey:(NSString *)key
+                      value:(NSString *)value
+                  appUserID:(NSString *)appUserID
+               dateProvider:(RCDateProvider *)dateProvider {
+    return [self initWithKey:key
+                       value:value
+                   appUserID:appUserID
+                    isSynced:NO
+                     setTime:dateProvider.now];
 }
 
 - (instancetype)initWithDictionary:(NSDictionary <NSString *, NSObject *> *)dict {

--- a/Purchases/SubscriberAttributes/RCSubscriberAttribute.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttribute.m
@@ -1,0 +1,89 @@
+//
+// Created by Andrés Boedo on 2/17/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "RCSubscriberAttribute.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+#define KEY_KEY @"key"
+#define VALUE_KEY @"value"
+#define APP_USER_ID_KEY @"appUserID"
+#define SET_TIME_KEY @"setTime"
+#define IS_SYNCED_KEY @"isSynced"
+
+#define BACKEND_VALUE_KEY @"value"
+#define BACKEND_TIMESTAMP_KEY @"updated_at"
+
+
+@interface RCSubscriberAttribute ()
+
+@property (nonatomic, copy) NSString *key;
+@property (nonatomic, copy) NSString *value;
+@property (nonatomic, copy) NSString *appUserID;
+@property (nonatomic) NSDate *setTime;
+
+@end
+
+
+NS_ASSUME_NONNULL_END
+
+
+@implementation RCSubscriberAttribute
+
+- (instancetype)initWithKey:(NSString *)key value:(NSString *)value appUserID:(NSString *)appUserID {
+    return [self initWithKey:key
+                       value:value
+                   appUserID:appUserID
+                    isSynced:NO
+                     setTime:[NSDate date]];
+}
+
+- (instancetype)initWithKey:(NSString *)key
+                      value:(NSString *)value
+                  appUserID:(NSString *)appUserID
+                   isSynced:(BOOL)isSynced
+                    setTime:(NSDate *)setTime {
+    if (self = [super init]) {
+        self.key = key;
+        self.value = value;
+        self.appUserID = appUserID;
+        self.isSynced = isSynced;
+        self.setTime = setTime;
+    }
+    return self;
+}
+
+- (instancetype)initWithDictionary:(NSDictionary <NSString *, NSObject *> *)dict {
+    return [self initWithKey:(NSString *) dict[KEY_KEY]
+                       value:(NSString *) dict[VALUE_KEY]
+                   appUserID:(NSString *) dict[APP_USER_ID_KEY]
+                    isSynced:((NSNumber *) dict[IS_SYNCED_KEY]).boolValue
+                     setTime:(NSDate *) dict[SET_TIME_KEY]];
+}
+
+- (NSDictionary <NSString *, NSObject *> *)asDictionary {
+    return @{
+        KEY_KEY: self.key,
+        VALUE_KEY: self.value ?: @"",
+        APP_USER_ID_KEY: self.appUserID,
+        IS_SYNCED_KEY: @(self.isSynced),
+        SET_TIME_KEY: self.setTime,
+    };
+}
+
+- (NSDictionary <NSString *, NSObject *> *)asBackendDictionary {
+    return @{
+        BACKEND_VALUE_KEY: self.value ?: @"",
+        BACKEND_TIMESTAMP_KEY: @(self.setTime.timeIntervalSince1970)
+    };
+}
+
+- (NSString *)description {
+    return [NSString stringWithFormat:@"Subscriber attribute: key: %@ value: %@ appUserID: %@ setTime: %@",
+                                      self.key, self.value, self.appUserID, self.setTime];
+}
+
+@end

--- a/PurchasesTests/Mocks/MockDateProvider.swift
+++ b/PurchasesTests/Mocks/MockDateProvider.swift
@@ -1,0 +1,22 @@
+//
+// Created by RevenueCat on 2/27/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+import Purchases
+
+class MockDateProvider: RCDateProvider {
+    var invokedNow = false
+    var invokedNowCount = 0
+    var stubbedNowResult: Date!
+
+    init(stubbedNow: Date) {
+        self.stubbedNowResult = stubbedNow
+    }
+
+    override func now() -> Date {
+        invokedNow = true
+        invokedNowCount += 1
+        return stubbedNowResult
+    }
+}

--- a/PurchasesTests/PurchasesTests-Bridging-Header.h
+++ b/PurchasesTests/PurchasesTests-Bridging-Header.h
@@ -29,3 +29,4 @@
 #include <Purchases/RCSubscriberAttribute.h>
 #include <Purchases/RCSubscriberAttribute+Protected.h>
 #include <Purchases/RCSpecialSubscriberAttributes.h>
+#include <Purchases/RCDateProvider.h>

--- a/PurchasesTests/PurchasesTests-Bridging-Header.h
+++ b/PurchasesTests/PurchasesTests-Bridging-Header.h
@@ -27,4 +27,5 @@
 #include <Purchases/RCInMemoryCachedObject+Protected.h>
 #include <Purchases/RCIdentityManager.h>
 #include <Purchases/RCSubscriberAttribute.h>
+#include <Purchases/RCSubscriberAttribute+Protected.h>
 #include <Purchases/RCSpecialSubscriberAttributes.h>

--- a/PurchasesTests/PurchasesTests-Bridging-Header.h
+++ b/PurchasesTests/PurchasesTests-Bridging-Header.h
@@ -26,3 +26,5 @@
 #include <Purchases/RCDeviceCache+Protected.h>
 #include <Purchases/RCInMemoryCachedObject+Protected.h>
 #include <Purchases/RCIdentityManager.h>
+#include <Purchases/RCSubscriberAttribute.h>
+#include <Purchases/RCSpecialSubscriberAttributes.h>

--- a/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
@@ -86,7 +86,6 @@ class SubscriberAttributeTests: XCTestCase {
 
         expect(receivedDictionary["value"] as? String) == value
         let updatedAtEpoch = (receivedDictionary["updated_at"] as! NSNumber).doubleValue
-        let updatedAtDate = Date(timeIntervalSince1970: updatedAtEpoch)
-        expect(updatedAtDate).to(beCloseTo(now))
+        expect(updatedAtEpoch) == now.timeIntervalSince1970
     }
 }

--- a/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
@@ -10,16 +10,14 @@ import Nimble
 import Purchases
 
 class SubscriberAttributeTests: XCTestCase {
-    func testInitWithKeyValueAppUserIDSetsRightValues() {
+    func testInitWithKeyValueSetsRightValues() {
         let now = Date()
         let dateProvider = MockDateProvider(stubbedNow: now)
         let subscriberAttribute = RCSubscriberAttribute(key: "a key",
                                                         value: "a value",
-                                                        appUserID: "user id",
                                                         dateProvider: dateProvider)
         expect(subscriberAttribute.key) == "a key"
         expect(subscriberAttribute.value) == "a value"
-        expect(subscriberAttribute.appUserID) == "user id"
         expect(subscriberAttribute.setTime) == now
         expect(subscriberAttribute.isSynced) == false
     }
@@ -27,13 +25,11 @@ class SubscriberAttributeTests: XCTestCase {
     func testInitWithDictionarySetsRightValues() {
         let key = "some key"
         let value = "some value"
-        let appUserID = "68asdfa4g3210"
         let setTime = NSDate()
         let isSynced = true
         let subscriberDict: [String: NSObject] = [
             "key": NSString(string: key),
             "value": NSString(string: value),
-            "appUserID": NSString(string: appUserID),
             "setTime": setTime,
             "isSynced": NSNumber(booleanLiteral: isSynced),
         ]
@@ -42,7 +38,6 @@ class SubscriberAttributeTests: XCTestCase {
 
         expect(subscriberAttribute.key) == key
         expect(subscriberAttribute.value) == value
-        expect(subscriberAttribute.appUserID) == appUserID
         expect(subscriberAttribute.setTime as NSDate) == setTime
         expect(subscriberAttribute.isSynced) == isSynced
     }
@@ -50,21 +45,18 @@ class SubscriberAttributeTests: XCTestCase {
     func testAsDictionaryReturnsCorrectFormat() {
         let key = "some key"
         let value = "some value"
-        let appUserID = "68asdfa4g3210"
         let now = Date()
         let dateProvider = MockDateProvider(stubbedNow: now)
 
         let subscriberAttribute = RCSubscriberAttribute(key: key,
                                                         value: value,
-                                                        appUserID: appUserID,
                                                         dateProvider: dateProvider)
 
         let receivedDictionary = subscriberAttribute.asDictionary()
-        expect(receivedDictionary.keys.count) == 5
+        expect(receivedDictionary.keys.count) == 4
 
         expect(receivedDictionary["key"] as? String) == key
         expect(receivedDictionary["value"] as? String) == value
-        expect(receivedDictionary["appUserID"] as? String) == appUserID
         expect(receivedDictionary["setTime"] as! Date) == now
         expect((receivedDictionary["isSynced"] as! NSNumber).boolValue) == false
     }
@@ -72,13 +64,11 @@ class SubscriberAttributeTests: XCTestCase {
     func testAsBackendDictionaryReturnsCorrectFormat() {
         let key = "some key"
         let value = "some value"
-        let appUserID = "68asdfa4g3210"
         let now = Date()
         let dateProvider = MockDateProvider(stubbedNow: now)
 
         let subscriberAttribute = RCSubscriberAttribute(key: key,
                                                         value: value,
-                                                        appUserID: appUserID,
                                                         dateProvider: dateProvider)
 
         let receivedDictionary = subscriberAttribute.asBackendDictionary()

--- a/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
@@ -87,6 +87,6 @@ class SubscriberAttributeTests: XCTestCase {
         expect(receivedDictionary["value"] as? String) == value
         let updatedAtEpoch = (receivedDictionary["updated_at"] as! NSNumber).doubleValue
         let updatedAtDate = Date(timeIntervalSince1970: updatedAtEpoch)
-        expect(updatedAtDate) == now
+        expect(updatedAtDate).to(beCloseTo(now))
     }
 }

--- a/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
@@ -11,26 +11,17 @@ import Purchases
 
 class SubscriberAttributeTests: XCTestCase {
     func testInitWithKeyValueAppUserIDSetsRightValues() {
+        let now = Date()
+        let dateProvider = MockDateProvider(stubbedNow: now)
         let subscriberAttribute = RCSubscriberAttribute(key: "a key",
                                                         value: "a value",
-                                                        appUserID: "user id")
+                                                        appUserID: "user id",
+                                                        dateProvider: dateProvider)
         expect(subscriberAttribute.key) == "a key"
         expect(subscriberAttribute.value) == "a value"
         expect(subscriberAttribute.appUserID) == "user id"
-        expect(subscriberAttribute.setTime).to(beCloseTo(Date(), within: 0.5))
+        expect(subscriberAttribute.setTime) == now
         expect(subscriberAttribute.isSynced) == false
-
-        let setTime = Date()
-        let subscriberAttribute2 = RCSubscriberAttribute(key: "another key",
-                                                         value: "another value",
-                                                         appUserID: "user id2",
-                                                         isSynced: true,
-                                                         setTime: setTime)
-        expect(subscriberAttribute2.key) == "another key"
-        expect(subscriberAttribute2.value) == "another value"
-        expect(subscriberAttribute2.appUserID) == "user id2"
-        expect(subscriberAttribute2.setTime) == setTime
-        expect(subscriberAttribute2.isSynced) == true
     }
 
     func testInitWithDictionarySetsRightValues() {
@@ -60,9 +51,13 @@ class SubscriberAttributeTests: XCTestCase {
         let key = "some key"
         let value = "some value"
         let appUserID = "68asdfa4g3210"
+        let now = Date()
+        let dateProvider = MockDateProvider(stubbedNow: now)
+
         let subscriberAttribute = RCSubscriberAttribute(key: key,
                                                         value: value,
-                                                        appUserID: appUserID)
+                                                        appUserID: appUserID,
+                                                        dateProvider: dateProvider)
 
         let receivedDictionary = subscriberAttribute.asDictionary()
         expect(receivedDictionary.keys.count) == 5
@@ -70,7 +65,7 @@ class SubscriberAttributeTests: XCTestCase {
         expect(receivedDictionary["key"] as? String) == key
         expect(receivedDictionary["value"] as? String) == value
         expect(receivedDictionary["appUserID"] as? String) == appUserID
-        expect(receivedDictionary["setTime"] as! Date).to(beCloseTo(Date(), within: 0.5))
+        expect(receivedDictionary["setTime"] as! Date) == now
         expect((receivedDictionary["isSynced"] as! NSNumber).boolValue) == false
     }
 
@@ -78,9 +73,13 @@ class SubscriberAttributeTests: XCTestCase {
         let key = "some key"
         let value = "some value"
         let appUserID = "68asdfa4g3210"
+        let now = Date()
+        let dateProvider = MockDateProvider(stubbedNow: now)
+
         let subscriberAttribute = RCSubscriberAttribute(key: key,
                                                         value: value,
-                                                        appUserID: appUserID)
+                                                        appUserID: appUserID,
+                                                        dateProvider: dateProvider)
 
         let receivedDictionary = subscriberAttribute.asBackendDictionary()
         expect(receivedDictionary.keys.count) == 2
@@ -88,6 +87,6 @@ class SubscriberAttributeTests: XCTestCase {
         expect(receivedDictionary["value"] as? String) == value
         let updatedAtEpoch = (receivedDictionary["updated_at"] as! NSNumber).doubleValue
         let updatedAtDate = Date(timeIntervalSince1970: updatedAtEpoch)
-        expect(updatedAtDate).to(beCloseTo(Date(), within: 0.5))
+        expect(updatedAtDate) == now
     }
 }

--- a/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
@@ -1,0 +1,93 @@
+//
+// Created by RevenueCat on 2/26/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+import XCTest
+import OHHTTPStubs
+import Nimble
+
+import Purchases
+
+class SubscriberAttributeTests: XCTestCase {
+    func testInitWithKeyValueAppUserIDSetsRightValues() {
+        let subscriberAttribute = RCSubscriberAttribute(key: "a key",
+                                                        value: "a value",
+                                                        appUserID: "user id")
+        expect(subscriberAttribute.key) == "a key"
+        expect(subscriberAttribute.value) == "a value"
+        expect(subscriberAttribute.appUserID) == "user id"
+        expect(subscriberAttribute.setTime).to(beCloseTo(Date(), within: 0.5))
+        expect(subscriberAttribute.isSynced) == false
+
+        let setTime = Date()
+        let subscriberAttribute2 = RCSubscriberAttribute(key: "another key",
+                                                         value: "another value",
+                                                         appUserID: "user id2",
+                                                         isSynced: true,
+                                                         setTime: setTime)
+        expect(subscriberAttribute2.key) == "another key"
+        expect(subscriberAttribute2.value) == "another value"
+        expect(subscriberAttribute2.appUserID) == "user id2"
+        expect(subscriberAttribute2.setTime) == setTime
+        expect(subscriberAttribute2.isSynced) == true
+    }
+
+    func testInitWithDictionarySetsRightValues() {
+        let key = "some key"
+        let value = "some value"
+        let appUserID = "68asdfa4g3210"
+        let setTime = NSDate()
+        let isSynced = true
+        let subscriberDict: [String: NSObject] = [
+            "key": NSString(string: key),
+            "value": NSString(string: value),
+            "appUserID": NSString(string: appUserID),
+            "setTime": setTime,
+            "isSynced": NSNumber(booleanLiteral: isSynced),
+        ]
+
+        let subscriberAttribute = RCSubscriberAttribute(dictionary: subscriberDict)
+
+        expect(subscriberAttribute.key) == key
+        expect(subscriberAttribute.value) == value
+        expect(subscriberAttribute.appUserID) == appUserID
+        expect(subscriberAttribute.setTime as NSDate) == setTime
+        expect(subscriberAttribute.isSynced) == isSynced
+    }
+
+    func testAsDictionaryReturnsCorrectFormat() {
+        let key = "some key"
+        let value = "some value"
+        let appUserID = "68asdfa4g3210"
+        let subscriberAttribute = RCSubscriberAttribute(key: key,
+                                                        value: value,
+                                                        appUserID: appUserID)
+
+        let receivedDictionary = subscriberAttribute.asDictionary()
+        expect(receivedDictionary.keys.count) == 5
+
+        expect(receivedDictionary["key"] as? String) == key
+        expect(receivedDictionary["value"] as? String) == value
+        expect(receivedDictionary["appUserID"] as? String) == appUserID
+        expect(receivedDictionary["setTime"] as! Date).to(beCloseTo(Date(), within: 0.5))
+        expect((receivedDictionary["isSynced"] as! NSNumber).boolValue) == false
+    }
+
+    func testAsBackendDictionaryReturnsCorrectFormat() {
+        let key = "some key"
+        let value = "some value"
+        let appUserID = "68asdfa4g3210"
+        let subscriberAttribute = RCSubscriberAttribute(key: key,
+                                                        value: value,
+                                                        appUserID: appUserID)
+
+        let receivedDictionary = subscriberAttribute.asBackendDictionary()
+        expect(receivedDictionary.keys.count) == 2
+
+        expect(receivedDictionary["value"] as? String) == value
+        let updatedAtEpoch = (receivedDictionary["updated_at"] as! NSNumber).doubleValue
+        let updatedAtDate = Date(timeIntervalSince1970: updatedAtEpoch)
+        expect(updatedAtDate).to(beCloseTo(Date(), within: 0.5))
+    }
+}


### PR DESCRIPTION
I split up https://github.com/RevenueCat/purchases-ios/pull/186 into 4 smaller, more focused PRs. 

Part 1 contains the `RCSubscriberAttributes` class, a simple data class that can hold info for subscriber attributes, and knows how to convert into NSUserDefaults format as well as backend format. 

### Requirements: 
- [x] unit tests