### PR TITLE
Replace a double space with a single space

### DIFF
--- a/Examples/SwiftExample/SwiftExample/SwiftPaywall.swift
+++ b/Examples/SwiftExample/SwiftExample/SwiftPaywall.swift
@@ -174,7 +174,7 @@ class SwiftPaywall: UIViewController {
                         self.showAlert(title: "Error", message: error.localizedDescription)
                     }
                 }
-            } else  {
+            } else {
                 if let purchaseCompletedHandler = self.delegate?.purchaseCompleted {
                     purchaseCompletedHandler(self, trans!, info!)
                 } else {


### PR DESCRIPTION
**Description**

I noticed a double space after an `else` statement. This change is purely cosmetic and has no effect on the behavior.