### PR TITLE
[final] fix subscriber attributes error codes

### DIFF
--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -121,6 +121,10 @@ static NSString *const RCPurchasesErrorCodeString(RCPurchasesErrorCode code) {
             return @"INVALID_APPLE_SUBSCRIPTION_KEY";
         case RCIneligibleError:
             return @"INELIGIBLE_ERROR";
+        case RCInsufficientPermissionsError:
+            return @"INSUFFICIENT_PERMISSIONS_ERROR";
+        case RCPaymentPendingError:
+            return @"payment_pending_error";
         case RCInvalidSubscriberAttributesError:
             return @"INVALID_SUBSCRIBER_ATTRIBUTES";
     }
@@ -155,6 +159,7 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromRCBackendErrorCode(RCBackend
         case RCBackendUserIneligibleForPromoOffer:
             return RCIneligibleError;
         case RCBackendInvalidSubscriberAttributes:
+        case RCBackendInvalidSubscriberAttributesBody:
             return RCInvalidSubscriberAttributesError;
     }
     return RCUnknownError;

--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -124,7 +124,7 @@ static NSString *const RCPurchasesErrorCodeString(RCPurchasesErrorCode code) {
         case RCInsufficientPermissionsError:
             return @"INSUFFICIENT_PERMISSIONS_ERROR";
         case RCPaymentPendingError:
-            return @"payment_pending_error";
+            return @"PAYMENT_PENDING_ERROR";
         case RCInvalidSubscriberAttributesError:
             return @"INVALID_SUBSCRIBER_ATTRIBUTES";
     }

--- a/Purchases/Public/RCPurchasesErrors.h
+++ b/Purchases/Public/RCPurchasesErrors.h
@@ -75,7 +75,8 @@ typedef NS_ENUM(NSInteger, RCBackendErrorCode) {
     RCBackendPlayStoreGenericError = 7231,
     RCBackendUserIneligibleForPromoOffer = 7232,
     RCBackendInvalidAppleSubscriptionKey = 7234,
-    RCBackendInvalidSubscriberAttributes = 7262
+    RCBackendInvalidSubscriberAttributes = 7263,
+    RCBackendInvalidSubscriberAttributesBody = 7264
 } NS_SWIFT_NAME(Purchases.RevenueCatBackendErrorCode);
 
 @end


### PR DESCRIPTION
* updated invalid subscriber attributes error code: 7262 -> 7263
* added invalid subscriber attributes request body error code: 7264
* added a couple of error codes cases missing from a switch statement

✅  tested and working with a local khepri instance, forcing the error codes to appear on every request for test purposes. 