### PR TITLE
[Final] Subscriber attributes Part 2: Backend

### DIFF
--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -95,9 +95,11 @@
 		37E356619BE46B3AA82A69E8 /* RCInMemoryCachedObject+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35483531C5A5E6BF09BBD /* RCInMemoryCachedObject+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E3585E0B39722838F235BD /* MockUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E357D16038F07915D7825D /* MockUserDefaults.swift */; };
 		37E358E75F7A3C75F2CA10BA /* RCDateProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E35642B1AD2A45A7152CD5 /* RCDateProvider.m */; };
+		37E35971060F603C2F028D1F /* NSDate+RCExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E356CA7C7188A8B6E2811A /* NSDate+RCExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E3598A1AAA3D70EA01C82D /* RCInMemoryCachedObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35C6CBB3229AA53ECEB58 /* RCInMemoryCachedObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E35AE982974800FF079C14 /* RCSubscriberAttribute+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35C82A59C953A5F6017BB /* RCSubscriberAttribute+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E35AF213F2F79CB067FDC2 /* InMemoryCachedObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35E3250FBBB03D92E06EC /* InMemoryCachedObjectTests.swift */; };
+		37E35BCE176D557487A903CC /* NSDate+RCExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E358235BB58A968B059B6B /* NSDate+RCExtensions.m */; };
 		37E35D4498633E73BF02BAE7 /* RCDeviceCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E356820F0AD560FA23F3BF /* RCDeviceCache.m */; };
 		37E35EA06000D9C8AFE77348 /* RCPurchasesErrorUtils+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35D0E675B0E6829E7968F /* RCPurchasesErrorUtils+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E35EC177759FE5350F53B3 /* RCDateProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35192068E91782835FA85 /* RCDateProvider.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -212,9 +214,11 @@
 		37E3555AC54BD10BE56F2B6B /* RCDeviceCache+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCDeviceCache+Protected.h"; sourceTree = "<group>"; };
 		37E35642B1AD2A45A7152CD5 /* RCDateProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCDateProvider.m; sourceTree = "<group>"; };
 		37E356820F0AD560FA23F3BF /* RCDeviceCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCDeviceCache.m; sourceTree = "<group>"; };
+		37E356CA7C7188A8B6E2811A /* NSDate+RCExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDate+RCExtensions.h"; sourceTree = "<group>"; };
 		37E3578BD602C7B8E2274279 /* MockDateProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDateProvider.swift; sourceTree = "<group>"; };
 		37E357D16038F07915D7825D /* MockUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockUserDefaults.swift; sourceTree = "<group>"; };
 		37E357F69438004E1F443C03 /* BackendSubscriberAttributesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackendSubscriberAttributesTests.swift; sourceTree = "<group>"; };
+		37E358235BB58A968B059B6B /* NSDate+RCExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDate+RCExtensions.m"; sourceTree = "<group>"; };
 		37E359893D3371FC3497D957 /* RCInMemoryCachedObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCInMemoryCachedObject.m; sourceTree = "<group>"; };
 		37E35C5A65AAF701DED59800 /* MockInMemoryCachedOfferings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockInMemoryCachedOfferings.swift; sourceTree = "<group>"; };
 		37E35C6CBB3229AA53ECEB58 /* RCInMemoryCachedObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCInMemoryCachedObject.h; sourceTree = "<group>"; };
@@ -362,6 +366,8 @@
 				37E35642B1AD2A45A7152CD5 /* RCDateProvider.m */,
 				37E35192068E91782835FA85 /* RCDateProvider.h */,
 				37E35D0E675B0E6829E7968F /* RCPurchasesErrorUtils+Protected.h */,
+				37E358235BB58A968B059B6B /* NSDate+RCExtensions.m */,
+				37E356CA7C7188A8B6E2811A /* NSDate+RCExtensions.h */,
 			);
 			path = Purchases;
 			sourceTree = "<group>";
@@ -491,6 +497,7 @@
 				37E35EC177759FE5350F53B3 /* RCDateProvider.h in Headers */,
 				37E35EA06000D9C8AFE77348 /* RCPurchasesErrorUtils+Protected.h in Headers */,
 				37E352F9B7505A398D578F53 /* RCDeviceCache+Protected.h in Headers */,
+				37E35971060F603C2F028D1F /* NSDate+RCExtensions.h in Headers */,
 				35C98D9520B7306A006DCBB5 /* RCCrossPlatformSupport.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -643,6 +650,7 @@
 				37E3526C938D7B291671BE8A /* RCInMemoryCachedObject.m in Sources */,
 				37E358E75F7A3C75F2CA10BA /* RCDateProvider.m in Sources */,
 				2D8DB34E240731E000BE3D31 /* NSError+RCExtensions.m in Sources */,
+				37E35BCE176D557487A903CC /* NSDate+RCExtensions.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -90,6 +90,8 @@
 		37E352F9B7505A398D578F53 /* RCDeviceCache+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E3555AC54BD10BE56F2B6B /* RCDeviceCache+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E353851D42047D5B0A57D0 /* MockDateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3578BD602C7B8E2274279 /* MockDateProvider.swift */; };
 		37E354BE25CE61E55E4FD89C /* MockDeviceCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E354BEB8FDE39CAB7C4D69 /* MockDeviceCache.swift */; };
+		37E354C46A8A3C2DC861C224 /* MockHTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35292137BBF2810CE4F4B /* MockHTTPClient.swift */; };
+		37E355E7EB509047724841F4 /* BackendSubscriberAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E357F69438004E1F443C03 /* BackendSubscriberAttributesTests.swift */; };
 		37E356619BE46B3AA82A69E8 /* RCInMemoryCachedObject+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35483531C5A5E6BF09BBD /* RCInMemoryCachedObject+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E3585E0B39722838F235BD /* MockUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E357D16038F07915D7825D /* MockUserDefaults.swift */; };
 		37E358E75F7A3C75F2CA10BA /* RCDateProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E35642B1AD2A45A7152CD5 /* RCDateProvider.m */; };
@@ -202,6 +204,7 @@
 		35E5B1DB1F80026C00B2537C /* StoreKitWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitWrapperTests.swift; sourceTree = "<group>"; };
 		37E35192068E91782835FA85 /* RCDateProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCDateProvider.h; sourceTree = "<group>"; };
 		37E3524E3032ABC72467AA43 /* RCDeviceCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCDeviceCache.h; sourceTree = "<group>"; };
+		37E35292137BBF2810CE4F4B /* MockHTTPClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockHTTPClient.swift; sourceTree = "<group>"; };
 		37E35483531C5A5E6BF09BBD /* RCInMemoryCachedObject+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCInMemoryCachedObject+Protected.h"; sourceTree = "<group>"; };
 		37E354BEB8FDE39CAB7C4D69 /* MockDeviceCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDeviceCache.swift; sourceTree = "<group>"; };
 		37E3550459807FF5636B2667 /* NSError+RCExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSError+RCExtensionsTests.swift"; sourceTree = "<group>"; };
@@ -210,6 +213,7 @@
 		37E356820F0AD560FA23F3BF /* RCDeviceCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCDeviceCache.m; sourceTree = "<group>"; };
 		37E3578BD602C7B8E2274279 /* MockDateProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDateProvider.swift; sourceTree = "<group>"; };
 		37E357D16038F07915D7825D /* MockUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockUserDefaults.swift; sourceTree = "<group>"; };
+		37E357F69438004E1F443C03 /* BackendSubscriberAttributesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackendSubscriberAttributesTests.swift; sourceTree = "<group>"; };
 		37E359893D3371FC3497D957 /* RCInMemoryCachedObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCInMemoryCachedObject.m; sourceTree = "<group>"; };
 		37E35C5A65AAF701DED59800 /* MockInMemoryCachedOfferings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockInMemoryCachedOfferings.swift; sourceTree = "<group>"; };
 		37E35C6CBB3229AA53ECEB58 /* RCInMemoryCachedObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCInMemoryCachedObject.h; sourceTree = "<group>"; };
@@ -399,6 +403,7 @@
 				37E357D16038F07915D7825D /* MockUserDefaults.swift */,
 				37E35C5A65AAF701DED59800 /* MockInMemoryCachedOfferings.swift */,
 				37E3578BD602C7B8E2274279 /* MockDateProvider.swift */,
+				37E35292137BBF2810CE4F4B /* MockHTTPClient.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -429,6 +434,7 @@
 			isa = PBXGroup;
 			children = (
 				2D8DB34A24072AAE00BE3D31 /* SubscriberAttributeTests.swift */,
+				37E357F69438004E1F443C03 /* BackendSubscriberAttributesTests.swift */,
 			);
 			path = SubscriberAttributes;
 			sourceTree = "<group>";
@@ -659,6 +665,8 @@
 				37E351E3AC0B5F67305B4CB6 /* DeviceCacheTests.swift in Sources */,
 				37E35AF213F2F79CB067FDC2 /* InMemoryCachedObjectTests.swift in Sources */,
 				37E353851D42047D5B0A57D0 /* MockDateProvider.swift in Sources */,
+				37E355E7EB509047724841F4 /* BackendSubscriberAttributesTests.swift in Sources */,
+				37E354C46A8A3C2DC861C224 /* MockHTTPClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		37E35AE982974800FF079C14 /* RCSubscriberAttribute+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35C82A59C953A5F6017BB /* RCSubscriberAttribute+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E35AF213F2F79CB067FDC2 /* InMemoryCachedObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35E3250FBBB03D92E06EC /* InMemoryCachedObjectTests.swift */; };
 		37E35D4498633E73BF02BAE7 /* RCDeviceCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E356820F0AD560FA23F3BF /* RCDeviceCache.m */; };
+		37E35EA06000D9C8AFE77348 /* RCPurchasesErrorUtils+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35D0E675B0E6829E7968F /* RCPurchasesErrorUtils+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E35EC177759FE5350F53B3 /* RCDateProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35192068E91782835FA85 /* RCDateProvider.h */; settings = {ATTRIBUTES = (Private, ); }; };
 /* End PBXBuildFile section */
 
@@ -218,6 +219,7 @@
 		37E35C5A65AAF701DED59800 /* MockInMemoryCachedOfferings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockInMemoryCachedOfferings.swift; sourceTree = "<group>"; };
 		37E35C6CBB3229AA53ECEB58 /* RCInMemoryCachedObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCInMemoryCachedObject.h; sourceTree = "<group>"; };
 		37E35C82A59C953A5F6017BB /* RCSubscriberAttribute+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "RCSubscriberAttribute+Protected.h"; path = "Purchases/SubscriberAttributes/RCSubscriberAttribute+Protected.h"; sourceTree = SOURCE_ROOT; };
+		37E35D0E675B0E6829E7968F /* RCPurchasesErrorUtils+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCPurchasesErrorUtils+Protected.h"; sourceTree = "<group>"; };
 		37E35D87B7E6F91E27E98F42 /* DeviceCacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceCacheTests.swift; sourceTree = "<group>"; };
 		37E35E3250FBBB03D92E06EC /* InMemoryCachedObjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InMemoryCachedObjectTests.swift; sourceTree = "<group>"; };
 		EF6FB66AA75A6EA23ACC0A9E /* RCPackage+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCPackage+Protected.h"; sourceTree = "<group>"; };
@@ -359,6 +361,7 @@
 				37E359927177DF24576FF361 /* Caching */,
 				37E35642B1AD2A45A7152CD5 /* RCDateProvider.m */,
 				37E35192068E91782835FA85 /* RCDateProvider.h */,
+				37E35D0E675B0E6829E7968F /* RCPurchasesErrorUtils+Protected.h */,
 			);
 			path = Purchases;
 			sourceTree = "<group>";
@@ -486,6 +489,7 @@
 				2D8DB34F240731E000BE3D31 /* NSError+RCExtensions.h in Headers */,
 				37E35AE982974800FF079C14 /* RCSubscriberAttribute+Protected.h in Headers */,
 				37E35EC177759FE5350F53B3 /* RCDateProvider.h in Headers */,
+				37E35EA06000D9C8AFE77348 /* RCPurchasesErrorUtils+Protected.h in Headers */,
 				37E352F9B7505A398D578F53 /* RCDeviceCache+Protected.h in Headers */,
 				35C98D9520B7306A006DCBB5 /* RCCrossPlatformSupport.h in Headers */,
 			);

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		2D5033252406E4E8009CAE61 /* RCSubscriberAttribute.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D5033222406E4E8009CAE61 /* RCSubscriberAttribute.m */; };
 		2D5033262406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5033232406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D8DB34B24072AAE00BE3D31 /* SubscriberAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8DB34A24072AAE00BE3D31 /* SubscriberAttributeTests.swift */; };
