### PR TITLE
Fixes handling of deferred payments (ask to buy)

### DIFF
--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -1044,11 +1044,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
             @synchronized (self) {
                 completion = self.purchaseCompleteCallbacks[transaction.payment.productIdentifier];
             }
-            NSError *pendingError = [NSError errorWithDomain:RCPurchasesErrorDomain
-                                                        code:RCPaymentPendingError
-                                                    userInfo:@{
-                                                        NSLocalizedDescriptionKey: @"The payment is deferred."
-                                                    }];
+            NSError *pendingError = [RCPurchasesErrorUtils paymentDeferredError];
             CALL_IF_SET_ON_MAIN_THREAD(completion,
                                        transaction,
                                        nil,

--- a/Purchases/Public/RCPurchasesErrorUtils.h
+++ b/Purchases/Public/RCPurchasesErrorUtils.h
@@ -40,7 +40,6 @@ NS_SWIFT_NAME(Purchases.ErrorUtils)
  */
 + (NSError *)backendErrorWithBackendCode:(nullable NSNumber *)backendCode backendMessage:(nullable NSString *)backendMessage;
 
-
 /**
  * Maps an RCBackendError code to a [RCPurchasesErrorCode] code. Constructs an NSError with the mapped code and adds a
  * [RCUnderlyingErrorKey] in the [NSError.userInfo] dictionary. The backend error code will be mapped using
@@ -78,6 +77,14 @@ NS_SWIFT_NAME(Purchases.ErrorUtils)
  * are removed manually or if the OS deletes entries when running out of space.
  */
 + (NSError *)missingAppUserIDError;
+
+/**
+ * Constructs an NSError with the [RCPaymentPendingError] code.
+ *
+ * @note This error is used during an “ask to buy” flow for a payment. The completion block of the purchasing function
+ * will get this error to indicate the guardian has to complete the purchase.
+ */
++ (NSError *)paymentDeferredError;
 
 /**
  * Maps an SKErrorCode code to a RCPurchasesErrorCode code. Constructs an NSError with the mapped code and adds a

--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -210,7 +210,6 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
     return [self errorWithCode:code message:message underlyingError:nil];
 }
 
-
 + (NSError *)errorWithCode:(RCPurchasesErrorCode)code
            underlyingError:(nullable NSError *)underlyingError {
     return [self errorWithCode:code message:nil underlyingError:underlyingError extraUserInfo:nil];
@@ -298,6 +297,11 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
 
 + (NSError *)missingAppUserIDError {
     return [self errorWithCode:RCInvalidAppUserIdError];
+}
+
++ (NSError *)paymentDeferredError {
+    return [self errorWithCode:RCPaymentPendingError
+                       message:@"The payment is deferred."];
 }
 
 + (NSError *)purchasesErrorWithSKError:(NSError *)skError {

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -2046,6 +2046,27 @@ class PurchasesTests: XCTestCase {
         expect(RCSystemInfo.serverHostURL()) == defaultHostURL
     }
 
+    func testNotifiesIfTransactionIsDeferredFromStoreKit() {
+        setupPurchases()
+        let product = MockSKProduct(mockProductIdentifier: "com.product.id1")
+        var receivedError: NSError?
+        self.purchases?.purchaseProduct(product) { (tx, info, error, userCancelled) in
+            receivedError = error as NSError?
+        }
+
+        let transaction = MockTransaction()
+        transaction.mockPayment = self.storeKitWrapper.payment!
+
+        transaction.mockState = SKPaymentTransactionState.deferred
+        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+
+        expect(self.backend.postReceiptDataCalled).to(beFalse())
+        expect(self.storeKitWrapper.finishCalled).to(beFalse())
+        expect(receivedError).toEventuallyNot(beNil())
+        expect(receivedError?.domain).toEventually(equal(Purchases.ErrorDomain))
+        expect(receivedError?.code).toEventually(equal(Purchases.ErrorCode.paymentPendingError.rawValue))
+    }
+
     private func verifyUpdatedCaches(newAppUserID: String) {
         expect(self.backend.getSubscriberCallCount).toEventually(equal(2))
         expect(self.deviceCache.cachedPurchaserInfo.count).toEventually(equal(2))


### PR DESCRIPTION
Should fix https://github.com/RevenueCat/purchases-ios/issues/273

In order to test it add:

```
    payment.simulatesAskToBuyInSandbox = YES;
```

to the `SKMutablePayment`. This flag will trigger a `SKPaymentTransactionStateDeferred`. The flow in sandbox is not the same as in production. In production, guardians get a notification with an approval request. In sandbox I have only managed to get that `SKPaymentTransactionStateDeferred` transaction. 

Please note that we are not finishing the transaction. The documentation is not clear, but looking at [https://developer.apple.com/documentation/storekit/in-app_purchase/offering_completing_and_restoring_in-app_purchases](https://developer.apple.com/documentation/storekit/in-app_purchase/offering_completing_and_restoring_in-app_purchases), it looks like we only need to "Call finishTransaction(_:) on transactions whose state is SKPaymentTransactionState.failed, SKPaymentTransactionState.purchased, or SKPaymentTransactionState.restored to remove them from the queue."