### PR TITLE
fix: string comparison when deleting synced attributes

### DIFF
--- a/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
@@ -141,7 +141,7 @@ NS_ASSUME_NONNULL_BEGIN
                                      error:(NSError *)error {
     if (error == nil) {
         RCLog(@"Subscriber attributes synced successfully for appUserID: %@", syncingAppUserID);
-        if (syncingAppUserID != currentAppUserID) {
+        if (![syncingAppUserID isEqualToString:currentAppUserID]) {
             [self.deviceCache deleteAttributesIfSyncedForAppUserID:syncingAppUserID];
         }
     } else {


### PR DESCRIPTION
This is kind of a fascinating one to me. 
Tests were failing on 32-bit devices, on something that didn't seem arch-related to me at least in an obvious way. 
The actual bug was really clear: we were doing
```objective-c
        if (syncingAppUserID != currentAppUserID) {
```
where both arguments are strings, so that comparison meant to check for value but was actually checking equality. 

The interesting part, though, was that it works for 64 bit devices (we would have caught it straight away in the tests if it didn't). 

Turns out, an implementation detail within `NSString` actually makes it work in 64-bit, but not 32-bit. 

| 64-bit | 32-bit |
| :-: | :-: |
| <img width="437" alt="image" src="https://user-images.githubusercontent.com/3922667/98559039-e6509400-2284-11eb-9f5d-696c6e128538.png"> <img width="389" alt="image" src="https://user-images.githubusercontent.com/3922667/98559060-ebadde80-2284-11eb-994b-cf090043ca7d.png"> | <img width="321" alt="image" src="https://user-images.githubusercontent.com/3922667/98559575-8c9c9980-2285-11eb-9090-62f81e909c06.png"> <img width="385" alt="image" src="https://user-images.githubusercontent.com/3922667/98559561-873f4f00-2285-11eb-98a0-e14befd45a41.png"> |

I believe 64-bit devices are internally doing something akin to [ruby's symbols ](https://medium.com/@pk60905/string-and-symbol-in-ruby-cb0bf0d4dd2c) where they reuse the same memory address for immutable strings that have the same value, but I couldn't find any docs on it. 


Fortunately, the impact of the bug is small - it just means that devices might try to re-sync the same subscriber attribute if it's set to the same value after syncing. 
And, although I can't confirm it, from the tests it would seem like it only affects 32-bit devices, which there aren't that many of in the wild. 

