### PR TITLE
Observer mode header + cleanup

### DIFF
--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		37E3524CB70618E6C5F3DB49 /* MockPurchasesDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35838A7FD36982EE14100 /* MockPurchasesDelegate.swift */; };
 		37E3526C938D7B291671BE8A /* RCInMemoryCachedObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E359893D3371FC3497D957 /* RCInMemoryCachedObject.m */; };
 		37E352897F7CB3A122F9739F /* PurchasesSubscriberAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3508E52201122137D4B4A /* PurchasesSubscriberAttributesTests.swift */; };
+		37E352C38681981D6179C71D /* RCSystemInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E35825FB4C24DED1094649 /* RCSystemInfo.m */; };
 		37E352F190E0E957E8D932F8 /* RCDeviceCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E3524E3032ABC72467AA43 /* RCDeviceCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E352F9B7505A398D578F53 /* RCDeviceCache+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E3555AC54BD10BE56F2B6B /* RCDeviceCache+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E353851D42047D5B0A57D0 /* MockDateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3578BD602C7B8E2274279 /* MockDateProvider.swift */; };
@@ -115,6 +116,7 @@
 		37E35AD3BB8E99D2AA325825 /* DeviceCacheSubscriberAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35C4A795A0F056381A1B3 /* DeviceCacheSubscriberAttributesTests.swift */; };
 		37E35AE982974800FF079C14 /* RCSubscriberAttribute+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35C82A59C953A5F6017BB /* RCSubscriberAttribute+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E35AF213F2F79CB067FDC2 /* InMemoryCachedObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35E3250FBBB03D92E06EC /* InMemoryCachedObjectTests.swift */; };
+		37E35B0940EE505602A2486B /* RCSystemInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35BCA450E95B0273976BE /* RCSystemInfo.h */; };
 		37E35B1F34D1624509012749 /* MockSubscriberAttributesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E351D48260D9DC8B1EE360 /* MockSubscriberAttributesManager.swift */; };
 		37E35BCE176D557487A903CC /* NSDate+RCExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E358235BB58A968B059B6B /* NSDate+RCExtensions.m */; };
 		37E35CCE215E9EABFB88F3BD /* NSData+RCExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E355C86ED87895B04E0E99 /* NSData+RCExtensions.m */; };
@@ -264,9 +266,11 @@
 		37E357F69438004E1F443C03 /* BackendSubscriberAttributesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackendSubscriberAttributesTests.swift; sourceTree = "<group>"; };
 		37E357FBA3184BDE6E95DED4 /* MockSKProduct.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockSKProduct.swift; sourceTree = "<group>"; };
 		37E358235BB58A968B059B6B /* NSDate+RCExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDate+RCExtensions.m"; sourceTree = "<group>"; };
+		37E35825FB4C24DED1094649 /* RCSystemInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCSystemInfo.m; sourceTree = "<group>"; };
 		37E35838A7FD36982EE14100 /* MockPurchasesDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockPurchasesDelegate.swift; sourceTree = "<group>"; };
 		37E359893D3371FC3497D957 /* RCInMemoryCachedObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCInMemoryCachedObject.m; sourceTree = "<group>"; };
 		37E35A0D4A561C51185F82EB /* MockNotificationCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockNotificationCenter.swift; sourceTree = "<group>"; };
+		37E35BCA450E95B0273976BE /* RCSystemInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCSystemInfo.h; sourceTree = "<group>"; };
 		37E35C4A795A0F056381A1B3 /* DeviceCacheSubscriberAttributesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceCacheSubscriberAttributesTests.swift; sourceTree = "<group>"; };
 		37E35C5A65AAF701DED59800 /* MockInMemoryCachedOfferings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockInMemoryCachedOfferings.swift; sourceTree = "<group>"; };
 		37E35C6CBB3229AA53ECEB58 /* RCInMemoryCachedObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCInMemoryCachedObject.h; sourceTree = "<group>"; };
@@ -431,6 +435,8 @@
 				37E355C86ED87895B04E0E99 /* NSData+RCExtensions.m */,
 				37E350352D8DCFAAA06662ED /* NSData+RCExtensions.h */,
 				37E354FADC6628DE00935866 /* RCHTTPStatusCodes.h */,
+				37E35825FB4C24DED1094649 /* RCSystemInfo.m */,
+				37E35BCA450E95B0273976BE /* RCSystemInfo.h */,
 			);
 			path = Purchases;
 			sourceTree = "<group>";
@@ -584,6 +590,7 @@
 				37E3559878659F4EA93ADDE6 /* NSData+RCExtensions.h in Headers */,
 				35C98D9520B7306A006DCBB5 /* RCCrossPlatformSupport.h in Headers */,
 				37E35A524749D5A223DF85E8 /* RCHTTPStatusCodes.h in Headers */,
+				37E35B0940EE505602A2486B /* RCSystemInfo.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -740,6 +747,7 @@
 				2D8DB34E240731E000BE3D31 /* NSError+RCExtensions.m in Sources */,
 				37E35BCE176D557487A903CC /* NSDate+RCExtensions.m in Sources */,
 				37E35CCE215E9EABFB88F3BD /* NSData+RCExtensions.m in Sources */,
+				37E352C38681981D6179C71D /* RCSystemInfo.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		37E3591A10D3219021886E0C /* NSDate+RCExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3544C8038CB83310C3598 /* NSDate+RCExtensionsTests.swift */; };
 		37E35971060F603C2F028D1F /* NSDate+RCExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E356CA7C7188A8B6E2811A /* NSDate+RCExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E3598A1AAA3D70EA01C82D /* RCInMemoryCachedObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35C6CBB3229AA53ECEB58 /* RCInMemoryCachedObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		37E35A524749D5A223DF85E8 /* RCHTTPStatusCodes.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E354FADC6628DE00935866 /* RCHTTPStatusCodes.h */; };
 		37E35AD0B0D9EF0CDA29DAC2 /* MockStoreKitWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E351AC0FF9607719F7A29A /* MockStoreKitWrapper.swift */; };
 		37E35AD3BB8E99D2AA325825 /* DeviceCacheSubscriberAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35C4A795A0F056381A1B3 /* DeviceCacheSubscriberAttributesTests.swift */; };
 		37E35AE982974800FF079C14 /* RCSubscriberAttribute+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35C82A59C953A5F6017BB /* RCSubscriberAttribute+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -244,6 +245,7 @@
 		37E3544C8038CB83310C3598 /* NSDate+RCExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDate+RCExtensionsTests.swift"; sourceTree = "<group>"; };
 		37E35483531C5A5E6BF09BBD /* RCInMemoryCachedObject+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCInMemoryCachedObject+Protected.h"; sourceTree = "<group>"; };
 		37E354BEB8FDE39CAB7C4D69 /* MockDeviceCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDeviceCache.swift; sourceTree = "<group>"; };
+		37E354FADC6628DE00935866 /* RCHTTPStatusCodes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCHTTPStatusCodes.h; sourceTree = "<group>"; };
 		37E3550459807FF5636B2667 /* NSError+RCExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSError+RCExtensionsTests.swift"; sourceTree = "<group>"; };
 		37E3550C031F1FD95B366998 /* MockTransaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockTransaction.swift; sourceTree = "<group>"; };
 		37E3555AC54BD10BE56F2B6B /* RCDeviceCache+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCDeviceCache+Protected.h"; sourceTree = "<group>"; };
@@ -428,6 +430,7 @@
 				37E356CA7C7188A8B6E2811A /* NSDate+RCExtensions.h */,
 				37E355C86ED87895B04E0E99 /* NSData+RCExtensions.m */,
 				37E350352D8DCFAAA06662ED /* NSData+RCExtensions.h */,
