### PR TITLE
release: 3.6.0-beta-2

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -5,9 +5,9 @@ objc: true
 sdk: iphonesimulator
 module: Purchases
 umbrella_header: Purchases/Public/Purchases.h
-module_version: 3.6.0
+module_version: 3.6.0-beta-2
 github_url: https://github.com/revenuecat/purchases-ios
-github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.6.0
+github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.6.0-beta-2
 output: docs
 # Leaving this commented out. We used to specify this before, but now it's working without it
 # xcodebuild_arguments: [--objc,Purchases/Public/Purchases.h,--,-x,objective-c,-isysroot,$(xcrun --show-sdk-path),-I,$(pwd)]

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -5,9 +5,9 @@ objc: true
 sdk: iphonesimulator
 module: Purchases
 umbrella_header: Purchases/Public/Purchases.h
-module_version: 3.6.0-SNAPSHOT
+module_version: 3.6.0
 github_url: https://github.com/revenuecat/purchases-ios
-github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.6.0-SNAPSHOT
+github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.6.0
 output: docs
 # Leaving this commented out. We used to specify this before, but now it's working without it
 # xcodebuild_arguments: [--objc,Purchases/Public/Purchases.h,--,-x,objective-c,-isysroot,$(xcrun --show-sdk-path),-I,$(pwd)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
-## 3.6.0
+## 3.6.0-beta-2
+- Fixed a race condition with purchase completed callbacks
+	https://github.com/RevenueCat/purchases-ios/pull/313
+- Made RCTransaction public to fix compiling issues on Swift Package Manager
+	https://github.com/RevenueCat/purchases-ios/pull/315
+- Added ability to export XCFrameworks
+	https://github.com/RevenueCat/purchases-ios/pull/317
+- Cleaned up dispatch calls
+	https://github.com/RevenueCat/purchases-ios/pull/318
+- Created a separate module and framework for the Swift code
+	https://github.com/RevenueCat/purchases-ios/pull/319
+- Updated release scripts to be able to release the new Pod as well
+	https://github.com/RevenueCat/purchases-ios/pull/320
+- Added a local receipt parser, updated intro eligibility calculation to perform on device first
+	https://github.com/RevenueCat/purchases-ios/pull/302
+
+## 3.6.0-beta-1
 - Fix crash when productIdentifier or payment is nil.
     https://github.com/RevenueCat/purchases-ios/pull/297
 - Fixes ask-to-buy flow and will now send an error indicating there's a deferred payment.

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Purchases"
-  s.version          = "3.6.0"
+  s.version          = "3.6.0-beta-2"
   s.summary          = "Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Purchases"
-  s.version          = "3.6.0-SNAPSHOT"
+  s.version          = "3.6.0"
   s.summary          = "Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/Purchases/Info.plist
