### PR TITLE
Fix non determistic tests

### DIFF
--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -13,8 +13,8 @@
 		2D5033262406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5033232406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D50332A2406EA61009CAE61 /* RCSubscriberAttributesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5033272406EA61009CAE61 /* RCSubscriberAttributesManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D50332B2406EA61009CAE61 /* RCSubscriberAttributesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D5033282406EA61009CAE61 /* RCSubscriberAttributesManager.m */; };
-		2D59D15B24DAEA1D0057BB58 /* RCTransactionsFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D59D15A24DAEA1D0057BB58 /* RCTransactionsFactory.h */; };
-		2D59D15D24DAEA620057BB58 /* RCLocalReceiptParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D59D15C24DAEA620057BB58 /* RCLocalReceiptParser.h */; };
+		2D59D15B24DAEA1D0057BB58 /* RCTransactionsFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D59D15A24DAEA1D0057BB58 /* RCTransactionsFactory.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		2D59D15D24DAEA620057BB58 /* RCLocalReceiptParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D59D15C24DAEA620057BB58 /* RCLocalReceiptParser.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D8DB34B24072AAE00BE3D31 /* SubscriberAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8DB34A24072AAE00BE3D31 /* SubscriberAttributeTests.swift */; };
 		2DD02D5524AD011600419CD9 /* RCPurchasesSwiftImport.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DD02D5424AD00ED00419CD9 /* RCPurchasesSwiftImport.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2DD02D5724AD0B0500419CD9 /* RCIntroEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD02D5624AD0B0500419CD9 /* RCIntroEligibilityTests.swift */; };
@@ -22,6 +22,8 @@
 		2DD448FF24088473002F5694 /* RCPurchases+SubscriberAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DD448FD24088473002F5694 /* RCPurchases+SubscriberAttributes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2DD4490024088473002F5694 /* RCPurchases+SubscriberAttributes.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DD448FE24088473002F5694 /* RCPurchases+SubscriberAttributes.m */; };
 		2DD7BA4D24C63A830066B4C2 /* MockSystemInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD7BA4C24C63A830066B4C2 /* MockSystemInfo.swift */; };
