### PR TITLE
[final] Version 3.1.1

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -5,9 +5,9 @@ objc: true
 sdk: iphonesimulator
 module: Purchases
 umbrella_header: Purchases/Public/Purchases.h
-module_version: 3.2.0-SNAPSHOT
+module_version: 3.1.1
 github_url: https://github.com/revenuecat/purchases-ios
-github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.2.0-SNAPSHOT
+github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.1.1
 output: docs
 # Leaving this commented out. We used to specify this before, but now it's working without it
 # xcodebuild_arguments: [--objc,Purchases/Public/Purchases.h,--,-x,objective-c,-isysroot,$(xcrun --show-sdk-path),-I,$(pwd)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 3.1.1
+- small fixes to docs and release scripts: 
+    - the release script was referencing a fastlane lane that was under the group ios, 
+    so it needs to be called with ios first
+    - the docs for setPushToken in RCPurchases.m say to pass an empty string or nil to erase data, 
+    however since the param is of type NSData, you can't pass in an empty string.
+    
+    https://github.com/RevenueCat/purchases-ios/pull/203
 ## 3.1.0
 - Added Subscriber Attributes, which allow developers to store additional, structured information 
 for a user in RevenueCat. More info: // More info: https://docs.revenuecat.com/docs/user-attributes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     however since the param is of type NSData, you can't pass in an empty string.
     
     https://github.com/RevenueCat/purchases-ios/pull/203
+    
 ## 3.1.0
 - Added Subscriber Attributes, which allow developers to store additional, structured information 
 for a user in RevenueCat. More info: // More info: https://docs.revenuecat.com/docs/user-attributes.

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Purchases"
-  s.version          = "3.2.0-SNAPSHOT"
+  s.version          = "3.1.1"
   s.summary          = "Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/Purchases/Info.plist
+++ b/Purchases/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.0-SNAPSHOT</string>
+	<string>3.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -100,7 +100,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 }
 
 + (NSString *)frameworkVersion {
-    return @"3.2.0-SNAPSHOT";
+    return @"3.1.1";
 }
 
 + (instancetype)sharedPurchases {

--- a/PurchasesTests/Info.plist
+++ b/PurchasesTests/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.0-SNAPSHOT</string>
+	<string>3.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
## 3.1.1
- small fixes to docs and release scripts: 
    - the release script was referencing a fastlane lane that was under the group ios, 
    so it needs to be called with ios first
    - the docs for setPushToken in RCPurchases.m say to pass an empty string or nil to erase data, 
    however since the param is of type NSData, you can't pass in an empty string.
    
    https://github.com/RevenueCat/purchases-ios/pull/203