### PR TITLE
fix crash when payment.productIdentifier is nil

### DIFF
--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -461,7 +461,9 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                                     @synchronized (self) {
                                         for (SKProduct *p in newProducts)
                                         {
-                                            self.productsByIdentifier[p.productIdentifier] = p;
+                                            if (p.productIdentifier) {
+                                                self.productsByIdentifier[p.productIdentifier] = p;
+                                            }
                                         }
                                     }
                                     CALL_IF_SET_ON_MAIN_THREAD(completion, [products arrayByAddingObjectsFromArray:newProducts]);

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -527,10 +527,10 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
     } else {
         RCLog(@"makePurchase - Could not purchase SKProduct. Couldn't find its product identifier. This is possibly an App Store quirk.");
         completion(nil, nil, [NSError errorWithDomain:RCPurchasesErrorDomain
-            code:RCUnknownError
-        userInfo:@{
-                   NSLocalizedDescriptionKey: @"There was problem purchasing the product."
-                   }], false);
+                                                 code:RCUnknownError
+                                             userInfo:@{
+                                                 NSLocalizedDescriptionKey: @"There was problem purchasing the product."
+                                             }], false);
         return;
     }
 
@@ -545,9 +545,9 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
     [self.deviceCache setOfferingsCacheTimestampToNow];
 
     if (presentedOfferingIdentifier) {
-        RCDebugLog(@"makePurchase - %@ - Offering: %@", payment.productIdentifier, presentedOfferingIdentifier);
+        RCDebugLog(@"makePurchase - %@ - Offering: %@", productIdentifier, presentedOfferingIdentifier);
     } else {
-        RCDebugLog(@"makePurchase - %@", payment.productIdentifier);
+        RCDebugLog(@"makePurchase - %@", productIdentifier);
     }
 
     @synchronized (self) {
@@ -555,11 +555,11 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
     }
 
     @synchronized (self) {
-        self.presentedOfferingsByProductIdentifier[payment.productIdentifier] = presentedOfferingIdentifier;
+        self.presentedOfferingsByProductIdentifier[productIdentifier] = presentedOfferingIdentifier;
     }
 
     @synchronized (self) {
-        if (self.purchaseCompleteCallbacks[product.productIdentifier]) {
+        if (self.purchaseCompleteCallbacks[productIdentifier]) {
             completion(nil, nil, [NSError errorWithDomain:RCPurchasesErrorDomain
                                                      code:RCOperationAlreadyInProgressError
                                                  userInfo:@{


### PR DESCRIPTION
Addresses #225, there was an issue where: 
- the productIdentifier in either payment or product can be nil
- we check which one we should use and assign it to `productIdentifier`
- but afterwards, we were using the ones in the payment and product directly, assuming them to be non-nil, instead of the `productIdentifier` we created previously. 