### PR TITLE
fixed tests for iOS < 12.2

### DIFF
--- a/PurchasesTests/Misc/ISOPeriodFormatterTests.swift
+++ b/PurchasesTests/Misc/ISOPeriodFormatterTests.swift
@@ -12,70 +12,78 @@ import Nimble
 
 import Purchases
 
-@available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *)
+
 class ISOPeriodFormatterTests: XCTestCase {
-        
+    
     func testStringFromProductSubscriptionPeriodDay() {
-        let formatter = Purchases.ISOPeriodFormatter()
-        
-        var period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .day)
-        expect(formatter.string(from: period)) == "P1D"
-
-        period = SKProductSubscriptionPeriod(numberOfUnits: 10, unit: .day)
-        expect(formatter.string(from: period)) == "P10D"
-
-        period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .day)
-        expect(formatter.string(from: period)) == "P3D"
-
-        period = SKProductSubscriptionPeriod(numberOfUnits: 8, unit: .day)
-        expect(formatter.string(from: period)) == "P8D"
+        if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *) {
+            let formatter = Purchases.ISOPeriodFormatter()
+            
+            var period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .day)
+            expect(formatter.string(from: period)) == "P1D"
+            
+            period = SKProductSubscriptionPeriod(numberOfUnits: 10, unit: .day)
+            expect(formatter.string(from: period)) == "P10D"
+            
+            period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .day)
+            expect(formatter.string(from: period)) == "P3D"
+            
+            period = SKProductSubscriptionPeriod(numberOfUnits: 8, unit: .day)
+            expect(formatter.string(from: period)) == "P8D"
+        }
     }
-
+    
     func testStringFromProductSubscriptionPeriodMonth() {
-        let formatter = Purchases.ISOPeriodFormatter()
-        
-        var period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .month)
-        expect(formatter.string(from: period)) == "P1M"
-
-        period = SKProductSubscriptionPeriod(numberOfUnits: 10, unit: .month)
-        expect(formatter.string(from: period)) == "P10M"
-
-        period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .month)
-        expect(formatter.string(from: period)) == "P3M"
-
-        period = SKProductSubscriptionPeriod(numberOfUnits: 8, unit: .month)
-        expect(formatter.string(from: period)) == "P8M"
+        if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *) {
+            let formatter = Purchases.ISOPeriodFormatter()
+            
+            var period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .month)
+            expect(formatter.string(from: period)) == "P1M"
+            
+            period = SKProductSubscriptionPeriod(numberOfUnits: 10, unit: .month)
+            expect(formatter.string(from: period)) == "P10M"
+            
+            period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .month)
+            expect(formatter.string(from: period)) == "P3M"
+            
+            period = SKProductSubscriptionPeriod(numberOfUnits: 8, unit: .month)
+            expect(formatter.string(from: period)) == "P8M"
+        }
     }
     
     func testStringFromProductSubscriptionPeriodWeek() {
-        let formatter = Purchases.ISOPeriodFormatter()
-        
-        var period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .week)
-        expect(formatter.string(from: period)) == "P1W"
-
-        period = SKProductSubscriptionPeriod(numberOfUnits: 10, unit: .week)
-        expect(formatter.string(from: period)) == "P10W"
-
-        period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .week)
-        expect(formatter.string(from: period)) == "P3W"
-
-        period = SKProductSubscriptionPeriod(numberOfUnits: 8, unit: .week)
-        expect(formatter.string(from: period)) == "P8W"
+        if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *) {
+            let formatter = Purchases.ISOPeriodFormatter()
+            
+            var period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .week)
+            expect(formatter.string(from: period)) == "P1W"
+            
+            period = SKProductSubscriptionPeriod(numberOfUnits: 10, unit: .week)
+            expect(formatter.string(from: period)) == "P10W"
+            
+            period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .week)
+            expect(formatter.string(from: period)) == "P3W"
+            
+            period = SKProductSubscriptionPeriod(numberOfUnits: 8, unit: .week)
+            expect(formatter.string(from: period)) == "P8W"
+        }
     }
     
     func testStringFromProductSubscriptionPeriodYear() {
-        let formatter = Purchases.ISOPeriodFormatter()
-        
-        var period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .year)
-        expect(formatter.string(from: period)) == "P1Y"
-
-        period = SKProductSubscriptionPeriod(numberOfUnits: 10, unit: .year)
-        expect(formatter.string(from: period)) == "P10Y"
-
-        period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .year)
-        expect(formatter.string(from: period)) == "P3Y"
-
-        period = SKProductSubscriptionPeriod(numberOfUnits: 8, unit: .year)
-        expect(formatter.string(from: period)) == "P8Y"
+        if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *) {
+            let formatter = Purchases.ISOPeriodFormatter()
+            
+            var period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .year)
+            expect(formatter.string(from: period)) == "P1Y"
+            
+            period = SKProductSubscriptionPeriod(numberOfUnits: 10, unit: .year)
+            expect(formatter.string(from: period)) == "P10Y"
+            
+            period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .year)
+            expect(formatter.string(from: period)) == "P3Y"
+            
+            period = SKProductSubscriptionPeriod(numberOfUnits: 8, unit: .year)
+            expect(formatter.string(from: period)) == "P8Y"
+        }
     }
 }

