### PR TITLE
Logging v2: part 1

### DIFF
--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		2D8E9D482523747D00AFEE11 /* NSDictionaryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD269162522A20A006AC4BC /* NSDictionaryExtensionsTests.swift */; };
 		2D8E9D54252374A600AFEE11 /* NSDictionary+RCExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D8E9D52252374A600AFEE11 /* NSDictionary+RCExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D8E9D55252374A600AFEE11 /* NSDictionary+RCExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D8E9D53252374A600AFEE11 /* NSDictionary+RCExtensions.m */; };
+		2DC19195255F36D10039389A /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC19194255F36D10039389A /* Logger.swift */; };
 		2DC5621F24EC63430031F69B /* PurchasesCoreSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2DC5621624EC63420031F69B /* PurchasesCoreSwift.framework */; };
 		2DC5622624EC63430031F69B /* PurchasesCoreSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DC5621824EC63430031F69B /* PurchasesCoreSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2DC5622E24EC636C0031F69B /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E355CBB3F3A31A32687B14 /* Transaction.swift */; };
@@ -268,6 +269,7 @@
 		2D8F622224D30F9D00F993AA /* ReceiptParsingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptParsingError.swift; sourceTree = "<group>"; };
 		2D97458E24BDFCEF006245E9 /* IntroEligibilityCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroEligibilityCalculator.swift; sourceTree = "<group>"; };
 		2DA0068E24E2E515002C59D3 /* MockIntroEligibilityCalculator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockIntroEligibilityCalculator.swift; sourceTree = "<group>"; };
+		2DC19194255F36D10039389A /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		2DC5621624EC63420031F69B /* PurchasesCoreSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PurchasesCoreSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2DC5621824EC63430031F69B /* PurchasesCoreSwift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PurchasesCoreSwift.h; sourceTree = "<group>"; };
 		2DC5621924EC63430031F69B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -512,6 +514,7 @@
 			isa = PBXGroup;
 			children = (
 				2D11F5DF250FF658005A70E8 /* Strings */,
+				2DC19194255F36D10039389A /* Logger.swift */,
 			);
 			path = Logging;
 			sourceTree = "<group>";
@@ -1349,6 +1352,7 @@
 				2DDF41A324F6F331005BC22D /* ReceiptParser.swift in Sources */,
 				2DDF41BA24F6F392005BC22D /* ISO3601DateFormatter.swift in Sources */,
 				2DDF41AE24F6F37C005BC22D /* InAppPurchase.swift in Sources */,
+				2DC19195255F36D10039389A /* Logger.swift in Sources */,
 				2DDF419F24F6F331005BC22D /* ReceiptParsingError.swift in Sources */,
 				2DDF419D24F6F331005BC22D /* IntroEligibilityCalculator.swift in Sources */,
 				2DC5623224EC63730031F69B /* TransactionsFactory.swift in Sources */,

--- a/Purchases/Misc/RCLogUtils.h
+++ b/Purchases/Misc/RCLogUtils.h
@@ -12,10 +12,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 void RCSetShowDebugLogs(BOOL showDebugLogs);
 BOOL RCShowDebugLogs(void);
-void RCDebugLog(NSString *format, ...);
 void RCErrorLog(NSString *format, ...);
 void RCLog(NSString *format, ...);
 
-#define RCNewLog(args, ...) [RCLogger logWithLevel:RCLogLevelDebug message: [NSString stringWithFormat: args, ##__VA_ARGS__]]
+#define RCDebugLog(args, ...) [RCLogger logWithLevel:RCLogLevelDebug message: [NSString stringWithFormat: args, ##__VA_ARGS__]]
 
 NS_ASSUME_NONNULL_END

--- a/Purchases/Misc/RCLogUtils.h
+++ b/Purchases/Misc/RCLogUtils.h
@@ -12,9 +12,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 void RCSetShowDebugLogs(BOOL showDebugLogs);
 BOOL RCShowDebugLogs(void);
-void RCErrorLog(NSString *format, ...);
-void RCLog(NSString *format, ...);
 
 #define RCDebugLog(args, ...) [RCLogger logWithLevel:RCLogLevelDebug message: [NSString stringWithFormat: args, ##__VA_ARGS__]]