+++ b/Purchases/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.6.0-SNAPSHOT</string>
+	<string>3.6.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Purchases/Misc/RCSystemInfo.m
+++ b/Purchases/Misc/RCSystemInfo.m
@@ -47,7 +47,7 @@ static NSURL * _Nullable proxyURL;
 }
 
 + (NSString *)frameworkVersion {
-    return @"3.6.0";
+    return @"3.6.0-beta-2";
 }
 
 + (NSString *)systemVersion {

--- a/Purchases/Misc/RCSystemInfo.m
+++ b/Purchases/Misc/RCSystemInfo.m
@@ -47,7 +47,7 @@ static NSURL * _Nullable proxyURL;
 }
 
 + (NSString *)frameworkVersion {
-    return @"3.6.0-SNAPSHOT";
+    return @"3.6.0";
 }
 
 + (NSString *)systemVersion {

--- a/PurchasesCoreSwift.podspec
+++ b/PurchasesCoreSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesCoreSwift"
-  s.version          = "3.6.0-SNAPSHOT"
+  s.version          = "3.6.0-beta-2"
   s.summary          = "Swift portion of RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/PurchasesCoreSwift/Info.plist
+++ b/PurchasesCoreSwift/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>3.6.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/PurchasesCoreSwiftTests/Info.plist
+++ b/PurchasesCoreSwiftTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>3.6.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/PurchasesTests/Info.plist
+++ b/PurchasesTests/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.6.0-SNAPSHOT</string>
+	<string>3.6.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,7 +22,7 @@ This will do all of the other steps in the manual process.
 1. `git tag -a x.y.z -m "Version x.y.z"`
 1. `git push origin bump/x.y.z && git push --tags`
 1. `pod trunk push Purchases.podspec`
-1. `carthage build --archive
+1. `carthage build --archive`
 1. Create a [new github release](https://github.com/revenuecat/purchases-ios/releases)
 1. Upload to the new release `Purchases.framework.zip`
 1. Create a branch bump/a.b.c, where a.b.c is the next version of the app after this release.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,8 +2,7 @@
 1. Start a git-flow release/x.y.z
 1. Create a CHANGELOG.latest.md with the changes for the current 
 version (to be used by Fastlane for the github release notes)
-1. Update the version number in `RCPurchases.m`, `Purchases.podspec` and in 
-`Purchases/Info.plist` by running `fastlane bump_and_update_changelog version:x.y.z`
+1. Update the version number by running `fastlane bump_and_update_changelog version:x.y.z`
 1. Commit the changes `git commit -am "Version x.y.z"`
 1. Make a PR, merge when approved
 1. `cd bin`

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -32,7 +32,8 @@ platform :ios do
     fail ArgumentError, "missing version" unless new_version_number
     previous_version_number = get_version_number(target: "Purchases")
     increment_version_number(version_number: new_version_number)
-    version_bump_podspec(version_number: new_version_number)
+    version_bump_podspec(version_number: new_version_number, path: "Purchases.podspec")
+    version_bump_podspec(version_number: new_version_number, path: "PurchasesCoreSwift.podspec")
     increment_build_number(previous_version_number, new_version_number, '../Purchases/Misc/RCSystemInfo.m')
     increment_build_number(previous_version_number, new_version_number, '../.jazzy.yaml')
   end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -12,7 +12,7 @@ Install _fastlane_ using
 ```
 [sudo] gem install fastlane -NV
 ```
-or alternatively using `brew cask install fastlane`
+or alternatively using `brew install fastlane`
 
 # Available Actions
 ## iOS


### PR DESCRIPTION
## 3.6.0-beta-2
- Fixed a race condition with purchase completed callbacks
	https://github.com/RevenueCat/purchases-ios/pull/313
- Made RCTransaction public to fix compiling issues on Swift Package Manager
	https://github.com/RevenueCat/purchases-ios/pull/315
- Added ability to export XCFrameworks
	https://github.com/RevenueCat/purchases-ios/pull/317
- Cleaned up dispatch calls
	https://github.com/RevenueCat/purchases-ios/pull/318
- Created a separate module and framework for the Swift code
	https://github.com/RevenueCat/purchases-ios/pull/319
- Updated release scripts to be able to release the new Pod as well
	https://github.com/RevenueCat/purchases-ios/pull/320
- Added a local receipt parser, updated intro eligibility calculation to perform on device first
	https://github.com/RevenueCat/purchases-ios/pull/302

## 3.6.0-beta-1
- Fix crash when productIdentifier or payment is nil.
    https://github.com/RevenueCat/purchases-ios/pull/297
- Fixes ask-to-buy flow and will now send an error indicating there's a deferred payment.
    https://github.com/RevenueCat/purchases-ios/pull/296
- Fixes application state check on app extensions, which threw a compilation error.
    https://github.com/RevenueCat/purchases-ios/pull/303
- Restores will now always refresh the receipt.
    https://github.com/RevenueCat/purchases-ios/pull/287
- New properties added to the PurchaserInfo to better manage non-subscriptions.
    https://github.com/RevenueCat/purchases-ios/pull/281
