### PR TITLE
[final] subscriber attributes part 5: push token as data

### DIFF
--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		37E354C46A8A3C2DC861C224 /* MockHTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35292137BBF2810CE4F4B /* MockHTTPClient.swift */; };
 		37E354E0A9A371481540B2B0 /* MockAttributionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E351CD1EE6B897F434EA40 /* MockAttributionFetcher.swift */; };
 		37E3554836D4DA9336B9FA70 /* MockProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3572040A16F10B957563A /* MockProductDiscount.swift */; };
+		37E3559878659F4EA93ADDE6 /* NSData+RCExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E350352D8DCFAAA06662ED /* NSData+RCExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E355E7EB509047724841F4 /* BackendSubscriberAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E357F69438004E1F443C03 /* BackendSubscriberAttributesTests.swift */; };
 		37E356619BE46B3AA82A69E8 /* RCInMemoryCachedObject+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35483531C5A5E6BF09BBD /* RCInMemoryCachedObject+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E357E33F0E20D92EE6372E /* MockSKProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E357FBA3184BDE6E95DED4 /* MockSKProduct.swift */; };
@@ -115,6 +116,7 @@
 		37E35AF213F2F79CB067FDC2 /* InMemoryCachedObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35E3250FBBB03D92E06EC /* InMemoryCachedObjectTests.swift */; };
 		37E35BCE176D557487A903CC /* NSDate+RCExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E358235BB58A968B059B6B /* NSDate+RCExtensions.m */; };
 		37E35B1F34D1624509012749 /* MockSubscriberAttributesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E351D48260D9DC8B1EE360 /* MockSubscriberAttributesManager.swift */; };
+		37E35CCE215E9EABFB88F3BD /* NSData+RCExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E355C86ED87895B04E0E99 /* NSData+RCExtensions.m */; };
 		37E35D4498633E73BF02BAE7 /* RCDeviceCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E356820F0AD560FA23F3BF /* RCDeviceCache.m */; };
 		37E35DD380900220C34BB222 /* MockTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3550C031F1FD95B366998 /* MockTransaction.swift */; };
 		37E35EA06000D9C8AFE77348 /* RCPurchasesErrorUtils+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35D0E675B0E6829E7968F /* RCPurchasesErrorUtils+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -229,6 +231,7 @@
 		35D3AB412030B4C600DE42C5 /* RCIntroEligibility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCIntroEligibility.h; sourceTree = "<group>"; };
 		35D3AB422030B4C600DE42C5 /* RCIntroEligibility.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCIntroEligibility.m; sourceTree = "<group>"; };
 		35E5B1DB1F80026C00B2537C /* StoreKitWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitWrapperTests.swift; sourceTree = "<group>"; };
+		37E350352D8DCFAAA06662ED /* NSData+RCExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+RCExtensions.h"; sourceTree = "<group>"; };
 		37E3508E52201122137D4B4A /* PurchasesSubscriberAttributesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchasesSubscriberAttributesTests.swift; sourceTree = "<group>"; };
 		37E35192068E91782835FA85 /* RCDateProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCDateProvider.h; sourceTree = "<group>"; };
 		37E351AC0FF9607719F7A29A /* MockStoreKitWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockStoreKitWrapper.swift; sourceTree = "<group>"; };
@@ -244,6 +247,7 @@
 		37E3550C031F1FD95B366998 /* MockTransaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockTransaction.swift; sourceTree = "<group>"; };
 		37E3555AC54BD10BE56F2B6B /* RCDeviceCache+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCDeviceCache+Protected.h"; sourceTree = "<group>"; };
 		37E3555B4BE0A4F7222E7B00 /* MockOfferingsFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockOfferingsFactory.swift; sourceTree = "<group>"; };
+		37E355C86ED87895B04E0E99 /* NSData+RCExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+RCExtensions.m"; sourceTree = "<group>"; };
 		37E35609E46E869675A466C1 /* MockRequestFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockRequestFetcher.swift; sourceTree = "<group>"; };
 		37E35642B1AD2A45A7152CD5 /* RCDateProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCDateProvider.m; sourceTree = "<group>"; };
 		37E35645928A0009F4C105A7 /* MockBackend.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockBackend.swift; sourceTree = "<group>"; };
@@ -312,8 +316,6 @@
 		2DCB85BF2406EC3F003C1260 /* Recovered References */ = {
 			isa = PBXGroup;
 			children = (
-				2D50332E2406EAAD009CAE61,
-				2D50332D2406EAAD009CAE61,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -422,6 +424,8 @@
 				37E35D0E675B0E6829E7968F /* RCPurchasesErrorUtils+Protected.h */,
 				37E358235BB58A968B059B6B /* NSDate+RCExtensions.m */,
 				37E356CA7C7188A8B6E2811A /* NSDate+RCExtensions.h */,
+				37E355C86ED87895B04E0E99 /* NSData+RCExtensions.m */,
+				37E350352D8DCFAAA06662ED /* NSData+RCExtensions.h */,
 			);
 			path = Purchases;
 			sourceTree = "<group>";
@@ -570,6 +574,7 @@
 				37E35EA06000D9C8AFE77348 /* RCPurchasesErrorUtils+Protected.h in Headers */,
 				37E352F9B7505A398D578F53 /* RCDeviceCache+Protected.h in Headers */,
 				37E35971060F603C2F028D1F /* NSDate+RCExtensions.h in Headers */,
+				37E3559878659F4EA93ADDE6 /* NSData+RCExtensions.h in Headers */,
 				35C98D9520B7306A006DCBB5 /* RCCrossPlatformSupport.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -725,6 +730,7 @@
 				37E358E75F7A3C75F2CA10BA /* RCDateProvider.m in Sources */,
 				2D8DB34E240731E000BE3D31 /* NSError+RCExtensions.m in Sources */,
 				37E35BCE176D557487A903CC /* NSDate+RCExtensions.m in Sources */,
+				37E35CCE215E9EABFB88F3BD /* NSData+RCExtensions.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		37E3554836D4DA9336B9FA70 /* MockProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3572040A16F10B957563A /* MockProductDiscount.swift */; };
 		37E3559878659F4EA93ADDE6 /* NSData+RCExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E350352D8DCFAAA06662ED /* NSData+RCExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E355E7EB509047724841F4 /* BackendSubscriberAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E357F69438004E1F443C03 /* BackendSubscriberAttributesTests.swift */; };
