### PR TITLE
Fix build issues in hybrid sdks

### DIFF
--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -23,6 +23,8 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.dependency 'PurchasesCoreSwift', '3.8.0-SNAPSHOT'
+  s.static_framework = true
+
 
   s.source_files = ['Purchases/**/*.{h,m}']
   s.public_header_files = [

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -115,7 +115,7 @@
 		37E351B84EBE06E2F370A835 /* RCISOPeriodFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E35CC6289D46E544F5F006 /* RCISOPeriodFormatter.m */; };
 		37E351E3AC0B5F67305B4CB6 /* DeviceCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35D87B7E6F91E27E98F42 /* DeviceCacheTests.swift */; };
 		37E351F90612047842AFF1A6 /* ProductInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E350E57B0A393455A72B40 /* ProductInfoTests.swift */; };
-		37E352039F075299CD4CF6B0 /* RCHTTPRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35B76B22E9086A5BABECB /* RCHTTPRequest.h */; };
+		37E352039F075299CD4CF6B0 /* RCHTTPRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35B76B22E9086A5BABECB /* RCHTTPRequest.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E3524628A1D7568679FEE2 /* SusbcriberAttributesManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3567E972B9B04FE079ABA /* SusbcriberAttributesManagerTests.swift */; };
 		37E3524CB70618E6C5F3DB49 /* MockPurchasesDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35838A7FD36982EE14100 /* MockPurchasesDelegate.swift */; };
 		37E352897F7CB3A122F9739F /* PurchasesSubscriberAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3508E52201122137D4B4A /* PurchasesSubscriberAttributesTests.swift */; };
@@ -1102,8 +1102,8 @@
 				37E35312E13F08FD8C7CC275 /* RCProductInfo.h in Headers */,
 				3589D15624C21DBD00A65CBB /* RCAttributionFetcher+Protected.h in Headers */,
 				37E357301A5D15C0E90C9BD3 /* RCProductInfoExtractor.h in Headers */,
-				37E35A328C4DC8A4D2DB4B06 /* RCAttributionNetwork.h in Headers */,
 				37E352039F075299CD4CF6B0 /* RCHTTPRequest.h in Headers */,
+				37E35A328C4DC8A4D2DB4B06 /* RCAttributionNetwork.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -8,11 +8,9 @@
 
 #import <Foundation/Foundation.h>
 
-#import "RCOffering.h"
-#import "RCOfferings.h"
 #import "RCAttributionNetwork.h"
 
-@class SKProduct, SKPayment, SKPaymentTransaction, SKPaymentDiscount, SKProductDiscount, RCPurchaserInfo, RCIntroEligibility;
+@class SKProduct, SKPayment, SKPaymentTransaction, SKPaymentDiscount, SKProductDiscount, RCPurchaserInfo, RCIntroEligibility, RCOfferings, RCOffering, RCPackage;
 @protocol RCPurchasesDelegate;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.m
+++ b/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.m
@@ -9,6 +9,8 @@
 #import "RCCrossPlatformSupport.h"
 #import "RCLogUtils.h"
 #import "NSError+RCExtensions.h"
+#import "RCOffering.h"
+#import "RCOfferings.h"
 @import PurchasesCoreSwift;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/PurchasesCoreSwift.podspec
+++ b/PurchasesCoreSwift.podspec
@@ -20,6 +20,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.12'
   s.watchos.deployment_target = '6.2'
   s.tvos.deployment_target = '9.0'
+  s.static_framework = true
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 


### PR DESCRIPTION
This is part 1 of fixing build issues for cocoapods projects in hybrid sdks. 
Fixes: 

- makes the `Purchases` and `PurchasesCoreSwift` frameworks static. This means that other frameworks built from them will need to be static as well, since this is a cocoapods restriction. 
- replaced a couple of imports in `RCPurchases.h` with forward declarations, which is the way they should be done. This might also prevent issues with `RCPurchases.h` not being a modular header. 
- Moves `RCHTTPClient` from `Project` to `Private`. This is unrelated, but I missed this when writing it. 

Should address https://github.com/RevenueCat/purchases-flutter/issues/99
