### PR TITLE
Prevent unnecessary receipt posts

### DIFF
--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -201,6 +201,7 @@
 		37E35F20B49BCE1B6D76B084 /* RCStoreKitRequestFetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35804C14F5E6CEAF3909C /* RCStoreKitRequestFetcher.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E35F20FB949985BEEB4B58 /* MockRequestFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35609E46E869675A466C1 /* MockRequestFetcher.swift */; };
 		37E35F549AEB655AB6DA83B3 /* MockSKDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35EABF6D7AFE367718784 /* MockSKDiscount.swift */; };
+		37E35F67255A87BD86B39D43 /* MockReceiptParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3558F697A939D2BBD7FEC /* MockReceiptParser.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -374,6 +375,7 @@
 		37E35548F15DE7CFFCE3AA8A /* NSLocale+RCExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSLocale+RCExtensions.m"; sourceTree = "<group>"; };
 		37E3555B4BE0A4F7222E7B00 /* MockOfferingsFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockOfferingsFactory.swift; sourceTree = "<group>"; };
 		37E355744D64075AA91342DE /* MockInAppPurchaseBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockInAppPurchaseBuilder.swift; sourceTree = "<group>"; };
+		37E3558F697A939D2BBD7FEC /* MockReceiptParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockReceiptParser.swift; sourceTree = "<group>"; };
 		37E355AE6CB674484555D1AC /* NSDate+RCExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDate+RCExtensions.h"; sourceTree = "<group>"; };
 		37E355CBB3F3A31A32687B14 /* Transaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Transaction.swift; sourceTree = "<group>"; };
 		37E35609E46E869675A466C1 /* MockRequestFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockRequestFetcher.swift; sourceTree = "<group>"; };
@@ -784,6 +786,7 @@
 				2DD7BA4C24C63A830066B4C2 /* MockSystemInfo.swift */,
 				37E35659EB530A5109AFAB50 /* MockOperationDispatcher.swift */,
 				2D4D6AF224F7172900B656BE /* MockProductsRequest.swift */,
+				37E3558F697A939D2BBD7FEC /* MockReceiptParser.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -1428,6 +1431,7 @@
 				37E35F0387D0ADE014186924 /* ProductInfoExtractorTests.swift in Sources */,
 				37E351505CB4764821451E27 /* ProductInfoExtensions.swift in Sources */,
 				37E3599326581376E0142EEC /* SystemInfoTests.swift in Sources */,