+		37E35623114E9172D57D7534 /* NSData+RCExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35326207CA74A0D5B00B8 /* NSData+RCExtensionsTests.swift */; };
 		37E356619BE46B3AA82A69E8 /* RCInMemoryCachedObject+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35483531C5A5E6BF09BBD /* RCInMemoryCachedObject+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E357E33F0E20D92EE6372E /* MockSKProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E357FBA3184BDE6E95DED4 /* MockSKProduct.swift */; };
 		37E3585E0B39722838F235BD /* MockUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E357D16038F07915D7825D /* MockUserDefaults.swift */; };
@@ -241,6 +242,7 @@
 		37E35292137BBF2810CE4F4B /* MockHTTPClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockHTTPClient.swift; sourceTree = "<group>"; };
 		37E352B11676F7DC51559E84 /* MockReceiptFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockReceiptFetcher.swift; sourceTree = "<group>"; };
 		37E3544C8038CB83310C3598 /* NSDate+RCExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDate+RCExtensionsTests.swift"; sourceTree = "<group>"; };
+		37E35326207CA74A0D5B00B8 /* NSData+RCExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSData+RCExtensionsTests.swift"; sourceTree = "<group>"; };
 		37E35483531C5A5E6BF09BBD /* RCInMemoryCachedObject+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCInMemoryCachedObject+Protected.h"; sourceTree = "<group>"; };
 		37E354BEB8FDE39CAB7C4D69 /* MockDeviceCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDeviceCache.swift; sourceTree = "<group>"; };
 		37E3550459807FF5636B2667 /* NSError+RCExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSError+RCExtensionsTests.swift"; sourceTree = "<group>"; };
@@ -450,6 +452,7 @@
 				37E35E77A60AC8D3F0E1A23D /* SubscriberAttributes */,
 				37E3550459807FF5636B2667 /* NSError+RCExtensionsTests.swift */,
 				37E3544C8038CB83310C3598 /* NSDate+RCExtensionsTests.swift */,
+				37E35326207CA74A0D5B00B8 /* NSData+RCExtensionsTests.swift */,
 			);
 			path = PurchasesTests;
 			sourceTree = "<group>";
@@ -775,6 +778,7 @@
 				37E357E33F0E20D92EE6372E /* MockSKProduct.swift in Sources */,
 				37E3524CB70618E6C5F3DB49 /* MockPurchasesDelegate.swift in Sources */,
 				37E35B1F34D1624509012749 /* MockSubscriberAttributesManager.swift in Sources */,