+		2DDA3E4324DB06E000EDFE5B /* RCOperationDispatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DDA3E4124DB06E000EDFE5B /* RCOperationDispatcher.h */; };
+		2DDA3E4724DB0B5400EDFE5B /* OperationDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DDA3E4624DB0B5400EDFE5B /* OperationDispatcher.swift */; };
 		2DEB9767247DB46900A92099 /* RCISOPeriodFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DEB9766247DB46900A92099 /* RCISOPeriodFormatter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2DEB976B247DB85400A92099 /* SKProductSubscriptionDurationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DEB976A247DB85400A92099 /* SKProductSubscriptionDurationExtensions.swift */; };
 		350FBDE91F7EEF070065833D /* RCPurchases.h in Headers */ = {isa = PBXBuildFile; fileRef = 350FBDE71F7EEF070065833D /* RCPurchases.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -195,6 +197,8 @@
 		2DD448FD24088473002F5694 /* RCPurchases+SubscriberAttributes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "RCPurchases+SubscriberAttributes.h"; path = "Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.h"; sourceTree = SOURCE_ROOT; };
 		2DD448FE24088473002F5694 /* RCPurchases+SubscriberAttributes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "RCPurchases+SubscriberAttributes.m"; path = "Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.m"; sourceTree = SOURCE_ROOT; };
 		2DD7BA4C24C63A830066B4C2 /* MockSystemInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSystemInfo.swift; sourceTree = "<group>"; };
+		2DDA3E4124DB06E000EDFE5B /* RCOperationDispatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCOperationDispatcher.h; sourceTree = "<group>"; };
+		2DDA3E4624DB0B5400EDFE5B /* OperationDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationDispatcher.swift; sourceTree = "<group>"; };
 		2DEB9766247DB46900A92099 /* RCISOPeriodFormatter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCISOPeriodFormatter.h; sourceTree = "<group>"; };
 		2DEB976A247DB85400A92099 /* SKProductSubscriptionDurationExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKProductSubscriptionDurationExtensions.swift; sourceTree = "<group>"; };
 		2DEC0CFB24A2A1B100B0E5BB /* Package.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = SOURCE_ROOT; };
@@ -382,6 +386,7 @@
 		2D59D15724DAE7690057BB58 /* SwiftInterfaces */ = {
 			isa = PBXGroup;
 			children = (
+				2DDA3E4124DB06E000EDFE5B /* RCOperationDispatcher.h */,
 				2D59D15A24DAEA1D0057BB58 /* RCTransactionsFactory.h */,
 				2D59D15C24DAEA620057BB58 /* RCLocalReceiptParser.h */,
 			);
@@ -391,9 +396,9 @@
 		2D9AF7B124A2B2F000E1D023 /* SwiftSources */ = {
 			isa = PBXGroup;
 			children = (
+				2DDA3E4524DB0B4500EDFE5B /* Misc */,
 				354235D524C11138008C84EE /* Purchasing */,
 				2D1A28CB24AA6F4B006BE931 /* LocalReceiptParsing */,
-				37E35E82A21BCF3EDC9E6057 /* Misc */,
 			);
 			path = SwiftSources;
 			sourceTree = "<group>";
@@ -420,6 +425,14 @@
 				2DD02D5A24AD129A00419CD9 /* LocalReceiptParserTests.swift */,
 			);
 			path = LocalReceiptParsing;
+			sourceTree = "<group>";
+		};
+		2DDA3E4524DB0B4500EDFE5B /* Misc */ = {
+			isa = PBXGroup;
+			children = (
+				2DDA3E4624DB0B5400EDFE5B /* OperationDispatcher.swift */,
+			);
+			path = Misc;
 			sourceTree = "<group>";
 		};
 		350FBDD61F7DF1640065833D /* Frameworks */ = {
@@ -711,9 +724,9 @@
 				2DD02D5424AD00ED00419CD9 /* RCPurchasesSwiftImport.h */,
 				37E35EB9B60477A7AD2C2EB5 /* RCLogUtils.h */,
 				37E353471F474D9092560033 /* RCSystemInfo.h */,
+				37E35A7A70B77C0526EA3A28 /* RCSystemInfo.m */,
 				37E35F1729999CFCA36E877D /* RCDateProvider.m */,
 				37E352FDEEAD2E4EA0D2C16B /* RCDateProvider.h */,
-				37E35A7A70B77C0526EA3A28 /* RCSystemInfo.m */,
 				37E352229DFDDA008BB029C2 /* RCLogUtils.m */,
 				37E35DE721FC2A73255D505E /* RCCrossPlatformSupport.h */,
 				2DEB9766247DB46900A92099 /* RCISOPeriodFormatter.h */,
@@ -758,7 +771,6 @@
 				350FBDE91F7EEF070065833D /* RCPurchases.h in Headers */,
 				354D50DF22E7D014009B870C /* RCOfferings.h in Headers */,
 				351F4FAF1F803D0700F245F4 /* RCPurchaserInfo.h in Headers */,
-				2D59D15B24DAEA1D0057BB58 /* RCTransactionsFactory.h in Headers */,
 				2DD02D5524AD011600419CD9 /* RCPurchasesSwiftImport.h in Headers */,
 				35262A0F1F7C4B9100C04F2C /* Purchases.h in Headers */,
 				37E3598A1AAA3D70EA01C82D /* RCInMemoryCachedObject.h in Headers */,
@@ -780,11 +792,11 @@
 				37E354159288DE3D23212382 /* RCCrossPlatformSupport.h in Headers */,
 				37E35E9CEC36E93AF682D012 /* RCPromotionalOffer+Protected.h in Headers */,
 				37E352E86A182E92130B823C /* RCIntroEligibility+Protected.h in Headers */,
-				2D59D15D24DAEA620057BB58 /* RCLocalReceiptParser.h in Headers */,
 				37E35C5A53AC7CF63B240FEC /* RCEntitlementInfos+Protected.h in Headers */,
 				37E3575B0FFDD90D01861D81 /* RCPurchasesErrorUtils+Protected.h in Headers */,
 				37E35D04747C56E85F1B9679 /* RCPurchaserInfo+Protected.h in Headers */,
 				37E35473E5952D7500FF4BD8 /* RCEntitlementInfo+Protected.h in Headers */,
+				2DDA3E4324DB06E000EDFE5B /* RCOperationDispatcher.h in Headers */,
 				37E3500156786798CB166571 /* RCPurchases+Protected.h in Headers */,
 				37E35D757DE82291BFFCFB91 /* RCOfferings+Protected.h in Headers */,
 				37E35E3CFED4426C0EE1302C /* RCOffering+Protected.h in Headers */,
@@ -802,6 +814,8 @@
 				37E35C1B3C0170F15FC920F5 /* RCPackage+Protected.h in Headers */,
 				37E35010ECA71A4CE6E16307 /* RCDeviceCache+Protected.h in Headers */,
 				37E35312E13F08FD8C7CC275 /* RCProductInfo.h in Headers */,
+				2D59D15B24DAEA1D0057BB58 /* RCTransactionsFactory.h in Headers */,
+				2D59D15D24DAEA620057BB58 /* RCLocalReceiptParser.h in Headers */,
 				3589D15624C21DBD00A65CBB /* RCAttributionFetcher+Protected.h in Headers */,
 				37E357301A5D15C0E90C9BD3 /* RCProductInfoExtractor.h in Headers */,
 			);
@@ -950,6 +964,7 @@
 				37E352E9231D083B78E2E345 /* RCBackend.m in Sources */,
 				37E35D561B3F5AC49FD6C2CF /* RCHTTPClient.m in Sources */,
 				37E35EB1B9FE3F739B8C0D71 /* RCDateProvider.m in Sources */,
+				2DDA3E4724DB0B5400EDFE5B /* OperationDispatcher.swift in Sources */,
 				37E35DC1B42094073EB105AC /* RCSystemInfo.m in Sources */,
 				37E352BAA55C31B1E278CA8A /* RCLogUtils.m in Sources */,
 				37E35EACCCC014F719E63D5F /* RCAttributionData.m in Sources */,

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -22,8 +22,9 @@
 		2DD448FF24088473002F5694 /* RCPurchases+SubscriberAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DD448FD24088473002F5694 /* RCPurchases+SubscriberAttributes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2DD4490024088473002F5694 /* RCPurchases+SubscriberAttributes.m in Sources */ = {isa = PBXBuildFile; fileRef = 2DD448FE24088473002F5694 /* RCPurchases+SubscriberAttributes.m */; };
 		2DD7BA4D24C63A830066B4C2 /* MockSystemInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD7BA4C24C63A830066B4C2 /* MockSystemInfo.swift */; };
