### PR TITLE
fix: receipt parser crash with unexpected number of attributes

### DIFF
--- a/PurchasesCoreSwift/LocalReceiptParsing/Builders/InAppPurchaseBuilder.swift
+++ b/PurchasesCoreSwift/LocalReceiptParsing/Builders/InAppPurchaseBuilder.swift
@@ -35,7 +35,9 @@ class InAppPurchaseBuilder {
         var promotionalOfferIdentifier: String?
 
         for internalContainer in container.internalContainers {
-            guard internalContainer.internalContainers.count == expectedInternalContainersCount else { fatalError() }
+            guard internalContainer.internalContainers.count == expectedInternalContainersCount else {
+                throw ReceiptReadingError.inAppPurchaseParsingError
+            }
             let typeContainer = internalContainer.internalContainers[typeContainerIndex]
             let valueContainer = internalContainer.internalContainers[attributeTypeContainerIndex]
 

--- a/PurchasesCoreSwiftTests/LocalReceiptParsing/Builders/InAppPurchaseBuilderTests.swift
+++ b/PurchasesCoreSwiftTests/LocalReceiptParsing/Builders/InAppPurchaseBuilderTests.swift
@@ -36,6 +36,17 @@ class InAppPurchaseBuilderTests: XCTestCase {
         let sampleReceiptContainer = sampleInAppPurchaseContainerWithMinimalAttributes()
         expect { try self.inAppPurchaseBuilder.build(fromContainer: sampleReceiptContainer) }.notTo(throwError())
     }
+    
+    func testBuildThrowsIfUnexpectedNumberOfInternalContainers() {
+        let typeContainer = containerFactory.intContainer(int: 1)
+        let versionContainer = containerFactory.intContainer(int: 1)
+        let valueContainer = containerFactory.constructedContainer(containers: [containerFactory.stringContainer(string: "test")])
+        let unexpectedContainer = containerFactory.intContainer(int: 2)
+        
+        let inAppPurchaseContainer = containerFactory.constructedContainer(containers: [typeContainer, versionContainer, valueContainer, unexpectedContainer])
+        
+        expect { try self.inAppPurchaseBuilder.build(fromContainer: inAppPurchaseContainer) }.to(throwError())
+    }
 
     func testBuildGetsCorrectQuantity() {
         let sampleInAppPurchaseContainer = sampleInAppPurchaseContainerWithMinimalAttributes()
@@ -137,7 +148,7 @@ class InAppPurchaseBuilderTests: XCTestCase {
         ])
         expect { try self.inAppPurchaseBuilder.build(fromContainer: inAppPurchaseContainer) }.to(throwError())
     }
-
+    
     func testBuildThrowsIfProductIdIsMissing() {
         let inAppPurchaseContainer = containerFactory.inAppPurchaseContainerFromContainers(containers: [
             quantityContainer(),

--- a/PurchasesCoreSwiftTests/LocalReceiptParsing/Builders/InAppPurchaseBuilderTests.swift
+++ b/PurchasesCoreSwiftTests/LocalReceiptParsing/Builders/InAppPurchaseBuilderTests.swift
@@ -148,7 +148,7 @@ class InAppPurchaseBuilderTests: XCTestCase {
         ])
         expect { try self.inAppPurchaseBuilder.build(fromContainer: inAppPurchaseContainer) }.to(throwError())
     }
-    
+
     func testBuildThrowsIfProductIdIsMissing() {
         let inAppPurchaseContainer = containerFactory.inAppPurchaseContainerFromContainers(containers: [
             quantityContainer(),

--- a/PurchasesCoreSwiftTests/TestHelpers/ContainerFactory.swift
+++ b/PurchasesCoreSwiftTests/TestHelpers/ContainerFactory.swift
@@ -117,22 +117,22 @@ class ContainerFactory {
         let typeContainer = intContainer(int: attributeType.rawValue)
         let versionContainer = intContainer(int: 1)
         let valueContainer = constructedContainer(containers: [stringContainer(string: string)])
-
+        
         return constructedContainer(containers: [typeContainer, versionContainer, valueContainer])
     }
-
+    
     func receiptContainerFromContainers(containers: [ASN1Container]) -> ASN1Container {
         let attributesContainer = constructedContainer(containers: containers)
 
         let receiptWrapper = constructedContainer(containers: [attributesContainer],
-                                                       encodingType: .primitive)
+                                                  encodingType: .primitive)
         return constructedContainer(containers: [receiptWrapper],
-                                         encodingType: .constructed)
+                                    encodingType: .constructed)
     }
-
+    
     func inAppPurchaseContainerFromContainers(containers: [ASN1Container]) -> ASN1Container {
         return constructedContainer(containers: containers,
-                                         encodingType: .constructed)
+                                    encodingType: .constructed)
     }
 
     func objectIdentifierContainer(_ objectIdentifier: ASN1ObjectIdentifier) -> ASN1Container {
@@ -157,8 +157,8 @@ private extension ContainerFactory {
 
     func headerBytes(forContainer container: ASN1Container) -> [UInt8] {
         let identifierHeader = (container.containerClass.rawValue << 6
-            | container.encodingType.rawValue << 5
-            | container.containerIdentifier.rawValue)
+                                    | container.encodingType.rawValue << 5
+                                    | container.containerIdentifier.rawValue)
         if container.length.value < 128 {
             return [identifierHeader] + [UInt8(container.length.value)]
         } else {

--- a/PurchasesCoreSwiftTests/TestHelpers/ContainerFactory.swift
+++ b/PurchasesCoreSwiftTests/TestHelpers/ContainerFactory.swift
@@ -129,7 +129,7 @@ class ContainerFactory {
         return constructedContainer(containers: [receiptWrapper],
                                     encodingType: .constructed)
     }
-    
+
     func inAppPurchaseContainerFromContainers(containers: [ASN1Container]) -> ASN1Container {
         return constructedContainer(containers: containers,
                                     encodingType: .constructed)

--- a/PurchasesCoreSwiftTests/TestHelpers/ContainerFactory.swift
+++ b/PurchasesCoreSwiftTests/TestHelpers/ContainerFactory.swift
@@ -117,10 +117,10 @@ class ContainerFactory {
         let typeContainer = intContainer(int: attributeType.rawValue)
         let versionContainer = intContainer(int: 1)
         let valueContainer = constructedContainer(containers: [stringContainer(string: string)])
-        
+
         return constructedContainer(containers: [typeContainer, versionContainer, valueContainer])
     }
-    
+
     func receiptContainerFromContainers(containers: [ASN1Container]) -> ASN1Container {
         let attributesContainer = constructedContainer(containers: containers)
 


### PR DESCRIPTION
Attempt at fixing https://github.com/RevenueCat/purchases-ios/issues/358

If an in-app purchase container inside a receipt as an unexpected number of internal containers, the app will crash. 
The expected number of containers is exactly 3: type, version and value. But if for whatever reason that's not the case, the current code will crash with a `fatalError()`, which can't be caught by `try`. 

This is a problem, since this could be caused by a corrupt receipt file, but won't be recoverable. 
Fixed by replacing the `fatalError` with a custom exception. I missed this one when replacing all fatalErrors with custom exceptions initially. 
