### PR TITLE
Forces refreshing the receipt when calling restore

### DIFF
--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -47,10 +47,15 @@ typedef void (^RCPurchaseCompletedBlock)(SKPaymentTransaction * _Nullable, RCPur
 typedef void (^RCDeferredPromotionalPurchaseBlock)(RCPurchaseCompletedBlock);
 
 /**
-Deferred block for `-[RCPurchases paymentDiscountForProductDiscount:product:completion:]`
-*/
+ * Deferred block for `-[RCPurchases paymentDiscountForProductDiscount:product:completion:]`
+ */
 API_AVAILABLE(ios(12.2), macos(10.14.4))
 typedef void (^RCPaymentDiscountBlock)(SKPaymentDiscount * _Nullable, NSError * _Nullable) NS_SWIFT_NAME(Purchases.PaymentDiscountBlock);
+
+/**
+ * Completion block for calls that send back receipt data
+ */
+typedef void (^RCReceiveReceiptDataBlock)(NSData *);
 
 /**
  Enum of supported attribution networks

--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -53,11 +53,6 @@ API_AVAILABLE(ios(12.2), macos(10.14.4))
 typedef void (^RCPaymentDiscountBlock)(SKPaymentDiscount * _Nullable, NSError * _Nullable) NS_SWIFT_NAME(Purchases.PaymentDiscountBlock);
 
 /**
- * Completion block for calls that send back receipt data
- */
-typedef void (^RCReceiveReceiptDataBlock)(NSData *);
-
-/**
  Enum of supported attribution networks
  */
 typedef NS_ENUM(NSInteger, RCAttributionNetwork) {

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -921,6 +921,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 
 - (void)receiptDataWithForceRefresh:(BOOL)forceRefresh completion:(RCReceiveReceiptDataBlock)completion  {
     if (forceRefresh) {
+        RCDebugLog(@"Forced receipt refresh");
         [self refreshReceipt:completion];
         return;
     }

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -911,7 +911,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 }
 
 - (void)receiptData:(void (^ _Nonnull)(NSData * _Nonnull data))completion {
-    [self receiptDataWithForceRefresh:false completion:completion];
+    [self receiptDataWithForceRefresh:NO completion:completion];
 }
 
 - (void)receiptDataWithForceRefresh:(BOOL)forceRefresh completion:(void (^ _Nonnull)(NSData * _Nonnull data))completion  {

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -910,11 +910,11 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
     CALL_IF_SET_ON_MAIN_THREAD(completion, nil, error);
 }
 
-- (void)receiptData:(void (^ _Nonnull)(NSData * _Nonnull data))completion {
+- (void)receiptData:(RCReceiveReceiptDataBlock)completion {
     [self receiptDataWithForceRefresh:NO completion:completion];
 }
 
-- (void)receiptDataWithForceRefresh:(BOOL)forceRefresh completion:(void (^ _Nonnull)(NSData * _Nonnull data))completion  {
+- (void)receiptDataWithForceRefresh:(BOOL)forceRefresh completion:(RCReceiveReceiptDataBlock)completion  {
     NSData *receiptData = [self.receiptFetcher receiptData];
     if (receiptData == nil) {
         RCDebugLog(@"Receipt empty, fetching");
@@ -927,7 +927,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
     }
 }
 
-- (void)refreshReceipt:(void (^ _Nonnull)(NSData * _Nonnull data))completion
+- (void)refreshReceipt:(RCReceiveReceiptDataBlock)completion
 {
     [self.requestFetcher fetchReceiptData:^{
         NSData *newReceiptData = [self.receiptFetcher receiptData];

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -920,12 +920,13 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 }
 
 - (void)receiptDataWithForceRefresh:(BOOL)forceRefresh completion:(RCReceiveReceiptDataBlock)completion  {
+    if (forceRefresh) {
+        [self refreshReceipt:completion];
+        return;
+    }
     NSData *receiptData = [self.receiptFetcher receiptData];
     if (receiptData == nil || receiptData.length == 0) {
         RCDebugLog(@"Receipt empty, fetching");
-        [self refreshReceipt:completion];
-    } else if (forceRefresh) {
-        RCDebugLog(@"Forced receipt refresh");
         [self refreshReceipt:completion];
     } else {
         completion(receiptData);

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -42,6 +42,11 @@
     NSNumber * _Nullable _allowSharingAppStoreAccount;
 }
 
+/**
+ * Completion block for calls that send back receipt data
+ */
+typedef void (^RCReceiveReceiptDataBlock)(NSData *);
+
 @property (nonatomic) RCStoreKitRequestFetcher *requestFetcher;
 @property (nonatomic) RCReceiptFetcher *receiptFetcher;
 @property (nonatomic) RCBackend *backend;

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -916,7 +916,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 
 - (void)receiptDataWithForceRefresh:(BOOL)forceRefresh completion:(RCReceiveReceiptDataBlock)completion  {
     NSData *receiptData = [self.receiptFetcher receiptData];
-    if (receiptData == nil) {
+    if (receiptData == nil || receiptData.length == 0) {
         RCDebugLog(@"Receipt empty, fetching");
         [self refreshReceipt:completion];
     } else if (forceRefresh) {
@@ -931,7 +931,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 {
     [self.requestFetcher fetchReceiptData:^{
         NSData *newReceiptData = [self.receiptFetcher receiptData];
-        if (newReceiptData == nil) {
+        if (newReceiptData == nil || newReceiptData.length == 0) {
             RCLog(@"Unable to load receipt, ensure you are logged in to the correct iTunes account.");
         }
         completion(newReceiptData ?: [NSData data]);

--- a/PurchasesTests/Mocks/MockReceiptFetcher.swift
+++ b/PurchasesTests/Mocks/MockReceiptFetcher.swift
@@ -6,12 +6,16 @@
 class MockReceiptFetcher: RCReceiptFetcher {
     var receiptDataCalled = false
     var shouldReturnReceipt = true
+    var shouldReturnZeroBytesReceipt = false
     var receiptDataTimesCalled = 0
 
     override func receiptData() -> Data? {
         receiptDataCalled = true
         receiptDataTimesCalled += 1
         if (shouldReturnReceipt) {
+            if (shouldReturnZeroBytesReceipt) {
+                return Data()
+            }
             return Data(1...3)
         } else {
             return nil

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -1539,32 +1539,34 @@ class PurchasesTests: XCTestCase {
 
     func testWhenNoReceiptReceiptIsRefreshed() {
         setupPurchases()
-        self.receiptFetcher.shouldReturnReceipt = false
+        receiptFetcher.shouldReturnReceipt = false
         
         makeAPurchase()
         
-        expect(self.requestFetcher.refreshReceiptCalled).to(beTrue())
+        expect(requestFetcher.refreshReceiptCalled).to(beTrue())
     }
 
     func testWhenNoReceiptDataReceiptIsRefreshed() {
         setupPurchases()
-        self.receiptFetcher.shouldReturnReceipt = true
-        self.receiptFetcher.shouldReturnZeroBytesReceipt = true
+        receiptFetcher.shouldReturnReceipt = true
+        receiptFetcher.shouldReturnZeroBytesReceipt = true
         
         makeAPurchase()
         
-        expect(self.requestFetcher.refreshReceiptCalled).to(beTrue())
+        expect(requestFetcher.refreshReceiptCalled).to(beTrue())
     }
     
     private func makeAPurchase() {
         let product = MockSKProduct(mockProductIdentifier: "com.product.id1")
         
-        self.purchases?.purchaseProduct(product) { (tx, info, error, userCancelled) in }
-
+        guard let purchases = purchases else { fatalError("purchases is not initialized") }
+        purchases.purchaseProduct(product) { }
+        
         let transaction = MockTransaction()
         transaction.mockPayment = self.storeKitWrapper.payment!
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        
+        storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
     }
 
     func testRestoresDontPostMissingReceipts() {

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -1559,7 +1559,6 @@ class PurchasesTests: XCTestCase {
     private func makeAPurchase() {
         let product = MockSKProduct(mockProductIdentifier: "com.product.id1")
         
-        // Second one issues an error
         self.purchases?.purchaseProduct(product) { (tx, info, error, userCancelled) in }
 
         let transaction = MockTransaction()
@@ -1584,7 +1583,6 @@ class PurchasesTests: XCTestCase {
         let product = MockSKProduct(mockProductIdentifier: "com.product.id1")
         var receivedUserCancelled: Bool?
 
-        // Second one issues an error
         self.purchases?.purchaseProduct(product) { (tx, info, error, userCancelled) in
             receivedUserCancelled = userCancelled
         }

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -1543,7 +1543,7 @@ class PurchasesTests: XCTestCase {
         
         makeAPurchase()
         
-        expect(requestFetcher.refreshReceiptCalled).to(beTrue())
+        expect(self.requestFetcher.refreshReceiptCalled).to(beTrue())
     }
 
     func testWhenNoReceiptDataReceiptIsRefreshed() {
@@ -1553,14 +1553,14 @@ class PurchasesTests: XCTestCase {
         
         makeAPurchase()
         
-        expect(requestFetcher.refreshReceiptCalled).to(beTrue())
+        expect(self.requestFetcher.refreshReceiptCalled).to(beTrue())
     }
     
     private func makeAPurchase() {
         let product = MockSKProduct(mockProductIdentifier: "com.product.id1")
         
         guard let purchases = purchases else { fatalError("purchases is not initialized") }
-        purchases.purchaseProduct(product) { }
+        purchases.purchaseProduct(product) { _,_,_,_ in }
         
         let transaction = MockTransaction()
         transaction.mockPayment = self.storeKitWrapper.payment!


### PR DESCRIPTION
If the receipt does not contain any subscription purchases, calling /verifyReceipt will not update an empty receipt with any purchased subscriptions.

We should trigger an SKReceiptRefresh if the device receipt does not contain any subscription purchases.

### Things missing

- [x] I have tested this but we really need to make sure it will not trigger login popups constantly. Maybe worth releasing a beta? 
- [x] Unit tests
- [x] Test with Mac