### PR TITLE
Add jitter and extra cache for background processes

### DIFF
--- a/Purchases/Caching/RCDeviceCache.h
+++ b/Purchases/Caching/RCDeviceCache.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)cachePurchaserInfo:(NSData *)data forAppUserID:(NSString *)appUserID;
 
-- (BOOL)isPurchaserInfoCacheStale;
+- (BOOL)isPurchaserInfoCacheStaleWithIsAppBackgrounded:(BOOL)isAppBackgrounded;
 
 - (void)clearPurchaserInfoCacheTimestamp;
 
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)cacheOfferings:(RCOfferings *)offerings;
 
-- (BOOL)isOfferingsCacheStale;
+- (BOOL)isOfferingsCacheStaleWithIsAppBackgrounded:(BOOL)isAppBackgrounded;
 
 - (void)clearOfferingsCacheTimestamp;
 

--- a/Purchases/Caching/RCDeviceCache.h
+++ b/Purchases/Caching/RCDeviceCache.h
@@ -33,13 +33,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)cachePurchaserInfo:(NSData *)data forAppUserID:(NSString *)appUserID;
 
-- (BOOL)isPurchaserInfoCacheStaleWithIsAppBackgrounded:(BOOL)isAppBackgrounded;
+- (BOOL)isPurchaserInfoCacheStaleForAppUserID:(NSString *)appUserID isAppBackgrounded:(BOOL)isAppBackgrounded;
 
-- (void)clearPurchaserInfoCacheTimestamp;
+- (void)clearPurchaserInfoCacheTimestampForAppUserID:(NSString *)appUserID;
 
 - (void)clearPurchaserInfoCacheForAppUserID:(NSString *)appUserID;
 
-- (void)setPurchaserInfoCacheTimestampToNow;
+- (void)setPurchaserInfoCacheTimestampToNowForAppUserID:(NSString *)appUserID;
 
 #pragma mark - offerings
 