--- a/PurchasesTests/Purchasing/ProductInfoExtractorTests.swift
+++ b/PurchasesTests/Purchasing/ProductInfoExtractorTests.swift
@@ -58,7 +58,7 @@ class ProductInfoExtractorTests: XCTestCase {
 
             let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
 
-            expect(receivedProductInfo.paymentMode).to(beNil())
+            expect(receivedProductInfo.paymentMode) == RCPaymentMode.none
         }
     }
 
@@ -147,7 +147,7 @@ class ProductInfoExtractorTests: XCTestCase {
     func testExtractInfoFromProductExtractsIntroDurationType() {
         let product = MockSKProduct(mockProductIdentifier: "cool_product")
 
-        if #available(iOS 12.2, *) {
+        if #available(iOS 12.2, macOS 10.14.4, *) {
             let mockDiscount = MockDiscount()
             mockDiscount.mockPaymentMode = .freeTrial
 
@@ -156,13 +156,13 @@ class ProductInfoExtractorTests: XCTestCase {
 
             let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
 
-            expect(receivedProductInfo.introDurationType.rawValue) == RCIntroDurationType.freeTrial.rawValue
+            expect(receivedProductInfo.introDurationType) == .freeTrial
         } else {
             let productInfoExtractor = RCProductInfoExtractor()
 
             let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
 
-            expect(receivedProductInfo.introDurationType).to(beNil())
+            expect(receivedProductInfo.introDurationType) == RCIntroDurationType.none
         }
     }
 
@@ -182,7 +182,7 @@ class ProductInfoExtractorTests: XCTestCase {
 
             let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
 
-            expect(receivedProductInfo.subscriptionGroup).to(beNil())
+            expect(receivedProductInfo.subscriptionGroup).to(beEmpty())
         }
     }
 