-		2DDA3E4324DB06E000EDFE5B /* RCOperationDispatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DDA3E4124DB06E000EDFE5B /* RCOperationDispatcher.h */; };
+		2DDA3E4324DB06E000EDFE5B /* RCOperationDispatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DDA3E4124DB06E000EDFE5B /* RCOperationDispatcher.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2DDA3E4724DB0B5400EDFE5B /* OperationDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DDA3E4624DB0B5400EDFE5B /* OperationDispatcher.swift */; };
+		2DDA3E4824DB101C00EDFE5B /* MockOperationDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35659EB530A5109AFAB50 /* MockOperationDispatcher.swift */; };
 		2DEB9767247DB46900A92099 /* RCISOPeriodFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DEB9766247DB46900A92099 /* RCISOPeriodFormatter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2DEB976B247DB85400A92099 /* SKProductSubscriptionDurationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DEB976A247DB85400A92099 /* SKProductSubscriptionDurationExtensions.swift */; };
 		350FBDE91F7EEF070065833D /* RCPurchases.h in Headers */ = {isa = PBXBuildFile; fileRef = 350FBDE71F7EEF070065833D /* RCPurchases.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -280,6 +281,7 @@
 		37E355AE6CB674484555D1AC /* NSDate+RCExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDate+RCExtensions.h"; sourceTree = "<group>"; };
 		37E35609E46E869675A466C1 /* MockRequestFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockRequestFetcher.swift; sourceTree = "<group>"; };
 		37E35645928A0009F4C105A7 /* MockBackend.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockBackend.swift; sourceTree = "<group>"; };
+		37E35659EB530A5109AFAB50 /* MockOperationDispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockOperationDispatcher.swift; sourceTree = "<group>"; };
 		37E3567271C2172DA3ED1B16 /* RCAttributionData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCAttributionData.h; sourceTree = "<group>"; };
 		37E3567E972B9B04FE079ABA /* SusbcriberAttributesManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SusbcriberAttributesManagerTests.swift; sourceTree = "<group>"; };
 		37E356C39D29EB6C8EC2D6BD /* RCHTTPClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCHTTPClient.h; sourceTree = "<group>"; };
@@ -579,6 +581,7 @@
 				2DEB976A247DB85400A92099 /* SKProductSubscriptionDurationExtensions.swift */,
 				37E35EABF6D7AFE367718784 /* MockSKDiscount.swift */,
 				2DD7BA4C24C63A830066B4C2 /* MockSystemInfo.swift */,
+				37E35659EB530A5109AFAB50 /* MockOperationDispatcher.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -796,7 +799,6 @@
 				37E3575B0FFDD90D01861D81 /* RCPurchasesErrorUtils+Protected.h in Headers */,
 				37E35D04747C56E85F1B9679 /* RCPurchaserInfo+Protected.h in Headers */,
 				37E35473E5952D7500FF4BD8 /* RCEntitlementInfo+Protected.h in Headers */,
-				2DDA3E4324DB06E000EDFE5B /* RCOperationDispatcher.h in Headers */,
 				37E3500156786798CB166571 /* RCPurchases+Protected.h in Headers */,
 				37E35D757DE82291BFFCFB91 /* RCOfferings+Protected.h in Headers */,
 				37E35E3CFED4426C0EE1302C /* RCOffering+Protected.h in Headers */,
@@ -817,6 +819,7 @@
 				2D59D15B24DAEA1D0057BB58 /* RCTransactionsFactory.h in Headers */,
 				2D59D15D24DAEA620057BB58 /* RCLocalReceiptParser.h in Headers */,
 				3589D15624C21DBD00A65CBB /* RCAttributionFetcher+Protected.h in Headers */,
+				2DDA3E4324DB06E000EDFE5B /* RCOperationDispatcher.h in Headers */,
 				37E357301A5D15C0E90C9BD3 /* RCProductInfoExtractor.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1027,6 +1030,7 @@
 				37E35F150166B248756AAFEF /* NSData+RCExtensionsTests.swift in Sources */,
 				37E3594AE079F6528C024B60 /* PurchasesTests.swift in Sources */,
 				37E3595F797614307CBA329A /* StoreKitWrapperTests.swift in Sources */,
+				2DDA3E4824DB101C00EDFE5B /* MockOperationDispatcher.swift in Sources */,
 				37E35E3A834982B03BC633BC /* StoreKitRequestFetcherTests.swift in Sources */,
 				37E35DD66736A6669A746334 /* PurchaserInfoTests.swift in Sources */,
 				37E351F90612047842AFF1A6 /* ProductInfoTests.swift in Sources */,

--- a/Purchases/ProtectedExtensions/RCPurchases+Protected.h
+++ b/Purchases/ProtectedExtensions/RCPurchases+Protected.h
@@ -17,7 +17,8 @@
     RCDeviceCache,
     RCIdentityManager,
     RCSubscriberAttributesManager,
-    RCSystemInfo;
+    RCSystemInfo,
+    RCOperationDispatcher;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -36,7 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
                  offeringsFactory:(RCOfferingsFactory *)offeringsFactory
                       deviceCache:(RCDeviceCache *)deviceCache
                   identityManager:(RCIdentityManager *)identityManager
-      subscriberAttributesManager:(RCSubscriberAttributesManager *)subscriberAttributesManager;
+      subscriberAttributesManager:(RCSubscriberAttributesManager *)subscriberAttributesManager
+              operationDispatcher:(RCOperationDispatcher *)operationDispatcher;
 
 + (void)setDefaultInstance:(nullable RCPurchases *)instance;
 

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -237,7 +237,8 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                   offeringsFactory:offeringsFactory
                        deviceCache:deviceCache
                    identityManager:identityManager
-       subscriberAttributesManager:subscriberAttributesManager];
+       subscriberAttributesManager:subscriberAttributesManager
+               operationDispatcher:operationDispatcher];
 }
 
 - (instancetype)initWithAppUserID:(nullable NSString *)appUserID

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -35,6 +35,7 @@
 #import "RCIntroEligibility+Protected.h"
 #import "RCPurchasesSwiftImport.h"
 #import "RCLocalReceiptParser.h"