+				37E35F67255A87BD86B39D43 /* MockReceiptParser.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Purchases/ProtectedExtensions/RCPurchases+Protected.h
+++ b/Purchases/ProtectedExtensions/RCPurchases+Protected.h
@@ -19,7 +19,8 @@
     RCSubscriberAttributesManager,
     RCSystemInfo,
     RCOperationDispatcher,
-    RCIntroEligibilityCalculator;
+    RCIntroEligibilityCalculator,
+    RCReceiptParser;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -40,7 +41,8 @@ NS_ASSUME_NONNULL_BEGIN
                   identityManager:(RCIdentityManager *)identityManager
       subscriberAttributesManager:(RCSubscriberAttributesManager *)subscriberAttributesManager
               operationDispatcher:(RCOperationDispatcher *)operationDispatcher
-       introEligibilityCalculator:(RCIntroEligibilityCalculator *)introEligibilityCalculator;
+       introEligibilityCalculator:(RCIntroEligibilityCalculator *)introEligibilityCalculator
+                    receiptParser:(RCReceiptParser *)receiptParser;
 
 + (void)setDefaultInstance:(nullable RCPurchases *)instance;
 

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -625,6 +625,15 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
             CALL_IF_SET_ON_MAIN_THREAD(completion, nil, [RCPurchasesErrorUtils missingReceiptFileError]);
             return;
         }
+        
+        RCPurchaserInfo * _Nullable cachedPurchaserInfo = [self readPurchaserInfoFromCache];
+        BOOL hasOriginalPurchaseDate = cachedPurchaserInfo != nil && cachedPurchaserInfo.originalPurchaseDate != nil;
+        BOOL receiptHasTransactions = NO; // TODO
+        if (!receiptHasTransactions && hasOriginalPurchaseDate) {
+            CALL_IF_SET_ON_MAIN_THREAD(completion, cachedPurchaserInfo, nil);
+            return;
+        }
+            
         RCSubscriberAttributeDict subscriberAttributes = self.unsyncedAttributesByKey;
         [self.backend postReceiptData:data
                             appUserID:self.appUserID

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -628,7 +628,7 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
         
         RCPurchaserInfo * _Nullable cachedPurchaserInfo = [self readPurchaserInfoFromCache];
         BOOL hasOriginalPurchaseDate = cachedPurchaserInfo != nil && cachedPurchaserInfo.originalPurchaseDate != nil;
-        BOOL receiptHasTransactions = NO; // TODO
+        BOOL receiptHasTransactions = [[[RCReceiptParser alloc] init] receiptHasTransactionsWithReceiptData:data];
         if (!receiptHasTransactions && hasOriginalPurchaseDate) {
             CALL_IF_SET_ON_MAIN_THREAD(completion, cachedPurchaserInfo, nil);
             return;

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -66,6 +66,7 @@ typedef void (^RCReceiveReceiptDataBlock)(NSData *);
 @property (nonatomic) RCSystemInfo *systemInfo;
 @property (nonatomic) RCOperationDispatcher *operationDispatcher;
 @property (nonatomic) RCIntroEligibilityCalculator *introEligibilityCalculator;
+@property (nonatomic) RCReceiptParser *receiptParser;
 
 @end
 
@@ -225,6 +226,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                                                        deviceCache:deviceCache];
     RCOperationDispatcher *operationDispatcher = [[RCOperationDispatcher alloc] init];
     RCIntroEligibilityCalculator *introCalculator = [[RCIntroEligibilityCalculator alloc] init];
+    RCReceiptParser *receiptParser = [[RCReceiptParser alloc] init];
     
     return [self initWithAppUserID:appUserID
                     requestFetcher:fetcher
@@ -240,7 +242,8 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                    identityManager:identityManager
        subscriberAttributesManager:subscriberAttributesManager
                operationDispatcher:operationDispatcher
-        introEligibilityCalculator:introCalculator];
+        introEligibilityCalculator:introCalculator
+                     receiptParser:receiptParser];
 }
 
 - (instancetype)initWithAppUserID:(nullable NSString *)appUserID
@@ -257,7 +260,8 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                   identityManager:(RCIdentityManager *)identityManager
       subscriberAttributesManager:(RCSubscriberAttributesManager *)subscriberAttributesManager
               operationDispatcher:(RCOperationDispatcher *)operationDispatcher
-       introEligibilityCalculator:(RCIntroEligibilityCalculator *)introEligibilityCalculator {
+       introEligibilityCalculator:(RCIntroEligibilityCalculator *)introEligibilityCalculator
+                    receiptParser:(RCReceiptParser *)receiptParser {
     if (self = [super init]) {
         RCDebugLog(@"Debug logging enabled.");
         RCDebugLog(@"SDK Version - %@", self.class.frameworkVersion);
@@ -283,6 +287,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
         self.subscriberAttributesManager = subscriberAttributesManager;
         self.operationDispatcher = operationDispatcher;
         self.introEligibilityCalculator = introEligibilityCalculator;
+        self.receiptParser = receiptParser;
 
         RCReceivePurchaserInfoBlock callDelegate = ^void(RCPurchaserInfo *info, NSError *error) {
             if (info) {
@@ -628,7 +633,7 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
         
         RCPurchaserInfo * _Nullable cachedPurchaserInfo = [self readPurchaserInfoFromCache];
         BOOL hasOriginalPurchaseDate = cachedPurchaserInfo != nil && cachedPurchaserInfo.originalPurchaseDate != nil;
-        BOOL receiptHasTransactions = [[[RCReceiptParser alloc] init] receiptHasTransactionsWithReceiptData:data];
+        BOOL receiptHasTransactions = [self.receiptParser receiptHasTransactionsWithReceiptData:data];
         if (!receiptHasTransactions && hasOriginalPurchaseDate) {
             CALL_IF_SET_ON_MAIN_THREAD(completion, cachedPurchaserInfo, nil);
             return;

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -630,7 +630,7 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
             CALL_IF_SET_ON_MAIN_THREAD(completion, nil, [RCPurchasesErrorUtils missingReceiptFileError]);
             return;
         }
-        
+
         RCPurchaserInfo * _Nullable cachedPurchaserInfo = [self readPurchaserInfoFromCache];
         BOOL hasOriginalPurchaseDate = cachedPurchaserInfo != nil && cachedPurchaserInfo.originalPurchaseDate != nil;
         BOOL receiptHasTransactions = [self.receiptParser receiptHasTransactionsWithReceiptData:data];
@@ -638,7 +638,7 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
             CALL_IF_SET_ON_MAIN_THREAD(completion, cachedPurchaserInfo, nil);
             return;
         }
-            
+
         RCSubscriberAttributeDict subscriberAttributes = self.unsyncedAttributesByKey;
         [self.backend postReceiptData:data
                             appUserID:self.appUserID

--- a/PurchasesCoreSwift/LocalReceiptParsing/ReceiptParser.swift
+++ b/PurchasesCoreSwift/LocalReceiptParsing/ReceiptParser.swift
@@ -8,17 +8,31 @@
 
 import Foundation
 
-class ReceiptParser {
-    private let objectIdentifierParser: ASN1ObjectIdentifierBuilder
+@objc(RCReceiptParser) public class ReceiptParser: NSObject {
+    private let objectIdentifierBuilder: ASN1ObjectIdentifierBuilder
     private let containerBuilder: ASN1ContainerBuilder
     private let receiptBuilder: AppleReceiptBuilder
 
-    init(objectIdentifierParser: ASN1ObjectIdentifierBuilder = ASN1ObjectIdentifierBuilder(),
-         containerBuilder: ASN1ContainerBuilder = ASN1ContainerBuilder(),
-         receiptBuilder: AppleReceiptBuilder = AppleReceiptBuilder()) {
-        self.objectIdentifierParser = objectIdentifierParser
+    @objc public convenience override init() {
+        self.init(objectIdentifierBuilder: ASN1ObjectIdentifierBuilder(),
+                  containerBuilder: ASN1ContainerBuilder(),
+                  receiptBuilder: AppleReceiptBuilder())
+    }
+    
+    init(objectIdentifierBuilder: ASN1ObjectIdentifierBuilder,
+         containerBuilder: ASN1ContainerBuilder,
+         receiptBuilder: AppleReceiptBuilder) {
+        self.objectIdentifierBuilder = objectIdentifierBuilder
         self.containerBuilder = containerBuilder
         self.receiptBuilder = receiptBuilder
+        super.init()
+    }
+    
+    @objc public func receiptHasTransactions(receiptData: Data) -> Bool {
+        if let receipt = try? parse(from: receiptData) {
+            return receipt.inAppPurchases.count > 0
+        }
+        return false
     }
 
     func parse(from receiptData: Data) throws -> AppleReceipt {
@@ -40,7 +54,7 @@ private extension ReceiptParser {
         if container.encodingType == .constructed {
             for (index, internalContainer) in container.internalContainers.enumerated() {
                 if internalContainer.containerIdentifier == .objectIdentifier {
-                    let objectIdentifier = objectIdentifierParser.build(fromPayload: internalContainer.internalPayload)
+                    let objectIdentifier = objectIdentifierBuilder.build(fromPayload: internalContainer.internalPayload)
                     if objectIdentifier == objectId && index < container.internalContainers.count - 1 {
                         // the container that holds the data comes right after the one with the object identifier
                         return container.internalContainers[index + 1]

--- a/PurchasesCoreSwift/LocalReceiptParsing/ReceiptParser.swift
+++ b/PurchasesCoreSwift/LocalReceiptParsing/ReceiptParser.swift
@@ -32,7 +32,8 @@ import Foundation
         if let receipt = try? parse(from: receiptData) {
             return receipt.inAppPurchases.count > 0
         }
-        return false
+        // if the receipt can't be parsed, conservatively return true
+        return true
     }
 
     func parse(from receiptData: Data) throws -> AppleReceipt {

--- a/PurchasesCoreSwiftTests/LocalReceiptParsing/ReceiptParserTests.swift
+++ b/PurchasesCoreSwiftTests/LocalReceiptParsing/ReceiptParserTests.swift
@@ -119,9 +119,9 @@ class ReceiptParserTests: XCTestCase {
         expect(self.receiptParser.receiptHasTransactions(receiptData: Data())) == false
     }
 
-    func testReceiptHasTransactionsFalseIfReceiptCantBeParsed() {
+    func testReceiptHasTransactionsTrueIfReceiptCantBeParsed() {
         mockASN1ContainerBuilder.stubbedBuildError = ReceiptReadingError.receiptParsingError
-        expect(self.receiptParser.receiptHasTransactions(receiptData: Data())) == false
+        expect(self.receiptParser.receiptHasTransactions(receiptData: Data())) == true
     }
 }
 

--- a/PurchasesCoreSwiftTests/LocalReceiptParsing/ReceiptParserTests.swift
+++ b/PurchasesCoreSwiftTests/LocalReceiptParsing/ReceiptParserTests.swift
@@ -28,7 +28,7 @@ class ReceiptParserTests: XCTestCase {
         ])
 
         mockASN1ContainerBuilder.stubbedBuildResult = constructedContainer
-        let expectedReceipt = mockAppleReceipt()
+        let expectedReceipt = mockAppleReceiptWithoutPurchases()
         mockAppleReceiptBuilder.stubbedBuildResult = expectedReceipt
 
         let receivedReceipt = try! self.receiptParser.parse(from: Data())
@@ -64,7 +64,7 @@ class ReceiptParserTests: XCTestCase {
         ])
 
         mockASN1ContainerBuilder.stubbedBuildResult = complexContainer
-        let expectedReceipt = mockAppleReceipt()
+        let expectedReceipt = mockAppleReceiptWithoutPurchases()
         mockAppleReceiptBuilder.stubbedBuildResult = expectedReceipt
 
         let receivedReceipt = try! self.receiptParser.parse(from: Data())
@@ -106,6 +106,23 @@ class ReceiptParserTests: XCTestCase {
         expect { try self.receiptParser.parse(from: Data()) }
             .to(throwError(ReceiptReadingError.dataObjectIdentifierMissing))
     }
+
+    func testReceiptHasTransactionsTrueIfReceiptHasTransactions() {
+        mockASN1ContainerBuilder.stubbedBuildResult = containerWithDataObjectIdentifier()
+        mockAppleReceiptBuilder.stubbedBuildResult = mockAppleReceiptWithPurchases()
+        expect(self.receiptParser.receiptHasTransactions(receiptData: Data())) == true
+    }
+
+    func testReceiptHasTransactionsFalseIfNoIAPsInReceipt() {
+        mockASN1ContainerBuilder.stubbedBuildResult = containerWithDataObjectIdentifier()
+        mockAppleReceiptBuilder.stubbedBuildResult = mockAppleReceiptWithoutPurchases()
+        expect(self.receiptParser.receiptHasTransactions(receiptData: Data())) == false
+    }
+
+    func testReceiptHasTransactionsFalseIfReceiptCantBeParsed() {
+        mockASN1ContainerBuilder.stubbedBuildError = ReceiptReadingError.receiptParsingError
+        expect(self.receiptParser.receiptHasTransactions(receiptData: Data())) == false
+    }
 }
 
 private extension ReceiptParserTests {
@@ -119,7 +136,7 @@ private extension ReceiptParserTests {
         return constructedContainer
     }
 
-    func mockAppleReceipt() -> AppleReceipt {
+    func mockAppleReceiptWithoutPurchases() -> AppleReceipt {
         return AppleReceipt(bundleId: "com.revenuecat.testapp",
                             applicationVersion: "3.2.3",
                             originalApplicationVersion: "3.1.1",
@@ -128,5 +145,43 @@ private extension ReceiptParserTests {
                             creationDate: Date(),
                             expirationDate: nil,
                             inAppPurchases: [])
+    }
+
+    func mockAppleReceiptWithPurchases() -> AppleReceipt {
+        return AppleReceipt(bundleId: "com.revenuecat.testapp",
+                            applicationVersion: "3.2.3",
+                            originalApplicationVersion: "3.1.1",
+                            opaqueValue: Data(),
+                            sha1Hash: Data(),
+                            creationDate: Date(),
+                            expirationDate: nil,
+                            inAppPurchases: [
+                                InAppPurchase(quantity: 1,
+                                              productId: "com.revenuecat.test",
+                                              transactionId: "892398531",
+                                              originalTransactionId: "892398531",
+                                              productType: .autoRenewableSubscription,
+                                              purchaseDate: Date(),
+                                              originalPurchaseDate: Date(),
+                                              expiresDate: nil,
+                                              cancellationDate: Date(),
+                                              isInTrialPeriod: false,
+                                              isInIntroOfferPeriod: false,
+                                              webOrderLineItemId: 79238531,
+                                              promotionalOfferIdentifier: nil),
+                                InAppPurchase(quantity: 1,
+                                              productId: "com.revenuecat.test",
+                                              transactionId: "892398532",
+                                              originalTransactionId: "892398531",
+                                              productType: .autoRenewableSubscription,
+                                              purchaseDate: Date(),
+                                              originalPurchaseDate: Date(),
+                                              expiresDate: nil,
+                                              cancellationDate: Date(),
+                                              isInTrialPeriod: false,
+                                              isInIntroOfferPeriod: false,
+                                              webOrderLineItemId: 79238532,
+                                              promotionalOfferIdentifier: nil)
+                            ])
     }
 }

--- a/PurchasesCoreSwiftTests/LocalReceiptParsing/ReceiptParserTests.swift
+++ b/PurchasesCoreSwiftTests/LocalReceiptParsing/ReceiptParserTests.swift
@@ -14,7 +14,8 @@ class ReceiptParserTests: XCTestCase {
         super.setUp()
         mockAppleReceiptBuilder = MockAppleReceiptBuilder()
         mockASN1ContainerBuilder = MockASN1ContainerBuilder()
-        receiptParser = ReceiptParser(containerBuilder: mockASN1ContainerBuilder,
+        receiptParser = ReceiptParser(objectIdentifierBuilder: ASN1ObjectIdentifierBuilder(),
+                                      containerBuilder: mockASN1ContainerBuilder,
                                       receiptBuilder: mockAppleReceiptBuilder)
     }
 

--- a/PurchasesCoreSwiftTests/Mocks/MockReceiptParser.swift
+++ b/PurchasesCoreSwiftTests/Mocks/MockReceiptParser.swift
@@ -22,6 +22,11 @@ class MockReceiptParser: ReceiptParser {
                                           expirationDate: nil,
                                           inAppPurchases: [])
 
+    convenience init() {
+        self.init(objectIdentifierBuilder: ASN1ObjectIdentifierBuilder(),
+                  containerBuilder: MockASN1ContainerBuilder(),
+                  receiptBuilder: MockAppleReceiptBuilder())
+    }
     override func parse(from receiptData: Data) throws -> AppleReceipt {
         invokedParse = true
         invokedParseCount += 1

--- a/PurchasesCoreSwiftTests/Mocks/MockReceiptParser.swift
+++ b/PurchasesCoreSwiftTests/Mocks/MockReceiptParser.swift
@@ -27,6 +27,7 @@ class MockReceiptParser: ReceiptParser {
                   containerBuilder: MockASN1ContainerBuilder(),
                   receiptBuilder: MockAppleReceiptBuilder())
     }
+
     override func parse(from receiptData: Data) throws -> AppleReceipt {
         invokedParse = true
         invokedParseCount += 1

--- a/PurchasesTests/Mocks/MockReceiptParser.swift
+++ b/PurchasesTests/Mocks/MockReceiptParser.swift
@@ -1,0 +1,30 @@
+//
+// Created by Andrés Boedo on 8/27/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+import Foundation
+@testable import PurchasesCoreSwift
+
+class MockReceiptParser: ReceiptParser {
+    
+    init() {
+        super.init(objectIdentifierBuilder: ASN1ObjectIdentifierBuilder(),
+                   containerBuilder: ASN1ContainerBuilder(),
+                   receiptBuilder: AppleReceiptBuilder())
+    }
+
+    var invokedReceiptHasTransactions = false
+    var invokedReceiptHasTransactionsCount = 0
+    var invokedReceiptHasTransactionsParameters: (receiptData: Data, Void)?
+    var invokedReceiptHasTransactionsParametersList = [(receiptData: Data, Void)]()
+    var stubbedReceiptHasTransactionsResult: Bool! = false
+
+    override func receiptHasTransactions(receiptData: Data) -> Bool {
+        invokedReceiptHasTransactions = true
+        invokedReceiptHasTransactionsCount += 1
+        invokedReceiptHasTransactionsParameters = (receiptData, ())
+        invokedReceiptHasTransactionsParametersList.append((receiptData, ()))
+        return stubbedReceiptHasTransactionsResult
+    }
+}

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -16,6 +16,7 @@ class PurchasesTests: XCTestCase {
         systemInfo = MockSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: true)
         mockOperationDispatcher = MockOperationDispatcher()
         mockIntroEligibilityCalculator = MockIntroEligibilityCalculator()
+        mockReceiptParser = MockReceiptParser()
     }
 
     override func tearDown() {
@@ -186,7 +187,8 @@ class PurchasesTests: XCTestCase {
     var systemInfo: MockSystemInfo!
     var mockOperationDispatcher: MockOperationDispatcher!
     var mockIntroEligibilityCalculator: MockIntroEligibilityCalculator!
-    
+    var mockReceiptParser: MockReceiptParser!
+
     let purchasesDelegate = MockPurchasesDelegate()
 
     var purchases: Purchases!
@@ -194,53 +196,23 @@ class PurchasesTests: XCTestCase {
     func setupPurchases(automaticCollection: Bool = false) {
         Purchases.automaticAppleSearchAdsAttributionCollection = automaticCollection
         self.identityManager.mockIsAnonymous = false
-        
-        purchases = Purchases(appUserID: identityManager.currentAppUserID,
-                              requestFetcher: requestFetcher,
-                              receiptFetcher: receiptFetcher,
-                              attributionFetcher: attributionFetcher,
-                              backend: backend,
-                              storeKitWrapper: storeKitWrapper,
-                              notificationCenter: notificationCenter,
-                              userDefaults: userDefaults,
-                              systemInfo: systemInfo,
-                              offeringsFactory: offeringsFactory,
-                              deviceCache: deviceCache,
-                              identityManager: identityManager,
-                              subscriberAttributesManager: subscriberAttributesManager,
-                              operationDispatcher: mockOperationDispatcher,
-                              introEligibilityCalculator: mockIntroEligibilityCalculator)
-        purchases!.delegate = purchasesDelegate
-        Purchases.setDefaultInstance(purchases!)
+
+        initializePurchasesInstance(appUserId: identityManager.currentAppUserID)
     }
 
     func setupAnonPurchases() {
         Purchases.automaticAppleSearchAdsAttributionCollection = false
         self.identityManager.mockIsAnonymous = true
-        
-        purchases = Purchases(appUserID: nil,
-                              requestFetcher: requestFetcher,
-                              receiptFetcher: receiptFetcher,
-                              attributionFetcher: attributionFetcher,
-                              backend: backend,
-                              storeKitWrapper: storeKitWrapper,
-                              notificationCenter: notificationCenter,
-                              userDefaults: userDefaults,
-                              systemInfo: systemInfo,
-                              offeringsFactory: offeringsFactory,
-                              deviceCache: deviceCache,
-                              identityManager: identityManager,
-                              subscriberAttributesManager: subscriberAttributesManager,
-                              operationDispatcher: mockOperationDispatcher,
-                              introEligibilityCalculator: mockIntroEligibilityCalculator)
-
-        purchases!.delegate = purchasesDelegate
+        initializePurchasesInstance(appUserId: nil)
     }
 
     func setupPurchasesObserverModeOn() {
-        let systemInfo = RCSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: false)
+        systemInfo = MockSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: false)
+        initializePurchasesInstance(appUserId: nil)
+    }
 
-        purchases = Purchases(appUserID: nil,
+    private func initializePurchasesInstance(appUserId: String?) {
+        purchases = Purchases(appUserID: appUserId,
                               requestFetcher: requestFetcher,
                               receiptFetcher: receiptFetcher,
                               attributionFetcher: attributionFetcher,
@@ -254,7 +226,8 @@ class PurchasesTests: XCTestCase {
                               identityManager: identityManager,
                               subscriberAttributesManager: subscriberAttributesManager,
                               operationDispatcher: mockOperationDispatcher,
-                              introEligibilityCalculator: mockIntroEligibilityCalculator)
+                              introEligibilityCalculator: mockIntroEligibilityCalculator,
+                              receiptParser: mockReceiptParser)
 
         purchases!.delegate = purchasesDelegate
         Purchases.setDefaultInstance(purchases!)

--- a/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -27,7 +27,8 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
     let systemInfo: RCSystemInfo = RCSystemInfo(platformFlavor: nil,
                                                 platformFlavorVersion: nil,
                                                 finishTransactions: true)
-    
+    var mockReceiptParser: MockReceiptParser!
+
     var mockOperationDispatcher: MockOperationDispatcher!
     var mockIntroEligibilityCalculator: MockIntroEligibilityCalculator!
 
@@ -47,6 +48,7 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
         ]
         self.mockOperationDispatcher = MockOperationDispatcher()
         self.mockIntroEligibilityCalculator = MockIntroEligibilityCalculator()
+        self.mockReceiptParser = MockReceiptParser()
     }
 
     override func tearDown() {
@@ -73,7 +75,8 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
                               identityManager: mockIdentityManager,
                               subscriberAttributesManager: mockSubscriberAttributesManager,
                               operationDispatcher: mockOperationDispatcher,
-                              introEligibilityCalculator: mockIntroEligibilityCalculator)
+                              introEligibilityCalculator: mockIntroEligibilityCalculator,
+                              receiptParser: mockReceiptParser)
         purchases!.delegate = purchasesDelegate
         Purchases.setDefaultInstance(purchases!)
     }


### PR DESCRIPTION
https://app.clubhouse.io/revenuecat/story/70/ios-only-post-receipt-on-restore-if-there-are-transactions

Adds logic to check if a receipt has transactions, and if it doesn't, prevent an unnecessary post. 
The one exception to the rule is if `purchaserInfo` is empty or it doesn't have an `originalPurchaseDate`, since that data is sometimes used to grandfather in subscribers. 

### Requirements: 
- [x] ~Tests~