### PR TITLE
skip offerings backend call with error if appUserID is empty

### DIFF
--- a/Purchases/Networking/RCBackend.m
+++ b/Purchases/Networking/RCBackend.m
@@ -296,6 +296,12 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
                       completion:(RCOfferingsResponseHandler)completion
 {
     NSString *escapedAppUserID = [self escapedAppUserID:appUserID];
+    if (!escapedAppUserID || [escapedAppUserID isEqualToString:@""]) {
+        RCWarnLog(@"called getOfferings with an empty appUserID!");
+        completion(nil, RCPurchasesErrorUtils.missingAppUserIDError);
+        return;
+    }
+
     NSString *path = [NSString stringWithFormat:@"/subscribers/%@/offerings", escapedAppUserID];
 
     if ([self addCallback:completion forKey:path]) {

--- a/Purchases/Purchasing/RCIdentityManager.m
+++ b/Purchases/Purchasing/RCIdentityManager.m
@@ -69,7 +69,7 @@
 - (void)createAlias:(NSString *)alias withCompletionBlock:(void (^)(NSError *_Nullable error))completion {
     NSString *currentAppUserID = self.currentAppUserID;
     if (!currentAppUserID) {
-        RCDebugLog(@"Couldn't create an alias because the currentAppUserID is null. "
+        RCWarnLog(@"Couldn't create an alias because the currentAppUserID is null. "
                    "This might happen if the entry in UserDefaults is missing.");
         completion(RCPurchasesErrorUtils.missingAppUserIDError);
         return;


### PR DESCRIPTION
We're getting a few calls to the backend for offerings on empty appUserID strings. 
This checks whether the appUserID is empty before posting to the backend, and early exists with an error if that's the case. 