### PR TITLE
fix crash after identify and alias

### DIFF
--- a/Purchases/Caching/RCDeviceCache.h
+++ b/Purchases/Caching/RCDeviceCache.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)cacheAppUserID:(NSString *)appUserID;
 
-- (void)clearCachesForAppUserID:(NSString *)appUserID;
+- (void)clearCachesForAppUserID:(NSString *)oldAppUserID andSaveNewUserID:(NSString *)newUserID;
 
 #pragma mark - purchaserInfo
 

--- a/Purchases/Caching/RCDeviceCache.m
+++ b/Purchases/Caching/RCDeviceCache.m
@@ -110,7 +110,7 @@ NSString *RCSubscriberAttributesKey = RC_CACHE_KEY_PREFIX @".subscriberAttribute
 
         [self deleteAttributesIfSyncedForAppUserID:oldAppUserID];
 
-        [self.userDefaults setObject:newUserID forKey:RCAppUserDefaultsKey];
+        [self cacheAppUserID:newUserID];
     }
 }
 

--- a/Purchases/Caching/RCDeviceCache.m
+++ b/Purchases/Caching/RCDeviceCache.m
@@ -101,15 +101,16 @@ NSString *RCSubscriberAttributesKey = RC_CACHE_KEY_PREFIX @".subscriberAttribute
     [self.userDefaults setObject:appUserID forKey:RCAppUserDefaultsKey];
 }
 
