### PR TITLE
Fix termination warnings for finished SKRequests

### DIFF
--- a/Purchases/Purchasing/RCStoreKitRequestFetcher.m
+++ b/Purchases/Purchasing/RCStoreKitRequestFetcher.m
@@ -135,6 +135,7 @@
             receiptHandler();
         }
     }
+    [request cancel];
 }
 
 - (void)request:(SKRequest *)request didFailWithError:(NSError *)error
@@ -152,6 +153,7 @@
             handler(@[]);
         }
     }
+    [request cancel];
 }
 
 - (void)productsRequest:(SKProductsRequest *)request didReceiveResponse:(SKProductsResponse *)response

--- a/PurchasesCoreSwift/Purchasing/ProductsManager.swift
+++ b/PurchasesCoreSwift/Purchasing/ProductsManager.swift
@@ -68,6 +68,7 @@ extension ProductsManager: SKProductsRequestDelegate {
 
     func requestDidFinish(_ request: SKRequest) {
         Logger.debug("SKProductsRequest did finish")
+        request.cancel()
     }
 
     func request(_ request: SKRequest, didFailWithError error: Error) {
@@ -84,6 +85,7 @@ extension ProductsManager: SKProductsRequestDelegate {
                 completion(Set())
             }
         }
+        request.cancel()
     }
 }
 


### PR DESCRIPTION
Addresses 
https://github.com/RevenueCat/purchases-ios/issues/391

We’ve been getting warnings when debugging for a while, where iOS seems to issue a warning for SKReceiptRefreshRequest and SKProductsRequest not getting terminated correctly.

My guess is that this is an OS bug.

However, canceling the tasks manually after they are done seems to fix it. 

I've verified that without this change, the `SKReceiptRefreshRequest` stays in memory after the finish calls happen, and that it gets released with this change. 

Screenshots from before the change:
<img width="926" alt="Screen Shot 2020-12-07 at 5 33 05 PM" src="https://user-images.githubusercontent.com/3922667/101402577-afd15d80-38b2-11eb-90ca-cdf382556369.png">
<img width="265" alt="Screen Shot 2020-12-07 at 5 33 02 PM" src="https://user-images.githubusercontent.com/3922667/101402582-b1028a80-38b2-11eb-9272-712afacda61e.png">


The [docs](https://developer.apple.com/documentation/storekit/skrequestdelegate/1385536-request?language=objc) don't say anything specifically about canceling the requests, but they do specify that after `didFinish` and `didFailWithError` are called you should release the objects, and that they won't send any more messages to their delegates. So the changes should be safe memory-wise. 


