### PR TITLE
Fix for posting wrong duration P0D

### DIFF
--- a/Purchases/Purchasing/RCProductInfoExtractor.m
+++ b/Purchases/Purchasing/RCProductInfoExtractor.m
@@ -122,7 +122,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)extractNormalDurationForProduct:(SKProduct *)product {
     NSString *normalDuration = nil;
     if (@available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *)) {
-        if (product.subscriptionPeriod) {
+        if (product.subscriptionPeriod && product.subscriptionPeriod.numberOfUnits != 0) {
             normalDuration = [self.formatter stringFromProductSubscriptionPeriod:product.subscriptionPeriod];
         }
     }

--- a/PurchasesTests/Purchasing/ProductInfoExtractorTests.swift
+++ b/PurchasesTests/Purchasing/ProductInfoExtractorTests.swift
@@ -103,6 +103,25 @@ class ProductInfoExtractorTests: XCTestCase {
         }
     }
 
+    func testExtractInfoFromProductDoesNotExtractNormalDurationIfSubscriptionPeriodIsZero() {
+        let product = MockSKProduct(mockProductIdentifier: "cool_product")
+
+        if #available(iOS 11.2, *) {
+            product.mockSubscriptionPeriod = SKProductSubscriptionPeriod(numberOfUnits: 0, unit: .month)
+            let productInfoExtractor = RCProductInfoExtractor()
+
+            let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
+
+            expect(receivedProductInfo.normalDuration).to(beNil())
+        } else {
+            let productInfoExtractor = RCProductInfoExtractor()
+
+            let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
+
+            expect(receivedProductInfo.normalDuration).to(beNil())
+        }
+    }
+
     func testExtractInfoFromProductExtractsIntroDuration() {
         let product = MockSKProduct(mockProductIdentifier: "cool_product")
 


### PR DESCRIPTION
It looks like some consumables have a non nil `subscriptionPeriod` and we are posting P0D to the backend when posting the product duration. I was only able to replicate this on a 12.2 iPad pro simulator. 

This PR adds a check to make sure we don't post these wrong durations.