### PR TITLE
Feature/private swift dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,8 @@ func resolveTargets() -> [Target] {
                        "Purchases/Public",
                        "Purchases/Purchasing",
                        "Purchases/ProtectedExtensions",
-                       "Purchases/SubscriberAttributes"]
+                       "Purchases/SubscriberAttributes",
+                       "Purchases/SwiftInterfaces"]
     let infoPlist = "Purchases/Info.plist"
     let swiftSources = "Purchases/SwiftSources"
     

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -13,7 +13,8 @@
 		2D5033262406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5033232406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D50332A2406EA61009CAE61 /* RCSubscriberAttributesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5033272406EA61009CAE61 /* RCSubscriberAttributesManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D50332B2406EA61009CAE61 /* RCSubscriberAttributesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D5033282406EA61009CAE61 /* RCSubscriberAttributesManager.m */; };
-		2D59D15924DAE78A0057BB58 /* RCTransactionsFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D59D15824DAE78A0057BB58 /* RCTransactionsFactory.h */; };
+		2D59D15B24DAEA1D0057BB58 /* RCTransactionsFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D59D15A24DAEA1D0057BB58 /* RCTransactionsFactory.h */; };
+		2D59D15D24DAEA620057BB58 /* RCLocalReceiptParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D59D15C24DAEA620057BB58 /* RCLocalReceiptParser.h */; };
 		2D8DB34B24072AAE00BE3D31 /* SubscriberAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8DB34A24072AAE00BE3D31 /* SubscriberAttributeTests.swift */; };
 		2DD02D5524AD011600419CD9 /* RCPurchasesSwiftImport.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DD02D5424AD00ED00419CD9 /* RCPurchasesSwiftImport.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2DD02D5724AD0B0500419CD9 /* RCIntroEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD02D5624AD0B0500419CD9 /* RCIntroEligibilityTests.swift */; };
