### PR TITLE
Fix: application state check on app extensions

### DIFF
--- a/Purchases/Misc/RCCrossPlatformSupport.h
+++ b/Purchases/Misc/RCCrossPlatformSupport.h
@@ -61,11 +61,3 @@
 #else
 #define PURCHASES_INITIATED_FROM_APP_STORE_AVAILABLE 0
 #endif
-
-#if TARGET_OS_IOS || TARGET_OS_TV
-#define IS_APPLICATION_BACKGROUNDED UIApplication.sharedApplication.applicationState == UIApplicationStateBackground
-#elif TARGET_OS_OSX
-#define IS_APPLICATION_BACKGROUNDED NO
-#elif TARGET_OS_WATCH
-#define IS_APPLICATION_BACKGROUNDED WKExtension.sharedExtension.applicationState == WKApplicationStateBackground
-#endif

--- a/Purchases/Misc/RCSystemInfo.h
+++ b/Purchases/Misc/RCSystemInfo.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, copy, readonly) NSString *platformFlavorVersion;
 
 
-- (BOOL)isApplicationBackgrounded;
+- (void)isApplicationBackgroundedWithCompletion:(void(^)(BOOL))completion; // calls completion on the main thread
 
 + (BOOL)isSandbox;
 + (NSString *)frameworkVersion;

--- a/Purchases/Misc/RCSystemInfo.m
+++ b/Purchases/Misc/RCSystemInfo.m
@@ -103,7 +103,9 @@ static NSURL * _Nullable proxyURL;
 }
 
 #if TARGET_OS_IOS
-
+// iOS App extensions can't access UIApplication.sharedApplication, and will fail to compile if any calls to
+// it are made. There are no pre-processor macros available to check if the code is running in an app extension,
+// so we check if we're running in an app extension at runtime, and if not, we use KVC to call sharedApplication. 
 - (BOOL)isApplicationBackgroundedIOS {
     if (self.isAppExtension) {
         return YES;

--- a/Purchases/Misc/RCSystemInfo.m
+++ b/Purchases/Misc/RCSystemInfo.m
@@ -84,8 +84,34 @@ static NSURL * _Nullable proxyURL;
 }
 
 - (BOOL)isApplicationBackgrounded {
-    return IS_APPLICATION_BACKGROUNDED;
+#if TARGET_OS_IOS
+    return self.isApplicationBackgroundedIOS;
+#elif TARGET_OS_TV
+    return  UIApplication.sharedApplication.applicationState == UIApplicationStateBackground;
+#elif TARGET_OS_OSX
+    return  NO;
+#elif TARGET_OS_WATCH
+    return  WKExtension.sharedExtension.applicationState == WKApplicationStateBackground;
+#endif
 }
+
+#if TARGET_OS_IOS
+
+- (BOOL)isApplicationBackgroundedIOS {
+    if (self.isAppExtension) {
+        return YES;
+    }
+    NSString *sharedApplicationPropertyName = @"sharedApplication";
+
+    UIApplication *sharedApplication = [UIApplication valueForKey:sharedApplicationPropertyName];
+    return sharedApplication.applicationState == UIApplicationStateBackground;
+}
+
+- (BOOL)isAppExtension {
+    return [NSBundle.mainBundle.bundlePath hasSuffix:@".appex"];
+}
+
+#endif
 
 @end
 

--- a/Purchases/Misc/RCSystemInfo.m
+++ b/Purchases/Misc/RCSystemInfo.m
@@ -83,6 +83,13 @@ static NSURL * _Nullable proxyURL;
     }
 }
 
+- (void)isApplicationBackgroundedWithCompletion:(void(^)(BOOL))completion {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        BOOL isApplicationBackgrounded = self.isApplicationBackgrounded;
+        completion(isApplicationBackgrounded);
+    });
+}
+
 - (BOOL)isApplicationBackgrounded {
 #if TARGET_OS_IOS
     return self.isApplicationBackgroundedIOS;

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -295,12 +295,18 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
         };
 
         [self.identityManager configureWithAppUserID:appUserID];
