### PR TITLE
fix: subscriber attributes migration edge cases

### DIFF
--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -31,7 +31,6 @@
 		350FBDF01F7EFC410065833D /* StoreKitRequestFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 350FBDEF1F7EFC410065833D /* StoreKitRequestFetcherTests.swift */; };
 		350FBDF31F7FFD350065833D /* RCStoreKitWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 350FBDF11F7FFD340065833D /* RCStoreKitWrapper.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		350FBDF41F7FFD350065833D /* RCStoreKitWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 350FBDF21F7FFD340065833D /* RCStoreKitWrapper.m */; };
-		350FD38422E90EDB00B803AD /* RCOfferings.m in Sources */ = {isa = PBXBuildFile; fileRef = 354D50DE22E7D014009B870C /* RCOfferings.m */; };
 		351280382318AFB400BD2163 /* RCOfferingsFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 351280372318AFB400BD2163 /* RCOfferingsFactory.m */; };
 		351703CD1F805E5D00EEE27A /* PurchaserInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351703CC1F805E5D00EEE27A /* PurchaserInfoTests.swift */; };
 		351F4FAB1F80190700F245F4 /* RCBackend.h in Headers */ = {isa = PBXBuildFile; fileRef = 351F4FA91F80190700F245F4 /* RCBackend.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -62,7 +61,6 @@
 		35846AFF226A56AE00CC9E56 /* RCPromotionalOffer+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 35846AFE226A554300CC9E56 /* RCPromotionalOffer+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3585D6A322E680E30079E2C5 /* RCPackage.h in Headers */ = {isa = PBXBuildFile; fileRef = 3585D6A122E680E30079E2C5 /* RCPackage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3585D6A422E680E30079E2C5 /* RCPackage.m in Sources */ = {isa = PBXBuildFile; fileRef = 3585D6A222E680E30079E2C5 /* RCPackage.m */; };
-		3585D6A522E680E30079E2C5 /* RCPackage.m in Sources */ = {isa = PBXBuildFile; fileRef = 3585D6A222E680E30079E2C5 /* RCPackage.m */; };
 		359A0EA12003C8CD002D8C7F /* NSLocale+RCExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 359A0E9F2003C8CD002D8C7F /* NSLocale+RCExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		359A0EA22003C8CD002D8C7F /* NSLocale+RCExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 359A0EA02003C8CD002D8C7F /* NSLocale+RCExtensions.m */; };
 		35A3F73323172D9900559FF9 /* RCOfferings+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 35A3F73223172D9900559FF9 /* RCOfferings+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -745,7 +743,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				350FD38422E90EDB00B803AD /* RCOfferings.m in Sources */,
 				35262A211F7D77E600C04F2C /* PurchasesTests.swift in Sources */,
 				351F4FB21F803D9C00F245F4 /* BackendTests.swift in Sources */,
 				35262A301F7D78C600C04F2C /* HTTPClientTests.swift in Sources */,
@@ -757,7 +754,6 @@
 				350FBDF01F7EFC410065833D /* StoreKitRequestFetcherTests.swift in Sources */,
 				351703CD1F805E5D00EEE27A /* PurchaserInfoTests.swift in Sources */,
 				35B1635223467C10003371A3 /* IdentityManagerTests.swift in Sources */,
-				3585D6A522E680E30079E2C5 /* RCPackage.m in Sources */,
 				37E354BE25CE61E55E4FD89C /* MockDeviceCache.swift in Sources */,
 				37E3585E0B39722838F235BD /* MockUserDefaults.swift in Sources */,
 				37E351AB03EE37534CA10B59 /* MockInMemoryCachedOfferings.swift in Sources */,

--- a/Purchases/Caching/RCDeviceCache.h
+++ b/Purchases/Caching/RCDeviceCache.h
@@ -64,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSUInteger)numberOfUnsyncedAttributesForAppUserID:(NSString *)appUserID;
 
-- (void)migrateSubscriberAttributesIfNeededForAppUserID:(NSString *)appUserID;
+- (void)cleanupSubscriberAttributes;
 
 - (NSDictionary<NSString *, RCSubscriberAttributeDict> *)unsyncedAttributesForAllUsers;
 

