### PR TITLE
Feature: run backend requests serially

### DIFF
--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		37E351B84EBE06E2F370A835 /* RCISOPeriodFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E35CC6289D46E544F5F006 /* RCISOPeriodFormatter.m */; };
 		37E351E3AC0B5F67305B4CB6 /* DeviceCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35D87B7E6F91E27E98F42 /* DeviceCacheTests.swift */; };
 		37E351F90612047842AFF1A6 /* ProductInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E350E57B0A393455A72B40 /* ProductInfoTests.swift */; };
+		37E352039F075299CD4CF6B0 /* RCHTTPRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35B76B22E9086A5BABECB /* RCHTTPRequest.h */; };
 		37E3524628A1D7568679FEE2 /* SusbcriberAttributesManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3567E972B9B04FE079ABA /* SusbcriberAttributesManagerTests.swift */; };
 		37E3524CB70618E6C5F3DB49 /* MockPurchasesDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35838A7FD36982EE14100 /* MockPurchasesDelegate.swift */; };
 		37E352897F7CB3A122F9739F /* PurchasesSubscriberAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3508E52201122137D4B4A /* PurchasesSubscriberAttributesTests.swift */; };
@@ -121,6 +122,7 @@
 		37E352E86A182E92130B823C /* RCIntroEligibility+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E359D128E667D950598853 /* RCIntroEligibility+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E352E9231D083B78E2E345 /* RCBackend.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E35E282619939718FC7DBE /* RCBackend.m */; };
 		37E352F190E0E957E8D932F8 /* RCDeviceCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E3524E3032ABC72467AA43 /* RCDeviceCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		37E35302FD31A094AAE30BFA /* RCHTTPRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E356988CFAEA3E06597850 /* RCHTTPRequest.m */; };
 		37E35312E13F08FD8C7CC275 /* RCProductInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E354FA06E2FDFB81EE3937 /* RCProductInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E353437E49AA49D6ECC03F /* RCInMemoryCachedObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E35B655B1BA8F52C4349ED /* RCInMemoryCachedObject.m */; };
 		37E353851D42047D5B0A57D0 /* MockDateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3578BD602C7B8E2274279 /* MockDateProvider.swift */; };
@@ -385,6 +387,7 @@
 		37E3567189CF6A746EE3CCC2 /* DateExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateExtensions.swift; sourceTree = "<group>"; };
 		37E3567271C2172DA3ED1B16 /* RCAttributionData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCAttributionData.h; sourceTree = "<group>"; };
 		37E3567E972B9B04FE079ABA /* SusbcriberAttributesManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SusbcriberAttributesManagerTests.swift; sourceTree = "<group>"; };
+		37E356988CFAEA3E06597850 /* RCHTTPRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCHTTPRequest.m; sourceTree = "<group>"; };
 		37E356C39D29EB6C8EC2D6BD /* RCHTTPClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCHTTPClient.h; sourceTree = "<group>"; };
 		37E356F4B9FCED933CD9C1CA /* RCDeviceCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCDeviceCache.m; sourceTree = "<group>"; };
 		37E3571B552018D47A6ED7C6 /* MockIdentityManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockIdentityManager.swift; sourceTree = "<group>"; };
@@ -415,6 +418,7 @@
 		37E35B08709090FBBFB16EBD /* MockProductsRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockProductsRequest.swift; sourceTree = "<group>"; };
 		37E35B2CE711472BE58F51ED /* RCEntitlementInfo+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCEntitlementInfo+Protected.h"; sourceTree = "<group>"; };
 		37E35B655B1BA8F52C4349ED /* RCInMemoryCachedObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCInMemoryCachedObject.m; sourceTree = "<group>"; };
+		37E35B76B22E9086A5BABECB /* RCHTTPRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCHTTPRequest.h; sourceTree = "<group>"; };
 		37E35B9AC7A350CA2437049D /* ISOPeriodFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ISOPeriodFormatterTests.swift; sourceTree = "<group>"; };
 		37E35BC489985F613020035D /* RCProductInfoExtractor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCProductInfoExtractor.h; sourceTree = "<group>"; };
 		37E35C1554F296F7F1317747 /* MockAppleReceiptBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockAppleReceiptBuilder.swift; sourceTree = "<group>"; };
@@ -802,6 +806,8 @@
 				37E356C39D29EB6C8EC2D6BD /* RCHTTPClient.h */,
 				37E35EDEA372C1D8E03118FF /* RCHTTPClient.m */,
 				37E35331DBA29B3C17D0F507 /* RCHTTPStatusCodes.h */,
+				37E356988CFAEA3E06597850 /* RCHTTPRequest.m */,
+				37E35B76B22E9086A5BABECB /* RCHTTPRequest.h */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -1075,6 +1081,7 @@
 				3589D15624C21DBD00A65CBB /* RCAttributionFetcher+Protected.h in Headers */,
 				37E357301A5D15C0E90C9BD3 /* RCProductInfoExtractor.h in Headers */,
 				37E35A328C4DC8A4D2DB4B06 /* RCAttributionNetwork.h in Headers */,
+				37E352039F075299CD4CF6B0 /* RCHTTPRequest.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1378,6 +1385,7 @@
 				37E351B84EBE06E2F370A835 /* RCISOPeriodFormatter.m in Sources */,
 				37E3506DF4FDFCE5CA75B057 /* RCProductInfo.m in Sources */,
 				37E353FA89D4F510BA73F0D3 /* RCProductInfoExtractor.m in Sources */,