--- a/PurchasesTests/Purchasing/ProductInfoTests.swift
+++ b/PurchasesTests/Purchasing/ProductInfoTests.swift
@@ -89,65 +89,69 @@ class ProductInfoTests: XCTestCase {
     }
 
     func testAsDictionaryConvertsDiscountsCorrectly() {
-        let discount1 = RCPromotionalOffer()
-        discount1.offerIdentifier = "offerid1"
-        discount1.paymentMode = .payAsYouGo
-        discount1.price = 11
+        if #available(iOS 12.2, macOS 10.14.4, *) {
+            let discount1 = RCPromotionalOffer()
+            discount1.offerIdentifier = "offerid1"
+            discount1.paymentMode = .payAsYouGo
+            discount1.price = 11
 
-        let discount2 = RCPromotionalOffer()
-        discount2.offerIdentifier = "offerid2"
-        discount2.paymentMode = .payUpFront
-        discount2.price = 12
+            let discount2 = RCPromotionalOffer()
+            discount2.offerIdentifier = "offerid2"
+            discount2.paymentMode = .payUpFront
+            discount2.price = 12
 
-        let discount3 = RCPromotionalOffer()
-        discount3.offerIdentifier = "offerid3"
-        discount3.paymentMode = .freeTrial
-        discount3.price = 13
+            let discount3 = RCPromotionalOffer()
+            discount3.offerIdentifier = "offerid3"
+            discount3.paymentMode = .freeTrial
+            discount3.price = 13
 
-        let productInfo: RCProductInfo = .createMockProductInfo(discounts: [discount1, discount2, discount3])
+            let productInfo: RCProductInfo = .createMockProductInfo(discounts: [discount1, discount2, discount3])
 
-        expect(productInfo.asDictionary()["offers"] as? [[String: NSObject]]).toNot(beNil())
-        guard let receivedOffers = productInfo.asDictionary()["offers"] as? [[String: NSObject]] else { fatalError() }
+            expect(productInfo.asDictionary()["offers"] as? [[String: NSObject]]).toNot(beNil())
+            guard let receivedOffers = productInfo.asDictionary()["offers"] as? [[String: NSObject]] else { fatalError() }
 
-        expect(receivedOffers[0]["offer_identifier"] as? String) == discount1.offerIdentifier
-        expect(receivedOffers[0]["price"] as? NSDecimalNumber) == discount1.price
-        expect((receivedOffers[0]["payment_mode"] as? NSNumber)?.intValue) == discount1.paymentMode.rawValue
+            expect(receivedOffers[0]["offer_identifier"] as? String) == discount1.offerIdentifier
+            expect(receivedOffers[0]["price"] as? NSDecimalNumber) == discount1.price
+            expect((receivedOffers[0]["payment_mode"] as? NSNumber)?.intValue) == discount1.paymentMode.rawValue
 
-        expect(receivedOffers[1]["offer_identifier"] as? String) == discount2.offerIdentifier
-        expect(receivedOffers[1]["price"] as? NSDecimalNumber) == discount2.price
-        expect((receivedOffers[1]["payment_mode"] as? NSNumber)?.intValue) == discount2.paymentMode.rawValue
+            expect(receivedOffers[1]["offer_identifier"] as? String) == discount2.offerIdentifier
+            expect(receivedOffers[1]["price"] as? NSDecimalNumber) == discount2.price
+            expect((receivedOffers[1]["payment_mode"] as? NSNumber)?.intValue) == discount2.paymentMode.rawValue
 
-        expect(receivedOffers[2]["offer_identifier"] as? String) == discount3.offerIdentifier
-        expect(receivedOffers[2]["price"] as? NSDecimalNumber) == discount3.price
-        expect((receivedOffers[2]["payment_mode"] as? NSNumber)?.intValue) == discount3.paymentMode.rawValue
+            expect(receivedOffers[2]["offer_identifier"] as? String) == discount3.offerIdentifier
+            expect(receivedOffers[2]["price"] as? NSDecimalNumber) == discount3.price
+            expect((receivedOffers[2]["payment_mode"] as? NSNumber)?.intValue) == discount3.paymentMode.rawValue
+        }
     }
 
     func testCacheKey() {
-        let discount1 = RCPromotionalOffer()
-        discount1.offerIdentifier = "offerid1"
-        discount1.paymentMode = .payAsYouGo
-        discount1.price = 11
+        if #available(iOS 12.2, macOS 10.14.4, *) {
+            let discount1 = RCPromotionalOffer()
+            discount1.offerIdentifier = "offerid1"
+            discount1.paymentMode = .payAsYouGo
+            discount1.price = 11
 
-        let discount2 = RCPromotionalOffer()
-        discount2.offerIdentifier = "offerid2"
-        discount2.paymentMode = .payUpFront
-        discount2.price = 12
+            let discount2 = RCPromotionalOffer()
+            discount2.offerIdentifier = "offerid2"
+            discount2.paymentMode = .payUpFront
+            discount2.price = 12
 
-        let discount3 = RCPromotionalOffer()
-        discount3.offerIdentifier = "offerid3"
-        discount3.paymentMode = .freeTrial
-        discount3.price = 13
+            let discount3 = RCPromotionalOffer()
+            discount3.offerIdentifier = "offerid3"
+            discount3.paymentMode = .freeTrial
+            discount3.price = 13
 
-        let productInfo: RCProductInfo = .createMockProductInfo(productIdentifier: "cool_product",
-                                                                paymentMode: .payUpFront,
-                                                                currencyCode: "UYU",
-                                                                price: 49.99,
-                                                                normalDuration: "P3Y",
-                                                                introDuration: "P3W",
-                                                                introDurationType: .freeTrial,
-                                                                introPrice: 0,
-                                                                subscriptionGroup: "cool_group",
-                                                                discounts: [discount1, discount2, discount3])
-        expect(productInfo.cacheKey()) == "cool_product-49.99-UYU-1-0-cool_group-P3Y-P3W-0-offerid1-offerid2-offerid3"
+            let productInfo: RCProductInfo = .createMockProductInfo(productIdentifier: "cool_product",
+                                                                    paymentMode: .payUpFront,
+                                                                    currencyCode: "UYU",
+                                                                    price: 49.99,
+                                                                    normalDuration: "P3Y",
+                                                                    introDuration: "P3W",
+                                                                    introDurationType: .freeTrial,
+                                                                    introPrice: 0,
+                                                                    subscriptionGroup: "cool_group",
+                                                                    discounts: [discount1, discount2, discount3])
+            expect(productInfo.cacheKey()) == "cool_product-49.99-UYU-1-0-cool_group-P3Y-P3W-0-offerid1-offerid2-offerid3"
+        }
     }
 }

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -672,8 +672,10 @@ class PurchasesTests: XCTestCase {
 
         expect(self.backend.postedProductID).toNot(beNil())
         expect(self.backend.postedPrice).toNot(beNil())
-        expect(self.backend.postedIntroPrice).toNot(beNil())
         expect(self.backend.postedCurrencyCode).toNot(beNil())
+        if #available(iOS 12.2, macOS 10.14.4, *) {
+            expect(self.backend.postedIntroPrice).toNot(beNil())
+        }
     }
 
     enum BackendError: Error {


### PR DESCRIPTION
Tests currently fail on iOS < 12.2, because they assume that the APIs for subscription offers are available. 

This fixes those tests. 

Tested on my local computer on iOS 11. 

We should get CircleCI to also test on old OS versions, but I'm doing that as a part of integration tests later. 