### PR TITLE
version 3.7.1

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -5,9 +5,9 @@ objc: true
 sdk: iphonesimulator
 module: Purchases
 umbrella_header: Purchases/Public/Purchases.h
-module_version: 3.7.0
+module_version: 3.7.1
 github_url: https://github.com/revenuecat/purchases-ios
-github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.7.0
+github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.7.1
 output: docs
 # Leaving this commented out. We used to specify this before, but now it's working without it
 # xcodebuild_arguments: [--objc,Purchases/Public/Purchases.h,--,-x,objective-c,-isysroot,$(xcrun --show-sdk-path),-I,$(pwd)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.1
+-  Fix 'Invalid bundle' validation error when uploading builds to App Store using Carthage or binary
+    https://github.com/RevenueCat/purchases-ios/pull/346
+
 ## 3.7.0
 - Attribution V2:
         - Deprecated `addAttributionData:fromNetwork:` and `addAttributionData:fromNetwork:forNetworkUserId:` in favor of `setAdjustId`, `setAppsflyerId`, `setFbAnonymousId`, `setMparticleId`

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Purchases"
-  s.version          = "3.7.0"
+  s.version          = "3.7.1"
   s.summary          = "Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
-  s.dependency 'PurchasesCoreSwift', '3.7.0'
+  s.dependency 'PurchasesCoreSwift', '3.7.1'
 
   s.source_files = ['Purchases/**/*.{h,m}']
   s.public_header_files = [

--- a/Purchases/Info.plist
+++ b/Purchases/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7.0</string>
+	<string>3.7.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Purchases/Misc/RCSystemInfo.m
+++ b/Purchases/Misc/RCSystemInfo.m
@@ -48,7 +48,7 @@ static BOOL _forceUniversalAppStore = NO;
 }
 
 + (NSString *)frameworkVersion {
-    return @"3.7.0";
+    return @"3.7.1";
 }
 
 + (NSString *)systemVersion {

--- a/PurchasesCoreSwift.podspec
+++ b/PurchasesCoreSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesCoreSwift"
-  s.version          = "3.7.0"
+  s.version          = "3.7.1"
   s.summary          = "Swift portion of RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/PurchasesCoreSwift/Info.plist
+++ b/PurchasesCoreSwift/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7.0</string>
+	<string>3.7.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/PurchasesCoreSwiftTests/Info.plist
+++ b/PurchasesCoreSwiftTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7.0</string>
+	<string>3.7.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/PurchasesTests/Info.plist
+++ b/PurchasesTests/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7.0</string>
+	<string>3.7.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
## 3.7.1
-  Fix 'Invalid bundle' validation error when uploading builds to App Store using Carthage or binary
    https://github.com/RevenueCat/purchases-ios/pull/346
