### PR TITLE
Feature/defer cache updates if woken from push notification

### DIFF
--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		2DD02D5B24AD129A00419CD9 /* LocalReceiptParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD02D5A24AD129A00419CD9 /* LocalReceiptParserTests.swift */; };
 		2DD448FF24088473002F5694 /* RCPurchases+SubscriberAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DD448FD24088473002F5694 /* RCPurchases+SubscriberAttributes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2DD4490024088473002F5694 /* RCPurchases+SubscriberAttributes.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DD448FE24088473002F5694 /* RCPurchases+SubscriberAttributes.m */; };
+		2DD7BA4D24C63A830066B4C2 /* MockSystemInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD7BA4C24C63A830066B4C2 /* MockSystemInfo.swift */; };
 		2DEB9767247DB46900A92099 /* RCISOPeriodFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DEB9766247DB46900A92099 /* RCISOPeriodFormatter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2DEB976B247DB85400A92099 /* SKProductSubscriptionDurationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DEB976A247DB85400A92099 /* SKProductSubscriptionDurationExtensions.swift */; };
 		350FBDE91F7EEF070065833D /* RCPurchases.h in Headers */ = {isa = PBXBuildFile; fileRef = 350FBDE71F7EEF070065833D /* RCPurchases.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -184,6 +185,7 @@
 		2DD02D5A24AD129A00419CD9 /* LocalReceiptParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalReceiptParserTests.swift; sourceTree = "<group>"; };
 		2DD448FD24088473002F5694 /* RCPurchases+SubscriberAttributes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "RCPurchases+SubscriberAttributes.h"; path = "Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.h"; sourceTree = SOURCE_ROOT; };
 		2DD448FE24088473002F5694 /* RCPurchases+SubscriberAttributes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "RCPurchases+SubscriberAttributes.m"; path = "Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.m"; sourceTree = SOURCE_ROOT; };
+		2DD7BA4C24C63A830066B4C2 /* MockSystemInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSystemInfo.swift; sourceTree = "<group>"; };
 		2DEB9766247DB46900A92099 /* RCISOPeriodFormatter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCISOPeriodFormatter.h; sourceTree = "<group>"; };
 		2DEB976A247DB85400A92099 /* SKProductSubscriptionDurationExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKProductSubscriptionDurationExtensions.swift; sourceTree = "<group>"; };
 		2DEC0CFB24A2A1B100B0E5BB /* Package.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = SOURCE_ROOT; };
@@ -519,6 +521,7 @@
 				37E351D48260D9DC8B1EE360 /* MockSubscriberAttributesManager.swift */,
 				2DEB976A247DB85400A92099 /* SKProductSubscriptionDurationExtensions.swift */,
 				37E35EABF6D7AFE367718784 /* MockSKDiscount.swift */,
+				2DD7BA4C24C63A830066B4C2 /* MockSystemInfo.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -942,6 +945,7 @@
 				37E35EBDFC5CD3068E1792A3 /* MockNotificationCenter.swift in Sources */,
 				37E354E0A9A371481540B2B0 /* MockAttributionFetcher.swift in Sources */,
 				37E35EDC57C486AC2D66B4B8 /* MockOfferingsFactory.swift in Sources */,
+				2DD7BA4D24C63A830066B4C2 /* MockSystemInfo.swift in Sources */,
 				37E35EB7B35C86140B96C58B /* MockUserManager.swift in Sources */,
 				37E357E33F0E20D92EE6372E /* MockSKProduct.swift in Sources */,
 				37E3524CB70618E6C5F3DB49 /* MockPurchasesDelegate.swift in Sources */,

--- a/Purchases/Misc/RCCrossPlatformSupport.h
+++ b/Purchases/Misc/RCCrossPlatformSupport.h
@@ -63,9 +63,9 @@
 #endif
 
 #if TARGET_OS_IOS || TARGET_OS_TV
-#define IS_APPLICATION_ACTIVE UIApplication.sharedApplication.applicationState == UIApplicationStateActive
+#define IS_APPLICATION_BACKGROUNDED UIApplication.sharedApplication.applicationState == UIApplicationStateBackground
 #elif TARGET_OS_OSX
-#define IS_APPLICATION_ACTIVE NSApplication.sharedApplication.isActive
+#define IS_APPLICATION_BACKGROUNDED !NSApplication.sharedApplication.isActive
 #elif TARGET_OS_WATCH
-#define IS_APPLICATION_ACTIVE WKExtension.sharedExtension.applicationState == WKApplicationStateActive
+#define IS_APPLICATION_BACKGROUNDED WKExtension.sharedExtension.applicationState == WKApplicationStateBackground
 #endif

--- a/Purchases/Misc/RCCrossPlatformSupport.h
+++ b/Purchases/Misc/RCCrossPlatformSupport.h
@@ -17,10 +17,13 @@
 #define APP_WILL_RESIGN_ACTIVE_NOTIFICATION_NAME NSExtensionHostWillResignActiveNotification
 #endif
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_MACCATALYST
 #import <UIKit/UIKit.h>
 #elif TARGET_OS_OSX
 #import <AppKit/AppKit.h>
+#elif TARGET_OS_WATCH
+#import <UIKit/UIKit.h>
+#import <WatchKit/WatchKit.h>
 #endif
 
 #if TARGET_OS_MACCATALYST
@@ -57,4 +60,12 @@
 #define PURCHASES_INITIATED_FROM_APP_STORE_AVAILABLE 1
 #else
 #define PURCHASES_INITIATED_FROM_APP_STORE_AVAILABLE 0
+#endif
+
+#if TARGET_OS_IOS || TARGET_OS_TV
+#define IS_APPLICATION_ACTIVE UIApplication.sharedApplication.applicationState == UIApplicationStateActive
+#elif TARGET_OS_OSX
+#define IS_APPLICATION_ACTIVE NSApplication.sharedApplication.isActive
+#elif TARGET_OS_WATCH
+#define IS_APPLICATION_ACTIVE WKExtension.sharedExtension.applicationState == WKApplicationStateActive
 #endif

--- a/Purchases/Misc/RCCrossPlatformSupport.h
+++ b/Purchases/Misc/RCCrossPlatformSupport.h
@@ -65,7 +65,7 @@
 #if TARGET_OS_IOS || TARGET_OS_TV
 #define IS_APPLICATION_BACKGROUNDED UIApplication.sharedApplication.applicationState == UIApplicationStateBackground
 #elif TARGET_OS_OSX
-#define IS_APPLICATION_BACKGROUNDED !NSApplication.sharedApplication.isActive
+#define IS_APPLICATION_BACKGROUNDED NO
 #elif TARGET_OS_WATCH
 #define IS_APPLICATION_BACKGROUNDED WKExtension.sharedExtension.applicationState == WKApplicationStateBackground
 #endif

--- a/Purchases/Misc/RCSystemInfo.h
+++ b/Purchases/Misc/RCSystemInfo.h
@@ -19,12 +19,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy, readonly) NSString *platformFlavor;
 @property(nonatomic, copy, readonly) NSString *platformFlavorVersion;
 
