### PR TITLE
fix: `(null)` aliases

### DIFF
--- a/Purchases/Public/RCPurchasesErrorUtils.h
+++ b/Purchases/Public/RCPurchasesErrorUtils.h
@@ -72,6 +72,14 @@ NS_SWIFT_NAME(Purchases.ErrorUtils)
 + (NSError *)missingReceiptFileError;
 
 /**
+ * Constructs an NSError with the [RCMissingReceiptFileError] code.
+ *
+ * @note This error is used when the appUserID can't be found in user defaults. This can happen if user defaults
+ * are removed manually or if the OS deletes entries when running out of space.
+ */
++ (NSError *)missingAppUserIDError;
+
+/**
  * Maps an SKErrorCode code to a RCPurchasesErrorCode code. Constructs an NSError with the mapped code and adds a
  * [RCUnderlyingErrorKey] in the NSError.userInfo dictionary. The SKErrorCode code will be mapped using
  * [RCPurchasesErrorCodeFromSKError].

--- a/Purchases/Public/RCPurchasesErrorUtils.h
+++ b/Purchases/Public/RCPurchasesErrorUtils.h
@@ -72,7 +72,7 @@ NS_SWIFT_NAME(Purchases.ErrorUtils)
 + (NSError *)missingReceiptFileError;
 
 /**
- * Constructs an NSError with the [RCMissingReceiptFileError] code.
+ * Constructs an NSError with the [RCInvalidAppUserIdError] code.
  *
  * @note This error is used when the appUserID can't be found in user defaults. This can happen if user defaults
  * are removed manually or if the OS deletes entries when running out of space.

--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -72,6 +72,8 @@ static NSString *RCPurchasesErrorDescription(RCPurchasesErrorCode code) {
             return @"The payment is pending.";
         case RCInvalidSubscriberAttributesError:
             return @"One or more of the attributes sent could not be saved.";
+        case RCMissingAppUserIDError:
+            return @"The appUserID is missing.";
     }
     return @"Something went wrong.";
 }
@@ -127,6 +129,8 @@ static NSString *const RCPurchasesErrorCodeString(RCPurchasesErrorCode code) {
             return @"PAYMENT_PENDING_ERROR";
         case RCInvalidSubscriberAttributesError:
             return @"INVALID_SUBSCRIBER_ATTRIBUTES";
+        case RCMissingAppUserIDError:
+            return @"MISSING_APP_USER_ID";
     }
     return @"UNRECOGNIZED_ERROR";
 }
@@ -201,36 +205,31 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
 
 @implementation RCPurchasesErrorUtils
 
-+ (NSError *)errorWithCode:(RCPurchasesErrorCode)code
-{
++ (NSError *)errorWithCode:(RCPurchasesErrorCode)code {
     return [self errorWithCode:code message:nil];
 }
 
 + (NSError *)errorWithCode:(RCPurchasesErrorCode)code
-                   message:(nullable NSString *)message
-{
+                   message:(nullable NSString *)message {
     return [self errorWithCode:code message:message underlyingError:nil];
 }
 
 
 + (NSError *)errorWithCode:(RCPurchasesErrorCode)code
-           underlyingError:(nullable NSError *)underlyingError
-{
+           underlyingError:(nullable NSError *)underlyingError {
     return [self errorWithCode:code message:nil underlyingError:underlyingError extraUserInfo:nil];
 }
 
 + (NSError *)errorWithCode:(RCPurchasesErrorCode)code
                    message:(nullable NSString *)message
-           underlyingError:(nullable NSError *)underlyingError
-{
+           underlyingError:(nullable NSError *)underlyingError {
     return [self errorWithCode:code message:message underlyingError:underlyingError extraUserInfo:nil];
 }
 
 + (NSError *)errorWithCode:(RCPurchasesErrorCode)code
                    message:(nullable NSString *)message
            underlyingError:(nullable NSError *)underlyingError
-             extraUserInfo:(nullable NSDictionary *)extraUserInfo
-{
+             extraUserInfo:(nullable NSDictionary *)extraUserInfo {
 
     NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:extraUserInfo];
     userInfo[NSLocalizedDescriptionKey] = message ?: RCPurchasesErrorDescription(code);
@@ -242,21 +241,18 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
 }
 
 + (NSError *)errorWithCode:(RCPurchasesErrorCode)code
-                  userInfo:(NSDictionary *)userInfo
-{
+                  userInfo:(NSDictionary *)userInfo {
     RCErrorLog(@"%@", RCPurchasesErrorDescription(code));
     return [NSError errorWithDomain:RCPurchasesErrorDomain code:code userInfo:userInfo];
 }
 
-+ (NSError *)networkErrorWithUnderlyingError:(NSError *)underlyingError
-{
++ (NSError *)networkErrorWithUnderlyingError:(NSError *)underlyingError {
     return [self errorWithCode:RCNetworkError
                underlyingError:underlyingError];
 }
 
 + (NSError *)backendUnderlyingError:(nullable NSNumber *)backendCode
-                     backendMessage:(nullable NSString *)backendMessage
-{
+                     backendMessage:(nullable NSString *)backendMessage {
 
     return [NSError errorWithDomain:RCBackendErrorDomain
                                code:[backendCode integerValue] ?: RCUnknownError
@@ -266,15 +262,13 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
 }
 
 + (NSError *)backendErrorWithBackendCode:(nullable NSNumber *)backendCode
-                          backendMessage:(nullable NSString *)backendMessage
-{
+                          backendMessage:(nullable NSString *)backendMessage {
     return [self backendErrorWithBackendCode:backendCode backendMessage:backendMessage extraUserInfo:nil];
 }
 
 + (NSError *)backendErrorWithBackendCode:(nullable NSNumber *)backendCode
                           backendMessage:(nullable NSString *)backendMessage
-                              finishable:(BOOL)finishable
-{
+                              finishable:(BOOL)finishable {
     return [self backendErrorWithBackendCode:backendCode
                               backendMessage:backendMessage
                                extraUserInfo:@{
@@ -284,8 +278,7 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
 
 + (NSError *)backendErrorWithBackendCode:(nullable NSNumber *)backendCode
                           backendMessage:(nullable NSString *)backendMessage
-                           extraUserInfo:(nullable NSDictionary *)extraUserInfo
-{
+                           extraUserInfo:(nullable NSDictionary *)extraUserInfo {
     RCPurchasesErrorCode errorCode;
     if (backendCode != nil) {
         errorCode = RCPurchasesErrorCodeFromRCBackendErrorCode((RCBackendErrorCode) [backendCode integerValue]);
@@ -299,18 +292,19 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
                  extraUserInfo:extraUserInfo];
 }
 
-+ (NSError *)unexpectedBackendResponseError
-{
++ (NSError *)unexpectedBackendResponseError {
     return [self errorWithCode:RCUnexpectedBackendResponseError];
 }
 
-+ (NSError *)missingReceiptFileError
-{
++ (NSError *)missingReceiptFileError {
     return [self errorWithCode:RCMissingReceiptFileError];
 }
 
-+ (NSError *)purchasesErrorWithSKError:(NSError *)skError
-{
++ (NSError *)missingAppUserIDError {
+    return [self errorWithCode:RCMissingAppUserIDError];
+}
+
++ (NSError *)purchasesErrorWithSKError:(NSError *)skError {
 
     RCPurchasesErrorCode errorCode = RCPurchasesErrorCodeFromSKError(skError);
     return [self errorWithCode:errorCode

--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -72,8 +72,6 @@ static NSString *RCPurchasesErrorDescription(RCPurchasesErrorCode code) {
             return @"The payment is pending.";
         case RCInvalidSubscriberAttributesError:
             return @"One or more of the attributes sent could not be saved.";
-        case RCMissingAppUserIDError:
-            return @"The appUserID is missing.";
     }
     return @"Something went wrong.";
 }
@@ -129,8 +127,6 @@ static NSString *const RCPurchasesErrorCodeString(RCPurchasesErrorCode code) {
             return @"PAYMENT_PENDING_ERROR";
         case RCInvalidSubscriberAttributesError:
             return @"INVALID_SUBSCRIBER_ATTRIBUTES";
-        case RCMissingAppUserIDError:
-            return @"MISSING_APP_USER_ID";
     }
     return @"UNRECOGNIZED_ERROR";
 }
@@ -301,7 +297,7 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
 }
 
 + (NSError *)missingAppUserIDError {
-    return [self errorWithCode:RCMissingAppUserIDError];
+    return [self errorWithCode:RCInvalidAppUserIdError];
 }
 
 + (NSError *)purchasesErrorWithSKError:(NSError *)skError {

--- a/Purchases/Public/RCPurchasesErrors.h
+++ b/Purchases/Public/RCPurchasesErrors.h
@@ -52,7 +52,8 @@ typedef NS_ERROR_ENUM(RCPurchasesErrorDomain, RCPurchasesErrorCode) {
     RCIneligibleError,
     RCInsufficientPermissionsError,
     RCPaymentPendingError,
-    RCInvalidSubscriberAttributesError
+    RCInvalidSubscriberAttributesError,
+    RCMissingAppUserIDError
 } NS_SWIFT_NAME(Purchases.ErrorCode);
 
 /**

--- a/Purchases/Public/RCPurchasesErrors.h
+++ b/Purchases/Public/RCPurchasesErrors.h
@@ -53,7 +53,6 @@ typedef NS_ERROR_ENUM(RCPurchasesErrorDomain, RCPurchasesErrorCode) {
     RCInsufficientPermissionsError,
     RCPaymentPendingError,
     RCInvalidSubscriberAttributesError,
-    RCMissingAppUserIDError
 } NS_SWIFT_NAME(Purchases.ErrorCode);
 
 /**

--- a/Purchases/Purchasing/RCIdentityManager.m
+++ b/Purchases/Purchasing/RCIdentityManager.m
@@ -64,6 +64,10 @@
 }
 
 - (void)createAlias:(NSString *)alias withCompletionBlock:(void (^)(NSError *_Nullable error))completion {
+    if (!self.currentAppUserID) {
+        RCDebugLog(@"Couldn't create an alias because the currentAppUserID is null. This might happen if the entry in UserDefaults is missing.");
+        return;
+    }
     RCDebugLog(@"Creating an alias to %@ from %@", self.currentAppUserID, alias);
     [self.backend createAliasForAppUserID:self.currentAppUserID withNewAppUserID:alias completion:^(NSError *_Nullable error) {
         if (error == nil) {

--- a/Purchases/Purchasing/RCIdentityManager.m
+++ b/Purchases/Purchasing/RCIdentityManager.m
@@ -6,6 +6,8 @@
 #import "RCIdentityManager.h"
 #import "RCLogUtils.h"
 #import "RCBackend.h"
+#import "RCPurchasesErrorUtils.h"
+
 
 @interface RCIdentityManager ()
 
@@ -65,7 +67,9 @@
 
 - (void)createAlias:(NSString *)alias withCompletionBlock:(void (^)(NSError *_Nullable error))completion {
     if (!self.currentAppUserID) {
-        RCDebugLog(@"Couldn't create an alias because the currentAppUserID is null. This might happen if the entry in UserDefaults is missing.");
+        RCDebugLog(@"Couldn't create an alias because the currentAppUserID is null. "
+                   "This might happen if the entry in UserDefaults is missing.");
+        completion(RCPurchasesErrorUtils.missingAppUserIDError);
         return;
     }
     RCDebugLog(@"Creating an alias to %@ from %@", self.currentAppUserID, alias);

--- a/Purchases/Purchasing/RCIdentityManager.m
+++ b/Purchases/Purchasing/RCIdentityManager.m
@@ -66,17 +66,18 @@
 }
 
 - (void)createAlias:(NSString *)alias withCompletionBlock:(void (^)(NSError *_Nullable error))completion {
-    if (!self.currentAppUserID) {
+    NSString *currentAppUserID = self.currentAppUserID;
+    if (!currentAppUserID) {
         RCDebugLog(@"Couldn't create an alias because the currentAppUserID is null. "
                    "This might happen if the entry in UserDefaults is missing.");
         completion(RCPurchasesErrorUtils.missingAppUserIDError);
         return;
     }
-    RCDebugLog(@"Creating an alias to %@ from %@", self.currentAppUserID, alias);
-    [self.backend createAliasForAppUserID:self.currentAppUserID withNewAppUserID:alias completion:^(NSError *_Nullable error) {
+    RCDebugLog(@"Creating an alias to %@ from %@", currentAppUserID, alias);
+    [self.backend createAliasForAppUserID:currentAppUserID withNewAppUserID:alias completion:^(NSError *_Nullable error) {
         if (error == nil) {
             RCDebugLog(@"Alias created");
-            [self.deviceCache clearCachesForAppUserID:self.currentAppUserID andSaveNewUserID:alias];
+            [self.deviceCache clearCachesForAppUserID:currentAppUserID andSaveNewUserID:alias];
         }
         completion(error);
     }];

--- a/PurchasesTests/IdentityManagerTests.swift
+++ b/PurchasesTests/IdentityManagerTests.swift
@@ -61,7 +61,6 @@ class IdentityManagerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        
         self.identityManager = RCIdentityManager(mockDeviceCache, backend: mockBackend)
     }
 
@@ -121,6 +120,23 @@ class IdentityManagerTests: XCTestCase {
         }
 
         expect(self.mockBackend.aliasCalled).toEventually(beFalse())
+    }
+
+    func testCreateAliasCallsCompletionWithErrorIfNilAppUserID() {
+        self.mockBackend.aliasCalled = false
+        self.mockDeviceCache.stubbedAppUserID = nil
+        var completionCalled = false
+        var receivedNSError: NSError?
+        self.identityManager.createAlias("cesar") { (error: Error?) in
+            completionCalled = true
+
+            guard let receivedError = error else { fatalError() }
+            receivedNSError = receivedError as NSError
+            expect(receivedNSError!.code) == Purchases.ErrorCode.missingAppUserIDError.rawValue
+        }
+
+        expect(completionCalled).toEventually(beTrue())
+        expect(receivedNSError).toNotEventually(beNil())
     }
 
     func testCreateAliasIdentifiesWhenSuccessful() {

--- a/PurchasesTests/IdentityManagerTests.swift
+++ b/PurchasesTests/IdentityManagerTests.swift
@@ -132,7 +132,7 @@ class IdentityManagerTests: XCTestCase {
 
             guard let receivedError = error else { fatalError() }
             receivedNSError = receivedError as NSError
-            expect(receivedNSError!.code) == Purchases.ErrorCode.missingAppUserIDError.rawValue
+            expect(receivedNSError!.code) == Purchases.ErrorCode.invalidAppUserIdError.rawValue
         }
 
         expect(completionCalled).toEventually(beTrue())


### PR DESCRIPTION
Fixes an issue where if the appUserID is missing for whatever reason and you call createAlias, an alias to `(null)` would be created. 
This fix makes the method no-op and return an error with a specific error code. 

I was hesitant about adding the error code at first, but it's probably the best way to get developers to notice without sending the call to the backend. 