### PR TITLE
Fix/race condition after uninstalling app

### DIFF
--- a/Purchases/Caching/RCDeviceCache.m
+++ b/Purchases/Caching/RCDeviceCache.m
@@ -100,8 +100,8 @@ int cacheDurationInSecondsInBackground = 60 * 60 * 24;
 
 - (void)cacheAppUserID:(NSString *)appUserID {
     @synchronized (self) {
-        self.appUserIDHasBeenSet = YES;
         [self.userDefaults setObject:appUserID forKey:RCAppUserDefaultsKey];
+        self.appUserIDHasBeenSet = YES;
     }
 }
 

--- a/Purchases/Caching/RCDeviceCache.m
+++ b/Purchases/Caching/RCDeviceCache.m
@@ -99,7 +99,10 @@ int cacheDurationInSecondsInBackground = 60 * 60 * 24;
 }
 
 - (void)cacheAppUserID:(NSString *)appUserID {
-    [self.userDefaults setObject:appUserID forKey:RCAppUserDefaultsKey];
+    @synchronized (self) {
+        self.appUserIDHasBeenSet = YES;
+        [self.userDefaults setObject:appUserID forKey:RCAppUserDefaultsKey];
+    }
 }
 
 - (void)clearCachesForAppUserID:(NSString *)oldAppUserID andSaveNewUserID:(NSString *)newUserID {
@@ -112,7 +115,6 @@ int cacheDurationInSecondsInBackground = 60 * 60 * 24;
         [self deleteAttributesIfSyncedForAppUserID:oldAppUserID];
 
         [self cacheAppUserID:newUserID];
-        self.appUserIDHasBeenSet = YES;
     }
 }
 

--- a/Purchases/Caching/RCDeviceCache.m
+++ b/Purchases/Caching/RCDeviceCache.m
@@ -15,6 +15,8 @@
 @property (nonatomic) NSNotificationCenter *notificationCenter;
 @property (nonatomic, nonnull) RCInMemoryCachedObject<RCOfferings *> *offeringsCachedObject;
 
+@property (nonatomic, assign) BOOL appUserIDHasBeenSet;
+
 @end
 
 
@@ -55,6 +57,7 @@ int cacheDurationInSecondsInBackground = 60 * 60 * 24;
             userDefaults = NSUserDefaults.standardUserDefaults;
         }
         self.userDefaults = userDefaults;
+        self.appUserIDHasBeenSet = self.cachedAppUserID != nil;
         [self observeAppUserIDChanges];
     }
 
@@ -71,7 +74,7 @@ int cacheDurationInSecondsInBackground = 60 * 60 * 24;
 }
 
 - (void)handleUserDefaultsChanged:(NSNotification *)notification {
-    if (notification.object == self.userDefaults) {
+    if (self.appUserIDHasBeenSet && notification.object == self.userDefaults) {
         if (!self.cachedAppUserID) {
             NSAssert(false, @"[Purchases] - Cached appUserID has been deleted from user defaults. "
                             "This leaves the SDK in an undetermined state. Please make sure that RevenueCat "
@@ -109,6 +112,7 @@ int cacheDurationInSecondsInBackground = 60 * 60 * 24;
         [self deleteAttributesIfSyncedForAppUserID:oldAppUserID];
 
         [self cacheAppUserID:newUserID];
+        self.appUserIDHasBeenSet = YES;
     }
 }
 

--- a/PurchasesTests/Caching/DeviceCacheTests.swift
+++ b/PurchasesTests/Caching/DeviceCacheTests.swift
@@ -201,16 +201,28 @@ class DeviceCacheTests: XCTestCase {
 
     func testCrashesWhenAppUserIDIsDeleted() {
         let mockNotificationCenter = MockNotificationCenter()
+        mockUserDefaults.mockValues["com.revenuecat.userdefaults.appUserID.new"] = "Rage Against the Machine"
+
         self.deviceCache = RCDeviceCache(mockUserDefaults,
                                          offeringsCachedObject: nil,
                                          notificationCenter: mockNotificationCenter)
-        mockUserDefaults.mockValues["com.revenuecat.userdefaults.appUserID.new"] = "Rage Against the Machine"
 
         expect { mockNotificationCenter.fireNotifications() }.notTo(raiseException())
 
         mockUserDefaults.mockValues["com.revenuecat.userdefaults.appUserID.new"] = nil
 
         expect { mockNotificationCenter.fireNotifications() }.to(raiseException())
+    }
+
+    func testDoesntCrashIfOtherSettingIsDeletedAndAppUserIDHadntBeenSet() {
+        let mockNotificationCenter = MockNotificationCenter()
+        mockUserDefaults.mockValues["com.revenuecat.userdefaults.appUserID.new"] = nil
+
+        self.deviceCache = RCDeviceCache(mockUserDefaults,
+                                         offeringsCachedObject: nil,
+                                         notificationCenter: mockNotificationCenter)
+
+        expect { mockNotificationCenter.fireNotifications() }.notTo(raiseException())
     }
 
     func testNewDeviceCacheInstanceWithExistingValidPurchaserInfoCacheIsntStale() {


### PR DESCRIPTION
Addresses https://github.com/RevenueCat/purchases-ios/issues/375

Fixes an issue where if the app modifies other userDefaults preferences, and the appUserID had never been set in RevenueCat, the SDK will crash. 
