### PR TITLE
added swift version to podspec

### DIFF
--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.documentation_url = "https://docs.revenuecat.com/"
 
   s.framework      = 'StoreKit'
+  s.swift_version       = '5.0'
 
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.12'


### PR DESCRIPTION
`pod lib lint` would issue warnings because the swift version wasn't specified. 
This fixes it by specifying the swift version.

```
Validating podspec
 -> Purchases (3.6.0-beta)
    - WARN  | swift: The validator used Swift `4.0` by default because no Swift version was specified. To specify a Swift version during validation, add the `swift_versions` attribute in your podspec. Note that usage of a `.swift-version` file is now deprecated.
    - NOTE  | xcodebuild:  note: Using new build system
    - NOTE  | xcodebuild:  note: Building targets in parallel
    - NOTE  | xcodebuild:  note: Planning build
    - NOTE  | xcodebuild:  note: Constructing build description
    - NOTE  | xcodebuild:  warning: Skipping code signing because the target does not have an Info.plist file and one is not being generated automatically. (in target 'App' from project 'App')
    - NOTE  | xcodebuild:  note: Execution policy exception registration failed and was skipped: Error Domain=NSPOSIXErrorDomain Code=1 "Operation not permitted" (in target 'Purchases' from project 'Pods')
    - NOTE  | xcodebuild:  note: Execution policy exception registration failed and was skipped: Error Domain=NSPOSIXErrorDomain Code=1 "Operation not permitted" (in target 'Pods-App' from project 'Pods')
    - NOTE  | xcodebuild:  note: Execution policy exception registration failed and was skipped: Error Domain=NSPOSIXErrorDomain Code=1 "Operation not permitted" (in target 'App' from project 'App')
[!] The spec did not pass validation, due to 1 warning (but you can use `--allow-warnings` to ignore it).
```