-- (void)clearCachesForAppUserID:(NSString *)appUserID {
+- (void)clearCachesForAppUserID:(NSString *)oldAppUserID andSaveNewUserID:(NSString *)newUserID {
     @synchronized (self) {
         [self.userDefaults removeObjectForKey:RCLegacyGeneratedAppUserDefaultsKey];
-        [self.userDefaults removeObjectForKey:RCAppUserDefaultsKey];
-        [self.userDefaults removeObjectForKey:[self purchaserInfoUserDefaultCacheKeyForAppUserID:appUserID]];
+        [self.userDefaults removeObjectForKey:[self purchaserInfoUserDefaultCacheKeyForAppUserID:oldAppUserID]];
         [self clearPurchaserInfoCacheTimestamp];
         [self clearOfferingsCache];
 
-        [self deleteAttributesIfSyncedForAppUserID:appUserID];
+        [self deleteAttributesIfSyncedForAppUserID:oldAppUserID];
+
+        [self.userDefaults setObject:newUserID forKey:RCAppUserDefaultsKey];
     }
 }
 

--- a/Purchases/RCIdentityManager.m
+++ b/Purchases/RCIdentityManager.m
@@ -77,7 +77,6 @@
 
 - (void)resetAppUserID {
     NSString *randomId = [self generateRandomID];
-    [self saveAppUserID:randomId];
     [self.deviceCache clearCachesForAppUserID:self.currentAppUserID andSaveNewUserID:randomId];
 }
 

--- a/PurchasesTests/Caching/DeviceCacheTests.swift
+++ b/PurchasesTests/Caching/DeviceCacheTests.swift
@@ -37,63 +37,63 @@ class DeviceCacheTests: XCTestCase {
             .to(equal(userID))
     }
 
-    func testClearCachesRemovesCachedPurchaserInfo() {
-        self.deviceCache.clearCaches(forAppUserID: "cesar")
+    func testClearCachesForAppUserIDAndSaveNewUserIDRemovesCachedPurchaserInfo() {
+        self.deviceCache.clearCaches(forAppUserID: "cesar", andSaveNewUserID: "newUser")
         expect(self.mockUserDefaults.removeObjectForKeyCalledValues.contains("com.revenuecat.userdefaults.purchaserInfo.cesar"))
             .to(beTrue())
     }
 
-    func testClearCachesRemovesCachedOfferings() {
+    func testClearCachesForAppUserIDAndSaveNewUserIDRemovesCachedOfferings() {
         let offerings = Purchases.Offerings()
         self.deviceCache.cacheOfferings(offerings)
         expect(self.deviceCache.cachedOfferings).to(equal(offerings))
-        self.deviceCache.clearCaches(forAppUserID: "cesar")
+        self.deviceCache.clearCaches(forAppUserID: "cesar", andSaveNewUserID: "newUser")
         expect(self.deviceCache.cachedOfferings).to(beNil())
     }
 
-    func testClearCachesClearsCachesTimestamp() {
+    func testClearCachesForAppUserIDAndSaveNewUserIDClearsCachesTimestamp() {
         self.deviceCache.setPurchaserInfoCacheTimestampToNow()
-        self.deviceCache.clearCaches(forAppUserID: "cesar")
+        self.deviceCache.clearCaches(forAppUserID: "cesar", andSaveNewUserID: "newUser")
         expect(self.deviceCache.isPurchaserInfoCacheStale()).to(beTrue())
     }
 
-    func testClearCachesRemovesCachedAppUserIDs() {
-        self.deviceCache.clearCaches(forAppUserID: "cesar")
-        expect(self.mockUserDefaults.removeObjectForKeyCalledValues.contains("com.revenuecat.userdefaults.appUserID.new"))
-            .to(beTrue())
-        expect(self.mockUserDefaults.removeObjectForKeyCalledValues.contains("com.revenuecat.userdefaults.appUserID"))
-            .to(beTrue())
+    func testClearCachesForAppUserIDAndSaveNewUserIDUpdatesCachedAppUserID() {
+        self.deviceCache.clearCaches(forAppUserID: "cesar", andSaveNewUserID: "newUser")
+        expect(self.mockUserDefaults.mockValues["com.revenuecat.userdefaults.appUserID.new"] as? String) == "newUser"
     }
 
-    func testClearCachesDoesntRemoveCachedSubscriberAttributesIfUnsynced() {
+    func testClearCachesForAppUserIDAndSaveNewUserIDDoesntRemoveCachedSubscriberAttributesIfUnsynced() {
         let userID = "andy"
         let attributesKey = "com.revenuecat.userdefaults.subscriberAttributes"
         let key = "band"
         let unsyncedSubscriberAttribute = RCSubscriberAttribute(key: key, value: "La Renga",
                                                                 isSynced: false, setTime: Date()).asDictionary()
-        mockUserDefaults.mockValues[attributesKey] = [
+        let mockAttributes: [String: [String: [String: NSObject]]] = [
             userID: [key: unsyncedSubscriberAttribute]
         ]
+        mockUserDefaults.mockValues[attributesKey] = mockAttributes
 
-        self.deviceCache.clearCaches(forAppUserID: userID)
-
-        expect(self.mockUserDefaults.setObjectForKeyCallCount) == 0
+        self.deviceCache.clearCaches(forAppUserID: userID, andSaveNewUserID: "newUser")
+        expect(self.mockUserDefaults.mockValues[attributesKey] as? [String: [String: [String: NSObject]]])
+            == mockAttributes
     }
 
-    func testClearCachesRemovesCachedSubscriberAttributesIfSynced() {
+    func testClearCachesForAppUserIDAndSaveNewUserIDRemovesCachedSubscriberAttributesIfSynced() {
         let userID = "andy"
         let attributesKey = "com.revenuecat.userdefaults.subscriberAttributes"
         let key = "band"
         let unsyncedSubscriberAttribute = RCSubscriberAttribute(key: key, value: "La Renga",
                                                                 isSynced: true, setTime: Date()).asDictionary()
+
         mockUserDefaults.mockValues[attributesKey] = [
             userID: [key: unsyncedSubscriberAttribute]
         ]
 
-        self.deviceCache.clearCaches(forAppUserID: userID)
+        expect(self.mockUserDefaults.mockValues[attributesKey] as? [String: NSObject]).notTo(beEmpty())
 
-        expect(self.mockUserDefaults.setObjectForKeyCallCount) == 1
-        expect(self.mockUserDefaults.setObjectForKeyCalledValue?.contains(attributesKey)) == true
+        self.deviceCache.clearCaches(forAppUserID: userID, andSaveNewUserID: "newUser")
+
+        expect(self.mockUserDefaults.mockValues[attributesKey] as? [String: NSObject]).to(beEmpty())
 
     }
 

--- a/PurchasesTests/Caching/DeviceCacheTests.swift
+++ b/PurchasesTests/Caching/DeviceCacheTests.swift
@@ -60,6 +60,7 @@ class DeviceCacheTests: XCTestCase {
     func testClearCachesForAppUserIDAndSaveNewUserIDUpdatesCachedAppUserID() {
         self.deviceCache.clearCaches(forAppUserID: "cesar", andSaveNewUserID: "newUser")
         expect(self.mockUserDefaults.mockValues["com.revenuecat.userdefaults.appUserID.new"] as? String) == "newUser"
+        expect(self.mockUserDefaults.mockValues["com.revenuecat.userdefaults.appUserID"]).to(beNil())
     }
 
     func testClearCachesForAppUserIDAndSaveNewUserIDDoesntRemoveCachedSubscriberAttributesIfUnsynced() {

--- a/PurchasesTests/IdentityManagerTests.swift
+++ b/PurchasesTests/IdentityManagerTests.swift
@@ -94,7 +94,7 @@ class IdentityManagerTests: XCTestCase {
         let initialAppUserID: String = self.identityManager.currentAppUserID
         let newAppUserID = "cesar"
         self.identityManager.identifyAppUserID(newAppUserID) { (error: Error?) in  }
-        expect(self.mockDeviceCache.clearCachesCalledUserID).toEventually(equal(initialAppUserID))
+        expect(self.mockDeviceCache.clearCachesCalledOldUserID).toEventually(equal(initialAppUserID))
     }
 
     func testIdentifyingCorrectlyIdentifies() {
@@ -122,7 +122,7 @@ class IdentityManagerTests: XCTestCase {
         let initialAppUserID: String = self.identityManager.currentAppUserID
         self.identityManager.createAlias("cesar") { (error: Error?) in
         }
-        expect(self.mockDeviceCache.clearCachesCalledUserID).to(equal(initialAppUserID))
+        expect(self.mockDeviceCache.clearCachesCalledOldUserID).to(equal(initialAppUserID))
     }
 
     func testCreateAliasForwardsErrors() {
@@ -138,7 +138,7 @@ class IdentityManagerTests: XCTestCase {
         self.identityManager.configure(withAppUserID: nil)
         let initialAppUserID: String = self.identityManager.currentAppUserID
         self.identityManager.resetAppUserID()
-        expect(self.mockDeviceCache.clearCachesCalledUserID).to(equal(initialAppUserID))
+        expect(self.mockDeviceCache.clearCachesCalledOldUserID).to(equal(initialAppUserID))
     }
 
     func testResetCreatesRandomIDAndCachesIt() {

--- a/PurchasesTests/Mocks/MockDeviceCache.swift
+++ b/PurchasesTests/Mocks/MockDeviceCache.swift
@@ -13,10 +13,13 @@ class MockDeviceCache: RCDeviceCache {
     var stubbedLegacyAppUserID: String? = nil
     var userIDStoredInCache: String? = nil
     var stubbedAnonymous: Bool = false
-    var clearCachesCalledUserID: String? = nil
+    var clearCachesCalledOldUserID: String? = nil
+    var clearCachesCalleNewUserID: String? = nil
 
-    override func clearCaches(forAppUserID appUserId: String) {
-        clearCachesCalledUserID = appUserId
+    override func clearCaches(forAppUserID oldUserId: String, andSaveNewUserID newUserID: String) {
+        clearCachesCalledOldUserID = oldUserId
+        clearCachesCalleNewUserID = newUserID
+        userIDStoredInCache = newUserID
     }
 
     override var cachedLegacyAppUserID: String? {


### PR DESCRIPTION
Fixes a bug in #232 that would cause identify and alias to crash. 

Also, fixes race conditions that we've had here forever, since you could potentially have a nil appUserID between clearing cache and saving a new appUserID

Missing tests but reviewable otherwise