-        if (!self.systemInfo.isApplicationBackgrounded) {
-            [self updateAllCachesWithCompletionBlock:callDelegate];
-        } else {
-            [self sendCachedPurchaserInfoIfAvailable];
-        }
-        
+
+        [self.systemInfo isApplicationBackgroundedWithCompletion:^(BOOL isBackgrounded) {
+            if (!isBackgrounded) {
+                dispatch_queue_t backgroundQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+                dispatch_async(backgroundQueue, ^{
+                    [self updateAllCachesWithCompletionBlock:callDelegate];
+                });
+            } else {
+                [self sendCachedPurchaserInfoIfAvailable];
+            }
+        }];
+
         [self configureSubscriberAttributesManager];
 
         self.storeKitWrapper.delegate = self;

--- a/PurchasesTests/Mocks/MockSystemInfo.swift
+++ b/PurchasesTests/Mocks/MockSystemInfo.swift
@@ -11,7 +11,7 @@ import Foundation
 class MockSystemInfo: RCSystemInfo {
     var stubbedIsApplicationBackgrounded: Bool?
 
-    override func isApplicationBackgrounded() -> Bool {
-        return stubbedIsApplicationBackgrounded ?? super.isApplicationBackgrounded()
+    override func isApplicationBackgrounded(completion: @escaping (Bool) -> Void) {
+        completion(stubbedIsApplicationBackgrounded ?? false)
     }
 }

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -206,12 +206,14 @@ class HTTPClientTests: XCTestCase {
         }
 
         self.client.performRequest("GET", path: path, body: nil, headers: nil) { (status, data, responseError) in
-            guard let responseNSError = responseError as? NSError else { successFailed = false }
-            successFailed = (status >= 500
-                             && data == nil
-                             && error.domain == responseNSError.domain
-                             && error.code == responseNSError.code
-                             && error.userInfo == responseNSError.userInfo)
+            if let responseNSError = responseError as? NSError {
+                successFailed = (status >= 500
+                                 && data == nil
+                                 && error.domain == responseNSError.domain
+                                 && error.code == responseNSError.code)
+            } else {
+                successFailed = false
+            }
         }
 
         expect(successFailed).toEventually(equal(true))

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -206,10 +206,15 @@ class HTTPClientTests: XCTestCase {
         }
 
         self.client.performRequest("GET", path: path, body: nil, headers: nil) { (status, data, responseError) in
-            successFailed = (status >= 500) && (data == nil) && (error == responseError as NSError?)
+            guard let responseNSError = responseError as? NSError else { successFailed = false }
+            successFailed = (status >= 500
+                             && data == nil
+                             && error.domain == responseNSError.domain
+                             && error.code == responseNSError.code
+                             && error.userInfo == responseNSError.userInfo)
         }
 
-        expect(successFailed).toEventually(equal(true), timeout: 1.0)
+        expect(successFailed).toEventually(equal(true))
     }
 
     func testServerSide400s() {

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -2074,7 +2074,7 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.getSubscriberCallCount).toEventually(equal(2))
         expect(self.deviceCache.cachedPurchaserInfo.count).toEventually(equal(2))
         expect(self.deviceCache.cachedPurchaserInfo[newAppUserID]).toNot(beNil())
-        expect(self.purchasesDelegate.purchaserInfoReceivedCount).toEventually(equal(2), timeout: .seconds(3))
+        expect(self.purchasesDelegate.purchaserInfoReceivedCount).toEventually(equal(2), timeout: 3.0)
         expect(self.deviceCache.setPurchaserInfoCacheTimestampToNowCount).toEventually(equal(2))
         expect(self.deviceCache.setOfferingsCacheTimestampToNowCount).toEventually(equal(2))
         expect(self.backend.gotOfferings).toEventually(equal(2))

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -657,7 +657,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        expect(self.requestFetcher.requestedProducts! as NSSet).to(contain([product.productIdentifier]))
+        expect(self.requestFetcher.requestedProducts! as NSSet).toEventually(contain([product.productIdentifier]))
 
         expect(self.backend.postedProductID).toNot(beNil())
         expect(self.backend.postedPrice).toNot(beNil())
