### PR TITLE
fix overflow of web_order_line_item_id in 32-bit devices

### DIFF
--- a/PurchasesCoreSwift/LocalReceiptParsing/BasicTypes/InAppPurchase.swift
+++ b/PurchasesCoreSwift/LocalReceiptParsing/BasicTypes/InAppPurchase.swift
@@ -42,7 +42,7 @@ struct InAppPurchase: Equatable {
     let cancellationDate: Date?
     let isInTrialPeriod: Bool?
     let isInIntroOfferPeriod: Bool
-    let webOrderLineItemId: Int
+    let webOrderLineItemId: Int64
     let promotionalOfferIdentifier: String?
 
     var asDict: [String: Any] {

--- a/PurchasesCoreSwift/LocalReceiptParsing/Builders/InAppPurchaseBuilder.swift
+++ b/PurchasesCoreSwift/LocalReceiptParsing/Builders/InAppPurchaseBuilder.swift
@@ -31,7 +31,7 @@ class InAppPurchaseBuilder {
         var cancellationDate: Date?
         var isInTrialPeriod: Bool?
         var isInIntroOfferPeriod: Bool?
-        var webOrderLineItemId: Int?
+        var webOrderLineItemId: Int64?
         var promotionalOfferIdentifier: String?
 
         for internalContainer in container.internalContainers {
@@ -51,7 +51,7 @@ class InAppPurchaseBuilder {
             case .quantity:
                 quantity = internalContainer.internalPayload.toInt()
             case .webOrderLineItemId:
-                webOrderLineItemId = internalContainer.internalPayload.toInt()
+                webOrderLineItemId = internalContainer.internalPayload.toInt64()
             case .productType:
                 productType = InAppPurchaseProductType(rawValue: internalContainer.internalPayload.toInt())
             case .isInIntroOfferPeriod:

--- a/PurchasesCoreSwift/LocalReceiptParsing/DataConverters/ArraySlice_UInt8+Extensions.swift
+++ b/PurchasesCoreSwift/LocalReceiptParsing/DataConverters/ArraySlice_UInt8+Extensions.swift
@@ -6,18 +6,22 @@
 import Foundation
 
 extension ArraySlice where Element == UInt8 {
-    func toUInt() -> UInt {
+    func toUInt() -> UInt64 {
         let array = Array(self)
-        var result: UInt = 0
+        var result: UInt64 = 0
         for idx in 0..<(array.count) {
             let shiftAmount = UInt((array.count) - idx - 1) * 8
-            result += UInt(array[idx]) << shiftAmount
+            result += UInt64(array[idx]) << shiftAmount
         }
         return result
     }
 
     func toInt() -> Int {
         return Int(self.toUInt())
+    }
+
+    func toInt64() -> Int64 {
+        return Int64(self.toUInt())
     }
 
     func toBool() -> Bool {

--- a/PurchasesCoreSwiftTests/LocalReceiptParsing/Builders/AppleReceiptBuilderTests.swift
+++ b/PurchasesCoreSwiftTests/LocalReceiptParsing/Builders/AppleReceiptBuilderTests.swift
@@ -92,7 +92,7 @@ class AppleReceiptBuilderTests: XCTestCase {
                                                                     cancellationDate: nil,
                                                                     isInTrialPeriod: false,
                                                                     isInIntroOfferPeriod: false,
-                                                                    webOrderLineItemId: 658464,
+                                                                    webOrderLineItemId: Int64(658464),
                                                                     promotionalOfferIdentifier: nil)
 
         let receipt = try! self.appleReceiptBuilder.build(fromContainer: receiptContainer)

--- a/PurchasesCoreSwiftTests/LocalReceiptParsing/Builders/InAppPurchaseBuilderTests.swift
+++ b/PurchasesCoreSwiftTests/LocalReceiptParsing/Builders/InAppPurchaseBuilderTests.swift
@@ -21,7 +21,7 @@ class InAppPurchaseBuilderTests: XCTestCase {
     let cancellationDate = Date.from(year: 2019, month: 7, day: 4, hour: 7, minute: 1, second: 45)
     let isInTrialPeriod = false
     let isInIntroOfferPeriod = true
-    let webOrderLineItemId = 897501072
+    let webOrderLineItemId = Int64(897501072)
     let promotionalOfferIdentifier = "com.revenuecat.productPromoOffer"
 
     private let containerFactory = ContainerFactory()

--- a/PurchasesCoreSwiftTests/LocalReceiptParsing/DataConverters/UInt8+ExtensionsTests.swift
+++ b/PurchasesCoreSwiftTests/LocalReceiptParsing/DataConverters/UInt8+ExtensionsTests.swift
@@ -17,8 +17,10 @@ class UInt8ExtensionsTests: XCTestCase {
     }
 
     func testBitAtIndexRaisesIfInvalidIndex() {
+        #if arch(x86_64)
         expect { _ = UInt8(0b1).bitAtIndex(7) }.notTo(throwAssertion())
         expect { _ = UInt8(0b1).bitAtIndex(8) }.to(throwAssertion())
+        #endif
     }
     
     func testValueInRangeGetsCorrectValue() {
@@ -32,8 +34,10 @@ class UInt8ExtensionsTests: XCTestCase {
     }
     
     func testValueInRangeRaisesIfInvalidRange() {
+        #if arch(x86_64)
         expect{ _ = UInt8(0b10000010).valueInRange(from: 1, to: 6)}.notTo(throwAssertion())
         expect{ _ = UInt8(0b10000010).valueInRange(from: 6, to: 1)}.to(throwAssertion())
         expect{ _ = UInt8(0b10000010).valueInRange(from: 6, to: 8)}.to(throwAssertion())
+        #endif
     }
 }

--- a/PurchasesCoreSwiftTests/LocalReceiptParsing/DataConverters/UInt8+ExtensionsTests.swift
+++ b/PurchasesCoreSwiftTests/LocalReceiptParsing/DataConverters/UInt8+ExtensionsTests.swift
@@ -17,6 +17,8 @@ class UInt8ExtensionsTests: XCTestCase {
     }
 
     func testBitAtIndexRaisesIfInvalidIndex() {
+        // throwAssertion isn't supported on 32-bit simulators
+        // https://github.com/Quick/Nimble/blob/master/Sources/Nimble/Matchers/ThrowAssertion.swift#L46
         #if arch(x86_64)
         expect { _ = UInt8(0b1).bitAtIndex(7) }.notTo(throwAssertion())
         expect { _ = UInt8(0b1).bitAtIndex(8) }.to(throwAssertion())
@@ -34,6 +36,8 @@ class UInt8ExtensionsTests: XCTestCase {
     }
     
     func testValueInRangeRaisesIfInvalidRange() {
+        // throwAssertion isn't supported on 32-bit simulators
+        // https://github.com/Quick/Nimble/blob/master/Sources/Nimble/Matchers/ThrowAssertion.swift#L46
         #if arch(x86_64)
         expect{ _ = UInt8(0b10000010).valueInRange(from: 1, to: 6)}.notTo(throwAssertion())
         expect{ _ = UInt8(0b10000010).valueInRange(from: 6, to: 1)}.to(throwAssertion())

--- a/PurchasesCoreSwiftTests/LocalReceiptParsing/TestsAgainstRealReceipts/ReceiptParsing+TestsWithRealReceipts.swift
+++ b/PurchasesCoreSwiftTests/LocalReceiptParsing/TestsAgainstRealReceipts/ReceiptParsing+TestsWithRealReceipts.swift
@@ -48,7 +48,7 @@ class ReceiptParsingRealReceiptTests: XCTestCase {
         expect(inAppPurchase0.cancellationDate).to(beNil())
         expect(inAppPurchase0.isInTrialPeriod) == false
         expect(inAppPurchase0.isInIntroOfferPeriod) == false
-        expect(inAppPurchase0.webOrderLineItemId) == 1000000054042695
+        expect(inAppPurchase0.webOrderLineItemId) == Int64(1000000054042695)
         expect(inAppPurchase0.promotionalOfferIdentifier).to(beNil())
         
         let inAppPurchase1 = inAppPurchases[1]
@@ -63,7 +63,7 @@ class ReceiptParsingRealReceiptTests: XCTestCase {
         expect(inAppPurchase1.cancellationDate).to(beNil())
         expect(inAppPurchase1.isInTrialPeriod) == false
         expect(inAppPurchase1.isInIntroOfferPeriod) == false
-        expect(inAppPurchase1.webOrderLineItemId) == 1000000054042739
+        expect(inAppPurchase1.webOrderLineItemId) == Int64(1000000054042739)
         expect(inAppPurchase1.promotionalOfferIdentifier).to(beNil())
         
         let inAppPurchase2 = inAppPurchases[2]
@@ -78,7 +78,7 @@ class ReceiptParsingRealReceiptTests: XCTestCase {
         expect(inAppPurchase2.cancellationDate).to(beNil())
         expect(inAppPurchase2.isInTrialPeriod) == false
         expect(inAppPurchase2.isInIntroOfferPeriod) == false
-        expect(inAppPurchase2.webOrderLineItemId) == 1000000054044460
+        expect(inAppPurchase2.webOrderLineItemId) == Int64(1000000054044460)
         expect(inAppPurchase2.promotionalOfferIdentifier).to(beNil())
 
         let inAppPurchase3 = inAppPurchases[3]
@@ -93,7 +93,7 @@ class ReceiptParsingRealReceiptTests: XCTestCase {
         expect(inAppPurchase3.cancellationDate).to(beNil())
         expect(inAppPurchase3.isInTrialPeriod) == false
         expect(inAppPurchase3.isInIntroOfferPeriod) == false
-        expect(inAppPurchase3.webOrderLineItemId) == 1000000054044520
+        expect(inAppPurchase3.webOrderLineItemId) == Int64(1000000054044520)
         expect(inAppPurchase3.promotionalOfferIdentifier).to(beNil())
 
         let inAppPurchase4 = inAppPurchases[4]
@@ -108,7 +108,7 @@ class ReceiptParsingRealReceiptTests: XCTestCase {
         expect(inAppPurchase4.cancellationDate).to(beNil())
         expect(inAppPurchase4.isInTrialPeriod) == false
         expect(inAppPurchase4.isInIntroOfferPeriod) == false
-        expect(inAppPurchase4.webOrderLineItemId) == 1000000054044587
+        expect(inAppPurchase4.webOrderLineItemId) == Int64(1000000054044587)
         expect(inAppPurchase4.promotionalOfferIdentifier).to(beNil())
 
         let inAppPurchase5 = inAppPurchases[5]
@@ -123,7 +123,7 @@ class ReceiptParsingRealReceiptTests: XCTestCase {
         expect(inAppPurchase5.cancellationDate).to(beNil())
         expect(inAppPurchase5.isInTrialPeriod) == false
         expect(inAppPurchase5.isInIntroOfferPeriod) == false
-        expect(inAppPurchase5.webOrderLineItemId) == 1000000054044637
+        expect(inAppPurchase5.webOrderLineItemId) == Int64(1000000054044637)
         expect(inAppPurchase5.promotionalOfferIdentifier).to(beNil())
 
         let inAppPurchase6 = inAppPurchases[6]
@@ -138,7 +138,7 @@ class ReceiptParsingRealReceiptTests: XCTestCase {
         expect(inAppPurchase6.cancellationDate).to(beNil())
         expect(inAppPurchase6.isInTrialPeriod) == false
         expect(inAppPurchase6.isInIntroOfferPeriod) == false
-        expect(inAppPurchase6.webOrderLineItemId) == 1000000054044710
+        expect(inAppPurchase6.webOrderLineItemId) == Int64(1000000054044710)
         expect(inAppPurchase6.promotionalOfferIdentifier).to(beNil())
 
         let inAppPurchase7 = inAppPurchases[7]
@@ -153,7 +153,7 @@ class ReceiptParsingRealReceiptTests: XCTestCase {
         expect(inAppPurchase7.cancellationDate).to(beNil())
         expect(inAppPurchase7.isInTrialPeriod) == false
         expect(inAppPurchase7.isInIntroOfferPeriod) == false
-        expect(inAppPurchase7.webOrderLineItemId) == 1000000054044800
+        expect(inAppPurchase7.webOrderLineItemId) == Int64(1000000054044800)
         expect(inAppPurchase7.promotionalOfferIdentifier).to(beNil())
 
         let inAppPurchase8 = inAppPurchases[8]
@@ -168,7 +168,7 @@ class ReceiptParsingRealReceiptTests: XCTestCase {
         expect(inAppPurchase8.cancellationDate).to(beNil())
         expect(inAppPurchase8.isInTrialPeriod) == true
         expect(inAppPurchase8.isInIntroOfferPeriod) == false
-        expect(inAppPurchase8.webOrderLineItemId) == 1000000054042694
+        expect(inAppPurchase8.webOrderLineItemId) == Int64(1000000054042694)
         expect(inAppPurchase8.promotionalOfferIdentifier).to(beNil())
     }
 }

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -1112,7 +1112,7 @@ class BackendTests: XCTestCase {
                     "signature_data": [
                         "signature": "Base64 encoded signature",
                         "nonce": "A UUID",
-                        "timestamp": 123413232131
+                        "timestamp": Int64(123413232131)
                     ],
                     "signature_error": nil
                 ]

--- a/PurchasesTests/Purchasing/PurchaserInfoTests.swift
+++ b/PurchasesTests/Purchasing/PurchaserInfoTests.swift
@@ -23,7 +23,7 @@ class EmptyPurchaserInfoTests: XCTestCase {
 class BasicPurchaserInfoTests: XCTestCase {
     let validSubscriberResponse = [
         "request_date": "2018-10-19T02:40:36Z",
-        "request_date_ms": 1563379533946,
+        "request_date_ms": Int64(1563379533946),
         "subscriber": [
             "original_app_user_id": "app_user_id",
             "original_application_version": "2083",

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -1812,7 +1812,7 @@ class PurchasesTests: XCTestCase {
         if #available(iOS 12.2, *) {
             setupPurchases()
             let product = MockSKProduct(mockProductIdentifier: "com.product.id1")
-            let discount = SKPaymentDiscount.init(identifier: "discount", keyIdentifier: "TIKAMASALA1", nonce: UUID(), signature: "Base64 encoded signature", timestamp: 123413232131)
+            let discount = SKPaymentDiscount.init(identifier: "discount", keyIdentifier: "TIKAMASALA1", nonce: UUID(), signature: "Base64 encoded signature", timestamp: NSNumber(value: Int64(123413232131)))
 
             self.purchases?.purchaseProduct(product, discount: discount) { (tx, info, error, userCancelled) in
 


### PR DESCRIPTION
Addresses https://github.com/RevenueCat/purchases-ios/issues/379

the `web_order_line_item_id` is actually a 64-bit integer, so parsing it would crash on 32-bit devices. 

This PR forces the type to `Int64`, which will of course be slower but work correctly. 

I believe there's another issue in 64-bit devices, because unrelated tests are not passing correctly for me on iPhone 5. I'll work on those separately. 