### PR TITLE
Sync purchases improvements

### DIFF
--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -291,7 +291,7 @@ NS_SWIFT_NAME(purchasePackage(_:_:));
  the same `appUserId` used to purchase originally.
 
  @note This may force your users to enter the App Store password so should only be performed on request of the user.
- Typically with a button in settings or near your purchase UI. Use restoreTransactionsProgrammaticallyWithCompletionBlock
+ Typically with a button in settings or near your purchase UI. Use syncPurchasesWithCompletionBlock
  if you need to restore transactions programmatically.
  */
 - (void)restoreTransactionsWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion
@@ -302,14 +302,13 @@ NS_SWIFT_NAME(restoreTransactions(_:));
  If the receipt is being used by an existing user, the current `appUserID` will be aliased together with the `appUserID` of the existing user.
  Going forward, either `appUserID` will be able to reference the same user.
 
- You shouldn't use this method if you have your own account system. In that case "restoration" is provided by your app passing
- the same `appUserId` used to purchase originally.
+ @warning This function should only be called if you're not calling any purchase method.
 
  @note This method will not trigger a login prompt from App Store. However, if the receipt currently on the device does not contain subscriptions,
  but the user has made subscription purchases, this method won't be able to restore them. Use restoreTransactionsWithCompletionBlock to cover those cases.
  */
