### PR TITLE
[final] fix call to pip to update jazzy docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           command: fastlane run jazzy
       - run:
           name: Install awscli
-          command: sudo pip install awscli
+          command: sudo python -m pip install awscli
       - run:
           name: Deploy to S3
           command: aws s3 sync docs s3://purchases-docs/ios --delete --acl public-read


### PR DESCRIPTION
Context: updating the xcode version to 11.4 updated the Circle CI docker image, which in turn updated the python version used for jazzy docs. 

This unfortunately broke the call to `pip install`. 

This attempt to fix jazzy docs process by updating the call to pip to `python -m pip`, which should get the right instance of `pip` for the python installation, independently of how `pip` is aliased. 

Note: I'm not sure whether `sudo` is still needed here. 