+
+- (BOOL)isApplicationBackgrounded;
+
 + (BOOL)isSandbox;
 + (NSString *)frameworkVersion;
 + (NSString *)systemVersion;
 + (NSString *)appVersion;
 + (NSString *)platformHeader;
-+ (BOOL)isApplicationBackgrounded;
 
 + (NSURL *)serverHostURL;
 + (nullable NSURL *)proxyURL;

--- a/Purchases/Misc/RCSystemInfo.h
+++ b/Purchases/Misc/RCSystemInfo.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)systemVersion;
 + (NSString *)appVersion;
 + (NSString *)platformHeader;
++ (BOOL)isApplicationActive;
 
 + (NSURL *)serverHostURL;
 + (nullable NSURL *)proxyURL;

--- a/Purchases/Misc/RCSystemInfo.h
+++ b/Purchases/Misc/RCSystemInfo.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)systemVersion;
 + (NSString *)appVersion;
 + (NSString *)platformHeader;
-+ (BOOL)isApplicationActive;
++ (BOOL)isApplicationBackgrounded;
 
 + (NSURL *)serverHostURL;
 + (nullable NSURL *)proxyURL;

--- a/Purchases/Misc/RCSystemInfo.m
+++ b/Purchases/Misc/RCSystemInfo.m
@@ -75,11 +75,16 @@ static NSURL * _Nullable proxyURL;
 + (nullable NSURL *)proxyURL {
     return proxyURL;
 }
+
 + (void)setProxyURL:(nullable NSURL *)newProxyURL {
     proxyURL = newProxyURL;
     if (newProxyURL) {
         RCLog(@"Purchases is being configured using a proxy for RevenueCat with URL: %@", newProxyURL);
     }
+}
+
++ (BOOL)isApplicationActive {
+    return IS_APPLICATION_ACTIVE;
 }
 
 @end

--- a/Purchases/Misc/RCSystemInfo.m
+++ b/Purchases/Misc/RCSystemInfo.m
@@ -83,8 +83,8 @@ static NSURL * _Nullable proxyURL;
     }
 }
 
-+ (BOOL)isApplicationActive {
-    return IS_APPLICATION_ACTIVE;
++ (BOOL)isApplicationBackgrounded {
+    return IS_APPLICATION_BACKGROUNDED;
 }
 
 @end

--- a/Purchases/Misc/RCSystemInfo.m
+++ b/Purchases/Misc/RCSystemInfo.m
@@ -83,7 +83,7 @@ static NSURL * _Nullable proxyURL;
     }
 }
 
