### PR TITLE
[final] version 3.2.1

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -5,9 +5,9 @@ objc: true
 sdk: iphonesimulator
 module: Purchases
 umbrella_header: Purchases/Public/Purchases.h
-module_version: 3.2.0
+module_version: 3.2.1
 github_url: https://github.com/revenuecat/purchases-ios
-github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.2.0
+github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.2.1
 output: docs
 # Leaving this commented out. We used to specify this before, but now it's working without it
 # xcodebuild_arguments: [--objc,Purchases/Public/Purchases.h,--,-x,objective-c,-isysroot,$(xcrun --show-sdk-path),-I,$(pwd)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.1
+- Fixed build warnings on tvOS and API availability checks
+    https://github.com/RevenueCat/purchases-ios/pull/212
+
 ## 3.2.0
 - Added support for WatchOS and tvOS, fixed some issues with pre-processor macro checks on different platforms. 
     https://github.com/RevenueCat/purchases-ios/pull/183

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Purchases"
-  s.version          = "3.2.0"
+  s.version          = "3.2.1"
   s.summary          = "Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/Purchases/Info.plist
+++ b/Purchases/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.0</string>
+	<string>3.2.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -100,7 +100,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 }
 
 + (NSString *)frameworkVersion {
-    return @"3.2.0";
+    return @"3.2.1";
 }
 
 + (instancetype)sharedPurchases {

--- a/PurchasesTests/Info.plist
+++ b/PurchasesTests/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.0</string>
+	<string>3.2.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
- Fixed build warnings on tvOS and API availability checks
    https://github.com/RevenueCat/purchases-ios/pull/212
