### PR TITLE
feature: restoreTransactionsProgrammatically

### DIFF
--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		37E35BE05E2A8BB2BD310CB0 /* RCHTTPClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E356C39D29EB6C8EC2D6BD /* RCHTTPClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E35C1B3C0170F15FC920F5 /* RCPackage+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35DF0786134609B68FA23 /* RCPackage+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E35C5A53AC7CF63B240FEC /* RCEntitlementInfos+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E354902741920FC5AE69A5 /* RCEntitlementInfos+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		37E35C5E805407840AC79468 /* RCReceiptRefreshPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E3585E07410DC8470406D5 /* RCReceiptRefreshPolicy.h */; };
 		37E35C7C3BADD6D1BBAE7129 /* RCSubscriberAttribute+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 37E35C1DFC68AC9E58E868F2 /* RCSubscriberAttribute+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		37E35C8515C5E2D01B0AF5C1 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3507939634ED5A9280544 /* Strings.swift */; };
 		37E35C90AAEFEA77BB48DC0F /* NSData+RCExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 37E357FA5215FF384262957E /* NSData+RCExtensions.m */; };
@@ -415,6 +416,7 @@
 		37E3582920E16E065502E5FC /* EntitlementInfosTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EntitlementInfosTests.swift; sourceTree = "<group>"; };
 		37E3583675928C01D92E3166 /* ProductInfoExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductInfoExtensions.swift; sourceTree = "<group>"; };
 		37E35838A7FD36982EE14100 /* MockPurchasesDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockPurchasesDelegate.swift; sourceTree = "<group>"; };
+		37E3585E07410DC8470406D5 /* RCReceiptRefreshPolicy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCReceiptRefreshPolicy.h; sourceTree = "<group>"; };
 		37E358BF58C99AC39073B96C /* BackendTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackendTests.swift; sourceTree = "<group>"; };
 		37E359B77C1E588C9C009D2B /* RCStoreKitWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCStoreKitWrapper.h; sourceTree = "<group>"; };
 		37E359D128E667D950598853 /* RCIntroEligibility+Protected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCIntroEligibility+Protected.h"; sourceTree = "<group>"; };
@@ -966,6 +968,7 @@
 				37E354FA06E2FDFB81EE3937 /* RCProductInfo.h */,
 				37E35E5C3D1B1D6814496C89 /* RCProductInfoExtractor.m */,
 				37E35BC489985F613020035D /* RCProductInfoExtractor.h */,
+				37E3585E07410DC8470406D5 /* RCReceiptRefreshPolicy.h */,
 			);
 			path = Purchasing;
 			sourceTree = "<group>";
@@ -1118,6 +1121,7 @@
 				37E352039F075299CD4CF6B0 /* RCHTTPRequest.h in Headers */,
 				2D8E9D54252374A600AFEE11 /* NSDictionary+RCExtensions.h in Headers */,
 				37E35A328C4DC8A4D2DB4B06 /* RCAttributionNetwork.h in Headers */,
+				37E35C5E805407840AC79468 /* RCReceiptRefreshPolicy.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -291,7 +291,8 @@ NS_SWIFT_NAME(purchasePackage(_:_:));
  the same `appUserId` used to purchase originally.
 
  @note This may force your users to enter the App Store password so should only be performed on request of the user.
- Typically with a button in settings or near your purchase UI. Use silentRestoreTransactionsWithCompletionBlock if you need to restore transactions programatically.
+ Typically with a button in settings or near your purchase UI. Use restoreTransactionsProgrammaticallyWithCompletionBlock
+ if you need to restore transactions programmatically.
  */
 - (void)restoreTransactionsWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion
 NS_SWIFT_NAME(restoreTransactions(_:));
@@ -307,8 +308,8 @@ NS_SWIFT_NAME(restoreTransactions(_:));
  @note This method will not trigger a login prompt from App Store. However, if the receipt currently on the device does not contain subscriptions,
  but the user has made subscription purchases, this method won't be able to restore them. Use restoreTransactionsWithCompletionBlock to cover those cases.
  */
