### PR TITLE
Fix bug caused by workaround for watchOS sandbox receipts being stored at wrong path

### DIFF
--- a/Purchases/Purchasing/RCReceiptFetcher.m
+++ b/Purchases/Purchasing/RCReceiptFetcher.m
@@ -22,7 +22,9 @@
     // correct receipt.
     // This has been filed as radar FB7699277. More info in https://github.com/RevenueCat/purchases-ios/issues/207.
     
-    if (RCSystemInfo.isSandbox) {
+    NSOperatingSystemVersion minimumOSVersionWithoutBug = { .majorVersion = 7, .minorVersion = 0, .patchVersion = 0 };
+    BOOL isBelowMinimumOSVersionWithoutBug = ![NSProcessInfo.processInfo isOperatingSystemAtLeastVersion:minimumOSVersionWithoutBug];
+    if (isBelowMinimumOSVersionWithoutBug && RCSystemInfo.isSandbox) {
         NSString *receiptURLFolder = [[receiptURL absoluteString] stringByDeletingLastPathComponent];
         NSURL *productionReceiptURL = [NSURL URLWithString:[receiptURLFolder stringByAppendingPathComponent:@"receipt"]];
         receiptURL = productionReceiptURL;


### PR DESCRIPTION
The fix in https://github.com/RevenueCat/purchases-ios/pull/263 that was discussed in https://github.com/RevenueCat/purchases-ios/issues/207 now itself causes a bug when using sandbox on watchOS 7 as of beta 7. The bug that this workaround was added for appears to no longer occur, as when I remove the workaround, the receipt data is successfully retrieved.

```
DEBUG: Loaded receipt from file:///private/var/mobile/Containers/Data/PluginKitPlugin/DC8F7577-9BE0-4A54-81CE-0CECB386EC5C/StoreKit/sandboxReceipt
DEBUG: POST /v1/receipts
DEBUG: POST /v1/receipts 200
```

However, when the workaround is left in, retrieving the receipt data fails.

```
DEBUG: Loaded receipt from file:/private/var/mobile/Containers/Data/PluginKitPlugin/D857C0D0-2739-4D9B-A011-144948BC8274/StoreKit/receipt
DEBUG: Receipt empty, fetching
DEBUG: GET /v1/subscribers/$RCAnonymousID:d9e6c1c36cff458e9375cb846413128e 200
DEBUG: Loaded receipt from file:/private/var/mobile/Containers/Data/PluginKitPlugin/D857C0D0-2739-4D9B-A011-144948BC8274/StoreKit/receipt
INFO: Unable to load receipt, ensure you are logged in to the correct iTunes account.
ERROR: The receipt is missing.
```

Therefore, I have added a check for the watchOS version. Only if it is below 7.0.0 will the workaround be applied. Otherwise, the workaround will not be used.