### PR TITLE
version 3.9.1

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -5,9 +5,9 @@ objc: true
 sdk: iphonesimulator
 module: Purchases
 umbrella_header: Purchases/Public/Purchases.h
-module_version: 3.10.0-SNAPSHOT
+module_version: 3.9.1
 github_url: https://github.com/revenuecat/purchases-ios
-github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.10.0-SNAPSHOT
+github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.9.1
 output: docs
 # Leaving this commented out. We used to specify this before, but now it's working without it
 # xcodebuild_arguments: [--objc,Purchases/Public/Purchases.h,--,-x,objective-c,-isysroot,$(xcrun --show-sdk-path),-I,$(pwd)]

--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,6 +1,4 @@
-- Added support for StoreKit Config Files and StoreKitTest testing
-    https://github.com/RevenueCat/purchases-ios/pull/407
-- limit running integration tests to tags and release branches
-    https://github.com/RevenueCat/purchases-ios/pull/406
-- added deployment checks
-    https://github.com/RevenueCat/purchases-ios/pull/404
+- Added support for `SKPaymentQueue`'s `didRevokeEntitlementsForProductIdentifiers:`, so entitlements are automatically revoked from a family-shared purchase when a family member leaves or the subscription is canceled.
+    https://github.com/RevenueCat/purchases-ios/pull/413
+- Added support for automated deploys
+    https://github.com/RevenueCat/purchases-ios/pull/411

--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -2,3 +2,5 @@
     https://github.com/RevenueCat/purchases-ios/pull/413
 - Added support for automated deploys
     https://github.com/RevenueCat/purchases-ios/pull/411
+- Fixed Xcode direct integration failing on Mac Catalyst builds
+    https://github.com/RevenueCat/purchases-ios/pull/419

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
     https://github.com/RevenueCat/purchases-ios/pull/413
 - Added support for automated deploys
     https://github.com/RevenueCat/purchases-ios/pull/411
+- Fixed Xcode direct integration failing on Mac Catalyst builds
+    https://github.com/RevenueCat/purchases-ios/pull/419
 
 ## 3.9.0
 - Added support for StoreKit Config Files and StoreKitTest testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 3.9.1
 - Added support for `SKPaymentQueue`'s `didRevokeEntitlementsForProductIdentifiers:`, so entitlements are automatically revoked from a family-shared purchase when a family member leaves or the subscription is canceled.
     https://github.com/RevenueCat/purchases-ios/pull/413
+- Added support for automated deploys
+    https://github.com/RevenueCat/purchases-ios/pull/411
 
 ## 3.9.0
 - Added support for StoreKit Config Files and StoreKitTest testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.9.1
+- Added support for `SKPaymentQueue`'s `didRevokeEntitlementsForProductIdentifiers:`, so entitlements are automatically revoked from a family-shared purchase when a family member leaves or the subscription is canceled.
+    https://github.com/RevenueCat/purchases-ios/pull/413
+
 ## 3.9.0
 - Added support for StoreKit Config Files and StoreKitTest testing
     https://github.com/RevenueCat/purchases-ios/pull/407

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Purchases"
-  s.version          = "3.10.0-SNAPSHOT"
+  s.version          = "3.9.1"
   s.summary          = "Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
-  s.dependency 'PurchasesCoreSwift', '3.10.0-SNAPSHOT'
+  s.dependency 'PurchasesCoreSwift', '3.9.1'
 
 
   s.source_files = ['Purchases/**/*.{h,m}']

--- a/Purchases/Info.plist
+++ b/Purchases/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.10.0-SNAPSHOT</string>
+	<string>3.9.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Purchases/Misc/RCSystemInfo.m
+++ b/Purchases/Misc/RCSystemInfo.m
@@ -49,7 +49,7 @@ static BOOL _forceUniversalAppStore = NO;
 }
 
 + (NSString *)frameworkVersion {
-    return @"3.10.0-SNAPSHOT";
+    return @"3.9.1";
 }
 
 + (NSString *)systemVersion {

--- a/PurchasesCoreSwift.podspec
+++ b/PurchasesCoreSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesCoreSwift"
-  s.version          = "3.10.0-SNAPSHOT"
+  s.version          = "3.9.1"
   s.summary          = "Swift portion of RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/PurchasesCoreSwift/Info.plist
+++ b/PurchasesCoreSwift/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.10.0-SNAPSHOT</string>
+	<string>3.9.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/PurchasesCoreSwiftTests/Info.plist
+++ b/PurchasesCoreSwiftTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.10.0-SNAPSHOT</string>
+	<string>3.9.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/PurchasesTests/Info.plist
+++ b/PurchasesTests/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.10.0-SNAPSHOT</string>
+	<string>3.9.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -67,7 +67,7 @@ platform :ios do
       tag_name: "#{release_version}",
       description: changelog,
       commitish: "master",
-      upload_assets: ["CarthageUploads/Purchases.framework.zip"],
+      upload_assets: ["Purchases.framework.zip"],
       is_draft: false
   )
   end
@@ -162,9 +162,6 @@ def carthage_archive
   Dir.chdir("..") do
     sh("./carthage.sh", "build", "--no-skip-current")
     sh("./carthage.sh", "archive", "Purchases")
-    carthage_uploads_path = './CarthageUploads'
-    sh("mkdir", carthage_uploads_path)
-    sh("mv", "Purchases.zip", carthage_uploads_path)
   end
 end
 


### PR DESCRIPTION
## 3.9.1
- Added support for `SKPaymentQueue`'s `didRevokeEntitlementsForProductIdentifiers:`, so entitlements are automatically revoked from a family-shared purchase when a family member leaves or the subscription is canceled.
    https://github.com/RevenueCat/purchases-ios/pull/413
