### PR TITLE
version 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## 3.3.0
+- Reorganized file system structure for the project
+	https://github.com/RevenueCat/purchases-ios/pull/242
+- New headers for observer mode and platform version
+    https://github.com/RevenueCat/purchases-ios/pull/237
+    https://github.com/RevenueCat/purchases-ios/pull/240
+    https://github.com/RevenueCat/purchases-ios/pull/241
+- Fixes subscriber attributes migration edge cases
+	https://github.com/RevenueCat/purchases-ios/pull/233
+- Autodetect appUserID deletion
+    https://github.com/RevenueCat/purchases-ios/pull/232
+    https://github.com/RevenueCat/purchases-ios/pull/236
+- Removes old trello link
+    https://github.com/RevenueCat/purchases-ios/pull/231
+- Removes unused functions
+    https://github.com/RevenueCat/purchases-ios/pull/228
+- Removes unnecessary no-op call to RCBackend's postSubscriberAttributes
+	https://github.com/RevenueCat/purchases-ios/pull/227
+- Fixes a bug where subscriber attributes are deleted when an alias is created.
+    https://github.com/RevenueCat/purchases-ios/pull/222
+- Fixes crash when payment.productIdentifier is nil
+    https://github.com/RevenueCat/purchases-ios/pull/226
+- Updates invalidatePurchaserInfoCache docs 
+    https://github.com/RevenueCat/purchases-ios/pull/223
+
 ## 3.2.2
 - Fixed build warnings about nil being passed to callees that require non-null parameters
     https://github.com/RevenueCat/purchases-ios/pull/216

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Purchases"
-  s.version          = "3.3.0-SNAPSHOT"
+  s.version          = "3.3.0"
   s.summary          = "Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/Purchases/Info.plist
+++ b/Purchases/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.0-SNAPSHOT</string>
+	<string>3.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/PurchasesTests/Info.plist
+++ b/PurchasesTests/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.0-SNAPSHOT</string>
+	<string>3.3.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,7 +33,7 @@ platform :ios do
     previous_version_number = get_version_number
     increment_version_number(version_number: new_version_number)
     version_bump_podspec(version_number: new_version_number)
-    increment_build_number(previous_version_number, new_version_number, '../Purchases/RCSystemInfo.m')
+    increment_build_number(previous_version_number, new_version_number, '../Purchases/Misc/RCSystemInfo.m')
     increment_build_number(previous_version_number, new_version_number, '../.jazzy.yaml')
   end
 


### PR DESCRIPTION
Bump version number, also updates `Fastfile`'s `bump_and_update_changelog` to reflect the new file system structure

## 3.3.0
- Reorganized file system structure for the project
	https://github.com/RevenueCat/purchases-ios/pull/242
- New headers for observer mode and platform version
    https://github.com/RevenueCat/purchases-ios/pull/237
    https://github.com/RevenueCat/purchases-ios/pull/240
    https://github.com/RevenueCat/purchases-ios/pull/241
- Fixes subscriber attributes migration edge cases
	https://github.com/RevenueCat/purchases-ios/pull/233
- Autodetect appUserID deletion
    https://github.com/RevenueCat/purchases-ios/pull/232
    https://github.com/RevenueCat/purchases-ios/pull/236
- Removes old trello link
    https://github.com/RevenueCat/purchases-ios/pull/231
- Removes unused functions
    https://github.com/RevenueCat/purchases-ios/pull/228
- Removes unnecessary no-op call to RCBackend's postSubscriberAttributes
	https://github.com/RevenueCat/purchases-ios/pull/227
- Fixes a bug where subscriber attributes are deleted when an alias is created.
    https://github.com/RevenueCat/purchases-ios/pull/222
- Fixes crash when payment.productIdentifier is nil
    https://github.com/RevenueCat/purchases-ios/pull/226
- Updates invalidatePurchaserInfoCache docs 
    https://github.com/RevenueCat/purchases-ios/pull/223
