### PR TITLE
Cache carthage files to speed up build times

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ jobs:
       - restore_cache:
           keys: 
             - carthage-cache-{{ checksum "Cartfile.resolved" }}
-            - gem-cache-{{ checksum "Gemfile.lock" }}
       - run:
           name: Carthage Bootstrap
           command: |
@@ -19,7 +18,10 @@ jobs:
           key: carthage-cache-{{ checksum "Cartfile.resolved" }}
           paths:
             - Carthage
-      - run: bundle install --path vendor/bundle
+      - restore_cache:
+          keys: 
+            - gem-cache-{{ checksum "Gemfile.lock" }}
+      - run: bundle install --clean --path vendor/bundle
       - save_cache:
           key: gem-cache-{{ checksum "Gemfile.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: carthage-cache-{{ checksum "Cartfile.resolved" }}
+          keys: 
+            - carthage-cache-{{ checksum "Cartfile.resolved" }}
+            - gem-cache-{{ checksum "Gemfile.lock" }}
       - run:
           name: Carthage Bootstrap
           command: |
@@ -17,7 +19,11 @@ jobs:
           key: carthage-cache-{{ checksum "Cartfile.resolved" }}
           paths:
             - Carthage
-      - run: bundle install
+      - run: bundle install --path vendor/bundle
+      - save_cache:
+          key: gem-cache-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
       - run:
           name: Run tests
           command: fastlane scan

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,16 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
+      - restore_cache:
+          key: carthage-cache-{{ checksum "Cartfile.resolved" }}
       - run:
           name: Carthage Bootstrap
-          command: carthage bootstrap
+          command: |
+              carthage bootstrap --cache-builds
+      - save_cache:
+          key: carthage-cache-{{ checksum "Cartfile.resolved" }}
+          paths:
+            - Carthage
       - run: bundle install
       - run:
           name: Run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,8 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
+      
+      # Carthage
       - restore_cache:
           keys: 
             - carthage-cache-{{ checksum "Cartfile.resolved" }}
@@ -18,6 +20,8 @@ jobs:
           key: carthage-cache-{{ checksum "Cartfile.resolved" }}
           paths:
             - Carthage
+      
+      # Bundler
       - restore_cache:
           keys: 
             - gem-cache-{{ checksum "Gemfile.lock" }}
@@ -26,6 +30,7 @@ jobs:
           key: gem-cache-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
+      
       - run:
           name: Run tests
           command: fastlane scan


### PR DESCRIPTION

We were not caching the Carthage folder and `carthage bootstrap` takes 4 minutes atm. Hopefully this PR reduces that time to seconds

Before (10-15 min):
![Screen Shot 2020-08-04 at 3 19 59 PM](https://user-images.githubusercontent.com/664544/89351010-f9404080-d665-11ea-9360-9db0b549045f.png)

After (2 min):
![Screen Shot 2020-08-04 at 3 31 50 PM](https://user-images.githubusercontent.com/664544/89351823-a4052e80-d667-11ea-83c4-04824f25fcb3.png)