### PR TITLE
add support for didRevokeEntitlementsForProductIdentifiers

### DIFF
--- a/Purchases/ProtectedExtensions/RCPurchases+Protected.h
+++ b/Purchases/ProtectedExtensions/RCPurchases+Protected.h
@@ -22,10 +22,12 @@
     RCIntroEligibilityCalculator,
     RCReceiptParser;
 
+#import "RCStoreKitWrapper.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 
-@interface RCPurchases (Protected)
+@interface RCPurchases (Protected) <RCStoreKitWrapperDelegate>
 
 - (instancetype)initWithAppUserID:(nullable NSString *)appUserID
                    requestFetcher:(RCStoreKitRequestFetcher *)requestFetcher

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -1161,6 +1161,14 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 
     return NO;
 }
+- (void)paymentQueue:(SKPaymentQueue *)queue
+didRevokeEntitlementsForProductIdentifiers:(NSArray<NSString *> *)productIdentifiers
+API_AVAILABLE(ios(14.0), macos(11.0), tvos(14.0), watchos(7.0)) {
+    RCDebugLog(@"entitlements revoked for product identifiers: @%.\nsyncing purchases", productIdentifiers);
+    [self syncPurchasesWithCompletionBlock:^(RCPurchaserInfo * _Nullable purchaserInfo, NSError * _Nullable error) {
+        RCDebugLog(@"Purchases synced");
+    }];
+}
 
 - (void)handlePurchasedTransaction:(SKPaymentTransaction *)transaction {
     [self receiptData:^(NSData * _Nonnull data) {

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -1161,10 +1161,10 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 
     return NO;
 }
-- (void)paymentQueue:(SKPaymentQueue *)queue
+- (void)storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper
 didRevokeEntitlementsForProductIdentifiers:(NSArray<NSString *> *)productIdentifiers
 API_AVAILABLE(ios(14.0), macos(11.0), tvos(14.0), watchos(7.0)) {
-    RCDebugLog(@"entitlements revoked for product identifiers: @%.\nsyncing purchases", productIdentifiers);
+    RCDebugLog(@"entitlements revoked for product identifiers: %@. \nsyncing purchases", productIdentifiers);
     [self syncPurchasesWithCompletionBlock:^(RCPurchaserInfo * _Nullable purchaserInfo, NSError * _Nullable error) {
         RCDebugLog(@"Purchases synced");
     }];

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -1161,7 +1161,7 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 
     return NO;
 }
-- (void)storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper
+- (void)                   storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper
 didRevokeEntitlementsForProductIdentifiers:(NSArray<NSString *> *)productIdentifiers
 API_AVAILABLE(ios(14.0), macos(11.0), tvos(14.0), watchos(7.0)) {
     RCDebugLog(@"entitlements revoked for product identifiers: %@. \nsyncing purchases", productIdentifiers);

--- a/Purchases/Purchasing/RCStoreKitWrapper.h
+++ b/Purchases/Purchasing/RCStoreKitWrapper.h
@@ -37,6 +37,10 @@ NS_ASSUME_NONNULL_BEGIN
   shouldAddStorePayment:(SKPayment *)payment
              forProduct:(SKProduct *)product;
 
+- (void)storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper
+didRevokeEntitlementsForProductIdentifiers:(NSArray<NSString *> *)productIdentifiers
+API_AVAILABLE(ios(14.0), macos(11.0), tvos(14.0), watchos(7.0));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Purchases/Purchasing/RCStoreKitWrapper.h
+++ b/Purchases/Purchasing/RCStoreKitWrapper.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
   shouldAddStorePayment:(SKPayment *)payment
              forProduct:(SKProduct *)product;
 
-- (void)storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper
+- (void)                   storeKitWrapper:(RCStoreKitWrapper *)storeKitWrapper
 didRevokeEntitlementsForProductIdentifiers:(NSArray<NSString *> *)productIdentifiers
 API_AVAILABLE(ios(14.0), macos(11.0), tvos(14.0), watchos(7.0));
 

--- a/Purchases/Purchasing/RCStoreKitWrapper.m
+++ b/Purchases/Purchasing/RCStoreKitWrapper.m
@@ -20,26 +20,22 @@
 
 @synthesize delegate = _delegate;
 
-- (instancetype)init
-{
+- (instancetype)init {
     return [self initWithPaymentQueue:SKPaymentQueue.defaultQueue];
 }
 
-- (nullable instancetype)initWithPaymentQueue:(SKPaymentQueue *)paymentQueue
-{
+- (nullable instancetype)initWithPaymentQueue:(SKPaymentQueue *)paymentQueue {
     if (self = [super init]) {
         self.paymentQueue = paymentQueue;
     }
     return self;
 }
 
-- (void)dealloc
-{
+- (void)dealloc {
     [self.paymentQueue removeTransactionObserver:self];
 }
 
-- (void)setDelegate:(id<RCStoreKitWrapperDelegate>)delegate
-{
+- (void)setDelegate:(id<RCStoreKitWrapperDelegate>)delegate {
     _delegate = delegate;
 
     if (_delegate != nil) {
@@ -49,20 +45,19 @@
     }
 }
 
-- (id<RCStoreKitWrapperDelegate>)delegate
-{
+- (id<RCStoreKitWrapperDelegate>)delegate {
     return _delegate;
 }
 
-- (void)addPayment:(SKPayment *)payment
-{
+- (void)addPayment:(SKPayment *)payment {
     [self.paymentQueue addPayment:payment];
 }
 
-- (void)finishTransaction:(SKPaymentTransaction *)transaction
-{
-    RCDebugLog(@"Finishing %@ %@ (%@)", transaction.payment.productIdentifier,
-                transaction.transactionIdentifier, transaction.originalTransaction.transactionIdentifier);
+- (void)finishTransaction:(SKPaymentTransaction *)transaction {
+    RCDebugLog(@"Finishing %@ %@ (%@)",
+               transaction.payment.productIdentifier,
+               transaction.transactionIdentifier,
+               transaction.originalTransaction.transactionIdentifier);
 
     [self.paymentQueue finishTransaction:transaction];
 }
@@ -75,26 +70,38 @@
     }
 }
 
-- (void)paymentQueue:(SKPaymentQueue *)queue updatedTransactions:(NSArray<SKPaymentTransaction *> *)transactions
-{
+- (void)paymentQueue:(SKPaymentQueue *)queue
+ updatedTransactions:(NSArray<SKPaymentTransaction *> *)transactions {
     for (SKPaymentTransaction *transaction in transactions) {
-        RCDebugLog(@"PaymentQueue updatedTransaction: %@ %@ (%@) %@ - %ld", transaction.payment.productIdentifier, transaction.transactionIdentifier, transaction.error, transaction.originalTransaction.transactionIdentifier, (long)transaction.transactionState);
+        RCDebugLog(@"PaymentQueue updatedTransaction: %@ %@ (%@) %@ - %ld",
+                   transaction.payment.productIdentifier,
+                   transaction.transactionIdentifier,
+                   transaction.error,
+                   transaction.originalTransaction.transactionIdentifier,
+                   (long)transaction.transactionState);
         [self.delegate storeKitWrapper:self updatedTransaction:transaction];
     }
 }
 
 // Sent when transactions are removed from the queue (via finishTransaction:).
-- (void)paymentQueue:(SKPaymentQueue *)queue removedTransactions:(NSArray<SKPaymentTransaction *> *)transactions
-{
+- (void)paymentQueue:(SKPaymentQueue *)queue
+ removedTransactions:(NSArray<SKPaymentTransaction *> *)transactions {
     for (SKPaymentTransaction *transaction in transactions) {
-        RCDebugLog(@"PaymentQueue removedTransaction: %@ %@ (%@ %@) %@ - %ld", transaction.payment.productIdentifier, transaction.transactionIdentifier, transaction.originalTransaction.transactionIdentifier, transaction.error, transaction.error.userInfo, (long)transaction.transactionState);
+        RCDebugLog(@"PaymentQueue removedTransaction: %@ %@ (%@ %@) %@ - %ld",
+                   transaction.payment.productIdentifier,
+                   transaction.transactionIdentifier,
+                   transaction.originalTransaction.transactionIdentifier,
+                   transaction.error,
+                   transaction.error.userInfo,
+                   (long)transaction.transactionState);
         [self.delegate storeKitWrapper:self removedTransaction:transaction];
     }
 }
 
 #if PURCHASES_INITIATED_FROM_APP_STORE_AVAILABLE
-- (BOOL)paymentQueue:(SKPaymentQueue *)queue shouldAddStorePayment:(SKPayment *)payment forProduct:(SKProduct *)product
-{
+- (BOOL)paymentQueue:(SKPaymentQueue *)queue
+shouldAddStorePayment:(SKPayment *)payment
+          forProduct:(SKProduct *)product {
     return [self.delegate storeKitWrapper:self shouldAddStorePayment:payment forProduct:product];
 }
 #endif

--- a/Purchases/Purchasing/RCStoreKitWrapper.m
+++ b/Purchases/Purchasing/RCStoreKitWrapper.m
@@ -106,4 +106,12 @@ shouldAddStorePayment:(SKPayment *)payment
 }
 #endif
 
+// Sent when the owner of a family shared subscription revokes access to a family member or cancels the subscription
+- (void)paymentQueue:(SKPaymentQueue *)queue
+didRevokeEntitlementsForProductIdentifiers:(NSArray<NSString *> *)productIdentifiers
+API_AVAILABLE(ios(14.0), macos(11.0), tvos(14.0), watchos(7.0)) {
+    RCDebugLog(@"PaymentQueue didRevokeEntitlementsForProductIdentifiers: %@", productIdentifiers);
+    [self.delegate storeKitWrapper:self didRevokeEntitlementsForProductIdentifiers:productIdentifiers];
+}
+
 @end

--- a/Purchases/Purchasing/RCStoreKitWrapper.m
+++ b/Purchases/Purchasing/RCStoreKitWrapper.m
@@ -99,15 +99,15 @@
 }
 
 #if PURCHASES_INITIATED_FROM_APP_STORE_AVAILABLE
-- (BOOL)paymentQueue:(SKPaymentQueue *)queue
+- (BOOL) paymentQueue:(SKPaymentQueue *)queue
 shouldAddStorePayment:(SKPayment *)payment
-          forProduct:(SKProduct *)product {
+           forProduct:(SKProduct *)product {
     return [self.delegate storeKitWrapper:self shouldAddStorePayment:payment forProduct:product];
 }
 #endif
 
 // Sent when access to a family shared subscription is revoked from a family member or canceled the subscription
-- (void)paymentQueue:(SKPaymentQueue *)queue
+- (void)                      paymentQueue:(SKPaymentQueue *)queue
 didRevokeEntitlementsForProductIdentifiers:(NSArray<NSString *> *)productIdentifiers
 API_AVAILABLE(ios(14.0), macos(11.0), tvos(14.0), watchos(7.0)) {
     RCDebugLog(@"PaymentQueue didRevokeEntitlementsForProductIdentifiers: %@", productIdentifiers);

--- a/Purchases/Purchasing/RCStoreKitWrapper.m
+++ b/Purchases/Purchasing/RCStoreKitWrapper.m
@@ -106,7 +106,7 @@ shouldAddStorePayment:(SKPayment *)payment
 }
 #endif
 
-// Sent when the owner of a family shared subscription revokes access to a family member or cancels the subscription
+// Sent when access to a family shared subscription is revoked from a family member or canceled the subscription
 - (void)paymentQueue:(SKPaymentQueue *)queue
 didRevokeEntitlementsForProductIdentifiers:(NSArray<NSString *> *)productIdentifiers
 API_AVAILABLE(ios(14.0), macos(11.0), tvos(14.0), watchos(7.0)) {

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -2494,13 +2494,14 @@ class PurchasesTests: XCTestCase {
     }
 
 
-    @available(iOS 14.0, *)
     func testSyncsPurchasesIfEntitlementsRevokedForProductIDs() {
-        setupPurchases()
-        guard let purchases = purchases else { fatalError() }
-        expect(self.backend.postReceiptDataCalled).to(beFalse())
-        purchases.storeKitWrapper(storeKitWrapper, didRevokeEntitlementsForProductIdentifiers: ["a", "b"])
-        expect(self.backend.postReceiptDataCalled).to(beTrue())
+        if #available(iOS 14.0, macOS 14.0, tvOS 14.0, watchOS 7.0, *) {
+            setupPurchases()
+            guard let purchases = purchases else { fatalError() }
+            expect(self.backend.postReceiptDataCalled).to(beFalse())
+            purchases.storeKitWrapper(storeKitWrapper, didRevokeEntitlementsForProductIdentifiers: ["a", "b"])
+            expect(self.backend.postReceiptDataCalled).to(beTrue())
+        }
     }
 
 

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -2493,6 +2493,17 @@ class PurchasesTests: XCTestCase {
         expect(receivedError?.code).toEventually(equal(Purchases.ErrorCode.paymentPendingError.rawValue))
     }
 
+
+    @available(iOS 14.0, *)
+    func testSyncsPurchasesIfEntitlementsRevokedForProductIDs() {
+        setupPurchases()
+        guard let purchases = purchases else { fatalError() }
+        expect(self.backend.postReceiptDataCalled).to(beFalse())
+        purchases.storeKitWrapper(storeKitWrapper, didRevokeEntitlementsForProductIdentifiers: ["a", "b"])
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
+    }
+
+
     private func verifyUpdatedCaches(newAppUserID: String) {
         let expectedCallCount = 2
         expect(self.backend.getSubscriberCallCount).toEventually(equal(expectedCallCount))

--- a/PurchasesTests/Purchasing/StoreKitWrapperTests.swift
+++ b/PurchasesTests/Purchasing/StoreKitWrapperTests.swift
@@ -36,6 +36,10 @@ class MockPaymentQueue: SKPaymentQueue {
 }
 
 class StoreKitWrapperTests: XCTestCase, RCStoreKitWrapperDelegate {
+    func storeKitWrapper(_ storeKitWrapper: RCStoreKitWrapper, didRevokeEntitlementsForProductIdentifiers productIdentifiers: [String]) {
+
+    }
+
 
     let paymentQueue = MockPaymentQueue()
 

--- a/PurchasesTests/Purchasing/StoreKitWrapperTests.swift
+++ b/PurchasesTests/Purchasing/StoreKitWrapperTests.swift
@@ -36,11 +36,6 @@ class MockPaymentQueue: SKPaymentQueue {
 }
 
 class StoreKitWrapperTests: XCTestCase, RCStoreKitWrapperDelegate {
-    func storeKitWrapper(_ storeKitWrapper: RCStoreKitWrapper, didRevokeEntitlementsForProductIdentifiers productIdentifiers: [String]) {
-
-    }
-
-
     let paymentQueue = MockPaymentQueue()
 
     var wrapper: RCStoreKitWrapper?
@@ -70,6 +65,12 @@ class StoreKitWrapperTests: XCTestCase, RCStoreKitWrapperDelegate {
         promoPayment = payment
         promoProduct = product
         return shouldAddPromo
+    }
+
+    var productIdentifiersWithRevokedEntitlements: [String]?
+
+    func storeKitWrapper(_ storeKitWrapper: RCStoreKitWrapper, didRevokeEntitlementsForProductIdentifiers productIdentifiers: [String]) {
+        productIdentifiersWithRevokedEntitlements = productIdentifiers
     }
 
     func testObservesThePaymentQueue() {
@@ -170,5 +171,18 @@ class StoreKitWrapperTests: XCTestCase, RCStoreKitWrapperDelegate {
 
         expect(self.paymentQueue.observers.count).to(equal(1))
 
+    }
+
+    func testDidRevokeEntitlementsForProductIdentifiersCallsDelegateWithRightArguments() {
+        expect(self.productIdentifiersWithRevokedEntitlements).to(beNil())
+        let revokedProductIdentifiers = [
+            "mySuperProduct",
+            "theOtherProduct"
+        ]
+
+        if #available(iOS 14.0, *) {
+            wrapper?.paymentQueue(paymentQueue, didRevokeEntitlementsForProductIdentifiers: revokedProductIdentifiers)
+            expect(self.productIdentifiersWithRevokedEntitlements) == revokedProductIdentifiers
+        }
     }
 }

--- a/PurchasesTests/Purchasing/StoreKitWrapperTests.swift
+++ b/PurchasesTests/Purchasing/StoreKitWrapperTests.swift
@@ -174,13 +174,13 @@ class StoreKitWrapperTests: XCTestCase, RCStoreKitWrapperDelegate {
     }
 
     func testDidRevokeEntitlementsForProductIdentifiersCallsDelegateWithRightArguments() {
-        expect(self.productIdentifiersWithRevokedEntitlements).to(beNil())
-        let revokedProductIdentifiers = [
-            "mySuperProduct",
-            "theOtherProduct"
-        ]
+        if #available(iOS 14.0, macOS 14.0, tvOS 14.0, watchOS 7.0, *) {
+            expect(self.productIdentifiersWithRevokedEntitlements).to(beNil())
+            let revokedProductIdentifiers = [
+                "mySuperProduct",
+                "theOtherProduct"
+            ]
 
-        if #available(iOS 14.0, *) {
             wrapper?.paymentQueue(paymentQueue, didRevokeEntitlementsForProductIdentifiers: revokedProductIdentifiers)
             expect(self.productIdentifiersWithRevokedEntitlements) == revokedProductIdentifiers
         }


### PR DESCRIPTION
adds support for `didRevokeEntitlementsForProductIdentifiers`, the new `SKPaymentQueue` method for handling cases where a family-shareable subscription is no longer shared. 

Note that this does not involve any user-facing changes, so it can be released in a patch release. 