### PR TITLE
improve migration process for legacy Mac App Store apps to Universal Store

### DIFF
--- a/Purchases/Misc/RCSystemInfo.h
+++ b/Purchases/Misc/RCSystemInfo.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, assign) BOOL finishTransactions;
 @property(nonatomic, copy, readonly) NSString *platformFlavor;
 @property(nonatomic, copy, readonly) NSString *platformFlavorVersion;
-
+@property(class, nonatomic, assign) BOOL forceUniversalAppStore;
 
 - (void)isApplicationBackgroundedWithCompletion:(void(^)(BOOL))completion; // calls completion on the main thread
 

--- a/Purchases/Misc/RCSystemInfo.m
+++ b/Purchases/Misc/RCSystemInfo.m
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 NSString *const defaultServerHostName = @"https://api.revenuecat.com";
 static NSURL * _Nullable proxyURL;
+static BOOL _forceUniversalAppStore = NO;
 
 - (instancetype)initWithPlatformFlavor:(nullable NSString *)platformFlavor
                  platformFlavorVersion:(nullable NSString *)platformFlavorVersion
@@ -61,7 +62,7 @@ static NSURL * _Nullable proxyURL;
 }
 
 + (NSString *)platformHeader {
-    return PLATFORM_HEADER;
+    return self.forceUniversalAppStore ? @"iOS" : PLATFORM_HEADER;
 }
 
 + (NSURL *)defaultServerHostURL {
@@ -74,6 +75,14 @@ static NSURL * _Nullable proxyURL;
 
 + (nullable NSURL *)proxyURL {
     return proxyURL;
+}
+
++ (BOOL)forceUniversalAppStore {
+    return _forceUniversalAppStore;
+}
+
++ (void)setForceUniversalAppStore:(BOOL)forceUniversalAppStore {
+    _forceUniversalAppStore = forceUniversalAppStore;
 }
 
 + (void)setProxyURL:(nullable NSURL *)newProxyURL {

--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -77,6 +77,12 @@ NS_SWIFT_NAME(Purchases)
 @property (class, nonatomic, copy, nullable) NSURL *proxyURL;
 
 /**
+ Set this property to true *only* if you're transitioning an existing Mac app from the Legacy Mac App Store
+ into the Universal Store, and you've configured your RevenueCat app accordingly. Contact support before using this.
+*/
+@property (class, nonatomic, assign) BOOL forceUniversalAppStore;
+
+/**
  Configures an instance of the Purchases SDK with a specified API key. The instance will be set as a singleton. You should access the singleton instance using [RCPurchases sharedPurchases]
 
  @note Use this initializer if your app does not have an account system. `RCPurchases` will generate a unique identifier for the current device and persist it to `NSUserDefaults`. This also affects the behavior of `restoreTransactionsForAppStoreAccount`.

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -108,6 +108,14 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
     RCSystemInfo.proxyURL = proxyURL;
 }
 
++ (BOOL)forceUniversalAppStore {
+    return RCSystemInfo.forceUniversalAppStore;
+}
+
++ (void)setForceUniversalAppStore:(BOOL)forceUniversalAppStore {
+    RCSystemInfo.forceUniversalAppStore = forceUniversalAppStore;
+}
+
 + (NSString *)frameworkVersion {
     return RCSystemInfo.frameworkVersion;
 }


### PR DESCRIPTION
We support Universal Purchases for Mac, but the migration path is a bit clunky right now. 

Our implementation allows for an app configured on the Dashboard to either be fully Universal or not, but it doesn't support having two versions of a Mac app, one for each store.
However, developers who have an existing Mac App may want their old (pre-universal purchases) version to live on a bit longer while they transition users into the new Mac app, and purchases for the old app should continue to work. 

Our workaround, previous to this PR, is to ask devs to: 
1. Have one version of the Mac app on the legacy store that uses the regular SDK
2. Have a new version of the Mac app, fork our repo, and override the value for `platformHeader` so that the backend interprets the new app as an iOS app (or Universal Store app, really), and correctly serves the universal offerings for it. 

This PR adds native support for it, so that instead of having to fork our repo, developers only need to update a static property on `Purchases`, similar to how they set `proxyURL` for kids apps. 
