### PR TITLE
[final] fix build warnings on tvOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   runtest:
     macos:
-      xcode: "10.2.0"
+      xcode: "11.4"
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
     steps:
@@ -23,7 +23,7 @@ jobs:
           destination: test_report.html
   docs-deploy:
     macos:
-      xcode: "10.2.0"
+      xcode: "11.4"
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   runtest:
     macos:
-      xcode: "11.4"
+      xcode: "11.4.0"
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
     steps:
@@ -23,7 +23,7 @@ jobs:
           destination: test_report.html
   docs-deploy:
     macos:
-      xcode: "11.4"
+      xcode: "11.4.0"
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
     steps:

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -115,8 +115,8 @@
 		37E35AD0B0D9EF0CDA29DAC2 /* MockStoreKitWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E351AC0FF9607719F7A29A /* MockStoreKitWrapper.swift */; };
 		37E35AE982974800FF079C14 /* RCSubscriberAttribute+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35C82A59C953A5F6017BB /* RCSubscriberAttribute+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E35AF213F2F79CB067FDC2 /* InMemoryCachedObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35E3250FBBB03D92E06EC /* InMemoryCachedObjectTests.swift */; };
-		37E35BCE176D557487A903CC /* NSDate+RCExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E358235BB58A968B059B6B /* NSDate+RCExtensions.m */; };
 		37E35B1F34D1624509012749 /* MockSubscriberAttributesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E351D48260D9DC8B1EE360 /* MockSubscriberAttributesManager.swift */; };
+		37E35BCE176D557487A903CC /* NSDate+RCExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E358235BB58A968B059B6B /* NSDate+RCExtensions.m */; };
 		37E35CCE215E9EABFB88F3BD /* NSData+RCExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E355C86ED87895B04E0E99 /* NSData+RCExtensions.m */; };
 		37E35D4498633E73BF02BAE7 /* RCDeviceCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E356820F0AD560FA23F3BF /* RCDeviceCache.m */; };
 		37E35DD380900220C34BB222 /* MockTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3550C031F1FD95B366998 /* MockTransaction.swift */; };
