### PR TITLE
replace CALL_IF_SET macros

### DIFF
--- a/Purchases/SwiftInterfaces/RCOperationDispatcher.h
+++ b/Purchases/SwiftInterfaces/RCOperationDispatcher.h
@@ -13,9 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(OperationDispatcher)
 @interface RCOperationDispatcher : NSObject
 
-- (void)dispatchOnMainThreadIfSet:(void (^ _Nullable)(void))block;
 - (void)dispatchOnMainThread:(void (^)(void))block;
-- (void)dispatchOnSameThreadIfSet:(void (^ _Nullable)(void))block;
+- (void)dispatchOnSameThread:(void (^)(void))block;
 - (void)dispatchOnWorkerThread:(void (^)(void))block;
 
 @end

--- a/Purchases/SwiftSources/Misc/OperationDispatcher.swift
+++ b/Purchases/SwiftSources/Misc/OperationDispatcher.swift
@@ -20,12 +20,13 @@ import Foundation
     
     @objc func dispatchOnMainThreadIfSet(_ block: (() -> Void)?) {
         if let block = block {
-            dispatchOnMainThread {
+            dispatch(onMainThread: {
                 block()
-            }
+            })
         }
     }
-    @objc func dispatchOnMainThread(_ block: @escaping () -> Void) {
+    
+    @objc func dispatch(onMainThread block: @escaping () -> Void) {
         if Thread.isMainThread {
             block()
         } else {
@@ -37,7 +38,7 @@ import Foundation
         block()
     }
 
-    @objc func dispatchOnWorkerThread(_ block: @escaping () -> Void) {
+    @objc func dispatch(onWorkerThread block: @escaping () -> Void) {
         workerQueue.async { block() }
     }
 

--- a/Purchases/SwiftSources/Misc/OperationDispatcher.swift
+++ b/Purchases/SwiftSources/Misc/OperationDispatcher.swift
@@ -26,12 +26,7 @@ import Foundation
         }
     }
 
-    @objc func dispatch(onSameThread block: () -> Void) {
-        block()
-    }
-
     @objc func dispatch(onWorkerThread block: @escaping () -> Void) {
         workerQueue.async { block() }
     }
-
 }

--- a/Purchases/SwiftSources/Misc/OperationDispatcher.swift
+++ b/Purchases/SwiftSources/Misc/OperationDispatcher.swift
@@ -18,14 +18,6 @@ import Foundation
         workerQueue = DispatchQueue(label: "OperationDispatcherWorkerQueue")
     }
     
-    @objc func dispatchOnMainThreadIfSet(_ block: (() -> Void)?) {
-        if let block = block {
-            dispatch(onMainThread: {
-                block()
-            })
-        }
-    }
-    
     @objc func dispatch(onMainThread block: @escaping () -> Void) {
         if Thread.isMainThread {
             block()
@@ -34,7 +26,7 @@ import Foundation
         }
     }
 
-    @objc func dispatchOnSameThreadIfSet(_ block: () -> Void) {
+    @objc func dispatch(onSameThread block: () -> Void) {
         block()
     }
 


### PR DESCRIPTION
Replaces the `CALL_IF_SET_... ` macros in `RCPurchases` with operationDispatcher. 

This has a couple of advantages: 
- Since the macros were relying on variadic arguments, there was no compiler check to prevent us from calling a completion block with an invalid number of arguments, or invalid types. Calling the methods explicitly gives us these compiler checks. 
- We can now use the `operationDispatcher` to check if a given block gets called, or to make sure that it gets sent to the right thread. 

### Requirements: 
- [X] ~Based on #309~
- [X] ~More testing, since this does affect numerous callbacks.~