@@ -185,6 +186,8 @@
 		2D5033232406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCSpecialSubscriberAttributes.h; path = Purchases/SubscriberAttributes/RCSpecialSubscriberAttributes.h; sourceTree = SOURCE_ROOT; };
 		2D5033272406EA61009CAE61 /* RCSubscriberAttributesManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCSubscriberAttributesManager.h; path = Purchases/SubscriberAttributes/RCSubscriberAttributesManager.h; sourceTree = SOURCE_ROOT; };
 		2D5033282406EA61009CAE61 /* RCSubscriberAttributesManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCSubscriberAttributesManager.m; path = Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m; sourceTree = SOURCE_ROOT; };
+		2D59D15A24DAEA1D0057BB58 /* RCTransactionsFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTransactionsFactory.h; sourceTree = "<group>"; };
+		2D59D15C24DAEA620057BB58 /* RCLocalReceiptParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCLocalReceiptParser.h; sourceTree = "<group>"; };
 		2D8DB34A24072AAE00BE3D31 /* SubscriberAttributeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriberAttributeTests.swift; sourceTree = "<group>"; };
 		2DD02D5424AD00ED00419CD9 /* RCPurchasesSwiftImport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCPurchasesSwiftImport.h; sourceTree = "<group>"; };
 		2DD02D5624AD0B0500419CD9 /* RCIntroEligibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RCIntroEligibilityTests.swift; sourceTree = "<group>"; };
@@ -379,7 +382,8 @@
 		2D59D15724DAE7690057BB58 /* SwiftInterfaces */ = {
 			isa = PBXGroup;
 			children = (
-				2D59D15824DAE78A0057BB58 /* RCTransactionsFactory.h */,
+				2D59D15A24DAEA1D0057BB58 /* RCTransactionsFactory.h */,
+				2D59D15C24DAEA620057BB58 /* RCLocalReceiptParser.h */,
 			);
 			path = SwiftInterfaces;
 			sourceTree = "<group>";
@@ -751,10 +755,10 @@
 				353AB5E4222F624E003754E6 /* RCPurchasesErrors.h in Headers */,
 				3585D6A322E680E30079E2C5 /* RCPackage.h in Headers */,
 				353AB5E6222F633D003754E6 /* RCPurchasesErrorUtils.h in Headers */,
-				2D59D15924DAE78A0057BB58 /* RCTransactionsFactory.h in Headers */,
 				350FBDE91F7EEF070065833D /* RCPurchases.h in Headers */,
 				354D50DF22E7D014009B870C /* RCOfferings.h in Headers */,
 				351F4FAF1F803D0700F245F4 /* RCPurchaserInfo.h in Headers */,
+				2D59D15B24DAEA1D0057BB58 /* RCTransactionsFactory.h in Headers */,
 				2DD02D5524AD011600419CD9 /* RCPurchasesSwiftImport.h in Headers */,
 				35262A0F1F7C4B9100C04F2C /* Purchases.h in Headers */,
 				37E3598A1AAA3D70EA01C82D /* RCInMemoryCachedObject.h in Headers */,
@@ -776,6 +780,7 @@
 				37E354159288DE3D23212382 /* RCCrossPlatformSupport.h in Headers */,
 				37E35E9CEC36E93AF682D012 /* RCPromotionalOffer+Protected.h in Headers */,
 				37E352E86A182E92130B823C /* RCIntroEligibility+Protected.h in Headers */,
+				2D59D15D24DAEA620057BB58 /* RCLocalReceiptParser.h in Headers */,
 				37E35C5A53AC7CF63B240FEC /* RCEntitlementInfos+Protected.h in Headers */,
 				37E3575B0FFDD90D01861D81 /* RCPurchasesErrorUtils+Protected.h in Headers */,
 				37E35D04747C56E85F1B9679 /* RCPurchaserInfo+Protected.h in Headers */,

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		2D5033262406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5033232406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D50332A2406EA61009CAE61 /* RCSubscriberAttributesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5033272406EA61009CAE61 /* RCSubscriberAttributesManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D50332B2406EA61009CAE61 /* RCSubscriberAttributesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D5033282406EA61009CAE61 /* RCSubscriberAttributesManager.m */; };
+		2D59D15924DAE78A0057BB58 /* RCTransactionsFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D59D15824DAE78A0057BB58 /* RCTransactionsFactory.h */; };
 		2D8DB34B24072AAE00BE3D31 /* SubscriberAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8DB34A24072AAE00BE3D31 /* SubscriberAttributeTests.swift */; };
 		2DD02D5524AD011600419CD9 /* RCPurchasesSwiftImport.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DD02D5424AD00ED00419CD9 /* RCPurchasesSwiftImport.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2DD02D5724AD0B0500419CD9 /* RCIntroEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD02D5624AD0B0500419CD9 /* RCIntroEligibilityTests.swift */; };
@@ -375,11 +376,20 @@
 			path = Public/SubscriberAttributes;
 			sourceTree = "<group>";
 		};