-- (void)silentRestoreTransactionsWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion
-NS_SWIFT_NAME(silentRestoreTransactions(_:));
+- (void)restoreTransactionsProgrammaticallyWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion
+NS_SWIFT_NAME(restoreTransactionsProgrammatically(_:));
 
 
 /**

--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -283,23 +283,29 @@ NS_SWIFT_NAME(purchaseProduct(_:_:));
 NS_SWIFT_NAME(purchasePackage(_:_:));
 
 /**
- This method will post all purchases associated with the current App Store account to RevenueCat and become associated with the current `appUserID`. If the receipt is being used by an existing user, the current `appUserID` will be aliased together with the `appUserID` of the existing user. Going forward, either `appUserID` will be able to reference the same user.
+ This method will post all purchases associated with the current App Store account to RevenueCat and become associated with the current `appUserID`.
+ If the receipt is being used by an existing user, the current `appUserID` will be aliased together with the `appUserID` of the existing user.
+ Going forward, either `appUserID` will be able to reference the same user.
 
  You shouldn't use this method if you have your own account system. In that case "restoration" is provided by your app passing
  the same `appUserId` used to purchase originally.
 
- @note This may force your users to enter the App Store password so should only be performed on request of the user. Typically with a button in settings or near your purchase UI. Use silentRestoreTransactionsWithCompletionBlock if you need to restore transactions programatically.
+ @note This may force your users to enter the App Store password so should only be performed on request of the user.
+ Typically with a button in settings or near your purchase UI. Use silentRestoreTransactionsWithCompletionBlock if you need to restore transactions programatically.
  */
 - (void)restoreTransactionsWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion
 NS_SWIFT_NAME(restoreTransactions(_:));
 
 /**
- This method will post all purchases associated with the current App Store account to RevenueCat and become associated with the current `appUserID`. If the receipt is being used by an existing user, the current `appUserID` will be aliased together with the `appUserID` of the existing user. Going forward, either `appUserID` will be able to reference the same user.
+ This method will post all purchases associated with the current App Store account to RevenueCat and become associated with the current `appUserID`.
+ If the receipt is being used by an existing user, the current `appUserID` will be aliased together with the `appUserID` of the existing user.
+ Going forward, either `appUserID` will be able to reference the same user.
 
  You shouldn't use this method if you have your own account system. In that case "restoration" is provided by your app passing
  the same `appUserId` used to purchase originally.
 
- @note This method will not trigger a login prompt from App Store. However, if the receipt currently on the device does not contain subscriptions, but the user has made subscription purchases, this method won't be able to restore them. Use restoreTransactionsWithCompletionBlock to cover those cases.
+ @note This method will not trigger a login prompt from App Store. However, if the receipt currently on the device does not contain subscriptions,
+ but the user has made subscription purchases, this method won't be able to restore them. Use restoreTransactionsWithCompletionBlock to cover those cases.
  */
 - (void)silentRestoreTransactionsWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion
 NS_SWIFT_NAME(silentRestoreTransactions(_:));

--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -288,10 +288,22 @@ NS_SWIFT_NAME(purchasePackage(_:_:));
  You shouldn't use this method if you have your own account system. In that case "restoration" is provided by your app passing
  the same `appUserId` used to purchase originally.
 
- @note This may force your users to enter the App Store password so should only be performed on request of the user. Typically with a button in settings or near your purchase UI.
+ @note This may force your users to enter the App Store password so should only be performed on request of the user. Typically with a button in settings or near your purchase UI. Use silentRestoreTransactionsWithCompletionBlock if you need to restore transactions programatically.
  */
 - (void)restoreTransactionsWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion
 NS_SWIFT_NAME(restoreTransactions(_:));
