### PR TITLE
limit running integration tests to tags and release branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ workflows:
           tags:
             ignore: /^.*-SNAPSHOT/
           branches:
-            only: /release\/.*/
+            only: /^release\/(\d+\.)(\d+\.)(\d+)$/
       - integration-tests-swift-package-manager:
         filters:
           tags:
@@ -199,13 +199,13 @@ workflows:
           tags:
             ignore: /^.*-SNAPSHOT/
           branches:
-            only: /release\/.*/
+            only: /^release\/(\d+\.)(\d+\.)(\d+)$/
       - integration-tests-xcode-direct-integration:
         filters:
           tags:
             ignore: /^.*-SNAPSHOT/
           branches:
-            only: /release\/.*/
+            only: /^release\/(\d+\.)(\d+\.)(\d+)$/
   docs:
     jobs:
       - docs-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,25 +187,25 @@ workflows:
           tags:
             ignore: /^.*-SNAPSHOT/
           branches:
-            only: /^release\/(\d+\.)(\d+\.)(\d+)$/
+            only: /^release\/.*/
       - integration-tests-swift-package-manager:
         filters:
           tags:
             ignore: /^.*-SNAPSHOT/
           branches:
-            only: /release\/.*/
+            only: /^release\/.*/
       - integration-tests-carthage:
         filters:
           tags:
             ignore: /^.*-SNAPSHOT/
           branches:
-            only: /^release\/(\d+\.)(\d+\.)(\d+)$/
+            only: /^release\/.*/
       - integration-tests-xcode-direct-integration:
         filters:
           tags:
             ignore: /^.*-SNAPSHOT/
           branches:
-            only: /^release\/(\d+\.)(\d+\.)(\d+)$/
+            only: /^release\/.*/
   docs:
     jobs:
       - docs-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,10 @@
+only-release-tags: &only-release-tags
+  filters:
+    tags:
+      ignore: /^.*-SNAPSHOT/
+    branches:
+      only: /^release\/.*/
+
 version: 2.1
 commands:
   install-gems:
@@ -182,30 +189,10 @@ workflows:
   build-test:
     jobs:
       - runtest
-      - integration-tests-cocoapods:
-        filters:
-          tags:
-            ignore: /^.*-SNAPSHOT/
-          branches:
-            only: /^release\/.*/
-      - integration-tests-swift-package-manager:
-        filters:
-          tags:
-            ignore: /^.*-SNAPSHOT/
-          branches:
-            only: /^release\/.*/
-      - integration-tests-carthage:
-        filters:
-          tags:
-            ignore: /^.*-SNAPSHOT/
-          branches:
-            only: /^release\/.*/
-      - integration-tests-xcode-direct-integration:
-        filters:
-          tags:
-            ignore: /^.*-SNAPSHOT/
-          branches:
-            only: /^release\/.*/
+      - integration-tests-cocoapods: *only-release-tags
+      - integration-tests-swift-package-manager: *only-release-tags
+      - integration-tests-carthage: *only-release-tags
+      - integration-tests-xcode-direct-integration: *only-release-tags
   docs:
     jobs:
       - docs-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,10 +182,30 @@ workflows:
   build-test:
     jobs:
       - runtest
-      - integration-tests-cocoapods
-      - integration-tests-swift-package-manager
-      - integration-tests-carthage
-      - integration-tests-xcode-direct-integration
+      - integration-tests-cocoapods:
+        filters:
+          tags:
+            ignore: /^.*-SNAPSHOT/
+          branches:
+            only: /release\/.*/
+      - integration-tests-swift-package-manager:
+        filters:
+          tags:
+            ignore: /^.*-SNAPSHOT/
+          branches:
+            only: /release\/.*/
+      - integration-tests-carthage:
+        filters:
+          tags:
+            ignore: /^.*-SNAPSHOT/
+          branches:
+            only: /release\/.*/
+      - integration-tests-xcode-direct-integration:
+        filters:
+          tags:
+            ignore: /^.*-SNAPSHOT/
+          branches:
+            only: /release\/.*/
   docs:
     jobs:
       - docs-deploy:


### PR DESCRIPTION
I forgot to add this before merging. This limits running integration tests to tags and release branches