### PR TITLE
fix: Xcode 11 compatibility

### DIFF
--- a/Purchases/Purchasing/RCStoreKitWrapper.m
+++ b/Purchases/Purchasing/RCStoreKitWrapper.m
@@ -63,11 +63,13 @@
 }
 
 - (void)presentCodeRedemptionSheet API_AVAILABLE(ios(14.0)) API_UNAVAILABLE(tvos, macos, watchos) {
+#ifdef __IPHONE_14_0
     if (@available(iOS 14.0, *)) {
         [self.paymentQueue presentCodeRedemptionSheet];
     } else {
         RCLog(@"Attempted to present code redemption sheet, but it's not available on this device.");
     }
+#endif
 }
 
 - (void)paymentQueue:(SKPaymentQueue *)queue

--- a/PurchasesTests/Purchasing/StoreKitWrapperTests.swift
+++ b/PurchasesTests/Purchasing/StoreKitWrapperTests.swift
@@ -174,6 +174,7 @@ class StoreKitWrapperTests: XCTestCase, RCStoreKitWrapperDelegate {
     }
 
     func testDidRevokeEntitlementsForProductIdentifiersCallsDelegateWithRightArguments() {
+        #if swift(>=5.3)
         if #available(iOS 14.0, macOS 14.0, tvOS 14.0, watchOS 7.0, *) {
             expect(self.productIdentifiersWithRevokedEntitlements).to(beNil())
             let revokedProductIdentifiers = [
@@ -184,5 +185,6 @@ class StoreKitWrapperTests: XCTestCase, RCStoreKitWrapperDelegate {
             wrapper?.paymentQueue(paymentQueue, didRevokeEntitlementsForProductIdentifiers: revokedProductIdentifiers)
             expect(self.productIdentifiersWithRevokedEntitlements) == revokedProductIdentifiers
         }
+        #endif
     }
 }


### PR DESCRIPTION
`purchases-ios` currently is incompatible with Xcode 11, because we're using a couple of APIs that are available on Xcode 12+ only. 

This adds a couple of compiler-time checks to ensure that those APIs are only used when building using Xcode 12+ 