### PR TITLE
fix intro eligibility not returning on old OS versions

### DIFF
--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -655,6 +655,13 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
                         }];
                     }
                 }];
+            } else {
+                [self.backend getIntroEligibilityForAppUserID:self.appUserID
+                                                  receiptData:data
+                                           productIdentifiers:productIdentifiers
+                                                   completion:^(NSDictionary<NSString *, RCIntroEligibility *> *_Nonnull result) {
+                                                       CALL_IF_SET_ON_MAIN_THREAD(receiveEligibility, result);
+                                                   }];
             }
         } else {
             [self.backend getIntroEligibilityForAppUserID:self.appUserID


### PR DESCRIPTION
Addresses https://github.com/RevenueCat/purchases-ios/issues/341

