### PR TITLE
Add X-Client-Build-Version header

### DIFF
--- a/Purchases/Misc/RCSystemInfo.h
+++ b/Purchases/Misc/RCSystemInfo.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)frameworkVersion;
 + (NSString *)systemVersion;
 + (NSString *)appVersion;
++ (NSString *)bundleVersion;
 + (NSString *)platformHeader;
 
 + (NSURL *)serverHostURL;

--- a/Purchases/Misc/RCSystemInfo.m
+++ b/Purchases/Misc/RCSystemInfo.m
@@ -61,6 +61,12 @@ static BOOL _forceUniversalAppStore = NO;
     return version ?: @"";
 }
 
+
++ (NSString *)bundleVersion {
+    NSString *version = NSBundle.mainBundle.infoDictionary[@"CFBundleVersion"];
+    return version ?: @"";
+}
+
 + (NSString *)platformHeader {
     return self.forceUniversalAppStore ? @"iOS" : PLATFORM_HEADER;
 }
@@ -114,7 +120,7 @@ static BOOL _forceUniversalAppStore = NO;
 #if TARGET_OS_IOS
 // iOS App extensions can't access UIApplication.sharedApplication, and will fail to compile if any calls to
 // it are made. There are no pre-processor macros available to check if the code is running in an app extension,
-// so we check if we're running in an app extension at runtime, and if not, we use KVC to call sharedApplication. 
+// so we check if we're running in an app extension at runtime, and if not, we use KVC to call sharedApplication.
 - (BOOL)isApplicationBackgroundedIOS {
     if (self.isAppExtension) {
         return YES;

--- a/Purchases/Networking/RCHTTPClient.m
+++ b/Purchases/Networking/RCHTTPClient.m
@@ -204,6 +204,7 @@ beginNextRequestWhenFinished:(BOOL)beginNextRequestWhenFinished {
         @"X-Platform-Version": RCSystemInfo.systemVersion,
         @"X-Platform-Flavor": self.systemInfo.platformFlavor,
         @"X-Client-Version": RCSystemInfo.appVersion,
+        @"X-Bundle-Version": RCSystemInfo.bundleVersion,
         @"X-Observer-Mode-Enabled": observerMode,
 #if UI_DEVICE_AVAILABLE
         @"X-Apple-Device-Identifier": UIDevice.currentDevice.identifierForVendor.UUIDString,


### PR DESCRIPTION
Adds a new header `X-Client-Build-Version` that hold `CFBundleVersion` as the value. 
This is needed to validate iOS receipts locally. The existing `X-Client-Version` header uses `CFBundleShortVersionString`, which can only be used to validate macOS receipts. 