### PR TITLE
added new SKError codes

### DIFF
--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -198,11 +198,14 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
         #ifdef __IPHONE_14_0
             case SKErrorOverlayCancelled:
                 return RCPurchaseCancelledError;
-            case SKErrorOverlayInvalidConfiguration:
             case SKErrorIneligibleForOffer:
+                return RCPurchaseNotAllowedError;
+            #if !TARGET_OS_TV
+            case SKErrorOverlayInvalidConfiguration:
                 return RCPurchaseNotAllowedError;
             case SKErrorOverlayTimeout:
                 return RCStoreProblemError;
+            #endif
         #endif
         }
     }

--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -173,7 +173,8 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromRCBackendErrorCode(RCBackend
 
 static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
     if ([[skError domain] isEqualToString:SKErrorDomain]) {
-        switch ((SKErrorCode) skError.code) {
+        NSInteger code = (SKErrorCode) skError.code;
+        switch (code) {
             case SKErrorUnknown:
             case CODE_IF_TARGET_IPHONE(SKErrorCloudServiceNetworkConnectionFailed, 7): // Available on iOS 9.3
             case CODE_IF_TARGET_IPHONE(SKErrorCloudServiceRevoked, 8): // Available on iOS 10.3
@@ -194,6 +195,15 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
                 return RCPurchaseInvalidError;
             case CODE_IF_TARGET_IPHONE(SKErrorStoreProductNotAvailable, 5):
                 return RCProductNotAvailableForPurchaseError;
+        #ifdef __IPHONE_14_0
+            case SKErrorOverlayCancelled:
+                return RCPurchaseCancelledError;
+            case SKErrorOverlayInvalidConfiguration:
+            case SKErrorIneligibleForOffer:
+                return RCPurchaseNotAllowedError;
+            case SKErrorOverlayTimeout:
+                return RCStoreProblemError;
+        #endif
         }
     }
     return RCUnknownError;


### PR DESCRIPTION
Added the new SKError codes introduced with Xcode 12. 

Addresses https://github.com/RevenueCat/purchases-ios/issues/292

I'm using `#ifdef __IPHONE_14_0` as a proxy to check that the Xcode version is at least 12, and it works correctly in practice. 
A couple of the codes are not compatible specifically with Apple TV, so I added a check for those as well. 