@@ -241,8 +241,8 @@
 		37E3524E3032ABC72467AA43 /* RCDeviceCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCDeviceCache.h; sourceTree = "<group>"; };
 		37E35292137BBF2810CE4F4B /* MockHTTPClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockHTTPClient.swift; sourceTree = "<group>"; };
 		37E352B11676F7DC51559E84 /* MockReceiptFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockReceiptFetcher.swift; sourceTree = "<group>"; };
-		37E3544C8038CB83310C3598 /* NSDate+RCExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDate+RCExtensionsTests.swift"; sourceTree = "<group>"; };
 		37E35326207CA74A0D5B00B8 /* NSData+RCExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSData+RCExtensionsTests.swift"; sourceTree = "<group>"; };
+		37E3544C8038CB83310C3598 /* NSDate+RCExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDate+RCExtensionsTests.swift"; sourceTree = "<group>"; };
 		37E35483531C5A5E6BF09BBD /* RCInMemoryCachedObject+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCInMemoryCachedObject+Protected.h"; sourceTree = "<group>"; };
 		37E354BEB8FDE39CAB7C4D69 /* MockDeviceCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDeviceCache.swift; sourceTree = "<group>"; };
 		37E3550459807FF5636B2667 /* NSError+RCExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSError+RCExtensionsTests.swift"; sourceTree = "<group>"; };
@@ -255,9 +255,9 @@
 		37E35645928A0009F4C105A7 /* MockBackend.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockBackend.swift; sourceTree = "<group>"; };
 		37E3567E972B9B04FE079ABA /* SusbcriberAttributesManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SusbcriberAttributesManagerTests.swift; sourceTree = "<group>"; };
 		37E356820F0AD560FA23F3BF /* RCDeviceCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCDeviceCache.m; sourceTree = "<group>"; };
+		37E356CA7C7188A8B6E2811A /* NSDate+RCExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDate+RCExtensions.h"; sourceTree = "<group>"; };
 		37E3571B552018D47A6ED7C6 /* MockUserManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockUserManager.swift; sourceTree = "<group>"; };
 		37E3572040A16F10B957563A /* MockProductDiscount.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockProductDiscount.swift; sourceTree = "<group>"; };
-		37E356CA7C7188A8B6E2811A /* NSDate+RCExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDate+RCExtensions.h"; sourceTree = "<group>"; };
 		37E3578BD602C7B8E2274279 /* MockDateProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDateProvider.swift; sourceTree = "<group>"; };
 		37E357D16038F07915D7825D /* MockUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockUserDefaults.swift; sourceTree = "<group>"; };
 		37E357F69438004E1F443C03 /* BackendSubscriberAttributesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackendSubscriberAttributesTests.swift; sourceTree = "<group>"; };
@@ -929,6 +929,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
 		};
@@ -957,6 +958,7 @@
 				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
 		};

--- a/Purchases/NSLocale+RCExtensions.m
+++ b/Purchases/NSLocale+RCExtensions.m
@@ -11,7 +11,7 @@
 @implementation NSLocale (RCExtensions)
 
 - (nullable NSString *)rc_currencyCode {
-    if(@available(iOS 10.0, *)) {
+    if(@available(iOS 10.0, macOS 10.12, tvos 10.0, macCatalyst 13.0, *)) {
         return self.currencyCode;
     } else {
         return [self objectForKey:NSLocaleCurrencyCode];

--- a/Purchases/Public/RCPackage.m
+++ b/Purchases/Public/RCPackage.m
@@ -66,7 +66,7 @@
 }
 
 - (NSString *)localizedIntroductoryPriceString {
-    if (@available(iOS 11.2, macOS 10.13.2, *)) {
+    if (@available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *)) {
         NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
         formatter.numberStyle = NSNumberFormatterCurrencyStyle;
         formatter.locale = self.product.priceLocale;

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -1027,7 +1027,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                                   RCPaymentMode paymentMode = RCPaymentModeNone;
                                   NSDecimalNumber *introPrice = nil;
 
-                                  if (@available(iOS 11.2, macOS 10.13.2, *)) {
+                                  if (@available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *)) {
                                       if (product.introductoryPrice) {
                                           paymentMode = RCPaymentModeFromSKProductDiscountPaymentMode(product.introductoryPrice.paymentMode);
                                           introPrice = product.introductoryPrice.price;
@@ -1035,12 +1035,12 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                                   }
 
                                   NSString *subscriptionGroup = nil;
-                                  if (@available(iOS 12.0, macOS 10.14.0, *)) {
+                                  if (@available(iOS 12.0, macOS 10.14.0, tvOS 12.0, *)) {
                                       subscriptionGroup = product.subscriptionGroupIdentifier;
                                   }
 
                                   NSMutableArray *discounts = nil;
-                                  if (@available(iOS 12.2, macOS 10.14.4, *)) {
+                                  if (@available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *)) {
                                       discounts = [NSMutableArray new];
                                       for (SKProductDiscount *discount in product.discounts) {
                                           [discounts addObject:[[RCPromotionalOffer alloc] initWithProductDiscount:discount]];

--- a/Purchases/RCBackend.m
+++ b/Purchases/RCBackend.m
@@ -210,7 +210,7 @@ presentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
                                                     @(observerMode),
                                                     subscriberAttributesByKey];
 
-    if (@available(iOS 12.2, macOS 10.14.4, *)) {
+    if (@available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *)) {
         for (RCPromotionalOffer *discount in discounts) {
             cacheKey = [NSString stringWithFormat:@"%@-%@", cacheKey, discount.offerIdentifier];
         }
@@ -249,7 +249,7 @@ presentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
         body[@"attributes"] = attributesInBackendFormat;
     }
 
-    if (@available(iOS 12.2, macOS 10.14.4, *)) {
+    if (@available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *)) {
         if (discounts) {
             NSMutableArray *offers = [NSMutableArray array];
             for (RCPromotionalOffer *discount in discounts) {

--- a/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
@@ -77,7 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma MARK - Private methods
 
-- (void)setAttributeWithKey:(nullable NSString *)key value:(NSString *)value appUserID:(NSString *)appUserID {
+- (void)setAttributeWithKey:(NSString *)key value:(nullable NSString *)value appUserID:(NSString *)appUserID {
     [self storeAttributeLocallyIfNeededWithKey:key value:value appUserID:appUserID];
 }
 


### PR DESCRIPTION
there were a couple of build warnings on tvOS because we weren't checking for API availability on tvOS. 

This fixes them and sets the min deployment target for tvOS to 9.0