### PR TITLE
Platform flavor version header

### DIFF
--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -156,7 +156,12 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                        observerMode:(BOOL)observerMode
                        userDefaults:(nullable NSUserDefaults *)userDefaults
 {
-    return [self configureWithAPIKey:APIKey appUserID:appUserID observerMode:observerMode userDefaults:userDefaults platformFlavor:nil];
+    return [self configureWithAPIKey:APIKey
+                           appUserID:appUserID
+                        observerMode:observerMode
+                        userDefaults:userDefaults
+                      platformFlavor:nil
+               platformFlavorVersion:nil];
 }
 
 + (instancetype)configureWithAPIKey:(NSString *)APIKey
@@ -164,15 +169,26 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                        observerMode:(BOOL)observerMode
                        userDefaults:(nullable NSUserDefaults *)userDefaults
                      platformFlavor:(NSString *)platformFlavor
+              platformFlavorVersion:(NSString *)platformFlavorVersion
 {
-    RCPurchases *purchases = [[self alloc] initWithAPIKey:APIKey appUserID:appUserID userDefaults:userDefaults observerMode:observerMode platformFlavor:platformFlavor];
+    RCPurchases *purchases = [[self alloc] initWithAPIKey:APIKey
+                                                appUserID:appUserID
+                                             userDefaults:userDefaults
+                                             observerMode:observerMode
+                                           platformFlavor:platformFlavor
+                                    platformFlavorVersion:platformFlavorVersion];
     [self setDefaultInstance:purchases];
     return purchases;
 }
 
 - (instancetype)initWithAPIKey:(NSString *)APIKey appUserID:(nullable NSString *)appUserID
 {
-    return [self initWithAPIKey:APIKey appUserID:appUserID userDefaults:nil observerMode:false platformFlavor:nil];
+    return [self initWithAPIKey:APIKey
+                      appUserID:appUserID
+                   userDefaults:nil
+                   observerMode:false
+                 platformFlavor:nil
+          platformFlavorVersion:nil];
 }
 
 - (instancetype)initWithAPIKey:(NSString *)APIKey
@@ -180,11 +196,13 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                   userDefaults:(nullable NSUserDefaults *)userDefaults
                   observerMode:(BOOL)observerMode
                 platformFlavor:(nullable NSString *)platformFlavor