+				37E354FADC6628DE00935866 /* RCHTTPStatusCodes.h */,
 			);
 			path = Purchases;
 			sourceTree = "<group>";
@@ -580,6 +583,7 @@
 				37E35971060F603C2F028D1F /* NSDate+RCExtensions.h in Headers */,
 				37E3559878659F4EA93ADDE6 /* NSData+RCExtensions.h in Headers */,
 				35C98D9520B7306A006DCBB5 /* RCCrossPlatformSupport.h in Headers */,
+				37E35A524749D5A223DF85E8 /* RCHTTPStatusCodes.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -76,7 +76,7 @@
 		35B54E5222EF88CE005918B1 /* RCEntitlementInfos+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 35B54E5122EF88CE005918B1 /* RCEntitlementInfos+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		35C514BE2321AC23000FFD78 /* OfferingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C514BD2321AC23000FFD78 /* OfferingsTests.swift */; };
 		35C514BF2321DCAC000FFD78 /* RCPackage+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = EF6FB66AA75A6EA23ACC0A9E /* RCPackage+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		35C98D9520B7306A006DCBB5 /* RCCrossPlatformSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 35C98D9420B7306A006DCBB5 /* RCCrossPlatformSupport.h */; };
+		35C98D9520B7306A006DCBB5 /* RCCrossPlatformSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 35C98D9420B7306A006DCBB5 /* RCCrossPlatformSupport.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		35CE74FB20C38A7100CE09D8 /* RCOffering.h in Headers */ = {isa = PBXBuildFile; fileRef = 35CE74F920C38A7100CE09D8 /* RCOffering.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		35CE74FD20C38A7100CE09D8 /* RCOffering.m in Sources */ = {isa = PBXBuildFile; fileRef = 35CE74FA20C38A7100CE09D8 /* RCOffering.m */; };
 		35CE750120C3932900CE09D8 /* RCOffering+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 35CE750020C3932900CE09D8 /* RCOffering+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -111,12 +111,12 @@
 		37E3591A10D3219021886E0C /* NSDate+RCExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3544C8038CB83310C3598 /* NSDate+RCExtensionsTests.swift */; };
 		37E35971060F603C2F028D1F /* NSDate+RCExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E356CA7C7188A8B6E2811A /* NSDate+RCExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E3598A1AAA3D70EA01C82D /* RCInMemoryCachedObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35C6CBB3229AA53ECEB58 /* RCInMemoryCachedObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		37E35A524749D5A223DF85E8 /* RCHTTPStatusCodes.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E354FADC6628DE00935866 /* RCHTTPStatusCodes.h */; };
+		37E35A524749D5A223DF85E8 /* RCHTTPStatusCodes.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E354FADC6628DE00935866 /* RCHTTPStatusCodes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E35AD0B0D9EF0CDA29DAC2 /* MockStoreKitWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E351AC0FF9607719F7A29A /* MockStoreKitWrapper.swift */; };
 		37E35AD3BB8E99D2AA325825 /* DeviceCacheSubscriberAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35C4A795A0F056381A1B3 /* DeviceCacheSubscriberAttributesTests.swift */; };
 		37E35AE982974800FF079C14 /* RCSubscriberAttribute+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35C82A59C953A5F6017BB /* RCSubscriberAttribute+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E35AF213F2F79CB067FDC2 /* InMemoryCachedObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35E3250FBBB03D92E06EC /* InMemoryCachedObjectTests.swift */; };
-		37E35B0940EE505602A2486B /* RCSystemInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35BCA450E95B0273976BE /* RCSystemInfo.h */; };
+		37E35B0940EE505602A2486B /* RCSystemInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35BCA450E95B0273976BE /* RCSystemInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E35B1F34D1624509012749 /* MockSubscriberAttributesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E351D48260D9DC8B1EE360 /* MockSubscriberAttributesManager.swift */; };
 		37E35BCE176D557487A903CC /* NSDate+RCExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E358235BB58A968B059B6B /* NSDate+RCExtensions.m */; };
 		37E35CCE215E9EABFB88F3BD /* NSData+RCExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E355C86ED87895B04E0E99 /* NSData+RCExtensions.m */; };
@@ -588,8 +588,8 @@
 				37E352F9B7505A398D578F53 /* RCDeviceCache+Protected.h in Headers */,
 				37E35971060F603C2F028D1F /* NSDate+RCExtensions.h in Headers */,
 				37E3559878659F4EA93ADDE6 /* NSData+RCExtensions.h in Headers */,
-				35C98D9520B7306A006DCBB5 /* RCCrossPlatformSupport.h in Headers */,
 				37E35A524749D5A223DF85E8 /* RCHTTPStatusCodes.h in Headers */,