-- (void)restoreTransactionsProgrammaticallyWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion
-NS_SWIFT_NAME(restoreTransactionsProgrammatically(_:));
+- (void)syncPurchasesWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion
+NS_SWIFT_NAME(syncPurchases(_:));
 
 
 /**

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -574,7 +574,7 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
     [self.storeKitWrapper addPayment:[payment copy]];
 }
 
-- (void)restoreTransactionsProgrammaticallyWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion {
+- (void)syncPurchasesWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion {
     [self restoreTransactionsWithReceiptRefreshPolicy:RCReceiptRefreshPolicyNever completionBlock:completion];
 }
 

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -575,15 +575,20 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 }
 
 - (void)syncPurchasesWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion {
-    [self restoreTransactionsWithReceiptRefreshPolicy:RCReceiptRefreshPolicyNever completionBlock:completion];
+    [self syncPurchasesWithReceiptRefreshPolicy:RCReceiptRefreshPolicyNever
+                                      isRestore:self.allowSharingAppStoreAccount
+                                     completion:completion];
 }
 
 - (void)restoreTransactionsWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion {
-    [self restoreTransactionsWithReceiptRefreshPolicy:RCReceiptRefreshPolicyAlways completionBlock:completion];
+    [self syncPurchasesWithReceiptRefreshPolicy:RCReceiptRefreshPolicyAlways
+                                      isRestore:YES
+                                     completion:completion];
 }
 
-- (void)restoreTransactionsWithReceiptRefreshPolicy:(RCReceiptRefreshPolicy)refreshPolicy
-                                    completionBlock:(nullable RCReceivePurchaserInfoBlock)completion {
+- (void)syncPurchasesWithReceiptRefreshPolicy:(RCReceiptRefreshPolicy)refreshPolicy
+                                    isRestore:(BOOL)isRestore
+                                   completion:(nullable RCReceivePurchaserInfoBlock)completion {
     if (!self.allowSharingAppStoreAccount) {
         RCDebugLog(@"allowSharingAppStoreAccount is set to false and restoreTransactions has been called. "
                    "Are you sure you want to do this?");
@@ -611,7 +616,7 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
         RCSubscriberAttributeDict subscriberAttributes = self.unsyncedAttributesByKey;
         [self.backend postReceiptData:data
                             appUserID:self.appUserID
-                            isRestore:YES
+                            isRestore:isRestore
                           productInfo:nil
           presentedOfferingIdentifier:nil
                          observerMode:!self.finishTransactions

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -1148,17 +1148,28 @@ class PurchasesTests: XCTestCase {
         expect(self.requestFetcher.refreshReceiptCalled) == false
     }
 
-    func testSyncPurchasesSetsIsRestore() {
+    func testSyncPurchasesPassesIsRestoreAsAllowSharingAppStoreAccount() {
         setupPurchases()
-        purchases!.syncPurchases(nil)
-        expect(self.backend.postedIsRestore!).to(beTrue())
+
+        purchases.allowSharingAppStoreAccount = false
+        purchases!.syncPurchases()
+        expect(self.backend.postedIsRestore!) == false
+
+        purchases.allowSharingAppStoreAccount = true
+        purchases!.syncPurchases()
+        expect(self.backend.postedIsRestore!) == true
     }
 
     func testSyncPurchasesSetsIsRestoreForAnon() {
         setupAnonPurchases()
-        purchases!.syncPurchases(nil)
 
-        expect(self.backend.postedIsRestore!).to(beTrue())
+        purchases.allowSharingAppStoreAccount = false
+        purchases!.syncPurchases()
+        expect(self.backend.postedIsRestore!) == false
+
+        purchases.allowSharingAppStoreAccount = true
+        purchases!.syncPurchases()
+        expect(self.backend.postedIsRestore!) == true
     }
 
     func testSyncPurchasesCallsSuccessDelegateMethod() {

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -1062,13 +1062,13 @@ class PurchasesTests: XCTestCase {
         expect(receivedError).toEventuallyNot(beNil())
     }
 
-    func testRestoringPurchasesProgrammaticallyPostsTheReceipt() {
+    func testSyncPurchasesPostsTheReceipt() {
         setupPurchases()
-        purchases!.restoreTransactionsProgrammatically()
+        purchases!.syncPurchases()
         expect(self.backend.postReceiptDataCalled).to(beTrue())
     }
 
-    func testRestoringPurchasesProgrammaticallyDoesntPostIfReceiptEmptyAndPurchaserInfoLoaded() {
+    func testSyncPurchasesDoesntPostIfReceiptEmptyAndPurchaserInfoLoaded() {
         let info = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
@@ -1085,21 +1085,21 @@ class PurchasesTests: XCTestCase {
         mockReceiptParser.stubbedReceiptHasTransactionsResult = false
 
         setupPurchases()
-        purchases!.restoreTransactionsProgrammatically()
+        purchases!.syncPurchases()
 
         expect(self.backend.postReceiptDataCalled) == false
     }
 
-    func testRestoringPurchasesProgrammaticallyPostsIfReceiptEmptyAndPurchaserInfoNotLoaded() {
+    func testSyncPurchasesPostsIfReceiptEmptyAndPurchaserInfoNotLoaded() {
         mockReceiptParser.stubbedReceiptHasTransactionsResult = false
 
         setupPurchases()
-        purchases!.restoreTransactionsProgrammatically()
+        purchases!.syncPurchases()
 
         expect(self.backend.postReceiptDataCalled) == true
     }
 
-    func testRestoringPurchasesProgrammaticallyPostsIfReceiptHasTransactionsAndPurchaserInfoLoaded() {
+    func testSyncPurchasesPostsIfReceiptHasTransactionsAndPurchaserInfoLoaded() {
         let info = Purchases.PurchaserInfo(data: [
             "subscriber": [
                 "subscriptions": [:],
@@ -1116,52 +1116,52 @@ class PurchasesTests: XCTestCase {
         mockReceiptParser.stubbedReceiptHasTransactionsResult = true
 
         setupPurchases()
-        purchases!.restoreTransactionsProgrammatically()
+        purchases!.syncPurchases()
 
         expect(self.backend.postReceiptDataCalled) == true
     }
 
-    func testRestoringPurchasesProgrammaticallyPostsIfReceiptHasTransactionsAndPurchaserInfoNotLoaded() {
+    func testSyncPurchasesPostsIfReceiptHasTransactionsAndPurchaserInfoNotLoaded() {
         mockReceiptParser.stubbedReceiptHasTransactionsResult = true
 
         setupPurchases()
-        purchases!.restoreTransactionsProgrammatically()
+        purchases!.syncPurchases()
 
         expect(self.backend.postReceiptDataCalled) == true
     }
 
-    func testRestoringPurchasesProgrammaticallyDoesntRefreshTheReceiptIfNotEmpty() {
+    func testSyncPurchasesDoesntRefreshTheReceiptIfNotEmpty() {
         setupPurchases()
         self.receiptFetcher.shouldReturnReceipt = true
-        purchases!.restoreTransactionsProgrammatically()
+        purchases!.syncPurchases()
 
         expect(self.receiptFetcher.receiptDataTimesCalled) == 1
         expect(self.requestFetcher.refreshReceiptCalled) == false
     }
 
-    func testRestoringPurchasesProgrammaticallyDoesntRefreshTheReceiptIfEmpty() {
+    func testSyncPurchasesDoesntRefreshTheReceiptIfEmpty() {
         setupPurchases()
         self.receiptFetcher.shouldReturnReceipt = false
-        purchases!.restoreTransactionsProgrammatically()
+        purchases!.syncPurchases()
 
         expect(self.receiptFetcher.receiptDataTimesCalled) == 1
         expect(self.requestFetcher.refreshReceiptCalled) == false
     }
 
-    func testRestoringPurchasesProgrammaticallySetsIsRestore() {
+    func testSyncPurchasesSetsIsRestore() {
         setupPurchases()
-        purchases!.restoreTransactionsProgrammatically(nil)
+        purchases!.syncPurchases(nil)
         expect(self.backend.postedIsRestore!).to(beTrue())
     }
 
-    func testRestoringPurchasesProgrammaticallySetsIsRestoreForAnon() {
+    func testSyncPurchasesSetsIsRestoreForAnon() {
         setupAnonPurchases()
-        purchases!.restoreTransactionsProgrammatically(nil)
+        purchases!.syncPurchases(nil)
 
         expect(self.backend.postedIsRestore!).to(beTrue())
     }
 
-    func testRestoringPurchasesProgrammaticallyCallsSuccessDelegateMethod() {
+    func testSyncPurchasesCallsSuccessDelegateMethod() {
         setupPurchases()
 
         let purchaserInfo = Purchases.PurchaserInfo()
@@ -1169,14 +1169,14 @@ class PurchasesTests: XCTestCase {
 
         var receivedPurchaserInfo: Purchases.PurchaserInfo?
 
-        purchases!.restoreTransactionsProgrammatically { (info, error) in
+        purchases!.syncPurchases { (info, error) in
             receivedPurchaserInfo = info
         }
 
         expect(receivedPurchaserInfo).toEventually(be(purchaserInfo))
     }
 
-    func testRestoringPurchasesProgrammaticallyPassesErrorOnFailure() {
+    func testSyncPurchasesPassesErrorOnFailure() {
         setupPurchases()
 
         let errorCode = Purchases.RevenueCatBackendErrorCode.invalidAPIKey.rawValue as NSNumber
@@ -1189,7 +1189,7 @@ class PurchasesTests: XCTestCase {
 
         var receivedError: Error?
 
-        purchases!.restoreTransactionsProgrammatically { (_, newError) in
+        purchases!.syncPurchases { (_, newError) in
             receivedError = newError
         }
 


### PR DESCRIPTION
from yesterday's meeting: 
- renamed `restoreTransactionsProgrammatically` -> `syncPurchases` for consistency with android
- passed `isRestore` as the value of `allowSharingAppStoreAccount`