### PR TITLE
version 3.7.6

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -5,9 +5,9 @@ objc: true
 sdk: iphonesimulator
 module: Purchases
 umbrella_header: Purchases/Public/Purchases.h
-module_version: 3.8.0-SNAPSHOT
+module_version: 3.7.6
 github_url: https://github.com/revenuecat/purchases-ios
-github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.8.0-SNAPSHOT
+github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.7.6
 output: docs
 # Leaving this commented out. We used to specify this before, but now it's working without it
 # xcodebuild_arguments: [--objc,Purchases/Public/Purchases.h,--,-x,objective-c,-isysroot,$(xcrun --show-sdk-path),-I,$(pwd)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 3.7.6
+- Fixed a race condition that could cause a crash after deleting and reinstalling the app
+    https://github.com/RevenueCat/purchases-ios/pull/383
+- Fixed possible overflow when performing local receipt parsing on 32-bit devices
+    https://github.com/RevenueCat/purchases-ios/pull/384
+- Fixed string comparison when deleting synced subscriber attributes
+    https://github.com/RevenueCat/purchases-ios/pull/385
+- Fixed docs-deploy job
+    https://github.com/RevenueCat/purchases-ios/pull/386
+- Fixed a typo in a RCPurchases.h
+    https://github.com/RevenueCat/purchases-ios/pull/380
+
 ## 3.7.5
 - Move test dependencies back to carthage
     https://github.com/RevenueCat/purchases-ios/pull/371

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Purchases"
-  s.version          = "3.8.0-SNAPSHOT"
+  s.version          = "3.7.6"
   s.summary          = "Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
-  s.dependency 'PurchasesCoreSwift', '3.8.0-SNAPSHOT'
+  s.dependency 'PurchasesCoreSwift', '3.7.6'
 
 
   s.source_files = ['Purchases/**/*.{h,m}']

--- a/Purchases/Info.plist
+++ b/Purchases/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.8.0-SNAPSHOT</string>
+	<string>3.7.6</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Purchases/Misc/RCSystemInfo.m
+++ b/Purchases/Misc/RCSystemInfo.m
@@ -48,7 +48,7 @@ static BOOL _forceUniversalAppStore = NO;
 }
 
 + (NSString *)frameworkVersion {
-    return @"3.8.0-SNAPSHOT";
+    return @"3.7.6";
 }
 
 + (NSString *)systemVersion {

--- a/PurchasesCoreSwift.podspec
+++ b/PurchasesCoreSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesCoreSwift"
-  s.version          = "3.8.0-SNAPSHOT"
+  s.version          = "3.7.6"
   s.summary          = "Swift portion of RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/PurchasesCoreSwift/Info.plist
+++ b/PurchasesCoreSwift/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.8.0-SNAPSHOT</string>
+	<string>3.7.6</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/PurchasesCoreSwiftTests/Info.plist
+++ b/PurchasesCoreSwiftTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.8.0-SNAPSHOT</string>
+	<string>3.7.6</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/PurchasesTests/Info.plist
+++ b/PurchasesTests/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.8.0-SNAPSHOT</string>
+	<string>3.7.6</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 1. Start a git-flow release/x.y.z
 1. Create a CHANGELOG.latest.md with the changes for the current 
 version (to be used by Fastlane for the github release notes)
-1. Update the version number by running `fastlane bump_and_update_changelog version:x.y.z`
+1. Update the version number by running `bundle exec fastlane bump_and_update_changelog version:x.y.z`
 1. Commit the changes `git commit -am "Version x.y.z"`
 1. Make a PR, merge when approved
 1. `cd bin`


### PR DESCRIPTION
## 3.7.6
- Fixed a race condition that could cause a crash after deleting and reinstalling the app
    https://github.com/RevenueCat/purchases-ios/pull/383
- Fixed possible overflow when performing local receipt parsing on 32-bit devices
    https://github.com/RevenueCat/purchases-ios/pull/384
- Fixed string comparison when deleting synced subscriber attributes
    https://github.com/RevenueCat/purchases-ios/pull/385
- Fixed docs-deploy job
    https://github.com/RevenueCat/purchases-ios/pull/386
- Fixed a typo in a RCPurchases.h
    https://github.com/RevenueCat/purchases-ios/pull/380
