### PR TITLE
fix issues on develop

### DIFF
--- a/Examples/SwiftExample/Podfile.lock
+++ b/Examples/SwiftExample/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Purchases (3.6.0-SNAPSHOT):
-    - PurchasesCoreSwift
-  - PurchasesCoreSwift (3.6.0-SNAPSHOT)
+  - Purchases (3.7.0-SNAPSHOT):
+    - PurchasesCoreSwift (= 3.7.0-SNAPSHOT)
+  - PurchasesCoreSwift (3.7.0-SNAPSHOT)
 
 DEPENDENCIES:
   - Purchases (from `../../`)
@@ -14,8 +14,8 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  Purchases: e3fcd9abe9f62befdd27e01d80507f5c2abfb090
-  PurchasesCoreSwift: 9d3843b7ce1032835428e0b5cb08296c6a74acb5
+  Purchases: 646df90239df1b8245395d7e15c5741ac1f15aed
+  PurchasesCoreSwift: 72df98f7f32ea1c646e8bdb25df3d71559cfeed2
 
 PODFILE CHECKSUM: abf85a7b493b4247cdd1f63fcaee462b025a5eed
 

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
-  s.dependency 'PurchasesCoreSwift', '3.6.0'
+  s.dependency 'PurchasesCoreSwift'
 
   s.source_files = ['Purchases/**/*.{h,m}']
   s.public_header_files = [

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
-  s.dependency 'PurchasesCoreSwift'
+  s.dependency 'PurchasesCoreSwift', '3.7.0-SNAPSHOT'
 
   s.source_files = ['Purchases/**/*.{h,m}']
   s.public_header_files = [

--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -200,10 +200,10 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
                 return RCPurchaseCancelledError;
             case SKErrorIneligibleForOffer:
                 return RCPurchaseNotAllowedError;
-            #if !TARGET_OS_TV
-            case SKErrorOverlayInvalidConfiguration:
+            #if TARGET_OS
+            case CODE_IF_TARGET_IPHONE(SKErrorOverlayInvalidConfiguration, 16):
                 return RCPurchaseNotAllowedError;
-            case SKErrorOverlayTimeout:
+            case CODE_IF_TARGET_IPHONE(SKErrorOverlayTimeout, 17):
                 return RCStoreProblemError;
             #endif
         #endif

--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -200,12 +200,10 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
                 return RCPurchaseCancelledError;
             case SKErrorIneligibleForOffer:
                 return RCPurchaseNotAllowedError;
-            #if TARGET_OS
             case CODE_IF_TARGET_IPHONE(SKErrorOverlayInvalidConfiguration, 16):
                 return RCPurchaseNotAllowedError;
             case CODE_IF_TARGET_IPHONE(SKErrorOverlayTimeout, 17):
                 return RCStoreProblemError;
-            #endif
         #endif
         }
     }

--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -200,10 +200,12 @@ static RCPurchasesErrorCode RCPurchasesErrorCodeFromSKError(NSError *skError) {
                 return RCPurchaseCancelledError;
             case SKErrorIneligibleForOffer:
                 return RCPurchaseNotAllowedError;
-            case CODE_IF_TARGET_IPHONE(SKErrorOverlayInvalidConfiguration, 16):
+            #if TARGET_OS_IOS
+            case SKErrorOverlayInvalidConfiguration:
                 return RCPurchaseNotAllowedError;
-            case CODE_IF_TARGET_IPHONE(SKErrorOverlayTimeout, 17):
+            case SKErrorOverlayTimeout:
                 return RCStoreProblemError;
+            #endif
         #endif
         }
     }


### PR DESCRIPTION
Fixes a couple of issues on develop: 

- in https://github.com/RevenueCat/purchases-ios/pull/334, I missed the fact that a couple of SKErrors weren't just unavailable on tvOS - they were unavailable everywhere except for iOS. Updated accordingly. 
- the `Purchases.podspec` file still depends on `PurchasesCoreSwift` 3.6.0, removed the number so that the version can be resolved correctly when running locally. 