+				37E35623114E9172D57D7534 /* NSData+RCExtensionsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Purchases/NSData+RCExtensions.h
+++ b/Purchases/NSData+RCExtensions.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSData (RCExtensions)
 
-- (NSString *)dataAsString;
+- (NSString *)asString;
 
 @end
 

--- a/Purchases/NSData+RCExtensions.h
+++ b/Purchases/NSData+RCExtensions.h
@@ -1,0 +1,18 @@
+//
+// Created by Andrés Boedo on 3/4/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+@interface NSData (RCExtensions)
+
+- (NSString *)dataAsString;
+
+@end
+
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/NSData+RCExtensions.m
+++ b/Purchases/NSData+RCExtensions.m
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_END
 
 @implementation NSData (RCExtensions)
 
-- (NSString *)dataAsString {
+- (NSString *)asString {
     NSMutableString *deviceTokenString = [NSMutableString string];
     [self enumerateByteRangesUsingBlock:^(const void *bytes,
                                           NSRange byteRange,

--- a/Purchases/NSData+RCExtensions.m
+++ b/Purchases/NSData+RCExtensions.m
@@ -1,0 +1,34 @@
+//
+// Created by Andrés Boedo on 3/4/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+#import "NSData+RCExtensions.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+@interface NSData (RCExtensions)
+@end
+
+
+NS_ASSUME_NONNULL_END
+
+
+@implementation NSData (RCExtensions)
+
+- (NSString *)dataAsString {
+    NSMutableString *deviceTokenString = [NSMutableString string];
+    [self enumerateByteRangesUsingBlock:^(const void *bytes,
+                                          NSRange byteRange,
+                                          BOOL *stop) {
+
+        for (NSUInteger i = 0; i < byteRange.length; ++i) {
+            [deviceTokenString appendFormat:@"%02x", ((uint8_t *) bytes)[i]];
+        }
+    }];
+    return deviceTokenString;
+}
+
+
+@end

--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -393,7 +393,7 @@ NS_SWIFT_NAME(restoreTransactions(_:));
 
 - (void)setDisplayName:(nullable NSString *)displayName;
 
-- (void)setPushToken:(nullable NSString *)pushToken;
+- (void)setPushToken:(nullable NSData *)pushToken;
 
 #pragma mark Unavailable Methods
 #define RC_UNAVAILABLE(msg) __attribute__((unavailable(msg)));

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -682,7 +682,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
     [self _setDisplayName:displayName];
 }
 
-- (void)setPushToken:(nullable NSString *)pushToken {
+- (void)setPushToken:(nullable NSData *)pushToken {
     [self _setPushToken:pushToken];
 }
 

--- a/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.h
+++ b/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)_setEmail:(nullable NSString *)email;
 - (void)_setPhoneNumber:(nullable NSString *)phoneNumber;
 - (void)_setDisplayName:(nullable NSString *)displayName;
-- (void)_setPushToken:(nullable NSString *)pushToken;
+- (void)_setPushToken:(nullable NSData *)pushToken;
 
 - (void)configureSubscriberAttributesManager;
 - (RCSubscriberAttributeDict)unsyncedAttributesByKey;

--- a/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.m
+++ b/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.m
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self.subscriberAttributesManager setDisplayName:displayName appUserID:self.appUserID];
 }
 
-- (void)_setPushToken:(nullable NSString *)pushToken {
+- (void)_setPushToken:(nullable NSData *)pushToken {
     RCDebugLog(@"setPushToken called");
     [self.subscriberAttributesManager setPushToken:pushToken appUserID:self.appUserID];
 }

--- a/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.h
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.h
@@ -26,11 +26,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setDisplayName:(nullable NSString *)displayName appUserID:(NSString *)appUserID;
 
-- (void)setPushToken:(nullable NSString *)pushToken appUserID:(NSString *)appUserID;
+- (void)setPushToken:(nullable NSData *)pushToken appUserID:(NSString *)appUserID;
 
 - (void)syncIfNeededWithAppUserID:(NSString *)appUserID completion:(void (^)(NSError *_Nullable error))completion;
 
-- (NSDictionary <NSString *, RCSubscriberAttribute *> *)unsyncedAttributesByKeyForAppUserID:(NSString *)appUserID;
+- (RCSubscriberAttributeDict)unsyncedAttributesByKeyForAppUserID:(NSString *)appUserID;
 
 - (void)markAttributesAsSynced:(RCSubscriberAttributeDict)syncedAttributes
                      appUserID:(NSString *)appUserID;

--- a/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setPushToken:(nullable NSData *)pushToken appUserID:(NSString *)appUserID {
-    NSString *deviceTokenString = pushToken.dataAsString;
+    NSString *deviceTokenString = pushToken.asString;
     [self setAttributeWithKey:SPECIAL_ATTRIBUTE_PUSH_TOKEN value:deviceTokenString appUserID:appUserID];
 }
 

--- a/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
@@ -113,7 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)storeAttributeLocallyIfNeededWithKey:(NSString *)key value:(NSString *)value appUserID:(NSString *)appUserID {
     NSString *valueOrEmpty = value ?: @"";
-    NSString *_Nullable currentValue = [self currentValueForAttributeWithKey:key appUserID:appUserID];
+    NSString * _Nullable currentValue = [self currentValueForAttributeWithKey:key appUserID:appUserID];
     if (!currentValue || ![currentValue isEqualToString:valueOrEmpty]) {
         [self storeAttributeLocallyWithKey:key value:value appUserID:appUserID];
     }

--- a/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setPushToken:(nullable NSData *)pushToken appUserID:(NSString *)appUserID {
-    NSString *deviceTokenString = pushToken.asString;
+    NSString *deviceTokenString = pushToken ? pushToken.asString : nil;
     [self setAttributeWithKey:SPECIAL_ATTRIBUTE_PUSH_TOKEN value:deviceTokenString appUserID:appUserID];
 }
 

--- a/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setPushToken:(nullable NSData *)pushToken appUserID:(NSString *)appUserID {
-    NSMutableString *deviceTokenString = pushToken.dataAsString;
+    NSString *deviceTokenString = pushToken.dataAsString;
     [self setAttributeWithKey:SPECIAL_ATTRIBUTE_PUSH_TOKEN value:deviceTokenString appUserID:appUserID];
 }
 

--- a/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
@@ -4,11 +4,11 @@
 //
 
 #import "RCSubscriberAttributesManager.h"
-#import "RCSubscriberAttribute.h"
 #import "RCSpecialSubscriberAttributes.h"
 #import "RCBackend.h"
 #import "RCDeviceCache.h"
 #import "NSError+RCExtensions.h"
+#import "NSData+RCExtensions.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -54,8 +54,9 @@ NS_ASSUME_NONNULL_BEGIN
     [self setAttributeWithKey:SPECIAL_ATTRIBUTE_DISPLAY_NAME value:displayName appUserID:appUserID];
 }
 
-- (void)setPushToken:(nullable NSString *)pushToken appUserID:(NSString *)appUserID {
-    [self setAttributeWithKey:SPECIAL_ATTRIBUTE_PUSH_TOKEN value:pushToken appUserID:appUserID];
+- (void)setPushToken:(nullable NSData *)pushToken appUserID:(NSString *)appUserID {
+    NSMutableString *deviceTokenString = pushToken.dataAsString;
+    [self setAttributeWithKey:SPECIAL_ATTRIBUTE_PUSH_TOKEN value:deviceTokenString appUserID:appUserID];
 }
 
 - (void)syncIfNeededWithAppUserID:(NSString *)appUserID completion:(void (^)(NSError *_Nullable error))completion {
@@ -112,7 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)storeAttributeLocallyIfNeededWithKey:(NSString *)key value:(NSString *)value appUserID:(NSString *)appUserID {
     NSString *valueOrEmpty = value ?: @"";
-    NSString * _Nullable currentValue = [self currentValueForAttributeWithKey:key appUserID:appUserID];
+    NSString *_Nullable currentValue = [self currentValueForAttributeWithKey:key appUserID:appUserID];
     if (!currentValue || ![currentValue isEqualToString:valueOrEmpty]) {
         [self storeAttributeLocallyWithKey:key value:value appUserID:appUserID];
     }

--- a/PurchasesTests/Mocks/MockSubscriberAttributesManager.swift
+++ b/PurchasesTests/Mocks/MockSubscriberAttributesManager.swift
@@ -55,10 +55,10 @@ class MockSubscriberAttributesManager: RCSubscriberAttributesManager {
 
     var invokedSetPushToken = false
     var invokedSetPushTokenCount = 0
-    var invokedSetPushTokenParameters: (pushToken: String?, appUserID: String)?
-    var invokedSetPushTokenParametersList = [(pushToken: String?, appUserID: String)]()
+    var invokedSetPushTokenParameters: (pushToken: Data?, appUserID: String)?
+    var invokedSetPushTokenParametersList = [(pushToken: Data?, appUserID: String)]()
 
-    override func setPushToken(_ pushToken: String?, appUserID: String) {
+    override func setPushToken(_ pushToken: Data?, appUserID: String) {
         invokedSetPushToken = true
         invokedSetPushTokenCount += 1
         invokedSetPushTokenParameters = (pushToken, appUserID)

--- a/PurchasesTests/NSData+RCExtensionsTests.swift
+++ b/PurchasesTests/NSData+RCExtensionsTests.swift
@@ -1,0 +1,29 @@
+//
+// Created by RevenueCat on 3/4/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+import Nimble
+import XCTest
+
+import Purchases
+
+class NSDataExtensionsTests: XCTestCase {
+
+    func testAsString() {
+        let data = Data([
+            0xe3, 0x88, 0x15, 0x2d,
+            0x6c, 0x67, 0xf4, 0xd5,
+            0xf7, 0xa7, 0x8e, 0xdf,
+            0x07, 0x39, 0x46, 0xf1,
+            0x58, 0x35, 0x7f, 0x89,
+            0xa1, 0xdc, 0x74, 0xdf,
+            0xf8, 0x0a, 0x79, 0x67,
+            0x40, 0xfd, 0x9d, 0x91
+        ])
+
+        let nsData = data as NSData
+
+        expect(nsData.asString()) == "e388152d6c67f4d5f7a78edf073946f158357f89a1dc74dff80a796740fd9d91"
+    }
+}

--- a/PurchasesTests/PurchasesTests-Bridging-Header.h
+++ b/PurchasesTests/PurchasesTests-Bridging-Header.h
@@ -36,3 +36,4 @@
 #include <Purchases/NSDate+RCExtensions.h>
 #include <Purchases/RCSubscriberAttributesManager.h>
 #include <Purchases/RCPurchases+SubscriberAttributes.h>
+#include <Purchases/NSData+RCExtensions.h>

--- a/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -158,10 +158,15 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
 
     func testSetPushTokenMakesRightCalls() {
         setupPurchases()
+        let tokenData = Data("ligai32g32ig".data(using: .utf8)!)
+        let tokenString = (tokenData as NSData).dataAsString()
 
-        Purchases.shared.setPushToken("asdf45asdg35asd5")
+        Purchases.shared.setPushToken(tokenData)
         expect(self.mockSubscriberAttributesManager.invokedSetPushTokenCount) == 1
-        expect(self.mockSubscriberAttributesManager.invokedSetPushTokenParameters?.pushToken) == "asdf45asdg35asd5"
+
+        let receivedPushToken = self.mockSubscriberAttributesManager.invokedSetPushTokenParameters!.pushToken!
+
+        expect((receivedPushToken as NSData).dataAsString()) == tokenString
         expect(self.mockSubscriberAttributesManager.invokedSetPushTokenParameters?.appUserID) == mockIdentityManager
             .currentAppUserID
     }

--- a/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -159,14 +159,14 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
     func testSetPushTokenMakesRightCalls() {
         setupPurchases()
         let tokenData = Data("ligai32g32ig".data(using: .utf8)!)
-        let tokenString = (tokenData as NSData).dataAsString()
+        let tokenString = (tokenData as NSData).asString()
 
         Purchases.shared.setPushToken(tokenData)
         expect(self.mockSubscriberAttributesManager.invokedSetPushTokenCount) == 1
 
         let receivedPushToken = self.mockSubscriberAttributesManager.invokedSetPushTokenParameters!.pushToken!
 
-        expect((receivedPushToken as NSData).dataAsString()) == tokenString
+        expect((receivedPushToken as NSData).asString()) == tokenString
         expect(self.mockSubscriberAttributesManager.invokedSetPushTokenParameters?.appUserID) == mockIdentityManager
             .currentAppUserID
     }

--- a/PurchasesTests/SubscriberAttributes/SusbcriberAttributesManagerTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SusbcriberAttributesManagerTests.swift
@@ -286,7 +286,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
         let receivedAttribute = invokedParams.attribute
         expect(receivedAttribute.key) == "$apnsTokens"
 
-        let tokenString = (tokenData as NSData).dataAsString()
+        let tokenString = (tokenData as NSData).asString()
         expect(receivedAttribute.value) == tokenString
         expect(receivedAttribute.isSynced) == false
     }
@@ -309,7 +309,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
 
     func testSetPushTokenSkipsIfSameValue() {
         let tokenData = "ligai32g32ig".data(using: .utf8)!
-        let tokenString = (tokenData as NSData).dataAsString()
+        let tokenString = (tokenData as NSData).asString()
         self.mockDeviceCache.stubbedSubscriberAttributeResult = RCSubscriberAttribute(key: "$apnsTokens",
                                                                                       value: tokenString)
 
@@ -320,7 +320,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
 
     func testSetPushTokenOverwritesIfNewValue() {
         let tokenData = "ligai32g32ig".data(using: .utf8)!
-        let tokenString = (tokenData as NSData).dataAsString()
+        let tokenString = (tokenData as NSData).asString()
         let oldSyncTime = Date()
 
         self.mockDeviceCache.stubbedSubscriberAttributeResult = RCSubscriberAttribute(key: "$apnsTokens",

--- a/PurchasesTests/SubscriberAttributes/SusbcriberAttributesManagerTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SusbcriberAttributesManagerTests.swift
@@ -276,7 +276,8 @@ class SubscriberAttributesManagerTests: XCTestCase {
     }
 
     func testSetPushToken() {
-        self.subscriberAttributesManager.setPushToken("laisbawba2332g", appUserID: "kratos")
+        let tokenData = "ligai32g32ig".data(using: .utf8)!
+        self.subscriberAttributesManager.setPushToken(tokenData, appUserID: "kratos")
 
         expect(self.mockDeviceCache.invokedStoreCount) == 1
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
@@ -284,12 +285,15 @@ class SubscriberAttributesManagerTests: XCTestCase {
         }
         let receivedAttribute = invokedParams.attribute
         expect(receivedAttribute.key) == "$apnsTokens"
-        expect(receivedAttribute.value) == "laisbawba2332g"
+
+        let tokenString = (tokenData as NSData).dataAsString()
+        expect(receivedAttribute.value) == tokenString
         expect(receivedAttribute.isSynced) == false
     }
 
     func testSetPushTokenSetsEmptyIfNil() {
-        self.subscriberAttributesManager.setPushToken("laisbawba2332g", appUserID: "kratos")
+        let tokenData = "ligai32g32ig".data(using: .utf8)!
+        self.subscriberAttributesManager.setPushToken(tokenData, appUserID: "kratos")
 
         self.subscriberAttributesManager.setPushToken(nil, appUserID: "kratos")
 
@@ -304,22 +308,27 @@ class SubscriberAttributesManagerTests: XCTestCase {
     }
 
     func testSetPushTokenSkipsIfSameValue() {
+        let tokenData = "ligai32g32ig".data(using: .utf8)!
+        let tokenString = (tokenData as NSData).dataAsString()
         self.mockDeviceCache.stubbedSubscriberAttributeResult = RCSubscriberAttribute(key: "$apnsTokens",
-                                                                                      value: "laisbawba2332g")
+                                                                                      value: tokenString)
 
-        self.subscriberAttributesManager.setPushToken("laisbawba2332g", appUserID: "kratos")
+        self.subscriberAttributesManager.setPushToken(tokenData, appUserID: "kratos")
 
         expect(self.mockDeviceCache.invokedStoreCount) == 0
     }
 
     func testSetPushTokenOverwritesIfNewValue() {
+        let tokenData = "ligai32g32ig".data(using: .utf8)!
+        let tokenString = (tokenData as NSData).dataAsString()
         let oldSyncTime = Date()
+
         self.mockDeviceCache.stubbedSubscriberAttributeResult = RCSubscriberAttribute(key: "$apnsTokens",
-                                                                                      value: "oagi3wg93wg",
+                                                                                      value: "other value",
                                                                                       isSynced: true,
                                                                                       setTime: oldSyncTime)
 
-        self.subscriberAttributesManager.setPushToken("8jb4g203g3jg2p3", appUserID: "kratos")
+        self.subscriberAttributesManager.setPushToken(tokenData, appUserID: "kratos")
 
         expect(self.mockDeviceCache.invokedStoreCount) == 1
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
@@ -327,7 +336,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
         }
         let receivedAttribute = invokedParams.attribute
         expect(receivedAttribute.key) == "$apnsTokens"
-        expect(receivedAttribute.value) == "8jb4g203g3jg2p3"
+        expect(receivedAttribute.value) == tokenString
         expect(receivedAttribute.isSynced) == false
         expect(receivedAttribute.setTime) > oldSyncTime
     }


### PR DESCRIPTION
Updated the `setPushToken` call to receive `NSData` instead of `NSString` to make it easier for developers to send us the value, since this way they won't have to do any form of conversion themselves. 

### Requirements
- [X] ~Part 4 #190~