+				35C98D9520B7306A006DCBB5 /* RCCrossPlatformSupport.h in Headers */,
 				37E35B0940EE505602A2486B /* RCSystemInfo.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -106,11 +106,11 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 }
 
 - (BOOL)finishTransactions {
-    return self.systemInfo.observerMode;
+    return self.systemInfo.finishTransactions;
 }
 
-- (void)setFinishTransactions:(BOOL)observerMode {
-    self.systemInfo.observerMode = observerMode;
+- (void)setFinishTransactions:(BOOL)finishTransactions {
+    self.systemInfo.finishTransactions = finishTransactions;
 }
 
 + (instancetype)sharedPurchases {
@@ -184,7 +184,8 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
     RCStoreKitRequestFetcher *fetcher = [[RCStoreKitRequestFetcher alloc] init];
     RCReceiptFetcher *receiptFetcher = [[RCReceiptFetcher alloc] init];
     RCAttributionFetcher *attributionFetcher = [[RCAttributionFetcher alloc] init];
-    RCSystemInfo *systemInfo = [[RCSystemInfo alloc] initWithPlatformFlavor:platformFlavor observerMode:observerMode];
+    RCSystemInfo *systemInfo = [[RCSystemInfo alloc] initWithPlatformFlavor:platformFlavor
+                                                         finishTransactions:!observerMode];
     RCBackend *backend = [[RCBackend alloc] initWithAPIKey:APIKey systemInfo:systemInfo];
     RCStoreKitWrapper *storeKitWrapper = [[RCStoreKitWrapper alloc] init];
     RCOfferingsFactory *offeringsFactory = [[RCOfferingsFactory alloc] init];
@@ -207,7 +208,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                    storeKitWrapper:storeKitWrapper
                 notificationCenter:[NSNotificationCenter defaultCenter]
                       userDefaults:userDefaults
-                      observerMode:observerMode
+                        systemInfo:systemInfo
                   offeringsFactory:offeringsFactory
                        deviceCache:deviceCache
                    identityManager:identityManager
@@ -222,7 +223,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                   storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper
                notificationCenter:(NSNotificationCenter *)notificationCenter
                      userDefaults:(NSUserDefaults *)userDefaults
-                     observerMode:(BOOL)observerMode
+                       systemInfo:systemInfo
                  offeringsFactory:(RCOfferingsFactory *)offeringsFactory
                       deviceCache:(RCDeviceCache *)deviceCache
                   identityManager:(RCIdentityManager *)identityManager
@@ -249,7 +250,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
         self.presentedOfferingsByProductIdentifier = [NSMutableDictionary new];
         self.purchaseCompleteCallbacks = [NSMutableDictionary new];
 
-        self.finishTransactions = !observerMode;
+        self.systemInfo = systemInfo;
         self.subscriberAttributesManager = subscriberAttributesManager;
 
         RCReceivePurchaserInfoBlock callDelegate = ^void(RCPurchaserInfo *info, NSError *error) {

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -29,6 +29,7 @@
 #import "RCIdentityManager.h"
 #import "NSError+RCExtensions.h"
 #import "RCSubscriberAttributesManager.h"
+#import "RCSystemInfo.h"
 
 #define CALL_IF_SET_ON_MAIN_THREAD(completion, ...) if (completion) [self dispatch:^{ completion(__VA_ARGS__); }];
 #define CALL_IF_SET_ON_SAME_THREAD(completion, ...) if (completion) completion(__VA_ARGS__);
@@ -100,7 +101,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 }
 
 + (NSString *)frameworkVersion {
-    return @"3.3.0-SNAPSHOT";
+    return RCSystemInfo.frameworkVersion;
 }
 
 + (instancetype)sharedPurchases {
@@ -585,7 +586,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
     // https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/StoreKitGuide/Chapters/Restoring.html
     [self receiptData:^(NSData * _Nonnull data) {
         if (data.length == 0) {
-            if (RCIsSandbox()) {
+            if (RCSystemInfo.isSandbox) {
                 RCLog(@"App running on sandbox without a receipt file. Restoring transactions won't work unless you've purchased before and there is a receipt available.");
             }
             CALL_IF_SET_ON_MAIN_THREAD(completion, nil, [RCPurchasesErrorUtils missingReceiptFileError]);

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -53,6 +53,7 @@
 @property (nonatomic) RCOfferingsFactory *offeringsFactory;
 @property (nonatomic) RCDeviceCache *deviceCache;
 @property (nonatomic) RCIdentityManager *identityManager;
+@property (nonatomic) RCSystemInfo *systemInfo;
 
 @end
 
@@ -102,6 +103,14 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 
 + (NSString *)frameworkVersion {
     return RCSystemInfo.frameworkVersion;
+}
+
+- (BOOL)finishTransactions {
+    return self.systemInfo.observerMode;
+}
+
+- (void)setFinishTransactions:(BOOL)observerMode {
+    self.systemInfo.observerMode = observerMode;
 }
 
 + (instancetype)sharedPurchases {
@@ -175,7 +184,8 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
     RCStoreKitRequestFetcher *fetcher = [[RCStoreKitRequestFetcher alloc] init];
     RCReceiptFetcher *receiptFetcher = [[RCReceiptFetcher alloc] init];
     RCAttributionFetcher *attributionFetcher = [[RCAttributionFetcher alloc] init];
-    RCBackend *backend = [[RCBackend alloc] initWithAPIKey:APIKey platformFlavor:platformFlavor];
+    RCSystemInfo *systemInfo = [[RCSystemInfo alloc] initWithPlatformFlavor:platformFlavor observerMode:observerMode];
+    RCBackend *backend = [[RCBackend alloc] initWithAPIKey:APIKey systemInfo:systemInfo];
     RCStoreKitWrapper *storeKitWrapper = [[RCStoreKitWrapper alloc] init];
     RCOfferingsFactory *offeringsFactory = [[RCOfferingsFactory alloc] init];
 

--- a/Purchases/RCBackend.h
+++ b/Purchases/RCBackend.h
@@ -14,7 +14,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class RCPurchaserInfo, RCHTTPClient, RCIntroEligibility, RCPromotionalOffer, RCSubscriberAttribute;
+@class RCPurchaserInfo, RCHTTPClient, RCIntroEligibility, RCPromotionalOffer, RCSubscriberAttribute, RCSystemInfo;
 
 typedef NS_ENUM(NSInteger, RCPaymentMode) {
     RCPaymentModeNone = -1,
@@ -46,7 +46,7 @@ typedef void(^RCOfferSigningResponseHandler)(NSString * _Nullable signature,
 
 @interface RCBackend : NSObject
 
-- (nullable instancetype)initWithAPIKey:(NSString *)APIKey platformFlavor:(nullable NSString *)platformFlavor;
+- (nullable instancetype)initWithAPIKey:(NSString *)APIKey systemInfo:(RCSystemInfo *)systemInfo;
 
 - (nullable instancetype)initWithHTTPClient:(RCHTTPClient *)client
                                      APIKey:(NSString *)APIKey;

--- a/Purchases/RCBackend.m
+++ b/Purchases/RCBackend.m
@@ -16,6 +16,7 @@
 #import "RCPurchasesErrorUtils+Protected.h"
 #import "RCUtils.h"
 #import "RCPromotionalOffer.h"
+#import "RCSystemInfo.h"
 
 #define RC_HAS_KEY(dictionary, key) (dictionary[key] == nil || dictionary[key] != [NSNull null])
 NSErrorUserInfoKey const RCSuccessfullySyncedKey = @"successfullySynced";
@@ -309,7 +310,7 @@ presentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
         return;
     }
     if (receiptData.length == 0) {
-        if (RCIsSandbox()) {
+        if (RCSystemInfo.isSandbox) {
             RCLog(@"App running on sandbox without a receipt file. Unable to determine into eligibility unless you've purchased before and there is a receipt available.");
         }
         NSMutableDictionary *eligibilities = [NSMutableDictionary new];

--- a/Purchases/RCBackend.m
+++ b/Purchases/RCBackend.m
@@ -49,16 +49,14 @@ RCPaymentMode RCPaymentModeFromSKProductDiscountPaymentMode(SKProductDiscountPay
 
 @implementation RCBackend
 
-- (nullable instancetype)initWithAPIKey:(NSString *)APIKey platformFlavor:(nullable NSString *)platformFlavor
-{
-    RCHTTPClient *client = [[RCHTTPClient alloc] initWithPlatformFlavor:platformFlavor];
+- (nullable instancetype)initWithAPIKey:(NSString *)APIKey systemInfo:(RCSystemInfo *)systemInfo {
+    RCHTTPClient *client = [[RCHTTPClient alloc] initWithSystemInfo:systemInfo];
     return [self initWithHTTPClient:client
                              APIKey:APIKey];
 }
 
 - (nullable instancetype)initWithHTTPClient:(RCHTTPClient *)client
-                                      APIKey:(NSString *)APIKey
-{
+                                     APIKey:(NSString *)APIKey {
     if (self = [super init]) {
         self.httpClient = client;
         self.APIKey = APIKey;

--- a/Purchases/RCHTTPClient.h
+++ b/Purchases/RCHTTPClient.h
@@ -10,13 +10,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class RCSystemInfo;
+
 typedef void(^RCHTTPClientResponseHandler)(NSInteger statusCode,
                                            NSDictionary * _Nullable response,
                                            NSError * _Nullable error);
 
 @interface RCHTTPClient : NSObject
 
-- (instancetype)initWithPlatformFlavor:(nullable NSString *)platformFlavor;
+- (instancetype)initWithSystemInfo:(RCSystemInfo *)systemInfo NS_DESIGNATED_INITIALIZER;
 
 + (NSString *)serverHostName;
 

--- a/Purchases/RCHTTPClient.h
+++ b/Purchases/RCHTTPClient.h
@@ -19,6 +19,7 @@ typedef void(^RCHTTPClientResponseHandler)(NSInteger statusCode,
 @interface RCHTTPClient : NSObject
 
 - (instancetype)initWithSystemInfo:(RCSystemInfo *)systemInfo NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
 
 + (NSString *)serverHostName;
 

--- a/Purchases/RCHTTPClient.m
+++ b/Purchases/RCHTTPClient.m
@@ -23,7 +23,7 @@ void RCOverrideServerHost(NSString *hostname) {
 @interface RCHTTPClient ()
 
 @property (nonatomic) NSURLSession *session;
-@property (nonatomic) NSString *platformFlavor;
+@property (nonatomic, weak) RCSystemInfo *systemInfo;
 
 @end
 
@@ -34,12 +34,12 @@ void RCOverrideServerHost(NSString *hostname) {
     return (overrideHostName) ? overrideHostName : @"api.revenuecat.com";
 }
 
-- (instancetype)initWithPlatformFlavor:(nullable NSString *)platformFlavor {
+- (instancetype)initWithSystemInfo:(RCSystemInfo *)systemInfo {
     if (self = [super init]) {
         NSURLSessionConfiguration *config = [NSURLSessionConfiguration ephemeralSessionConfiguration];
         config.HTTPMaximumConnectionsPerHost = 1;
         self.session = [NSURLSession sessionWithConfiguration:config];
-        self.platformFlavor = platformFlavor;
+        self.systemInfo = systemInfo;
     }
     return self;
 }
@@ -135,8 +135,9 @@ void RCOverrideServerHost(NSString *hostname) {
         @"X-Version": RCSystemInfo.frameworkVersion,
         @"X-Platform": RCSystemInfo.platformHeader,
         @"X-Platform-Version": RCSystemInfo.systemVersion,
-        @"X-Platform-Flavor": self.platformFlavor ?: @"native",
-        @"X-Client-Version": RCSystemInfo.appVersion
+        @"X-Platform-Flavor": self.systemInfo.platformFlavor,
+        @"X-Client-Version": RCSystemInfo.appVersion,
+        @"X-Observer-Mode-Enabled": @(self.systemInfo.observerMode)
     };
 }
 

--- a/Purchases/RCHTTPClient.m
+++ b/Purchases/RCHTTPClient.m
@@ -145,13 +145,14 @@ void RCOverrideServerHost(NSString *hostname) {
 }
 
 - (NSDictionary *)defaultHeaders {
-    return [NSMutableDictionary
-        dictionaryWithDictionary:@{@"content-type": @"application/json",
-            @"X-Version": RCPurchases.frameworkVersion,
-            @"X-Platform": PLATFORM_HEADER,
-            @"X-Platform-Version": self.class.systemVersion,
-            @"X-Platform-Flavor": self.platformFlavor ?: @"native",
-            @"X-Client-Version": self.class.appVersion}];
+    return @{
+        @"content-type": @"application/json",
+        @"X-Version": RCPurchases.frameworkVersion,
+        @"X-Platform": PLATFORM_HEADER,
+        @"X-Platform-Version": self.class.systemVersion,
+        @"X-Platform-Flavor": self.platformFlavor ?: @"native",
+        @"X-Client-Version": self.class.appVersion
+    };
 }
 
 

--- a/Purchases/RCHTTPClient.m
+++ b/Purchases/RCHTTPClient.m
@@ -8,9 +8,8 @@
 
 #import "RCHTTPClient.h"
 #import "RCUtils.h"
-#import "RCPurchases.h"
-#import "RCCrossPlatformSupport.h"
 #import "RCHTTPStatusCodes.h"
+#import "RCSystemInfo.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -43,20 +42,6 @@ void RCOverrideServerHost(NSString *hostname) {
         self.platformFlavor = platformFlavor;
     }
     return self;
-}
-
-+ (NSString *)systemVersion {
-    NSProcessInfo *info = [[NSProcessInfo alloc] init];
-    return info.operatingSystemVersionString;
-}
-
-+ (NSString *)appVersion {
-    NSString *version = NSBundle.mainBundle.infoDictionary[@"CFBundleShortVersionString"];
-    if (version) {
-        return version;
-    } else {
-        return @"";
-    }
 }
 
 - (void)performRequest:(NSString *)HTTPMethod
@@ -147,11 +132,11 @@ void RCOverrideServerHost(NSString *hostname) {
 - (NSDictionary *)defaultHeaders {
     return @{
         @"content-type": @"application/json",
-        @"X-Version": RCPurchases.frameworkVersion,
-        @"X-Platform": PLATFORM_HEADER,
-        @"X-Platform-Version": self.class.systemVersion,
+        @"X-Version": RCSystemInfo.frameworkVersion,
+        @"X-Platform": RCSystemInfo.platformHeader,
+        @"X-Platform-Version": RCSystemInfo.systemVersion,
         @"X-Platform-Flavor": self.platformFlavor ?: @"native",
-        @"X-Client-Version": self.class.appVersion
+        @"X-Client-Version": RCSystemInfo.appVersion
     };
 }
 

--- a/Purchases/RCHTTPClient.m
+++ b/Purchases/RCHTTPClient.m
@@ -11,12 +11,14 @@
 #import "RCPurchases.h"
 #import "RCCrossPlatformSupport.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 static NSString *overrideHostName = nil;
 
-void RCOverrideServerHost(NSString *hostname)
-{
+void RCOverrideServerHost(NSString *hostname) {
     overrideHostName = hostname;
 }
+
 
 @interface RCHTTPClient ()
 
@@ -25,15 +27,14 @@ void RCOverrideServerHost(NSString *hostname)
 
 @end
 
+
 @implementation RCHTTPClient
 
-+ (NSString *)serverHostName
-{
-    return  (overrideHostName) ? overrideHostName : @"api.revenuecat.com";
++ (NSString *)serverHostName {
+    return (overrideHostName) ? overrideHostName : @"api.revenuecat.com";
 }
 
-- (instancetype)initWithPlatformFlavor:(nullable NSString *)platformFlavor
-{
+- (instancetype)initWithPlatformFlavor:(nullable NSString *)platformFlavor {
     if (self = [super init]) {
         NSURLSessionConfiguration *config = [NSURLSessionConfiguration ephemeralSessionConfiguration];
         config.HTTPMaximumConnectionsPerHost = 1;
@@ -49,7 +50,7 @@ void RCOverrideServerHost(NSString *hostname)
 }
 
 + (NSString *)appVersion {
-    NSString *version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+    NSString *version = NSBundle.mainBundle.infoDictionary[@"CFBundleShortVersionString"];
     if (version) {
         return version;
     } else {
@@ -61,22 +62,66 @@ void RCOverrideServerHost(NSString *hostname)
                   path:(NSString *)path
                   body:(nullable NSDictionary *)requestBody
                headers:(nullable NSDictionary<NSString *, NSString *> *)headers
-     completionHandler:(nullable RCHTTPClientResponseHandler)completionHandler
-{
-    NSParameterAssert(!([HTTPMethod isEqualToString:@"GET"] && requestBody));
-    NSParameterAssert(([HTTPMethod isEqualToString:@"GET"] || [HTTPMethod isEqualToString:@"POST"]));
+     completionHandler:(nullable RCHTTPClientResponseHandler)completionHandler {
+    [self assertIsValidRequestWithMethod:HTTPMethod body:requestBody];
 
-    NSString *urlString = [NSString stringWithFormat:@"https://%@/v1%@", self.class.serverHostName, path];
-
-    NSMutableDictionary *defaultHeaders = [NSMutableDictionary
-                                           dictionaryWithDictionary:@{@"content-type": @"application/json",
-                                                                      @"X-Version": [RCPurchases frameworkVersion],
-                                                                      @"X-Platform": PLATFORM_HEADER,
-                                                                      @"X-Platform-Version": [self.class systemVersion],
-                                                                      @"X-Platform-Flavor": self.platformFlavor ? self.platformFlavor : @"native",
-                                                                      @"X-Client-Version": [self.class appVersion]}];
+    NSMutableDictionary *defaultHeaders = self.defaultHeaders.mutableCopy;
     [defaultHeaders addEntriesFromDictionary:headers];
 
+    NSMutableURLRequest *request = [self createRequestWithMethod:HTTPMethod
+                                                            path:path
+                                                     requestBody:requestBody
+                                                         headers:defaultHeaders];
+
+    typedef void (^SessionCompletionBlock)(NSData *_Nullable, NSURLResponse *_Nullable, NSError *_Nullable);
+
+    SessionCompletionBlock block = ^void(NSData *_Nullable data,
+                                         NSURLResponse *_Nullable response,
+                                         NSError *_Nullable error) {
+        [self handleResponse:response data:data error:error request:request completionHandler:completionHandler];
+    };
+
+    RCDebugLog(@"%@ %@", request.HTTPMethod, request.URL.path);
+    NSURLSessionTask *task = [self.session dataTaskWithRequest:request
+                                             completionHandler:block];
+    [task resume];
+}
+
+- (void)handleResponse:(NSURLResponse *)response
+                  data:(NSData *)data
+                 error:(NSError *)error
+               request:(NSMutableURLRequest *)request
+     completionHandler:(RCHTTPClientResponseHandler)completionHandler {
+    NSInteger statusCode = 599;
+    NSDictionary *responseObject = nil;
+
+    if (error == nil) {
+        statusCode = ((NSHTTPURLResponse *) response).statusCode;
+
+        RCDebugLog(@"%@ %@ %d", request.HTTPMethod, request.URL.path, statusCode);
+
+        NSError *jsonError;
+        responseObject = [NSJSONSerialization JSONObjectWithData:data
+                                                         options:0
+                                                           error:&jsonError];
+
+        if (jsonError) {
+            RCLog(@"Error parsing JSON %@", jsonError.localizedDescription);
+            RCLog(@"Data received: %@", [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
+            error = jsonError;
+        }
+    }
+
+    if (completionHandler != nil) {
+        completionHandler(statusCode, responseObject, error);
+    }
+}
+
+- (NSMutableURLRequest *)createRequestWithMethod:(NSString *)HTTPMethod
+                                            path:(NSString *)path
+                                     requestBody:(NSDictionary *)requestBody
+                                         headers:(NSMutableDictionary *)defaultHeaders {
+    NSString *urlString = [NSString stringWithFormat:@"https://%@/v1%@", self.class.serverHostName, path];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:urlString]];
 
     request.HTTPMethod = HTTPMethod;
@@ -90,46 +135,26 @@ void RCOverrideServerHost(NSString *hostname)
         }
         request.HTTPBody = body;
     }
+    return request;
+}
 
-    typedef void (^SessionCompletionBlock)(NSData * _Nullable, NSURLResponse * _Nullable, NSError * _Nullable);
+- (void)assertIsValidRequestWithMethod:(NSString *)HTTPMethod body:(NSDictionary *)requestBody {
+    NSParameterAssert(!([HTTPMethod isEqualToString:@"GET"] && requestBody));
+    NSParameterAssert(([HTTPMethod isEqualToString:@"GET"] || [HTTPMethod isEqualToString:@"POST"]));
+}
 
-    SessionCompletionBlock block = ^void(NSData * _Nullable data,
-                                         NSURLResponse * _Nullable response,
-                                         NSError * _Nullable error)
-    {
-
-
-        NSInteger statusCode = 599;
-        NSDictionary *responseObject = nil;
-
-        if (error == nil) {
-            statusCode = ((NSHTTPURLResponse *)response).statusCode;
-
-            RCDebugLog(@"%@ %@ %d", request.HTTPMethod, request.URL.path, statusCode);
-
-            NSError *jsonError;
-            responseObject = [NSJSONSerialization JSONObjectWithData:data
-                                                             options:0
-                                                               error:&jsonError];
-            
-            if (jsonError) {
-                RCLog(@"Error parsing JSON %@", jsonError.localizedDescription);
-                RCLog(@"Data received: %@", [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
-                error = jsonError;
-            }
-        }
-
-        if (completionHandler != nil) {
-            completionHandler(statusCode, responseObject, error);
-        }
-    };
-
-    RCDebugLog(@"%@ %@", request.HTTPMethod, request.URL.path);
-
-    NSURLSessionTask *task = [self.session dataTaskWithRequest:request
-                                             completionHandler:block];
-    [task resume];
+- (NSDictionary *)defaultHeaders {
+    return [NSMutableDictionary
+        dictionaryWithDictionary:@{@"content-type": @"application/json",
+            @"X-Version": RCPurchases.frameworkVersion,
+            @"X-Platform": PLATFORM_HEADER,
+            @"X-Platform-Version": self.class.systemVersion,
+            @"X-Platform-Flavor": self.platformFlavor ?: @"native",
+            @"X-Client-Version": self.class.appVersion}];
 }
 
 
 @end
+
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/RCHTTPClient.m
+++ b/Purchases/RCHTTPClient.m
@@ -10,6 +10,7 @@
 #import "RCUtils.h"
 #import "RCPurchases.h"
 #import "RCCrossPlatformSupport.h"
+#import "RCHTTPStatusCodes.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -92,7 +93,7 @@ void RCOverrideServerHost(NSString *hostname) {
                  error:(NSError *)error
                request:(NSMutableURLRequest *)request
      completionHandler:(RCHTTPClientResponseHandler)completionHandler {
-    NSInteger statusCode = 599;
+    NSInteger statusCode = RC_NETWORK_CONNECT_TIMEOUT_ERROR;
     NSDictionary *responseObject = nil;
 
     if (error == nil) {

--- a/Purchases/RCHTTPClient.m
+++ b/Purchases/RCHTTPClient.m
@@ -130,6 +130,7 @@ void RCOverrideServerHost(NSString *hostname) {
 }
 
 - (NSDictionary *)defaultHeaders {
+    NSString *observerMode = [NSString stringWithFormat:@"%@", self.systemInfo.finishTransactions ? @"false" : @"true"];
     return @{
         @"content-type": @"application/json",
         @"X-Version": RCSystemInfo.frameworkVersion,
@@ -137,7 +138,7 @@ void RCOverrideServerHost(NSString *hostname) {
         @"X-Platform-Version": RCSystemInfo.systemVersion,
         @"X-Platform-Flavor": self.systemInfo.platformFlavor,
         @"X-Client-Version": RCSystemInfo.appVersion,
-        @"X-Observer-Mode-Enabled": @(self.systemInfo.observerMode)
+        @"X-Observer-Mode-Enabled": observerMode
     };
 }
 

--- a/Purchases/RCHTTPStatusCodes.h
+++ b/Purchases/RCHTTPStatusCodes.h
@@ -1,0 +1,13 @@
+//
+// Created by Andrés Boedo on 5/6/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSUInteger, RCHTTPStatusCodes) {
+    RC_NETWORK_CONNECT_TIMEOUT_ERROR = 599
+};
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/RCPurchases+Protected.h
+++ b/Purchases/RCPurchases+Protected.h
@@ -16,7 +16,8 @@
     RCOfferingsFactory,
     RCDeviceCache,
     RCIdentityManager,
-    RCSubscriberAttributesManager;
+    RCSubscriberAttributesManager,
+    RCSystemInfo;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -31,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
                   storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper
                notificationCenter:(NSNotificationCenter *)notificationCenter
                      userDefaults:(NSUserDefaults *)userDefaults
-                     observerMode:(BOOL)observerMode
+                       systemInfo:(RCSystemInfo *)systemInfo
                  offeringsFactory:(RCOfferingsFactory *)offeringsFactory
                       deviceCache:(RCDeviceCache *)deviceCache
                   identityManager:(RCIdentityManager *)identityManager

--- a/Purchases/RCSystemInfo.h
+++ b/Purchases/RCSystemInfo.h
@@ -11,10 +11,10 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RCSystemInfo : NSObject
 
 - (instancetype)initWithPlatformFlavor:(nullable NSString *)platformFlavor
-                          observerMode:(BOOL)observerMode NS_DESIGNATED_INITIALIZER;
+                    finishTransactions:(BOOL)finishTransactions NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;
 
-@property(nonatomic, assign) BOOL observerMode;
+@property(nonatomic, assign) BOOL finishTransactions;
 @property(nonatomic, copy, readonly) NSString *platformFlavor;
 
 + (BOOL)isSandbox;

--- a/Purchases/RCSystemInfo.h
+++ b/Purchases/RCSystemInfo.h
@@ -15,7 +15,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)systemVersion;
 + (NSString *)appVersion;
 + (NSString *)platformHeader;
-+ (NSString *)platformFlavor;
 
 @end
 

--- a/Purchases/RCSystemInfo.h
+++ b/Purchases/RCSystemInfo.h
@@ -1,0 +1,23 @@
+//
+// Created by Andrés Boedo on 5/7/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+@interface RCSystemInfo : NSObject
+
++ (BOOL)isSandbox;
++ (NSString *)frameworkVersion;
++ (NSString *)systemVersion;
++ (NSString *)appVersion;
++ (NSString *)platformHeader;
++ (NSString *)platformFlavor;
+
+@end
+
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/RCSystemInfo.h
+++ b/Purchases/RCSystemInfo.h
@@ -10,6 +10,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RCSystemInfo : NSObject
 
+- (instancetype)initWithPlatformFlavor:(nullable NSString *)platformFlavor
+                          observerMode:(BOOL)observerMode NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+
+@property(nonatomic, assign) BOOL observerMode;
+@property(nonatomic, copy, readonly) NSString *platformFlavor;
+
 + (BOOL)isSandbox;
 + (NSString *)frameworkVersion;
 + (NSString *)systemVersion;

--- a/Purchases/RCSystemInfo.m
+++ b/Purchases/RCSystemInfo.m
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
                     finishTransactions:(BOOL)finishTransactions {
     if (self = [super init]) {
         if (!platformFlavor) {
-            platformFlavor =  @"native";
+            platformFlavor = @"native";
         }
         self.platformFlavor = platformFlavor;
         self.finishTransactions = finishTransactions;

--- a/Purchases/RCSystemInfo.m
+++ b/Purchases/RCSystemInfo.m
@@ -17,13 +17,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation RCSystemInfo
 
-- (instancetype)initWithPlatformFlavor:(nullable NSString *)platformFlavor observerMode:(BOOL)observerMode {
+- (instancetype)initWithPlatformFlavor:(nullable NSString *)platformFlavor
+                    finishTransactions:(BOOL)finishTransactions {
     if (self = [super init]) {
         if (!platformFlavor) {
             platformFlavor =  @"native";
         }
         self.platformFlavor = platformFlavor;
-        self.observerMode = observerMode;
+        self.finishTransactions = finishTransactions;
     }
     return self;
 }

--- a/Purchases/RCSystemInfo.m
+++ b/Purchases/RCSystemInfo.m
@@ -4,14 +4,9 @@
 //
 
 #import "RCSystemInfo.h"
+#import "RCCrossPlatformSupport.h"
 
 NS_ASSUME_NONNULL_BEGIN
-
-
-@interface RCSystemInfo ()
-
-
-@end
 
 
 @implementation RCSystemInfo
@@ -27,19 +22,17 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (NSString *)systemVersion {
-    return nil;
+    NSProcessInfo *info = [[NSProcessInfo alloc] init];
+    return info.operatingSystemVersionString;
 }
 
 + (NSString *)appVersion {
-    return nil;
+    NSString *version = NSBundle.mainBundle.infoDictionary[@"CFBundleShortVersionString"];
+    return version ?: @"";
 }
 
 + (NSString *)platformHeader {
-    return nil;
-}
-
-+ (NSString *)platformFlavor {
-    return nil;
+    return PLATFORM_HEADER;
 }
 
 @end

--- a/Purchases/RCSystemInfo.m
+++ b/Purchases/RCSystemInfo.m
@@ -9,7 +9,24 @@
 NS_ASSUME_NONNULL_BEGIN
 
 
+@interface RCSystemInfo()
+
+@property(nonatomic, copy, nullable) NSString *platformFlavor;
+
+@end
+
 @implementation RCSystemInfo
+
+- (instancetype)initWithPlatformFlavor:(nullable NSString *)platformFlavor observerMode:(BOOL)observerMode {
+    if (self = [super init]) {
+        if (!platformFlavor) {
+            platformFlavor =  @"native";
+        }
+        self.platformFlavor = platformFlavor;
+        self.observerMode = observerMode;
+    }
+    return self;
+}
 
 + (BOOL)isSandbox {
     NSURL *url = NSBundle.mainBundle.appStoreReceiptURL;

--- a/Purchases/RCSystemInfo.m
+++ b/Purchases/RCSystemInfo.m
@@ -1,0 +1,48 @@
+//
+// Created by Andrés Boedo on 5/7/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+#import "RCSystemInfo.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+@interface RCSystemInfo ()
+
+
+@end
+
+
+@implementation RCSystemInfo
+
++ (BOOL)isSandbox {
+    NSURL *url = NSBundle.mainBundle.appStoreReceiptURL;
+    NSString *receiptURLString = url.path;
+    return ([receiptURLString rangeOfString:@"sandboxReceipt"].location != NSNotFound);
+}
+
++ (NSString *)frameworkVersion {
+    return @"3.3.0-SNAPSHOT";
+}
+
++ (NSString *)systemVersion {
+    return nil;
+}
+
++ (NSString *)appVersion {
+    return nil;
+}
+
++ (NSString *)platformHeader {
+    return nil;
+}
+
++ (NSString *)platformFlavor {
+    return nil;
+}
+
+@end
+
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/RCUtils.h
+++ b/Purchases/RCUtils.h
@@ -15,6 +15,5 @@ BOOL RCShowDebugLogs(void);
 void RCDebugLog(NSString *format, ...);
 void RCErrorLog(NSString *format, ...);
 void RCLog(NSString *format, ...);
-BOOL RCIsSandbox(void);
 
 NS_ASSUME_NONNULL_END

--- a/Purchases/RCUtils.m
+++ b/Purchases/RCUtils.m
@@ -57,10 +57,3 @@ void RCLog(NSString *format, ...)
     NSLogv(format, args);
     va_end(args);
 }
-
-BOOL RCIsSandbox()
-{
-    NSURL *url = [[NSBundle mainBundle] appStoreReceiptURL];
-    NSString *receiptURLString = [url path];
-    return ([receiptURLString rangeOfString:@"sandboxReceipt"].location != NSNotFound);
-}

--- a/PurchasesTests/BackendTests.swift
+++ b/PurchasesTests/BackendTests.swift
@@ -54,7 +54,8 @@ class BackendTests: XCTestCase {
         }
     }
 
-    let httpClient = MockHTTPClient()
+    let systemInfo = RCSystemInfo(platformFlavor: nil, finishTransactions: true)
+    var httpClient: MockHTTPClient!
     let apiKey = "asharedsecret"
     let bundleID = "com.bundle.id"
     let userID = "user"
@@ -79,6 +80,7 @@ class BackendTests: XCTestCase {
     var backend: RCBackend?
 
     override func setUp() {
+        httpClient = MockHTTPClient(systemInfo: systemInfo)
         backend = RCBackend.init(httpClient: httpClient,
                                  apiKey: apiKey)
     }

--- a/PurchasesTests/HTTPClientTests.swift
+++ b/PurchasesTests/HTTPClientTests.swift
@@ -15,7 +15,7 @@ import Purchases
 
 class HTTPClientTests: XCTestCase {
 
-    let client = RCHTTPClient(platformFlavor: nil)
+    let client = RCHTTPClient(systemInfo: RCSystemInfo(platformFlavor: nil, observerMode: false))
 
     override func tearDown() {
         HTTPStubs.removeAllStubs()
@@ -328,7 +328,8 @@ class HTTPClientTests: XCTestCase {
             headerPresent = true
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
         }
-        let client = RCHTTPClient(platformFlavor: "react-native")
+        let systemInfo = RCSystemInfo(platformFlavor: "react-native", observerMode: false)
+        let client = RCHTTPClient(systemInfo: systemInfo)
 
         client.performRequest("POST", path: path, body: Dictionary.init(),
                                    headers: ["test_header": "value"], completionHandler:nil)

--- a/PurchasesTests/HTTPClientTests.swift
+++ b/PurchasesTests/HTTPClientTests.swift
@@ -15,7 +15,13 @@ import Purchases
 
 class HTTPClientTests: XCTestCase {
 
-    let client = RCHTTPClient(systemInfo: RCSystemInfo(platformFlavor: nil, observerMode: false))
+    let systemInfo = RCSystemInfo(platformFlavor: nil, finishTransactions: true)
+    var client: RCHTTPClient!
+
+    override func setUp() {
+        super.setUp()
+        client = RCHTTPClient(systemInfo: systemInfo)
+    }
 
     override func tearDown() {
         HTTPStubs.removeAllStubs()
@@ -328,7 +334,7 @@ class HTTPClientTests: XCTestCase {
             headerPresent = true
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
         }
-        let systemInfo = RCSystemInfo(platformFlavor: "react-native", observerMode: false)
+        let systemInfo = RCSystemInfo(platformFlavor: "react-native", finishTransactions: true)
         let client = RCHTTPClient(systemInfo: systemInfo)
 
         client.performRequest("POST", path: path, body: Dictionary.init(),

--- a/PurchasesTests/HTTPClientTests.swift
+++ b/PurchasesTests/HTTPClientTests.swift
@@ -342,5 +342,39 @@ class HTTPClientTests: XCTestCase {
 
         expect(headerPresent).toEventually(equal(true))
     }
+
+    func testPassesObserverModeHeaderCorrectlyWhenEnabled() {
+        let path = "/a_random_path"
+        var headerPresent = false
+
+        stub(condition: hasHeaderNamed("X-Observer-Mode-Enabled", value: "false")) { request in
+            headerPresent = true
+            return HTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
+        }
+        let systemInfo = RCSystemInfo(platformFlavor: nil, finishTransactions: true)
+        let client = RCHTTPClient(systemInfo: systemInfo)
+
+        client.performRequest("POST", path: path, body: Dictionary.init(),
+                                   headers: ["test_header": "value"], completionHandler:nil)
+
+        expect(headerPresent).toEventually(equal(true))
+    }
+
+    func testPassesObserverModeHeaderCorrectlyWhenDisabled() {
+        let path = "/a_random_path"
+        var headerPresent = false
+
+        stub(condition: hasHeaderNamed("X-Observer-Mode-Enabled", value: "true")) { request in
+            headerPresent = true
+            return HTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
+        }
+        let systemInfo = RCSystemInfo(platformFlavor: nil, finishTransactions: false)
+        let client = RCHTTPClient(systemInfo: systemInfo)
+
+        client.performRequest("POST", path: path, body: Dictionary.init(),
+                                   headers: ["test_header": "value"], completionHandler:nil)
+
+        expect(headerPresent).toEventually(equal(true))
+    }
 }
 

--- a/PurchasesTests/PurchasesTests-Bridging-Header.h
+++ b/PurchasesTests/PurchasesTests-Bridging-Header.h
@@ -37,3 +37,4 @@
 #include <Purchases/RCSubscriberAttributesManager.h>
 #include <Purchases/RCPurchases+SubscriberAttributes.h>
 #include <Purchases/NSData+RCExtensions.h>
+#include <Purchases/RCSystemInfo.h>

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -188,6 +188,8 @@ class PurchasesTests: XCTestCase {
     func setupPurchases(automaticCollection: Bool = false) {
         Purchases.automaticAppleSearchAdsAttributionCollection = automaticCollection
         self.identityManager.mockIsAnonymous = false
+        let systemInfo: RCSystemInfo = RCSystemInfo(platformFlavor: nil, finishTransactions: true)
+
         purchases = Purchases(appUserID: identityManager.currentAppUserID,
                               requestFetcher: requestFetcher,
                               receiptFetcher: receiptFetcher,
@@ -196,7 +198,7 @@ class PurchasesTests: XCTestCase {
                               storeKitWrapper: storeKitWrapper,
                               notificationCenter: notificationCenter,
                               userDefaults: userDefaults,
-                              observerMode: false,
+                              systemInfo: systemInfo,
                               offeringsFactory: offeringsFactory,
                               deviceCache: deviceCache,
                               identityManager: identityManager,
@@ -208,6 +210,8 @@ class PurchasesTests: XCTestCase {
     func setupAnonPurchases() {
         Purchases.automaticAppleSearchAdsAttributionCollection = false
         self.identityManager.mockIsAnonymous = true
+        let systemInfo: RCSystemInfo = RCSystemInfo(platformFlavor: nil, finishTransactions: true)
+
         purchases = Purchases(appUserID: nil,
                               requestFetcher: requestFetcher,
                               receiptFetcher: receiptFetcher,
@@ -216,7 +220,7 @@ class PurchasesTests: XCTestCase {
                               storeKitWrapper: storeKitWrapper,
                               notificationCenter: notificationCenter,
                               userDefaults: userDefaults,
-                              observerMode: false,
+                              systemInfo: systemInfo,
                               offeringsFactory: offeringsFactory,
                               deviceCache: deviceCache,
                               identityManager: identityManager,
@@ -226,6 +230,8 @@ class PurchasesTests: XCTestCase {
     }
 
     func setupPurchasesObserverModeOn() {
+        let systemInfo: RCSystemInfo = RCSystemInfo(platformFlavor: nil, finishTransactions: false)
+
         purchases = Purchases(appUserID: nil,
                               requestFetcher: requestFetcher,
                               receiptFetcher: receiptFetcher,
@@ -234,7 +240,7 @@ class PurchasesTests: XCTestCase {
                               storeKitWrapper: storeKitWrapper,
                               notificationCenter: notificationCenter,
                               userDefaults: userDefaults,
-                              observerMode: true,
+                              systemInfo: systemInfo,
                               offeringsFactory: offeringsFactory,
                               deviceCache: deviceCache,
                               identityManager: identityManager,

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -31,7 +31,8 @@ class BackendSubscriberAttributesTests: XCTestCase {
     ]
 
     override func setUp() {
-        mockHTTPClient = MockHTTPClient(platformFlavor: "iPhone")
+        let systemInfo = RCSystemInfo(platformFlavor: "iPhone", observerMode: false)
+        mockHTTPClient = MockHTTPClient(systemInfo: systemInfo)
         guard let backend = RCBackend(httpClient: mockHTTPClient, apiKey: "key") else { fatalError() }
         self.backend = backend
         dateProvider = MockDateProvider(stubbedNow: now)

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -30,8 +30,9 @@ class BackendSubscriberAttributesTests: XCTestCase {
         ]
     ]
 
+    let systemInfo = RCSystemInfo(platformFlavor: "iPhone", finishTransactions: true)
+
     override func setUp() {
-        let systemInfo = RCSystemInfo(platformFlavor: "iPhone", observerMode: false)
         mockHTTPClient = MockHTTPClient(systemInfo: systemInfo)
         guard let backend = RCBackend(httpClient: mockHTTPClient, apiKey: "key") else { fatalError() }
         self.backend = backend

--- a/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -4,7 +4,6 @@
 //
 
 import XCTest
-import OHHTTPStubs
 import Nimble
 
 import Purchases
@@ -25,6 +24,7 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
     var subscriberAttributeHeight: RCSubscriberAttribute!
     var subscriberAttributeWeight: RCSubscriberAttribute!
     var mockAttributes: [String: RCSubscriberAttribute]!
+    let systemInfo: RCSystemInfo = RCSystemInfo(platformFlavor: nil, finishTransactions: true)
 
     let purchasesDelegate = MockPurchasesDelegate()
 
@@ -60,7 +60,7 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
                               storeKitWrapper: mockStoreKitWrapper,
                               notificationCenter: mockNotificationCenter,
                               userDefaults: userDefaults,
-                              observerMode: false,
+                              systemInfo: systemInfo,
                               offeringsFactory: mockOfferingsFactory,
                               deviceCache: mockDeviceCache,
                               identityManager: mockIdentityManager,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,7 +33,7 @@ platform :ios do
     previous_version_number = get_version_number
     increment_version_number(version_number: new_version_number)
     version_bump_podspec(version_number: new_version_number)
-    increment_build_number(previous_version_number, new_version_number, '../Purchases/Public/RCPurchases.m')
+    increment_build_number(previous_version_number, new_version_number, '../Purchases/RCSystemInfo.m')
     increment_build_number(previous_version_number, new_version_number, '../.jazzy.yaml')
   end
 


### PR DESCRIPTION
This adds the new `X-Observer-Mode-Enabled` header, and does quite a bit of refactoring: 

- Created new enum for http status codes: `HTTPStatusCodes`
- Clean up on RCHTTPClient: 
    - Extract methods and clean up / modernize logic
    - The class was violating SRP by including logic for system metadata, this was extracted into a separate data class, `RCSystemInfo`. 
- Move storage of the `finishTransactions` property and `platformFlavor` to `RCSystemInfo`
- Updated tests and added tests for the new header