### PR TITLE
storekit tests

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "AliSoftware/OHHTTPStubs" "9.0.0"
-github "Quick/Nimble" "v8.0.7"
+github "Quick/Nimble" "v8.1.1"

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -14,6 +14,11 @@
 		2D50332A2406EA61009CAE61 /* RCSubscriberAttributesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5033272406EA61009CAE61 /* RCSubscriberAttributesManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D50332B2406EA61009CAE61 /* RCSubscriberAttributesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D5033282406EA61009CAE61 /* RCSubscriberAttributesManager.m */; };
 		2D8DB34B24072AAE00BE3D31 /* SubscriberAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8DB34A24072AAE00BE3D31 /* SubscriberAttributeTests.swift */; };
+		2D97457E24BCE001006245E9 /* PurchasesIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D97457D24BCE001006245E9 /* PurchasesIntegrationTests.swift */; };
+		2D97458324BCE00D006245E9 /* Purchases.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 352629FE1F7C4B9100C04F2C /* Purchases.framework */; };
+		2D97458424BCE039006245E9 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 350FBDDC1F7EA3570065833D /* Nimble.framework */; };
+		2D97458824BCE04A006245E9 /* StoreKitTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D97458724BCE04A006245E9 /* StoreKitTest.framework */; };
+		2D97458924BCE068006245E9 /* Configuration.storekit in Resources */ = {isa = PBXBuildFile; fileRef = 2D97457424B920E1006245E9 /* Configuration.storekit */; };
 		2DD02D5524AD011600419CD9 /* RCPurchasesSwiftImport.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DD02D5424AD00ED00419CD9 /* RCPurchasesSwiftImport.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2DD02D5724AD0B0500419CD9 /* RCIntroEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD02D5624AD0B0500419CD9 /* RCIntroEligibilityTests.swift */; };
 		2DD02D5B24AD129A00419CD9 /* LocalReceiptParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD02D5A24AD129A00419CD9 /* LocalReceiptParserTests.swift */; };
