### PR TITLE
Prevent a warning when compiling for Mac Catalyst

### DIFF
--- a/Purchases/Misc/RCCrossPlatformSupport.h
+++ b/Purchases/Misc/RCCrossPlatformSupport.h
@@ -53,7 +53,9 @@
 
 // Should match available platforms in
 // https://developer.apple.com/documentation/storekit/skpaymenttransactionobserver/2877502-paymentqueue?language=objc
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_MACCATALYST
+#define PURCHASES_INITIATED_FROM_APP_STORE_AVAILABLE 0
+#elif TARGET_OS_IOS || TARGET_OS_TV
 #define PURCHASES_INITIATED_FROM_APP_STORE_AVAILABLE 1
 #else
 #define PURCHASES_INITIATED_FROM_APP_STORE_AVAILABLE 0


### PR DESCRIPTION
**Description:**

As described on https://developer.apple.com/documentation/storekit/skpaymenttransactionobserver/2877502-paymentqueue?language=objc , the method ```- (BOOL)paymentQueue:(SKPaymentQueue *)queue shouldAddStorePayment:(SKPayment *)payment forProduct:(SKProduct *)product``` is only available for iOS and tvOS but not for Mac Catalyst.

However `PURCHASES_INITIATED_FROM_APP_STORE_AVAILABLE` is set to 1 for Mac Catalyst which leads to a unavailable method warning:

```
RevenueCat/purchases-ios/Purchases/Purchasing/RCStoreKitWrapper.m:87:1: warning: implementing unavailable method [-Wdeprecated-implementations]
- (BOOL)paymentQueue:(SKPaymentQueue *)queue shouldAddStorePayment:(SKPayment *)payment forProduct:(SKProduct *)product
^
In module 'StoreKit' imported from RevenueCat/purchases-ios/Purchases/Purchasing/RCStoreKitWrapper.h:10:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/iOSSupport/System/Library/Frameworks/StoreKit.framework/Headers/SKPaymentQueue.h:99:1: note: method 'paymentQueue:shouldAddStorePayment:forProduct:' declared here
- (BOOL)paymentQueue:(SKPaymentQueue *)queue shouldAddStorePayment:(SKPayment *)payment forProduct:(SKProduct *)product NS_SWIFT_NAME(paymentQueue(_:shouldAddStorePayment:for:)) API_AVAILABLE(ios(11.0)) API_UNAVAILABLE(macos, macCatalyst, watchos);
```

**Steps to reproduce**

1. Compile Purchases iOS for Mac Catalyst

Result: You see the warning.

**Proposed solution:**

To fix this warning, `PURCHASES_INITIATED_FROM_APP_STORE_AVAILABLE` is set to 0 when compiling for Mac Catalyst.