--- a/Purchases/Caching/RCDeviceCache.m
+++ b/Purchases/Caching/RCDeviceCache.m
@@ -311,6 +311,7 @@ NSString *RCSubscriberAttributesKey = RC_CACHE_KEY_PREFIX @".subscriberAttribute
         NSString *legacyAttributesKey = [self legacySubscriberAttributesCacheKeyForAppUserID:appUserID];
         [self.userDefaults removeObjectForKey:legacyAttributesKey];
     }
+    [self.userDefaults setObject:attributesInNewFormat forKey:RCSubscriberAttributesKey];
 }
 
 - (void)deleteSyncedSubscriberAttributesForOtherUsers {
@@ -342,7 +343,9 @@ NSString *RCSubscriberAttributesKey = RC_CACHE_KEY_PREFIX @".subscriberAttribute
     NSDictionary *userDefaultsDict = [self.userDefaults dictionaryRepresentation];
     for (NSString *key in userDefaultsDict.allKeys) {
         if ([key containsString:RCLegacySubscriberAttributesKeyBase]) {
-            [appUserIDsWithLegacyAttributes addObject:key];
+            NSString *appUserID = [key stringByReplacingOccurrencesOfString:RCLegacySubscriberAttributesKeyBase
+                                                                 withString:@""];
+            [appUserIDsWithLegacyAttributes addObject:appUserID];
         }
     }
     return appUserIDsWithLegacyAttributes;

--- a/Purchases/Caching/RCDeviceCache.m
+++ b/Purchases/Caching/RCDeviceCache.m
@@ -317,20 +317,23 @@ NSString *RCSubscriberAttributesKey = RC_CACHE_KEY_PREFIX @".subscriberAttribute
 - (void)deleteSyncedSubscriberAttributesForOtherUsers {
     NSDictionary<NSString *, NSDictionary *> *allStoredAttributes = self.storedAttributesForAllUsers;
     NSMutableDictionary<NSString *, NSDictionary *> *unsyncedAttributes = [[NSMutableDictionary alloc] init];
+
     NSString *currentAppUserID = self.cachedAppUserID;
+    NSParameterAssert(currentAppUserID);
+    unsyncedAttributes[currentAppUserID] = allStoredAttributes[currentAppUserID];
+
     for (NSString *appUserID in allStoredAttributes.allKeys) {
-        if ([appUserID isEqualToString:currentAppUserID]) {
+        if (![appUserID isEqualToString:currentAppUserID]) {
             NSMutableDictionary *unsyncedAttributesForUser = [[NSMutableDictionary alloc] init];
             for (NSString *attributeKey in allStoredAttributes[appUserID].allKeys) {
                 RCSubscriberAttribute *attribute = [[RCSubscriberAttribute alloc]
                                                                            initWithDictionary:allStoredAttributes[appUserID][attributeKey]];
                 if (!attribute.isSynced) {
-                    unsyncedAttributesForUser[currentAppUserID][attributeKey] =
-                        allStoredAttributes[appUserID][attributeKey];
+                    unsyncedAttributesForUser[attributeKey] = allStoredAttributes[appUserID][attributeKey];
                 }
             }
             if (unsyncedAttributesForUser.count > 0) {
-                unsyncedAttributes[currentAppUserID] = unsyncedAttributesForUser;
+                unsyncedAttributes[appUserID] = unsyncedAttributesForUser;
             }
         }
     }

--- a/Purchases/Caching/RCDeviceCache.m
+++ b/Purchases/Caching/RCDeviceCache.m
@@ -304,10 +304,11 @@ NSString *RCSubscriberAttributesKey = RC_CACHE_KEY_PREFIX @".subscriberAttribute
     NSArray *appUserIDsWithLegacyAttributes = [self appUserIDsWithLegacyAttributes];
     NSMutableDictionary *attributesInNewFormat = self.storedAttributesForAllUsers.mutableCopy;
     for (NSString *appUserID in appUserIDsWithLegacyAttributes) {
-        NSDictionary *legacyAttributes = ([self valueForLegacySubscriberAttributes:appUserID] ?: @{}).mutableCopy;
-        NSMutableDictionary *currentAttributesForAppUserID = (legacyAttributes ?: @{}).mutableCopy;
+        NSDictionary *legacyAttributes = [self valueForLegacySubscriberAttributes:appUserID] ?: @{};
+        NSDictionary *existingAttributes = self.storedAttributesForAllUsers[appUserID] ?: @{};
+
         NSMutableDictionary *allAttributesForUser = legacyAttributes.mutableCopy;
-        [allAttributesForUser addEntriesFromDictionary:currentAttributesForAppUserID];
+        [allAttributesForUser addEntriesFromDictionary:existingAttributes];
 
         attributesInNewFormat[appUserID] = allAttributesForUser;
 

--- a/Purchases/RCIdentityManager.m
+++ b/Purchases/RCIdentityManager.m
@@ -48,7 +48,7 @@
     }
 
     [self saveAppUserID:appUserID];
-    [self.deviceCache migrateSubscriberAttributesIfNeededForAppUserID:appUserID];
+    [self.deviceCache cleanupSubscriberAttributes];
 }
 
 - (void)identifyAppUserID:(NSString *)appUserID withCompletionBlock:(void (^)(NSError *_Nullable error))completion

--- a/Purchases/RCStoreKitRequestFetcher.m
+++ b/Purchases/RCStoreKitRequestFetcher.m
@@ -72,7 +72,7 @@
         }
         
         NSMutableArray *handlers = self.productsCompletionHandlers[identifiers];
-        NSAssert(handlers != nil, @"Curropted handler storage");
+        NSAssert(handlers != nil, @"Corrupted handler storage");
         
         [handlers addObject:completion];
         

--- a/PurchasesTests/IdentityManagerTests.swift
+++ b/PurchasesTests/IdentityManagerTests.swift
@@ -79,9 +79,9 @@ class IdentityManagerTests: XCTestCase {
         assertCorrectlyIdentified(expectedAppUserID: "cesar")
     }
 
-    func testConfigureMigratesSubscriberAttributes() {
+    func testConfigureCleansUpSubscriberAttributes() {
         identityManager.configure(withAppUserID: "andy")
-        expect(self.mockDeviceCache.invokedMigrateSubscriberAttributesIfNeededCount) == 1
+        expect(self.mockDeviceCache.invokedCleanupSubscriberAttributesCount) == 1
     }
 
     func testConfigureWithAnonymousUserSavesTheIDInTheCache() {

--- a/PurchasesTests/Mocks/MockDeviceCache.swift
+++ b/PurchasesTests/Mocks/MockDeviceCache.swift
@@ -151,6 +151,14 @@ class MockDeviceCache: RCDeviceCache {
         return stubbedUnsyncedAttributesByKeyResult
     }
 
+    var invokedCleanupSubscriberAttributes = false
+    var invokedCleanupSubscriberAttributesCount = 0
+
+    override func cleanupSubscriberAttributes() {
+        invokedCleanupSubscriberAttributes = true
+        invokedCleanupSubscriberAttributesCount += 1
+    }
+
     var invokedNumberOfUnsyncedAttributes = false
     var invokedNumberOfUnsyncedAttributesCount = 0
     var invokedNumberOfUnsyncedAttributesParameters: (appUserID: String, Void)?
@@ -163,18 +171,6 @@ class MockDeviceCache: RCDeviceCache {
         invokedNumberOfUnsyncedAttributesParameters = (appUserID, ())
         invokedNumberOfUnsyncedAttributesParametersList.append((appUserID, ()))
         return stubbedNumberOfUnsyncedAttributesResult
-    }
-
-    var invokedMigrateSubscriberAttributesIfNeeded = false
-    var invokedMigrateSubscriberAttributesIfNeededCount = 0
-    var invokedMigrateSubscriberAttributesIfNeededParameters: (appUserID: String?, Void)?
-    var invokedMigrateSubscriberAttributesIfNeededParametersList = [(appUserID: String?, Void)]()
-
-    override func migrateSubscriberAttributesIfNeeded(forAppUserID appUserID: String) {
-        invokedMigrateSubscriberAttributesIfNeeded = true
-        invokedMigrateSubscriberAttributesIfNeededCount += 1
-        invokedMigrateSubscriberAttributesIfNeededParameters = (appUserID, ())
-        invokedMigrateSubscriberAttributesIfNeededParametersList.append((appUserID, ()))
     }
 
     var invokedUnsyncedAttributesForAllUsers = false

--- a/PurchasesTests/Mocks/MockUserDefaults.swift
+++ b/PurchasesTests/Mocks/MockUserDefaults.swift
@@ -54,4 +54,6 @@ class MockUserDefaults: UserDefaults {
         dictionaryForKeyCalledValue = defaultName
         return mockValues[defaultName] as? [String : Any]
     }
+
+    override func dictionaryRepresentation() -> [String: Any] { mockValues }
 }

--- a/PurchasesTests/SubscriberAttributes/DeviceCacheSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/DeviceCacheSubscriberAttributesTests.swift
@@ -321,6 +321,7 @@ class DeviceCacheSubscriberAttributesTests: XCTestCase {
         mockUserDefaults.mockValues = [
             "com.revenuecat.userdefaults.subscriberAttributes.\(userID1)": userID1Attributes,
             "com.revenuecat.userdefaults.subscriberAttributes.\(userID2)": userID2Attributes,
+            "com.revenuecat.userdefaults.appUserID.new": userID1
         ]
 
         deviceCache.cleanupSubscriberAttributes()
@@ -348,14 +349,18 @@ class DeviceCacheSubscriberAttributesTests: XCTestCase {
             "com.revenuecat.userdefaults.subscriberAttributes": [
                 userID1: userID1Attributes,
                 userID2: userID2Attributes
-            ]
-        ]
+            ],
+            "com.revenuecat.userdefaults.appUserID.new": userID1
+        ] as [String: AnyObject]
         mockUserDefaults.mockValues = valuesBeforeMigration
 
         deviceCache.cleanupSubscriberAttributes()
 
-        let valuesAfterMigration = self.mockUserDefaults.mockValues as? [String: [String: [String: [String: NSObject]]]]
-        expect(valuesBeforeMigration) == valuesAfterMigration
+        expect(valuesBeforeMigration["com.revenuecat.userdefaults.subscriberAttributes"] as? [String: [String: NSDictionary]]) == mockUserDefaults
+            .mockValues["com.revenuecat.userdefaults.subscriberAttributes"] as? [String: [String: NSDictionary]]
+
+        expect(valuesBeforeMigration["com.revenuecat.userdefaults.appUserID.new"] as? String) == 
+            mockUserDefaults.mockValues["com.revenuecat.userdefaults.appUserID.new"] as? String
     }
 
     func testMigrateSubscriberAttributesIfNeededForAppUserDeletesOldFormatAfterFinishing() {
@@ -374,6 +379,7 @@ class DeviceCacheSubscriberAttributesTests: XCTestCase {
         mockUserDefaults.mockValues = [
             userID1AttributesKey: userID1Attributes,
             userID2AttributesKey: userID2Attributes,
+            "com.revenuecat.userdefaults.appUserID.new": userID1
         ]
 
         self.deviceCache.cleanupSubscriberAttributes()

--- a/PurchasesTests/SubscriberAttributes/DeviceCacheSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/DeviceCacheSubscriberAttributesTests.swift
@@ -324,7 +324,6 @@ class DeviceCacheSubscriberAttributesTests: XCTestCase {
         ]
 
         deviceCache.cleanupSubscriberAttributes()
-        deviceCache.cleanupSubscriberAttributes()
 
         let storedAttributes = self.mockUserDefaults.mockValues[
             "com.revenuecat.userdefaults.subscriberAttributes"
@@ -377,7 +376,6 @@ class DeviceCacheSubscriberAttributesTests: XCTestCase {
             userID2AttributesKey: userID2Attributes,
         ]
 
-        self.deviceCache.cleanupSubscriberAttributes()
         self.deviceCache.cleanupSubscriberAttributes()
 
         expect(self.mockUserDefaults.mockValues[userID1AttributesKey]).to(beNil())

--- a/PurchasesTests/SubscriberAttributes/DeviceCacheSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/DeviceCacheSubscriberAttributesTests.swift
@@ -301,9 +301,9 @@ class DeviceCacheSubscriberAttributesTests: XCTestCase {
         expect(self.deviceCache.numberOfUnsyncedAttributes(forAppUserID: "waldo")) == 2
     }
 
-    // mark: migrateSubscriberAttributesIfNeededForAppUserID
+    // mark: cleanupSubscriberAttributes
 
-    func testMigrateSubscriberAttributesIfNeededForAppUserIDMigratesIfOldAttributesFound() {
+    func testCleanupSubscriberAttributesMigratesIfOldAttributesFound() {
         let userID1 = "userID1"
         let userID2 = "userID2"
         let userID1Attributes = [
@@ -323,8 +323,8 @@ class DeviceCacheSubscriberAttributesTests: XCTestCase {
             "com.revenuecat.userdefaults.subscriberAttributes.\(userID2)": userID2Attributes,
         ]
 
-        deviceCache.migrateSubscriberAttributesIfNeeded(forAppUserID: userID1)
-        deviceCache.migrateSubscriberAttributesIfNeeded(forAppUserID: userID2)
+        deviceCache.cleanupSubscriberAttributes()
+        deviceCache.cleanupSubscriberAttributes()
 
         let storedAttributes = self.mockUserDefaults.mockValues[
             "com.revenuecat.userdefaults.subscriberAttributes"
@@ -333,7 +333,7 @@ class DeviceCacheSubscriberAttributesTests: XCTestCase {
         expect(storedAttributes) == newSubscriberAttributes
     }
 
-    func testMigrateSubscriberAttributesIfNeededForAppUserIDSkipsIfNoOldAttributesFound() {
+    func testCleanupSubscriberAttributesSkipsIfNoOldAttributesFound() {
         let userID1 = "userID1"
         let userID2 = "userID2"
         let userID1Attributes = [
@@ -353,7 +353,7 @@ class DeviceCacheSubscriberAttributesTests: XCTestCase {
         ]
         mockUserDefaults.mockValues = valuesBeforeMigration
 
-        deviceCache.migrateSubscriberAttributesIfNeeded(forAppUserID: userID1)
+        deviceCache.cleanupSubscriberAttributes()
 
         let valuesAfterMigration = self.mockUserDefaults.mockValues as? [String: [String: [String: [String: NSObject]]]]
         expect(valuesBeforeMigration) == valuesAfterMigration
@@ -377,8 +377,8 @@ class DeviceCacheSubscriberAttributesTests: XCTestCase {
             userID2AttributesKey: userID2Attributes,
         ]
 
-        self.deviceCache.migrateSubscriberAttributesIfNeeded(forAppUserID: userID1)
-        self.deviceCache.migrateSubscriberAttributesIfNeeded(forAppUserID: userID2)
+        self.deviceCache.cleanupSubscriberAttributes()
+        self.deviceCache.cleanupSubscriberAttributes()
 
         expect(self.mockUserDefaults.mockValues[userID1AttributesKey]).to(beNil())
         expect(self.mockUserDefaults.mockValues[userID2AttributesKey]).to(beNil())


### PR DESCRIPTION
This fixes edge cases in the subscriber attributes bug fixes: 

### case 1: 
- Alice sets attributes and syncs
- Alice is aliased to Bob
- Bob syncs attributes, but never deletes attributes for Alice because they've already been successfully synced. 

### case 2: 
- Attributes are set for more than 1 user before migrating to the new format
- Attributes are migrated to the new format only for the current user. 

### Solution: 
- Upon initializing, we look for subscriber attributes in the old format for all users and migrate them. 
- After this step, we look for subscriber attributes for all users but the current one, that are already synced. We delete them. 

### Missing: 
- more detailed tests for the edge cases described above 
- cleanup for readability