### PR TITLE
Fix: cached purchaserInfo returned after invalidating purchaserInfo cache

### DIFF
--- a/Purchases/Caching/RCDeviceCache.h
+++ b/Purchases/Caching/RCDeviceCache.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)clearPurchaserInfoCacheTimestamp;
 
-- (void)clearPurchaserInfoCache;
+- (void)clearPurchaserInfoCacheForAppUserID:(NSString *)appUserID;
 
 - (void)setPurchaserInfoCacheTimestampToNow;
 

--- a/Purchases/Caching/RCDeviceCache.h
+++ b/Purchases/Caching/RCDeviceCache.h
@@ -37,6 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)clearPurchaserInfoCacheTimestamp;
 
+- (void)clearPurchaserInfoCache;
+
 - (void)setPurchaserInfoCacheTimestampToNow;
 
 #pragma mark - offerings

--- a/Purchases/Caching/RCDeviceCache.m
+++ b/Purchases/Caching/RCDeviceCache.m
@@ -138,10 +138,10 @@ NSString *RCAttributionDataDefaultsKeyBase = RC_CACHE_KEY_PREFIX @".attribution.
     self.purchaserInfoCachesLastUpdated = nil;
 }
 
-- (void)clearPurchaserInfoCache {
+- (void)clearPurchaserInfoCacheForAppUserID:(NSString *)appUserID {
     @synchronized (self) {
         [self clearPurchaserInfoCacheTimestamp];
-        [self.userDefaults removeObjectForKey:[self purchaserInfoUserDefaultCacheKeyForAppUserID:self.cachedAppUserID]];
+        [self.userDefaults removeObjectForKey:[self purchaserInfoUserDefaultCacheKeyForAppUserID:appUserID]];
     }
 }
 

--- a/Purchases/Caching/RCDeviceCache.m
+++ b/Purchases/Caching/RCDeviceCache.m
@@ -138,6 +138,13 @@ NSString *RCAttributionDataDefaultsKeyBase = RC_CACHE_KEY_PREFIX @".attribution.
     self.purchaserInfoCachesLastUpdated = nil;
 }
 
+- (void)clearPurchaserInfoCache {
+    @synchronized (self) {
+        [self clearPurchaserInfoCacheTimestamp];
+        [self.userDefaults dataForKey:[self purchaserInfoUserDefaultCacheKeyForAppUserID:self.cachedAppUserID]];
+    }
+}
+
 - (void)setPurchaserInfoCacheTimestampToNow {
     self.purchaserInfoCachesLastUpdated = [NSDate date];
 }

--- a/Purchases/Caching/RCDeviceCache.m
+++ b/Purchases/Caching/RCDeviceCache.m
@@ -141,7 +141,7 @@ NSString *RCAttributionDataDefaultsKeyBase = RC_CACHE_KEY_PREFIX @".attribution.
 - (void)clearPurchaserInfoCache {
     @synchronized (self) {
         [self clearPurchaserInfoCacheTimestamp];
-        [self.userDefaults dataForKey:[self purchaserInfoUserDefaultCacheKeyForAppUserID:self.cachedAppUserID]];
+        [self.userDefaults removeObjectForKey:[self purchaserInfoUserDefaultCacheKeyForAppUserID:self.cachedAppUserID]];
     }
 }
 

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -685,7 +685,7 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 
 - (void)invalidatePurchaserInfoCache {
     RCDebugLog(@"Purchaser info cache is invalidated");
-    [self.deviceCache clearPurchaserInfoCache];
+    [self.deviceCache clearPurchaserInfoCacheForAppUserID:self.appUserID];
 }
 
 #pragma mark Subcriber Attributes

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -685,7 +685,7 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 
 - (void)invalidatePurchaserInfoCache {
     RCDebugLog(@"Purchaser info cache is invalidated");
-    [self.deviceCache clearPurchaserInfoCacheTimestamp];
+    [self.deviceCache clearPurchaserInfoCache];
 }
 
 #pragma mark Subcriber Attributes

--- a/PurchasesTests/Mocks/MockDeviceCache.swift
+++ b/PurchasesTests/Mocks/MockDeviceCache.swift
@@ -197,4 +197,18 @@ class MockDeviceCache: RCDeviceCache {
         invokedDeleteAttributesIfSyncedParameters = (appUserID, ())
         invokedDeleteAttributesIfSyncedParametersList.append(appUserID)
     }
+
+
+    var invokedClearPurchaserInfoCache = false
+    var invokedClearPurchaserInfoCacheCount = 0
+    var invokedClearPurchaserInfoCacheParameters: (appUserID: String, Void)?
+    var invokedClearPurchaserInfoCacheParametersList = [(appUserID: String, Void)]()
+
+    override func clearPurchaserInfoCache(forAppUserID appUserID: String) {
+        cachedPurchaserInfo.removeValue(forKey: appUserID)
+        invokedClearPurchaserInfoCache = true
+        invokedClearPurchaserInfoCacheCount += 1
+        invokedClearPurchaserInfoCacheParameters = (appUserID, ())
+        invokedClearPurchaserInfoCacheParametersList.append((appUserID, ()))
+    }
 }


### PR DESCRIPTION
Fixes an issue where after calling `invalidatePurchaserInfoCache` and then `purchaserInfoWithCompletion`, the invalidated cached version of purchaserInfo would be returned first, and only the delegate would get the updated version. 

This is fixed by entirely removing the cached version from storage, so that the SDK forcibly only returns a new version, if communication with the backend succeeds. 