### PR TITLE
Fixed issue in RCPurchases.m where isRestore value is set to YES rath…

### DIFF
--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -623,7 +623,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
         RCSubscriberAttributeDict subscriberAttributes = self.unsyncedAttributesByKey;
         [self.backend postReceiptData:data
                             appUserID:self.appUserID
-                            isRestore:YES
+                            isRestore:self.allowSharingAppStoreAccount
                     productIdentifier:nil
                                 price:nil
                           paymentMode:RCPaymentModeNone


### PR DESCRIPTION
Fixed issue in RCPurchases.m where isRestore value is set to YES rather than self.allowSharingAppStoreAccount as with handlePurchasedTransaction method