-+ (BOOL)isApplicationBackgrounded {
+- (BOOL)isApplicationBackgrounded {
     return IS_APPLICATION_BACKGROUNDED;
 }
 

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -290,7 +290,10 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
         };
 
         [self.identityManager configureWithAppUserID:appUserID];
-        [self updateAllCachesWithCompletionBlock:callDelegate];
+        if (RCSystemInfo.isApplicationActive) {
+            [self updateAllCachesWithCompletionBlock:callDelegate];
+        }
+        
         [self configureSubscriberAttributesManager];
 
         self.storeKitWrapper.delegate = self;
@@ -758,6 +761,10 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 
 - (void)applicationDidBecomeActive:(__unused NSNotification *)notif
 {
+    [self updateAllCachesIfNeeded];
+}
+
+- (void)updateAllCachesIfNeeded {
     RCDebugLog(@"applicationDidBecomeActive");
     if ([self.deviceCache isPurchaserInfoCacheStale]) {
         RCDebugLog(@"PurchaserInfo cache is stale, updating caches");

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -290,8 +290,10 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
         };
 
         [self.identityManager configureWithAppUserID:appUserID];
-        if (!RCSystemInfo.isApplicationBackgrounded) {
+        if (!self.systemInfo.isApplicationBackgrounded) {
             [self updateAllCachesWithCompletionBlock:callDelegate];
+        } else {
+            [self sendCachedPurchaserInfoIfAvailable];
         }
         
         [self configureSubscriberAttributesManager];
@@ -340,11 +342,8 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 {
     _delegate = delegate;
     RCDebugLog(@"Delegate set");
-    
-    RCPurchaserInfo *infoFromCache = [self readPurchaserInfoFromCache];
-    if (infoFromCache) {
-        [self sendUpdatedPurchaserInfoToDelegateIfChanged:infoFromCache];
-    }
+
+    [self sendCachedPurchaserInfoIfAvailable];
 }
 
 #pragma mark - Public Methods
@@ -762,6 +761,13 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 - (void)applicationDidBecomeActive:(__unused NSNotification *)notif
 {
     [self updateAllCachesIfNeeded];
+}
+
+- (void)sendCachedPurchaserInfoIfAvailable {
+    RCPurchaserInfo *infoFromCache = [self readPurchaserInfoFromCache];
+    if (infoFromCache) {
+        [self sendUpdatedPurchaserInfoToDelegateIfChanged:infoFromCache];
+    }
 }
 
 - (void)updateAllCachesIfNeeded {

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -290,7 +290,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
         };
 
         [self.identityManager configureWithAppUserID:appUserID];
-        if (RCSystemInfo.isApplicationActive) {
+        if (!RCSystemInfo.isApplicationBackgrounded) {
             [self updateAllCachesWithCompletionBlock:callDelegate];
         }
         

--- a/PurchasesTests/Mocks/MockSystemInfo.swift
+++ b/PurchasesTests/Mocks/MockSystemInfo.swift
@@ -1,0 +1,17 @@
+//
+//  MockSystemInfo.swift
+//  PurchasesTests
+//
+//  Created by Andrés Boedo on 7/20/20.
+//  Copyright © 2020 Purchases. All rights reserved.
+//
+
+import Foundation
+
+class MockSystemInfo: RCSystemInfo {
+    var stubbedIsApplicationBackgrounded: Bool?
+
+    override func isApplicationBackgrounded() -> Bool {
+        return stubbedIsApplicationBackgrounded ?? super.isApplicationBackgrounded()
+    }
+}


### PR DESCRIPTION
Updates so that when the SDK's `configure` is called with the app in the background, it won't try to update offerings or purchaser info. 

They will, however, be updated if the app becomes active, per the `didBecomeActive`notification (that was already the current behavior). 

This also ensures that if the app is in the background and there's purchaser info cached, the purchaserInfo delegate gets called with the cached value. I believe this is different than the android behavior. 

This behavior ensures that we don't make unnecessary backend calls in the following two scenarios: 
- when the app wakes up from a background content notification [(a special type of remote push notification that allows for the app to wake)](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/pushing_background_updates_to_your_app)
- when the app wakes for background app refresh [(a mechanism meant to let email and social media apps (among others) stay up to date by refreshing content in the background)](https://developer.apple.com/documentation/uikit/app_and_environment/scenes/preparing_your_ui_to_run_in_the_background/updating_your_app_with_background_app_refresh). 

Note: this is the iOS equivalent of 
https://github.com/RevenueCat/purchases-android/pull/94/
