### PR TITLE
Autodetect appUserID deletion

### DIFF
--- a/Purchases/Caching/RCDeviceCache+Protected.h
+++ b/Purchases/Caching/RCDeviceCache+Protected.h
@@ -8,13 +8,18 @@
 #import "RCInMemoryCachedObject.h"
 #import "RCOfferings.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 
 @interface RCDeviceCache (Protected)
 
 @property (nonatomic, nullable) NSDate *purchaserInfoCachesLastUpdated;
 
 - (nullable instancetype)initWith:(nullable NSUserDefaults *)userDefaults
-            offeringsCachedObject:(nullable RCInMemoryCachedObject<RCOfferings *> *)offeringsCachedObject;
+            offeringsCachedObject:(nullable RCInMemoryCachedObject<RCOfferings *> *)offeringsCachedObject
+               notificationCenter:(nullable NSNotificationCenter *)notificationCenter;
 
 @end
 
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/Caching/RCDeviceCache.m
+++ b/Purchases/Caching/RCDeviceCache.m
@@ -69,7 +69,7 @@ NSString *RCSubscriberAttributesKey = RC_CACHE_KEY_PREFIX @".subscriberAttribute
     [self.notificationCenter addObserver:self
                                 selector:@selector(handleUserDefaultsChanged:)
                                     name:NSUserDefaultsDidChangeNotification
-                                  object:nil];
+                                  object:self.userDefaults];
 }
 
 - (void)handleUserDefaultsChanged:(NSNotification *)notification {

--- a/Purchases/Caching/RCDeviceCache.m
+++ b/Purchases/Caching/RCDeviceCache.m
@@ -82,6 +82,10 @@ NSString *RCSubscriberAttributesKey = RC_CACHE_KEY_PREFIX @".subscriberAttribute
     }
 }
 
+- (void)dealloc {
+    [self.notificationCenter removeObserver:self];
+}
+
 #pragma mark - appUserID
 
 - (nullable NSString *)cachedLegacyAppUserID {

--- a/Purchases/Caching/RCDeviceCache.m
+++ b/Purchases/Caching/RCDeviceCache.m
@@ -77,7 +77,8 @@ NSString *RCSubscriberAttributesKey = RC_CACHE_KEY_PREFIX @".subscriberAttribute
         if (!self.cachedAppUserID) {
             NSAssert(false, @"[Purchases] - Cached appUserID has been deleted from user defaults. "
                             "This leaves the SDK in an undetermined state. Please make sure that RevenueCat "
-                            "entries in user defaults don't get deleted by anything other than the SDK.");
+                            "entries in user defaults don't get deleted by anything other than the SDK. "
+                            "More info: https://support.revenuecat.com/hc/en-us/articles/360047927393");
         }
     }
 }

--- a/PurchasesTests/Caching/DeviceCacheTests.swift
+++ b/PurchasesTests/Caching/DeviceCacheTests.swift
@@ -131,7 +131,9 @@ class DeviceCacheTests: XCTestCase {
 
     func testOfferingsCacheIsStaleIfCachedObjectIsStale() {
         let mockCachedObject = MockInMemoryCachedOfferings<Purchases.Offerings>(cacheDurationInSeconds: 5 * 60)
-        self.deviceCache = RCDeviceCache(mockUserDefaults, offeringsCachedObject: mockCachedObject)
+        self.deviceCache = RCDeviceCache(mockUserDefaults,
+                                         offeringsCachedObject: mockCachedObject,
+                                         notificationCenter: nil)
         let offerings = Purchases.Offerings()
         self.deviceCache.cacheOfferings(offerings)
 
@@ -176,5 +178,19 @@ class DeviceCacheTests: XCTestCase {
         self.deviceCache.cacheOfferings(expectedOfferings)
 
         expect(self.deviceCache.cachedOfferings).to(beIdenticalTo(expectedOfferings))
+    }
+
+    func testCrashesWhenAppUserIDIsDeleted() {
+        let mockNotificationCenter = MockNotificationCenter()
+        self.deviceCache = RCDeviceCache(mockUserDefaults,
+                                         offeringsCachedObject: nil,
+                                         notificationCenter: mockNotificationCenter)
+        mockUserDefaults.mockValues["com.revenuecat.userdefaults.appUserID.new"] = "Rage Against the Machine"
+
+        expect { mockNotificationCenter.fireNotifications() }.notTo(raiseException())
+
+        mockUserDefaults.mockValues["com.revenuecat.userdefaults.appUserID.new"] = nil
+
+        expect { mockNotificationCenter.fireNotifications() }.to(raiseException())
     }
 }

--- a/PurchasesTests/Mocks/MockNotificationCenter.swift
+++ b/PurchasesTests/Mocks/MockNotificationCenter.swift
@@ -23,8 +23,12 @@ class MockNotificationCenter: NotificationCenter {
     }
 
     func fireNotifications() {
-        for (observer, selector, _, _) in observers {
-            _ = observer.perform(selector, with: nil)
+        for (observer, selector, name, object) in observers {
+            var notification: NSNotification? = nil
+            if let name = name {
+                notification = NSNotification(name: name, object: object)
+            }
+            _ = observer.perform(selector, with: notification)
         }
     }
 }


### PR DESCRIPTION
To prevent cases where the appUserID is deleted accidentally, this adds observing changes to the userDefaults's appUserID, and crashes whenever the value gets deleted. 