@@ -2074,7 +2074,7 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.getSubscriberCallCount).toEventually(equal(2))
         expect(self.deviceCache.cachedPurchaserInfo.count).toEventually(equal(2))
         expect(self.deviceCache.cachedPurchaserInfo[newAppUserID]).toNot(beNil())
-        expect(self.purchasesDelegate.purchaserInfoReceivedCount).toEventually(equal(2))
+        expect(self.purchasesDelegate.purchaserInfoReceivedCount).toEventually(equal(2), timeout: .seconds(3))
         expect(self.deviceCache.setPurchaserInfoCacheTimestampToNowCount).toEventually(equal(2))
         expect(self.deviceCache.setOfferingsCacheTimestampToNowCount).toEventually(equal(2))
         expect(self.backend.gotOfferings).toEventually(equal(2))

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -1273,7 +1273,7 @@ class PurchasesTests: XCTestCase {
 
         setupPurchases()
 
-        expect(self.backend.getSubscriberCallCount).to(equal(1))
+        expect(self.backend.getSubscriberCallCount).toEventually(equal(1))
 
         purchases!.purchaserInfo { (info, error) in
         }

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -12,6 +12,8 @@ class PurchasesTests: XCTestCase {
 
     override func setUp() {
         self.userDefaults = UserDefaults(suiteName: "TestDefaults")
+        requestFetcher = MockRequestFetcher()
+        systemInfo = MockSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: true)
     }
 
     override func tearDown() {
@@ -169,7 +171,7 @@ class PurchasesTests: XCTestCase {
 
 
     let receiptFetcher = MockReceiptFetcher()
-    let requestFetcher = MockRequestFetcher()
+    var requestFetcher: MockRequestFetcher!
     let backend = MockBackend()
     let storeKitWrapper = MockStoreKitWrapper()
     let notificationCenter = MockNotificationCenter()
@@ -179,7 +181,7 @@ class PurchasesTests: XCTestCase {
     let deviceCache = MockDeviceCache()
     let subscriberAttributesManager = MockSubscriberAttributesManager()
     let identityManager = MockUserManager(mockAppUserID: "app_user");
-    let systemInfo = MockSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: true)
+    var systemInfo: MockSystemInfo!
     
     let purchasesDelegate = MockPurchasesDelegate()
 
@@ -641,7 +643,8 @@ class PurchasesTests: XCTestCase {
         }
     }
 
-    func testFetchesProductInfoIfNotCachedAndAppActive() {
+    func testFetchesProductInfoIfNotCached() {
+        systemInfo.stubbedIsApplicationBackgrounded = true
         setupPurchases()
         let product = MockSKProduct(mockProductIdentifier: "com.product.id1")
 


### PR DESCRIPTION
`UIApplication.sharedApplication` isn't available in iOS app extensions. They won't compile if the method is used. 

Unfortunately, there's no pre-processor macro to check if the code is running within an app extension. There's also no direct API. 
Most of the solutions I found online seem to involve adding a custom flag to the app extension target's build settings... which is fine, if you're the app developer. If you're developing an SDK, however, this isn't an option. 

I realized that MParticle used to ask developers to create this custom flag, but afterwards removed that and instead they now check if the app's bundle has the filename extension `.appex`. 
This only works at runtime, so I had to refactor the related code a bit: I use KVC to call the method by name, if and only if the code is not running inside an app extension. 

That should solve the app extension issue. 

On another note, since the code is calling `UIApplication` but _may_ be running in a background thread, this might raise warnings from the Main Thread Checker (see #300). 
To address this, I moved the call to `UIApplication.sharedApplication` to the main thread. However, the rest of the method (fetching purchaser info and offerings from the backend) runs in a background operation thread. 
