### PR TITLE
Expose original_purchase_date

### DIFF
--- a/Purchases/Public/RCPurchaserInfo.h
+++ b/Purchases/Public/RCPurchaserInfo.h
@@ -34,10 +34,10 @@ NS_SWIFT_NAME(Purchases.PurchaserInfo)
 @property (readonly) NSSet<NSString *> *nonConsumablePurchases;
 
 /**
- Returns the build number for the version of the application when the user bought the app.
- Use this for grandfathering users when migrating to subscriptions.
- 
- This corresponds to the value of CFBundleVersion (in iOS) or CFBundleShortVersionString (in macOS) in the Info.plist file when the purchase was originally made.
+Returns the build number (in iOS) or the marketing version (in macOS) for the version of the application when the user bought the app.
+This corresponds to the value of CFBundleVersion (in iOS) or CFBundleShortVersionString (in macOS) in the Info.plist file when the purchase was originally made.
+Use this for grandfathering users when migrating to subscriptions.
+
  
  @note This can be nil, see -[RCPurchases restoreTransactionsForAppStore:]
  */

--- a/Purchases/Public/RCPurchaserInfo.h
+++ b/Purchases/Public/RCPurchaserInfo.h
@@ -34,7 +34,7 @@ NS_SWIFT_NAME(Purchases.PurchaserInfo)
 @property (readonly) NSSet<NSString *> *nonConsumablePurchases;
 
 /**
- Returns the version number for the version of the application when the user bought the app.
+ Returns the build number for the version of the application when the user bought the app.
  Use this for grandfathering users when migrating to subscriptions.
  
  This corresponds to the value of CFBundleVersion (in iOS) or CFBundleShortVersionString (in macOS) in the Info.plist file when the purchase was originally made.
@@ -42,6 +42,14 @@ NS_SWIFT_NAME(Purchases.PurchaserInfo)
  @note This can be nil, see -[RCPurchases restoreTransactionsForAppStore:]
  */
 @property (readonly, nullable) NSString *originalApplicationVersion;
+
+/**
+Returns the purchase date for the version of the application when the user bought the app.
+Use this for grandfathering users when migrating to subscriptions.
+
+@note This can be nil, see -[RCPurchases restoreTransactionsForAppStore:]
+ */
+@property (readonly, nullable) NSDate *originalPurchaseDate;
 
 /**
  Returns the fetch date of this Purchaser info.

--- a/Purchases/Public/RCPurchaserInfo.m
+++ b/Purchases/Public/RCPurchaserInfo.m
@@ -18,6 +18,7 @@
 @property (nonatomic) NSDictionary<NSString *, NSDate *> *purchaseDatesByProduct;
 @property (nonatomic) NSSet<NSString *> *nonConsumablePurchases;
 @property (nonatomic, nullable) NSString *originalApplicationVersion;
+@property (nonatomic, nullable) NSDate *originalPurchaseDate;
 @property (nonatomic) NSDictionary *originalData;
 @property (nonatomic, nullable) NSDate *requestDate;
 @property (nonatomic) NSDate *firstSeen;
@@ -78,6 +79,9 @@ static dispatch_once_t onceToken;
         
         NSString *originalApplicationVersion = subscriberData[@"original_application_version"];
         self.originalApplicationVersion = [originalApplicationVersion isKindOfClass:[NSNull class]] ? nil : originalApplicationVersion;
+
+        NSDate *originalPurchaseDate = [self parseDate:subscriberData[@"original_purchase_date"] withDateFormatter:dateFormatter];
+        self.originalPurchaseDate = [originalPurchaseDate isKindOfClass:[NSNull class]] ? nil : originalPurchaseDate;
 
         self.firstSeen = [self parseDate:subscriberData[@"first_seen"] withDateFormatter:dateFormatter];
         

--- a/Purchases/RCPurchaserInfo+Protected.h
+++ b/Purchases/RCPurchaserInfo+Protected.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSDictionary<NSString *, NSDate *> *purchaseDatesByProduct;
 @property (nonatomic, readonly) NSSet<NSString *> *nonConsumablePurchases;
 @property (nonatomic, readonly, nullable) NSString  *originalApplicationVersion;
+@property (nonatomic, readonly, nullable) NSDate *originalPurchaseDate;
 @property (readonly, nullable) NSString *schemaVersion;
 
 - (NSDictionary *)JSONObject;

--- a/PurchasesTests/PurchaserInfoTests.swift
+++ b/PurchasesTests/PurchaserInfoTests.swift
@@ -132,6 +132,17 @@ class BasicPurchaserInfoTests: XCTestCase {
         expect(purchaserInfo!.originalApplicationVersion).to(equal("1.0"))
     }
 
+    func testOriginalPurchaseDate() {
+        let purchaserInfo = Purchases.PurchaserInfo(data: [
+            "subscriber": [
+                "original_application_version": "1.0",
+                "original_purchase_date": "2018-10-26T23:17:53Z",
+                "subscriptions": [:],
+                "other_purchases": [:]
+            ]])
+        expect(purchaserInfo!.originalPurchaseDate).to(equal(Date(timeIntervalSinceReferenceDate: 562288673)))
+    }
+
     func testPreservesOriginalJSONSerializableObject() {
         let json = purchaserInfo?.jsonObject()
         let newInfo = Purchases.PurchaserInfo(data: json!)

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -127,6 +127,7 @@ class PurchasesTests: XCTestCase {
     class MockBackend: RCBackend {
         var userID: String?
         var originalApplicationVersion: String?
+        var originalPurchaseDate: Date?
         var timeout = false
         var getSubscriberCallCount = 0
         var overridePurchaserInfo = Purchases.PurchaserInfo(data: [
@@ -1256,7 +1257,8 @@ class PurchasesTests: XCTestCase {
             "subscriber": [
                 "subscriptions": [:],
                 "other_purchases": [:],
-                "original_application_version": "1.0"
+                "original_application_version": "1.0",
+                "original_purchase_date": "2018-10-26T23:17:53Z"
             ]
         ])
         
@@ -1267,6 +1269,7 @@ class PurchasesTests: XCTestCase {
         }
 
         expect(receivedPurchaserInfo?.originalApplicationVersion).toEventually(equal("1.0"))
+        expect(receivedPurchaserInfo?.originalPurchaseDate).toEventually(equal(Date(timeIntervalSinceReferenceDate: 562288673)))
         expect(self.backend.userID).toEventuallyNot(beNil())
         expect(self.backend.postReceiptDataCalled).toEventuallyNot(beFalse())
     }


### PR DESCRIPTION
For many apps using the originalApplicationVersion is no good since it returns the build number instead of the version number. The scope of this PR is to:
- Clearly indicate that **originalApplicationVersion** is the **build number**
- Expose **originalPurchaseDate** to be used as an alternative for migrating paid apps to freemium

Edit: Added tests
Edit 2: Fixed the naming mixup in the PR description