### PR TITLE
Removes old trello link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@
 🔀 | [Integrations](https://www.revenuecat.com/integrations) - over a dozen integrations to easily send purchase data where you need it
 💯 | Well maintained - [frequent releases](https://github.com/RevenueCat/purchases-ios/releases)
 📮 | Great support - [Help Center](https://revenuecat.zendesk.com)
-🤩 | Awesome [new features](https://trello.com/b/RZRnWRbI/revenuecat-product-roadmap)
 
 ## Getting Started
 For more detailed information, you can view our complete documentation at [docs.revenuecat.com](https://docs.revenuecat.com/v3.0/docs).


### PR DESCRIPTION
The Trello board has been removed since we weren’t doing a good job of keeping it up to date and have decided to sunset it for now.

https://github.com/RevenueCat/purchases-ios/issues/230