### PR TITLE
fix docs-deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,11 +53,8 @@ jobs:
           name: Build docs
           command: fastlane run jazzy
       - run:
-          name: Install pip
-          command: sudo easy_install pip
-      - run:
           name: Install awscli
-          command: sudo python -m pip install awscli
+          command: sudo python3 -m pip install awscli
       - run:
           name: Deploy to S3
           command: aws s3 sync docs s3://purchases-docs/ios --delete --acl public-read


### PR DESCRIPTION
The `docs-deploy` job was failing with error:
```
ERROR: Could not install packages due to an EnvironmentError: [Errno 30] Read-only file system: '/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/dateutil/parser.pyc'
```

I believe this error is happening because of how python2 is set up in circleci. In any case, we should be moving to python 3, and ~I also think this might fix the job.~
Update: confirmed that using python3, the `awscli` tool is installed correctly. 
