### PR TITLE
version 3.7.5

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -5,9 +5,9 @@ objc: true
 sdk: iphonesimulator
 module: Purchases
 umbrella_header: Purchases/Public/Purchases.h
-module_version: 3.8.0-SNAPSHOT
+module_version: 3.7.5
 github_url: https://github.com/revenuecat/purchases-ios
-github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.8.0-SNAPSHOT
+github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.7.5
 output: docs
 # Leaving this commented out. We used to specify this before, but now it's working without it
 # xcodebuild_arguments: [--objc,Purchases/Public/Purchases.h,--,-x,objective-c,-isysroot,$(xcrun --show-sdk-path),-I,$(pwd)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+## 3.7.5
+- Move test dependencies back to carthage
+    https://github.com/RevenueCat/purchases-ios/pull/371
+    https://github.com/RevenueCat/purchases-ios/pull/373
+- fixed tests for iOS < 12.2
+    https://github.com/RevenueCat/purchases-ios/pull/372
+- Make cocoapods linking dynamic again
+    https://github.com/RevenueCat/purchases-ios/pull/374
+
+## 3.7.4
+- Fix parsing of dates in receipts with milliseconds
+    https://github.com/RevenueCat/purchases-ios/pull/367
+- Add jitter and extra cache for background processes
+    https://github.com/RevenueCat/purchases-ios/pull/366
+- Skip install to fix archives with direct integration
+    https://github.com/RevenueCat/purchases-ios/pull/364
+
+## 3.7.3
+- Renames files with names that caused issues when building on Windows
+    https://github.com/RevenueCat/purchases-ios/pull/362
+- Fixes crash when parsing receipts with an unexpected number of internal containers in an IAP ASN.1 Container
+    https://github.com/RevenueCat/purchases-ios/pull/360
+- Fixes crash when sending `NSNull` attributes to `addAttributionData:fromNetwork:`
+    https://github.com/RevenueCat/purchases-ios/pull/359
+- Added starter string constants file for logging
+    https://github.com/RevenueCat/purchases-ios/pull/339
+
 ## 3.7.2
 - Updates the Pod to make it compile as a static framework, fixing build issues on hybrid SDKs. Cleans up imports in `RCPurchases.h`.
     https://github.com/RevenueCat/purchases-ios/pull/353
@@ -62,6 +89,10 @@
 	https://github.com/RevenueCat/purchases-ios/pull/330
 - Fix bug where 404s in subscriber attributes POST would mark them as synced
     https://github.com/RevenueCat/purchases-ios/pull/328
+
+## 3.5.3
+- Addresses an issue where subscriber attributes might not sync correctly if subscriber info for the user hadn't been synced before the subscriber attributes sync was performed.
+    https://github.com/RevenueCat/purchases-ios/pull/327
 
 ## 3.5.2
 - Feature/defer cache updates if woken from push notification

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Purchases"
-  s.version          = "3.8.0-SNAPSHOT"
+  s.version          = "3.7.5"
   s.summary          = "Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
-  s.dependency 'PurchasesCoreSwift', '3.8.0-SNAPSHOT'
+  s.dependency 'PurchasesCoreSwift', '3.7.5'
 
 
   s.source_files = ['Purchases/**/*.{h,m}']

--- a/Purchases/Info.plist
+++ b/Purchases/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.8.0-SNAPSHOT</string>
+	<string>3.7.5</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Purchases/Misc/RCSystemInfo.m
+++ b/Purchases/Misc/RCSystemInfo.m
@@ -48,7 +48,7 @@ static BOOL _forceUniversalAppStore = NO;
 }
 
 + (NSString *)frameworkVersion {
-    return @"3.8.0-SNAPSHOT";
+    return @"3.7.5";
 }
 
 + (NSString *)systemVersion {

--- a/PurchasesCoreSwift.podspec
+++ b/PurchasesCoreSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesCoreSwift"
-  s.version          = "3.8.0-SNAPSHOT"
+  s.version          = "3.7.5"
   s.summary          = "Swift portion of RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/PurchasesCoreSwift/Info.plist
+++ b/PurchasesCoreSwift/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.8.0-SNAPSHOT</string>
+	<string>3.7.5</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/PurchasesCoreSwiftTests/Info.plist
+++ b/PurchasesCoreSwiftTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.8.0-SNAPSHOT</string>
+	<string>3.7.5</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/PurchasesTests/Info.plist
+++ b/PurchasesTests/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.8.0-SNAPSHOT</string>
+	<string>3.7.5</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
## 3.7.5
- Move test dependencies back to carthage
    https://github.com/RevenueCat/purchases-ios/pull/371
    https://github.com/RevenueCat/purchases-ios/pull/373
- fixed tests for iOS < 12.2
    https://github.com/RevenueCat/purchases-ios/pull/372
- Make cocoapods linking dynamic again
    https://github.com/RevenueCat/purchases-ios/pull/374
