### PR TITLE
[final] fix: release script and docs

### DIFF
--- a/Examples/SwiftExample/SwiftExample/AppDelegate.swift
+++ b/Examples/SwiftExample/SwiftExample/AppDelegate.swift
@@ -26,7 +26,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Purchases.shared.setAttributes(["favorite_cat" : "garfield"])
 
         // we're requesting push notifications on app start only to showcase how to set the push token in RevenueCat
-        requestPushNotificationsPermisssions()
+        requestPushNotificationsPermissions()
 
         return true
     }
@@ -39,7 +39,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         print("Failed to register: \(error)")
     }
 
-    private func requestPushNotificationsPermisssions() {
+    private func requestPushNotificationsPermissions() {
         let userNotificationCenter = UNUserNotificationCenter.current()
         userNotificationCenter.requestAuthorization(options: [.alert, .sound, .badge]) { [weak self] granted, error in
             print("Permission granted: \(granted)")

--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -421,7 +421,7 @@ NS_SWIFT_NAME(restoreTransactions(_:));
 /**
  * Subscriber attribute associated with the push token for the user
  *
- *  @param pushToken Empty String or nil will delete the subscriber attribute.
+ *  @param pushToken nil will delete the subscriber attribute.
  */
 - (void)setPushToken:(nullable NSData *)pushToken;
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 </p>
 <h3 align="center">😻 In-app Subscriptions Made Easy 😻</h1>
 
-[![Version](https://img.shields.io/cocoapods/v/Purchases.svg?style=flat)](https://cocoapods.org/pods/Purchases)
 [![License](https://img.shields.io/cocoapods/l/Purchases.svg?style=flat)](http://cocoapods.org/pods/Purchases)
-[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+[![Version](https://img.shields.io/cocoapods/v/Purchases.svg?style=flat)](https://cocoapods.org/pods/Purchases)
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://docs.revenuecat.com/docs/ios#section-install-via-carthage)
+[![SwiftPM compatible](https://img.shields.io/badge/SwiftPM-compatible-orange.svg)](https://docs.revenuecat.com/docs/ios#section-install-via-swift-package-manager)
 
 ## Purchases.framework
 

--- a/bin/release_version.sh
+++ b/bin/release_version.sh
@@ -52,7 +52,7 @@ FRAMEWORK_NAME=Purchases.framework
 
 mv $FRAMEWORK_NAME.zip $CARTHAGE_UPLOADS_PATH
 
-fastlane github_release $CURRENT_VERSION
+fastlane ios github_release version:$CURRENT_VERSION
 
 echo "Preparing next version"
 


### PR DESCRIPTION
Small fixes: 
- the release script was referencing a fastlane lane that was under the group `ios`, so it needs to be called with `ios` first
- the docs for `setPushToken` in `RCPurchases.m` say to pass an empty string or nil to erase data, however since the param is of type NSData, you can't pass in an empty string. 