+#import "RCOperationDispatcher.h"
 
 #define CALL_IF_SET_ON_MAIN_THREAD(completion, ...) if (completion) [self dispatch:^{ completion(__VA_ARGS__); }];
 #define CALL_IF_SET_ON_SAME_THREAD(completion, ...) if (completion) completion(__VA_ARGS__);
@@ -64,6 +65,7 @@ typedef void (^RCReceiveReceiptDataBlock)(NSData *);
 @property (nonatomic) RCDeviceCache *deviceCache;
 @property (nonatomic) RCIdentityManager *identityManager;
 @property (nonatomic) RCSystemInfo *systemInfo;
+@property (nonatomic) RCOperationDispatcher *operationDispatcher;
 
 @end
 
@@ -273,6 +275,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 
         self.systemInfo = systemInfo;
         self.subscriberAttributesManager = subscriberAttributesManager;
+        self.operationDispatcher = [[RCOperationDispatcher alloc] init];
 
         RCReceivePurchaserInfoBlock callDelegate = ^void(RCPurchaserInfo *info, NSError *error) {
             if (info) {
@@ -284,10 +287,9 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 
         [self.systemInfo isApplicationBackgroundedWithCompletion:^(BOOL isBackgrounded) {
             if (!isBackgrounded) {
-                dispatch_queue_t backgroundQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-                dispatch_async(backgroundQueue, ^{
+                [self.operationDispatcher dispatchOnWorkerThread:^{
                     [self updateAllCachesWithCompletionBlock:callDelegate];
-                });
+                }];
             } else {
                 [self sendCachedPurchaserInfoIfAvailable];
             }

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -223,6 +223,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
     RCSubscriberAttributesManager *subscriberAttributesManager =
             [[RCSubscriberAttributesManager alloc] initWithBackend:backend
                                                        deviceCache:deviceCache];
+    RCOperationDispatcher *operationDispatcher = [[RCOperationDispatcher alloc] init];
 
     return [self initWithAppUserID:appUserID
                     requestFetcher:fetcher
@@ -251,7 +252,9 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                  offeringsFactory:(RCOfferingsFactory *)offeringsFactory
                       deviceCache:(RCDeviceCache *)deviceCache
                   identityManager:(RCIdentityManager *)identityManager
-      subscriberAttributesManager:(RCSubscriberAttributesManager *)subscriberAttributesManager {
+      subscriberAttributesManager:(RCSubscriberAttributesManager *)subscriberAttributesManager
+              operationDispatcher:(RCOperationDispatcher *)operationDispatcher {
+    
     if (self = [super init]) {
         RCDebugLog(@"Debug logging enabled.");
         RCDebugLog(@"SDK Version - %@", self.class.frameworkVersion);
@@ -275,7 +278,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 
         self.systemInfo = systemInfo;
         self.subscriberAttributesManager = subscriberAttributesManager;
-        self.operationDispatcher = [[RCOperationDispatcher alloc] init];
+        self.operationDispatcher = operationDispatcher;
 
         RCReceivePurchaserInfoBlock callDelegate = ^void(RCPurchaserInfo *info, NSError *error) {
             if (info) {

--- a/Purchases/SwiftInterfaces/RCOperationDispatcher.h
+++ b/Purchases/SwiftInterfaces/RCOperationDispatcher.h
@@ -1,0 +1,22 @@
+//
+//  RCOperationDispatcher.h
+//  Purchases
+//
+//  Created by Andrés Boedo on 8/5/20.
+//  Copyright © 2020 Purchases. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCOperationDispatcher : NSObject
+
+- (void)dispatchOnMainThreadIfSet:(void (^ _Nullable)(void))block;
+- (void)dispatchOnMainThread:(void (^)(void))block;
+- (void)dispatchOnSameThreadIfSet:(void (^ _Nullable)(void))block;
+- (void)dispatchOnWorkerThread:(void (^)(void))block;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/SwiftInterfaces/RCOperationDispatcher.h
+++ b/Purchases/SwiftInterfaces/RCOperationDispatcher.h
@@ -10,6 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+NS_SWIFT_NAME(OperationDispatcher)
 @interface RCOperationDispatcher : NSObject
 
 - (void)dispatchOnMainThreadIfSet:(void (^ _Nullable)(void))block;

--- a/Purchases/SwiftSources/Misc/OperationDispatcher.swift
+++ b/Purchases/SwiftSources/Misc/OperationDispatcher.swift
@@ -25,15 +25,19 @@ import Foundation
             }
         }
     }
-    @objc func dispatchOnMainThread(_ block: @escaping(() -> Void)) {
-        mainQueue.async { block() }
+    @objc func dispatchOnMainThread(_ block: @escaping () -> Void) {
+        if Thread.isMainThread {
+            block()
+        } else {
+            mainQueue.async { block() }
+        }
     }
 
     @objc func dispatchOnSameThreadIfSet(_ block: () -> Void) {
         block()
     }
 
-    @objc func dispatchOnWorkerThread(_ block: @escaping(() -> Void)) {
+    @objc func dispatchOnWorkerThread(_ block: @escaping () -> Void) {
         workerQueue.async { block() }
     }
 

--- a/Purchases/SwiftSources/Misc/OperationDispatcher.swift
+++ b/Purchases/SwiftSources/Misc/OperationDispatcher.swift
@@ -1,0 +1,40 @@
+//
+//  OperationDispatcher.swift
+//  Purchases
+//
+//  Created by Andrés Boedo on 8/5/20.
+//  Copyright © 2020 Purchases. All rights reserved.
+//
+
+import Foundation
+
+@objc(RCOperationDispatcher) class OperationDispatcher: NSObject {
+    
+    private let mainQueue: DispatchQueue
+    private let workerQueue: DispatchQueue
+    
+    override init() {
+        mainQueue = DispatchQueue.main
+        workerQueue = DispatchQueue(label: "OperationDispatcherWorkerQueue")
+    }
+    
+    @objc func dispatchOnMainThreadIfSet(_ block: (() -> Void)?) {
+        if let block = block {
+            dispatchOnMainThread {
+                block()
+            }
+        }
+    }
+    @objc func dispatchOnMainThread(_ block: @escaping(() -> Void)) {
+        mainQueue.async { block() }
+    }
+
+    @objc func dispatchOnSameThreadIfSet(_ block: () -> Void) {
+        block()
+    }
+
+    @objc func dispatchOnWorkerThread(_ block: @escaping(() -> Void)) {
+        workerQueue.async { block() }
+    }
+
+}

--- a/PurchasesTests/Mocks/MockOperationDispatcher.swift
+++ b/PurchasesTests/Mocks/MockOperationDispatcher.swift
@@ -1,0 +1,18 @@
+//
+// Created by Andrés Boedo on 8/5/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+import Foundation
+
+import Purchases
+
+class MockOperationDispatcher: OperationDispatcher {
+    override func dispatch(onMainThread block: @escaping () -> ()) {
+        block()
+    }
+
+    override func dispatch(onWorkerThread block: @escaping () -> ()) {
+        block()
+    }
+}

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -206,7 +206,7 @@ class HTTPClientTests: XCTestCase {
         }
 
         self.client.performRequest("GET", path: path, body: nil, headers: nil) { (status, data, responseError) in
-            if let responseNSError = responseError as? NSError {
+            if let responseNSError = responseError as NSError? {
                 successFailed = (status >= 500
                                  && data == nil
                                  && error.domain == responseNSError.domain

--- a/PurchasesTests/PurchasesTests-Bridging-Header.h
+++ b/PurchasesTests/PurchasesTests-Bridging-Header.h
@@ -42,4 +42,5 @@
 #include <Purchases/RCISOPeriodFormatter.h>
 #include <Purchases/RCProductInfo.h>
 #include <Purchases/RCProductInfoExtractor.h>
+#include <Purchases/RCOperationDispatcher.h>
 #include <Purchases/RCPurchasesSwiftImport.h>

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -206,7 +206,7 @@ class PurchasesTests: XCTestCase {
                               deviceCache: deviceCache,
                               identityManager: identityManager,
                               subscriberAttributesManager: subscriberAttributesManager,
-                              operationDispatcher: OperationDispatcher())
+                              operationDispatcher: mockOperationDispatcher)
         purchases!.delegate = purchasesDelegate
         Purchases.setDefaultInstance(purchases!)
     }
@@ -228,7 +228,7 @@ class PurchasesTests: XCTestCase {
                               deviceCache: deviceCache,
                               identityManager: identityManager,
                               subscriberAttributesManager: subscriberAttributesManager,
-                              operationDispatcher: OperationDispatcher())
+                              operationDispatcher: mockOperationDispatcher)
 
         purchases!.delegate = purchasesDelegate
     }
@@ -249,7 +249,7 @@ class PurchasesTests: XCTestCase {
                               deviceCache: deviceCache,
                               identityManager: identityManager,
                               subscriberAttributesManager: subscriberAttributesManager,
-                              operationDispatcher: OperationDispatcher())
+                              operationDispatcher: mockOperationDispatcher)
 
         purchases!.delegate = purchasesDelegate
         Purchases.setDefaultInstance(purchases!)

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -6,7 +6,7 @@
 import XCTest
 import Nimble
 
-import Purchases
+@testable import Purchases
 
 class PurchasesTests: XCTestCase {
 
@@ -14,6 +14,7 @@ class PurchasesTests: XCTestCase {
         self.userDefaults = UserDefaults(suiteName: "TestDefaults")
         requestFetcher = MockRequestFetcher()
         systemInfo = MockSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: true)
+        mockOperationDispatcher = MockOperationDispatcher()
     }
 
     override func tearDown() {
@@ -182,6 +183,7 @@ class PurchasesTests: XCTestCase {
     let subscriberAttributesManager = MockSubscriberAttributesManager()
     let identityManager = MockUserManager(mockAppUserID: "app_user");
     var systemInfo: MockSystemInfo!
+    var mockOperationDispatcher: MockOperationDispatcher!
     
     let purchasesDelegate = MockPurchasesDelegate()
 
@@ -203,7 +205,8 @@ class PurchasesTests: XCTestCase {
                               offeringsFactory: offeringsFactory,
                               deviceCache: deviceCache,
                               identityManager: identityManager,
-                              subscriberAttributesManager: subscriberAttributesManager)
+                              subscriberAttributesManager: subscriberAttributesManager,
+                              operationDispatcher: OperationDispatcher())
         purchases!.delegate = purchasesDelegate
         Purchases.setDefaultInstance(purchases!)
     }
@@ -224,7 +227,8 @@ class PurchasesTests: XCTestCase {
                               offeringsFactory: offeringsFactory,
                               deviceCache: deviceCache,
                               identityManager: identityManager,
-                              subscriberAttributesManager: subscriberAttributesManager)
+                              subscriberAttributesManager: subscriberAttributesManager,
+                              operationDispatcher: OperationDispatcher())
 
         purchases!.delegate = purchasesDelegate
     }
@@ -244,7 +248,8 @@ class PurchasesTests: XCTestCase {
                               offeringsFactory: offeringsFactory,
                               deviceCache: deviceCache,
                               identityManager: identityManager,
-                              subscriberAttributesManager: subscriberAttributesManager)
+                              subscriberAttributesManager: subscriberAttributesManager,
+                              operationDispatcher: OperationDispatcher())
 
         purchases!.delegate = purchasesDelegate
         Purchases.setDefaultInstance(purchases!)
@@ -2111,15 +2116,14 @@ class PurchasesTests: XCTestCase {
 
     private func verifyUpdatedCaches(newAppUserID: String) {
         let expectedCallCount = 2
-        let timeout = 5.0
-        expect(self.backend.getSubscriberCallCount).toEventually(equal(expectedCallCount), timeout: timeout)
-        expect(self.deviceCache.cachedPurchaserInfo.count).toEventually(equal(expectedCallCount), timeout: timeout)
-        expect(self.deviceCache.cachedPurchaserInfo[newAppUserID]).toEventuallyNot(beNil(), timeout: timeout)
-        expect(self.purchasesDelegate.purchaserInfoReceivedCount).toEventually(equal(expectedCallCount), timeout: timeout)
-        expect(self.deviceCache.setPurchaserInfoCacheTimestampToNowCount).toEventually(equal(expectedCallCount), timeout: timeout)
-        expect(self.deviceCache.setOfferingsCacheTimestampToNowCount).toEventually(equal(expectedCallCount), timeout: timeout)
-        expect(self.backend.gotOfferings).toEventually(equal(expectedCallCount), timeout: timeout)
-        expect(self.deviceCache.cachedOfferingsCount).toEventually(equal(expectedCallCount), timeout: timeout)
+        expect(self.backend.getSubscriberCallCount).toEventually(equal(expectedCallCount))
+        expect(self.deviceCache.cachedPurchaserInfo.count).toEventually(equal(expectedCallCount))
+        expect(self.deviceCache.cachedPurchaserInfo[newAppUserID]).toEventuallyNot(beNil())
+        expect(self.purchasesDelegate.purchaserInfoReceivedCount).toEventually(equal(expectedCallCount))
+        expect(self.deviceCache.setPurchaserInfoCacheTimestampToNowCount).toEventually(equal(expectedCallCount))
+        expect(self.deviceCache.setOfferingsCacheTimestampToNowCount).toEventually(equal(expectedCallCount))
+        expect(self.backend.gotOfferings).toEventually(equal(expectedCallCount))
+        expect(self.deviceCache.cachedOfferingsCount).toEventually(equal(expectedCallCount))
     }
 
 }

--- a/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -27,6 +27,8 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
     let systemInfo: RCSystemInfo = RCSystemInfo(platformFlavor: nil,
                                                 platformFlavorVersion: nil,
                                                 finishTransactions: true)
+    
+    var mockOperationDispatcher: MockOperationDispatcher!
 
     let purchasesDelegate = MockPurchasesDelegate()
 
@@ -42,6 +44,7 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
             subscriberAttributeHeight.key: subscriberAttributeHeight,
             subscriberAttributeWeight.key: subscriberAttributeWeight
         ]
+        self.mockOperationDispatcher = MockOperationDispatcher()
     }
 
     override func tearDown() {
@@ -66,7 +69,8 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
                               offeringsFactory: mockOfferingsFactory,
                               deviceCache: mockDeviceCache,
                               identityManager: mockIdentityManager,
-                              subscriberAttributesManager: mockSubscriberAttributesManager)
+                              subscriberAttributesManager: mockSubscriberAttributesManager,
+                              operationDispatcher: mockOperationDispatcher)
         purchases!.delegate = purchasesDelegate
         Purchases.setDefaultInstance(purchases!)
     }


### PR DESCRIPTION
The tests are failing intermittently failing on `develop` right now because we have a couple of operations running in a background thread, and there's no guarantee of how long they will take to start, especially on CircleCI machines, which are pretty slow. 

This PR replaces those calls with a new `OperationDispatcher` object, that dispatches the operations. This allows us to mock it for tests and have the operations running synchronously. 

`OperationDispatcher` also has a few convenience methods that will allow us to remove the `CALL_IF_SET_ON_MAIN_THREAD` calls from `RCPurchases.m`. 

### Requirements

- [x] ~Based on #308~