+         platformFlavorVersion:(nullable NSString *)platformFlavorVersion
 {
     RCStoreKitRequestFetcher *fetcher = [[RCStoreKitRequestFetcher alloc] init];
     RCReceiptFetcher *receiptFetcher = [[RCReceiptFetcher alloc] init];
     RCAttributionFetcher *attributionFetcher = [[RCAttributionFetcher alloc] init];
     RCSystemInfo *systemInfo = [[RCSystemInfo alloc] initWithPlatformFlavor:platformFlavor
+                                                      platformFlavorVersion:platformFlavorVersion
                                                          finishTransactions:!observerMode];
     RCBackend *backend = [[RCBackend alloc] initWithAPIKey:APIKey systemInfo:systemInfo];
     RCStoreKitWrapper *storeKitWrapper = [[RCStoreKitWrapper alloc] init];

--- a/Purchases/RCHTTPClient.m
+++ b/Purchases/RCHTTPClient.m
@@ -144,7 +144,7 @@ void RCOverrideServerHost(NSString *hostname) {
 
     NSString * _Nullable platformFlavorVersion = self.systemInfo.platformFlavorVersion;
     if (platformFlavorVersion) {
-        headers[@"X-Platform-Version-Flavor"] = platformFlavorVersion;
+        headers[@"X-Platform-Flavor-Version"] = platformFlavorVersion;
     }
 
     return headers;

--- a/Purchases/RCHTTPClient.m
+++ b/Purchases/RCHTTPClient.m
@@ -131,7 +131,8 @@ void RCOverrideServerHost(NSString *hostname) {
 
 - (NSDictionary *)defaultHeaders {
     NSString *observerMode = [NSString stringWithFormat:@"%@", self.systemInfo.finishTransactions ? @"false" : @"true"];
-    return @{
+    NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
+    [headers addEntriesFromDictionary: @{
         @"content-type": @"application/json",
         @"X-Version": RCSystemInfo.frameworkVersion,
         @"X-Platform": RCSystemInfo.platformHeader,
@@ -139,7 +140,14 @@ void RCOverrideServerHost(NSString *hostname) {
         @"X-Platform-Flavor": self.systemInfo.platformFlavor,
         @"X-Client-Version": RCSystemInfo.appVersion,
         @"X-Observer-Mode-Enabled": observerMode
-    };
+    }];
+
+    NSString * _Nullable platformFlavorVersion = self.systemInfo.platformFlavorVersion;
+    if (platformFlavorVersion) {
+        headers[@"X-Platform-Version-Flavor"] = platformFlavorVersion;
+    }
+
+    return headers;
 }
 
 

--- a/Purchases/RCSystemInfo.h
+++ b/Purchases/RCSystemInfo.h
@@ -11,11 +11,13 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RCSystemInfo : NSObject
 
 - (instancetype)initWithPlatformFlavor:(nullable NSString *)platformFlavor
+                 platformFlavorVersion:(nullable NSString *)platformFlavorVersion
                     finishTransactions:(BOOL)finishTransactions NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;
 
 @property(nonatomic, assign) BOOL finishTransactions;
 @property(nonatomic, copy, readonly) NSString *platformFlavor;
+@property(nonatomic, copy, readonly) NSString *platformFlavorVersion;
 
 + (BOOL)isSandbox;
 + (NSString *)frameworkVersion;

--- a/Purchases/RCSystemInfo.m
+++ b/Purchases/RCSystemInfo.m
@@ -28,8 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
         if (!platformFlavor) {
             platformFlavor = @"native";
         }
-        self.platformFlavor = platformFlavor;
 
+        self.platformFlavor = platformFlavor;
         self.platformFlavorVersion = platformFlavorVersion;
         self.finishTransactions = finishTransactions;
     }

--- a/Purchases/RCSystemInfo.m
+++ b/Purchases/RCSystemInfo.m
@@ -12,18 +12,25 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RCSystemInfo()
 
 @property(nonatomic, copy, nullable) NSString *platformFlavor;
+@property(nonatomic, copy, nullable) NSString *platformFlavorVersion;
 
 @end
 
 @implementation RCSystemInfo
 
 - (instancetype)initWithPlatformFlavor:(nullable NSString *)platformFlavor
+                 platformFlavorVersion:(nullable NSString *)platformFlavorVersion
                     finishTransactions:(BOOL)finishTransactions {
     if (self = [super init]) {
+        NSAssert((platformFlavor && platformFlavorVersion) || (!platformFlavor && !platformFlavorVersion),
+            @"RCSystemInfo initialized with non-matching platform flavor and platform flavor versions!");
+
         if (!platformFlavor) {
             platformFlavor = @"native";
         }
         self.platformFlavor = platformFlavor;
+
+        self.platformFlavorVersion = platformFlavorVersion;
         self.finishTransactions = finishTransactions;
     }
     return self;

--- a/PurchasesTests/BackendTests.swift
+++ b/PurchasesTests/BackendTests.swift
@@ -54,7 +54,7 @@ class BackendTests: XCTestCase {
         }
     }
 
-    let systemInfo = RCSystemInfo(platformFlavor: nil, finishTransactions: true)
+    let systemInfo = RCSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: true)
     var httpClient: MockHTTPClient!
     let apiKey = "asharedsecret"
     let bundleID = "com.bundle.id"

--- a/PurchasesTests/HTTPClientTests.swift
+++ b/PurchasesTests/HTTPClientTests.swift
@@ -15,7 +15,7 @@ import Purchases
 
 class HTTPClientTests: XCTestCase {
 
-    let systemInfo = RCSystemInfo(platformFlavor: nil, finishTransactions: true)
+    let systemInfo = RCSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: true)
     var client: RCHTTPClient!
 
     override func setUp() {
@@ -334,7 +334,9 @@ class HTTPClientTests: XCTestCase {
             headerPresent = true
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
         }
-        let systemInfo = RCSystemInfo(platformFlavor: "react-native", finishTransactions: true)
+        let systemInfo = RCSystemInfo(platformFlavor: "react-native",
+                                      platformFlavorVersion: "3.2.1",
+                                      finishTransactions: true)
         let client = RCHTTPClient(systemInfo: systemInfo)
 
         client.performRequest("POST", path: path, body: Dictionary.init(),
@@ -351,7 +353,7 @@ class HTTPClientTests: XCTestCase {
             headerPresent = true
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
         }
-        let systemInfo = RCSystemInfo(platformFlavor: nil, finishTransactions: true)
+        let systemInfo = RCSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: true)
         let client = RCHTTPClient(systemInfo: systemInfo)
 
         client.performRequest("POST", path: path, body: Dictionary.init(),
@@ -368,7 +370,7 @@ class HTTPClientTests: XCTestCase {
             headerPresent = true
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
         }
-        let systemInfo = RCSystemInfo(platformFlavor: nil, finishTransactions: false)
+        let systemInfo = RCSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: false)
         let client = RCHTTPClient(systemInfo: systemInfo)
 
         client.performRequest("POST", path: path, body: Dictionary.init(),

--- a/PurchasesTests/HTTPClientTests.swift
+++ b/PurchasesTests/HTTPClientTests.swift
@@ -345,6 +345,25 @@ class HTTPClientTests: XCTestCase {
         expect(headerPresent).toEventually(equal(true))
     }
 
+    func testPassesPlatformFlavorVersionHeader() {
+        let path = "/a_random_path"
+        var headerPresent = false
+
+        stub(condition: hasHeaderNamed("X-Platform-Flavor-Version", value: "1.2.3")) { request in
+            headerPresent = true
+            return HTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
+        }
+        let systemInfo = RCSystemInfo(platformFlavor: "react-native",
+                                      platformFlavorVersion: "1.2.3",
+                                      finishTransactions: true)
+        let client = RCHTTPClient(systemInfo: systemInfo)
+
+        client.performRequest("POST", path: path, body: Dictionary.init(),
+                                   headers: ["test_header": "value"], completionHandler:nil)
+
+        expect(headerPresent).toEventually(equal(true))
+    }
+
     func testPassesObserverModeHeaderCorrectlyWhenEnabled() {
         let path = "/a_random_path"
         var headerPresent = false

--- a/PurchasesTests/PurchasesTests.swift
+++ b/PurchasesTests/PurchasesTests.swift
@@ -188,7 +188,7 @@ class PurchasesTests: XCTestCase {
     func setupPurchases(automaticCollection: Bool = false) {
         Purchases.automaticAppleSearchAdsAttributionCollection = automaticCollection
         self.identityManager.mockIsAnonymous = false
-        let systemInfo: RCSystemInfo = RCSystemInfo(platformFlavor: nil, finishTransactions: true)
+        let systemInfo = RCSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: true)
 
         purchases = Purchases(appUserID: identityManager.currentAppUserID,
                               requestFetcher: requestFetcher,
@@ -210,7 +210,7 @@ class PurchasesTests: XCTestCase {
     func setupAnonPurchases() {
         Purchases.automaticAppleSearchAdsAttributionCollection = false
         self.identityManager.mockIsAnonymous = true
-        let systemInfo: RCSystemInfo = RCSystemInfo(platformFlavor: nil, finishTransactions: true)
+        let systemInfo = RCSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: true)
 
         purchases = Purchases(appUserID: nil,
                               requestFetcher: requestFetcher,
@@ -230,7 +230,7 @@ class PurchasesTests: XCTestCase {
     }
 
     func setupPurchasesObserverModeOn() {
-        let systemInfo: RCSystemInfo = RCSystemInfo(platformFlavor: nil, finishTransactions: false)
+        let systemInfo = RCSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: false)
 
         purchases = Purchases(appUserID: nil,
                               requestFetcher: requestFetcher,

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -30,7 +30,7 @@ class BackendSubscriberAttributesTests: XCTestCase {
         ]
     ]
 
-    let systemInfo = RCSystemInfo(platformFlavor: "iPhone", finishTransactions: true)
+    let systemInfo = RCSystemInfo(platformFlavor: "Unity", platformFlavorVersion: "2.3.3", finishTransactions: true)
 
     override func setUp() {
         mockHTTPClient = MockHTTPClient(systemInfo: systemInfo)

--- a/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -24,7 +24,9 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
     var subscriberAttributeHeight: RCSubscriberAttribute!
     var subscriberAttributeWeight: RCSubscriberAttribute!
     var mockAttributes: [String: RCSubscriberAttribute]!
-    let systemInfo: RCSystemInfo = RCSystemInfo(platformFlavor: nil, finishTransactions: true)
+    let systemInfo: RCSystemInfo = RCSystemInfo(platformFlavor: nil,
+                                                platformFlavorVersion: nil,
+                                                finishTransactions: true)
 
     let purchasesDelegate = MockPurchasesDelegate()
 


### PR DESCRIPTION
Adds new header, `X-Platform-Flavor-Version`, meant to indicate the version of the hybrid SDK, if any. 
For the native SDK, this header will not be passed. 