### PR TITLE
[final] Fix: completion called twice for get purchaser info

### DIFF
--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -428,7 +428,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
         CALL_IF_SET_ON_MAIN_THREAD(completion, infoFromCache, nil);
         if ([self.deviceCache isPurchaserInfoCacheStale]) {
             RCDebugLog(@"Cache is stale, updating caches");
-            [self fetchAndCachePurchaserInfoWithCompletion:completion];
+            [self fetchAndCachePurchaserInfoWithCompletion:nil];
         }
     } else {
         RCDebugLog(@"No cached purchaser info, fetching");

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -1155,6 +1155,28 @@ class PurchasesTests: XCTestCase {
         expect(receivedInfo).toNot(beNil())
     }
 
+    func testPurchaserInfoCompletionBlockCalledExactlyOnceWhenInfoCached() {
+        let info = Purchases.PurchaserInfo(data: [
+            "subscriber": [
+                "subscriptions": [:],
+                "other_purchases": [:]
+            ]]);
+        let object = try! JSONSerialization.data(withJSONObject: info!.jsonObject(), options: []);
+        self.deviceCache.cachedPurchaserInfo[identityManager.currentAppUserID] = object
+        self.deviceCache.stubbedIsPurchaserInfoCacheStale = true
+        self.backend.timeout = false
+
+        setupPurchases()
+
+        var callCount = 0
+
+        purchases!.purchaserInfo { (_, _) in
+            callCount += 1
+        }
+
+        expect(callCount).toEventually(equal(1))
+    }
+
     func testDoesntSendsCachedPurchaserInfoToGetterIfSchemaVersionDiffers() {
         let info = Purchases.PurchaserInfo(data: [
             "subscriber": [


### PR DESCRIPTION
The completion block for `purchaserInfoWithCompletionBlock` could be called more than once in the case where there was cached information, but it was outdated. 
This PR ensures that it gets called only once. 