+
+/**
+ This method will post all purchases associated with the current App Store account to RevenueCat and become associated with the current `appUserID`. If the receipt is being used by an existing user, the current `appUserID` will be aliased together with the `appUserID` of the existing user. Going forward, either `appUserID` will be able to reference the same user.
+
+ You shouldn't use this method if you have your own account system. In that case "restoration" is provided by your app passing
+ the same `appUserId` used to purchase originally.
+
+ @note This method will not trigger a login prompt from App Store. However, if the receipt currently on the device does not contain subscriptions, but the user has made subscription purchases, this method won't be able to restore them. Use restoreTransactionsWithCompletionBlock to cover those cases.
+ */
+- (void)silentRestoreTransactionsWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion
+NS_SWIFT_NAME(silentRestoreTransactions(_:));
+
 
 /**
  Computes whether or not a user is eligible for the introductory pricing period of a given product. You should use this method to determine whether or not you show the user the normal product price or the introductory price. This also applies to trials (trials are considered a type of introductory pricing).

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -573,7 +573,7 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
     [self.storeKitWrapper addPayment:[payment copy]];
 }
 
-- (void)silentRestoreTransactionsWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion {
+- (void)restoreTransactionsProgrammaticallyWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion {
     [self restoreTransactionsWithForceRefresh:NO completionBlock:completion];
 }
 

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -698,23 +698,27 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
                                   product:(SKProduct *)product
                                completion:(RCPaymentDiscountBlock)completion {
     [self receiptData:^(NSData *data) {
-        [self.backend postOfferForSigning:discount.identifier
-                    withProductIdentifier:product.productIdentifier
-                        subscriptionGroup:product.subscriptionGroupIdentifier
-                              receiptData:data
-                                appUserID:self.appUserID
-                               completion:^(NSString *_Nullable signature,
-                                       NSString *_Nullable keyIdentifier,
-                                       NSUUID *_Nullable nonce,
-                                       NSNumber *_Nullable timestamp,
-                                       NSError *_Nullable error) {
-                                   SKPaymentDiscount *paymentDiscount = [[SKPaymentDiscount alloc] initWithIdentifier:discount.identifier
-                                                                                                        keyIdentifier:keyIdentifier
-                                                                                                                nonce:nonce
-                                                                                                            signature:signature
-                                                                                                            timestamp:timestamp];
-                                   completion(paymentDiscount, error);
-                               }];
+        if (data == nil || data.length == 0) {
+            completion(nil, RCPurchasesErrorUtils.missingReceiptFileError);
+        } else {
+            [self.backend postOfferForSigning:discount.identifier
+                        withProductIdentifier:product.productIdentifier
+                            subscriptionGroup:product.subscriptionGroupIdentifier
+                                  receiptData:data
+                                    appUserID:self.appUserID
+                                   completion:^(NSString *_Nullable signature,
+                                                NSString *_Nullable keyIdentifier,
+                                                NSUUID *_Nullable nonce,
+                                                NSNumber *_Nullable timestamp,
+                                                NSError *_Nullable error) {
+                SKPaymentDiscount *paymentDiscount = [[SKPaymentDiscount alloc] initWithIdentifier:discount.identifier
+                                                                                     keyIdentifier:keyIdentifier
+                                                                                             nonce:nonce
+                                                                                         signature:signature
+                                                                                         timestamp:timestamp];
+                completion(paymentDiscount, error);
+            }];
+        }
     }];
 }
 

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -573,14 +573,22 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
     [self.storeKitWrapper addPayment:[payment copy]];
 }
 
+- (void)silentRestoreTransactionsWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion {
+    [self restoreTransactionsWithForceRefresh:NO completionBlock:completion];
+}
 
 - (void)restoreTransactionsWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion {
+    [self restoreTransactionsWithForceRefresh:YES completionBlock:completion];
+}
+
+- (void)restoreTransactionsWithForceRefresh:(BOOL)shouldForceRefresh
+                            completionBlock:(nullable RCReceivePurchaserInfoBlock)completion {
     if (!self.allowSharingAppStoreAccount) {
         RCDebugLog(@"allowSharingAppStoreAccount is set to false and restoreTransactions has been called. Are you sure you want to do this?");
     }
     // Refresh the receipt and post to backend, this will allow the transactions to be transferred.
     // https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/StoreKitGuide/Chapters/Restoring.html
-    [self receiptDataWithForceRefresh:YES completion:^(NSData * _Nonnull data) {
+    [self receiptDataWithForceRefresh:shouldForceRefresh completion:^(NSData * _Nonnull data) {
         if (data.length == 0) {
             if (RCSystemInfo.isSandbox) {
                 RCLog(@"App running on sandbox without a receipt file. Restoring transactions won't work unless you've purchased before and there is a receipt available.");

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -29,6 +29,7 @@
 #import "RCSystemInfo.h"
 #import "RCProductInfoExtractor.h"
 #import "RCIntroEligibility+Protected.h"
+#import "RCReceiptRefreshPolicy.h"
 @import PurchasesCoreSwift;
 
 
@@ -574,24 +575,26 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 }
 
 - (void)restoreTransactionsProgrammaticallyWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion {
-    [self restoreTransactionsWithForceRefresh:NO completionBlock:completion];
+    [self restoreTransactionsWithReceiptRefreshPolicy:RCReceiptRefreshPolicyNever completionBlock:completion];
 }
 
 - (void)restoreTransactionsWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion {
-    [self restoreTransactionsWithForceRefresh:YES completionBlock:completion];
+    [self restoreTransactionsWithReceiptRefreshPolicy:RCReceiptRefreshPolicyAlways completionBlock:completion];
 }
 
-- (void)restoreTransactionsWithForceRefresh:(BOOL)shouldForceRefresh
-                            completionBlock:(nullable RCReceivePurchaserInfoBlock)completion {
+- (void)restoreTransactionsWithReceiptRefreshPolicy:(RCReceiptRefreshPolicy)refreshPolicy
+                                    completionBlock:(nullable RCReceivePurchaserInfoBlock)completion {
     if (!self.allowSharingAppStoreAccount) {
-        RCDebugLog(@"allowSharingAppStoreAccount is set to false and restoreTransactions has been called. Are you sure you want to do this?");
+        RCDebugLog(@"allowSharingAppStoreAccount is set to false and restoreTransactions has been called. "
+                   "Are you sure you want to do this?");
     }
     // Refresh the receipt and post to backend, this will allow the transactions to be transferred.
     // https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/StoreKitGuide/Chapters/Restoring.html
-    [self receiptDataWithForceRefresh:shouldForceRefresh completion:^(NSData * _Nonnull data) {
+    [self receiptDataWithReceiptRefreshPolicy:refreshPolicy completion:^(NSData *_Nonnull data) {
         if (data.length == 0) {
             if (RCSystemInfo.isSandbox) {
-                RCLog(@"App running on sandbox without a receipt file. Restoring transactions won't work unless you've purchased before and there is a receipt available.");
+                RCLog(@"App running on sandbox without a receipt file. Restoring transactions won't work unless "
+                      "you've purchased before and there is a receipt available.");
             }
             CALL_IF_SET_ON_MAIN_THREAD(completion, nil, [RCPurchasesErrorUtils missingReceiptFileError]);
             return;
@@ -986,17 +989,20 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 }
 
 - (void)receiptData:(RCReceiveReceiptDataBlock)completion {
-    [self receiptDataWithForceRefresh:NO completion:completion];
+    [self receiptDataWithReceiptRefreshPolicy:RCReceiptRefreshPolicyOnlyIfEmpty
+                                   completion:completion];
 }
 
-- (void)receiptDataWithForceRefresh:(BOOL)forceRefresh completion:(RCReceiveReceiptDataBlock)completion {
-    if (forceRefresh) {
+- (void)receiptDataWithReceiptRefreshPolicy:(RCReceiptRefreshPolicy)refreshPolicy
+                                 completion:(RCReceiveReceiptDataBlock)completion {
+    if (refreshPolicy == RCReceiptRefreshPolicyAlways) {
         RCDebugLog(@"Forced receipt refresh");
         [self refreshReceipt:completion];
         return;
     }
     NSData *receiptData = [self.receiptFetcher receiptData];
-    if (receiptData == nil || receiptData.length == 0) {
+    BOOL receiptIsEmpty = receiptData == nil || receiptData.length == 0;
+    if (receiptIsEmpty && refreshPolicy == RCReceiptRefreshPolicyOnlyIfEmpty) {
         RCDebugLog(@"Receipt empty, fetching");
         [self refreshReceipt:completion];
     } else {

--- a/Purchases/Purchasing/RCReceiptRefreshPolicy.h
+++ b/Purchases/Purchasing/RCReceiptRefreshPolicy.h
@@ -1,0 +1,17 @@
+//
+// Created by Andrés Boedo on 11/12/20.
+// Copyright (c) 2020 Purchases. All rights reserved.
+//
+
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, RCReceiptRefreshPolicy) {
+    RCReceiptRefreshPolicyAlways = 0,
+    RCReceiptRefreshPolicyOnlyIfEmpty,
+    RCReceiptRefreshPolicyNever
+};
+
+NS_ASSUME_NONNULL_END

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -1044,8 +1044,11 @@ class PurchasesTests: XCTestCase {
 
     func testRestorePurchasesPassesErrorOnFailure() {
         setupPurchases()
-        
-        let error = Purchases.ErrorUtils.backendError(withBackendCode: Purchases.RevenueCatBackendErrorCode.invalidAPIKey.rawValue as NSNumber, backendMessage: "Invalid credentials", finishable:true)
+
+        let errorCode = Purchases.RevenueCatBackendErrorCode.invalidAPIKey.rawValue as NSNumber
+        let error = Purchases.ErrorUtils.backendError(withBackendCode: errorCode,
+                                                      backendMessage: "Invalid credentials",
+                                                      finishable: true)
         
         self.backend.postReceiptError = error
         self.purchasesDelegate.purchaserInfo = nil
@@ -1164,10 +1167,13 @@ class PurchasesTests: XCTestCase {
         expect(receivedPurchaserInfo).toEventually(be(purchaserInfo))
     }
 
-    func testSilentRestorePurchasesPassesErrorOnFailure() {
+    func testRestoringPurchasesProgrammaticallyPassesErrorOnFailure() {
         setupPurchases()
 
-        let error = Purchases.ErrorUtils.backendError(withBackendCode: Purchases.RevenueCatBackendErrorCode.invalidAPIKey.rawValue as NSNumber, backendMessage: "Invalid credentials", finishable:true)
+        let errorCode = Purchases.RevenueCatBackendErrorCode.invalidAPIKey.rawValue as NSNumber
+        let error = Purchases.ErrorUtils.backendError(withBackendCode: errorCode,
+                                                      backendMessage: "Invalid credentials",
+                                                      finishable: true)
 
         self.backend.postReceiptError = error
         self.purchasesDelegate.purchaserInfo = nil
@@ -1180,7 +1186,7 @@ class PurchasesTests: XCTestCase {
 
         expect(receivedError).toEventuallyNot(beNil())
     }
-
+    
     func testCallsShouldAddPromoPaymentDelegateMethod() {
         setupPurchases()
         let product = MockSKProduct(mockProductIdentifier: "mock_product")

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -1130,9 +1130,18 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.postReceiptDataCalled) == true
     }
 
-    func testRestoringPurchasesProgrammaticallyDoesntRefreshTheReceipt() {
+    func testRestoringPurchasesProgrammaticallyDoesntRefreshTheReceiptIfNotEmpty() {
         setupPurchases()
         self.receiptFetcher.shouldReturnReceipt = true
+        purchases!.restoreTransactionsProgrammatically()
+
+        expect(self.receiptFetcher.receiptDataTimesCalled) == 1
+        expect(self.requestFetcher.refreshReceiptCalled) == false
+    }
+
+    func testRestoringPurchasesProgrammaticallyDoesntRefreshTheReceiptIfEmpty() {
+        setupPurchases()
+        self.receiptFetcher.shouldReturnReceipt = false
         purchases!.restoreTransactionsProgrammatically()
 
         expect(self.receiptFetcher.receiptDataTimesCalled) == 1

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -1996,7 +1996,6 @@ class PurchasesTests: XCTestCase {
         }
     }
 
-
     func testPaymentDiscountForProductDiscountCallsCompletionWithErrorIfReceiptNil() {
         if #available(iOS 12.2, *) {
             setupPurchases()

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -1059,13 +1059,13 @@ class PurchasesTests: XCTestCase {
         expect(receivedError).toEventuallyNot(beNil())
     }
 
-    func testSilentRestoringPurchasesPostsTheReceipt() {
+    func testRestoringPurchasesProgrammaticallyPostsTheReceipt() {
         setupPurchases()
-        purchases!.silentRestoreTransactions()
+        purchases!.restoreTransactionsProgrammatically()
         expect(self.backend.postReceiptDataCalled).to(beTrue())
     }
 
-    func testSilentRestoringPurchasesDoesntPostIfReceiptEmptyAndPurchaserInfoLoaded() {
+    func testRestoringPurchasesProgrammaticallyDoesntPostIfReceiptEmptyAndPurchaserInfoLoaded() {
         let info = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
@@ -1082,21 +1082,21 @@ class PurchasesTests: XCTestCase {
         mockReceiptParser.stubbedReceiptHasTransactionsResult = false
 
         setupPurchases()
-        purchases!.silentRestoreTransactions()
+        purchases!.restoreTransactionsProgrammatically()
 
         expect(self.backend.postReceiptDataCalled) == false
     }
 
-    func testSilentRestoringPurchasesPostsIfReceiptEmptyAndPurchaserInfoNotLoaded() {
+    func testRestoringPurchasesProgrammaticallyPostsIfReceiptEmptyAndPurchaserInfoNotLoaded() {
         mockReceiptParser.stubbedReceiptHasTransactionsResult = false
 
         setupPurchases()
-        purchases!.silentRestoreTransactions()
+        purchases!.restoreTransactionsProgrammatically()
 
         expect(self.backend.postReceiptDataCalled) == true
     }
 
-    func testSilentRestoringPurchasesPostsIfReceiptHasTransactionsAndPurchaserInfoLoaded() {
+    func testRestoringPurchasesProgrammaticallyPostsIfReceiptHasTransactionsAndPurchaserInfoLoaded() {
         let info = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
@@ -1113,43 +1113,43 @@ class PurchasesTests: XCTestCase {
         mockReceiptParser.stubbedReceiptHasTransactionsResult = true
 
         setupPurchases()
-        purchases!.silentRestoreTransactions()
+        purchases!.restoreTransactionsProgrammatically()
 
         expect(self.backend.postReceiptDataCalled) == true
     }
 
-    func testSilentRestoringPurchasesPostsIfReceiptHasTransactionsAndPurchaserInfoNotLoaded() {
+    func testRestoringPurchasesProgrammaticallyPostsIfReceiptHasTransactionsAndPurchaserInfoNotLoaded() {
         mockReceiptParser.stubbedReceiptHasTransactionsResult = true
 
         setupPurchases()
-        purchases!.silentRestoreTransactions()
+        purchases!.restoreTransactionsProgrammatically()
 
         expect(self.backend.postReceiptDataCalled) == true
     }
 
-    func testSilentRestoringPurchasesDoesntRefreshTheReceipt() {
+    func testRestoringPurchasesProgrammaticallyDoesntRefreshTheReceipt() {
         setupPurchases()
         self.receiptFetcher.shouldReturnReceipt = true
-        purchases!.silentRestoreTransactions()
+        purchases!.restoreTransactionsProgrammatically()
 
         expect(self.receiptFetcher.receiptDataTimesCalled) == 1
         expect(self.requestFetcher.refreshReceiptCalled) == false
     }
 
-    func testSilentRestoringPurchasesSetsIsRestore() {
+    func testRestoringPurchasesProgrammaticallySetsIsRestore() {
         setupPurchases()
-        purchases!.silentRestoreTransactions(nil)
+        purchases!.restoreTransactionsProgrammatically(nil)
         expect(self.backend.postedIsRestore!).to(beTrue())
     }
 
-    func testSilentRestoringPurchasesSetsIsRestoreForAnon() {
+    func testRestoringPurchasesProgrammaticallySetsIsRestoreForAnon() {
         setupAnonPurchases()
-        purchases!.silentRestoreTransactions(nil)
+        purchases!.restoreTransactionsProgrammatically(nil)
 
         expect(self.backend.postedIsRestore!).to(beTrue())
     }
 
-    func testSilentRestoringPurchasesCallsSuccessDelegateMethod() {
+    func testRestoringPurchasesProgrammaticallyCallsSuccessDelegateMethod() {
         setupPurchases()
 
         let purchaserInfo = Purchases.PurchaserInfo()
@@ -1157,7 +1157,7 @@ class PurchasesTests: XCTestCase {
 
         var receivedPurchaserInfo: Purchases.PurchaserInfo?
 
-        purchases!.silentRestoreTransactions { (info, error) in
+        purchases!.restoreTransactionsProgrammatically { (info, error) in
             receivedPurchaserInfo = info
         }
 
@@ -1174,7 +1174,7 @@ class PurchasesTests: XCTestCase {
 
         var receivedError: Error?
 
-        purchases!.silentRestoreTransactions { (_, newError) in
+        purchases!.restoreTransactionsProgrammatically { (_, newError) in
             receivedError = newError
         }
 


### PR DESCRIPTION
Added a silent version of `restoreTransactions`, called `restoreTransactionsProgrammatically`. It will be useful for developers performing migrations for other systems.

The new method is exactly the same as `restoreTransactions`, but without refreshing the receipt. 

The tests are also exactly like the ones for `restoreTransactions`, except for the one that asserts that the receipt isn't refreshed. 

I added a new enum `RCRefreshReceiptPolicy`, which specifies what the policy should be for receipt refresh:
 - always refresh
- never refresh
- refresh only if the receipt is empty, which we do for most stuff
