### PR TITLE
release: 3.7.0

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -5,9 +5,9 @@ objc: true
 sdk: iphonesimulator
 module: Purchases
 umbrella_header: Purchases/Public/Purchases.h
-module_version: 3.7.0-SNAPSHOT
+module_version: 3.7.0
 github_url: https://github.com/revenuecat/purchases-ios
-github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.7.0-SNAPSHOT
+github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.7.0
 output: docs
 # Leaving this commented out. We used to specify this before, but now it's working without it
 # xcodebuild_arguments: [--objc,Purchases/Public/Purchases.h,--,-x,objective-c,-isysroot,$(xcrun --show-sdk-path),-I,$(pwd)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 3.7.0
+- Attribution V2
+    https://github.com/RevenueCat/purchases-ios/pull/321
+    https://github.com/RevenueCat/purchases-ios/pull/340
+    https://github.com/RevenueCat/purchases-ios/pull/331
+- Prevent unnecessary receipt posts
+    https://github.com/RevenueCat/purchases-ios/pull/323
+- Improved migration process for legacy Mac App Store apps moving to Universal Store 
+    https://github.com/RevenueCat/purchases-ios/pull/336
+- Added new SKError codes for Xcode 12
+    https://github.com/RevenueCat/purchases-ios/pull/334
+    https://github.com/RevenueCat/purchases-ios/pull/338
+- Renamed StoreKitConfig schemes
+    https://github.com/RevenueCat/purchases-ios/pull/329
+- Fixed an issue where cached purchaserInfo would be returned after invalidating purchaserInfo cache
+    https://github.com/RevenueCat/purchases-ios/pull/333
+- Fix cocoapods and carthage release scripts 
+    https://github.com/RevenueCat/purchases-ios/pull/324
+
 ## 3.6.0
 - Fixed a race condition with purchase completed callbacks
 	https://github.com/RevenueCat/purchases-ios/pull/313

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
     https://github.com/RevenueCat/purchases-ios/pull/333
 - Fix cocoapods and carthage release scripts 
     https://github.com/RevenueCat/purchases-ios/pull/324
+- Fixed a bug where `checkIntroTrialEligibility` wouldn't return when calling it from an OS version that didn't support intro offers
+    https://github.com/RevenueCat/purchases-ios/pull/343
 
 ## 3.6.0
 - Fixed a race condition with purchase completed callbacks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 3.7.0
-- Attribution V2
+- Attribution V2:
+        - Deprecated `addAttributionData:fromNetwork:` and `addAttributionData:fromNetwork:forNetworkUserId:` in favor of `setAdjustId`, `setAppsflyerId`, `setFbAnonymousId`, `setMparticleId`
+        - Added support for OneSignal via `setOnesignalId`
+        - Added `setMediaSource`, `setCampaign`, `setAdGroup`, `setAd`, `setKeyword`, `setCreative`, and `collectDeviceIdentifiers`
     https://github.com/RevenueCat/purchases-ios/pull/321
     https://github.com/RevenueCat/purchases-ios/pull/340
     https://github.com/RevenueCat/purchases-ios/pull/331

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Purchases"
-  s.version          = "3.7.0-SNAPSHOT"
+  s.version          = "3.7.0"
   s.summary          = "Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
-  s.dependency 'PurchasesCoreSwift', '3.7.0-SNAPSHOT'
+  s.dependency 'PurchasesCoreSwift', '3.7.0'
 
   s.source_files = ['Purchases/**/*.{h,m}']
   s.public_header_files = [

--- a/Purchases/Info.plist
+++ b/Purchases/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7.0-SNAPSHOT</string>
+	<string>3.7.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Purchases/Misc/RCSystemInfo.m
+++ b/Purchases/Misc/RCSystemInfo.m
@@ -48,7 +48,7 @@ static BOOL _forceUniversalAppStore = NO;
 }
 
 + (NSString *)frameworkVersion {
-    return @"3.7.0-SNAPSHOT";
+    return @"3.7.0";
 }
 
 + (NSString *)systemVersion {

--- a/PurchasesCoreSwift.podspec
+++ b/PurchasesCoreSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesCoreSwift"
-  s.version          = "3.7.0-SNAPSHOT"
+  s.version          = "3.7.0"
   s.summary          = "Swift portion of RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/PurchasesCoreSwift/Info.plist
+++ b/PurchasesCoreSwift/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7.0-SNAPSHOT</string>
+	<string>3.7.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/PurchasesCoreSwiftTests/Info.plist
+++ b/PurchasesCoreSwiftTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7.0-SNAPSHOT</string>
+	<string>3.7.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/PurchasesTests/Info.plist
+++ b/PurchasesTests/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7.0-SNAPSHOT</string>
+	<string>3.7.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -32,10 +32,15 @@ platform :ios do
     fail ArgumentError, "missing version" unless new_version_number
     previous_version_number = get_version_number(target: "Purchases")
     increment_version_number(version_number: new_version_number)
-    version_bump_podspec(version_number: new_version_number, path: "Purchases.podspec")
-    version_bump_podspec(version_number: new_version_number, path: "PurchasesCoreSwift.podspec")
-    increment_build_number(previous_version_number, new_version_number, '../Purchases/Misc/RCSystemInfo.m')
-    increment_build_number(previous_version_number, new_version_number, '../.jazzy.yaml')
+    files_to_update = [
+      '../PurchasesCoreSwift.podspec',
+      '../Purchases.podspec',
+      '../Purchases/Misc/RCSystemInfo.m',
+      '../.jazzy.yaml'
+    ]
+    for file_to_update in files_to_update
+      increment_build_number(previous_version_number, new_version_number, file_to_update)
+    end
   end
 
   desc "Increment build number and update changelog"


### PR DESCRIPTION
## 3.7.0
- Attribution V2:
        - Deprecated `addAttributionData:fromNetwork:` and `addAttributionData:fromNetwork:forNetworkUserId:` in favor of `setAdjustId`, `setAppsflyerId`, `setFbAnonymousId`, `setMparticleId`
        - Added support for OneSignal via `setOnesignalId`
        - Added `setMediaSource`, `setCampaign`, `setAdGroup`, `setAd`, `setKeyword`, `setCreative`, and `collectDeviceIdentifiers`
    https://github.com/RevenueCat/purchases-ios/pull/321
    https://github.com/RevenueCat/purchases-ios/pull/340
    https://github.com/RevenueCat/purchases-ios/pull/331
- Prevent unnecessary receipt posts
    https://github.com/RevenueCat/purchases-ios/pull/323
- Improved migration process for legacy Mac App Store apps moving to Universal Store 
    https://github.com/RevenueCat/purchases-ios/pull/336
- Added new SKError codes for Xcode 12
    https://github.com/RevenueCat/purchases-ios/pull/334
    https://github.com/RevenueCat/purchases-ios/pull/338
- Renamed StoreKitConfig schemes
    https://github.com/RevenueCat/purchases-ios/pull/329
- Fixed an issue where cached purchaserInfo would be returned after invalidating purchaserInfo cache
    https://github.com/RevenueCat/purchases-ios/pull/333
- Fix cocoapods and carthage release scripts 
    https://github.com/RevenueCat/purchases-ios/pull/324
- Fixed a bug where `checkIntroTrialEligibility` wouldn't return when calling it from an OS version that didn't support intro offers
    https://github.com/RevenueCat/purchases-ios/pull/343