### PR TITLE
[final] subscriber attributes: log errors on post receipt

### DIFF
--- a/Purchases/NSData+RCExtensions.m
+++ b/Purchases/NSData+RCExtensions.m
@@ -8,13 +8,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 
-@interface NSData (RCExtensions)
-@end
-
-
-NS_ASSUME_NONNULL_END
-
-
 @implementation NSData (RCExtensions)
 
 - (NSString *)asString {
@@ -29,6 +22,8 @@ NS_ASSUME_NONNULL_END
     }];
     return deviceTokenString;
 }
+
+NS_ASSUME_NONNULL_END
 
 
 @end

--- a/Purchases/NSError+RCExtensions.h
+++ b/Purchases/NSError+RCExtensions.h
@@ -11,6 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface NSError (RCExtensions)
 
 - (BOOL)successfullySynced;
+- (nullable NSDictionary *)subscriberAttributesErrors;
 
 @end
 

--- a/Purchases/NSError+RCExtensions.m
+++ b/Purchases/NSError+RCExtensions.m
@@ -26,6 +26,10 @@ NS_ASSUME_NONNULL_BEGIN
     return successfullySyncedNumber.boolValue;
 }
 
+- (nullable NSDictionary *)subscriberAttributesErrors {
+    return self.userInfo[RCAttributeErrorsKey];
+}
+
 @end
 
 

--- a/Purchases/RCBackend.h
+++ b/Purchases/RCBackend.h
@@ -24,6 +24,7 @@ typedef NS_ENUM(NSInteger, RCPaymentMode) {
 };
 
 extern NSErrorUserInfoKey const RCSuccessfullySyncedKey;
+extern NSString * const RCAttributeErrorsKey;
 
 API_AVAILABLE(ios(11.2), macos(10.13.2))
 RCPaymentMode RCPaymentModeFromSKProductDiscountPaymentMode(SKProductDiscountPaymentMode paymentMode);

