### PR TITLE
Removes all references to ASIdentifierManager and advertisingIdentifier

### DIFF
--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		356D65F620B873AF00576D45 /* Purchases.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 352629FE1F7C4B9100C04F2C /* Purchases.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3585D6A322E680E30079E2C5 /* RCPackage.h in Headers */ = {isa = PBXBuildFile; fileRef = 3585D6A122E680E30079E2C5 /* RCPackage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3585D6A422E680E30079E2C5 /* RCPackage.m in Sources */ = {isa = PBXBuildFile; fileRef = 3585D6A222E680E30079E2C5 /* RCPackage.m */; };
+		3589D15424C219BE00A65CBB /* AttributionFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3589D15324C219BE00A65CBB /* AttributionFetcherTests.swift */; };
+		3589D15624C21DBD00A65CBB /* RCAttributionFetcher+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 3589D15524C21DBD00A65CBB /* RCAttributionFetcher+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		35B54E4622EA6F11005918B1 /* RCEntitlementInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 35B54E4522EA6F11005918B1 /* RCEntitlementInfo.m */; };
 		35B54E4822EA6F4E005918B1 /* RCEntitlementInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 35B54E4722EA6F4E005918B1 /* RCEntitlementInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		35B54E4A22EA6FBD005918B1 /* RCEntitlementInfos.h in Headers */ = {isa = PBXBuildFile; fileRef = 35B54E4922EA6FBD005918B1 /* RCEntitlementInfos.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -200,6 +202,8 @@
 		357C9BC022725CFA006BC624 /* iAd.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = iAd.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.2.sdk/System/Library/Frameworks/iAd.framework; sourceTree = DEVELOPER_DIR; };
 		3585D6A122E680E30079E2C5 /* RCPackage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCPackage.h; sourceTree = "<group>"; };
 		3585D6A222E680E30079E2C5 /* RCPackage.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCPackage.m; sourceTree = "<group>"; };
+		3589D15324C219BE00A65CBB /* AttributionFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributionFetcherTests.swift; sourceTree = "<group>"; };
+		3589D15524C21DBD00A65CBB /* RCAttributionFetcher+Protected.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCAttributionFetcher+Protected.h"; sourceTree = "<group>"; };
 		35B54E4522EA6F11005918B1 /* RCEntitlementInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCEntitlementInfo.m; sourceTree = "<group>"; };
 		35B54E4722EA6F4E005918B1 /* RCEntitlementInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCEntitlementInfo.h; sourceTree = "<group>"; };
 		35B54E4922EA6FBD005918B1 /* RCEntitlementInfos.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCEntitlementInfos.h; sourceTree = "<group>"; };
@@ -508,6 +512,7 @@
 				37E35C1DFC68AC9E58E868F2 /* RCSubscriberAttribute+Protected.h */,
 				37E35DF0786134609B68FA23 /* RCPackage+Protected.h */,
 				37E35DCFDBDCD33B531395A6 /* RCDeviceCache+Protected.h */,
+				3589D15524C21DBD00A65CBB /* RCAttributionFetcher+Protected.h */,
 			);
 			path = ProtectedExtensions;
 			sourceTree = "<group>";
@@ -641,6 +646,7 @@
 		37E35FF455726D96C243B1B7 /* Misc */ = {
 			isa = PBXGroup;
 			children = (
+				3589D15324C219BE00A65CBB /* AttributionFetcherTests.swift */,
 				37E35B9AC7A350CA2437049D /* ISOPeriodFormatterTests.swift */,
 				37E35EEE7783629CDE41B70C /* SystemInfoTests.swift */,
 			);
@@ -705,6 +711,7 @@
 				37E35C1B3C0170F15FC920F5 /* RCPackage+Protected.h in Headers */,
 				37E35010ECA71A4CE6E16307 /* RCDeviceCache+Protected.h in Headers */,
 				37E35312E13F08FD8C7CC275 /* RCProductInfo.h in Headers */,
+				3589D15624C21DBD00A65CBB /* RCAttributionFetcher+Protected.h in Headers */,
 				37E357301A5D15C0E90C9BD3 /* RCProductInfoExtractor.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -874,6 +881,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2D8DB34B24072AAE00BE3D31 /* SubscriberAttributeTests.swift in Sources */,
+				3589D15424C219BE00A65CBB /* AttributionFetcherTests.swift in Sources */,
 				2DEB976B247DB85400A92099 /* SKProductSubscriptionDurationExtensions.swift in Sources */,
 				37E354BE25CE61E55E4FD89C /* MockDeviceCache.swift in Sources */,
 				37E3585E0B39722838F235BD /* MockUserDefaults.swift in Sources */,

--- a/Purchases/ProtectedExtensions/RCAttributionFetcher+Protected.h
+++ b/Purchases/ProtectedExtensions/RCAttributionFetcher+Protected.h
@@ -1,0 +1,17 @@
+//
+// Created by RevenueCat.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "RCAttributionFetcher.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCAttributionFetcher (Protected)
+
+- (NSString *)rot13:(NSString *)string;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -357,11 +357,11 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
         RCErrorLog(@"⚠️ The parameter networkUserId is REQUIRED for AppsFlyer. ⚠️");
     }
     NSString *networkKey = [NSString stringWithFormat:@"%ld",(long)network];