+		2D8DB34E240731E000BE3D31 /* NSError+RCExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D8DB34C240731E000BE3D31 /* NSError+RCExtensions.m */; };
+		2D8DB34F240731E000BE3D31 /* NSError+RCExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D8DB34D240731E000BE3D31 /* NSError+RCExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2D8DB3502407333100BE3D31 /* NSError+RCExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3550459807FF5636B2667 /* NSError+RCExtensionsTests.swift */; };
 		35095A6C2351461E00ADF0B2 /* RCIdentityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 35095A6A2351461E00ADF0B2 /* RCIdentityManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		35095A6D2351461E00ADF0B2 /* RCIdentityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 35095A6B2351461E00ADF0B2 /* RCIdentityManager.m */; };
 		350A1B87226F937F00CCA10F /* RCAttributionData.h in Headers */ = {isa = PBXBuildFile; fileRef = 350A1B86226F937F00CCA10F /* RCAttributionData.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -126,6 +129,8 @@
 		2D5033222406E4E8009CAE61 /* RCSubscriberAttribute.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCSubscriberAttribute.m; path = Purchases/SubscriberAttributes/RCSubscriberAttribute.m; sourceTree = SOURCE_ROOT; };
 		2D5033232406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCSpecialSubscriberAttributes.h; path = Purchases/SubscriberAttributes/RCSpecialSubscriberAttributes.h; sourceTree = SOURCE_ROOT; };
 		2D8DB34A24072AAE00BE3D31 /* SubscriberAttributeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriberAttributeTests.swift; sourceTree = "<group>"; };
+		2D8DB34C240731E000BE3D31 /* NSError+RCExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSError+RCExtensions.m"; sourceTree = "<group>"; };
+		2D8DB34D240731E000BE3D31 /* NSError+RCExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSError+RCExtensions.h"; sourceTree = "<group>"; };
 		35095A6A2351461E00ADF0B2 /* RCIdentityManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCIdentityManager.h; sourceTree = "<group>"; };
 		35095A6B2351461E00ADF0B2 /* RCIdentityManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCIdentityManager.m; sourceTree = "<group>"; };
 		350A1B84226E3E8700CCA10F /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -199,6 +204,7 @@
 		37E3524E3032ABC72467AA43 /* RCDeviceCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCDeviceCache.h; sourceTree = "<group>"; };
 		37E35483531C5A5E6BF09BBD /* RCInMemoryCachedObject+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCInMemoryCachedObject+Protected.h"; sourceTree = "<group>"; };
 		37E354BEB8FDE39CAB7C4D69 /* MockDeviceCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDeviceCache.swift; sourceTree = "<group>"; };
+		37E3550459807FF5636B2667 /* NSError+RCExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSError+RCExtensionsTests.swift"; sourceTree = "<group>"; };
 		37E3555AC54BD10BE56F2B6B /* RCDeviceCache+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCDeviceCache+Protected.h"; sourceTree = "<group>"; };
 		37E35642B1AD2A45A7152CD5 /* RCDateProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCDateProvider.m; sourceTree = "<group>"; };
 		37E356820F0AD560FA23F3BF /* RCDeviceCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCDeviceCache.m; sourceTree = "<group>"; };
@@ -309,6 +315,8 @@
 			children = (
 				350FBDE61F7EEEDF0065833D /* Public */,
 				2D5033202406E4C7009CAE61 /* SubscriberAttributes */,
+				2D8DB34D240731E000BE3D31 /* NSError+RCExtensions.h */,
+				2D8DB34C240731E000BE3D31 /* NSError+RCExtensions.m */,
 				35A60EA81F82993E00D2FAE8 /* RCPurchases+Protected.h */,
 				35395CB321B9EB1000286D13 /* RCIntroEligibility+Protected.h */,
 				352C36BE1F9D372D00A15783 /* RCPurchaserInfo+Protected.h */,
@@ -369,6 +377,7 @@
 				37E35081077192045E3A8080 /* Mocks */,
 				37E35AE0CDC4C2AA8260FB58 /* Caching */,
 				37E35E77A60AC8D3F0E1A23D /* SubscriberAttributes */,
+				37E3550459807FF5636B2667 /* NSError+RCExtensionsTests.swift */,
 			);
 			path = PurchasesTests;
 			sourceTree = "<group>";
@@ -468,6 +477,7 @@
 				2D5033242406E4E8009CAE61 /* RCSubscriberAttribute.h in Headers */,
 				37E356619BE46B3AA82A69E8 /* RCInMemoryCachedObject+Protected.h in Headers */,
 				35846AFD226940F600CC9E56 /* RCPromotionalOffer.h in Headers */,
+				2D8DB34F240731E000BE3D31 /* NSError+RCExtensions.h in Headers */,
 				37E35AE982974800FF079C14 /* RCSubscriberAttribute+Protected.h in Headers */,
 				37E35EC177759FE5350F53B3 /* RCDateProvider.h in Headers */,
 				37E352F9B7505A398D578F53 /* RCDeviceCache+Protected.h in Headers */,
@@ -622,6 +632,7 @@
 				37E35D4498633E73BF02BAE7 /* RCDeviceCache.m in Sources */,
 				37E3526C938D7B291671BE8A /* RCInMemoryCachedObject.m in Sources */,
 				37E358E75F7A3C75F2CA10BA /* RCDateProvider.m in Sources */,
+				2D8DB34E240731E000BE3D31 /* NSError+RCExtensions.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -637,6 +648,7 @@
 				35C514BE2321AC23000FFD78 /* OfferingsTests.swift in Sources */,
 				35E5B1DC1F80026C00B2537C /* StoreKitWrapperTests.swift in Sources */,
 				35B54E4E22ED1FA9005918B1 /* EntitlementInfosTests.swift in Sources */,
+				2D8DB3502407333100BE3D31 /* NSError+RCExtensionsTests.swift in Sources */,
 				350FBDF01F7EFC410065833D /* StoreKitRequestFetcherTests.swift in Sources */,
 				351703CD1F805E5D00EEE27A /* PurchaserInfoTests.swift in Sources */,
 				35B1635223467C10003371A3 /* UserManagerTests.swift in Sources */,

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		37E356619BE46B3AA82A69E8 /* RCInMemoryCachedObject+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35483531C5A5E6BF09BBD /* RCInMemoryCachedObject+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E3585E0B39722838F235BD /* MockUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E357D16038F07915D7825D /* MockUserDefaults.swift */; };
 		37E358E75F7A3C75F2CA10BA /* RCDateProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E35642B1AD2A45A7152CD5 /* RCDateProvider.m */; };
+		37E3591A10D3219021886E0C /* NSDate+RCExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3544C8038CB83310C3598 /* NSDate+RCExtensionsTests.swift */; };
 		37E35971060F603C2F028D1F /* NSDate+RCExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E356CA7C7188A8B6E2811A /* NSDate+RCExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E3598A1AAA3D70EA01C82D /* RCInMemoryCachedObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35C6CBB3229AA53ECEB58 /* RCInMemoryCachedObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E35AE982974800FF079C14 /* RCSubscriberAttribute+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35C82A59C953A5F6017BB /* RCSubscriberAttribute+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -208,6 +209,7 @@
 		37E35192068E91782835FA85 /* RCDateProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCDateProvider.h; sourceTree = "<group>"; };
 		37E3524E3032ABC72467AA43 /* RCDeviceCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCDeviceCache.h; sourceTree = "<group>"; };
 		37E35292137BBF2810CE4F4B /* MockHTTPClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockHTTPClient.swift; sourceTree = "<group>"; };
+		37E3544C8038CB83310C3598 /* NSDate+RCExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDate+RCExtensionsTests.swift"; sourceTree = "<group>"; };
 		37E35483531C5A5E6BF09BBD /* RCInMemoryCachedObject+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCInMemoryCachedObject+Protected.h"; sourceTree = "<group>"; };
 		37E354BEB8FDE39CAB7C4D69 /* MockDeviceCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDeviceCache.swift; sourceTree = "<group>"; };
 		37E3550459807FF5636B2667 /* NSError+RCExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSError+RCExtensionsTests.swift"; sourceTree = "<group>"; };
@@ -391,6 +393,7 @@
 				37E35AE0CDC4C2AA8260FB58 /* Caching */,
 				37E35E77A60AC8D3F0E1A23D /* SubscriberAttributes */,
 				37E3550459807FF5636B2667 /* NSError+RCExtensionsTests.swift */,
+				37E3544C8038CB83310C3598 /* NSDate+RCExtensionsTests.swift */,
 			);
 			path = PurchasesTests;
 			sourceTree = "<group>";
@@ -679,6 +682,7 @@
 				37E353851D42047D5B0A57D0 /* MockDateProvider.swift in Sources */,
 				37E355E7EB509047724841F4 /* BackendSubscriberAttributesTests.swift in Sources */,
 				37E354C46A8A3C2DC861C224 /* MockHTTPClient.swift in Sources */,