--- a/Purchases/RCBackend.h
+++ b/Purchases/RCBackend.h
@@ -25,6 +25,7 @@ typedef NS_ENUM(NSInteger, RCPaymentMode) {
 
 extern NSErrorUserInfoKey const RCSuccessfullySyncedKey;
 extern NSString * const RCAttributeErrorsKey;
+extern NSString * const RCAttributeErrorsResponseKey;
 
 API_AVAILABLE(ios(11.2), macos(10.13.2))
 RCPaymentMode RCPaymentModeFromSKProductDiscountPaymentMode(SKProductDiscountPaymentMode paymentMode);

--- a/Purchases/RCBackend.m
+++ b/Purchases/RCBackend.m
@@ -20,7 +20,7 @@
 #define RC_HAS_KEY(dictionary, key) (dictionary[key] == nil || dictionary[key] != [NSNull null])
 NSErrorUserInfoKey const RCSuccessfullySyncedKey = @"successfullySynced";
 NSString *const RCAttributeErrorsKey = @"attribute_errors";
-NSString *const RCAttributeErrorsResponseKey = @"attribute_errors_response";
+NSString *const RCAttributeErrorsResponseKey = @"attributes_error_response";
 
 API_AVAILABLE(ios(11.2), macos(10.13.2))
 RCPaymentMode RCPaymentModeFromSKProductDiscountPaymentMode(SKProductDiscountPaymentMode paymentMode)
@@ -101,7 +101,7 @@ RCPaymentMode RCPaymentModeFromSKProductDiscountPaymentMode(SKProductDiscountPay
     NSDictionary *subscriberAttributesErrorInfo = [self attributesUserInfoFromResponse:response
                                                                             statusCode:statusCode];
 
-    BOOL hasError = (isErrorStatusCode || subscriberAttributesErrorInfo != nil);
+    BOOL hasError = (isErrorStatusCode || subscriberAttributesErrorInfo.count > 0);
 
     if (hasError) {
         BOOL finishable = (statusCode < 500);
@@ -544,9 +544,6 @@ presentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 - (NSDictionary *)attributesUserInfoFromResponse:(NSDictionary *)response statusCode:(NSInteger)statusCode {
     NSMutableDictionary *resultDict = [[NSMutableDictionary alloc] init];
 
-    BOOL isInternalServerError = statusCode >= 300 && statusCode >= 500;
-    resultDict[RCSuccessfullySyncedKey] = @(!isInternalServerError);
-
     BOOL hasAttributesResponseContainerKey = (response[RCAttributeErrorsResponseKey] != nil);
     NSDictionary *attributesResponseDict = hasAttributesResponseContainerKey
                                            ? response[RCAttributeErrorsResponseKey]
@@ -555,6 +552,9 @@ presentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
     BOOL hasAttributeErrors = (attributesResponseDict[RCAttributeErrorsKey] != nil);
     if (hasAttributeErrors) {
         resultDict[RCAttributeErrorsKey] = attributesResponseDict[RCAttributeErrorsKey];
+
+        BOOL isInternalServerError = statusCode >= 300 && statusCode >= 500;
+        resultDict[RCSuccessfullySyncedKey] = @(!isInternalServerError);
     }
     return resultDict;
 }

--- a/Purchases/RCBackend.m
+++ b/Purchases/RCBackend.m
@@ -101,7 +101,7 @@ RCPaymentMode RCPaymentModeFromSKProductDiscountPaymentMode(SKProductDiscountPay
     NSDictionary *subscriberAttributesErrorInfo = [self attributesUserInfoFromResponse:response
                                                                             statusCode:statusCode];
 
-    BOOL hasError = (isErrorStatusCode || subscriberAttributesErrorInfo.count > 0);
+    BOOL hasError = (isErrorStatusCode || subscriberAttributesErrorInfo[RCAttributeErrorsKey] != nil);
 
     if (hasError) {
         BOOL finishable = (statusCode < 500);

--- a/Purchases/RCBackend.m
+++ b/Purchases/RCBackend.m
@@ -19,7 +19,9 @@
 
 #define RC_HAS_KEY(dictionary, key) (dictionary[key] == nil || dictionary[key] != [NSNull null])
 NSErrorUserInfoKey const RCSuccessfullySyncedKey = @"successfullySynced";
-NSString * const RCAttributeErrorsKey = @"attribute_errors";
+NSString *const RCAttributeErrorsKey = @"attribute_errors";
+NSString *const RCAttributeErrorsResponseKey = @"attribute_errors_response";
+
 API_AVAILABLE(ios(11.2), macos(10.13.2))
 RCPaymentMode RCPaymentModeFromSKProductDiscountPaymentMode(SKProductDiscountPaymentMode paymentMode)
 {
@@ -538,8 +540,14 @@ presentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
     BOOL isInternalServerError = statusCode >= 500;
     resultDict[RCSuccessfullySyncedKey] = @(!isInternalServerError);
 
-    if (response[RCAttributeErrorsKey] != nil) {
-        resultDict[RCAttributeErrorsKey] = response[RCAttributeErrorsKey];
+    BOOL hasAttributesResponseContainerKey = (response[RCAttributeErrorsResponseKey] != nil);
+    NSDictionary *attributesResponseDict = hasAttributesResponseContainerKey
+                                           ? response[RCAttributeErrorsResponseKey]
+                                           : response;
+
+    BOOL hasAttributeErrors = (attributesResponseDict[RCAttributeErrorsKey] != nil);
+    if (hasAttributeErrors) {
+        resultDict[RCAttributeErrorsKey] = attributesResponseDict[RCAttributeErrorsKey];
     }
     return resultDict;
 }

--- a/Purchases/RCBackend.m
+++ b/Purchases/RCBackend.m
@@ -543,6 +543,8 @@ presentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 
 - (NSDictionary *)attributesUserInfoFromResponse:(NSDictionary *)response statusCode:(NSInteger)statusCode {
     NSMutableDictionary *resultDict = [[NSMutableDictionary alloc] init];
+    BOOL isInternalServerError = statusCode >= 500;
+    resultDict[RCSuccessfullySyncedKey] = @(!isInternalServerError);
 
     BOOL hasAttributesResponseContainerKey = (response[RCAttributeErrorsResponseKey] != nil);
     NSDictionary *attributesResponseDict = hasAttributesResponseContainerKey
@@ -552,9 +554,6 @@ presentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
     BOOL hasAttributeErrors = (attributesResponseDict[RCAttributeErrorsKey] != nil);
     if (hasAttributeErrors) {
         resultDict[RCAttributeErrorsKey] = attributesResponseDict[RCAttributeErrorsKey];
-
-        BOOL isInternalServerError = statusCode >= 300 && statusCode >= 500;
-        resultDict[RCSuccessfullySyncedKey] = @(!isInternalServerError);
     }
     return resultDict;
 }

--- a/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.h
+++ b/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.h
@@ -22,8 +22,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)configureSubscriberAttributesManager;
 - (RCSubscriberAttributeDict)unsyncedAttributesByKey;
-- (void)markAttributesAsSynced:(RCSubscriberAttributeDict)syncedAttributes
-                     appUserID:(NSString *)appUserID;
+- (void)markAttributesAsSyncedIfNeeded:(RCSubscriberAttributeDict)syncedAttributes
+                             appUserID:(NSString *)appUserID
+                                 error:(nullable NSError *)error;
 @end
 
 @interface RCPurchases ()

--- a/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.m
+++ b/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.m
@@ -8,6 +8,7 @@
 #import "RCSubscriberAttributesManager.h"
 #import "RCCrossPlatformSupport.h"
 #import "RCUtils.h"
+#import "NSError+RCExtensions.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -50,8 +51,16 @@ NS_ASSUME_NONNULL_BEGIN
     return [self.subscriberAttributesManager unsyncedAttributesByKeyForAppUserID:self.appUserID];
 }
 
-- (void)markAttributesAsSynced:(RCSubscriberAttributeDict)syncedAttributes
-                     appUserID:(NSString *)appUserID {
+- (void)markAttributesAsSyncedIfNeeded:(RCSubscriberAttributeDict)syncedAttributes
+                             appUserID:(NSString *)appUserID
+                                 error:(nullable NSError *)error {
+    if (error && !error.successfullySynced) {
+        return;
+    }
+
+    if (error.subscriberAttributesErrors) {
+        RCLog(@"Subscriber attributes errors: %@", error.subscriberAttributesErrors);
+    }
     [self.subscriberAttributesManager markAttributesAsSynced:syncedAttributes appUserID:appUserID];
 }
 

--- a/PurchasesTests/NSError+RCExtensionsTests.swift
+++ b/PurchasesTests/NSError+RCExtensionsTests.swift
@@ -34,4 +34,21 @@ class NSErrorRCExtensionsTests: XCTestCase {
         let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [RCSuccessfullySyncedKey: true])
         expect(error.successfullySynced()) == true
     }
+
+    func testSubscriberAttributesErrorsNilIfNoAttributesErrors() {
+        let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
+        let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [RCSuccessfullySyncedKey: true])
+        expect(error.subscriberAttributesErrors()).to(beNil())
+    }
+
+    func testSubscriberAttributesErrorsReturnsAttributesErrorsInUserInfo() {
+        let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
+        let attributeErrors = ["$phoneNumber": "phone number is in invalid format",
+                               "$email": "email is too long"]
+        let error = NSError(domain: Purchases.ErrorDomain,
+                            code: errorCode,
+                            userInfo: [RCAttributeErrorsKey: attributeErrors])
+        expect(error.subscriberAttributesErrors()).toNot(beNil())
+        expect(error.subscriberAttributesErrors() as? [String: String]) == attributeErrors
+    }
 }

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -141,8 +141,8 @@ class BackendSubscriberAttributesTests: XCTestCase {
         let receivedNSError = receivedError! as NSError
         expect(receivedNSError.code) == Purchases.ErrorCode.unknownBackendError.rawValue
         expect(receivedNSError.successfullySynced()) == false
-        expect(receivedNSError.userInfo["successfullySynced"]).toNot(beNil())
-        expect((receivedNSError.userInfo["successfullySynced"] as! NSNumber).boolValue) == false
+        expect(receivedNSError.userInfo[RCSuccessfullySyncedKey]).toNot(beNil())
+        expect((receivedNSError.userInfo[RCSuccessfullySyncedKey] as! NSNumber).boolValue) == false
     }
 
     func testPostSubscriberAttributesSendsAttributesErrorsIfAny() {
@@ -204,8 +204,8 @@ class BackendSubscriberAttributesTests: XCTestCase {
         let receivedNSError = receivedError! as NSError
         expect(receivedNSError.code) == Purchases.ErrorCode.unknownBackendError.rawValue
         expect(receivedNSError.successfullySynced()) == true
-        expect(receivedNSError.userInfo["successfullySynced"]).toNot(beNil())
-        expect((receivedNSError.userInfo["successfullySynced"] as! NSNumber).boolValue) == true
+        expect(receivedNSError.userInfo[RCSuccessfullySyncedKey]).toNot(beNil())
+        expect((receivedNSError.userInfo[RCSuccessfullySyncedKey] as! NSNumber).boolValue) == true
     }
 
     func testPostSubscriberAttributesNoOpIfAttributesAreEmpty() {

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -150,7 +150,7 @@ class BackendSubscriberAttributesTests: XCTestCase {
         mockHTTPClient.shouldInvokeCompletion = true
         mockHTTPClient.stubbedCompletionStatusCode = 503
         mockHTTPClient.stubbedCompletionError = nil
-        let attributeErrors = ["attribute_errors": ["some_attribute": "wasn't valid"]]
+        let attributeErrors = [RCAttributeErrorsKey: ["some_attribute": "wasn't valid"]]
         mockHTTPClient.stubbedCompletionResponse = attributeErrors
 
         var receivedError: Error? = nil
@@ -171,9 +171,9 @@ class BackendSubscriberAttributesTests: XCTestCase {
 
         let receivedNSError = receivedError! as NSError
         expect(receivedNSError.code) == Purchases.ErrorCode.unknownBackendError.rawValue
-        expect(receivedNSError.userInfo["attribute_errors"]).toNot(beNil())
+        expect(receivedNSError.userInfo[RCAttributeErrorsKey]).toNot(beNil())
 
-        guard let receivedAttributeErrors = receivedNSError.userInfo["attribute_errors"] as? [String: String] else {
+        guard let receivedAttributeErrors = receivedNSError.userInfo[RCAttributeErrorsKey] as? [String: String] else {
             fatalError("received attribute errors are not of type [String: String]")
         }
         expect(receivedAttributeErrors) == ["some_attribute": "wasn't valid"]

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -302,10 +302,13 @@ class BackendSubscriberAttributesTests: XCTestCase {
         var completionCallCount = 0
 
         self.mockHTTPClient.stubbedCompletionStatusCode = 400
-        let attributesErrors = [
+        let attributeErrors = [
             RCAttributeErrorsKey: ["$email": "email is not in valid format"]
         ]
-        self.mockHTTPClient.stubbedCompletionResponse = attributesErrors
+        let attributesErrorsResponse = [
+            RCAttributeErrorsResponseKey: attributeErrors
+        ]
+        self.mockHTTPClient.stubbedCompletionResponse = attributesErrorsResponse
 
         let subscriberAttributesByKey: [String: RCSubscriberAttribute] = [
             subscriberAttribute1.key: subscriberAttribute1,
@@ -336,6 +339,6 @@ class BackendSubscriberAttributesTests: XCTestCase {
         guard let nonNilReceivedError = receivedError else { fatalError() }
         expect(nonNilReceivedError.successfullySynced()) == true
         expect(nonNilReceivedError.subscriberAttributesErrors() as? [String: String])
-            == attributesErrors[RCAttributeErrorsKey]
+            == attributeErrors[RCAttributeErrorsKey]
     }
 }

--- a/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -30,7 +30,6 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
 
     var purchases: Purchases!
 
-
     override func setUp() {
         self.userDefaults = UserDefaults(suiteName: "TestDefaults")
         self.subscriberAttributeHeight = RCSubscriberAttribute(key: "height",
@@ -198,7 +197,7 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
             .currentAppUserID
     }
 
-    func testPostReceiptMarksSubscriberAttributesSyncedIfBackendErrorIsFinishable() {
+    func testPostReceiptMarksSubscriberAttributesSyncedIfBackendSuccessfullySynced() {
         setupPurchases()
         let product = MockProduct(mockProductIdentifier: "com.product.id1")
         self.purchases?.purchaseProduct(product) { (tx, info, error, userCancelled) in }
@@ -211,9 +210,10 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
         self.mockStoreKitWrapper.delegate?.storeKitWrapper(self.mockStoreKitWrapper, updatedTransaction: transaction)
 
         let errorCode = Purchases.RevenueCatBackendErrorCode.invalidAPIKey.rawValue as NSNumber
+        let extraUserInfo = [RCSuccessfullySyncedKey: true]
         self.mockBackend.stubbedPostReceiptPurchaserError = Purchases.ErrorUtils.backendError(withBackendCode: errorCode,
                                                                                               backendMessage: "Invalid credentials",
-                                                                                              finishable: true)
+                                                                                              extraUserInfo: extraUserInfo)
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.mockStoreKitWrapper.delegate?.storeKitWrapper(self.mockStoreKitWrapper, updatedTransaction: transaction)
@@ -225,7 +225,7 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
             .currentAppUserID
     }
 
-    func testPostReceiptDoesntMarkSubscriberAttributesSyncedIfBackendErrorIsNotFinishable() {
+    func testPostReceiptDoesntMarkSubscriberAttributesSyncedIfBackendNotSuccessfullySynced() {
         setupPurchases()
         let product = MockProduct(mockProductIdentifier: "com.product.id1")
         self.purchases?.purchaseProduct(product) { (tx, info, error, userCancelled) in }
@@ -238,9 +238,10 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
         self.mockStoreKitWrapper.delegate?.storeKitWrapper(self.mockStoreKitWrapper, updatedTransaction: transaction)
 
         let errorCode = Purchases.RevenueCatBackendErrorCode.invalidAPIKey.rawValue as NSNumber
+        let extraUserInfo = [RCSuccessfullySyncedKey: false]
         self.mockBackend.stubbedPostReceiptPurchaserError = Purchases.ErrorUtils.backendError(withBackendCode: errorCode,
                                                                                               backendMessage: "Invalid credentials",
-                                                                                              finishable: false)
+                                                                                              extraUserInfo: extraUserInfo)
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.mockStoreKitWrapper.delegate?.storeKitWrapper(self.mockStoreKitWrapper, updatedTransaction: transaction)


### PR DESCRIPTION
Follow-up to comment in Part 4, @vegaro correctly pointed out that we're not printing out attributes errors on post receipt. 

https://github.com/RevenueCat/purchases-ios/pull/190#discussion_r389219164

This unifies the logic for attributes errors for post receipt and post subscriber attributes, and adds logging of the errors in the post receipt case. 