+		2D59D15724DAE7690057BB58 /* SwiftInterfaces */ = {
+			isa = PBXGroup;
+			children = (
+				2D59D15824DAE78A0057BB58 /* RCTransactionsFactory.h */,
+			);
+			path = SwiftInterfaces;
+			sourceTree = "<group>";
+		};
 		2D9AF7B124A2B2F000E1D023 /* SwiftSources */ = {
 			isa = PBXGroup;
 			children = (
 				354235D524C11138008C84EE /* Purchasing */,
 				2D1A28CB24AA6F4B006BE931 /* LocalReceiptParsing */,
+				37E35E82A21BCF3EDC9E6057 /* Misc */,
 			);
 			path = SwiftSources;
 			sourceTree = "<group>";
@@ -468,6 +478,7 @@
 		35262A001F7C4B9100C04F2C /* Purchases */ = {
 			isa = PBXGroup;
 			children = (
+				2D59D15724DAE7690057BB58 /* SwiftInterfaces */,
 				2D9AF7B124A2B2F000E1D023 /* SwiftSources */,
 				35262A021F7C4B9100C04F2C /* Info.plist */,
 				37E359927177DF24576FF361 /* Caching */,
@@ -740,6 +751,7 @@
 				353AB5E4222F624E003754E6 /* RCPurchasesErrors.h in Headers */,
 				3585D6A322E680E30079E2C5 /* RCPackage.h in Headers */,
 				353AB5E6222F633D003754E6 /* RCPurchasesErrorUtils.h in Headers */,
+				2D59D15924DAE78A0057BB58 /* RCTransactionsFactory.h in Headers */,
 				350FBDE91F7EEF070065833D /* RCPurchases.h in Headers */,
 				354D50DF22E7D014009B870C /* RCOfferings.h in Headers */,
 				351F4FAF1F803D0700F245F4 /* RCPurchaserInfo.h in Headers */,

--- a/Purchases/Misc/RCPurchasesSwiftImport.h
+++ b/Purchases/Misc/RCPurchasesSwiftImport.h
@@ -8,8 +8,4 @@
 
 #if SWIFT_PACKAGE
 @import PurchasesSwift;
-#elif __has_include("Purchases-Swift.h")
-#import "Purchases-Swift.h"
-#else
-#import <Purchases/Purchases-Swift.h>
 #endif

--- a/Purchases/Public/RCPurchaserInfo.m
+++ b/Purchases/Public/RCPurchaserInfo.m
@@ -12,6 +12,7 @@
 #import "RCEntitlementInfos+Protected.h"
 #import "RCEntitlementInfo.h"
 #import "RCPurchasesSwiftImport.h"
+#import "RCTransactionsFactory.h"
 
 @interface RCPurchaserInfo ()
 
@@ -86,7 +87,7 @@ static dispatch_once_t onceToken;
     self.nonConsumablePurchases = [NSSet setWithArray:[nonSubscriptionsData allKeys]];
     
     RCTransactionsFactory *transactionsFactory = [[RCTransactionsFactory alloc] init];
-    self.nonSubscriptionTransactions = [transactionsFactory nonSubscriptionTransactionsWith:nonSubscriptionsData dateFormatter:dateFormatter];
+    self.nonSubscriptionTransactions = [transactionsFactory nonSubscriptionTransactionsWithSubscriptionsData:nonSubscriptionsData dateFormatter:dateFormatter];
 
     NSMutableDictionary<NSString *, id> *nonSubscriptionsLatestPurchases = [[NSMutableDictionary alloc] init];
     for (NSString* productId in nonSubscriptionsData) {

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -34,6 +34,7 @@
 #import "RCProductInfoExtractor.h"
 #import "RCIntroEligibility+Protected.h"
 #import "RCPurchasesSwiftImport.h"
+#import "RCLocalReceiptParser.h"
 
 #define CALL_IF_SET_ON_MAIN_THREAD(completion, ...) if (completion) [self dispatch:^{ completion(__VA_ARGS__); }];
 #define CALL_IF_SET_ON_SAME_THREAD(completion, ...) if (completion) completion(__VA_ARGS__);
@@ -656,7 +657,7 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 - (void)checkTrialOrIntroductoryPriceEligibility:(NSArray<NSString *> *)productIdentifiers
                                  completionBlock:(RCReceiveIntroEligibilityBlock)receiveEligibility {
     [self receiptData:^(NSData * _Nonnull data) {
-        LocalReceiptParser *receiptParser = [[LocalReceiptParser alloc] init];
+        RCLocalReceiptParser *receiptParser = [[RCLocalReceiptParser alloc] init];
         [receiptParser checkTrialOrIntroductoryPriceEligibilityWithData:data
                                                      productIdentifiers:productIdentifiers
                                                              completion:^(NSDictionary<NSString *, NSNumber *> * _Nonnull receivedEligibility,

--- a/Purchases/SwiftInterfaces/RCLocalReceiptParser.h
+++ b/Purchases/SwiftInterfaces/RCLocalReceiptParser.h
@@ -1,0 +1,23 @@
+//
+//  RCLocalReceiptParser.h
+//  Purchases
+//
+//  Created by Andrés Boedo on 8/5/20.
+//  Copyright © 2020 Purchases. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCLocalReceiptParser : NSObject
+
+- (void)checkTrialOrIntroductoryPriceEligibilityWithData:(NSData *)data
+                                      productIdentifiers:(NSArray <NSString *>*)productIdentifiers
+                                              completion:(void (^)(NSDictionary<NSString *, NSNumber *> *,
+                                                                   NSError * _Nullable))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/Purchases/SwiftInterfaces/RCTransactionsFactory.h
+++ b/Purchases/SwiftInterfaces/RCTransactionsFactory.h
@@ -1,0 +1,18 @@
+//
+//  RCTransactionsFactory.h
+//  Purchases
+//
+//  Created by Andrés Boedo on 8/5/20.
+//  Copyright © 2020 Purchases. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class RCTransaction;
+
+@interface RCTransactionsFactory: NSObject
+
+- (NSArray <RCTransaction *> *) nonSubscriptionTransactionsWithSubscriptionsData:(NSDictionary *)subscriptionsData
+                                                                   dateFormatter:(NSDateFormatter *)dateFormatter;
+
+@end

--- a/Purchases/SwiftInterfaces/RCTransactionsFactory.h
+++ b/Purchases/SwiftInterfaces/RCTransactionsFactory.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class RCTransaction;
 
 @interface RCTransactionsFactory: NSObject
@@ -16,3 +18,5 @@
                                                                    dateFormatter:(NSDateFormatter *)dateFormatter;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/SwiftSources/LocalReceiptParsing/LocalReceiptParser.swift
+++ b/Purchases/SwiftSources/LocalReceiptParsing/LocalReceiptParser.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-@objc public enum LocalReceiptParserErrorCode: Int {
+@objc internal enum LocalReceiptParserErrorCode: Int {
     case ReceiptNotFound,
          UnknownError
 }
@@ -18,9 +18,9 @@ internal enum IntroEligibilityStatus: Int {
          eligible
 }
 
-@objc public class LocalReceiptParser: NSObject {
+@objc(RCLocalReceiptParser) internal class LocalReceiptParser: NSObject {
     
-    @objc public func checkTrialOrIntroductoryPriceEligibility(withData data: Data,
+    @objc internal func checkTrialOrIntroductoryPriceEligibility(withData data: Data,
                                                                productIdentifiers: [String],
                                                                completion: ([String : Int], Error?) -> Void) {
         completion([:], NSError(domain: "This method hasn't been implemented yet",

--- a/Purchases/SwiftSources/LocalReceiptParsing/LocalReceiptParser.swift
+++ b/Purchases/SwiftSources/LocalReceiptParsing/LocalReceiptParser.swift
@@ -21,8 +21,8 @@ internal enum IntroEligibilityStatus: Int {
 @objc(RCLocalReceiptParser) internal class LocalReceiptParser: NSObject {
     
     @objc internal func checkTrialOrIntroductoryPriceEligibility(withData data: Data,
-                                                               productIdentifiers: [String],
-                                                               completion: ([String : Int], Error?) -> Void) {
+                                                                 productIdentifiers: [String],
+                                                                 completion: ([String : Int], Error?) -> Void) {
         completion([:], NSError(domain: "This method hasn't been implemented yet",
                                 code: LocalReceiptParserErrorCode.UnknownError.rawValue,
                                 userInfo: nil))

--- a/Purchases/SwiftSources/Purchasing/Transaction.swift
+++ b/Purchases/SwiftSources/Purchasing/Transaction.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-@objc(RCTransaction) public class Transaction: NSObject {
+@objc(RCTransaction) internal class Transaction: NSObject {
 
     @available(*, unavailable, message: "Use init(transactionId, productId, purchaseDate) instead")
     override init() {

--- a/Purchases/SwiftSources/Purchasing/TransactionsFactory.swift
+++ b/Purchases/SwiftSources/Purchasing/TransactionsFactory.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-@objc(RCTransactionsFactory) public class TransactionsFactory: NSObject {
+@objc(RCTransactionsFactory) internal class TransactionsFactory: NSObject {
 
-    @objc public func nonSubscriptionTransactions(with subscriptionsData: [String: [[String: Any]]],
+    @objc internal func nonSubscriptionTransactions(withSubscriptionsData subscriptionsData: [String: [[String: Any]]],
                                                   dateFormatter: DateFormatter) -> [Transaction] {
         subscriptionsData.flatMap { (productId: String, transactionData: [[String: Any]]) -> [Transaction] in
             transactionData.map {

--- a/Purchases/SwiftSources/Purchasing/TransactionsFactory.swift
+++ b/Purchases/SwiftSources/Purchasing/TransactionsFactory.swift
@@ -9,9 +9,9 @@
 import Foundation
 
 @objc(RCTransactionsFactory) internal class TransactionsFactory: NSObject {
-
+    
     @objc internal func nonSubscriptionTransactions(withSubscriptionsData subscriptionsData: [String: [[String: Any]]],
-                                                  dateFormatter: DateFormatter) -> [Transaction] {
+                                                    dateFormatter: DateFormatter) -> [Transaction] {
         subscriptionsData.flatMap { (productId: String, transactionData: [[String: Any]]) -> [Transaction] in
             transactionData.map {
                 Transaction(with: $0, productId: productId, dateFormatter: dateFormatter)
@@ -20,5 +20,5 @@ import Foundation
             $0.purchaseDate < $1.purchaseDate
         }
     }
-
+    
 }

--- a/PurchasesTests/SwiftSources/Purchasing/TransactionsFactoryTests.swift
+++ b/PurchasesTests/SwiftSources/Purchasing/TransactionsFactoryTests.swift
@@ -61,7 +61,7 @@ class TransactionsFactoryTests: XCTestCase {
     }
 
     func testNonSubscriptionsIsCorrectlyCreated() {
-        let nonSubscriptionTransactions = transactionsFactory.nonSubscriptionTransactions(with: sampleTransactions, dateFormatter: dateFormatter)
+        let nonSubscriptionTransactions = transactionsFactory.nonSubscriptionTransactions(withSubscriptionsData: sampleTransactions, dateFormatter: dateFormatter)
         expect(nonSubscriptionTransactions.count) == 5
 
         sampleTransactions.forEach { productId, transactionsData in
@@ -77,7 +77,7 @@ class TransactionsFactoryTests: XCTestCase {
     }
 
     func testNonSubscriptionsIsEmptyIfThereAreNoNonSubscriptions() {
-        let list = transactionsFactory.nonSubscriptionTransactions(with: [:], dateFormatter: dateFormatter)
+        let list = transactionsFactory.nonSubscriptionTransactions(withSubscriptionsData: [:], dateFormatter: dateFormatter)
         expect(list).to(beEmpty())
     }
 


### PR DESCRIPTION
This had been bugging me - whenever we wrote Swift code that needed to be used from Objective-C, we'd have to make it public. This means that SDK clients would see classes like `LocalIntroEligibiilty` and `TransactionsFactory`

This would in turn make it public in the SDK for everything but SPM (since SPM actually has the swift stuff as a separate target). 

Thinking about this, I kept re-reading this phrase [Apple's docs on Swift / Objective C interoperability](https://developer.apple.com/documentation/swift/imported_c_and_objective-c_apis/importing_swift_into_objective-c):

> Because the generated header is part of the framework’s public interface, only declarations marked with the public or open modifier appear in the generated header for a framework target. Methods and properties that are marked with the internal modifier and declared within a class that inherits from an Objective-C class are accessible to the Objective-C runtime. However, they're inaccessible at compile time and don't appear in the generated header for a framework target.

It looked like it would mean that objective-c can access `internal` swift stuff, just not at compile time. 

So I tried creating a header for every public swift class, and making the swift class internal, and it worked 🎉 

So the new process from now on for accessing internal swift stuff from obj-c would be: 

- make the class internal
- make an obj-c header file that matches the public definition of the swift class
- in obj-c classes that use Swift, import both: 
    - the headers
    - `RCPurchasesSwiftImport.h`: this is exclusively for swift package manager, since it will see swift as a separate target. 

This has the added benefit of forcing us to think about the public interface for swift/objective-c, so we'll be guaranteed to make it nice and idiomatic. 