+#define RCLog(args, ...) [RCLogger logWithLevel:RCLogLevelInfo message: [NSString stringWithFormat: args, ##__VA_ARGS__]]
+#define RCWarnLog(args, ...) [RCLogger logWithLevel:RCLogLevelWarn message: [NSString stringWithFormat: args, ##__VA_ARGS__]]
+#define RCErrorLog(args, ...) [RCLogger logWithLevel:RCLogLevelError message: [NSString stringWithFormat: args, ##__VA_ARGS__]]
 
 NS_ASSUME_NONNULL_END

--- a/Purchases/Misc/RCLogUtils.h
+++ b/Purchases/Misc/RCLogUtils.h
@@ -13,9 +13,20 @@ NS_ASSUME_NONNULL_BEGIN
 void RCSetShowDebugLogs(BOOL showDebugLogs);
 BOOL RCShowDebugLogs(void);
 
-#define RCDebugLog(args, ...) [RCLogger logWithLevel:RCLogLevelDebug message: [NSString stringWithFormat: args, ##__VA_ARGS__]]
-#define RCLog(args, ...) [RCLogger logWithLevel:RCLogLevelInfo message: [NSString stringWithFormat: args, ##__VA_ARGS__]]
-#define RCWarnLog(args, ...) [RCLogger logWithLevel:RCLogLevelWarn message: [NSString stringWithFormat: args, ##__VA_ARGS__]]
-#define RCErrorLog(args, ...) [RCLogger logWithLevel:RCLogLevelError message: [NSString stringWithFormat: args, ##__VA_ARGS__]]
+#define RCDebugLog(args, ...) \
+    [RCLogger logWithLevel:RCLogLevelDebug \
+                   message:[NSString stringWithFormat: args, ##__VA_ARGS__]]
+
+#define RCLog(args, ...) \
+    [RCLogger logWithLevel:RCLogLevelInfo \
+                   message:[NSString stringWithFormat: args, ##__VA_ARGS__]]
+
+#define RCWarnLog(args, ...) \
+    [RCLogger logWithLevel:RCLogLevelWarn \
+                   message:[NSString stringWithFormat: args, ##__VA_ARGS__]]
+
+#define RCErrorLog(args, ...) \
+    [RCLogger logWithLevel:RCLogLevelError \
+                   message:[NSString stringWithFormat: args, ##__VA_ARGS__]]
 
 NS_ASSUME_NONNULL_END

--- a/Purchases/Misc/RCLogUtils.h
+++ b/Purchases/Misc/RCLogUtils.h
@@ -16,4 +16,6 @@ void RCDebugLog(NSString *format, ...);
 void RCErrorLog(NSString *format, ...);
 void RCLog(NSString *format, ...);
 
+#define RCNewLog(args, ...) [RCLogger logWithLevel:RCLogLevelDebug message: [NSString stringWithFormat: args, ##__VA_ARGS__]]
+
 NS_ASSUME_NONNULL_END

--- a/Purchases/Misc/RCLogUtils.m
+++ b/Purchases/Misc/RCLogUtils.m
@@ -9,8 +9,6 @@
 #import "RCLogUtils.h"
 @import PurchasesCoreSwift;
 
-static BOOL RCShouldShowLogs = NO;
-
 void RCSetShowDebugLogs(BOOL showDebugLogs) {
     RCLogger.shouldShowDebugLogs = showDebugLogs;
 }

--- a/Purchases/Misc/RCLogUtils.m
+++ b/Purchases/Misc/RCLogUtils.m
@@ -7,31 +7,16 @@
 //
 
 #import "RCLogUtils.h"
+@import PurchasesCoreSwift;
 
 static BOOL RCShouldShowLogs = NO;
 
-void RCSetShowDebugLogs(BOOL showDebugLogs)
-{
-    RCShouldShowLogs = showDebugLogs;
+void RCSetShowDebugLogs(BOOL showDebugLogs) {
+    RCLogger.shouldShowDebugLogs = showDebugLogs;
 }
 
-BOOL RCShowDebugLogs()
-{
-    return RCShouldShowLogs;
-}
-
-void RCDebugLog(NSString *format, ...)
-{
-    if (!RCShouldShowLogs)
-        return;
-
-    va_list args;
-    va_start(args, format);
-
-    format = [NSString stringWithFormat:@"[Purchases] - DEBUG: %@", format];
-
-    NSLogv(format, args);
-    va_end(args);
+BOOL RCShowDebugLogs() {
+    return RCLogger.shouldShowDebugLogs;
 }
 
 void RCErrorLog(NSString *format, ...)

--- a/Purchases/Misc/RCLogUtils.m
+++ b/Purchases/Misc/RCLogUtils.m
@@ -18,27 +18,3 @@ void RCSetShowDebugLogs(BOOL showDebugLogs) {
 BOOL RCShowDebugLogs() {
     return RCLogger.shouldShowDebugLogs;
 }
-
-void RCErrorLog(NSString *format, ...)
-{
-    if (!RCShouldShowLogs)
-        return;
-
-    va_list args;
-    va_start(args, format);
-
-    format = [NSString stringWithFormat:@"[Purchases] - ERROR: %@", format];
-
-    NSLogv(format, args);
-    va_end(args);
-}
-
-void RCLog(NSString *format, ...)
-{
-    va_list args;
-    va_start(args, format);
-
-    format = [NSString stringWithFormat:@"[Purchases] - INFO: %@", format];
-    NSLogv(format, args);
-    va_end(args);
-}

--- a/Purchases/Misc/RCSystemInfo.m
+++ b/Purchases/Misc/RCSystemInfo.m
@@ -6,6 +6,7 @@
 #import "RCSystemInfo.h"
 #import "RCCrossPlatformSupport.h"
 #import "RCLogUtils.h"
+@import PurchasesCoreSwift;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Purchases/Networking/RCBackend.m
+++ b/Purchases/Networking/RCBackend.m
@@ -17,6 +17,7 @@
 #import "RCLogUtils.h"
 #import "RCSystemInfo.h"
 #import "RCHTTPStatusCodes.h"
+@import PurchasesCoreSwift;
 
 #define RC_HAS_KEY(dictionary, key) (dictionary[key] == nil || dictionary[key] != [NSNull null])
 NSErrorUserInfoKey const RCSuccessfullySyncedKey = @"successfullySynced";

--- a/Purchases/Networking/RCHTTPClient.m
+++ b/Purchases/Networking/RCHTTPClient.m
@@ -102,7 +102,7 @@ NS_ASSUME_NONNULL_BEGIN
 beginNextRequestWhenFinished:performSerially];
     };
 
-    RCDebugLog(@"%@ %@", urlRequest.HTTPMethod, urlRequest.URL.path, nil);
+    RCDebugLog(@"%@ %@", urlRequest.HTTPMethod, urlRequest.URL.path);
     NSURLSessionTask *task = [self.session dataTaskWithRequest:urlRequest
                                              completionHandler:block];
     [task resume];

--- a/Purchases/Networking/RCHTTPClient.m
+++ b/Purchases/Networking/RCHTTPClient.m
@@ -11,6 +11,7 @@
 #import "RCHTTPStatusCodes.h"
 #import "RCSystemInfo.h"
 #import "RCHTTPRequest.h"
+@import PurchasesCoreSwift;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -65,14 +66,14 @@ NS_ASSUME_NONNULL_BEGIN
                                                            completionHandler:completionHandler];
         @synchronized (self) {
             if (self.currentSerialRequest) {
-                RCDebugLog(@"There's a request currently running and %ld requests left in the queue, queueing %@ %@",
+                RCNewLog(@"There's a request currently running and %ld requests left in the queue, queueing %@ %@",
                            self.queuedRequests.count,
                            httpMethod,
                            path);
                 [self.queuedRequests addObject:rcRequest];
                 return;
             } else {
-                RCDebugLog(@"there are no requests currently running, starting request %@ %@", httpMethod, path);
+                RCNewLog(@"there are no requests currently running, starting request %@ %@", httpMethod, path);
                 self.currentSerialRequest = rcRequest;
             }
         }
@@ -101,7 +102,7 @@ NS_ASSUME_NONNULL_BEGIN
 beginNextRequestWhenFinished:performSerially];
     };
 
-    RCDebugLog(@"%@ %@", urlRequest.HTTPMethod, urlRequest.URL.path);
+    RCNewLog(@"%@ %@", urlRequest.HTTPMethod, urlRequest.URL.path, nil);
     NSURLSessionTask *task = [self.session dataTaskWithRequest:urlRequest
                                              completionHandler:block];
     [task resume];
@@ -119,7 +120,7 @@ beginNextRequestWhenFinished:(BOOL)beginNextRequestWhenFinished {
     if (error == nil) {
         statusCode = ((NSHTTPURLResponse *) response).statusCode;
 
-        RCDebugLog(@"%@ %@ %d", request.HTTPMethod, request.URL.path, statusCode);
+        RCNewLog(@"%@ %@ %ld", request.HTTPMethod, request.URL.path, (long)statusCode);
 
         NSError *jsonError;
         responseObject = [NSJSONSerialization JSONObjectWithData:data
@@ -139,7 +140,7 @@ beginNextRequestWhenFinished:(BOOL)beginNextRequestWhenFinished {
 
     if (beginNextRequestWhenFinished) {
         @synchronized (self) {
-            RCDebugLog(@"serial request done: %@ %@, %ld requests left in the queue",
+            RCNewLog(@"serial request done: %@ %@, %ld requests left in the queue",
                        self.currentSerialRequest.httpMethod, self.currentSerialRequest.path, self.queuedRequests.count);
             RCHTTPRequest *nextRequest = nil;
             self.currentSerialRequest = nil;
@@ -148,7 +149,7 @@ beginNextRequestWhenFinished:(BOOL)beginNextRequestWhenFinished {
                 [self.queuedRequests removeObjectAtIndex:0];
             }
             if (nextRequest) {
-                RCDebugLog(@"starting the next request in the queue, %@", nextRequest);
+                RCNewLog(@"starting the next request in the queue, %@", nextRequest);
                 [self performRequest:nextRequest.httpMethod
                             serially:YES
                                 path:nextRequest.path

--- a/Purchases/Networking/RCHTTPClient.m
+++ b/Purchases/Networking/RCHTTPClient.m
@@ -66,14 +66,14 @@ NS_ASSUME_NONNULL_BEGIN
                                                            completionHandler:completionHandler];
         @synchronized (self) {
             if (self.currentSerialRequest) {
-                RCNewLog(@"There's a request currently running and %ld requests left in the queue, queueing %@ %@",
+                RCDebugLog(@"There's a request currently running and %ld requests left in the queue, queueing %@ %@",
                            self.queuedRequests.count,
                            httpMethod,
                            path);
                 [self.queuedRequests addObject:rcRequest];
                 return;
             } else {
-                RCNewLog(@"there are no requests currently running, starting request %@ %@", httpMethod, path);
+                RCDebugLog(@"there are no requests currently running, starting request %@ %@", httpMethod, path);
                 self.currentSerialRequest = rcRequest;
             }
         }
@@ -102,7 +102,7 @@ NS_ASSUME_NONNULL_BEGIN
 beginNextRequestWhenFinished:performSerially];
     };
 
-    RCNewLog(@"%@ %@", urlRequest.HTTPMethod, urlRequest.URL.path, nil);
+    RCDebugLog(@"%@ %@", urlRequest.HTTPMethod, urlRequest.URL.path, nil);
     NSURLSessionTask *task = [self.session dataTaskWithRequest:urlRequest
                                              completionHandler:block];
     [task resume];
@@ -120,7 +120,7 @@ beginNextRequestWhenFinished:(BOOL)beginNextRequestWhenFinished {
     if (error == nil) {
         statusCode = ((NSHTTPURLResponse *) response).statusCode;
 
-        RCNewLog(@"%@ %@ %ld", request.HTTPMethod, request.URL.path, (long)statusCode);
+        RCDebugLog(@"%@ %@ %ld", request.HTTPMethod, request.URL.path, (long)statusCode);
 
         NSError *jsonError;
         responseObject = [NSJSONSerialization JSONObjectWithData:data
@@ -140,7 +140,7 @@ beginNextRequestWhenFinished:(BOOL)beginNextRequestWhenFinished {
 
     if (beginNextRequestWhenFinished) {
         @synchronized (self) {
-            RCNewLog(@"serial request done: %@ %@, %ld requests left in the queue",
+            RCDebugLog(@"serial request done: %@ %@, %ld requests left in the queue",
                        self.currentSerialRequest.httpMethod, self.currentSerialRequest.path, self.queuedRequests.count);
             RCHTTPRequest *nextRequest = nil;
             self.currentSerialRequest = nil;
@@ -149,7 +149,7 @@ beginNextRequestWhenFinished:(BOOL)beginNextRequestWhenFinished {
                 [self.queuedRequests removeObjectAtIndex:0];
             }
             if (nextRequest) {
-                RCNewLog(@"starting the next request in the queue, %@", nextRequest);
+                RCDebugLog(@"starting the next request in the queue, %@", nextRequest);
                 [self performRequest:nextRequest.httpMethod
                             serially:YES
                                 path:nextRequest.path

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -366,10 +366,10 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                fromNetwork:(RCAttributionNetwork)network
           forNetworkUserId:(nullable NSString *)networkUserId {
     if (_sharedPurchases) {
-        RCLog(RCStrings.attribution.instance_configured_posting_attribution);
+        RCLog(@"%@", RCStrings.attribution.instance_configured_posting_attribution);
         [_sharedPurchases postAttributionData:data fromNetwork:network forNetworkUserId:networkUserId];
     } else {
-        RCLog(RCStrings.attribution.no_instance_configured_caching_attribution);
+        RCLog(@"%@", RCStrings.attribution.no_instance_configured_caching_attribution);
         [RCAttributionFetcher storePostponedAttributionData:data
                                                 fromNetwork:network
                                            forNetworkUserId:networkUserId];

--- a/Purchases/Public/RCPurchasesErrorUtils.m
+++ b/Purchases/Public/RCPurchasesErrorUtils.m
@@ -10,6 +10,7 @@
 #import "RCPurchasesErrors.h"
 #import "RCPurchasesErrorUtils.h"
 #import "RCLogUtils.h"
+@import PurchasesCoreSwift;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Purchases/Purchasing/RCAttributionFetcher.m
+++ b/Purchases/Purchasing/RCAttributionFetcher.m
@@ -13,6 +13,7 @@
 #import "RCIdentityManager.h"
 #import "RCBackend.h"
 #import "RCAttributionData.h"
+@import PurchasesCoreSwift;
 
 
 @protocol FakeAdClient <NSObject>

--- a/Purchases/Purchasing/RCIdentityManager.m
+++ b/Purchases/Purchasing/RCIdentityManager.m
@@ -7,6 +7,7 @@
 #import "RCLogUtils.h"
 #import "RCBackend.h"
 #import "RCPurchasesErrorUtils.h"
+@import PurchasesCoreSwift;
 
 
 @interface RCIdentityManager ()

--- a/Purchases/Purchasing/RCReceiptFetcher.m
+++ b/Purchases/Purchasing/RCReceiptFetcher.m
@@ -8,6 +8,7 @@
 
 #import "RCReceiptFetcher.h"
 #import "RCLogUtils.h"
+@import PurchasesCoreSwift;
 #import "RCSystemInfo.h"
 
 @implementation RCReceiptFetcher : NSObject

--- a/Purchases/Purchasing/RCStoreKitRequestFetcher.m
+++ b/Purchases/Purchasing/RCStoreKitRequestFetcher.m
@@ -165,7 +165,7 @@
     RCDebugLog(@"Invalid Product Identifiers - %@", response.invalidProductIdentifiers);
     
     NSArray<RCFetchProductsCompletionHandler> *handlers = [self finishProductsRequest:request];
-    RCDebugLog(@"%d completion handlers waiting on products", handlers.count);
+    RCDebugLog(@"%lu completion handlers waiting on products", (unsigned long)handlers.count);
     for (RCFetchProductsCompletionHandler handler in handlers)
     {
         handler(response.products);

--- a/Purchases/Purchasing/RCStoreKitRequestFetcher.m
+++ b/Purchases/Purchasing/RCStoreKitRequestFetcher.m
@@ -9,6 +9,7 @@
 #import <StoreKit/StoreKit.h>
 #import "RCStoreKitRequestFetcher.h"
 #import "RCLogUtils.h"
+@import PurchasesCoreSwift;
 
 @implementation RCProductsRequestFactory : NSObject
 - (SKProductsRequest *)requestForProductIdentifiers:(NSSet<NSString *> *)identifiers

--- a/Purchases/Purchasing/RCStoreKitWrapper.m
+++ b/Purchases/Purchasing/RCStoreKitWrapper.m
@@ -78,7 +78,7 @@
 - (void)paymentQueue:(SKPaymentQueue *)queue updatedTransactions:(NSArray<SKPaymentTransaction *> *)transactions
 {
     for (SKPaymentTransaction *transaction in transactions) {
-        RCDebugLog(@"PaymentQueue updatedTransaction: %@ %@ (%@) %@ - %d", transaction.payment.productIdentifier, transaction.transactionIdentifier, transaction.error, transaction.originalTransaction.transactionIdentifier, transaction.transactionState);
+        RCDebugLog(@"PaymentQueue updatedTransaction: %@ %@ (%@) %@ - %ld", transaction.payment.productIdentifier, transaction.transactionIdentifier, transaction.error, transaction.originalTransaction.transactionIdentifier, (long)transaction.transactionState);
         [self.delegate storeKitWrapper:self updatedTransaction:transaction];
     }
 }
@@ -87,7 +87,7 @@
 - (void)paymentQueue:(SKPaymentQueue *)queue removedTransactions:(NSArray<SKPaymentTransaction *> *)transactions
 {
     for (SKPaymentTransaction *transaction in transactions) {
-        RCDebugLog(@"PaymentQueue removedTransaction: %@ %@ (%@ %@) %@ - %d", transaction.payment.productIdentifier, transaction.transactionIdentifier, transaction.originalTransaction.transactionIdentifier, transaction.error, transaction.error.userInfo, transaction.transactionState);
+        RCDebugLog(@"PaymentQueue removedTransaction: %@ %@ (%@ %@) %@ - %ld", transaction.payment.productIdentifier, transaction.transactionIdentifier, transaction.originalTransaction.transactionIdentifier, transaction.error, transaction.error.userInfo, (long)transaction.transactionState);
         [self.delegate storeKitWrapper:self removedTransaction:transaction];
     }
 }

--- a/Purchases/Purchasing/RCStoreKitWrapper.m
+++ b/Purchases/Purchasing/RCStoreKitWrapper.m
@@ -10,6 +10,7 @@
 #import "RCCrossPlatformSupport.h"
 
 #import "RCLogUtils.h"
+@import PurchasesCoreSwift;
 
 @interface RCStoreKitWrapper ()
 @property (nonatomic) SKPaymentQueue *paymentQueue;

--- a/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
@@ -11,6 +11,7 @@
 #import "NSData+RCExtensions.h"
 #import "RCLogUtils.h"
 #import "RCAttributionFetcher.h"
+@import PurchasesCoreSwift;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/PurchasesCoreSwift/LocalReceiptParsing/ReceiptParser.swift
+++ b/PurchasesCoreSwift/LocalReceiptParsing/ReceiptParser.swift
@@ -29,9 +29,12 @@ import Foundation
     }
     
     @objc public func receiptHasTransactions(receiptData: Data) -> Bool {
+        Logger.log(level: .info, message: "Parsing local receipt")
         if let receipt = try? parse(from: receiptData) {
             return receipt.inAppPurchases.count > 0
         }
+
+        Logger.log(level: .warn, message: "\(#file) \(#function) Could not parse receipt, conservatively returning true")
         return true
     }
 

--- a/PurchasesCoreSwift/LocalReceiptParsing/ReceiptParser.swift
+++ b/PurchasesCoreSwift/LocalReceiptParsing/ReceiptParser.swift
@@ -32,7 +32,6 @@ import Foundation
         if let receipt = try? parse(from: receiptData) {
             return receipt.inAppPurchases.count > 0
         }
-        // if the receipt can't be parsed, conservatively return true
         return true
     }
 

--- a/PurchasesCoreSwift/Logging/Logger.swift
+++ b/PurchasesCoreSwift/Logging/Logger.swift
@@ -10,20 +10,23 @@ import Foundation
 
 @objc(RCLogLevel) public enum LogLevel: Int {
     case debug, info, warn, error
+
+    func description() -> String {
+        switch self {
+        case .debug: return "DEBUG"
+        case .info: return "INFO"
+        case .warn: return "WARN"
+        case .error: return "ERROR"
+        }
+    }
 }
 
 @objc(RCLogger) public class Logger: NSObject {
-    public static var shouldShowLogs = false
+    @objc public static var shouldShowDebugLogs = false
+    private static let frameworkDescription = "Purchases"
 
     @objc public static func log(level: LogLevel, message: String) {
-        let fullFormat = String(format: "NEW [Purchases] - DEBUG: %@ ", message)
-        NSLog(fullFormat)
-    }
-
-    public static func log(level: LogLevel, _ args: CVarArg...) {
-        withVaList(args) {
-            let fullFormat = String(format: "NEW [Purchases] - DEBUG: %@ ", args)
-            NSLogv(fullFormat, $0)
-        }
+        guard level != .debug || shouldShowDebugLogs else { return }
+        NSLog("[\(frameworkDescription)] - \(level.description()): \(message)")
     }
 }

--- a/PurchasesCoreSwift/Logging/Logger.swift
+++ b/PurchasesCoreSwift/Logging/Logger.swift
@@ -1,0 +1,29 @@
+//
+//  Logger.swift
+//  PurchasesCoreSwift
+//
+//  Created by Andrés Boedo on 11/13/20.
+//  Copyright © 2020 Purchases. All rights reserved.
+//
+
+import Foundation
+
+@objc(RCLogLevel) public enum LogLevel: Int {
+    case debug, info, warn, error
+}
+
+@objc(RCLogger) public class Logger: NSObject {
+    public static var shouldShowLogs = false
+
+    @objc public static func log(level: LogLevel, message: String) {
+        let fullFormat = String(format: "NEW [Purchases] - DEBUG: %@ ", message)
+        NSLog(fullFormat)
+    }
+
+    public static func log(level: LogLevel, _ args: CVarArg...) {
+        withVaList(args) {
+            let fullFormat = String(format: "NEW [Purchases] - DEBUG: %@ ", args)
+            NSLogv(fullFormat, $0)
+        }
+    }
+}

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -1206,7 +1206,7 @@ class PurchasesTests: XCTestCase {
 
         expect(receivedError).toEventuallyNot(beNil())
     }
-
+    
     func testCallsShouldAddPromoPaymentDelegateMethod() {
         setupPurchases()
         let product = MockSKProduct(mockProductIdentifier: "mock_product")

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -1206,7 +1206,7 @@ class PurchasesTests: XCTestCase {
 
         expect(receivedError).toEventuallyNot(beNil())
     }
-    
+
     func testCallsShouldAddPromoPaymentDelegateMethod() {
         setupPurchases()
         let product = MockSKProduct(mockProductIdentifier: "mock_product")


### PR DESCRIPTION
Since our logging logic lives in `Purchases` and `Purchases` depends on `PurchasesCoreSwift`, we couldn't use our logging logic in Swift. 

This moves our logging to Swift, while making a few updates: 
- adds `warn` level, which we didn't have before
- logs `error` level messages independently of the value of `showDebugLogs`, it feels more appropriate to me that errors are always shown
- cleans up the implementation
- adds Swift-compatible API
- adds sample Swift usage. 

### Part 2
A follow-up PR will update our Swift code to include more logging. 
We'll also update it further when we port over the changes currently being added to `purchases-android`. 
