### PR TITLE
Release 3.5.0

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -5,9 +5,9 @@ objc: true
 sdk: iphonesimulator
 module: Purchases
 umbrella_header: Purchases/Public/Purchases.h
-module_version: 3.5.0-SNAPSHOT
+module_version: 3.5.0
 github_url: https://github.com/revenuecat/purchases-ios
-github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.5.0-SNAPSHOT
+github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.5.0
 output: docs
 # Leaving this commented out. We used to specify this before, but now it's working without it
 # xcodebuild_arguments: [--objc,Purchases/Public/Purchases.h,--,-x,objective-c,-isysroot,$(xcrun --show-sdk-path),-I,$(pwd)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 3.5.0
+- Added a sample watchOS app to illustrate how to integrate in-app purchases on watchOS with RevenueCat
+https://github.com/RevenueCat/purchases-ios/pull/263
+- Fixed build warnings from Clang Static Analyzer
+https://github.com/RevenueCat/purchases-ios/pull/265
+- Added StoreKit Configuration files for local testing + new schemes configured to use them. 
+https://github.com/RevenueCat/purchases-ios/pull/267
+https://github.com/RevenueCat/purchases-ios/pull/270
+- Added GitHub Issue Templates
+https://github.com/RevenueCat/purchases-ios/pull/269
+
 ## 3.4.0
 - Added `proxyKey`, useful for kids category apps, so that they can set up a proxy to send requests through. **Do not use this** unless you've talked to RevenueCat support about it. 
 https://github.com/RevenueCat/purchases-ios/pull/258

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Purchases"
-  s.version          = "3.5.0-SNAPSHOT"
+  s.version          = "3.5.0"
   s.summary          = "Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/Purchases/Info.plist
+++ b/Purchases/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.5.0-SNAPSHOT</string>
+	<string>3.5.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Purchases/Misc/RCSystemInfo.m
+++ b/Purchases/Misc/RCSystemInfo.m
@@ -47,7 +47,7 @@ static NSURL * _Nullable proxyURL;
 }
 
 + (NSString *)frameworkVersion {
-    return @"3.5.0-SNAPSHOT";
+    return @"3.5.0";
 }
 
 + (NSString *)systemVersion {

--- a/PurchasesTests/Info.plist
+++ b/PurchasesTests/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.5.0-SNAPSHOT</string>
+	<string>3.5.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,5 +1,5 @@
 #### (Somewhat) automated process: 
-1. Create a branch bump/x.y.z
+1. Start a git-flow release/x.y.z
 1. Create a CHANGELOG.latest.md with the changes for the current 
 version (to be used by Fastlane for the github release notes)
 1. Update the version number in `RCPurchases.m`, `Purchases.podspec` and in 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -12,7 +12,7 @@ Install _fastlane_ using
 ```
 [sudo] gem install fastlane -NV
 ```
-or alternatively using `brew cask install fastlane`
+or alternatively using `brew install fastlane`
 
 # Available Actions
 ## iOS


### PR DESCRIPTION
## 3.5.0
- Added a sample watchOS app to illustrate how to integrate in-app purchases on watchOS with RevenueCat
https://github.com/RevenueCat/purchases-ios/pull/263
- Fixed build warnings from Clang Static Analyzer
https://github.com/RevenueCat/purchases-ios/pull/265
- Added StoreKit Configuration files for local testing + new schemes configured to use them. 
https://github.com/RevenueCat/purchases-ios/pull/267
https://github.com/RevenueCat/purchases-ios/pull/270
- Added GitHub Issue Templates
https://github.com/RevenueCat/purchases-ios/pull/269
