### PR TITLE
fix parsing of dates in receipts with milliseconds 

### DIFF
--- a/PurchasesCoreSwift/LocalReceiptParsing/DataConverters/ISO3601DateFormatter.swift
+++ b/PurchasesCoreSwift/LocalReceiptParsing/DataConverters/ISO3601DateFormatter.swift
@@ -13,7 +13,7 @@ struct ISO3601DateFormatter {
 
     private init() {
         secondsDateFormatter.dateFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ssZ"
-        milisecondsDateFormatter.dateFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSSZ"
+        milisecondsDateFormatter.dateFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'SSSZ"
     }
 
     func date(fromBytes bytes: ArraySlice<UInt8>) -> Date? {

--- a/PurchasesCoreSwift/LocalReceiptParsing/DataConverters/ISO3601DateFormatter.swift
+++ b/PurchasesCoreSwift/LocalReceiptParsing/DataConverters/ISO3601DateFormatter.swift
@@ -8,16 +8,17 @@ import Foundation
 struct ISO3601DateFormatter {
     static let shared = ISO3601DateFormatter()
 
-    private let dateFormatter = DateFormatter()
+    private let secondsDateFormatter = DateFormatter()
+    private let milisecondsDateFormatter = DateFormatter()
 
     private init() {
-        dateFormatter.dateFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ssZ"
+        secondsDateFormatter.dateFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ssZ"
+        milisecondsDateFormatter.dateFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSSZ"
     }
 
     func date(fromBytes bytes: ArraySlice<UInt8>) -> Date? {
-        if let dateString = String(bytes: Array(bytes), encoding: .ascii) {
-            return dateFormatter.date(from: dateString)
-        }
-        return nil
+        guard let dateString = String(bytes: Array(bytes), encoding: .ascii) else { return nil }
+        return (secondsDateFormatter.date(from: dateString)
+            ?? milisecondsDateFormatter.date(from: dateString))
     }
 }

--- a/PurchasesCoreSwiftTests/LocalReceiptParsing/Builders/AppleReceiptBuilderTests.swift
+++ b/PurchasesCoreSwiftTests/LocalReceiptParsing/Builders/AppleReceiptBuilderTests.swift
@@ -192,7 +192,7 @@ private extension AppleReceiptBuilderTests {
 
     func creationDateContainer() -> ASN1Container {
         containerFactory.receiptAttributeContainer(attributeType: ReceiptAttributeType.creationDate,
-                                                        creationDate)
+                                                   creationDate)
     }
 
     func sha1HashContainer() -> ASN1Container {
@@ -204,18 +204,17 @@ private extension AppleReceiptBuilderTests {
     }
 
     func originalAppVersionContainer() -> ASN1Container {
-        containerFactory
-            .receiptAttributeContainer(attributeType: ReceiptAttributeType.originalApplicationVersion,
-                                            originalApplicationVersion)
+        containerFactory.receiptAttributeContainer(attributeType: ReceiptAttributeType.originalApplicationVersion,
+                                                   originalApplicationVersion)
     }
 
     func appVersionContainer() -> ASN1Container {
         containerFactory.receiptAttributeContainer(attributeType: ReceiptAttributeType.applicationVersion,
-                                                        applicationVersion)
+                                                   applicationVersion)
     }
 
     func bundleIdContainer() -> ASN1Container {
         containerFactory.receiptAttributeContainer(attributeType: ReceiptAttributeType.bundleId,
-                                                        bundleId)
+                                                   bundleId)
     }
 }

--- a/PurchasesCoreSwiftTests/LocalReceiptParsing/DataConverters/ISO3601DateFormatterTests.swift
+++ b/PurchasesCoreSwiftTests/LocalReceiptParsing/DataConverters/ISO3601DateFormatterTests.swift
@@ -19,7 +19,7 @@ class ISO3601DateFormatterTests: XCTestCase {
         expect(ISO3601DateFormatter.shared.date(fromBytes: ArraySlice(dateBytes))) == date
     }
 
-    func testDateWithMilisecondsFromBytesReturnsCorrectValueIfPossible() {
+    func testDateWithMillisecondsFromBytesReturnsCorrectValueIfPossible() {
         let timeZone = TimeZone(identifier: "UTC")
         let dateComponents = DateComponents(timeZone: timeZone,
                                             year: 2020,

--- a/PurchasesCoreSwiftTests/LocalReceiptParsing/DataConverters/ISO3601DateFormatterTests.swift
+++ b/PurchasesCoreSwiftTests/LocalReceiptParsing/DataConverters/ISO3601DateFormatterTests.swift
@@ -15,8 +15,24 @@ class ISO3601DateFormatterTests: XCTestCase {
                                             minute: 36,
                                             second: 40)
         let date = Calendar.current.date(from: dateComponents)
-        guard let dateBytes = "2020-07-14T19:36:40+0000".data(using: .ascii) else { fatalError() }
+        guard let dateBytes = "2020-07-14T19:36:40Z".data(using: .ascii) else { fatalError() }
         expect(ISO3601DateFormatter.shared.date(fromBytes: ArraySlice(dateBytes))) == date
+    }
+
+    func testDateWithMilisecondsFromBytesReturnsCorrectValueIfPossible() {
+        let timeZone = TimeZone(identifier: "UTC")
+        let dateComponents = DateComponents(timeZone: timeZone,
+                                            year: 2020,
+                                            month: 7,
+                                            day: 14,
+                                            hour: 19,
+                                            minute: 36,
+                                            second: 40,
+                                            nanosecond: 202_000_000)
+        let date = Calendar.current.date(from: dateComponents)
+        guard let dateBytes = "2020-07-14T19:36:40.202Z".data(using: .ascii) else { fatalError() }
+        let receivedDate = ISO3601DateFormatter.shared.date(fromBytes: ArraySlice(dateBytes))
+        expect(receivedDate!.timeIntervalSince1970).to(beCloseTo(date!.timeIntervalSince1970))
     }
 
     func testDateFromBytesReturnsNilIfItCantBeParsedAsString() {


### PR DESCRIPTION
It looks like Apple might have changed the format of dates in receipts, updating the resolution from seconds to milliseconds. 

This PR updates our parser so that we handle both cases, since some receipts will still be in the old format even after the update. 

More info: https://twitter.com/depth42/status/1313750495710904320