### PR TITLE
cleanup: remove unnecessary no-op call to RCBackend's postSubscriberAttributes

### DIFF
--- a/Purchases/Caching/RCDeviceCache.m
+++ b/Purchases/Caching/RCDeviceCache.m
@@ -238,7 +238,9 @@ NSString *RCSubscriberAttributesKey = RC_CACHE_KEY_PREFIX @".subscriberAttribute
                 attributesForUser[attributeKey] = attribute;
             }
         }
-        attributes[appUserID] = attributesForUser;
+        if (attributesForUser.count > 0) {
+            attributes[appUserID] = attributesForUser;
+        }
     }
     return attributes;
 }

--- a/PurchasesTests/SubscriberAttributes/DeviceCacheSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/DeviceCacheSubscriberAttributesTests.swift
@@ -419,6 +419,30 @@ class DeviceCacheSubscriberAttributesTests: XCTestCase {
 
         expect(receivedUnsyncedAttributes["userID2"]?.keys).notTo(contain("album"))
     }
+    
+    func testUnsyncedAttributesByKeyForAllUsersOnlyIncludesUsersWithUnsyncedAttributes() {
+        let attributeLedZeppelin = RCSubscriberAttribute(key: "band", value: "Led Zeppelin")
+        let attributeWholeLottaLove = RCSubscriberAttribute(key: "song", value: "Whole Lotta Love")
+        let syncedAttribute = RCSubscriberAttribute(key: "album", value: "... And Justice for All", isSynced: true,
+                                                    setTime: Date())
+        mockUserDefaults.mockValues = [
+            "com.revenuecat.userdefaults.subscriberAttributes": [
+                "userID1": [
+                    "band": attributeLedZeppelin.asDictionary(),
+                    "song": attributeWholeLottaLove.asDictionary()
+                ],
+                "userID2": [
+                    "album": syncedAttribute.asDictionary()
+                ]
+            ]
+        ]
+        let receivedUnsyncedAttributes = self.deviceCache.unsyncedAttributesForAllUsers()
+        expect(receivedUnsyncedAttributes["userID1"]) == [
+            "band": attributeLedZeppelin,
+            "song": attributeWholeLottaLove
+        ]
+        expect(receivedUnsyncedAttributes["userID2"]).to(beNil())
+    }
 
     // mark: deleteAttributesIfSyncedForAppUserID
 


### PR DESCRIPTION
When all subscriber attributes had been synced for a user, we were still calling 
`RCBackend.postSubscriberAttributes` unnecessarily. 
This call was a no-op because the method checks if there are any attributes to sync and early-exists, so this is more of a cleanup. 
this was visible in the logs, where you'd see: `called post subscriber attributes with an empty attributes dict!`. 

