### PR TITLE
update git commit pointer in SPMIntegration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,6 +187,12 @@ jobs:
     steps:
       - checkout
       - trust-github-key
+      - run: 
+          name: Update git commit in SPM package
+          working_directory: IntegrationTests/SPMIntegration/
+          command: |
+              bundle exec fastlane update_swift_package_commit
+      
       - install-gems-scan-and-archive:
           directory: IntegrationTests/SPMIntegration/
       

--- a/IntegrationTests/SPMIntegration/SPMIntegration.xcodeproj/project.pbxproj
+++ b/IntegrationTests/SPMIntegration/SPMIntegration.xcodeproj/project.pbxproj
@@ -557,7 +557,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/RevenueCat/purchases-ios.git";
 			requirement = {
-				branch = HEAD;
+				branch = SPM_INTEGRATION_GIT_COMMIT;
 				kind = branch;
 			};
 		};

--- a/IntegrationTests/SPMIntegration/fastlane/Fastfile
+++ b/IntegrationTests/SPMIntegration/fastlane/Fastfile
@@ -1,1 +1,9 @@
 import("../../../fastlane/Fastfile")
+
+  desc "Update swift package commit"
+  lane :update_swift_package_commit do
+    commit_hash = last_git_commit[:commit_hash]
+    sed_regex = 's|' + "SPM_INTEGRATION_GIT_COMMIT" + '|' + commit_hash + '|'
+    backup_extension = '.bck'
+    sh("sed", '-i', backup_extension, sed_regex, '../SPMIntegration.xcodeproj/project.pbxproj')
+  end


### PR DESCRIPTION
I ran into a bit of an issue once the CI deployment checks were merged with integration tests: 
since SPM integration adds the Purchases package as a reference to its local path, and its local path *contains* the SPMIntegration folder, it would create a recursion that would make things fail when archiving with carthage or running integration tests for SPM. 

To address this, I replaced the integration pointer from a local path to a git path, and pointed to HEAD. This works, however, the value of HEAD won't necessarily match the value of HEAD being tested. 
So this adds an extra step to replace the git commit before running SPMIntegration tests.