+				37E35302FD31A094AAE30BFA /* RCHTTPRequest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Purchases/Caching/RCDeviceCache.m
+++ b/Purchases/Caching/RCDeviceCache.m
@@ -232,10 +232,6 @@ NSString *RCAttributionDataDefaultsKeyBase = RC_CACHE_KEY_PREFIX @".attribution.
                 unsyncedAttributesByKey[attribute.key] = attribute;
             }
         }
-        RCLog(@"found %lu unsynced attributes for appUserID: %@", unsyncedAttributesByKey.count, appUserID);
-        if (unsyncedAttributesByKey.count > 0) {
-            RCLog(@"unsynced attributes: %@", unsyncedAttributesByKey);
-        }
         return unsyncedAttributesByKey;
     }
 }

--- a/Purchases/Networking/RCBackend.m
+++ b/Purchases/Networking/RCBackend.m
@@ -200,6 +200,7 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
     }
 
     [self.httpClient performRequest:@"POST"
+                           serially:YES
                                path:@"/receipts"
                                body:body
                             headers:self.headers
@@ -222,6 +223,7 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
     }
 
     [self.httpClient performRequest:@"GET"
+                           serially:YES
                                path:path
                                body:nil
                             headers:self.headers
@@ -258,6 +260,7 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
     NSString *escapedAppUserID = [self escapedAppUserID:appUserID];
     NSString *path = [NSString stringWithFormat:@"/subscribers/%@/intro_eligibility", escapedAppUserID];
     [self.httpClient performRequest:@"POST"
+                           serially:YES
                                path:path
                                body:@{
                                       @"product_identifiers": productIdentifiers,
@@ -299,6 +302,7 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
     }
 
     [self.httpClient performRequest:@"GET"
+                           serially:NO
                                path:path
                                body:nil
                             headers:self.headers
@@ -331,6 +335,7 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
     NSString *path = [NSString stringWithFormat:@"/subscribers/%@/attribution", escapedAppUserID];
 
     [self.httpClient performRequest:@"POST"
+                           serially:YES
                                path:path
                                body:@{
                                       @"network": @(network),
@@ -349,6 +354,7 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
     NSString *escapedAppUserID = [self escapedAppUserID:appUserID];
     NSString *path = [NSString stringWithFormat:@"/subscribers/%@/alias", escapedAppUserID];
     [self.httpClient performRequest:@"POST"
+                           serially:YES
                                path:path
                                body:@{
                                        @"new_app_user_id": newAppUserID
@@ -368,7 +374,9 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
                  completion:(RCOfferSigningResponseHandler)completion
 {
     NSString *fetchToken = [receiptData base64EncodedStringWithOptions:0];
-    [self.httpClient performRequest:@"POST" path:@"/offers"
+    [self.httpClient performRequest:@"POST"
+                           serially:YES
+                               path:@"/offers"
                                body:@{
                                        @"app_user_id": appUserID,
                                        @"fetch_token": fetchToken,
@@ -426,6 +434,7 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
     NSString *path = [NSString stringWithFormat:@"/subscribers/%@/attributes", escapedAppUserID];
     NSDictionary *attributesInBackendFormat = [self subscriberAttributesByKey:subscriberAttributes];
     [self.httpClient performRequest:@"POST"
+                           serially:YES
                                path:path
                                body:@{
                                    @"attributes": attributesInBackendFormat

--- a/Purchases/Networking/RCHTTPClient.h
+++ b/Purchases/Networking/RCHTTPClient.h
@@ -27,12 +27,13 @@ typedef void(^RCHTTPClientResponseHandler)(NSInteger statusCode,
                headers:(nullable NSDictionary<NSString *, NSString *> *)headers
      completionHandler:(nullable RCHTTPClientResponseHandler)completionHandler;
 
-- (void)performSerialRequest:(NSString *)httpMethod
-                        path:(NSString *)path
-                        body:(nullable NSDictionary *)requestBody
-                     headers:(nullable NSDictionary<NSString *, NSString *> *)headers
-           completionHandler:(nullable RCHTTPClientResponseHandler)completionHandler;
+- (void)performRequest:(NSString *)httpMethod
+                  path:(NSString *)path
+                  body:(nullable NSDictionary *)requestBody
+               headers:(nullable NSDictionary<NSString *, NSString *> *)headers
+     completionHandler:(nullable RCHTTPClientResponseHandler)completionHandler
+        performSerially:(BOOL)performSerially;
 
-@end
+    @end
 
 NS_ASSUME_NONNULL_END

--- a/Purchases/Networking/RCHTTPClient.h
+++ b/Purchases/Networking/RCHTTPClient.h
@@ -13,8 +13,9 @@ NS_ASSUME_NONNULL_BEGIN
 @class RCSystemInfo;
 
 typedef void(^RCHTTPClientResponseHandler)(NSInteger statusCode,
-                                           NSDictionary * _Nullable response,
-                                           NSError * _Nullable error);
+                                           NSDictionary *_Nullable response,
+                                           NSError *_Nullable error);
+
 
 @interface RCHTTPClient : NSObject
 
@@ -28,6 +29,7 @@ typedef void(^RCHTTPClientResponseHandler)(NSInteger statusCode,
                headers:(nullable NSDictionary<NSString *, NSString *> *)headers
      completionHandler:(nullable RCHTTPClientResponseHandler)completionHandler;
 
-    @end
+@end
+
 
 NS_ASSUME_NONNULL_END

--- a/Purchases/Networking/RCHTTPClient.h
+++ b/Purchases/Networking/RCHTTPClient.h
@@ -28,11 +28,11 @@ typedef void(^RCHTTPClientResponseHandler)(NSInteger statusCode,
      completionHandler:(nullable RCHTTPClientResponseHandler)completionHandler;
 
 - (void)performRequest:(NSString *)httpMethod
+              serially:(BOOL)performSerially
                   path:(NSString *)path
                   body:(nullable NSDictionary *)requestBody
                headers:(nullable NSDictionary<NSString *, NSString *> *)headers
-     completionHandler:(nullable RCHTTPClientResponseHandler)completionHandler
-        performSerially:(BOOL)performSerially;
+     completionHandler:(nullable RCHTTPClientResponseHandler)completionHandler;
 
     @end
 

--- a/Purchases/Networking/RCHTTPClient.h
+++ b/Purchases/Networking/RCHTTPClient.h
@@ -27,6 +27,12 @@ typedef void(^RCHTTPClientResponseHandler)(NSInteger statusCode,
                headers:(nullable NSDictionary<NSString *, NSString *> *)headers
      completionHandler:(nullable RCHTTPClientResponseHandler)completionHandler;
 
+- (void)performSerialRequest:(NSString *)httpMethod
+                        path:(NSString *)path
+                        body:(nullable NSDictionary *)requestBody
+                     headers:(nullable NSDictionary<NSString *, NSString *> *)headers
+           completionHandler:(nullable RCHTTPClientResponseHandler)completionHandler;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Purchases/Networking/RCHTTPClient.h
+++ b/Purchases/Networking/RCHTTPClient.h
@@ -21,12 +21,6 @@ typedef void(^RCHTTPClientResponseHandler)(NSInteger statusCode,
 - (instancetype)initWithSystemInfo:(RCSystemInfo *)systemInfo NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;
 
-- (void)performRequest:(NSString *)HTTPMethod
-                  path:(NSString *)path
-                  body:(nullable NSDictionary *)requestBody
-               headers:(nullable NSDictionary<NSString *, NSString *> *)headers
-     completionHandler:(nullable RCHTTPClientResponseHandler)completionHandler;
-
 - (void)performRequest:(NSString *)httpMethod
               serially:(BOOL)performSerially
                   path:(NSString *)path

--- a/Purchases/Networking/RCHTTPClient.m
+++ b/Purchases/Networking/RCHTTPClient.m
@@ -67,7 +67,8 @@ NS_ASSUME_NONNULL_BEGIN
             if (self.currentSerialRequest) {
                 RCDebugLog(@"There's a request currently running and %ld requests left in the queue, queueing %@ %@",
                            self.queuedRequests.count,
-                           httpMethod, path);
+                           httpMethod,
+                           path);
                 [self.queuedRequests addObject:rcRequest];
                 return;
             } else {

--- a/Purchases/Networking/RCHTTPClient.m
+++ b/Purchases/Networking/RCHTTPClient.m
@@ -42,19 +42,19 @@ NS_ASSUME_NONNULL_BEGIN
                headers:(nullable NSDictionary<NSString *, NSString *> *)headers
      completionHandler:(nullable RCHTTPClientResponseHandler)completionHandler {
     [self performRequest:httpMethod
+                serially:NO
                     path:path
                     body:requestBody
                  headers:headers
-       completionHandler:completionHandler
-         performSerially:NO];
+       completionHandler:completionHandler];
 }
 
 - (void)performRequest:(NSString *)httpMethod
+              serially:(BOOL)performSerially
                   path:(NSString *)path
                   body:(nullable NSDictionary *)requestBody
                headers:(nullable NSDictionary<NSString *, NSString *> *)headers
-     completionHandler:(nullable RCHTTPClientResponseHandler)completionHandler
-       performSerially:(BOOL)performSerially {
+     completionHandler:(nullable RCHTTPClientResponseHandler)completionHandler {
     NSInteger queuedRequestsTotal = 0;
 
     if (performSerially) {
@@ -141,11 +141,11 @@ beginNextRequestWhenFinished:(BOOL)beginNextRequestWhenFinished {
         }
         if (nextRequest) {
             [self performRequest:nextRequest.httpMethod
+                        serially:YES
                             path:nextRequest.path
                             body:nextRequest.requestBody
                          headers:nextRequest.headers
-               completionHandler:nextRequest.completionHandler
-                 performSerially:YES];
+               completionHandler:nextRequest.completionHandler];
         }
     }
 }

--- a/Purchases/Networking/RCHTTPClient.m
+++ b/Purchases/Networking/RCHTTPClient.m
@@ -65,10 +65,12 @@ NS_ASSUME_NONNULL_BEGIN
                                                            completionHandler:completionHandler];
         @synchronized (self) {
             if (self.isPerformingSerialRequest) {
-                RCDebugLog(@"there are %ld requests left in the queue, queueing request", self.queuedRequests.count);
+                RCDebugLog(@"there are %ld requests left in the queue, queueing %@ %@",
+                           self.queuedRequests.count,
+                           httpMethod, path);
                 return;
             } else {
-                RCDebugLog(@"there are no requests left in the queue, starting request");
+                RCDebugLog(@"there are no requests left in the queue, starting request %@ %@", httpMethod, path);
                 self.isPerformingSerialRequest = YES;
             }
             [self.queuedRequests addObject:rcRequest];

--- a/Purchases/Networking/RCHTTPClient.m
+++ b/Purchases/Networking/RCHTTPClient.m
@@ -69,8 +69,10 @@ NS_ASSUME_NONNULL_BEGIN
         }
     }
     if (performSerially && queuedRequestsTotal > 0) {
+        RCDebugLog(@"there are %@ requests left in the queue, queueing request", queuedRequestsTotal);
         return;
     }
+    RCDebugLog(@"there are no requests left in the queue, starting request");
 
     [self assertIsValidRequestWithMethod:httpMethod body:requestBody];
 

--- a/Purchases/Networking/RCHTTPClient.m
+++ b/Purchases/Networking/RCHTTPClient.m
@@ -17,8 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RCHTTPClient ()
 
 @property (nonatomic) NSURLSession *session;
-@property (nonatomic, weak) RCSystemInfo *systemInfo;
-@property(nonatomic, copy) NSMutableArray<RCHTTPRequest *> *queuedRequests;
+@property (nonatomic) RCSystemInfo *systemInfo;
+@property (nonatomic) NSMutableArray<RCHTTPRequest *> *queuedRequests;
 
 @end
 

--- a/Purchases/Networking/RCHTTPClient.m
+++ b/Purchases/Networking/RCHTTPClient.m
@@ -139,9 +139,11 @@ beginNextRequestWhenFinished:(BOOL)beginNextRequestWhenFinished {
     RCHTTPRequest * _Nullable nextRequest;
     if (beginNextRequestWhenFinished) {
         @synchronized (self) {
+            RCHTTPRequest *request = self.queuedRequests[0];
             [self.queuedRequests removeObjectAtIndex:0];
             self.isPerformingSerialRequest = NO;
-            RCDebugLog(@"serial request done, %ld requests left in the queue", self.queuedRequests.count);
+            RCDebugLog(@"serial request done: %@ %@, %ld requests left in the queue",
+                       request.httpMethod, request.path, self.queuedRequests.count);
             if (self.queuedRequests.count > 0) {
                 nextRequest = self.queuedRequests[0];
             }

--- a/Purchases/Networking/RCHTTPRequest.h
+++ b/Purchases/Networking/RCHTTPRequest.h
@@ -1,0 +1,30 @@
+//
+// Created by Andrés Boedo on 9/4/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+
+#import <Foundation/Foundation.h>
+#import "RCHTTPClient.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+@interface RCHTTPRequest : NSObject
+
+- (instancetype)initWithHTTPMethod:(NSString *)httpMethod
+                              path:(NSString *)path
+                              body:(nullable NSDictionary *)requestBody
+                           headers:(nullable NSDictionary<NSString *, NSString *> *)headers
+                 completionHandler:(nullable RCHTTPClientResponseHandler)completionHandler;
+
+@property(readonly, copy, nonatomic) NSString *httpMethod;
+@property(readonly, copy, nonatomic) NSString *path;
+@property(readonly, copy, nonatomic, nullable)  NSDictionary *requestBody;
+@property(readonly, copy, nonatomic, nullable)  NSDictionary<NSString *, NSString *> *headers;
+@property(readonly, copy, nonatomic, nullable)  RCHTTPClientResponseHandler completionHandler;
+
+@end
+
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/Networking/RCHTTPRequest.h
+++ b/Purchases/Networking/RCHTTPRequest.h
@@ -20,11 +20,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (id)copyWithZone:(NSZone *)zone;
 - (NSString *)description;
 
-@property(readonly, copy, nonatomic) NSString *httpMethod;
-@property(readonly, copy, nonatomic) NSString *path;
-@property(readonly, copy, nonatomic, nullable)  NSDictionary *requestBody;
-@property(readonly, copy, nonatomic, nullable)  NSDictionary<NSString *, NSString *> *headers;
-@property(readonly, copy, nonatomic, nullable)  RCHTTPClientResponseHandler completionHandler;
+@property (readonly, copy, nonatomic) NSString *httpMethod;
+@property (readonly, copy, nonatomic) NSString *path;
+@property (readonly, copy, nonatomic, nullable) NSDictionary *requestBody;
+@property (readonly, copy, nonatomic, nullable) NSDictionary<NSString *, NSString *> *headers;
+@property (readonly, copy, nonatomic, nullable) RCHTTPClientResponseHandler completionHandler;
 
 @end
 

--- a/Purchases/Networking/RCHTTPRequest.h
+++ b/Purchases/Networking/RCHTTPRequest.h
@@ -10,13 +10,14 @@
 NS_ASSUME_NONNULL_BEGIN
 
 
-@interface RCHTTPRequest : NSObject
+@interface RCHTTPRequest : NSObject <NSCopying, NSCopying>
 
 - (instancetype)initWithHTTPMethod:(NSString *)httpMethod
                               path:(NSString *)path
                               body:(nullable NSDictionary *)requestBody
                            headers:(nullable NSDictionary<NSString *, NSString *> *)headers
                  completionHandler:(nullable RCHTTPClientResponseHandler)completionHandler;
+- (id)copyWithZone:(NSZone *)zone;
 
 @property(readonly, copy, nonatomic) NSString *httpMethod;
 @property(readonly, copy, nonatomic) NSString *path;

--- a/Purchases/Networking/RCHTTPRequest.h
+++ b/Purchases/Networking/RCHTTPRequest.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
                            headers:(nullable NSDictionary<NSString *, NSString *> *)headers
                  completionHandler:(nullable RCHTTPClientResponseHandler)completionHandler;
 - (id)copyWithZone:(NSZone *)zone;
+- (NSString *)description;
 
 @property(readonly, copy, nonatomic) NSString *httpMethod;
 @property(readonly, copy, nonatomic) NSString *path;

--- a/Purchases/Networking/RCHTTPRequest.m
+++ b/Purchases/Networking/RCHTTPRequest.m
@@ -36,6 +36,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(NSZone *)zone {
+    RCHTTPRequest *copy = [[RCHTTPRequest allocWithZone:zone]
+                                          initWithHTTPMethod:self.httpMethod
+                                                        path:self.path
+                                                        body:self.requestBody
+                                                     headers:self.headers
+                                           completionHandler:self.completionHandler];
+
+    return copy;
+}
+
+
 @end
 
 

--- a/Purchases/Networking/RCHTTPRequest.m
+++ b/Purchases/Networking/RCHTTPRequest.m
@@ -47,6 +47,16 @@ NS_ASSUME_NONNULL_BEGIN
     return copy;
 }
 
+- (NSString *)description {
+    NSMutableString *description = [NSMutableString stringWithFormat:@"<%@: ", NSStringFromClass([self class])];
+    [description appendFormat:@"httpMethod=%@\n", self.httpMethod];
+    [description appendFormat:@"path=%@\n", self.path];
+    [description appendFormat:@"requestBody=%@\n", self.requestBody];
+    [description appendFormat:@"headers=%@\n", self.headers];
+    [description appendString:@">"];
+    return description;
+}
+
 
 @end
 

--- a/Purchases/Networking/RCHTTPRequest.m
+++ b/Purchases/Networking/RCHTTPRequest.m
@@ -1,0 +1,42 @@
+//
+// Created by Andrés Boedo on 9/4/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+#import "RCHTTPRequest.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+@interface RCHTTPRequest ()
+
+@property(copy, nonatomic) NSString *httpMethod;
+@property(copy, nonatomic) NSString *path;
+@property(copy, nonatomic, nullable)  NSDictionary *requestBody;
+@property(copy, nonatomic, nullable)  NSDictionary<NSString *, NSString *> *headers;
+@property(copy, nonatomic, nullable)  RCHTTPClientResponseHandler completionHandler;
+
+@end
+
+
+@implementation RCHTTPRequest
+
+- (instancetype)initWithHTTPMethod:(NSString *)httpMethod
+                              path:(NSString *)path
+                              body:(nullable NSDictionary *)requestBody
+                           headers:(nullable NSDictionary<NSString *, NSString *> *)headers
+                 completionHandler:(nullable RCHTTPClientResponseHandler)completionHandler {
+    if (self = [super init]) {
+        self.httpMethod = httpMethod;
+        self.path = path;
+        self.requestBody = requestBody;
+        self.headers = headers;
+        self.completionHandler = completionHandler;
+    }
+    return self;
+}
+
+@end
+
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -316,7 +316,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                                 selector:@selector(applicationDidBecomeActive:)
                                     name:APP_DID_BECOME_ACTIVE_NOTIFICATION_NAME object:nil];
     [self.notificationCenter addObserver:self
-                                selector:@selector(syncSubscriberAttributesIfNeeded)
+                                selector:@selector(applicationWillResignActive:)
                                     name:APP_WILL_RESIGN_ACTIVE_NOTIFICATION_NAME
                                   object:nil];
 }
@@ -790,6 +790,10 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 
 - (void)applicationDidBecomeActive:(__unused NSNotification *)notif {
     [self updateAllCachesIfNeeded];
+    [self syncSubscriberAttributesIfNeeded];
+}
+
+- (void)applicationWillResignActive:(__unused NSNotification *)notif {
     [self syncSubscriberAttributesIfNeeded];
 }
 

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -298,13 +298,9 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                 [self sendCachedPurchaserInfoIfAvailable];
             }
         }];
-
-        [self configureSubscriberAttributesManager];
-
         self.storeKitWrapper.delegate = self;
-        [self.notificationCenter addObserver:self
-                                    selector:@selector(applicationDidBecomeActive:)
-                                        name:APP_DID_BECOME_ACTIVE_NOTIFICATION_NAME object:nil];
+
+        [self subscribeToAppStateNotifications];
 
         [self.attributionFetcher postPostponedAttributionDataIfNeeded];
         if (_automaticAppleSearchAdsAttributionCollection) {
@@ -313,6 +309,16 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
     }
 
     return self;
+}
+
+- (void)subscribeToAppStateNotifications {
+    [self.notificationCenter addObserver:self
+                                selector:@selector(applicationDidBecomeActive:)
+                                    name:APP_DID_BECOME_ACTIVE_NOTIFICATION_NAME object:nil];
+    [self.notificationCenter addObserver:self
+                                selector:@selector(syncSubscriberAttributesIfNeeded)
+                                    name:APP_WILL_RESIGN_ACTIVE_NOTIFICATION_NAME
+                                  object:nil];
 }
 
 - (void)dealloc {
@@ -784,6 +790,7 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 
 - (void)applicationDidBecomeActive:(__unused NSNotification *)notif {
     [self updateAllCachesIfNeeded];
+    [self syncSubscriberAttributesIfNeeded];
 }
 
 - (void)sendCachedPurchaserInfoIfAvailable {

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -836,10 +836,6 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
     }
 }
 
-- (void)updateAllCaches {
-    [self updateAllCachesWithCompletionBlock:nil];
-}
-
 - (void)updateAllCachesWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion {
     [self fetchAndCachePurchaserInfoWithCompletion:completion];
     [self updateOfferingsCache:nil];

--- a/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.h
+++ b/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.h
@@ -14,11 +14,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RCPurchases (SubscriberAttributes)
 
-- (void)configureSubscriberAttributesManager;
 - (RCSubscriberAttributeDict)unsyncedAttributesByKey;
 - (void)markAttributesAsSyncedIfNeeded:(nullable RCSubscriberAttributeDict)syncedAttributes
                              appUserID:(NSString *)appUserID
                                  error:(nullable NSError *)error;
+- (void)syncSubscriberAttributesIfNeeded;
+
 @end
 
 @interface RCPurchases ()

--- a/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.m
+++ b/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.m
@@ -18,11 +18,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark protected methods
 
-- (void)configureSubscriberAttributesManager {
-    [self subscribeToAppDidBecomeActiveNotifications];
-    [self subscribeToAppBackgroundedNotifications];
-}
-
 - (RCSubscriberAttributeDict)unsyncedAttributesByKey {
     NSString *appUserID = self.appUserID;
     RCSubscriberAttributeDict unsyncedAttributes = [self.subscriberAttributesManager
@@ -46,22 +41,6 @@ NS_ASSUME_NONNULL_BEGIN
         RCLog(@"Subscriber attributes errors: %@", error.subscriberAttributesErrors);
     }
     [self.subscriberAttributesManager markAttributesAsSynced:syncedAttributes appUserID:appUserID];
-}
-
-#pragma mark private methods
-
-- (void)subscribeToAppDidBecomeActiveNotifications {
-    [self.notificationCenter addObserver:self
-                                selector:@selector(syncSubscriberAttributesIfNeeded)
-                                    name:APP_DID_BECOME_ACTIVE_NOTIFICATION_NAME
-                                  object:nil];
-}
-
-- (void)subscribeToAppBackgroundedNotifications {
-    [self.notificationCenter addObserver:self
-                                selector:@selector(syncSubscriberAttributesIfNeeded)
-                                    name:APP_WILL_RESIGN_ACTIVE_NOTIFICATION_NAME
-                                  object:nil];
 }
 
 - (void)syncSubscriberAttributesIfNeeded {

--- a/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.m
+++ b/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.m
@@ -24,7 +24,15 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (RCSubscriberAttributeDict)unsyncedAttributesByKey {
-    return [self.subscriberAttributesManager unsyncedAttributesByKeyForAppUserID:self.appUserID];
+    NSString *appUserID = self.appUserID;
+    RCSubscriberAttributeDict unsyncedAttributes = [self.subscriberAttributesManager
+                                                    unsyncedAttributesByKeyForAppUserID:appUserID];
+    RCLog(@"found %lu unsynced attributes for appUserID: %@", unsyncedAttributes.count, appUserID);
+    if (unsyncedAttributes.count > 0) {
+        RCLog(@"unsynced attributes: %@", unsyncedAttributes);
+    }
+
+    return unsyncedAttributes;
 }
 
 - (void)markAttributesAsSyncedIfNeeded:(nullable RCSubscriberAttributeDict)syncedAttributes

--- a/PurchasesTests/Mocks/MockHTTPClient.swift
+++ b/PurchasesTests/Mocks/MockHTTPClient.swift
@@ -11,24 +11,29 @@ class MockHTTPClient: RCHTTPClient {
     var stubbedCompletionError: Error? = nil
 
     var invokedPerformRequestParameters: (HTTPMethod: String,
+                                          serially: Bool,
                                           path: String,
                                           requestBody: [AnyHashable: Any]?,
                                           headers: [String: String]?,
                                           completionHandler: RCHTTPClientResponseHandler?)?
     var invokedPerformRequestParametersList = [
         (HTTPMethod: String,
+            serially: Bool,
             path: String,
             requestBody: [AnyHashable: Any]?,
             headers: [String: String]?,
             completionHandler: RCHTTPClientResponseHandler?)]()
 
-    override func performRequest(_ HTTPMethod: String, path: String, body requestBody: [AnyHashable: Any]?,
+    override func performRequest(_ HTTPMethod: String,
+                                 serially: Bool,
+                                 path: String,
+                                 body requestBody: [AnyHashable: Any]?,
                                  headers: [String: String]?,
                                  completionHandler: RCHTTPClientResponseHandler?) {
         invokedPerformRequest = true
         invokedPerformRequestCount += 1
-        invokedPerformRequestParameters = (HTTPMethod, path, requestBody, headers, completionHandler)
-        invokedPerformRequestParametersList.append((HTTPMethod, path, requestBody, headers, completionHandler))
+        invokedPerformRequestParameters = (HTTPMethod, serially, path, requestBody, headers, completionHandler)
+        invokedPerformRequestParametersList.append((HTTPMethod, serially, path, requestBody, headers, completionHandler))
         if (shouldInvokeCompletion) {
             completionHandler?(stubbedCompletionStatusCode,
                                stubbedCompletionResponse,

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -16,6 +16,7 @@ import Purchases
 class BackendTests: XCTestCase {
     struct HTTPRequest {
         let HTTPMethod: String
+        let serially: Bool
         let path: String
         let body: [AnyHashable : Any]?
         let headers: [String: String]?
@@ -34,11 +35,20 @@ class BackendTests: XCTestCase {
 
         var shouldFinish = true
 
-        override func performRequest(_ HTTPMethod: String, path: String, body requestBody: [AnyHashable : Any]?, headers: [String : String]?, completionHandler: RCHTTPClientResponseHandler? = nil) {
+        override func performRequest(_ HTTPMethod: String,
+                                     serially: Bool,
+                                     path: String,
+                                     body requestBody: [AnyHashable : Any]?,
+                                     headers: [String : String]?,
+                                     completionHandler: RCHTTPClientResponseHandler? = nil) {
             assert(mocks[path] != nil, "Path " + path + " not mocked")
             let response = mocks[path]!
 
-            calls.append(HTTPRequest(HTTPMethod: HTTPMethod, path: path, body: requestBody, headers: headers))
+            calls.append(HTTPRequest(HTTPMethod: HTTPMethod,
+                                     serially: serially,
+                                     path: path,
+                                     body: requestBody,
+                                     headers: headers))
 
             if shouldFinish {
                 DispatchQueue.main.async {
@@ -105,7 +115,7 @@ class BackendTests: XCTestCase {
             completionCalled = true
         })
 
-        let expectedCall = HTTPRequest(HTTPMethod: "POST", path: "/receipts", body: [
+        let expectedCall = HTTPRequest(HTTPMethod: "POST", serially: true, path: "/receipts", body: [
             "app_user_id": userID,
             "fetch_token": receiptData.base64EncodedString(),
             "is_restore": isRestore,
@@ -374,7 +384,7 @@ class BackendTests: XCTestCase {
             "observer_mode": false
         ]
 
-        let expectedCall = HTTPRequest(HTTPMethod: "POST", path: "/receipts",
+        let expectedCall = HTTPRequest(HTTPMethod: "POST", serially: true, path: "/receipts",
                                        body: body , headers: ["Authorization": "Bearer " + apiKey])
 
         expect(self.httpClient.calls.count).to(equal(1))
@@ -1064,7 +1074,7 @@ class BackendTests: XCTestCase {
             ]
         ]
         
-        let expectedCall = HTTPRequest(HTTPMethod: "POST", path: "/receipts",
+        let expectedCall = HTTPRequest(HTTPMethod: "POST", serially: true, path: "/receipts",
                                        body: body , headers: ["Authorization": "Bearer " + apiKey])
         
         expect(self.httpClient.calls.count).to(equal(1))
@@ -1128,7 +1138,7 @@ class BackendTests: XCTestCase {
             ]
         ]
 
-        let expectedCall = HTTPRequest(HTTPMethod: "POST", path: "/offers",
+        let expectedCall = HTTPRequest(HTTPMethod: "POST", serially: true, path: "/offers",
                 body: body, headers: ["Authorization": "Bearer " + apiKey])
 
         expect(self.httpClient.calls.count).to(equal(1))

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -29,14 +29,14 @@ class HTTPClientTests: XCTestCase {
 
     func testCantPostABodyWithGet() {
         expect {
-            self.client.performRequest("GET", path: "/", body: Dictionary.init(),
+            self.client.performRequest("GET", serially: true, path: "/", body: Dictionary.init(),
                                        headers: nil, completionHandler: nil)
         }.to(raiseException())
     }
 
     func testUnrecognizedMethodFails() {
         expect {
-            self.client.performRequest("GE", path: "/", body: Dictionary.init(),
+            self.client.performRequest("GE", serially: true, path: "/", body: Dictionary.init(),
                                        headers: nil, completionHandler: nil)
             }.to(raiseException())
     }
@@ -51,7 +51,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
         }
 
-        self.client.performRequest("POST", path: path, body: Dictionary.init(),
+        self.client.performRequest("POST", serially: true, path: path, body: Dictionary.init(),
                                    headers: nil, completionHandler:nil)
 
         expect(hostCorrect).toEventually(equal(true), timeout: 1.0)
@@ -66,7 +66,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
         }
 
-        self.client.performRequest("POST", path: path, body: Dictionary.init(),
+        self.client.performRequest("POST", serially: true, path: path, body: Dictionary.init(),
                                    headers: ["test_header": "value"], completionHandler:nil)
 
         expect(headerPresent).toEventually(equal(true), timeout: 1.0)
@@ -81,7 +81,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
         }
 
-        self.client.performRequest("POST", path: path, body: Dictionary.init(),
+        self.client.performRequest("POST", serially: true, path: path, body: Dictionary.init(),
                                    headers: ["test_header": "value"], completionHandler:nil)
 
         expect(headerPresent).toEventually(equal(true), timeout: 1.0)
@@ -96,7 +96,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
         }
 
-        self.client.performRequest("POST", path: path, body: Dictionary.init(),
+        self.client.performRequest("POST", serially: true, path: path, body: Dictionary.init(),
                                    headers: ["test_header": "value"], completionHandler:nil)
 
         expect(headerPresent).toEventually(equal(true))
@@ -111,7 +111,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
         }
 
-        self.client.performRequest("POST", path: path, body: Dictionary.init(),
+        self.client.performRequest("POST", serially: true, path: path, body: Dictionary.init(),
                                    headers: ["test_header": "value"], completionHandler:nil)
 
         expect(headerPresent).toEventually(equal(true))
@@ -126,7 +126,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
         }
 
-        self.client.performRequest("POST", path: path, body: Dictionary.init(),
+        self.client.performRequest("POST", serially: true, path: path, body: Dictionary.init(),
                                    headers: ["test_header": "value"], completionHandler:nil)
 
         expect(headerPresent).toEventually(equal(true))
@@ -141,7 +141,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
         }
         
-        self.client.performRequest("POST", path: path, body: Dictionary.init(),
+        self.client.performRequest("POST", serially: true, path: path, body: Dictionary.init(),
                                    headers: nil, completionHandler:nil)
 
         expect(pathHit).toEventually(equal(true), timeout: 1.0)
@@ -157,7 +157,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
         }
 
-        self.client.performRequest(method, path: path, body: body, headers: nil, completionHandler:nil)
+        self.client.performRequest(method, serially: true, path: path, body: body, headers: nil, completionHandler:nil)
 
         expect(pathHit).toEventually(equal(true), timeout: 1.0)
     }
@@ -174,7 +174,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
         }
 
-        self.client.performRequest(method, path: path, body: body, headers: nil, completionHandler:nil)
+        self.client.performRequest(method, serially: true, path: path, body: body, headers: nil, completionHandler:nil)
 
         expect(pathHit).toEventually(equal(true))
     }
@@ -187,7 +187,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
         }
 
-        self.client.performRequest("GET", path: path, body: nil, headers: nil) { (status, data, error) in
+        self.client.performRequest("GET", serially: true, path: path, body: nil, headers: nil) { (status, data, error) in
             completionCalled = true
         }
 
@@ -205,7 +205,7 @@ class HTTPClientTests: XCTestCase {
             return response
         }
 
-        self.client.performRequest("GET", path: path, body: nil, headers: nil) { (status, data, responseError) in
+        self.client.performRequest("GET", serially: true, path: path, body: nil, headers: nil) { (status, data, responseError) in
             if let responseNSError = responseError as NSError? {
                 successFailed = (status >= 500
                                  && data == nil
@@ -230,7 +230,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: json.data(using: String.Encoding.utf8)!, statusCode:Int32(errorCode), headers:nil)
         }
 
-        self.client.performRequest("GET", path: path, body: nil, headers: nil) { (status, data, error) in
+        self.client.performRequest("GET", serially: true, path: path, body: nil, headers: nil) { (status, data, error) in
             correctResponse = (status == errorCode) && (data != nil) && (error == nil);
             if data != nil {
                 message = data!["message"] as! String?
@@ -252,7 +252,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: json.data(using: String.Encoding.utf8)!, statusCode:Int32(errorCode), headers:nil)
         }
 
-        self.client.performRequest("GET", path: path, body: nil, headers: nil) { (status, data, error) in
+        self.client.performRequest("GET", serially: true, path: path, body: nil, headers: nil) { (status, data, error) in
             correctResponse = (status == errorCode) && (data != nil) && (error == nil);
             if data != nil {
                 message = data!["message"] as! String?
@@ -273,7 +273,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: json.data(using: String.Encoding.utf8)!, statusCode:Int32(errorCode), headers:nil)
         }
 
-        self.client.performRequest("GET", path: path, body: nil, headers: nil) { (status, data, error) in
+        self.client.performRequest("GET", serially: true, path: path, body: nil, headers: nil) { (status, data, error) in
             correctResponse = (status == errorCode) && (data == nil) && (error != nil);
         }
 
@@ -291,7 +291,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: json.data(using: String.Encoding.utf8)!, statusCode:200, headers:nil)
         }
 
-        self.client.performRequest("GET", path: path, body: nil, headers: nil) { (status, data, error) in
+        self.client.performRequest("GET", serially: true, path: path, body: nil, headers: nil) { (status, data, error) in
             successIsTrue = (status == 200) && (error == nil);
             if data != nil {
                 message = data!["message"] as! String?
@@ -313,7 +313,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
         }
         
-        self.client.performRequest("POST", path: path, body: Dictionary.init(),
+        self.client.performRequest("POST", serially: true, path: path, body: Dictionary.init(),
                                    headers: ["test_header": "value"], completionHandler:nil)
         
         expect(headerPresent).toEventually(equal(true))
@@ -328,7 +328,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers:nil)
         }
 
-        self.client.performRequest("POST", path: path, body: Dictionary.init(),
+        self.client.performRequest("POST", serially: true, path: path, body: Dictionary.init(),
                                    headers: ["test_header": "value"], completionHandler:nil)
 
         expect(headerPresent).toEventually(equal(true))
@@ -347,7 +347,7 @@ class HTTPClientTests: XCTestCase {
                                       finishTransactions: true)
         let client = RCHTTPClient(systemInfo: systemInfo)
 
-        client.performRequest("POST", path: path, body: Dictionary.init(),
+        client.performRequest("POST", serially: true, path: path, body: Dictionary.init(),
                                    headers: ["test_header": "value"], completionHandler:nil)
 
         expect(headerPresent).toEventually(equal(true))
@@ -366,7 +366,7 @@ class HTTPClientTests: XCTestCase {
                                       finishTransactions: true)
         let client = RCHTTPClient(systemInfo: systemInfo)
 
-        client.performRequest("POST", path: path, body: Dictionary.init(),
+        client.performRequest("POST", serially: true, path: path, body: Dictionary.init(),
                                    headers: ["test_header": "value"], completionHandler:nil)
 
         expect(headerPresent).toEventually(equal(true))
@@ -383,7 +383,7 @@ class HTTPClientTests: XCTestCase {
         let systemInfo = RCSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: true)
         let client = RCHTTPClient(systemInfo: systemInfo)
 
-        client.performRequest("POST", path: path, body: Dictionary.init(),
+        client.performRequest("POST", serially: true, path: path, body: Dictionary.init(),
                                    headers: ["test_header": "value"], completionHandler:nil)
 
         expect(headerPresent).toEventually(equal(true))
@@ -400,7 +400,7 @@ class HTTPClientTests: XCTestCase {
         let systemInfo = RCSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: false)
         let client = RCHTTPClient(systemInfo: systemInfo)
 
-        client.performRequest("POST", path: path, body: Dictionary.init(),
+        client.performRequest("POST", serially: true, path: path, body: Dictionary.init(),
                                    headers: ["test_header": "value"], completionHandler:nil)
 
         expect(headerPresent).toEventually(equal(true))

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -419,6 +419,7 @@ class HTTPClientTests: XCTestCase {
 
             let json = "{\"message\": \"something is great up in the cloud\"}"
             return HTTPStubsResponse(data: json.data(using: String.Encoding.utf8)!, statusCode:200, headers:nil)
+                .responseTime(0.003)
         }
 
         let totalRequests = Int.random(in: 50..<100)
@@ -451,7 +452,7 @@ class HTTPClientTests: XCTestCase {
 
             let json = "{\"message\": \"something is great up in the cloud\"}"
             return HTTPStubsResponse(data: json.data(using: String.Encoding.utf8)!, statusCode:200, headers:nil)
-                .requestTime(0.1, responseTime: 0)
+                .responseTime(0.1)
         }
 
         self.client.performRequest("POST",
@@ -490,7 +491,7 @@ class HTTPClientTests: XCTestCase {
 
             let json = "{\"message\": \"something is great up in the cloud\"}"
             return HTTPStubsResponse(data: json.data(using: String.Encoding.utf8)!, statusCode:200, headers:nil)
-                .requestTime(0.1, responseTime: 0)
+                .responseTime(0.1)
         }
 
         self.client.performRequest("POST",

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -433,5 +433,84 @@ class HTTPClientTests: XCTestCase {
         }
         expect(completionCallCount).toEventually(equal(totalRequests))
     }
+
+    func testPerformSerialRequestWaitsUntilFirstRequestIsDoneBeforeStartingSecond() {
+        let path = "/a_random_path"
+        var firstRequestFinished = false
+        var secondRequestFinished = false
+
+        stub(condition: isPath("/v1" + path)) { request in
+            usleep(30)
+            let requestData = request.ohhttpStubs_httpBody!
+            let requestBodyDict = try! JSONSerialization.jsonObject(with: requestData, options: []) as! [String: Any]
+
+            let requestNumber = requestBodyDict["requestNumber"] as! Int
+            if requestNumber == 2 {
+                expect(firstRequestFinished) == true
+            }
+
+            let json = "{\"message\": \"something is great up in the cloud\"}"
+            return HTTPStubsResponse(data: json.data(using: String.Encoding.utf8)!, statusCode:200, headers:nil)
+                .requestTime(0.1, responseTime: 0)
+        }
+
+        self.client.performRequest("POST",
+                                   serially: true,
+                                   path: path,
+                                   body: ["requestNumber": 1],
+                                   headers: nil) { (status, data, error) in
+            firstRequestFinished = true
+        }
+
+        self.client.performRequest("POST",
+                                   serially: true,
+                                   path: path,
+                                   body: ["requestNumber": 2],
+                                   headers: nil) { (status, data, error) in
+            secondRequestFinished = true
+        }
+
+        expect(firstRequestFinished).toEventually(beTrue())
+        expect(secondRequestFinished).toEventually(beTrue())
+    }
+
+    func testPerformConcurrentRequestDoesntWaitUntilFirstRequestIsDoneBeforeStartingSecond() {
+        let path = "/a_random_path"
+        var firstRequestFinished = false
+        var secondRequestFinished = false
+
+        stub(condition: isPath("/v1" + path)) { request in
+            let requestData = request.ohhttpStubs_httpBody!
+            let requestBodyDict = try! JSONSerialization.jsonObject(with: requestData, options: []) as! [String: Any]
+
+            let requestNumber = requestBodyDict["requestNumber"] as! Int
+            if requestNumber == 2 {
+                expect(firstRequestFinished) == false
+            }
+
+            let json = "{\"message\": \"something is great up in the cloud\"}"
+            return HTTPStubsResponse(data: json.data(using: String.Encoding.utf8)!, statusCode:200, headers:nil)
+                .requestTime(0.1, responseTime: 0)
+        }
+
+        self.client.performRequest("POST",
+                                   serially: false,
+                                   path: path,
+                                   body: ["requestNumber": 1],
+                                   headers: nil) { (status, data, error) in
+            firstRequestFinished = true
+        }
+
+        self.client.performRequest("POST",
+                                   serially: false,
+                                   path: path,
+                                   body: ["requestNumber": 2],
+                                   headers: nil) { (status, data, error) in
+            secondRequestFinished = true
+        }
+
+        expect(firstRequestFinished).toEventually(beTrue())
+        expect(secondRequestFinished).toEventually(beTrue())
+    }
 }
 

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -867,7 +867,7 @@ class PurchasesTests: XCTestCase {
 
     func testSubscribesToUIApplicationDidBecomeActive() {
         setupPurchases()
-        expect(self.notificationCenter.observers.count).to(equal(3));
+        expect(self.notificationCenter.observers.count).to(equal(2));
         if self.notificationCenter.observers.count > 0 {
             let (_, _, name, _) = self.notificationCenter.observers[0];
             expect(name).to(equal(UIApplication.didBecomeActiveNotification))
@@ -896,7 +896,7 @@ class PurchasesTests: XCTestCase {
         setupPurchases()
         purchases!.delegate = nil
 
-        expect(self.notificationCenter.observers.count).to(equal(3));
+        expect(self.notificationCenter.observers.count).to(equal(2));
     }
 
     func testRestoringPurchasesPostsTheReceipt() {


### PR DESCRIPTION
Adds logic in `RCHTTPClient` so that it can perform requests either serially or in parallel. 
This works by keeping track of the request currently being performed (if any), and a queue of future requests, then when a serial request is finished, popping the queue and making the next request. 

Also solves the issues we had with 404s in attributes posts, since it fixes the order that the requests are performed in.

Adds a data class, `RCHTTPRequest`, as a convenience for making checks and passing information around. 

**Future work:** this does _not_ prevent duplicate requests in the queue. In order to do that correctly, we'd have to do something similar to what we're doing in `ProductsManager` and keep track of all completion blocks. 
I didn't want to go overboard and dive into something more complex yet, since this is already a good improvement over current behavior. 