### PR TITLE
Cleanup rc cross platform support & podspec

### DIFF
--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -23,14 +23,13 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 
   s.source_files = [
-    'Purchases/Public/Purchases.h',
-    'Purchases/**/*.h'
+    'Purchases/**/*.h',
+    'Purchases/**/*.m'
   ]
 
 
   s.public_header_files = [
-    'Purchases/Public/Purchases.h',
-    "Purchases/Public/*.h"
+    'Purchases/Public/*.h'
   ]
 
 end

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -24,22 +24,7 @@ Pod::Spec.new do |s|
 
   s.source_files = [
     'Purchases/Public/Purchases.h',
-    'Purchases/Caching/*.h',
-    'Purchases/Caching/*.m',
-    'Purchases/FoundationExtensions/*.h',
-    'Purchases/FoundationExtensions/*.m',
-    'Purchases/Misc/*.h',
-    'Purchases/Misc/*.m',
-    'Purchases/Networking/*.h',
-    'Purchases/Networking/*.m',
-    'Purchases/Public/*.h',
-    'Purchases/Public/*.m',
-    'Purchases/Purchasing/*.h',
-    'Purchases/Purchasing/*.m',
-    'Purchases/ProtectedExtensions/*.h',
-    'Purchases/ProtectedExtensions/*.m',
-    'Purchases/SubscriberAttributes/*.h',
-    'Purchases/SubscriberAttributes/*.m',
+    'Purchases/**/*.h'
   ]
 
 

--- a/Purchases/Misc/RCCrossPlatformSupport.h
+++ b/Purchases/Misc/RCCrossPlatformSupport.h
@@ -6,7 +6,7 @@
 //  Copyright © 2019 RevenueCat. All rights reserved.
 //
 
-#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
+#if TARGET_OS_IOS || TARGET_OS_TV
 #define APP_DID_BECOME_ACTIVE_NOTIFICATION_NAME UIApplicationDidBecomeActiveNotification
 #define APP_WILL_RESIGN_ACTIVE_NOTIFICATION_NAME UIApplicationWillResignActiveNotification
 #elif TARGET_OS_OSX
@@ -37,7 +37,7 @@
 
 // Should match available platforms in
 // https://developer.apple.com/documentation/uikit/uidevice?language=objc
-#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
+#if TARGET_OS_IOS || TARGET_OS_TV
 #define UI_DEVICE_AVAILABLE 1
 #else
 #define UI_DEVICE_AVAILABLE 0
@@ -45,7 +45,7 @@
 
 // Should match available platforms in
 // https://developer.apple.com/documentation/iad/adclient?language=objc
-#if TARGET_OS_IOS || TARGET_OS_MACCATALYST
+#if TARGET_OS_IOS
 #define AD_CLIENT_AVAILABLE 1
 #else
 #define AD_CLIENT_AVAILABLE 0
@@ -53,9 +53,7 @@
 
 // Should match available platforms in
 // https://developer.apple.com/documentation/storekit/skpaymenttransactionobserver/2877502-paymentqueue?language=objc
-#if TARGET_OS_MACCATALYST
-#define PURCHASES_INITIATED_FROM_APP_STORE_AVAILABLE 0
-#elif TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_TV || (TARGET_OS_IOS && !TARGET_OS_MACCATALYST)
 #define PURCHASES_INITIATED_FROM_APP_STORE_AVAILABLE 1
 #else
 #define PURCHASES_INITIATED_FROM_APP_STORE_AVAILABLE 0


### PR DESCRIPTION

 - clean up `RCCrossPlatformSupport`: `TARGET_OS_IOS` is always true if `TARGET_OS_MACCATALYST` is true, simplified related conditions
- clean up Podspec, used `**` for subfolders