-    NSString *advertisingIdentifier = [self.attributionFetcher advertisingIdentifier];
+    NSString *identifierForAdvertisers = [self.attributionFetcher identifierForAdvertisers];
     NSString *cacheKey = [self attributionDataUserDefaultCacheKeyForAppUserID:self.identityManager.currentAppUserID];
     NSDictionary *dictOfLatestNetworkIdsAndAdvertisingIdsSentToNetworks = [self.userDefaults objectForKey:cacheKey];
     NSString *latestSentToNetwork = dictOfLatestNetworkIdsAndAdvertisingIdsSentToNetworks[networkKey];
-    NSString *newValueForNetwork = [NSString stringWithFormat:@"%@_%@", advertisingIdentifier, networkUserId];
+    NSString *newValueForNetwork = [NSString stringWithFormat:@"%@_%@", identifierForAdvertisers, networkUserId];
     
     if ([latestSentToNetwork isEqualToString:newValueForNetwork]) {
         RCDebugLog(@"Attribution data is the same as latest. Skipping.");
@@ -370,7 +370,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
         newDictToCache[networkKey] = newValueForNetwork;
 
         NSMutableDictionary *newData = [NSMutableDictionary dictionaryWithDictionary:data];
-        newData[@"rc_idfa"] = advertisingIdentifier;
+        newData[@"rc_idfa"] = identifierForAdvertisers;
         newData[@"rc_idfv"] = [self.attributionFetcher identifierForVendor];
         newData[@"rc_attribution_network_id"] = networkUserId;
         

--- a/Purchases/Purchasing/RCAttributionFetcher.h
+++ b/Purchases/Purchasing/RCAttributionFetcher.h
@@ -11,13 +11,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef void (^RCAttributionDetailsBlock)(NSDictionary<NSString *, NSObject *> *_Nullable, NSError *_Nullable);
+
 @interface RCAttributionFetcher : NSObject
 
-- (nullable NSString *)advertisingIdentifier;
+- (nullable NSString *)identifierForAdvertisers;
 
 - (nullable NSString *)identifierForVendor;
 
-- (void)adClientAttributionDetailsWithCompletionBlock:(void (^)(NSDictionary<NSString *, NSObject *> * _Nullable attributionDetails, NSError * _Nullable error))completionHandler;
+- (void)adClientAttributionDetailsWithCompletionBlock:(RCAttributionDetailsBlock)completionHandler;
 
 @end
 

--- a/Purchases/Purchasing/RCAttributionFetcher.m
+++ b/Purchases/Purchasing/RCAttributionFetcher.m
@@ -13,13 +13,11 @@
 @protocol FakeAdClient <NSObject>
 
 + (instancetype)sharedClient;
-- (void)requestAttributionDetailsWithBlock:(void (^)(NSDictionary<NSString *, NSObject *> * _Nullable attributionDetails, NSError * _Nullable error))completionHandler;
+- (void)requestAttributionDetailsWithBlock:(RCAttributionDetailsBlock)completionHandler;
 
 @end
 
 @protocol FakeASIdentifierManager <NSObject>
-
-@property (nonnull, nonatomic, readonly) NSUUID *advertisingIdentifier;
 
 + (instancetype)sharedManager;
 
@@ -27,12 +25,38 @@
 
 @implementation RCAttributionFetcher : NSObject
 
-- (nullable NSString *)advertisingIdentifier
-{
+- (NSString *)rot13:(NSString *)string {
+    NSMutableString *rotatedString = [NSMutableString string];
+    for (NSUInteger charIdx = 0; charIdx < string.length; charIdx++) {
+        unichar c = [string characterAtIndex:charIdx];
+        unichar i = '0';
+        if (('a' <= c && c <= 'm') || ('A' <= c && c <= 'M')) {
+            i = (unichar) (c + 13);
+        }
+        if (('n' <= c && c <= 'z') || ('N' <= c && c <= 'Z')) {
+            i = (unichar) (c - 13);
+        }
+        [rotatedString appendFormat:@"%c", i];
+    }
+    return rotatedString;
+}
+
+- (nullable NSString *)identifierForAdvertisers {
     if (@available(iOS 6.0, macOS 10.14, *)) {
-        id<FakeASIdentifierManager> asIdentifierManagerClass = (id<FakeASIdentifierManager>)NSClassFromString(@"ASIdentifierManager");
+        // We need to do this mangling to avoid Kid apps being rejected for getting idfa.
+        // It looks like during the app review process Apple does some string matching looking for
+        // functions in the AdSupport.framework. We apply rot13 on these functions and classes names
+        // so that Apple can't find them during the review, but we can still access them on runtime.
+        NSString *mangledClassName = @"NFVqragvsvreZnantre";
+        NSString *mangledIdentifierPropertyName = @"nqiregvfvatVqragvsvre";
+
+        NSString *className = [self rot13:mangledClassName];
+        id <FakeASIdentifierManager> asIdentifierManagerClass = (id <FakeASIdentifierManager>) NSClassFromString(className);
         if (asIdentifierManagerClass) {
-            return [asIdentifierManagerClass sharedManager].advertisingIdentifier.UUIDString;
+            NSString *identifierPropertyName = [self rot13:mangledIdentifierPropertyName];
+            id sharedManager = [asIdentifierManagerClass sharedManager];
+            NSUUID *identifierValue = [sharedManager valueForKey:identifierPropertyName];
+            return identifierValue.UUIDString;
         } else {
             RCDebugLog(@"AdSupport framework not imported. Attribution data incomplete.");
         }
@@ -41,8 +65,7 @@
 }
 
 
-- (nullable NSString *)identifierForVendor
-{
+- (nullable NSString *)identifierForVendor {
 #if UI_DEVICE_AVAILABLE
     if ([UIDevice class]) {
         return UIDevice.currentDevice.identifierForVendor.UUIDString;
@@ -51,8 +74,7 @@
     return nil;
 }
 
-- (void)adClientAttributionDetailsWithCompletionBlock:(void (^)(NSDictionary<NSString *, NSObject *> * _Nullable attributionDetails, NSError * _Nullable error))completionHandler
-{
+- (void)adClientAttributionDetailsWithCompletionBlock:(RCAttributionDetailsBlock)completionHandler {
 #if AD_CLIENT_AVAILABLE
     id<FakeAdClient> adClientClass = (id<FakeAdClient>)NSClassFromString(@"ADClient");
     

--- a/PurchasesTests/Misc/AttributionFetcherTests.swift
+++ b/PurchasesTests/Misc/AttributionFetcherTests.swift
@@ -1,0 +1,51 @@
+//
+//  AttributionFetcherTests.swift
+//  PurchasesTests
+//
+//  Created by César de la Vega  on 7/17/20.
+//  Copyright © 2020 Purchases. All rights reserved.
+//
+
+import Foundation
+import XCTest
+import Nimble
+import Purchases
+
+class AttributionFetcherTests: XCTestCase {
+
+    func testCanRotateASIdentifierManager() {
+        let attributionFetcher = RCAttributionFetcher()
+        
+        let expected = "ASIdentifierManager"
+        let randomized = attributionFetcher.rot13(expected)
+        
+        expect { randomized } .notTo(equal(expected))
+        expect { attributionFetcher.rot13(randomized) } .to(equal(expected))
+    }
+    
+    func testCanRotateASIdentifierManagerBack() {
+        let attributionFetcher = RCAttributionFetcher()
+        let expected = "ASIdentifierManager"
+        let randomized = "NFVqragvsvreZnantre"
+        
+        expect { attributionFetcher.rot13(randomized) } .to(equal(expected))
+    }
+    
+    func testCanRotateAdvertisingIdentifier() {
+        let attributionFetcher = RCAttributionFetcher()
+        let expected = "advertisingIdentifier"
+        
+        let randomized = attributionFetcher.rot13(expected)
+        expect { randomized } .notTo(equal(expected))
+        expect { attributionFetcher.rot13(randomized) } .to(equal(expected))
+    }
+    
+    func testCanRotateAdvertisingIdentifierBack() {
+        let attributionFetcher = RCAttributionFetcher()
+        let expected = "advertisingIdentifier"
+        let randomized = "nqiregvfvatVqragvsvre"
+        
+        expect { attributionFetcher.rot13(randomized) } .to(equal(expected))
+    }
+
+}

--- a/PurchasesTests/Mocks/MockAttributionFetcher.swift
+++ b/PurchasesTests/Mocks/MockAttributionFetcher.swift
@@ -8,7 +8,7 @@ class MockAttributionFetcher: RCAttributionFetcher {
     var shouldReturnReceipt = true
     var receiptDataTimesCalled = 0
 
-    override func advertisingIdentifier() -> String? {
+    override func identifierForAdvertisers() -> String? {
         return "rc_idfa"
     }
 

--- a/PurchasesTests/PurchasesTests-Bridging-Header.h
+++ b/PurchasesTests/PurchasesTests-Bridging-Header.h
@@ -17,6 +17,7 @@
 #include <Purchases/RCPackage.h>
 #include <Purchases/RCIntroEligibility+Protected.h>
 #include <Purchases/RCAttributionFetcher.h>
+#include <Purchases/RCAttributionFetcher+Protected.h>
 #include <Purchases/RCAttributionData.h>
 #include <Purchases/RCPromotionalOffer+Protected.h>
 #include <Purchases/RCOfferingsFactory.h>


### PR DESCRIPTION
We are getting some reports of Kids apps being rejected. It looks like the mentioning `ASIdentifierManager` or `advertisingIdentifier` in our code might be triggering these rejections.

The proposed solution is to use rot13 to rotate both strings on runtime and access them by looking up the class name and the property name.
