### PR TITLE
Make cocoapods linking dynamic again

### DIFF
--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -23,7 +23,6 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.dependency 'PurchasesCoreSwift', '3.8.0-SNAPSHOT'
-  s.static_framework = true
 
 
   s.source_files = ['Purchases/**/*.{h,m}']

--- a/PurchasesCoreSwift.podspec
+++ b/PurchasesCoreSwift.podspec
@@ -20,7 +20,6 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.12'
   s.watchos.deployment_target = '6.2'
   s.tvos.deployment_target = '9.0'
-  s.static_framework = true
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 


### PR DESCRIPTION
I made cocoapods linking static after reports of a few build issues (), but I'm not sure those were strictly related - it might have been xcode 12's linking changes. 

In any case, customers who do require static linking will still be able to accomplish it by adding in the podfile:
```ruby
use_frameworks! :linkage => :static
```

This will have a `purchases-hybrid-common` counterpart and other counterparts for the hybrid sdks to ensure that they all work before shipping

Original PR to make cocoapods linking static and customer build issue reports:
https://github.com/RevenueCat/purchases-ios/pull/353
https://github.com/RevenueCat/purchases-flutter/issues/99

Tested on: 
- a sample app that integrates the library with cocoapods
- purchases-hybrid-common
- react native plugin
- unity
- cordova
- flutter

And it seems to work correctly on all of the above, both when building and archiving. 