+				37E3591A10D3219021886E0C /* NSDate+RCExtensionsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Purchases/NSDate+RCExtensions.h
+++ b/Purchases/NSDate+RCExtensions.h
@@ -1,0 +1,18 @@
+//
+// Created by Andrés Boedo on 3/4/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+@interface NSDate (RCExtensions)
+
+- (UInt64)millisecondsSince1970;
+
+@end
+
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/NSDate+RCExtensions.m
+++ b/Purchases/NSDate+RCExtensions.m
@@ -1,0 +1,20 @@
+//
+// Created by Andrés Boedo on 3/4/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+#import "NSDate+RCExtensions.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+@implementation NSDate (RCExtensions)
+
+- (UInt64)millisecondsSince1970 {
+    return (UInt64)([self timeIntervalSince1970] * 1000.0);
+}
+
+@end
+
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/NSError+RCExtensions.h
+++ b/Purchases/NSError+RCExtensions.h
@@ -1,0 +1,18 @@
+//
+// Created by Andrés Boedo on 2/24/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+@interface NSError (RCExtensions)
+
+- (BOOL)didBackendReceiveRequestCorrectly;
+
+@end
+
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/NSError+RCExtensions.h
+++ b/Purchases/NSError+RCExtensions.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSError (RCExtensions)
 
-- (BOOL)didBackendReceiveRequestCorrectly;
+- (BOOL)shouldMarkSyncedKeyPresent;
 
 @end
 

--- a/Purchases/NSError+RCExtensions.h
+++ b/Purchases/NSError+RCExtensions.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSError (RCExtensions)
 
-- (BOOL)shouldMarkSyncedKeyPresent;
+- (BOOL)successfullySynced;
 
 @end
 

--- a/Purchases/NSError+RCExtensions.m
+++ b/Purchases/NSError+RCExtensions.m
@@ -1,0 +1,36 @@
+//
+// Created by Andrés Boedo on 2/24/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+#import "NSError+RCExtensions.h"
+#import "RCPurchasesErrors.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+@implementation NSError (RCExtensions)
+
+- (BOOL)didBackendReceiveRequestCorrectly {
+    BOOL isNetworkError = self.code == RCNetworkError;
+    BOOL didBackendReceiveRequest = (
+        !isNetworkError
+        && self.userInfo[RCFinishableKey] != nil
+        && ((NSNumber *) self.userInfo[RCFinishableKey]).boolValue
+    );
+    if (didBackendReceiveRequest) {
+        return YES;
+    } else if (self.userInfo[NSUnderlyingErrorKey]) {
+        NSError *underlyingError = (NSError *) self.userInfo[NSUnderlyingErrorKey];
+        if (underlyingError) {
+            return underlyingError.didBackendReceiveRequestCorrectly;
+        }
+    }
+
+    return NO;
+}
+
+@end
+
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/NSError+RCExtensions.m
+++ b/Purchases/NSError+RCExtensions.m
@@ -5,25 +5,26 @@
 
 #import "NSError+RCExtensions.h"
 #import "RCPurchasesErrors.h"
+#import "RCBackend.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 
 @implementation NSError (RCExtensions)
 
-- (BOOL)didBackendReceiveRequestCorrectly {
+- (BOOL)shouldMarkSyncedKeyPresent {
     BOOL isNetworkError = self.code == RCNetworkError;
-    BOOL didBackendReceiveRequest = (
+    BOOL shouldMarkSynced = (
         !isNetworkError
-        && self.userInfo[RCFinishableKey] != nil
-        && ((NSNumber *) self.userInfo[RCFinishableKey]).boolValue
+        && self.userInfo[RCShouldMarkSyncedKey] != nil
+        && ((NSNumber *) self.userInfo[RCShouldMarkSyncedKey]).boolValue
     );
-    if (didBackendReceiveRequest) {
+    if (shouldMarkSynced) {
         return YES;
     } else if (self.userInfo[NSUnderlyingErrorKey]) {
         NSError *underlyingError = (NSError *) self.userInfo[NSUnderlyingErrorKey];
         if (underlyingError) {
-            return underlyingError.didBackendReceiveRequestCorrectly;
+            return underlyingError.shouldMarkSyncedKeyPresent;
         }
     }
 

--- a/Purchases/NSError+RCExtensions.m
+++ b/Purchases/NSError+RCExtensions.m
@@ -13,22 +13,17 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation NSError (RCExtensions)
 
 - (BOOL)successfullySynced {
-    BOOL isNetworkError = self.code == RCNetworkError;
-    BOOL successfullySynced = (
-        !isNetworkError
-        && self.userInfo[RCSuccessfullySyncedKey] != nil
-        && ((NSNumber *) self.userInfo[RCSuccessfullySyncedKey]).boolValue
-    );
-    if (successfullySynced) {
-        return YES;
-    } else if (self.userInfo[NSUnderlyingErrorKey]) {
-        NSError *underlyingError = (NSError *) self.userInfo[NSUnderlyingErrorKey];
-        if (underlyingError) {
-            return underlyingError.successfullySynced;
-        }
+    if (self.code == RCNetworkError) {
+        return NO;
     }
 
-    return NO;
+    if (self.userInfo[RCSuccessfullySyncedKey] == nil) {
+        return NO;
+    }
+
+    NSNumber *successfullySyncedNumber = self.userInfo[RCSuccessfullySyncedKey];
+
+    return successfullySyncedNumber.boolValue;
 }
 
 @end

--- a/Purchases/NSError+RCExtensions.m
+++ b/Purchases/NSError+RCExtensions.m
@@ -16,8 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
     BOOL isNetworkError = self.code == RCNetworkError;
     BOOL shouldMarkSynced = (
         !isNetworkError
-        && self.userInfo[RCShouldMarkSyncedKey] != nil
-        && ((NSNumber *) self.userInfo[RCShouldMarkSyncedKey]).boolValue
+        && self.userInfo[RCSuccessfullySyncedKey] != nil
+        && ((NSNumber *) self.userInfo[RCSuccessfullySyncedKey]).boolValue
     );
     if (shouldMarkSynced) {
         return YES;

--- a/Purchases/NSError+RCExtensions.m
+++ b/Purchases/NSError+RCExtensions.m
@@ -12,19 +12,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation NSError (RCExtensions)
 
-- (BOOL)shouldMarkSyncedKeyPresent {
+- (BOOL)successfullySynced {
     BOOL isNetworkError = self.code == RCNetworkError;
-    BOOL shouldMarkSynced = (
+    BOOL successfullySynced = (
         !isNetworkError
         && self.userInfo[RCSuccessfullySyncedKey] != nil
         && ((NSNumber *) self.userInfo[RCSuccessfullySyncedKey]).boolValue
     );
-    if (shouldMarkSynced) {
+    if (successfullySynced) {
         return YES;
     } else if (self.userInfo[NSUnderlyingErrorKey]) {
         NSError *underlyingError = (NSError *) self.userInfo[NSUnderlyingErrorKey];
         if (underlyingError) {
-            return underlyingError.shouldMarkSyncedKeyPresent;
+            return underlyingError.successfullySynced;
         }
     }
 

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -593,6 +593,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                             discounts:nil
           presentedOfferingIdentifier:nil
                          observerMode:!self.finishTransactions
+                 subscriberAttributes:nil
                            completion:^(RCPurchaserInfo *_Nullable info, NSError *_Nullable error) {
                                [self dispatch:^{
                                    if (error) {
@@ -1025,6 +1026,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                                                       discounts:discounts
                                     presentedOfferingIdentifier:presentedOffering
                                                    observerMode:!self.finishTransactions
+                                           subscriberAttributes:nil
                                                      completion:^(RCPurchaserInfo * _Nullable info,
                                                              NSError * _Nullable error) {
                                                          [self handleReceiptPostWithTransaction:transaction
@@ -1044,6 +1046,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                                                       discounts:nil
                                     presentedOfferingIdentifier:nil
                                                    observerMode:!self.finishTransactions
+                                           subscriberAttributes:nil
                                                      completion:^(RCPurchaserInfo * _Nullable info,
                                                              NSError * _Nullable error) {
                                                          [self handleReceiptPostWithTransaction:transaction

--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -66,6 +66,8 @@ static NSString *RCPurchasesErrorDescription(RCPurchasesErrorCode code) {
             return @"Apple Subscription Key is invalid or not present. In order to provide subscription offers, you must first generate a subscription key. Please see https://docs.revenuecat.com/docs/ios-subscription-offers for more info.";
         case RCIneligibleError:
             return @"The User is ineligible for that action.";
+        case RCBackendInvalidSubscriberAttributesError:
+            return @"One or more of the attributes sent could not be saved.";
     }
     return @"Something went wrong.";
 }
@@ -115,6 +117,8 @@ static NSString *const RCPurchasesErrorCodeString(RCPurchasesErrorCode code) {
             return @"INVALID_APPLE_SUBSCRIPTION_KEY";
         case RCIneligibleError:
             return @"INVALID_OFFER";
+        case RCBackendInvalidSubscriberAttributesError:
+            return @"SUBSCRIBER_ATTRIBUTES_SYNC_ERROR";
     }
     return @"UNRECOGNIZED_ERROR";
 }
@@ -146,6 +150,8 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromRCBackendErrorCode(RCBackend
             return RCInvalidAppleSubscriptionKeyError;
         case RCBackendUserIneligibleForPromoOffer:
             return RCIneligibleError;
+        case RCBackendInvalidSubscriberAttributes:
+            return RCBackendInvalidSubscriberAttributesError;
     }
     return RCUnknownError;
 }

--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -66,6 +66,10 @@ static NSString *RCPurchasesErrorDescription(RCPurchasesErrorCode code) {
             return @"Apple Subscription Key is invalid or not present. In order to provide subscription offers, you must first generate a subscription key. Please see https://docs.revenuecat.com/docs/ios-subscription-offers for more info.";
         case RCIneligibleError:
             return @"The User is ineligible for that action.";
+        case RCInsufficientPermissionsError:
+            return @"App does not have sufficient permissions to make purchases";
+        case RCPaymentPendingError:
+            return @"The payment is pending.";
         case RCInvalidSubscriberAttributesError:
             return @"One or more of the attributes sent could not be saved.";
     }

--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -66,7 +66,7 @@ static NSString *RCPurchasesErrorDescription(RCPurchasesErrorCode code) {
             return @"Apple Subscription Key is invalid or not present. In order to provide subscription offers, you must first generate a subscription key. Please see https://docs.revenuecat.com/docs/ios-subscription-offers for more info.";
         case RCIneligibleError:
             return @"The User is ineligible for that action.";
-        case RCBackendInvalidSubscriberAttributesError:
+        case RCInvalidSubscriberAttributesError:
             return @"One or more of the attributes sent could not be saved.";
     }
     return @"Something went wrong.";
@@ -116,9 +116,9 @@ static NSString *const RCPurchasesErrorCodeString(RCPurchasesErrorCode code) {
         case RCInvalidAppleSubscriptionKeyError:
             return @"INVALID_APPLE_SUBSCRIPTION_KEY";
         case RCIneligibleError:
-            return @"INVALID_OFFER";
-        case RCBackendInvalidSubscriberAttributesError:
-            return @"SUBSCRIBER_ATTRIBUTES_SYNC_ERROR";
+            return @"INELIGIBLE_ERROR";
+        case RCInvalidSubscriberAttributesError:
+            return @"INVALID_SUBSCRIBER_ATTRIBUTES";
     }
     return @"UNRECOGNIZED_ERROR";
 }
@@ -151,7 +151,7 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromRCBackendErrorCode(RCBackend
         case RCBackendUserIneligibleForPromoOffer:
             return RCIneligibleError;
         case RCBackendInvalidSubscriberAttributes:
-            return RCBackendInvalidSubscriberAttributesError;
+            return RCInvalidSubscriberAttributesError;
     }
     return RCUnknownError;
 }

--- a/Purchases/Public/RCPurchasesErrors.h
+++ b/Purchases/Public/RCPurchasesErrors.h
@@ -50,6 +50,8 @@ typedef NS_ERROR_ENUM(RCPurchasesErrorDomain, RCPurchasesErrorCode) {
     RCUnknownBackendError,
     RCInvalidAppleSubscriptionKeyError,
     RCIneligibleError,
+    RCInsufficientPermissionsError,
+    RCPaymentPendingError,
     RCInvalidSubscriberAttributesError
 } NS_SWIFT_NAME(Purchases.ErrorCode);
 

--- a/Purchases/Public/RCPurchasesErrors.h
+++ b/Purchases/Public/RCPurchasesErrors.h
@@ -50,7 +50,7 @@ typedef NS_ERROR_ENUM(RCPurchasesErrorDomain, RCPurchasesErrorCode) {
     RCUnknownBackendError,
     RCInvalidAppleSubscriptionKeyError,
     RCIneligibleError,
-    RCBackendInvalidSubscriberAttributesError
+    RCInvalidSubscriberAttributesError
 } NS_SWIFT_NAME(Purchases.ErrorCode);
 
 /**

--- a/Purchases/Public/RCPurchasesErrors.h
+++ b/Purchases/Public/RCPurchasesErrors.h
@@ -50,6 +50,7 @@ typedef NS_ERROR_ENUM(RCPurchasesErrorDomain, RCPurchasesErrorCode) {
     RCUnknownBackendError,
     RCInvalidAppleSubscriptionKeyError,
     RCIneligibleError,
+    RCBackendInvalidSubscriberAttributesError
 } NS_SWIFT_NAME(Purchases.ErrorCode);
 
 /**
@@ -71,7 +72,8 @@ typedef NS_ENUM(NSInteger, RCBackendErrorCode) {
     RCBackendPlayStoreInvalidPackageName = 7230,
     RCBackendPlayStoreGenericError = 7231,
     RCBackendUserIneligibleForPromoOffer = 7232,
-    RCBackendInvalidAppleSubscriptionKey = 7234
+    RCBackendInvalidAppleSubscriptionKey = 7234,
+    RCBackendInvalidSubscriberAttributes = 7262
 } NS_SWIFT_NAME(Purchases.RevenueCatBackendErrorCode);
 
 @end

--- a/Purchases/RCBackend.h
+++ b/Purchases/RCBackend.h
@@ -10,10 +10,11 @@
 #import <StoreKit/StoreKit.h>
 
 #import "RCPurchases.h"
+#import "RCSubscriberAttribute.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class RCPurchaserInfo, RCHTTPClient, RCIntroEligibility, RCPromotionalOffer;
+@class RCPurchaserInfo, RCHTTPClient, RCIntroEligibility, RCPromotionalOffer, RCSubscriberAttribute;
 
 typedef NS_ENUM(NSInteger, RCPaymentMode) {
     RCPaymentModeNone = -1,
@@ -58,6 +59,7 @@ typedef void(^RCOfferSigningResponseHandler)(NSString * _Nullable signature,
                   discounts:(nullable NSArray<RCPromotionalOffer *> *)discounts
 presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
                observerMode:(BOOL)observerMode
+       subscriberAttributes:(nullable RCSubscriberAttributeDict)subscriberAttributesByKey
                  completion:(RCBackendPurchaserInfoResponseHandler)completion;
 
 - (void)getSubscriberDataWithAppUserID:(NSString *)appUserID
@@ -87,6 +89,9 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
                   appUserID:(NSString *)applicationUsername
                  completion:(RCOfferSigningResponseHandler)completion;
 
+- (void)postSubscriberAttributes:(RCSubscriberAttributeDict)subscriberAttributes
+                       appUserID:(NSString *)appUserID
+                      completion:(void (^)(NSError *))completion;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Purchases/RCBackend.h
+++ b/Purchases/RCBackend.h
@@ -92,6 +92,9 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
 - (void)postSubscriberAttributes:(RCSubscriberAttributeDict)subscriberAttributes
                        appUserID:(NSString *)appUserID
                       completion:(void (^)(NSError *))completion;
+
+extern NSErrorUserInfoKey const RCShouldMarkSyncedKey;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Purchases/RCBackend.h
+++ b/Purchases/RCBackend.h
@@ -23,6 +23,8 @@ typedef NS_ENUM(NSInteger, RCPaymentMode) {
     RCPaymentModeFreeTrial = 2
 };
 
+extern NSErrorUserInfoKey const RCSuccessfullySyncedKey;
+
 API_AVAILABLE(ios(11.2), macos(10.13.2))
 RCPaymentMode RCPaymentModeFromSKProductDiscountPaymentMode(SKProductDiscountPaymentMode paymentMode);
 
@@ -92,8 +94,6 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
 - (void)postSubscriberAttributes:(RCSubscriberAttributeDict)subscriberAttributes
                        appUserID:(NSString *)appUserID
                       completion:(void (^)(NSError *))completion;
-
-extern NSErrorUserInfoKey const RCShouldMarkSyncedKey;
 
 @end
 

--- a/Purchases/RCBackend.m
+++ b/Purchases/RCBackend.m
@@ -18,7 +18,7 @@
 #import "RCPromotionalOffer.h"
 
 #define RC_HAS_KEY(dictionary, key) (dictionary[key] == nil || dictionary[key] != [NSNull null])
-NSErrorUserInfoKey const RCSuccessfullySyncedKey = @"shouldMarkSynced";
+NSErrorUserInfoKey const RCSuccessfullySyncedKey = @"successfullySynced";
 
 API_AVAILABLE(ios(11.2), macos(10.13.2))
 RCPaymentMode RCPaymentModeFromSKProductDiscountPaymentMode(SKProductDiscountPaymentMode paymentMode)

--- a/Purchases/RCBackend.m
+++ b/Purchases/RCBackend.m
@@ -472,7 +472,10 @@ presentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 - (void)postSubscriberAttributes:(RCSubscriberAttributeDict)subscriberAttributes
                        appUserID:(NSString *)appUserID
                       completion:(void (^)(NSError *))completion {
-
+    if (subscriberAttributes.count == 0) {
+        RCLog(@"called post subscriber attributes with an empty attributes dict!");
+        return;
+    }
     NSString *escapedAppUserID = [self escapedAppUserID:appUserID];
     NSString *path = [NSString stringWithFormat:@"/subscribers/%@/attributes", escapedAppUserID];
     NSDictionary *attributesInBackendFormat = [self subscriberAttributesByKey:subscriberAttributes];

--- a/Purchases/RCBackend.m
+++ b/Purchases/RCBackend.m
@@ -18,7 +18,7 @@
 #import "RCPromotionalOffer.h"
 
 #define RC_HAS_KEY(dictionary, key) (dictionary[key] == nil || dictionary[key] != [NSNull null])
-NSErrorUserInfoKey const RCShouldMarkSyncedKey = @"shouldMarkSynced";
+NSErrorUserInfoKey const RCSuccessfullySyncedKey = @"shouldMarkSynced";
 
 API_AVAILABLE(ios(11.2), macos(10.13.2))
 RCPaymentMode RCPaymentModeFromSKProductDiscountPaymentMode(SKProductDiscountPaymentMode paymentMode)
@@ -517,7 +517,7 @@ presentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
     if (statusCode > 300) {
         BOOL isInternalServerError = statusCode >= 500;
         NSDictionary *extraUserInfo = @{
-            RCShouldMarkSyncedKey: @(!isInternalServerError)
+            RCSuccessfullySyncedKey: @(!isInternalServerError)
         };
         NSError *responseError = [RCPurchasesErrorUtils backendErrorWithBackendCode:response[@"code"]
                                                                      backendMessage:response[@"message"]

--- a/Purchases/RCPurchasesErrorUtils+Protected.h
+++ b/Purchases/RCPurchasesErrorUtils+Protected.h
@@ -1,0 +1,21 @@
+//
+// Created by RevenueCat on 2/27/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "RCPurchasesErrorUtils.h"
+#import "RCPurchasesErrors.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+@interface RCPurchasesErrorUtils (Protected)
+
++ (NSError *)backendErrorWithBackendCode:(nullable NSNumber *)backendCode
+                          backendMessage:(nullable NSString *)backendMessage
+                           extraUserInfo:(nullable NSDictionary *)extraUserInfo;
+@end
+
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/SubscriberAttributes/RCSubscriberAttribute.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttribute.m
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 #define IS_SYNCED_KEY @"isSynced"
 
 #define BACKEND_VALUE_KEY @"value"
-#define BACKEND_TIMESTAMP_KEY @"updated_at"
+#define BACKEND_TIMESTAMP_KEY @"updated_at_ms"
 
 
 @interface RCSubscriberAttribute ()

--- a/Purchases/SubscriberAttributes/RCSubscriberAttribute.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttribute.m
@@ -6,6 +6,7 @@
 #import <Foundation/Foundation.h>
 #import "RCSubscriberAttribute.h"
 #import "RCDateProvider.h"
+#import "NSDate+RCExtensions.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -79,7 +80,7 @@ NS_ASSUME_NONNULL_END
 - (NSDictionary <NSString *, NSObject *> *)asBackendDictionary {
     return @{
         BACKEND_VALUE_KEY: self.value ?: @"",
-        BACKEND_TIMESTAMP_KEY: @(self.setTime.timeIntervalSince1970)
+        BACKEND_TIMESTAMP_KEY: @(self.setTime.millisecondsSince1970)
     };
 }
 

--- a/PurchasesTests/BackendTests.swift
+++ b/PurchasesTests/BackendTests.swift
@@ -92,12 +92,22 @@ class BackendTests: XCTestCase {
         let isRestore = arc4random_uniform(2) == 0
         let observerMode = arc4random_uniform(2) == 0
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil,
-                price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil,
-                subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
-                completion: { (purchaserInfo, error) in
-                    completionCalled = true
-                })
+        backend?.postReceiptData(receiptData,
+                                 appUserID: userID,
+                                 isRestore: isRestore,
+                                 productIdentifier: nil,
+                                 price: nil,
+                                 paymentMode: RCPaymentMode.none,
+                                 introductoryPrice: nil,
+                                 currencyCode: nil,
+                                 subscriptionGroup: nil,
+                                 discounts: nil,
+                                 presentedOfferingIdentifier: nil,
+                                 observerMode: observerMode,
+                                 subscriberAttributes: nil,
+                                 completion: { (purchaserInfo, error) in
+            completionCalled = true
+        })
 
         let expectedCall = HTTPRequest(HTTPMethod: "POST", path: "/receipts", body: [
             "app_user_id": userID,
@@ -130,19 +140,39 @@ class BackendTests: XCTestCase {
         let isRestore = arc4random_uniform(2) == 0
         let observerMode = arc4random_uniform(2) == 0
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
-                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
-                discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
-                completion: { (purchaserInfo, error) in
-                    completionCalled += 1
-                })
+        backend?.postReceiptData(receiptData,
+                                 appUserID: userID,
+                                 isRestore: isRestore,
+                                 productIdentifier: nil,
+                                 price: nil,
+                                 paymentMode: RCPaymentMode.none,
+                                 introductoryPrice: nil,
+                                 currencyCode: nil,
+                                 subscriptionGroup: nil,
+                                 discounts: nil,
+                                 presentedOfferingIdentifier: nil,
+                                 observerMode: observerMode,
+                                 subscriberAttributes: nil,
+                                 completion: { (purchaserInfo, error) in
+            completionCalled += 1
+        })
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
-                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
-                discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
-                completion: { (purchaserInfo, error) in
-                    completionCalled += 1
-                })
+        backend?.postReceiptData(receiptData,
+                                 appUserID: userID,
+                                 isRestore: isRestore,
+                                 productIdentifier: nil,
+                                 price: nil,
+                                 paymentMode: RCPaymentMode.none,
+                                 introductoryPrice: nil,
+                                 currencyCode: nil,
+                                 subscriptionGroup: nil,
+                                 discounts: nil,
+                                 presentedOfferingIdentifier: nil,
+                                 observerMode: observerMode,
+                                 subscriberAttributes: nil,
+                                 completion: { (purchaserInfo, error) in
+            completionCalled += 1
+        })
 
         expect(self.httpClient.calls.count).to(equal(1))
         expect(completionCalled).toEventually(equal(2))
@@ -157,19 +187,39 @@ class BackendTests: XCTestCase {
         let isRestore = arc4random_uniform(2) == 0
         let observerMode = arc4random_uniform(2) == 0
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
-                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
-                discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
-                completion: { (purchaserInfo, error) in
-                    completionCalled += 1
-                })
+        backend?.postReceiptData(receiptData,
+                                 appUserID: userID,
+                                 isRestore: isRestore,
+                                 productIdentifier: nil,
+                                 price: nil,
+                                 paymentMode: RCPaymentMode.none,
+                                 introductoryPrice: nil,
+                                 currencyCode: nil,
+                                 subscriptionGroup: nil,
+                                 discounts: nil,
+                                 presentedOfferingIdentifier: nil,
+                                 observerMode: observerMode,
+                                 subscriberAttributes: nil,
+                                 completion: { (purchaserInfo, error) in
+            completionCalled += 1
+        })
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: !isRestore, productIdentifier: nil, price: nil,
-                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
-                discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
-                completion: { (purchaserInfo, error) in
-                    completionCalled += 1
-                })
+        backend?.postReceiptData(receiptData,
+                                 appUserID: userID,
+                                 isRestore: !isRestore,
+                                 productIdentifier: nil,
+                                 price: nil,
+                                 paymentMode: RCPaymentMode.none,
+                                 introductoryPrice: nil,
+                                 currencyCode: nil,
+                                 subscriptionGroup: nil,
+                                 discounts: nil,
+                                 presentedOfferingIdentifier: nil,
+                                 observerMode: observerMode,
+                                 subscriberAttributes: nil,
+                                 completion: { (purchaserInfo, error) in
+            completionCalled += 1
+        })
 
         expect(self.httpClient.calls.count).to(equal(2))
         expect(completionCalled).toEventually(equal(2))
@@ -184,19 +234,39 @@ class BackendTests: XCTestCase {
         let isRestore = arc4random_uniform(2) == 0
         let observerMode = arc4random_uniform(2) == 0
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
-                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
-                discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
-                completion: { (purchaserInfo, error) in
-                    completionCalled += 1
-                })
+        backend?.postReceiptData(receiptData,
+                                 appUserID: userID,
+                                 isRestore: isRestore,
+                                 productIdentifier: nil,
+                                 price: nil,
+                                 paymentMode: RCPaymentMode.none,
+                                 introductoryPrice: nil,
+                                 currencyCode: nil,
+                                 subscriptionGroup: nil,
+                                 discounts: nil,
+                                 presentedOfferingIdentifier: nil,
+                                 observerMode: observerMode,
+                                 subscriberAttributes: nil,
+                                 completion: { (purchaserInfo, error) in
+            completionCalled += 1
+        })
 
-        backend?.postReceiptData(receiptData2, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
-                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
-                discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
-                completion: { (purchaserInfo, error) in
-                    completionCalled += 1
-                })
+        backend?.postReceiptData(receiptData2,
+                                 appUserID: userID,
+                                 isRestore: isRestore,
+                                 productIdentifier: nil,
+                                 price: nil,
+                                 paymentMode: RCPaymentMode.none,
+                                 introductoryPrice: nil,
+                                 currencyCode: nil,
+                                 subscriptionGroup: nil,
+                                 discounts: nil,
+                                 presentedOfferingIdentifier: nil,
+                                 observerMode: observerMode,
+                                 subscriberAttributes: nil,
+                                 completion: { (purchaserInfo, error) in
+            completionCalled += 1
+        })
 
         expect(self.httpClient.calls.count).to(equal(2))
         expect(completionCalled).toEventually(equal(2))
@@ -211,19 +281,39 @@ class BackendTests: XCTestCase {
         let isRestore = arc4random_uniform(2) == 0
         let observerMode = arc4random_uniform(2) == 0
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
-                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
-                discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
-                completion: { (purchaserInfo, error) in
-                    completionCalled += 1
-                })
+        backend?.postReceiptData(receiptData,
+                                 appUserID: userID,
+                                 isRestore: isRestore,
+                                 productIdentifier: nil,
+                                 price: nil,
+                                 paymentMode: RCPaymentMode.none,
+                                 introductoryPrice: nil,
+                                 currencyCode: nil,
+                                 subscriptionGroup: nil,
+                                 discounts: nil,
+                                 presentedOfferingIdentifier: nil,
+                                 observerMode: observerMode,
+                                 subscriberAttributes: nil,
+                                 completion: { (purchaserInfo, error) in
+            completionCalled += 1
+        })
 
-        backend?.postReceiptData(receiptData2, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
-                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: "USD", subscriptionGroup: nil,
-                discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
-                completion: { (purchaserInfo, error) in
-                    completionCalled += 1
-                })
+        backend?.postReceiptData(receiptData2,
+                                 appUserID: userID,
+                                 isRestore: isRestore,
+                                 productIdentifier: nil,
+                                 price: nil,
+                                 paymentMode: RCPaymentMode.none,
+                                 introductoryPrice: nil,
+                                 currencyCode: "USD", 
+                                 subscriptionGroup: nil,
+                                 discounts: nil,
+                                 presentedOfferingIdentifier: nil,
+                                 observerMode: observerMode,
+                                 subscriberAttributes: nil,
+                                 completion: { (purchaserInfo, error) in
+            completionCalled += 1
+        })
 
         expect(self.httpClient.calls.count).to(equal(2))
         expect(completionCalled).toEventually(equal(2))
@@ -238,19 +328,39 @@ class BackendTests: XCTestCase {
         let isRestore = arc4random_uniform(2) == 0
         let observerMode = arc4random_uniform(2) == 0
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
-                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
-                discounts: nil, presentedOfferingIdentifier: "offering_a", observerMode: observerMode,
-                completion: { (purchaserInfo, error) in
-                    completionCalled += 1
-                })
+        backend?.postReceiptData(receiptData,
+                                 appUserID: userID,
+                                 isRestore: isRestore,
+                                 productIdentifier: nil,
+                                 price: nil,
+                                 paymentMode: RCPaymentMode.none,
+                                 introductoryPrice: nil,
+                                 currencyCode: nil,
+                                 subscriptionGroup: nil,
+                                 discounts: nil,
+                                 presentedOfferingIdentifier: "offering_a", 
+                                 observerMode: observerMode,
+                                 subscriberAttributes: nil,
+                                 completion: { (purchaserInfo, error) in
+            completionCalled += 1
+        })
 
-        backend?.postReceiptData(receiptData2, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
-                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
-                discounts: nil, presentedOfferingIdentifier: "offering_b", observerMode: observerMode,
-                completion: { (purchaserInfo, error) in
-                    completionCalled += 1
-                })
+        backend?.postReceiptData(receiptData2,
+                                 appUserID: userID,
+                                 isRestore: isRestore,
+                                 productIdentifier: nil,
+                                 price: nil,
+                                 paymentMode: RCPaymentMode.none,
+                                 introductoryPrice: nil,
+                                 currencyCode: nil,
+                                 subscriptionGroup: nil,
+                                 discounts: nil,
+                                 presentedOfferingIdentifier: "offering_b", 
+                                 observerMode: observerMode,
+                                 subscriberAttributes: nil,
+                                 completion: { (purchaserInfo, error) in
+            completionCalled += 1
+        })
 
         expect(self.httpClient.calls.count).to(equal(2))
         expect(completionCalled).toEventually(equal(2))
@@ -299,12 +409,22 @@ class BackendTests: XCTestCase {
 
         var completionCalled = false
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: productIdentifier,
-                price: price, paymentMode: paymentMode, introductoryPrice: nil, currencyCode: currencyCode,
-                subscriptionGroup: group, discounts: nil, presentedOfferingIdentifier: offeringIdentifier,
-                observerMode: false, completion: { (purchaserInfo, error) in
-            completionCalled = true
-        })
+        backend?.postReceiptData(receiptData,
+                                 appUserID: userID,
+                                 isRestore: false,
+                                 productIdentifier: productIdentifier,
+                                 price: price,
+                                 paymentMode: paymentMode,
+                                 introductoryPrice: nil,
+                                 currencyCode: currencyCode,
+                                 subscriptionGroup: group,
+                                 discounts: nil,
+                                 presentedOfferingIdentifier: offeringIdentifier,
+                                 observerMode: false,
+                                 subscriberAttributes: nil,
+                                 completion: { (purchaserInfo, error) in
+    completionCalled = true
+})
 
         let body: [String: Any] = [
             "app_user_id": userID,
@@ -343,12 +463,22 @@ class BackendTests: XCTestCase {
 
         var completionCalled = false
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: "product_id",
-                price: 9.99, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil,
-                subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, observerMode: false,
-                completion: { (purchaserInfo, error) in
-                    completionCalled = true
-                })
+        backend?.postReceiptData(receiptData,
+                                 appUserID: userID,
+                                 isRestore: false,
+                                 productIdentifier: "product_id", 
+                                 price: 9.99,
+                                 paymentMode: RCPaymentMode.none,
+                                 introductoryPrice: nil,
+                                 currencyCode: nil,
+                                 subscriptionGroup: nil,
+                                 discounts: nil,
+                                 presentedOfferingIdentifier: nil,
+                                 observerMode: false,
+                                 subscriberAttributes: nil,
+                                 completion: { (purchaserInfo, error) in
+            completionCalled = true
+        })
 
         expect(self.httpClient.calls.count).to(equal(1))
         expect(completionCalled).toEventually(beTrue())
@@ -360,10 +490,20 @@ class BackendTests: XCTestCase {
     func postPaymentMode(paymentMode: RCPaymentMode) {
         var completionCalled = false
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: "product",
-                price: 2.99, paymentMode: paymentMode, introductoryPrice: 1.99, currencyCode: "USD",
-                subscriptionGroup: "group", discounts: nil, presentedOfferingIdentifier: nil, observerMode: false,
-                completion: { (purchaserInfo, error) in
+        backend?.postReceiptData(receiptData,
+                                 appUserID: userID,
+                                 isRestore: false,
+                                 productIdentifier: "product",
+                                 price: 2.99,
+                                 paymentMode: paymentMode,
+                                 introductoryPrice: 1.99,
+                                 currencyCode: "USD",
+                                 subscriptionGroup: "group",
+                                 discounts: nil,
+                                 presentedOfferingIdentifier: nil,
+                                 observerMode: false,
+                                 subscriberAttributes: nil,
+                                 completion: { (purchaserInfo, error) in
                     completionCalled = true
                 })
 
@@ -407,13 +547,23 @@ class BackendTests: XCTestCase {
 
         var error: NSError?
         var underlyingError: NSError?
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: nil,
-                price: nil, paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil,
-                subscriptionGroup: nil, discounts: nil, presentedOfferingIdentifier: nil, observerMode: false,
-                completion: { (purchaserInfo, newError) in
-                    error = newError as NSError?
-                    underlyingError = error?.userInfo[NSUnderlyingErrorKey] as! NSError?
-                })
+        backend?.postReceiptData(receiptData,
+                                 appUserID: userID,
+                                 isRestore: false,
+                                 productIdentifier: nil,
+                                 price: nil,
+                                 paymentMode: RCPaymentMode.none,
+                                 introductoryPrice: nil,
+                                 currencyCode: nil,
+                                 subscriptionGroup: nil,
+                                 discounts: nil,
+                                 presentedOfferingIdentifier: nil, observerMode:
+                                 false, subscriberAttributes:
+                                 nil, completion:
+                                 { (purchaserInfo, newError) in
+            error = newError as NSError?
+            underlyingError = error?.userInfo[NSUnderlyingErrorKey] as! NSError?
+        })
 
         expect(error).toEventuallyNot(beNil())
         expect(error?.code).toEventually(be(Purchases.ErrorCode.invalidCredentialsError.rawValue))
@@ -430,12 +580,22 @@ class BackendTests: XCTestCase {
         var error: Error?
         var underlyingError: Error?
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: nil, price: nil,
-                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
-                discounts: nil, presentedOfferingIdentifier: nil, observerMode: false,
-                completion: { (purchaserInfo, newError) in
-                    error = newError
-                })
+        backend?.postReceiptData(receiptData,
+                                 appUserID: userID,
+                                 isRestore: false,
+                                 productIdentifier: nil,
+                                 price: nil,
+                                 paymentMode: RCPaymentMode.none,
+                                 introductoryPrice: nil,
+                                 currencyCode: nil,
+                                 subscriptionGroup: nil,
+                                 discounts: nil,
+                                 presentedOfferingIdentifier: nil, observerMode:
+                                 false, subscriberAttributes:
+                                 nil, completion:
+                                 { (purchaserInfo, newError) in
+            error = newError
+        })
 
         expect(error).toEventuallyNot(beNil())
         expect((error as NSError?)?.code).toEventually(be(Purchases.ErrorCode.invalidCredentialsError.rawValue))
@@ -452,12 +612,22 @@ class BackendTests: XCTestCase {
 
         var purchaserInfo: Purchases.PurchaserInfo?
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: nil, price: nil,
-                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
-                discounts: nil, presentedOfferingIdentifier: nil, observerMode: false,
-                completion: { (newPurchaserInfo, newError) in
-                    purchaserInfo = newPurchaserInfo
-                })
+        backend?.postReceiptData(receiptData,
+                                 appUserID: userID,
+                                 isRestore: false,
+                                 productIdentifier: nil,
+                                 price: nil,
+                                 paymentMode: RCPaymentMode.none,
+                                 introductoryPrice: nil,
+                                 currencyCode: nil,
+                                 subscriptionGroup: nil,
+                                 discounts: nil,
+                                 presentedOfferingIdentifier: nil, observerMode:
+                                 false, subscriberAttributes:
+                                 nil, completion:
+                                 { (newPurchaserInfo, newError) in
+            purchaserInfo = newPurchaserInfo
+        })
 
         expect(purchaserInfo).toEventuallyNot(beNil())
         if purchaserInfo != nil {
@@ -782,13 +952,23 @@ class BackendTests: XCTestCase {
         httpClient.mock(requestPath: "/receipts", response: response)
         var receivedError : NSError?
         var receivedUnderlyingError : NSError?
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: true, productIdentifier: nil, price: nil,
-                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
-                discounts: nil, presentedOfferingIdentifier: nil, observerMode: false,
-                completion: { (purchaserInfo, error) in
-                    receivedError = error as NSError?
-                    receivedUnderlyingError = receivedError?.userInfo[NSUnderlyingErrorKey] as! NSError?
-                })
+        backend?.postReceiptData(receiptData,
+                                 appUserID: userID,
+                                 isRestore: true,
+                                 productIdentifier: nil,
+                                 price: nil,
+                                 paymentMode: RCPaymentMode.none,
+                                 introductoryPrice: nil,
+                                 currencyCode: nil,
+                                 subscriptionGroup: nil,
+                                 discounts: nil,
+                                 presentedOfferingIdentifier: nil, observerMode:
+                                 false, subscriberAttributes:
+                                 nil, completion:
+                                 { (purchaserInfo, error) in
+            receivedError = error as NSError?
+            receivedUnderlyingError = receivedError?.userInfo[NSUnderlyingErrorKey] as! NSError?
+        })
 
         expect(receivedError).toEventuallyNot(beNil())
         expect(receivedError?.domain).toEventually(equal(Purchases.ErrorDomain))
@@ -897,25 +1077,45 @@ class BackendTests: XCTestCase {
         let isRestore = arc4random_uniform(2) == 0
         let observerMode = arc4random_uniform(2) == 0
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
-                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
-                discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
-                completion: { (purchaserInfo, error) in
-                    completionCalled += 1
-                })
-        
+        backend?.postReceiptData(receiptData,
+                                 appUserID: userID,
+                                 isRestore: isRestore,
+                                 productIdentifier: nil,
+                                 price: nil,
+                                 paymentMode: RCPaymentMode.none,
+                                 introductoryPrice: nil,
+                                 currencyCode: nil,
+                                 subscriptionGroup: nil,
+                                 discounts: nil,
+                                 presentedOfferingIdentifier: nil, observerMode:
+                                 observerMode, subscriberAttributes:
+                                 nil, completion:
+                                 { (purchaserInfo, error) in
+            completionCalled += 1
+        })
+
         let discount = RCPromotionalOffer.init()
         discount.offerIdentifier = "offerid"
         discount.paymentMode = RCPaymentMode.payAsYouGo
         discount.price = 12
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
-                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
-                discounts: [discount], presentedOfferingIdentifier: nil, observerMode: observerMode,
-                completion: { (purchaserInfo, error) in
-                    completionCalled += 1
-                })
-        
+        backend?.postReceiptData(receiptData,
+                                 appUserID: userID,
+                                 isRestore: isRestore,
+                                 productIdentifier: nil,
+                                 price: nil,
+                                 paymentMode: RCPaymentMode.none,
+                                 introductoryPrice: nil,
+                                 currencyCode: nil,
+                                 subscriptionGroup: nil,
+                                 discounts: [discount],
+                                 presentedOfferingIdentifier: nil,
+                                 observerMode: observerMode,
+                                 subscriberAttributes: nil,
+                                 completion: { (purchaserInfo, error) in
+            completionCalled += 1
+        })
+
         expect(self.httpClient.calls.count).to(equal(2))
         expect(completionCalled).toEventually(equal(2))
     }
@@ -939,13 +1139,23 @@ class BackendTests: XCTestCase {
         discount.paymentMode = RCPaymentMode.payAsYouGo
         discount.price = 12
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: false, productIdentifier: productIdentifier,
-                price: price, paymentMode: paymentMode, introductoryPrice: nil, currencyCode: currencyCode,
-                subscriptionGroup: group, discounts: [discount], presentedOfferingIdentifier: nil, observerMode: false,
-                completion: { (purchaserInfo, error) in
-                    completionCalled = true
-                })
-        
+        backend?.postReceiptData(receiptData,
+                                 appUserID: userID,
+                                 isRestore: false,
+                                 productIdentifier: productIdentifier,
+                                 price: price,
+                                 paymentMode: paymentMode,
+                                 introductoryPrice: nil,
+                                 currencyCode: currencyCode,
+                                 subscriptionGroup: group,
+                                 discounts: [discount],
+                                 presentedOfferingIdentifier: nil,
+                                 observerMode: false,
+                                 subscriberAttributes: nil,
+                                 completion: { (purchaserInfo, error) in
+            completionCalled = true
+        })
+
         let body: [String: Any] = [
             "app_user_id": userID,
             "fetch_token": receiptData.base64EncodedString(),
@@ -1229,25 +1439,45 @@ class BackendTests: XCTestCase {
         let isRestore = arc4random_uniform(2) == 0
         let observerMode = arc4random_uniform(2) == 0
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
-                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
-                discounts: nil, presentedOfferingIdentifier: nil, observerMode: observerMode,
-                completion: { (purchaserInfo, error) in
-                    completionCalled += 1
-                })
-        
+        backend?.postReceiptData(receiptData,
+                                 appUserID: userID,
+                                 isRestore: isRestore,
+                                 productIdentifier: nil,
+                                 price: nil,
+                                 paymentMode: RCPaymentMode.none,
+                                 introductoryPrice: nil,
+                                 currencyCode: nil,
+                                 subscriptionGroup: nil,
+                                 discounts: nil,
+                                 presentedOfferingIdentifier: nil, observerMode:
+                                 observerMode, subscriberAttributes:
+                                 nil, completion:
+                                 { (purchaserInfo, error) in
+            completionCalled += 1
+        })
+
         let discount = RCPromotionalOffer.init()
         discount.offerIdentifier = "offerid"
         discount.paymentMode = RCPaymentMode.payAsYouGo
         discount.price = 12
 
-        backend?.postReceiptData(receiptData, appUserID: userID, isRestore: isRestore, productIdentifier: nil, price: nil,
-                paymentMode: RCPaymentMode.none, introductoryPrice: nil, currencyCode: nil, subscriptionGroup: nil,
-                discounts: nil, presentedOfferingIdentifier: "offering_a", observerMode: observerMode,
-                completion: { (purchaserInfo, error) in
-                    completionCalled += 1
-                })
-        
+        backend?.postReceiptData(receiptData,
+                                 appUserID: userID,
+                                 isRestore: isRestore,
+                                 productIdentifier: nil,
+                                 price: nil,
+                                 paymentMode: RCPaymentMode.none,
+                                 introductoryPrice: nil,
+                                 currencyCode: nil,
+                                 subscriptionGroup: nil,
+                                 discounts: nil,
+                                 presentedOfferingIdentifier: "offering_a",
+                                 observerMode: observerMode,
+                                 subscriberAttributes: nil,
+                                 completion: { (purchaserInfo, error) in
+            completionCalled += 1
+        })
+
         expect(self.httpClient.calls.count).to(equal(2))
         expect(completionCalled).toEventually(equal(2))
     }

--- a/PurchasesTests/Mocks/MockHTTPClient.swift
+++ b/PurchasesTests/Mocks/MockHTTPClient.swift
@@ -1,0 +1,46 @@
+import Purchases
+
+class MockHTTPClient: RCHTTPClient {
+
+//    override class func serverHostName() -> String { super.serverHostName() }
+
+//    override func performRequest(_ HTTPMethod: String, path: String, body requestBody: [AnyHashable: Any]?,
+//                                 headers: [String: String]?,
+//                                 completionHandler: RCHTTPClientResponseHandler?) {
+//        super.performRequest(HTTPMethod,
+//                             path: path,
+//                             body: requestBody,
+//                             headers: headers,
+//                             completionHandler: completionHandler)
+//    }
+//}
+
+//class MockHTTPClient2: MockHTTPClient {
+
+//    convenience init() {
+//        self.init(platformFlavor: nil)
+//    }
+
+    var invokedPerformRequest = false
+    var invokedPerformRequestCount = 0
+    var invokedPerformRequestParameters: (HTTPMethod: String,
+                                          path: String,
+                                          requestBody: [AnyHashable: Any]?,
+                                          headers: [String: String]?,
+                                          completionHandler: RCHTTPClientResponseHandler?)?
+    var invokedPerformRequestParametersList = [
+        (HTTPMethod: String,
+        path: String,
+        requestBody: [AnyHashable: Any]?,
+        headers: [String: String]?,
+        completionHandler: RCHTTPClientResponseHandler?)]()
+
+    override func performRequest(_ HTTPMethod: String, path: String, body requestBody: [AnyHashable: Any]?,
+                                 headers: [String: String]?,
+                                 completionHandler: RCHTTPClientResponseHandler?) {
+        invokedPerformRequest = true
+        invokedPerformRequestCount += 1
+        invokedPerformRequestParameters = (HTTPMethod, path, requestBody, headers, completionHandler)
+        invokedPerformRequestParametersList.append((HTTPMethod, path, requestBody, headers, completionHandler))
+    }
+}

--- a/PurchasesTests/Mocks/MockHTTPClient.swift
+++ b/PurchasesTests/Mocks/MockHTTPClient.swift
@@ -2,27 +2,14 @@ import Purchases
 
 class MockHTTPClient: RCHTTPClient {
 
-//    override class func serverHostName() -> String { super.serverHostName() }
-
-//    override func performRequest(_ HTTPMethod: String, path: String, body requestBody: [AnyHashable: Any]?,
-//                                 headers: [String: String]?,
-//                                 completionHandler: RCHTTPClientResponseHandler?) {
-//        super.performRequest(HTTPMethod,
-//                             path: path,
-//                             body: requestBody,
-//                             headers: headers,
-//                             completionHandler: completionHandler)
-//    }
-//}
-
-//class MockHTTPClient2: MockHTTPClient {
-
-//    convenience init() {
-//        self.init(platformFlavor: nil)
-//    }
-
     var invokedPerformRequest = false
     var invokedPerformRequestCount = 0
+    var shouldInvokeCompletion = true
+
+    var stubbedCompletionStatusCode = 200
+    var stubbedCompletionResponse: [AnyHashable: Any]? = [:]
+    var stubbedCompletionError: Error? = nil
+
     var invokedPerformRequestParameters: (HTTPMethod: String,
                                           path: String,
                                           requestBody: [AnyHashable: Any]?,
@@ -30,10 +17,10 @@ class MockHTTPClient: RCHTTPClient {
                                           completionHandler: RCHTTPClientResponseHandler?)?
     var invokedPerformRequestParametersList = [
         (HTTPMethod: String,
-        path: String,
-        requestBody: [AnyHashable: Any]?,
-        headers: [String: String]?,
-        completionHandler: RCHTTPClientResponseHandler?)]()
+            path: String,
+            requestBody: [AnyHashable: Any]?,
+            headers: [String: String]?,
+            completionHandler: RCHTTPClientResponseHandler?)]()
 
     override func performRequest(_ HTTPMethod: String, path: String, body requestBody: [AnyHashable: Any]?,
                                  headers: [String: String]?,
@@ -42,5 +29,10 @@ class MockHTTPClient: RCHTTPClient {
         invokedPerformRequestCount += 1
         invokedPerformRequestParameters = (HTTPMethod, path, requestBody, headers, completionHandler)
         invokedPerformRequestParametersList.append((HTTPMethod, path, requestBody, headers, completionHandler))
+        if (shouldInvokeCompletion) {
+            completionHandler?(stubbedCompletionStatusCode,
+                               stubbedCompletionResponse,
+                               stubbedCompletionError)
+        }
     }
 }

--- a/PurchasesTests/NSDate+RCExtensionsTests.swift
+++ b/PurchasesTests/NSDate+RCExtensionsTests.swift
@@ -1,0 +1,16 @@
+//
+// Created by RevenueCat on 3/4/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+import Nimble
+import XCTest
+
+import Purchases
+
+class NSDateExtensionsTests: XCTestCase {
+    func testMillisecondsSince1970() {
+        let date = NSDate()
+        expect(date.millisecondsSince1970()) == (UInt64)(date.timeIntervalSince1970 * 1000)
+    }
+}

--- a/PurchasesTests/NSError+RCExtensionsTests.swift
+++ b/PurchasesTests/NSError+RCExtensionsTests.swift
@@ -43,4 +43,14 @@ class NSErrorRCExtensionsTests: XCTestCase {
         let error = Purchases.ErrorUtils.networkError(withUnderlyingError: underlyingError)
         expect((error as NSError).didBackendReceiveRequestCorrectly()) == true
     }
+
+    func testDidBackendReceiveRequestCorrectlyFalseIfFalseForUnderlyingError() {
+        let errorCode = Purchases.ErrorCode.networkError.rawValue
+        let underlyingError = NSError(domain: Purchases.ErrorDomain, code: errorCode,
+                                      userInfo: [Purchases.FinishableKey: true])
+        expect(underlyingError.didBackendReceiveRequestCorrectly()) == false
+
+        let error = Purchases.ErrorUtils.networkError(withUnderlyingError: underlyingError)
+        expect((error as NSError).didBackendReceiveRequestCorrectly()) == false
+    }
 }

--- a/PurchasesTests/NSError+RCExtensionsTests.swift
+++ b/PurchasesTests/NSError+RCExtensionsTests.swift
@@ -11,47 +11,47 @@ import Purchases
 
 class NSErrorRCExtensionsTests: XCTestCase {
 
-    func testShouldMarkSyncedKeyPresentFalseIfCodeIsNetworkError() {
+    func testSuccessfullySyncedFalseIfCodeIsNetworkError() {
         let errorCode = Purchases.ErrorCode.networkError.rawValue
         let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [:])
-        expect(error.shouldMarkSyncedKeyPresent()) == false
+        expect(error.successfullySynced()) == false
     }
 
-    func testShouldMarkSyncedKeyPresentFalseIfNotShouldMarkSynced() {
+    func testSuccessfullySyncedFalseIfNotShouldMarkSynced() {
         let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
         let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [RCSuccessfullySyncedKey: false])
-        expect(error.shouldMarkSyncedKeyPresent()) == false
+        expect(error.successfullySynced()) == false
     }
 
-    func testShouldMarkSyncedKeyPresentFalseIfShouldMarkSyncedNotPresent() {
+    func testSuccessfullySyncedFalseIfShouldMarkSyncedNotPresent() {
         let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
         let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [:])
-        expect(error.shouldMarkSyncedKeyPresent()) == false
+        expect(error.successfullySynced()) == false
     }
 
-    func testShouldMarkSyncedKeyPresentTrueIfShouldMarkSynced() {
+    func testSuccessfullySyncedTrueIfShouldMarkSynced() {
         let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
         let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [RCSuccessfullySyncedKey: true])
-        expect(error.shouldMarkSyncedKeyPresent()) == true
+        expect(error.successfullySynced()) == true
     }
 
-    func testShouldMarkSyncedKeyPresentTrueIfTrueForUnderlyingError() {
+    func testSuccessfullySyncedTrueIfTrueForUnderlyingError() {
         let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
         let underlyingError = NSError(domain: Purchases.ErrorDomain, code: errorCode,
                                       userInfo: [RCSuccessfullySyncedKey: true])
-        expect(underlyingError.shouldMarkSyncedKeyPresent()) == true
+        expect(underlyingError.successfullySynced()) == true
 
         let error = Purchases.ErrorUtils.networkError(withUnderlyingError: underlyingError)
-        expect((error as NSError).shouldMarkSyncedKeyPresent()) == true
+        expect((error as NSError).successfullySynced()) == true
     }
 
-    func testShouldMarkSyncedKeyPresentFalseIfFalseForUnderlyingError() {
+    func testSuccessfullySyncedFalseIfFalseForUnderlyingError() {
         let errorCode = Purchases.ErrorCode.networkError.rawValue
         let underlyingError = NSError(domain: Purchases.ErrorDomain, code: errorCode,
                                       userInfo: [RCSuccessfullySyncedKey: true])
-        expect(underlyingError.shouldMarkSyncedKeyPresent()) == false
+        expect(underlyingError.successfullySynced()) == false
 
         let error = Purchases.ErrorUtils.networkError(withUnderlyingError: underlyingError)
-        expect((error as NSError).shouldMarkSyncedKeyPresent()) == false
+        expect((error as NSError).successfullySynced()) == false
     }
 }

--- a/PurchasesTests/NSError+RCExtensionsTests.swift
+++ b/PurchasesTests/NSError+RCExtensionsTests.swift
@@ -34,24 +34,4 @@ class NSErrorRCExtensionsTests: XCTestCase {
         let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [RCSuccessfullySyncedKey: true])
         expect(error.successfullySynced()) == true
     }
-
-    func testSuccessfullySyncedTrueIfTrueForUnderlyingError() {
-        let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
-        let underlyingError = NSError(domain: Purchases.ErrorDomain, code: errorCode,
-                                      userInfo: [RCSuccessfullySyncedKey: true])
-        expect(underlyingError.successfullySynced()) == true
-
-        let error = Purchases.ErrorUtils.networkError(withUnderlyingError: underlyingError)
-        expect((error as NSError).successfullySynced()) == true
-    }
-
-    func testSuccessfullySyncedFalseIfFalseForUnderlyingError() {
-        let errorCode = Purchases.ErrorCode.networkError.rawValue
-        let underlyingError = NSError(domain: Purchases.ErrorDomain, code: errorCode,
-                                      userInfo: [RCSuccessfullySyncedKey: true])
-        expect(underlyingError.successfullySynced()) == false
-
-        let error = Purchases.ErrorUtils.networkError(withUnderlyingError: underlyingError)
-        expect((error as NSError).successfullySynced()) == false
-    }
 }

--- a/PurchasesTests/NSError+RCExtensionsTests.swift
+++ b/PurchasesTests/NSError+RCExtensionsTests.swift
@@ -1,0 +1,46 @@
+//
+// Created by RevenueCat on 2/26/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+import XCTest
+import OHHTTPStubs
+import Nimble
+
+import Purchases
+
+class NSErrorRCExtensionsTests: XCTestCase {
+    func testDidBackendReceiveRequestCorrectlyFalseIfCodeIsNetworkError() {
+        let errorCode = Purchases.ErrorCode.networkError.rawValue
+        let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [:])
+        expect(error.didBackendReceiveRequestCorrectly()) == false
+    }
+
+    func testDidBackendReceiveRequestCorrectlyFalseIfNotFinishable() {
+        let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
+        let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [Purchases.FinishableKey: false])
+        expect(error.didBackendReceiveRequestCorrectly()) == false
+    }
+
+    func testDidBackendReceiveRequestCorrectlyFalseIfFinishableNotPresent() {
+        let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
+        let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [:])
+        expect(error.didBackendReceiveRequestCorrectly()) == false
+    }
+
+    func testDidBackendReceiveRequestCorrectlyTrueIfFinishable() {
+        let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
+        let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [Purchases.FinishableKey: true])
+        expect(error.didBackendReceiveRequestCorrectly()) == true
+    }
+
+    func testDidBackendReceiveRequestCorrectlyTrueIfTrueForUnderlyingError() {
+        let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
+        let underlyingError = NSError(domain: Purchases.ErrorDomain, code: errorCode,
+                                      userInfo: [Purchases.FinishableKey: true])
+        expect(underlyingError.didBackendReceiveRequestCorrectly()) == true
+
+        let error = Purchases.ErrorUtils.networkError(withUnderlyingError: underlyingError)
+        expect((error as NSError).didBackendReceiveRequestCorrectly()) == true
+    }
+}

--- a/PurchasesTests/NSError+RCExtensionsTests.swift
+++ b/PurchasesTests/NSError+RCExtensionsTests.swift
@@ -11,47 +11,47 @@ import Purchases
 
 class NSErrorRCExtensionsTests: XCTestCase {
 
-    func testDidBackendReceiveRequestCorrectlyFalseIfCodeIsNetworkError() {
+    func testShouldMarkSyncedKeyPresentFalseIfCodeIsNetworkError() {
         let errorCode = Purchases.ErrorCode.networkError.rawValue
         let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [:])
-        expect(error.didBackendReceiveRequestCorrectly()) == false
+        expect(error.shouldMarkSyncedKeyPresent()) == false
     }
 
-    func testDidBackendReceiveRequestCorrectlyFalseIfNotFinishable() {
+    func testShouldMarkSyncedKeyPresentFalseIfNotShouldMarkSynced() {
         let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
-        let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [Purchases.FinishableKey: false])
-        expect(error.didBackendReceiveRequestCorrectly()) == false
+        let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [RCShouldMarkSyncedKey: false])
+        expect(error.shouldMarkSyncedKeyPresent()) == false
     }
 
-    func testDidBackendReceiveRequestCorrectlyFalseIfFinishableNotPresent() {
+    func testShouldMarkSyncedKeyPresentFalseIfShouldMarkSyncedNotPresent() {
         let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
         let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [:])
-        expect(error.didBackendReceiveRequestCorrectly()) == false
+        expect(error.shouldMarkSyncedKeyPresent()) == false
     }
 
-    func testDidBackendReceiveRequestCorrectlyTrueIfFinishable() {
+    func testShouldMarkSyncedKeyPresentTrueIfShouldMarkSynced() {
         let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
-        let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [Purchases.FinishableKey: true])
-        expect(error.didBackendReceiveRequestCorrectly()) == true
+        let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [RCShouldMarkSyncedKey: true])
+        expect(error.shouldMarkSyncedKeyPresent()) == true
     }
 
-    func testDidBackendReceiveRequestCorrectlyTrueIfTrueForUnderlyingError() {
+    func testShouldMarkSyncedKeyPresentTrueIfTrueForUnderlyingError() {
         let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
         let underlyingError = NSError(domain: Purchases.ErrorDomain, code: errorCode,
-                                      userInfo: [Purchases.FinishableKey: true])
-        expect(underlyingError.didBackendReceiveRequestCorrectly()) == true
+                                      userInfo: [RCShouldMarkSyncedKey: true])
+        expect(underlyingError.shouldMarkSyncedKeyPresent()) == true
 
         let error = Purchases.ErrorUtils.networkError(withUnderlyingError: underlyingError)
-        expect((error as NSError).didBackendReceiveRequestCorrectly()) == true
+        expect((error as NSError).shouldMarkSyncedKeyPresent()) == true
     }
 
-    func testDidBackendReceiveRequestCorrectlyFalseIfFalseForUnderlyingError() {
+    func testShouldMarkSyncedKeyPresentFalseIfFalseForUnderlyingError() {
         let errorCode = Purchases.ErrorCode.networkError.rawValue
         let underlyingError = NSError(domain: Purchases.ErrorDomain, code: errorCode,
-                                      userInfo: [Purchases.FinishableKey: true])
-        expect(underlyingError.didBackendReceiveRequestCorrectly()) == false
+                                      userInfo: [RCShouldMarkSyncedKey: true])
+        expect(underlyingError.shouldMarkSyncedKeyPresent()) == false
 
         let error = Purchases.ErrorUtils.networkError(withUnderlyingError: underlyingError)
-        expect((error as NSError).didBackendReceiveRequestCorrectly()) == false
+        expect((error as NSError).shouldMarkSyncedKeyPresent()) == false
     }
 }

--- a/PurchasesTests/NSError+RCExtensionsTests.swift
+++ b/PurchasesTests/NSError+RCExtensionsTests.swift
@@ -10,6 +10,7 @@ import Nimble
 import Purchases
 
 class NSErrorRCExtensionsTests: XCTestCase {
+
     func testDidBackendReceiveRequestCorrectlyFalseIfCodeIsNetworkError() {
         let errorCode = Purchases.ErrorCode.networkError.rawValue
         let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [:])

--- a/PurchasesTests/NSError+RCExtensionsTests.swift
+++ b/PurchasesTests/NSError+RCExtensionsTests.swift
@@ -19,7 +19,7 @@ class NSErrorRCExtensionsTests: XCTestCase {
 
     func testShouldMarkSyncedKeyPresentFalseIfNotShouldMarkSynced() {
         let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
-        let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [RCShouldMarkSyncedKey: false])
+        let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [RCSuccessfullySyncedKey: false])
         expect(error.shouldMarkSyncedKeyPresent()) == false
     }
 
@@ -31,14 +31,14 @@ class NSErrorRCExtensionsTests: XCTestCase {
 
     func testShouldMarkSyncedKeyPresentTrueIfShouldMarkSynced() {
         let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
-        let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [RCShouldMarkSyncedKey: true])
+        let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [RCSuccessfullySyncedKey: true])
         expect(error.shouldMarkSyncedKeyPresent()) == true
     }
 
     func testShouldMarkSyncedKeyPresentTrueIfTrueForUnderlyingError() {
         let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
         let underlyingError = NSError(domain: Purchases.ErrorDomain, code: errorCode,
-                                      userInfo: [RCShouldMarkSyncedKey: true])
+                                      userInfo: [RCSuccessfullySyncedKey: true])
         expect(underlyingError.shouldMarkSyncedKeyPresent()) == true
 
         let error = Purchases.ErrorUtils.networkError(withUnderlyingError: underlyingError)
@@ -48,7 +48,7 @@ class NSErrorRCExtensionsTests: XCTestCase {
     func testShouldMarkSyncedKeyPresentFalseIfFalseForUnderlyingError() {
         let errorCode = Purchases.ErrorCode.networkError.rawValue
         let underlyingError = NSError(domain: Purchases.ErrorDomain, code: errorCode,
-                                      userInfo: [RCShouldMarkSyncedKey: true])
+                                      userInfo: [RCSuccessfullySyncedKey: true])
         expect(underlyingError.shouldMarkSyncedKeyPresent()) == false
 
         let error = Purchases.ErrorUtils.networkError(withUnderlyingError: underlyingError)

--- a/PurchasesTests/PurchasesTests-Bridging-Header.h
+++ b/PurchasesTests/PurchasesTests-Bridging-Header.h
@@ -31,3 +31,5 @@
 #include <Purchases/RCSpecialSubscriberAttributes.h>
 #include <Purchases/RCDateProvider.h>
 #include <Purchases/NSError+RCExtensions.h>
+#include <Purchases/RCPurchasesErrorUtils.h>
+#include <Purchases/RCPurchasesErrorUtils+Protected.h>

--- a/PurchasesTests/PurchasesTests-Bridging-Header.h
+++ b/PurchasesTests/PurchasesTests-Bridging-Header.h
@@ -33,3 +33,4 @@
 #include <Purchases/NSError+RCExtensions.h>
 #include <Purchases/RCPurchasesErrorUtils.h>
 #include <Purchases/RCPurchasesErrorUtils+Protected.h>
+#include <Purchases/NSDate+RCExtensions.h>

--- a/PurchasesTests/PurchasesTests-Bridging-Header.h
+++ b/PurchasesTests/PurchasesTests-Bridging-Header.h
@@ -30,3 +30,4 @@
 #include <Purchases/RCSubscriberAttribute+Protected.h>
 #include <Purchases/RCSpecialSubscriberAttributes.h>
 #include <Purchases/RCDateProvider.h>
+#include <Purchases/NSError+RCExtensions.h>

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -164,7 +164,20 @@ class PurchasesTests: XCTestCase {
         var aliasError: Error?
         var aliasCalled = false
 
-        override func postReceiptData(_ data: Data, appUserID: String, isRestore: Bool, productIdentifier: String?, price: NSDecimalNumber?, paymentMode: RCPaymentMode, introductoryPrice: NSDecimalNumber?, currencyCode: String?, subscriptionGroup: String?, discounts: Array<RCPromotionalOffer>?, presentedOfferingIdentifier: String?, observerMode: Bool, completion: @escaping RCBackendPurchaserInfoResponseHandler) {
+        override func postReceiptData(_ data: Data,
+                                      appUserID: String,
+                                      isRestore: Bool,
+                                      productIdentifier: String?,
+                                      price: NSDecimalNumber?,
+                                      paymentMode: RCPaymentMode,
+                                      introductoryPrice: NSDecimalNumber?,
+                                      currencyCode: String?,
+                                      subscriptionGroup: String?,
+                                      discounts: Array<RCPromotionalOffer>?,
+                                      presentedOfferingIdentifier: String?,
+                                      observerMode: Bool,
+                                      subscriberAttributes: [String: RCSubscriberAttribute]?,
+                                      completion: @escaping RCBackendPurchaserInfoResponseHandler) {
             postReceiptDataCalled = true
             postedIsRestore = isRestore
 

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -184,33 +184,7 @@ class BackendSubscriberAttributesTests: XCTestCase {
                                          })
         expect(self.mockHTTPClient.invokedPerformRequestCount) == 0
     }
-
-//    func testPostSubscriberAttributesErrorIncludesRCSuccessfullySyncedKeyIfInternalServerError() {
-//        var completionCallCount = 0
-//        mockHTTPClient.shouldInvokeCompletion = true
-//        mockHTTPClient.stubbedCompletionStatusCode = 503
-//        mockHTTPClient.stubbedCompletionError = nil
-//
-//        var receivedError: Error? = nil
-//        backend.postSubscriberAttributes([
-//                                             subscriberAttribute1.key: subscriberAttribute1,
-//                                             subscriberAttribute2.key: subscriberAttribute2
-//                                         ],
-//                                         appUserID: appUserID,
-//                                         completion: { (error: Error!) in
-//                                             completionCallCount += 1
-//                                             receivedError = error
-//                                         })
-//
-//        expect(self.mockHTTPClient.invokedPerformRequestCount) == 1
-//        expect(completionCallCount).toEventually(equal(1))
-//        expect(receivedError).toNot(beNil())
-//        expect(receivedError).to(beAKindOf(Error.self))
-//
-//        let receivedNSError = receivedError! as NSError
-//        expect(receivedNSError.code) == Purchases.ErrorCode.unknownBackendError.rawValue
-//    }
-
+    
     // MARK: PostReceipt with subscriberAttributes
 
     func testPostReceiptWithSubscriberAttributesSendsThemCorrectly() {

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -57,11 +57,11 @@ class BackendSubscriberAttributesTests: XCTestCase {
         let expectedBody: [String: [String: NSObject]] = [
             "attributes": [
                 subscriberAttribute1.key: [
-                    "updated_at": subscriberAttribute1.setTime.timeIntervalSince1970,
+                    "updated_at": (subscriberAttribute1.setTime as NSDate).millisecondsSince1970(),
                     "value": subscriberAttribute1.value
                 ] as NSObject,
                 subscriberAttribute2.key: [
-                    "updated_at": subscriberAttribute2.setTime.timeIntervalSince1970,
+                    "updated_at": (subscriberAttribute2.setTime as NSDate).millisecondsSince1970(),
                     "value": subscriberAttribute2.value
                 ] as NSObject,
             ]
@@ -249,11 +249,11 @@ class BackendSubscriberAttributesTests: XCTestCase {
 
         let expectedBody: [String: NSObject] = [
             subscriberAttribute1.key: [
-                "updated_at": subscriberAttribute1.setTime.timeIntervalSince1970,
+                "updated_at": (subscriberAttribute1.setTime as NSDate).millisecondsSince1970(),
                 "value": subscriberAttribute1.value
             ] as NSObject,
             subscriberAttribute2.key: [
-                "updated_at": subscriberAttribute2.setTime.timeIntervalSince1970,
+                "updated_at": (subscriberAttribute2.setTime as NSDate).millisecondsSince1970(),
                 "value": subscriberAttribute2.value
             ] as NSObject
         ]

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -27,12 +27,10 @@ class BackendSubscriberAttributesTests: XCTestCase {
         dateProvider = MockDateProvider(stubbedNow: now)
         subscriberAttribute1 = RCSubscriberAttribute(key: "a key",
                                                      value: "a value",
-                                                     appUserID: appUserID,
                                                      dateProvider: dateProvider)
 
         subscriberAttribute2 = RCSubscriberAttribute(key: "another key",
                                                      value: "another value",
-                                                     appUserID: appUserID,
                                                      dateProvider: dateProvider)
     }
 

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -1,0 +1,50 @@
+//
+// Created by RevenueCat on 2/27/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+import XCTest
+import OHHTTPStubs
+import Nimble
+
+import Purchases
+
+class BackendSubscriberAttributesTests: XCTestCase {
+
+    func testPostSubscriberAttributesSendsRightParameters() {
+        let mockHTTPClient = MockHTTPClient(platformFlavor: "iPhone")
+        guard let backend = RCBackend(httpClient: mockHTTPClient, apiKey: "key") else { fatalError() }
+        let appUserID = "abc123"
+        let subscriberAttribute = RCSubscriberAttribute(key: "a key",
+                                                        value: "a value",
+                                                        appUserID: appUserID)
+
+        backend.postSubscriberAttributes(["a key": subscriberAttribute], 
+                                         appUserID: appUserID,
+                                         completion: { (error: Error!) in })
+
+        expect(mockHTTPClient.invokedPerformRequest) == true
+        expect(mockHTTPClient.invokedPerformRequestCount) == 1
+
+        guard let receivedParameters = mockHTTPClient.invokedPerformRequestParameters else {
+            fatalError("no parameters sent!")
+        }
+
+        expect(receivedParameters.HTTPMethod) == "POST"
+        expect(receivedParameters.path) == "/subscribers/abc123/attributes"
+        expect(receivedParameters.requestBody).to(beNil())
+        expect(receivedParameters.headers) == ["Authorization": "Bearer key"]
+    }
+
+    func testPostSubscriberAttributesCallsCompletionInSuccessCase() {
+    }
+
+    func testPostSubscriberAttributesCallsCompletionInNetworkErrorCase() {
+    }
+
+    func testPostSubscriberAttributesCallsCompletionInBackendErrorCase() {
+    }
+
+    func testPostSubscriberAttributesNoOpIfAttributesAreEmpty() {
+    }
+}

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -57,11 +57,11 @@ class BackendSubscriberAttributesTests: XCTestCase {
         let expectedBody: [String: [String: NSObject]] = [
             "attributes": [
                 subscriberAttribute1.key: [
-                    "updated_at": (subscriberAttribute1.setTime as NSDate).millisecondsSince1970(),
+                    "updated_at_ms": (subscriberAttribute1.setTime as NSDate).millisecondsSince1970(),
                     "value": subscriberAttribute1.value
                 ] as NSObject,
                 subscriberAttribute2.key: [
-                    "updated_at": (subscriberAttribute2.setTime as NSDate).millisecondsSince1970(),
+                    "updated_at_ms": (subscriberAttribute2.setTime as NSDate).millisecondsSince1970(),
                     "value": subscriberAttribute2.value
                 ] as NSObject,
             ]
@@ -249,11 +249,11 @@ class BackendSubscriberAttributesTests: XCTestCase {
 
         let expectedBody: [String: NSObject] = [
             subscriberAttribute1.key: [
-                "updated_at": (subscriberAttribute1.setTime as NSDate).millisecondsSince1970(),
+                "updated_at_ms": (subscriberAttribute1.setTime as NSDate).millisecondsSince1970(),
                 "value": subscriberAttribute1.value
             ] as NSObject,
             subscriberAttribute2.key: [
-                "updated_at": (subscriberAttribute2.setTime as NSDate).millisecondsSince1970(),
+                "updated_at_ms": (subscriberAttribute2.setTime as NSDate).millisecondsSince1970(),
                 "value": subscriberAttribute2.value
             ] as NSObject
         ]

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -10,16 +10,33 @@ import Nimble
 import Purchases
 
 class BackendSubscriberAttributesTests: XCTestCase {
+    let appUserID = "abc123"
+    let now = Date()
+    var dateProvider: MockDateProvider!
+    var subscriberAttribute1: RCSubscriberAttribute!
+    var subscriberAttribute2: RCSubscriberAttribute!
+
+    override func setUp() {
+        dateProvider = MockDateProvider(stubbedNow: now)
+        subscriberAttribute1 = RCSubscriberAttribute(key: "a key",
+                                                     value: "a value",
+                                                     appUserID: appUserID,
+                                                     dateProvider: dateProvider)
+
+        subscriberAttribute2 = RCSubscriberAttribute(key: "another key",
+                                                     value: "another value",
+                                                     appUserID: appUserID,
+                                                     dateProvider: dateProvider)
+    }
 
     func testPostSubscriberAttributesSendsRightParameters() {
         let mockHTTPClient = MockHTTPClient(platformFlavor: "iPhone")
         guard let backend = RCBackend(httpClient: mockHTTPClient, apiKey: "key") else { fatalError() }
-        let appUserID = "abc123"
-        let subscriberAttribute = RCSubscriberAttribute(key: "a key",
-                                                        value: "a value",
-                                                        appUserID: appUserID)
 
-        backend.postSubscriberAttributes(["a key": subscriberAttribute], 
+        backend.postSubscriberAttributes([
+                                             subscriberAttribute1.key: subscriberAttribute1,
+                                             subscriberAttribute2.key: subscriberAttribute2
+                                         ],
                                          appUserID: appUserID,
                                          completion: { (error: Error!) in })
 
@@ -32,7 +49,21 @@ class BackendSubscriberAttributesTests: XCTestCase {
 
         expect(receivedParameters.HTTPMethod) == "POST"
         expect(receivedParameters.path) == "/subscribers/abc123/attributes"
-        expect(receivedParameters.requestBody).to(beNil())
+
+        let expectedBody: [String: [String: NSObject]] = [
+            "attributes": [
+                subscriberAttribute1.key: [
+                    "updated_at": subscriberAttribute1.setTime.timeIntervalSince1970,
+                    "value": subscriberAttribute1.value
+                ] as NSObject,
+                subscriberAttribute2.key: [
+                    "updated_at": subscriberAttribute2.setTime.timeIntervalSince1970,
+                    "value": subscriberAttribute2.value
+                ] as NSObject,
+            ]
+        ]
+
+        expect(receivedParameters.requestBody as? [String: [String: NSObject]]).to(equal(expectedBody))
         expect(receivedParameters.headers) == ["Authorization": "Bearer key"]
     }
 

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -138,7 +138,7 @@ class BackendSubscriberAttributesTests: XCTestCase {
         expect(receivedError).to(beAKindOf(Error.self))
 
         let receivedNSError = receivedError! as NSError
-        expect(receivedNSError.code) == Purchases.ErrorCode.networkError.rawValue
+        expect(receivedNSError.code) == Purchases.ErrorCode.unknownBackendError.rawValue
     }
 
     func testPostSubscriberAttributesNoOpIfAttributesAreEmpty() {

--- a/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
@@ -74,7 +74,7 @@ class SubscriberAttributeTests: XCTestCase {
         expect(receivedDictionary.keys.count) == 2
 
         expect(receivedDictionary["value"] as? String) == value
-        let updatedAtEpoch = (receivedDictionary["updated_at"] as! NSNumber).uint64Value
+        let updatedAtEpoch = (receivedDictionary["updated_at_ms"] as! NSNumber).uint64Value
         expect(updatedAtEpoch) == (now as NSDate).millisecondsSince1970()
     }
 }

--- a/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
@@ -57,7 +57,7 @@ class SubscriberAttributeTests: XCTestCase {
 
         expect(receivedDictionary["key"] as? String) == key
         expect(receivedDictionary["value"] as? String) == value
-        expect(receivedDictionary["setTime"] as! Date) == now
+        expect(receivedDictionary["appUserID"] as? String) == appUserID
         expect((receivedDictionary["isSynced"] as! NSNumber).boolValue) == false
     }
 

--- a/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
@@ -57,7 +57,6 @@ class SubscriberAttributeTests: XCTestCase {
 
         expect(receivedDictionary["key"] as? String) == key
         expect(receivedDictionary["value"] as? String) == value
-        expect(receivedDictionary["appUserID"] as? String) == appUserID
         expect((receivedDictionary["isSynced"] as! NSNumber).boolValue) == false
     }
 

--- a/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
@@ -74,7 +74,7 @@ class SubscriberAttributeTests: XCTestCase {
         expect(receivedDictionary.keys.count) == 2
 
         expect(receivedDictionary["value"] as? String) == value
-        let updatedAtEpoch = (receivedDictionary["updated_at"] as! NSNumber).doubleValue
-        expect(updatedAtEpoch) == now.timeIntervalSince1970
+        let updatedAtEpoch = (receivedDictionary["updated_at"] as! NSNumber).uint64Value
+        expect(updatedAtEpoch) == (now as NSDate).millisecondsSince1970()
     }
 }


### PR DESCRIPTION
This is the second part of the subscriber attributes PR: 
It adds backend methods for posting to the subscriber attributes endpoint, as well as logic for sending in the unsynced attributes on the post receipt request. 

### Requirements: 
- [x] ~Part 1 #187~
- [x] ~Unit tests~