### PR TITLE
clean up dispatch calls in RCPurchases

### DIFF
--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -36,7 +36,7 @@
 @import PurchasesCoreSwift;
 
 
-#define CALL_IF_SET_ON_MAIN_THREAD(completion, ...) if (completion) [self dispatch:^{ completion(__VA_ARGS__); }];
+#define CALL_IF_SET_ON_MAIN_THREAD(completion, ...) if (completion) [self.operationDispatcher dispatchOnMainThread:^{ completion(__VA_ARGS__); }];
 #define CALL_IF_SET_ON_SAME_THREAD(completion, ...) if (completion) completion(__VA_ARGS__);
 
 @interface RCPurchases () <RCStoreKitWrapperDelegate> {
@@ -642,7 +642,7 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
                                    error:(NSError *)error
                     subscriberAttributes:(RCSubscriberAttributeDict)subscriberAttributes
                               completion:(RCReceivePurchaserInfoBlock)completion {
-    [self dispatch:^{
+    [self.operationDispatcher dispatchOnMainThread:^{
         if (error) {
             [self markAttributesAsSyncedIfNeeded:subscriberAttributes
                                        appUserID:self.appUserID
@@ -782,7 +782,7 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 
 - (void)cachePurchaserInfo:(RCPurchaserInfo *)info forAppUserID:(NSString *)appUserID {
     if (info) {
-        [self dispatch:^{
+        [self.operationDispatcher dispatchOnMainThread:^{
             if (info.JSONObject) {
                 NSError *jsonError = nil;
                 NSData *jsonData = [NSJSONSerialization dataWithJSONObject:info.JSONObject
@@ -935,7 +935,7 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
                            purchaserInfo:(nullable RCPurchaserInfo *)info
                     subscriberAttributes:(nullable RCSubscriberAttributeDict)subscriberAttributes
                                    error:(nullable NSError *)error {
-    [self dispatch:^{
+    [self.operationDispatcher dispatchOnMainThread:^{
         [self markAttributesAsSyncedIfNeeded:subscriberAttributes appUserID:self.appUserID error:error];
 
         RCPurchaseCompletedBlock _Nullable completion = [self getAndRemovePurchaseCompletedBlockFor:transaction];
@@ -974,7 +974,7 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
                     RCDebugLog(@"Sending latest purchaser info to delegate");
                 }
                 self.lastSentPurchaserInfo = info;
-                [self dispatch:^{
+                [self.operationDispatcher dispatchOnMainThread:^{
                     [self.delegate purchases:self didReceiveUpdatedPurchaserInfo:info];
                 }];
             }
@@ -1066,14 +1066,6 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 
 - (NSString *)attributionDataUserDefaultCacheKeyForAppUserID:(NSString *)appUserID {
     return [RCAttributionDataDefaultsKeyBase stringByAppendingString:appUserID];
-}
-
-- (void)dispatch:(void (^ _Nonnull)(void))block {
-    if ([NSThread isMainThread]) {
-        block();
-    } else {
-        dispatch_async(dispatch_get_main_queue(), block);
-    }
 }
 
 - (void)handlePurchasedTransaction:(SKPaymentTransaction *)transaction {

--- a/PurchasesCoreSwift/Misc/OperationDispatcher.swift
+++ b/PurchasesCoreSwift/Misc/OperationDispatcher.swift
@@ -18,23 +18,12 @@ import Foundation
         workerQueue = DispatchQueue(label: "OperationDispatcherWorkerQueue")
     }
     
-    @objc public func dispatchOnMainThreadIfSet(_ block: (() -> Void)?) {
-        if let block = block {
-            dispatchOnMainThread {
-                block()
-            }
-        }
-    }
     @objc public func dispatchOnMainThread(_ block: @escaping () -> Void) {
         if Thread.isMainThread {
             block()
         } else {
             mainQueue.async { block() }
         }
-    }
-
-    @objc public func dispatchOnSameThreadIfSet(_ block: () -> Void) {
-        block()
     }
 
     @objc public func dispatchOnWorkerThread(_ block: @escaping () -> Void) {


### PR DESCRIPTION
Replacement of #310. 

This PR doesn't delete the macros, but rather makes sure that they use the `OperationDispatcher` instead of doing the dispatching directly from `RCPurchases`.

### Requirements: 
- [x] ~Based on #316~