@@ -182,6 +187,13 @@
 		2D5033272406EA61009CAE61 /* RCSubscriberAttributesManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCSubscriberAttributesManager.h; path = Purchases/SubscriberAttributes/RCSubscriberAttributesManager.h; sourceTree = SOURCE_ROOT; };
 		2D5033282406EA61009CAE61 /* RCSubscriberAttributesManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCSubscriberAttributesManager.m; path = Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m; sourceTree = SOURCE_ROOT; };
 		2D8DB34A24072AAE00BE3D31 /* SubscriberAttributeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriberAttributeTests.swift; sourceTree = "<group>"; };
+		2D97456D24B91E03006245E9 /* StoreKitTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKitTest.framework; path = Platforms/MacOSX.platform/Developer/Library/Frameworks/StoreKitTest.framework; sourceTree = DEVELOPER_DIR; };
+		2D97457424B920E1006245E9 /* Configuration.storekit */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Configuration.storekit; sourceTree = "<group>"; };
+		2D97457B24BCE001006245E9 /* PurchasesIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PurchasesIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		2D97457D24BCE001006245E9 /* PurchasesIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesIntegrationTests.swift; sourceTree = "<group>"; };
+		2D97457F24BCE001006245E9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		2D97458524BCE03E006245E9 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		2D97458724BCE04A006245E9 /* StoreKitTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKitTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/Developer/Library/Frameworks/StoreKitTest.framework; sourceTree = DEVELOPER_DIR; };
 		2DD02D5424AD00ED00419CD9 /* RCPurchasesSwiftImport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCPurchasesSwiftImport.h; sourceTree = "<group>"; };
 		2DD02D5624AD0B0500419CD9 /* RCIntroEligibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RCIntroEligibilityTests.swift; sourceTree = "<group>"; };
 		2DD02D5A24AD129A00419CD9 /* LocalReceiptParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalReceiptParserTests.swift; sourceTree = "<group>"; };
@@ -326,6 +338,16 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		2D97457824BCE001006245E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D97458824BCE04A006245E9 /* StoreKitTest.framework in Frameworks */,
+				2D97458424BCE039006245E9 /* Nimble.framework in Frameworks */,
+				2D97458324BCE00D006245E9 /* Purchases.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		352629FA1F7C4B9100C04F2C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -367,6 +389,24 @@
 			);
 			name = SubscriberAttributes;
 			path = Public/SubscriberAttributes;
+			sourceTree = "<group>";
+		};
+		2D97457624B920EA006245E9 /* StoreKit Configuration Files */ = {
+			isa = PBXGroup;
+			children = (
+				2D97457424B920E1006245E9 /* Configuration.storekit */,
+			);
+			path = "StoreKit Configuration Files";
+			sourceTree = "<group>";
+		};
+		2D97457C24BCE001006245E9 /* PurchasesIntegrationTests */ = {
+			isa = PBXGroup;
+			children = (
+				2D97457624B920EA006245E9 /* StoreKit Configuration Files */,
+				2D97457D24BCE001006245E9 /* PurchasesIntegrationTests.swift */,
+				2D97457F24BCE001006245E9 /* Info.plist */,
+			);
+			path = PurchasesIntegrationTests;
 			sourceTree = "<group>";
 		};
 		2D9AF7B124A2B2F000E1D023 /* SwiftSources */ = {
@@ -442,6 +482,7 @@
 				2DEC0CFB24A2A1B100B0E5BB /* Package.swift */,
 				35262A001F7C4B9100C04F2C /* Purchases */,
 				35262A1F1F7D77E600C04F2C /* PurchasesTests */,
+				2D97457C24BCE001006245E9 /* PurchasesIntegrationTests */,
 				352629FF1F7C4B9100C04F2C /* Products */,
 				3530C18722653E8F00D6DF52 /* Frameworks */,
 				2DCB85BF2406EC3F003C1260 /* Recovered References */,
@@ -453,6 +494,7 @@
 			children = (
 				352629FE1F7C4B9100C04F2C /* Purchases.framework */,
 				35262A1E1F7D77E600C04F2C /* PurchasesTests.xctest */,
+				2D97457B24BCE001006245E9 /* PurchasesIntegrationTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -495,6 +537,9 @@
 		3530C18722653E8F00D6DF52 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				2D97458724BCE04A006245E9 /* StoreKitTest.framework */,
+				2D97458524BCE03E006245E9 /* XCTest.framework */,
+				2D97456D24B91E03006245E9 /* StoreKitTest.framework */,
 				357C9BC022725CFA006BC624 /* iAd.framework */,
 				350A1B84226E3E8700CCA10F /* AppKit.framework */,
 				3530C18822653E8F00D6DF52 /* AdSupport.framework */,
@@ -768,6 +813,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		2D97457A24BCE001006245E9 /* PurchasesIntegrationTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2D97458224BCE001006245E9 /* Build configuration list for PBXNativeTarget "PurchasesIntegrationTests" */;
+			buildPhases = (
+				2D97457724BCE001006245E9 /* Sources */,
+				2D97457824BCE001006245E9 /* Frameworks */,
+				2D97457924BCE001006245E9 /* Resources */,
+				2D97458B24BCE399006245E9 /* Carthage Copy Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = PurchasesIntegrationTests;
+			productName = PurchasesIntegrationTests;
+			productReference = 2D97457B24BCE001006245E9 /* PurchasesIntegrationTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		352629FD1F7C4B9100C04F2C /* Purchases */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 35262A121F7C4B9100C04F2C /* Build configuration list for PBXNativeTarget "Purchases" */;
@@ -793,7 +856,7 @@
 				35262A1A1F7D77E600C04F2C /* Sources */,
 				35262A1B1F7D77E600C04F2C /* Frameworks */,
 				35262A1C1F7D77E600C04F2C /* Resources */,
-				35DFC68420B875B6004584CC /* Copy Frameworks */,
+				35DFC68420B875B6004584CC /* Carthage Copy Frameworks */,
 				350FBDD91F7DFD900065833D /* Copy Frameworks */,
 			);
 			buildRules = (
@@ -812,10 +875,14 @@
 		352629F51F7C4B9100C04F2C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0900;
+				LastSwiftUpdateCheck = 1200;
 				LastUpgradeCheck = 0930;
 				ORGANIZATIONNAME = Purchases;
 				TargetAttributes = {
+					2D97457A24BCE001006245E9 = {
+						CreatedOnToolsVersion = 12.0;
+						ProvisioningStyle = Automatic;
+					};
 					352629FD1F7C4B9100C04F2C = {
 						CreatedOnToolsVersion = 9.0;
 						LastSwiftMigration = 1200;
@@ -843,11 +910,20 @@
 			targets = (
 				352629FD1F7C4B9100C04F2C /* Purchases */,
 				35262A1D1F7D77E600C04F2C /* PurchasesTests */,
+				2D97457A24BCE001006245E9 /* PurchasesIntegrationTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		2D97457924BCE001006245E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D97458924BCE068006245E9 /* Configuration.storekit in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		352629FC1F7C4B9100C04F2C /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -865,7 +941,27 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		35DFC68420B875B6004584CC /* Copy Frameworks */ = {
+		2D97458B24BCE399006245E9 /* Carthage Copy Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/iOS/Nimble.framework",
+			);
+			name = "Carthage Copy Frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/NImble.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
+		};
+		35DFC68420B875B6004584CC /* Carthage Copy Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -874,8 +970,10 @@
 				"$(SRCROOT)/Carthage/Build/iOS/Nimble.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/OHHTTPStubs.framework",
 			);
-			name = "Copy Frameworks";
+			name = "Carthage Copy Frameworks";
 			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Nimble.framework",
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/OHHTTPStubs.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -884,6 +982,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		2D97457724BCE001006245E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D97457E24BCE001006245E9 /* PurchasesIntegrationTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		352629F91F7C4B9100C04F2C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -992,6 +1098,55 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		2D97458024BCE001006245E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 8SXR2327BM;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = PurchasesIntegrationTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.PurchasesIntegrationTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		2D97458124BCE001006245E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 8SXR2327BM;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = PurchasesIntegrationTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.PurchasesIntegrationTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		35262A101F7C4B9100C04F2C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1115,9 +1270,13 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = Purchases/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
@@ -1147,9 +1306,13 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = Purchases/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
@@ -1220,6 +1383,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		2D97458224BCE001006245E9 /* Build configuration list for PBXNativeTarget "PurchasesIntegrationTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2D97458024BCE001006245E9 /* Debug */,
+				2D97458124BCE001006245E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		352629F81F7C4B9100C04F2C /* Build configuration list for PBXProject "Purchases" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/PurchasesIntegrationTests/Info.plist
+++ b/PurchasesIntegrationTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/PurchasesIntegrationTests/PurchasesIntegrationTests.swift
+++ b/PurchasesIntegrationTests/PurchasesIntegrationTests.swift
@@ -14,7 +14,7 @@ import StoreKit
 
 
 class PurchasesIntegrationTests: XCTestCase {
-
+    
     var testSession: SKTestSession!
     var apiKey: String!
     var integrationTestsURL: URL?
@@ -28,7 +28,7 @@ class PurchasesIntegrationTests: XCTestCase {
         
         apiKey = <api_key_for_integration_tests_here>
         userDefaults = .standard
-
+        
         Purchases.proxyURL = integrationTestsURL
     }
     
@@ -66,7 +66,7 @@ class PurchasesIntegrationTests: XCTestCase {
                 print("purchaserInfo: \(String(describing: purchaserInfo))")
                 print("userCancelled: \(cancelled)")
                 let productId = currentPackage.product.productIdentifier
-                Purchases.shared.checkTrialOrIntroductoryPriceEligibility([productId, "lalala"]) { introEligibility in
+                Purchases.shared.checkTrialOrIntroductoryPriceEligibility([productId, "unknown product id"]) { introEligibility in
                     print("finished")
                     print("intro eligibility: \(introEligibility)")
                     expectation.fulfill()
@@ -89,43 +89,11 @@ class PurchasesIntegrationTests: XCTestCase {
         Purchases.configure(withAPIKey: "VtDdmbdWBySmqJeeQUTyrNxETUVkhuaJ", appUserID: "andyIntegrationTests", observerMode: false, userDefaults: userDefaults)
         let expectation = XCTestExpectation(description: "finish all async calls")
         
-//        Purchases.shared.offerings { offerings, error in
-//            if let error = error {
-//                print("error found while fetching offerings: \(error.localizedDescription)")
-//                expectation.fulfill()
-//                return
-//            }
-//
-//            guard let offerings = offerings,
-//                  let currentOffering = offerings.current else {
-//                print("couldn't unpack package")
-//                expectation.fulfill()
-//                return
-//            }
-//            let packages = currentOffering.availablePackages
-//            guard let currentPackage = packages.first else {
-//                print("packages is empty")
-//                expectation.fulfill()
-//                return
-//            }
-//
-//            Purchases.shared.purchasePackage(currentPackage) { (transaction, purchaserInfo, error, cancelled) in
-//                if let error = error {
-//                    print("error found while purchasing package: \(error.localizedDescription)")
-//                    expectation.fulfill()
-//                    return
-//                }
-//                print("transaction: \(String(describing: transaction))")
-//                print("purchaserInfo: \(String(describing: purchaserInfo))")
-//                print("userCancelled: \(cancelled)")
-//                let productId = currentPackage.product.productIdentifier
-                Purchases.shared.checkTrialOrIntroductoryPriceEligibility([productId, "lalala"]) { introEligibility in
-                    print("finished")
-                    print("intro eligibility: \(introEligibility)")
-                    expectation.fulfill()
-                }
-//            }
-//        }
+        Purchases.shared.checkTrialOrIntroductoryPriceEligibility([productId, "lalala"]) { introEligibility in
+            print("finished")
+            print("intro eligibility: \(introEligibility)")
+            expectation.fulfill()
+        }
         
         wait(for: [expectation], timeout: 30.0)
         

--- a/PurchasesIntegrationTests/PurchasesIntegrationTests.swift
+++ b/PurchasesIntegrationTests/PurchasesIntegrationTests.swift
@@ -1,0 +1,135 @@
+//
+//  PurchasesIntegrationTests.swift
+//  PurchasesIntegrationTests
+//
+//  Created by Andrés Boedo on 7/13/20.
+//  Copyright © 2020 Purchases. All rights reserved.
+//
+
+import Nimble
+import XCTest
+import StoreKitTest
+import StoreKit
+@testable import Purchases
+
+
+class PurchasesIntegrationTests: XCTestCase {
+
+    var testSession: SKTestSession!
+    var apiKey: String!
+    var integrationTestsURL: URL?
+    var userDefaults: UserDefaults!
+    
+    override func setUp() {
+        testSession = try! SKTestSession(configurationFileNamed: "Configuration")
+        
+        testSession.disableDialogs = true
+        testSession.clearTransactions()
+        
+        apiKey = <api_key_for_integration_tests_here>
+        userDefaults = .standard
+
+        Purchases.proxyURL = integrationTestsURL
+    }
+    
+    func testGetOfferings() {
+        Purchases.configure(withAPIKey: apiKey, appUserID: "andyIntegrationTests", observerMode: false, userDefaults: userDefaults)
+        let expectation = XCTestExpectation(description: "finish all async calls")
+        
+        Purchases.shared.offerings { offerings, error in
+            if let error = error {
+                print("error found while fetching offerings: \(error.localizedDescription)")
+                expectation.fulfill()
+                return
+            }
+            
+            guard let offerings = offerings,
+                  let currentOffering = offerings.current else {
+                print("couldn't unpack package")
+                expectation.fulfill()
+                return
+            }
+            let packages = currentOffering.availablePackages
+            guard let currentPackage = packages.first else {
+                print("packages is empty")
+                expectation.fulfill()
+                return
+            }
+            
+            Purchases.shared.purchasePackage(currentPackage) { (transaction, purchaserInfo, error, cancelled) in
+                if let error = error {
+                    print("error found while purchasing package: \(error.localizedDescription)")
+                    expectation.fulfill()
+                    return
+                }
+                print("transaction: \(String(describing: transaction))")
+                print("purchaserInfo: \(String(describing: purchaserInfo))")
+                print("userCancelled: \(cancelled)")
+                let productId = currentPackage.product.productIdentifier
+                Purchases.shared.checkTrialOrIntroductoryPriceEligibility([productId, "lalala"]) { introEligibility in
+                    print("finished")
+                    print("intro eligibility: \(introEligibility)")
+                    expectation.fulfill()
+                }
+            }
+        }
+        
+        wait(for: [expectation], timeout: 30.0)
+    }
+    
+    
+    func testParseReceipt2() {
+        testSession = try! SKTestSession(configurationFileNamed: "Configuration")
+        
+        testSession.disableDialogs = true
+        testSession.clearTransactions()
+        let productId = "com.revenuecat.annual_39.99.2_week_intro"
+        try! testSession.buyProduct(productIdentifier: productId)
+        let userDefaults: UserDefaults = .standard
+        Purchases.configure(withAPIKey: "VtDdmbdWBySmqJeeQUTyrNxETUVkhuaJ", appUserID: "andyIntegrationTests", observerMode: false, userDefaults: userDefaults)
+        let expectation = XCTestExpectation(description: "finish all async calls")
+        
+//        Purchases.shared.offerings { offerings, error in
+//            if let error = error {
+//                print("error found while fetching offerings: \(error.localizedDescription)")
+//                expectation.fulfill()
+//                return
+//            }
+//
+//            guard let offerings = offerings,
+//                  let currentOffering = offerings.current else {
+//                print("couldn't unpack package")
+//                expectation.fulfill()
+//                return
+//            }
+//            let packages = currentOffering.availablePackages
+//            guard let currentPackage = packages.first else {
+//                print("packages is empty")
+//                expectation.fulfill()
+//                return
+//            }
+//
+//            Purchases.shared.purchasePackage(currentPackage) { (transaction, purchaserInfo, error, cancelled) in
+//                if let error = error {
+//                    print("error found while purchasing package: \(error.localizedDescription)")
+//                    expectation.fulfill()
+//                    return
+//                }
+//                print("transaction: \(String(describing: transaction))")
+//                print("purchaserInfo: \(String(describing: purchaserInfo))")
+//                print("userCancelled: \(cancelled)")
+//                let productId = currentPackage.product.productIdentifier
+                Purchases.shared.checkTrialOrIntroductoryPriceEligibility([productId, "lalala"]) { introEligibility in
+                    print("finished")
+                    print("intro eligibility: \(introEligibility)")
+                    expectation.fulfill()
+                }
+//            }
+//        }
+        
+        wait(for: [expectation], timeout: 30.0)
+        
+        
+    }
+}
+

--- a/PurchasesIntegrationTests/PurchasesIntegrationTests.swift
+++ b/PurchasesIntegrationTests/PurchasesIntegrationTests.swift
@@ -33,7 +33,7 @@ class PurchasesIntegrationTests: XCTestCase {
     }
     
     func testGetOfferings() {
-        Purchases.configure(withAPIKey: apiKey, appUserID: "andyIntegrationTests", observerMode: false, userDefaults: userDefaults)
+        Purchases.configure(withAPIKey: apiKey, appUserID: "integrationTestsGetOfferings", observerMode: false, userDefaults: userDefaults)
         let expectation = XCTestExpectation(description: "finish all async calls")
         
         Purchases.shared.offerings { offerings, error in
@@ -78,7 +78,7 @@ class PurchasesIntegrationTests: XCTestCase {
     }
     
     
-    func testParseReceipt2() {
+    func testIntroEligibility() {
         testSession = try! SKTestSession(configurationFileNamed: "Configuration")
         
         testSession.disableDialogs = true
@@ -86,7 +86,7 @@ class PurchasesIntegrationTests: XCTestCase {
         let productId = "com.revenuecat.annual_39.99.2_week_intro"
         try! testSession.buyProduct(productIdentifier: productId)
         let userDefaults: UserDefaults = .standard
-        Purchases.configure(withAPIKey: "VtDdmbdWBySmqJeeQUTyrNxETUVkhuaJ", appUserID: "andyIntegrationTests", observerMode: false, userDefaults: userDefaults)
+        Purchases.configure(withAPIKey: apiKey, appUserID: "integrationTestsIntroEligibility", observerMode: false, userDefaults: userDefaults)
         let expectation = XCTestExpectation(description: "finish all async calls")
         
         Purchases.shared.checkTrialOrIntroductoryPriceEligibility([productId, "lalala"]) { introEligibility in

--- a/PurchasesIntegrationTests/StoreKit Configuration Files/Configuration.storekit
+++ b/PurchasesIntegrationTests/StoreKit Configuration Files/Configuration.storekit
@@ -1,0 +1,89 @@
+{
+  "products" : [
+    {
+      "displayPrice" : "199.99",
+      "familyShareable" : true,
+      "internalID" : "319A9C2C",
+      "localizations" : [
+        {
+          "description" : "",
+          "displayName" : "",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "lifetime",
+      "referenceName" : "lifetime",
+      "type" : "NonConsumable"
+    }
+  ],
+  "settings" : {
+
+  },
+  "subscriptionGroups" : [
+    {
+      "id" : "7096FF06",
+      "localizations" : [
+
+      ],
+      "name" : "subscription_group",
+      "subscriptions" : [
+        {
+          "adHocOffers" : [
+
+          ],
+          "displayPrice" : "4.99",
+          "familyShareable" : true,
+          "groupNumber" : 1,
+          "internalID" : "E5E51B92",
+          "introductoryOffer" : {
+            "internalID" : "D4FA46D0",
+            "paymentMode" : "free",
+            "subscriptionPeriod" : "P1W"
+          },
+          "localizations" : [
+            {
+              "description" : "",
+              "displayName" : "",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.revenuecat.monthly_4.99.1_week_intro",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "monthly free trial",
+          "subscriptionGroupID" : "7096FF06",
+          "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "displayPrice" : "39.99",
+          "familyShareable" : true,
+          "groupNumber" : 1,
+          "internalID" : "F04B58DC",
+          "introductoryOffer" : {
+            "internalID" : "0539C216",
+            "paymentMode" : "free",
+            "subscriptionPeriod" : "P2W"
+          },
+          "localizations" : [
+            {
+              "description" : "",
+              "displayName" : "",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.revenuecat.annual_39.99.2_week_intro",
+          "recurringSubscriptionPeriod" : "P1Y",
+          "referenceName" : "annual free trial",
+          "subscriptionGroupID" : "7096FF06",
+          "type" : "RecurringSubscription"
+        }
+      ]
+    }
+  ],
+  "version" : {
+    "major" : 1,
+    "minor" : 0
+  }
+}


### PR DESCRIPTION
Adds a new target and corresponding schema for integration tests. 

Since integration tests will only really make sense with `StoreKitTest`, the deployment target is set to iOS 14 and Xcode 12 beta. 
We should still be able to run these through CircleCI once they're set up [according to their docs](https://circleci.com/docs/2.0/testing-ios/). 

### Overview:

The idea is that we can use this as a base to set up tests for just about anything. 
We set up the tests using `StoreKitTest`, and use StoreKit Configuration files to provide sku information. 

### Requirements: 
- [ ] Instance of Khepri set up for integration tests
- [ ] Xcode Beta actually working as expected 🙄 (more details in Known Issues). 
- [ ] [Optional] Khepri support for Local certificate (instead of App Store certificate). As of the time of opening this PR, Khepri doesn't support Local certificates, which are used to sign the receipts in StoreKitTest. This means that posting receipts will result in a backend error. I tagged this as optional since we can support numerous integration tests regardless - fetching offerings, intro eligibility, etc, anything that doesn't involve posting a receipt should still work. 

### Known issues: 
As of Xcode beta 2, I've run into the following issues: 
- Even though `StoreKit` configuration files work as expected when running the app locally, it seems like they don't work correctly when used with `StoreKitTest`. This means that fetching products will produce `nil` results, for example. 
- `appStoreReceiptURL` returns nil when running on a simulator. Also looks like an Xcode bug. At first I thought that the issue might be that tests run on a different bundle (I've run into that before), but I tried calling the method on all available bundles and it's still `nil` 💔 . 

These are the real shipstoppers for the tests, but hopefully they get fixed soon and we can start using these. 