### PR TITLE
prevents POST requests when the JSON body couldn't be correctly formed

### DIFF
--- a/Purchases/Networking/RCHTTPClient.m
+++ b/Purchases/Networking/RCHTTPClient.m
@@ -148,30 +148,26 @@ beginNextRequestWhenFinished:(BOOL)beginNextRequestWhenFinished {
     }
 
     if (beginNextRequestWhenFinished) {
-        [self makeNextRequestIfNeeded];
-    }
-}
-
-- (void)makeNextRequestIfNeeded {
-    @synchronized (self) {
-        RCDebugLog(@"serial request done: %@ %@, %ld requests left in the queue",
-                   self.currentSerialRequest.httpMethod,
-                   self.currentSerialRequest.path,
-                   (unsigned long)self.queuedRequests.count);
-        RCHTTPRequest *nextRequest = nil;
-        self.currentSerialRequest = nil;
-        if (self.queuedRequests.count > 0) {
-            nextRequest = self.queuedRequests[0];
-            [self.queuedRequests removeObjectAtIndex:0];
-        }
-        if (nextRequest) {
-            RCDebugLog(@"starting the next request in the queue, %@", nextRequest);
-            [self performRequest:nextRequest.httpMethod
-                        serially:YES
-                            path:nextRequest.path
-                            body:nextRequest.requestBody
-                         headers:nextRequest.headers
-               completionHandler:nextRequest.completionHandler];
+        @synchronized (self) {
+            RCDebugLog(@"serial request done: %@ %@, %ld requests left in the queue",
+                       self.currentSerialRequest.httpMethod,
+                       self.currentSerialRequest.path,
+                       (unsigned long)self.queuedRequests.count);
+            RCHTTPRequest *nextRequest = nil;
+            self.currentSerialRequest = nil;
+            if (self.queuedRequests.count > 0) {
+                nextRequest = self.queuedRequests[0];
+                [self.queuedRequests removeObjectAtIndex:0];
+            }
+            if (nextRequest) {
+                RCDebugLog(@"starting the next request in the queue, %@", nextRequest);
+                [self performRequest:nextRequest.httpMethod
+                            serially:YES
+                                path:nextRequest.path
+                                body:nextRequest.requestBody
+                             headers:nextRequest.headers
+                   completionHandler:nextRequest.completionHandler];
+            }
         }
     }
 }

--- a/Purchases/Networking/RCHTTPClient.m
+++ b/Purchases/Networking/RCHTTPClient.m
@@ -64,10 +64,10 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableDictionary *defaultHeaders = self.defaultHeaders.mutableCopy;
     [defaultHeaders addEntriesFromDictionary:headers];
 
-    NSMutableURLRequest *urlRequest = [self createRequestWithMethod:httpMethod
-                                                               path:path
-                                                        requestBody:requestBody
-                                                            headers:defaultHeaders];
+    NSMutableURLRequest * _Nullable urlRequest = [self createRequestWithMethod:httpMethod
+                                                                          path:path
+                                                                   requestBody:requestBody
+                                                                       headers:defaultHeaders];
     if (!urlRequest) {
         RCErrorLog(@"Could not create request to %@ with body %@", path, requestBody);
         completionHandler(-1,
@@ -173,9 +173,9 @@ beginNextRequestWhenFinished:(BOOL)beginNextRequestWhenFinished {
 }
 
 - (nullable NSMutableURLRequest *)createRequestWithMethod:(NSString *)httpMethod
-                                            path:(NSString *)path
-                                     requestBody:(NSDictionary *)requestBody
-                                         headers:(NSMutableDictionary *)defaultHeaders {
+                                                     path:(NSString *)path
+                                              requestBody:(NSDictionary *)requestBody
+                                                  headers:(NSMutableDictionary *)defaultHeaders {
     NSString *relativeURLString = [NSString stringWithFormat:@"/v1%@", path];
     NSURL *requestURL = [NSURL URLWithString:relativeURLString relativeToURL:RCSystemInfo.serverHostURL];
 

--- a/Purchases/Networking/RCHTTPClient.m
+++ b/Purchases/Networking/RCHTTPClient.m
@@ -176,7 +176,7 @@ beginNextRequestWhenFinished:(BOOL)beginNextRequestWhenFinished {
     }
 }
 
-- (NSMutableURLRequest *)createRequestWithMethod:(NSString *)HTTPMethod
+- (nullable NSMutableURLRequest *)createRequestWithMethod:(NSString *)httpMethod
                                             path:(NSString *)path
                                      requestBody:(NSDictionary *)requestBody
                                          headers:(NSMutableDictionary *)defaultHeaders {
@@ -185,14 +185,18 @@ beginNextRequestWhenFinished:(BOOL)beginNextRequestWhenFinished {
 
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:requestURL];
 
-    request.HTTPMethod = HTTPMethod;
+    request.HTTPMethod = httpMethod;
     request.allHTTPHeaderFields = defaultHeaders;
 
-    if ([HTTPMethod isEqualToString:@"POST"]) {
-        NSError *JSONParseError;
-        NSData *body = [NSJSONSerialization dataWithJSONObject:requestBody options:0 error:&JSONParseError];
-        if (JSONParseError) {
-            RCErrorLog(@"Error creating request JSON: %@", requestBody);
+    if ([httpMethod isEqualToString:@"POST"]) {
+        NSError *jsonParseError;
+        NSData *body;
+        BOOL isValidJSONObject = [NSJSONSerialization isValidJSONObject:requestBody];
+        if (isValidJSONObject) {
+            body = [NSJSONSerialization dataWithJSONObject:requestBody options:0 error:&jsonParseError];
+        }
+        if (!isValidJSONObject || jsonParseError) {
+            RCErrorLog(@"Error creating request with JSON body: %@", requestBody);
             return nil;
         }
         request.HTTPBody = body;

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -625,5 +625,18 @@ class HTTPClientTests: XCTestCase {
         expect(firstRequestFinished).toEventually(beTrue())
         expect(secondRequestFinished).toEventually(beTrue())
     }
+
+    func testPerformRequestFailsAssertionIfPostWithNilBody() {
+
+    }
+
+    func testPerformRequestCancelsIfBodyCouldntBeParsedIntoJson() {
+
+    }
+
+    func testPerformSeriallyMovesOnToNextRequestIfRequestCanceledFromJsonParsingError() {
+
+    }
+
 }
 

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -638,7 +638,7 @@ class HTTPClientTests: XCTestCase {
         }.to(raiseException())
     }
 
-    func testPerformRequestCancelsIfBodyCouldntBeParsedIntoJson() {
+    func testPerformRequestExitsWithErrorIfBodyCouldntBeParsedIntoJSON() {
         // infinity can't be cast into JSON, so we use it to force a parsing exception. See:
         // https://developer.apple.com/documentation/foundation/nsjsonserialization?language=objc
         let nonJSONBody = ["something": Double.infinity]
@@ -665,6 +665,32 @@ class HTTPClientTests: XCTestCase {
         expect(receivedNSError.code) == Purchases.ErrorCode.networkError.rawValue
         expect(receivedData).to(beNil())
         expect(receivedStatus) == -1
+    }
+
+    func testPerformRequestDoesntPerformRequestIfBodyCouldntBeParsedIntoJSON() {
+        // infinity can't be cast into JSON, so we use it to force a parsing exception. See:
+        // https://developer.apple.com/documentation/foundation/nsjsonserialization?language=objc
+        let nonJSONBody = ["something": Double.infinity]
+
+        let path = "/a_random_path"
+        var completionCalled = false
+        var httpCallMade = false
+
+        stub(condition: isPath("/v1" + path)) { request in
+            httpCallMade = true
+            return HTTPStubsResponse(data: Data(), statusCode:200, headers:nil)
+        }
+
+        self.client.performRequest("POST",
+                                   serially: true,
+                                   path: path,
+                                   body: nonJSONBody,
+                                   headers: nil) { (status, data, error) in
+            completionCalled = true
+        }
+
+        expect(completionCalled).toEventually(beTrue())
+        expect(httpCallMade).toEventually(beFalse())
     }
 }
 

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -627,16 +627,44 @@ class HTTPClientTests: XCTestCase {
     }
 
     func testPerformRequestFailsAssertionIfPostWithNilBody() {
+        let path = "/a_random_path"
 
+        expect {
+            self.client.performRequest("POST",
+                                   serially: true,
+                                   path: path,
+                                   body: nil,
+                                   headers: nil, completionHandler: nil)
+        }.to(raiseException())
     }
 
     func testPerformRequestCancelsIfBodyCouldntBeParsedIntoJson() {
+        // infinity can't be cast into JSON, so we use it to force a parsing exception. See:
+        // https://developer.apple.com/documentation/foundation/nsjsonserialization?language=objc
+        let nonJSONBody = ["something": Double.infinity]
 
+        let path = "/a_random_path"
+        var completionCalled = false
+        var receivedError: Error? = nil
+        var receivedStatus: Int? = nil
+        var receivedData: [AnyHashable: Any]? = nil
+        self.client.performRequest("POST",
+                                   serially: true,
+                                   path: path,
+                                   body: nonJSONBody,
+                                   headers: nil) { (status, data, error) in
+            completionCalled = true
+            receivedError = error
+            receivedStatus = status
+            receivedData = data
+        }
+
+        expect(completionCalled).toEventually(beTrue())
+        expect(receivedError).toNot(beNil())
+        let receivedNSError = receivedError! as NSError
+        expect(receivedNSError.code) == Purchases.ErrorCode.networkError.rawValue
+        expect(receivedData).to(beNil())
+        expect(receivedStatus) == -1
     }
-
-    func testPerformSeriallyMovesOnToNextRequestIfRequestCanceledFromJsonParsingError() {
-
-    }
-
 }
 

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -631,10 +631,10 @@ class HTTPClientTests: XCTestCase {
 
         expect {
             self.client.performRequest("POST",
-                                   serially: true,
-                                   path: path,
-                                   body: nil,
-                                   headers: nil, completionHandler: nil)
+                                       serially: true,
+                                       path: path,
+                                       body: nil,
+                                       headers: nil, completionHandler: nil)
         }.to(raiseException())
     }
 


### PR DESCRIPTION
We're consistently getting a few POST requests on the backend which have empty body. 

Thing is, we never _create_ requests with `nil` bodies intentionally, so after looking at the code it seems like this might happen if the `body` dictionary couldn't be parsed into JSON. 
It doesn't make sense to still hit the backend if the body of the request couldn't be correctly formed, so this does an early exit before that happens. 
Also, when you hit the backend unnecessarily, a panda dies. Don't kill pandas. 