### PR TITLE
bump to version 3.2.3

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -5,9 +5,9 @@ objc: true
 sdk: iphonesimulator
 module: Purchases
 umbrella_header: Purchases/Public/Purchases.h
-module_version: 3.3.0-SNAPSHOT
+module_version: 3.2.3
 github_url: https://github.com/revenuecat/purchases-ios
-github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.3.0-SNAPSHOT
+github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.2.3
 output: docs
 # Leaving this commented out. We used to specify this before, but now it's working without it
 # xcodebuild_arguments: [--objc,Purchases/Public/Purchases.h,--,-x,objective-c,-isysroot,$(xcrun --show-sdk-path),-I,$(pwd)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.2.3
+- Fixes a bug where subscriber attributes are deleted when an alias is created.
+    https://github.com/RevenueCat/purchases-ios/pull/222
+- fix crash when payment.productIdentifier is nil #
+    https://github.com/RevenueCat/purchases-ios/pull/226
+- Fixes a bug where subscriber attributes are deleted when an alias is created.
+    https://github.com/RevenueCat/purchases-ios/pull/222
+- Update invalidatePurchaserInfoCache docs 
+    https://github.com/RevenueCat/purchases-ios/pull/223
+
 ## 3.2.2
 - Fixed build warnings about nil being passed to callees that require non-null parameters
     https://github.com/RevenueCat/purchases-ios/pull/216

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Purchases"
-  s.version          = "3.3.0-SNAPSHOT"
+  s.version          = "3.2.3"
   s.summary          = "Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/Purchases/Info.plist
+++ b/Purchases/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.0-SNAPSHOT</string>
+	<string>3.2.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -100,7 +100,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 }
 
 + (NSString *)frameworkVersion {
-    return @"3.3.0-SNAPSHOT";
+    return @"3.2.3";
 }
 
 + (instancetype)sharedPurchases {

--- a/PurchasesTests/Info.plist
+++ b/PurchasesTests/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.0-SNAPSHOT</string>
+	<string>3.2.3</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
## 3.2.3
- Fixes a bug where subscriber attributes are deleted when an alias is created.
    https://github.com/RevenueCat/purchases-ios/pull/222
- fix crash when payment.productIdentifier is nil #
    https://github.com/RevenueCat/purchases-ios/pull/226
- Update invalidatePurchaserInfoCache docs 
    https://github.com/RevenueCat/purchases-ios/pull/223