--- a/Purchases/Caching/RCDeviceCache.m
+++ b/Purchases/Caching/RCDeviceCache.m
@@ -163,7 +163,8 @@ int cacheDurationInSecondsInBackground = 60 * 60 * 24;
 }
 
 - (nullable NSDate *)purchaserInfoCachesLastUpdatedForAppUserID:(NSString *)appUserID {
-    return (NSDate*)[self.userDefaults objectForKey:[self purchaserInfoLastUpdatedCacheKeyForAppUserID:appUserID]];
+    NSString *cacheKey = [self purchaserInfoLastUpdatedCacheKeyForAppUserID:appUserID];
+    return (NSDate * _Nullable) [self.userDefaults objectForKey:cacheKey];
 }
 
 - (NSString *)purchaserInfoUserDefaultCacheKeyForAppUserID:(NSString *)appUserID {

--- a/Purchases/Caching/RCDeviceCache.m
+++ b/Purchases/Caching/RCDeviceCache.m
@@ -128,9 +128,12 @@ int cacheDurationInSecondsInBackground = 60 * 60 * 24;
 
 - (BOOL)isPurchaserInfoCacheStaleForAppUserID:(NSString *)appUserID isAppBackgrounded:(BOOL)isAppBackgrounded {
     NSDate * _Nullable purchaserInfoCachesLastUpdated = [self purchaserInfoCachesLastUpdatedForAppUserID:appUserID];
+    if (!purchaserInfoCachesLastUpdated) {
+        return YES;
+    }
     NSTimeInterval timeSinceLastCheck = -[purchaserInfoCachesLastUpdated timeIntervalSinceNow];
     int cacheDurationInSeconds = [self cacheDurationInSecondsWithIsAppBackgrounded:isAppBackgrounded];
-    return !(purchaserInfoCachesLastUpdated != nil && timeSinceLastCheck < cacheDurationInSeconds);
+    return timeSinceLastCheck >= cacheDurationInSeconds;
 }
 
 - (int)cacheDurationInSecondsWithIsAppBackgrounded:(BOOL)isAppBackgrounded {

--- a/Purchases/Caching/RCDeviceCache.m
+++ b/Purchases/Caching/RCDeviceCache.m
@@ -151,8 +151,12 @@ int cacheDurationInSecondsInBackground = 60 * 60 * 24;
 }
 
 - (void)setPurchaserInfoCacheTimestampToNowForAppUserID:(NSString *)appUserID {
+    [self setPurchaserInfoCacheTimestamp:[NSDate date] forAppUserID:appUserID];
+}
+
+- (void)setPurchaserInfoCacheTimestamp:(NSDate *)timestamp forAppUserID:(NSString *)appUserID {
     NSString *cacheKey = [self purchaserInfoLastUpdatedCacheKeyForAppUserID:appUserID];
-    [self.userDefaults setObject:[NSDate date] forKey:cacheKey];
+    [self.userDefaults setObject:timestamp forKey:cacheKey];
 }
 
 - (nullable NSDate *)purchaserInfoCachesLastUpdatedForAppUserID:(NSString *)appUserID {

--- a/Purchases/Caching/RCInMemoryCachedObject.h
+++ b/Purchases/Caching/RCInMemoryCachedObject.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RCInMemoryCachedObject<ObjectType: id<NSObject>> : NSObject
 
-- (BOOL)isCacheStale;
+- (BOOL)isCacheStaleWithDurationInSeconds:(int)durationInSeconds;
 
 - (void)clearCacheTimestamp;
 
@@ -21,10 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)cacheInstance:(ObjectType)instance;
 
 - (nullable ObjectType)cachedInstance;
-
-- (instancetype)init NS_UNAVAILABLE;
-
-- (instancetype)initWithCacheDurationInSeconds:(int)cacheDurationInSeconds;
 
 @end
 

--- a/Purchases/Caching/RCInMemoryCachedObject.m
+++ b/Purchases/Caching/RCInMemoryCachedObject.m
@@ -16,7 +16,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RCInMemoryCachedObject ()
 
 @property (nonatomic, nullable) NSDate *lastUpdatedAt;
-@property (nonatomic, assign) int cacheDurationInSeconds;
 @property (nonatomic, nullable) id cachedInstance;
 
 @end
@@ -24,20 +23,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation RCInMemoryCachedObject
 
-- (instancetype)initWithCacheDurationInSeconds:(int)cacheDurationInSeconds {
-    if (self = [super init]) {
-        self.cacheDurationInSeconds = cacheDurationInSeconds;
-    }
-    return self;
-}
-
-- (BOOL)isCacheStale {
+- (BOOL)isCacheStaleWithDurationInSeconds:(int)durationInSeconds {
     if (self.lastUpdatedAt == nil) {
         return YES;
     }
 
     NSTimeInterval timeSinceLastCheck = -1 * [self.lastUpdatedAt timeIntervalSinceNow];
-    return timeSinceLastCheck >= self.cacheDurationInSeconds;
+    return timeSinceLastCheck >= durationInSeconds;
 }
 
 - (void)clearCacheTimestamp {

--- a/Purchases/ProtectedExtensions/RCDeviceCache+Protected.h
+++ b/Purchases/ProtectedExtensions/RCDeviceCache+Protected.h
@@ -13,6 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RCDeviceCache (Protected)
 
+- (void)setPurchaserInfoCacheTimestamp:(NSDate *)timestamp forAppUserID:(NSString *)appUserID;
+
 - (nullable instancetype)initWith:(nullable NSUserDefaults *)userDefaults
             offeringsCachedObject:(nullable RCInMemoryCachedObject<RCOfferings *> *)offeringsCachedObject
                notificationCenter:(nullable NSNotificationCenter *)notificationCenter;

--- a/Purchases/ProtectedExtensions/RCDeviceCache+Protected.h
+++ b/Purchases/ProtectedExtensions/RCDeviceCache+Protected.h
@@ -13,8 +13,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RCDeviceCache (Protected)
 
-@property (nonatomic, nullable) NSDate *purchaserInfoCachesLastUpdated;
-
 - (nullable instancetype)initWith:(nullable NSUserDefaults *)userDefaults
             offeringsCachedObject:(nullable RCInMemoryCachedObject<RCOfferings *> *)offeringsCachedObject
                notificationCenter:(nullable NSNotificationCenter *)notificationCenter;

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -880,8 +880,8 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
     [self.deviceCache setPurchaserInfoCacheTimestampToNowForAppUserID:appUserID];
     [self.operationDispatcher dispatchOnWorkerThreadWithRandomDelay:isAppBackgrounded block:^{
         [self.backend getSubscriberDataWithAppUserID:appUserID
-                                          completion:^(RCPurchaserInfo *_Nullable info,
-                                                       NSError *_Nullable error) {
+                                          completion:^(RCPurchaserInfo * _Nullable info,
+                                                       NSError * _Nullable error) {
                                               if (error == nil) {
                                                   [self cachePurchaserInfo:info forAppUserID:appUserID];
                                                   [self sendUpdatedPurchaserInfoToDelegateIfChanged:info];

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -536,11 +536,12 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
     if (!self.finishTransactions) {
         RCDebugLog(@"makePurchase - Observer mode is active (finishTransactions is set to false) and makePurchase has been called. Are you sure you want to do this?");
     }
-    payment.applicationUsername = self.appUserID;
+    NSString *appUserID = self.appUserID;
+    payment.applicationUsername = appUserID;
 
     // This is to prevent the UIApplicationDidBecomeActive call from the purchase popup
     // from triggering a refresh.
-    [self.deviceCache setPurchaserInfoCacheTimestampToNow];
+    [self.deviceCache setPurchaserInfoCacheTimestampToNowForAppUserID:appUserID];
     [self.deviceCache setOfferingsCacheTimestampToNow];
 
     if (presentedOfferingIdentifier) {

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -425,10 +425,12 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
     if (infoFromCache) {
         RCDebugLog(@"Vending purchaserInfo from cache");
         CALL_IF_SET_ON_MAIN_THREAD(completion, infoFromCache, nil);
-        if ([self.deviceCache isPurchaserInfoCacheStale]) {
-            RCDebugLog(@"Cache is stale, updating caches");
-            [self fetchAndCachePurchaserInfoWithCompletion:nil];
-        }
+        [self.systemInfo isApplicationBackgroundedWithCompletion:^(BOOL isAppBackgrounded) {
+            if ([self.deviceCache isPurchaserInfoCacheStaleWithIsAppBackgrounded:isAppBackgrounded]) {
+                RCDebugLog(@"Cache is stale, updating caches");
+                [self fetchAndCachePurchaserInfoWithCompletion:nil];
+            }
+        }];
     } else {
         RCDebugLog(@"No cached purchaser info, fetching");
         [self fetchAndCachePurchaserInfoWithCompletion:completion];
@@ -821,14 +823,16 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 
 - (void)updateAllCachesIfNeeded {
     RCDebugLog(@"applicationDidBecomeActive");
-    if ([self.deviceCache isPurchaserInfoCacheStale]) {
-        RCDebugLog(@"PurchaserInfo cache is stale, updating caches");
-        [self fetchAndCachePurchaserInfoWithCompletion:nil];
-    }
-    if ([self.deviceCache isOfferingsCacheStale]) {
-        RCDebugLog(@"Offerings cache is stale, updating caches");
-        [self updateOfferingsCache:nil];
-    }
+    [self.systemInfo isApplicationBackgroundedWithCompletion:^(BOOL isAppBackgrounded) {
+        if ([self.deviceCache isPurchaserInfoCacheStaleWithIsAppBackgrounded:isAppBackgrounded]) {
+            RCDebugLog(@"PurchaserInfo cache is stale, updating caches");
+            [self fetchAndCachePurchaserInfoWithCompletion:nil];
+        }
+        if ([self.deviceCache isOfferingsCacheStaleWithIsAppBackgrounded:isAppBackgrounded]) {
+            RCDebugLog(@"Offerings cache is stale, updating caches");
+            [self updateOfferingsCache:nil];
+        }
+    }];
 }
 
 - (RCPurchaserInfo *)readPurchaserInfoFromCache {
@@ -897,10 +901,12 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
     if (self.deviceCache.cachedOfferings) {
         RCDebugLog(@"Vending offerings from cache");
         CALL_IF_SET_ON_MAIN_THREAD(completion, self.deviceCache.cachedOfferings, nil);
-        if (self.deviceCache.isOfferingsCacheStale) {
-            RCDebugLog(@"Offerings cache is stale, updating cache");
-            [self updateOfferingsCache:nil];
-        }
+        [self.systemInfo isApplicationBackgroundedWithCompletion:^(BOOL isAppBackgrounded) {
+            if ([self.deviceCache isOfferingsCacheStaleWithIsAppBackgrounded:isAppBackgrounded]) {
+                RCDebugLog(@"Offerings cache is stale, updating cache");
+                [self updateOfferingsCache:nil];
+            }
+        }];
     } else {
         RCDebugLog(@"No cached offerings, fetching");
         [self updateOfferingsCache:completion];

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -299,7 +299,7 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 
         [self.systemInfo isApplicationBackgroundedWithCompletion:^(BOOL isBackgrounded) {
             if (!isBackgrounded) {
-                [self.operationDispatcher dispatchOnWorkerThreadWithRandomDelay:NO :^{
+                [self.operationDispatcher dispatchOnWorkerThreadWithRandomDelay:NO block:^{
                     [self updateAllCachesWithCompletionBlock:callDelegate];
                 }];
             } else {
@@ -878,7 +878,7 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
                                isAppBackgrounded:(BOOL)isAppBackgrounded {
     NSString *appUserID = self.identityManager.currentAppUserID;
     [self.deviceCache setPurchaserInfoCacheTimestampToNowForAppUserID:appUserID];
-    [self.operationDispatcher dispatchOnWorkerThreadWithRandomDelay:isAppBackgrounded :^{
+    [self.operationDispatcher dispatchOnWorkerThreadWithRandomDelay:isAppBackgrounded block:^{
         [self.backend getSubscriberDataWithAppUserID:appUserID
                                           completion:^(RCPurchaserInfo *_Nullable info,
                                                        NSError *_Nullable error) {
@@ -921,7 +921,7 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 
 - (void)updateOfferingsCache:(nullable RCReceiveOfferingsBlock)completion isAppBackgrounded:(BOOL)isAppBackgrounded {
     [self.deviceCache setOfferingsCacheTimestampToNow];
-    [self.operationDispatcher dispatchOnWorkerThreadWithRandomDelay:isAppBackgrounded :^{
+    [self.operationDispatcher dispatchOnWorkerThreadWithRandomDelay:isAppBackgrounded block:^{
         [self.backend getOfferingsForAppUserID:self.appUserID
                                     completion:^(NSDictionary *data, NSError *error) {
                                         if (error != nil) {

--- a/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.m
+++ b/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.m
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)syncSubscriberAttributesIfNeeded {
-    [self.operationDispatcher dispatchOnWorkerThreadWithRandomDelay:NO :^{
+    [self.operationDispatcher dispatchOnWorkerThreadWithRandomDelay:NO block:^{
         [self.subscriberAttributesManager syncAttributesForAllUsersWithCurrentAppUserID:self.appUserID];
     }];
 }

--- a/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.m
+++ b/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.m
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)syncSubscriberAttributesIfNeeded {
-    [self.operationDispatcher dispatchOnWorkerThread:^{
+    [self.operationDispatcher dispatchOnWorkerThreadWithRandomDelay:NO :^{
         [self.subscriberAttributesManager syncAttributesForAllUsersWithCurrentAppUserID:self.appUserID];
     }];
 }

--- a/PurchasesCoreSwift/Misc/OperationDispatcher.swift
+++ b/PurchasesCoreSwift/Misc/OperationDispatcher.swift
@@ -12,7 +12,7 @@ import Foundation
     
     private let mainQueue: DispatchQueue
     private let workerQueue: DispatchQueue
-    private let maxJitterInSeconds: Double = 1
+    private let maxJitterInSeconds: Double = 5
     
     @objc public override init() {
         mainQueue = DispatchQueue.main

--- a/PurchasesCoreSwift/Misc/OperationDispatcher.swift
+++ b/PurchasesCoreSwift/Misc/OperationDispatcher.swift
@@ -28,7 +28,7 @@ import Foundation
     }
 
     @objc public func dispatchOnWorkerThread(withRandomDelay: Bool = false,
-                                             _ block: @escaping () -> ()) {
+                                             block: @escaping () -> ()) {
         if withRandomDelay {
             let delay = Double.random(in: 0..<maxJitterInSeconds)
             workerQueue.asyncAfter(deadline: .now() + delay) { block() }

--- a/PurchasesCoreSwift/Misc/OperationDispatcher.swift
+++ b/PurchasesCoreSwift/Misc/OperationDispatcher.swift
@@ -12,6 +12,7 @@ import Foundation
     
     private let mainQueue: DispatchQueue
     private let workerQueue: DispatchQueue
+    private let maxJitterInSeconds: Double = 1
     
     @objc public override init() {
         mainQueue = DispatchQueue.main
@@ -26,8 +27,13 @@ import Foundation
         }
     }
 
-    @objc public func dispatchOnWorkerThread(_ block: @escaping () -> Void) {
-        workerQueue.async { block() }
+    @objc public func dispatchOnWorkerThread(withRandomDelay: Bool = false,
+                                             _ block: @escaping () -> ()) {
+        if withRandomDelay {
+            let delay = Double.random(in: 0..<maxJitterInSeconds)
+            workerQueue.asyncAfter(deadline: .now() + delay) { block() }
+        } else {
+            workerQueue.async { block() }
+        }
     }
-
 }

--- a/PurchasesTests/Caching/DeviceCacheTests.swift
+++ b/PurchasesTests/Caching/DeviceCacheTests.swift
@@ -243,4 +243,57 @@ class DeviceCacheTests: XCTestCase {
         expect(self.deviceCache.isPurchaserInfoCacheStale(forAppUserID: appUserID,
                                                           isAppBackgrounded: false)) == true
     }
+
+    func testIsPurchaserInfoCacheStaleForBackground() {
+        let mockNotificationCenter = MockNotificationCenter()
+        let appUserID = "myUser"
+        self.deviceCache = RCDeviceCache(mockUserDefaults,
+                                         offeringsCachedObject: nil,
+                                         notificationCenter: mockNotificationCenter)
+        let outdatedCacheDateForBackground = Calendar.current.date(byAdding: .hour, value: -25, to: Date())!
+        self.deviceCache.setPurchaserInfoCacheTimestamp(outdatedCacheDateForBackground, forAppUserID: appUserID)
+
+        expect(self.deviceCache.isPurchaserInfoCacheStale(forAppUserID: appUserID,
+                                                          isAppBackgrounded: true)) == true
+
+        let validCacheDateForBackground = Calendar.current.date(byAdding: .hour, value: -15, to: Date())!
+        self.deviceCache.setPurchaserInfoCacheTimestamp(validCacheDateForBackground, forAppUserID: appUserID)
+
+        expect(self.deviceCache.isPurchaserInfoCacheStale(forAppUserID: appUserID,
+                                                          isAppBackgrounded: true)) == false
+    }
+
+    func testIsPurchaserInfoCacheStaleForForeground() {
+        let mockNotificationCenter = MockNotificationCenter()
+        let appUserID = "myUser"
+        self.deviceCache = RCDeviceCache(mockUserDefaults,
+                                         offeringsCachedObject: nil,
+                                         notificationCenter: mockNotificationCenter)
+        let outdatedCacheDateForForeground = Calendar.current.date(byAdding: .minute, value: -25, to: Date())!
+        self.deviceCache.setPurchaserInfoCacheTimestamp(outdatedCacheDateForForeground, forAppUserID: appUserID)
+
+        expect(self.deviceCache.isPurchaserInfoCacheStale(forAppUserID: appUserID,
+                                                          isAppBackgrounded: true)) == true
+
+        let validCacheDateForForeground = Calendar.current.date(byAdding: .minute, value: -3, to: Date())!
+        self.deviceCache.setPurchaserInfoCacheTimestamp(validCacheDateForForeground, forAppUserID: appUserID)
+
+        expect(self.deviceCache.isPurchaserInfoCacheStale(forAppUserID: appUserID,
+                                                          isAppBackgrounded: true)) == false
+    }
+
+    func testIsPurchaserInfoCacheStaleForDifferentAppUserID() {
+        let mockNotificationCenter = MockNotificationCenter()
+        let otherAppUserID = "some other user"
+        let currentAppUserID = "myUser"
+        self.deviceCache = RCDeviceCache(mockUserDefaults,
+                                         offeringsCachedObject: nil,
+                                         notificationCenter: mockNotificationCenter)
+        let validCacheDate = Calendar.current.date(byAdding: .minute, value: -3, to: Date())!
+        self.deviceCache.setPurchaserInfoCacheTimestamp(validCacheDate, forAppUserID: otherAppUserID)
+
+        expect(self.deviceCache.isPurchaserInfoCacheStale(forAppUserID: currentAppUserID,
+                                                          isAppBackgrounded: true)) == true
+
+    }
 }

--- a/PurchasesTests/Caching/DeviceCacheTests.swift
+++ b/PurchasesTests/Caching/DeviceCacheTests.swift
@@ -160,12 +160,11 @@ class DeviceCacheTests: XCTestCase {
 
     func testPurchaserInfoIsProperlyCached() {
         let data = Data()
-        let userDefaults: UserDefaults = .standard
-        self.deviceCache = RCDeviceCache(userDefaults)
         self.deviceCache.cachePurchaserInfo(data, forAppUserID: "cesar")
 
-        expect(self.deviceCache.cachedPurchaserInfoData(forAppUserID: "cesar")).to(equal(data))
-        expect(userDefaults.data(forKey: "com.revenuecat.userdefaults.purchaserInfo.cesar")) == data
+        expect(self.mockUserDefaults.mockValues["com.revenuecat.userdefaults.purchaserInfo.cesar"] as? Data)
+            .to(equal(data))
+        expect(self.deviceCache.cachedPurchaserInfoData(forAppUserID: "cesar")) == data
     }
 
     func testOfferingsAreProperlyCached() {

--- a/PurchasesTests/Caching/DeviceCacheTests.swift
+++ b/PurchasesTests/Caching/DeviceCacheTests.swift
@@ -206,4 +206,41 @@ class DeviceCacheTests: XCTestCase {
 
         expect { mockNotificationCenter.fireNotifications() }.to(raiseException())
     }
+
+    func testNewDeviceCacheInstanceWithExistingValidPurchaserInfoCacheIsntStale() {
+        let mockNotificationCenter = MockNotificationCenter()
+        let appUserID = "myUser"
+        let fourMinutesAgo = Calendar.current.date(byAdding: .minute, value: -4, to: Date())
+        mockUserDefaults.mockValues["com.revenuecat.userdefaults.purchaserInfoLastUpdated.\(appUserID)"] = fourMinutesAgo
+        self.deviceCache = RCDeviceCache(mockUserDefaults,
+                                         offeringsCachedObject: nil,
+                                         notificationCenter: mockNotificationCenter)
+
+        expect(self.deviceCache.isPurchaserInfoCacheStale(forAppUserID: appUserID,
+                                                          isAppBackgrounded: false)) == false
+    }
+
+    func testNewDeviceCacheInstanceWithExistingInvalidPurchaserInfoCacheIsStale() {
+        let mockNotificationCenter = MockNotificationCenter()
+        let appUserID = "myUser"
+        let fourDaysAgo = Calendar.current.date(byAdding: .day, value: -4, to: Date())
+        mockUserDefaults.mockValues["com.revenuecat.userdefaults.purchaserInfoLastUpdated.\(appUserID)"] = fourDaysAgo
+        self.deviceCache = RCDeviceCache(mockUserDefaults,
+                                         offeringsCachedObject: nil,
+                                         notificationCenter: mockNotificationCenter)
+
+        expect(self.deviceCache.isPurchaserInfoCacheStale(forAppUserID: appUserID,
+                                                          isAppBackgrounded: false)) == true
+    }
+
+    func testNewDeviceCacheInstanceWithNoCachedPurchaserInfoCacheIsStale() {
+        let mockNotificationCenter = MockNotificationCenter()
+        let appUserID = "myUser"
+        self.deviceCache = RCDeviceCache(mockUserDefaults,
+                                         offeringsCachedObject: nil,
+                                         notificationCenter: mockNotificationCenter)
+
+        expect(self.deviceCache.isPurchaserInfoCacheStale(forAppUserID: appUserID,
+                                                          isAppBackgrounded: false)) == true
+    }
 }

--- a/PurchasesTests/Caching/DeviceCacheTests.swift
+++ b/PurchasesTests/Caching/DeviceCacheTests.swift
@@ -54,7 +54,7 @@ class DeviceCacheTests: XCTestCase {
     func testClearCachesForAppUserIDAndSaveNewUserIDClearsCachesTimestamp() {
         self.deviceCache.setPurchaserInfoCacheTimestampToNow()
         self.deviceCache.clearCaches(forAppUserID: "cesar", andSaveNewUserID: "newUser")
-        expect(self.deviceCache.isPurchaserInfoCacheStale()).to(beTrue())
+        expect(self.deviceCache.isPurchaserInfoCacheStale(withIsAppBackgrounded: nil)).to(beTrue())
     }
 
     func testClearCachesForAppUserIDAndSaveNewUserIDUpdatesCachedAppUserID() {
@@ -99,23 +99,23 @@ class DeviceCacheTests: XCTestCase {
     }
 
     func testSetPurchaserInfoCacheTimestampToNow() {
-        expect(self.deviceCache.isPurchaserInfoCacheStale()).to(beTrue())
+        expect(self.deviceCache.isPurchaserInfoCacheStale(withIsAppBackgrounded: nil)).to(beTrue())
         self.deviceCache.setPurchaserInfoCacheTimestampToNow()
-        expect(self.deviceCache.isPurchaserInfoCacheStale()).to(beFalse())
+        expect(self.deviceCache.isPurchaserInfoCacheStale(withIsAppBackgrounded: nil)).to(beFalse())
     }
 
     func testPurchaserInfoCacheIsStaleIfNoCaches() {
-        expect(self.deviceCache.isPurchaserInfoCacheStale()).to(beTrue())
+        expect(self.deviceCache.isPurchaserInfoCacheStale(withIsAppBackgrounded: nil)).to(beTrue())
     }
 
     func testSetOfferingsCacheTimestampToNow() {
-        expect(self.deviceCache.isOfferingsCacheStale()).to(beTrue())
+        expect(self.deviceCache.isOfferingsCacheStale(withIsAppBackgrounded: nil)).to(beTrue())
         self.deviceCache.setOfferingsCacheTimestampToNow()
-        expect(self.deviceCache.isOfferingsCacheStale()).to(beFalse())
+        expect(self.deviceCache.isOfferingsCacheStale(withIsAppBackgrounded: nil)).to(beFalse())
     }
 
     func testOfferingsCacheIsStaleIfNoCaches() {
-        expect(self.deviceCache.isOfferingsCacheStale()).to(beTrue())
+        expect(self.deviceCache.isOfferingsCacheStale(withIsAppBackgrounded: nil)).to(beTrue())
     }
 
     func testPurchaserInfoCacheIsStaleIfLongerThanFiveMinutes() {
@@ -124,10 +124,10 @@ class DeviceCacheTests: XCTestCase {
         self.deviceCache.cachePurchaserInfo(Data(), forAppUserID: "waldo")
 
         self.deviceCache.purchaserInfoCachesLastUpdated = oldDate
-        expect(self.deviceCache.isPurchaserInfoCacheStale()).to(beTrue())
+        expect(self.deviceCache.isPurchaserInfoCacheStale(withIsAppBackgrounded: nil)).to(beTrue())
 
         self.deviceCache.purchaserInfoCachesLastUpdated = Date()
-        expect(self.deviceCache.isPurchaserInfoCacheStale()).to(beFalse())
+        expect(self.deviceCache.isPurchaserInfoCacheStale(withIsAppBackgrounded: nil)).to(beFalse())
     }
 
     func testOfferingsCacheIsStaleIfCachedObjectIsStale() {
@@ -139,10 +139,10 @@ class DeviceCacheTests: XCTestCase {
         self.deviceCache.cacheOfferings(offerings)
 
         mockCachedObject.stubbedIsCacheStaleResult = false
-        expect(self.deviceCache.isOfferingsCacheStale()).to(beFalse())
+        expect(self.deviceCache.isOfferingsCacheStale(withIsAppBackgrounded: nil)).to(beFalse())
 
         mockCachedObject.stubbedIsCacheStaleResult = true
-        expect(self.deviceCache.isOfferingsCacheStale()).to(beTrue())
+        expect(self.deviceCache.isOfferingsCacheStale(withIsAppBackgrounded: nil)).to(beTrue())
     }
 
     func testPurchaserInfoIsProperlyCached() {

--- a/PurchasesTests/Caching/DeviceCacheTests.swift
+++ b/PurchasesTests/Caching/DeviceCacheTests.swift
@@ -163,11 +163,14 @@ class DeviceCacheTests: XCTestCase {
 
     func testPurchaserInfoIsProperlyCached() {
         let data = Data()
+        expect(self.deviceCache.isPurchaserInfoCacheStale(forAppUserID: "cesar", isAppBackgrounded: false)) == true
+
         self.deviceCache.cachePurchaserInfo(data, forAppUserID: "cesar")
 
         expect(self.mockUserDefaults.mockValues["com.revenuecat.userdefaults.purchaserInfo.cesar"] as? Data)
             .to(equal(data))
         expect(self.deviceCache.cachedPurchaserInfoData(forAppUserID: "cesar")) == data
+        expect(self.deviceCache.isPurchaserInfoCacheStale(forAppUserID: "cesar", isAppBackgrounded: false)) == false
     }
 
     func testOfferingsAreProperlyCached() {
@@ -283,6 +286,25 @@ class DeviceCacheTests: XCTestCase {
 
         expect(self.deviceCache.isPurchaserInfoCacheStale(forAppUserID: appUserID,
                                                           isAppBackgrounded: true)) == false
+    }
+
+    func testIsPurchaserInfoCacheWithCachedInfoButNoTimestamp() {
+        let mockNotificationCenter = MockNotificationCenter()
+        let appUserID = "myUser"
+        self.deviceCache = RCDeviceCache(mockUserDefaults,
+                                         offeringsCachedObject: nil,
+                                         notificationCenter: mockNotificationCenter)
+
+        let data = Data()
+        self.deviceCache.cachePurchaserInfo(data, forAppUserID: appUserID)
+        expect(self.deviceCache.isPurchaserInfoCacheStale(forAppUserID: appUserID,
+                                                          isAppBackgrounded: false)) == false
+
+        self.deviceCache.clearPurchaserInfoCacheTimestamp(forAppUserID: appUserID)
+
+
+        expect(self.deviceCache.isPurchaserInfoCacheStale(forAppUserID: appUserID,
+                                                          isAppBackgrounded: false)) == true
     }
 
     func testIsPurchaserInfoCacheStaleForDifferentAppUserID() {

--- a/PurchasesTests/Caching/InMemoryCachedObjectTests.swift
+++ b/PurchasesTests/Caching/InMemoryCachedObjectTests.swift
@@ -17,22 +17,20 @@ class InMemoryCachedObjectTests: XCTestCase {
         let cacheDurationInSeconds: Int32 = 5
         let now = Date()
 
-        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSecondsInForeground: cacheDurationInSeconds,
-                                                            cacheDurationInSecondsInBackground: nil)
+        let cachedObject = RCInMemoryCachedObject<NSString>()
 
         cachedObject.cacheInstance("myString")
-        expect(cachedObject.isCacheStaleWithDuration(inSeconds: nil)) == false
+        expect(cachedObject.isCacheStaleWithDuration(inSeconds: cacheDurationInSeconds)) == false
 
         cachedObject.lastUpdatedAt = now
-        expect(cachedObject.isCacheStaleWithDuration(inSeconds: nil)) == false
+        expect(cachedObject.isCacheStaleWithDuration(inSeconds: cacheDurationInSeconds)) == false
     }
 
     func testIsCacheStaleIsTrueAfterDurationExpires() {
         let cacheDurationInSeconds: Int32 = 5
         let now = Date()
 
-        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSecondsInForeground: cacheDurationInSeconds,
-                                                            cacheDurationInSecondsInBackground: nil)
+        let cachedObject = RCInMemoryCachedObject<NSString>()
 
         guard let oldDate = Calendar.current.date(byAdding: .second, value: -5, to: now) else {
             fatalError("Couldn't set up date for tests")
@@ -40,29 +38,25 @@ class InMemoryCachedObjectTests: XCTestCase {
 
         cachedObject.cacheInstance("myString")
         cachedObject.lastUpdatedAt = oldDate
-        expect(cachedObject.isCacheStaleWithDuration(inSeconds: nil)) == true
+        expect(cachedObject.isCacheStaleWithDuration(inSeconds: cacheDurationInSeconds)) == true
     }
 
 
     func testIsCacheStaleIsTrueIfTheresNothingCached() {
-        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSecondsInForeground: 5,
-                                                            cacheDurationInSecondsInBackground: nil)
+        let cachedObject = RCInMemoryCachedObject<NSString>()
 
-        expect(cachedObject.isCacheStaleWithDuration(inSeconds: nil)) == true
+        expect(cachedObject.isCacheStaleWithDuration(inSeconds: 5)) == true
 
         cachedObject.cacheInstance("myString")
         cachedObject.clearCache()
 
-        expect(cachedObject.isCacheStaleWithDuration(inSeconds: nil)) == true
+        expect(cachedObject.isCacheStaleWithDuration(inSeconds: 5)) == true
     }
 
     // mark: clearCacheTimestamp
 
     func testClearCacheTimestampClearsCorrectly() {
-        let cacheDurationInSeconds: Int32 = 5
-
-        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSecondsInForeground: cacheDurationInSeconds,
-                                                            cacheDurationInSecondsInBackground: nil)
+        let cachedObject = RCInMemoryCachedObject<NSString>()
         cachedObject.cacheInstance("myString")
         expect(cachedObject.lastUpdatedAt).toNot(beNil())
         expect(cachedObject.cachedInstance()).toNot(beNil())
@@ -75,10 +69,7 @@ class InMemoryCachedObjectTests: XCTestCase {
     // mark: clearCache
 
     func testClearCacheClearsCorrectly() {
-        let cacheDurationInSeconds: Int32 = 5
-
-        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSecondsInForeground: cacheDurationInSeconds,
-                                                            cacheDurationInSecondsInBackground: nil)
+        let cachedObject = RCInMemoryCachedObject<NSString>()
         cachedObject.cacheInstance("myString")
 
         expect(cachedObject.lastUpdatedAt).toNot(beNil())
@@ -94,9 +85,7 @@ class InMemoryCachedObjectTests: XCTestCase {
 
     func testUpdateCacheTimestampWithDateUpdatesCorrectly() {
         let myString: NSString = "something"
-        let cacheDurationInSeconds: Int32 = 5
-        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSecondsInForeground: cacheDurationInSeconds,
-                                                            cacheDurationInSecondsInBackground: nil)
+        let cachedObject = RCInMemoryCachedObject<NSString>()
         expect(cachedObject.lastUpdatedAt).to(beNil())
         let firstDate = Date()
         cachedObject.cacheInstance(myString)
@@ -113,9 +102,7 @@ class InMemoryCachedObjectTests: XCTestCase {
 
     func testCacheInstanceWithDateCachesInstanceCorrectly() {
         let myString: NSString = "something"
-        let cacheDurationInSeconds: Int32 = 5
-        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSecondsInForeground: cacheDurationInSeconds,
-                                                            cacheDurationInSecondsInBackground: nil)
+        let cachedObject = RCInMemoryCachedObject<NSString>()
         cachedObject.cacheInstance(myString)
 
         expect(cachedObject.cachedInstance()) == myString
@@ -123,9 +110,7 @@ class InMemoryCachedObjectTests: XCTestCase {
 
     func testCacheInstanceWithDateSetsDateCorrectly() {
         let myString: NSString = "something"
-        let cacheDurationInSeconds: Int32 = 5
-        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSecondsInForeground: cacheDurationInSeconds,
-                                                            cacheDurationInSecondsInBackground: nil)
+        let cachedObject = RCInMemoryCachedObject<NSString>()
         expect(cachedObject.lastUpdatedAt).to(beNil())
         let newDate = Date()
         cachedObject.cacheInstance(myString)

--- a/PurchasesTests/Caching/InMemoryCachedObjectTests.swift
+++ b/PurchasesTests/Caching/InMemoryCachedObjectTests.swift
@@ -11,26 +11,28 @@ import Purchases
 
 class InMemoryCachedObjectTests: XCTestCase {
 
-    // mark: isCacheStale
+    // mark: isCacheStaleWithDurationInSeconds:
 
     func testIsCacheStaleIsFalseBeforeDurationExpires() {
         let cacheDurationInSeconds: Int32 = 5
         let now = Date()
 
-        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSeconds: cacheDurationInSeconds)
+        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSecondsInForeground: cacheDurationInSeconds,
+                                                            cacheDurationInSecondsInBackground: nil)
 
         cachedObject.cacheInstance("myString")
-        expect(cachedObject.isCacheStale()) == false
+        expect(cachedObject.isCacheStaleWithDuration(inSeconds: nil)) == false
 
         cachedObject.lastUpdatedAt = now
-        expect(cachedObject.isCacheStale()) == false
+        expect(cachedObject.isCacheStaleWithDuration(inSeconds: nil)) == false
     }
 
     func testIsCacheStaleIsTrueAfterDurationExpires() {
         let cacheDurationInSeconds: Int32 = 5
         let now = Date()
 
-        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSeconds: cacheDurationInSeconds)
+        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSecondsInForeground: cacheDurationInSeconds,
+                                                            cacheDurationInSecondsInBackground: nil)
 
         guard let oldDate = Calendar.current.date(byAdding: .second, value: -5, to: now) else {
             fatalError("Couldn't set up date for tests")
@@ -38,19 +40,20 @@ class InMemoryCachedObjectTests: XCTestCase {
 
         cachedObject.cacheInstance("myString")
         cachedObject.lastUpdatedAt = oldDate
-        expect(cachedObject.isCacheStale()) == true
+        expect(cachedObject.isCacheStaleWithDuration(inSeconds: nil)) == true
     }
 
 
     func testIsCacheStaleIsTrueIfTheresNothingCached() {
-        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSeconds: 5)
+        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSecondsInForeground: 5,
+                                                            cacheDurationInSecondsInBackground: nil)
 
-        expect(cachedObject.isCacheStale()) == true
+        expect(cachedObject.isCacheStaleWithDuration(inSeconds: nil)) == true
 
         cachedObject.cacheInstance("myString")
         cachedObject.clearCache()
 
-        expect(cachedObject.isCacheStale()) == true
+        expect(cachedObject.isCacheStaleWithDuration(inSeconds: nil)) == true
     }
 
     // mark: clearCacheTimestamp
@@ -58,7 +61,8 @@ class InMemoryCachedObjectTests: XCTestCase {
     func testClearCacheTimestampClearsCorrectly() {
         let cacheDurationInSeconds: Int32 = 5
 
-        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSeconds: cacheDurationInSeconds)
+        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSecondsInForeground: cacheDurationInSeconds,
+                                                            cacheDurationInSecondsInBackground: nil)
         cachedObject.cacheInstance("myString")
         expect(cachedObject.lastUpdatedAt).toNot(beNil())
         expect(cachedObject.cachedInstance()).toNot(beNil())
@@ -73,7 +77,8 @@ class InMemoryCachedObjectTests: XCTestCase {
     func testClearCacheClearsCorrectly() {
         let cacheDurationInSeconds: Int32 = 5
 
-        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSeconds: cacheDurationInSeconds)
+        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSecondsInForeground: cacheDurationInSeconds,
+                                                            cacheDurationInSecondsInBackground: nil)
         cachedObject.cacheInstance("myString")
 
         expect(cachedObject.lastUpdatedAt).toNot(beNil())
@@ -90,7 +95,8 @@ class InMemoryCachedObjectTests: XCTestCase {
     func testUpdateCacheTimestampWithDateUpdatesCorrectly() {
         let myString: NSString = "something"
         let cacheDurationInSeconds: Int32 = 5
-        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSeconds: cacheDurationInSeconds)
+        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSecondsInForeground: cacheDurationInSeconds,
+                                                            cacheDurationInSecondsInBackground: nil)
         expect(cachedObject.lastUpdatedAt).to(beNil())
         let firstDate = Date()
         cachedObject.cacheInstance(myString)
@@ -108,7 +114,8 @@ class InMemoryCachedObjectTests: XCTestCase {
     func testCacheInstanceWithDateCachesInstanceCorrectly() {
         let myString: NSString = "something"
         let cacheDurationInSeconds: Int32 = 5
-        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSeconds: cacheDurationInSeconds)
+        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSecondsInForeground: cacheDurationInSeconds,
+                                                            cacheDurationInSecondsInBackground: nil)
         cachedObject.cacheInstance(myString)
 
         expect(cachedObject.cachedInstance()) == myString
@@ -117,7 +124,8 @@ class InMemoryCachedObjectTests: XCTestCase {
     func testCacheInstanceWithDateSetsDateCorrectly() {
         let myString: NSString = "something"
         let cacheDurationInSeconds: Int32 = 5
-        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSeconds: cacheDurationInSeconds)
+        let cachedObject = RCInMemoryCachedObject<NSString>(cacheDurationInSecondsInForeground: cacheDurationInSeconds,
+                                                            cacheDurationInSecondsInBackground: nil)
         expect(cachedObject.lastUpdatedAt).to(beNil())
         let newDate = Date()
         cachedObject.cacheInstance(myString)

--- a/PurchasesTests/Mocks/MockDeviceCache.swift
+++ b/PurchasesTests/Mocks/MockDeviceCache.swift
@@ -56,15 +56,16 @@ class MockDeviceCache: RCDeviceCache {
         return cachedPurchaserInfo[appUserID];
     }
 
-    override func isPurchaserInfoCacheStale() -> Bool {
+    override func isPurchaserInfoCacheStale(forAppUserID appUserID: String,
+                                            isAppBackgrounded: Bool) -> Bool {
         return stubbedIsPurchaserInfoCacheStale
     }
 
-    override func clearPurchaserInfoCacheTimestamp() {
+    override func clearPurchaserInfoCacheTimestamp(forAppUserID appUserID: String) {
         clearPurchaserInfoCacheTimestampCount += 1
     }
 
-    override func setPurchaserInfoCacheTimestampToNow() {
+    override func setPurchaserInfoCacheTimestampToNowForAppUserID(_ appUserID: String) {
         setPurchaserInfoCacheTimestampToNowCount += 1
     }
 
@@ -85,7 +86,7 @@ class MockDeviceCache: RCDeviceCache {
         cachedOfferingsCount += 1
     }
 
-    override func isOfferingsCacheStale() -> Bool {
+    override func isOfferingsCacheStale(withIsAppBackgrounded isAppBackgrounded: Bool) -> Bool {
         return stubbedIsOfferingsCacheStale
     }
 

--- a/PurchasesTests/Mocks/MockInMemoryCachedOfferings.swift
+++ b/PurchasesTests/Mocks/MockInMemoryCachedOfferings.swift
@@ -12,7 +12,7 @@ class MockInMemoryCachedOfferings<T: Purchases.Offerings> : RCInMemoryCachedObje
     var invokedIsCacheStaleCount = 0
     var stubbedIsCacheStaleResult: Bool! = false
 
-    override func isCacheStale() -> Bool {
+    override func isCacheStaleWithDuration(inSeconds durationInSeconds: Int32) -> Bool {
         invokedIsCacheStale = true
         invokedIsCacheStaleCount += 1
         return stubbedIsCacheStaleResult

--- a/PurchasesTests/Mocks/MockOperationDispatcher.swift
+++ b/PurchasesTests/Mocks/MockOperationDispatcher.swift
@@ -31,7 +31,7 @@ class MockOperationDispatcher: OperationDispatcher {
     var shouldInvokeDispatchOnWorkerThreadBlock = true
     var forwardToOriginalDispatchOnWorkerThread = false
 
-    public override func dispatchOnWorkerThread(withRandomDelay withRandomDelay: BOOL = false,
+    public override func dispatchOnWorkerThread(withRandomDelay: Bool = false,
                                                 _ block: @escaping () -> ()) {
         invokedDispatchOnWorkerThread = true
         invokedDispatchOnWorkerThreadCount += 1

--- a/PurchasesTests/Mocks/MockOperationDispatcher.swift
+++ b/PurchasesTests/Mocks/MockOperationDispatcher.swift
@@ -31,7 +31,8 @@ class MockOperationDispatcher: OperationDispatcher {
     var shouldInvokeDispatchOnWorkerThreadBlock = true
     var forwardToOriginalDispatchOnWorkerThread = false
 
-    override func dispatchOnWorkerThread(_ block: @escaping () -> Void) {
+    public override func dispatchOnWorkerThread(withRandomDelay withRandomDelay: BOOL = false,
+                                                _ block: @escaping () -> ()) {
         invokedDispatchOnWorkerThread = true
         invokedDispatchOnWorkerThreadCount += 1
         if forwardToOriginalDispatchOnWorkerThread {

--- a/PurchasesTests/Mocks/MockOperationDispatcher.swift
+++ b/PurchasesTests/Mocks/MockOperationDispatcher.swift
@@ -31,12 +31,11 @@ class MockOperationDispatcher: OperationDispatcher {
     var shouldInvokeDispatchOnWorkerThreadBlock = true
     var forwardToOriginalDispatchOnWorkerThread = false
 
-    public override func dispatchOnWorkerThread(withRandomDelay: Bool = false,
-                                                _ block: @escaping () -> ()) {
+    public override func dispatchOnWorkerThread(withRandomDelay: Bool = false, block: @escaping () -> ()) {
         invokedDispatchOnWorkerThread = true
         invokedDispatchOnWorkerThreadCount += 1
         if forwardToOriginalDispatchOnWorkerThread {
-            super.dispatchOnWorkerThread(block)
+            super.dispatchOnWorkerThread(withRandomDelay: withRandomDelay, block: block)
             return
         }
         if shouldInvokeDispatchOnWorkerThreadBlock {

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -902,9 +902,23 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.userID).toEventuallyNot(beNil());
     }
 
-    func testAutomaticallyFetchesPurchaserInfoOnDidBecomeActive() {
+    func testAutomaticallyFetchesPurchaserInfoOnDidBecomeActiveIfCacheStale() {
         setupPurchases()
+        expect(self.backend.getSubscriberCallCount).toEventually(equal(1))
+
+        self.deviceCache.stubbedIsPurchaserInfoCacheStale = true
         notificationCenter.fireNotifications();
+
+        expect(self.backend.getSubscriberCallCount).toEventually(equal(2))
+    }
+
+    func testDoesntAutomaticallyFetchPurchaserInfoOnDidBecomeActiveIfCacheValid() {
+        setupPurchases()
+        expect(self.backend.getSubscriberCallCount).toEventually(equal(1))
+        self.deviceCache.stubbedIsPurchaserInfoCacheStale = false
+
+        notificationCenter.fireNotifications();
+
         expect(self.backend.getSubscriberCallCount).toEventually(equal(1))
     }
 
@@ -1372,7 +1386,7 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.gotOfferings).toEventually(equal(1))
     }
 
-    func testFirstInitializationDoesntProductInfoFromOfferingsIfAppBackgrounded() {
+    func testFirstInitializationDoesntFetchOfferingsIfAppBackgrounded() {
         systemInfo.stubbedIsApplicationBackgrounded = true
         setupPurchases()
         expect(self.backend.gotOfferings).toEventually(equal(0))

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -281,9 +281,31 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.getSubscriberCallCount).toEventually(equal(0))
     }
     
-    func testFirstInitializationFromForegroundUpdatesPurchaserInfoCache() {
+    func testFirstInitializationFromForegroundUpdatesPurchaserInfoCacheIfNotInUserDefaults() {
         systemInfo.stubbedIsApplicationBackgrounded = false
         setupPurchases()
+        expect(self.backend.getSubscriberCallCount).toEventually(equal(1))
+    }
+
+    func testFirstInitializationFromForegroundUpdatesPurchaserInfoCacheIfUserDefaultsCacheStale() {
+        let staleCacheDateForForeground = Calendar.current.date(byAdding: .minute, value: -20, to: Date())!
+        self.deviceCache.setPurchaserInfoCacheTimestamp(staleCacheDateForForeground,
+                                                        forAppUserID: identityManager.currentAppUserID)
+        systemInfo.stubbedIsApplicationBackgrounded = false
+
+        setupPurchases()
+
+        expect(self.backend.getSubscriberCallCount).toEventually(equal(1))
+    }
+
+    func testFirstInitializationFromForegroundUpdatesPurchaserInfoEvenIfCacheValid() {
+        let staleCacheDateForForeground = Calendar.current.date(byAdding: .minute, value: -2, to: Date())!
+        self.deviceCache.setPurchaserInfoCacheTimestamp(staleCacheDateForForeground,
+                                                        forAppUserID: identityManager.currentAppUserID)
+        systemInfo.stubbedIsApplicationBackgrounded = false
+
+        setupPurchases()
+
         expect(self.backend.getSubscriberCallCount).toEventually(equal(1))
     }
 

--- a/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -140,15 +140,15 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
 
         setupPurchases()
 
-        expect(self.mockOperationDispatcher.invokedDispatchOnWorkerThreadCount) == 1
         expect(self.mockBackend.invokedGetSubscriberDataCount) == 1
-        expect(self.mockSubscriberAttributesManager.invokedSyncAttributesForAllUsersCount) == 0
+        expect(self.mockDeviceCache.cachePurchaserInfoCount) == 1
         expect(self.mockDeviceCache.cachedPurchaserInfo.count) == 1
+        expect(self.mockSubscriberAttributesManager.invokedSyncAttributesForAllUsersCount) == 0
 
         self.mockNotificationCenter.fireNotifications()
 
-        expect(self.mockOperationDispatcher.invokedDispatchOnWorkerThreadCount) == 3
         expect(self.mockSubscriberAttributesManager.invokedSyncAttributesForAllUsersCount) == 2
+        expect(self.mockDeviceCache.cachePurchaserInfoCount) == 1
         expect(self.mockDeviceCache.cachedPurchaserInfo.count) == 1
     }
 


### PR DESCRIPTION
Apps opening from push notifications and potentially widgets may cause unnecessary strain on the backend by making calls simultaneously on all devices.

To alleviate the backend strain, we want to introduce a small, random delay to cache updates performed while the app is in the background. This will distribute requests over time so that the backend isn’t hit at once.

We’re also going to be more aggressive with the cache while the app is in the background, moving it from 5 mins to 1 day.

The value of 5 mins will still be used if the app is in the foreground.

Ruleset:

- if app is opened and in the foreground
    - if cache is older than 5 mins
        - update cache
- if app is opened and in the background:
    - if cache is older than one day:
        - update cache (with jitter)