### PR TITLE
[final] setPushTokenString

### DIFF
--- a/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.h
+++ b/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.h
@@ -19,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)_setPhoneNumber:(nullable NSString *)phoneNumber;
 - (void)_setDisplayName:(nullable NSString *)displayName;
 - (void)_setPushToken:(nullable NSData *)pushToken;
+- (void)_setPushTokenString:(nullable NSString *)pushToken;
 
 - (void)configureSubscriberAttributesManager;
 - (RCSubscriberAttributeDict)unsyncedAttributesByKey;

--- a/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.m
+++ b/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.m
@@ -42,6 +42,11 @@ NS_ASSUME_NONNULL_BEGIN
     [self.subscriberAttributesManager setPushToken:pushToken appUserID:self.appUserID];
 }
 
+- (void)_setPushTokenString:(nullable NSString *)pushToken {
+    RCDebugLog(@"setPushTokenString called");
+    [self.subscriberAttributesManager setPushTokenString:pushToken appUserID:self.appUserID];
+}
+
 - (void)configureSubscriberAttributesManager {
     [self subscribeToAppDidBecomeActiveNotifications];
     [self subscribeToAppBackgroundedNotifications];

--- a/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.h
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.h
@@ -28,6 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setPushToken:(nullable NSData *)pushToken appUserID:(NSString *)appUserID;
 
+- (void)setPushTokenString:(nullable NSString *)pushToken appUserID:(NSString *)appUserID;
+
 - (void)syncIfNeededWithAppUserID:(NSString *)appUserID completion:(void (^)(NSError *_Nullable error))completion;
 
 - (RCSubscriberAttributeDict)unsyncedAttributesByKeyForAppUserID:(NSString *)appUserID;

--- a/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
@@ -55,8 +55,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setPushToken:(nullable NSData *)pushToken appUserID:(NSString *)appUserID {
-    NSString *deviceTokenString = pushToken ? pushToken.asString : nil;
-    [self setAttributeWithKey:SPECIAL_ATTRIBUTE_PUSH_TOKEN value:deviceTokenString appUserID:appUserID];
+    NSString *pushTokenString = pushToken ? pushToken.asString : nil;
+    [self setPushTokenString:pushTokenString appUserID:appUserID];
+}
+
+- (void)setPushTokenString:(nullable NSString *)pushTokenString appUserID:(NSString *)appUserID {
+    [self setAttributeWithKey:SPECIAL_ATTRIBUTE_PUSH_TOKEN value:pushTokenString appUserID:appUserID];
 }
 
 - (void)syncIfNeededWithAppUserID:(NSString *)appUserID completion:(void (^)(NSError *_Nullable error))completion {

--- a/PurchasesTests/Mocks/MockSubscriberAttributesManager.swift
+++ b/PurchasesTests/Mocks/MockSubscriberAttributesManager.swift
@@ -65,6 +65,18 @@ class MockSubscriberAttributesManager: RCSubscriberAttributesManager {
         invokedSetPushTokenParametersList.append((pushToken, appUserID))
     }
 
+    var invokedSetPushTokenString = false
+    var invokedSetPushTokenStringCount = 0
+    var invokedSetPushTokenStringParameters: (pushToken: String?, appUserID: String?)?
+    var invokedSetPushTokenStringParametersList = [(pushToken: String?, appUserID: String?)]()
+
+    override func setPushTokenString(_ pushToken: String?, appUserID: String?) {
+        invokedSetPushTokenString = true
+        invokedSetPushTokenStringCount += 1
+        invokedSetPushTokenStringParameters = (pushToken, appUserID)
+        invokedSetPushTokenStringParametersList.append((pushToken, appUserID))
+    }
+
     var invokedSyncIfNeeded = false
     var invokedSyncIfNeededCount = 0
     var invokedSyncIfNeededParameters: (appUserID: String, Void)?

--- a/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -170,6 +170,20 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
             .currentAppUserID
     }
 
+    func testSetPushTokenStringMakesRightCalls() {
+        setupPurchases()
+        let tokenString = "ligai32g32ig"
+
+        Purchases.shared._setPushTokenString(tokenString)
+        expect(self.mockSubscriberAttributesManager.invokedSetPushTokenStringCount) == 1
+
+        let receivedPushToken = self.mockSubscriberAttributesManager.invokedSetPushTokenStringParameters!.pushToken!
+
+        expect(receivedPushToken) == tokenString
+        expect(self.mockSubscriberAttributesManager.invokedSetPushTokenStringParameters?.appUserID) ==
+            mockIdentityManager.currentAppUserID
+    }
+
     // MARK: Post receipt with attributes
 
     func testPostReceiptMarksSubscriberAttributesSyncedIfBackendSuccessful() {


### PR DESCRIPTION
SDKs like cordova don't have direct access to iOS push tokens. Instead, they go through libraries like [this one](https://github.com/phonegap/phonegap-plugin-push). Those libraries typically return the token as a string instead of the native `NSData *`. 

This PR adds an extra method, to be used by those libraries, so they can set push tokens. 
A follow-up PR on purchases-hybrid-common will expose the calls to the common repo, so the new method can be used solely by those SDKs, to avoid confusion. 