### PR TITLE
Fix CI deploy bugs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,13 @@ release-tags-and-branches: &release-tags-and-branches
     branches:
       only: /^release\/.*/
 
+release-branches: &release-branches
+  filters:
+    tags:
+      ignore: /.*/
+    branches:
+      only: /^release\/.*/
+
 release-tags: &release-tags
   filters: 
     tags:
@@ -252,7 +259,7 @@ workflows:
   build-test:
     jobs:
       - runtest
-      - deployment-checks: *release-tags-and-branches
+      - deployment-checks: *release-branches
       - integration-tests-cocoapods: *release-tags-and-branches
       - integration-tests-swift-package-manager: *release-tags-and-branches
       - integration-tests-carthage: *release-tags-and-branches

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -121,8 +121,8 @@ platform :ios do
 end
 
 def prepare_next_version(current_version)
-  major, minor, patch = current_version.split('.')
-  next_version = "#{major}.#{minor.to_i + 1}.#{patch}"
+  major, minor, _ = current_version.split('.')
+  next_version = "#{major}.#{minor.to_i + 1}.0"
 
   branch_name = "bump/#{next_version}-SNAPSHOT"
   sh("git", "checkout", "-b", branch_name)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -135,7 +135,8 @@ def prepare_next_version(current_version)
   create_pull_request(
     repo: "revenuecat/purchases-ios",
     title: "Prepare next version: #{next_version}",
-    base: "develop"
+    base: "develop",
+    api_token: ENV["GITHUB_TOKEN"]
   )
 end
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -56,6 +56,11 @@ archive
 fastlane ios replace_api_key_integration_tests
 ```
 replace API KEY for integration tests
+### ios deploy
+```
+fastlane ios deploy
+```
+Deploy
 
 ----
 


### PR DESCRIPTION
Fixes the following issues with CI deploys: 
1. deployment checks was running on tags as well as branches. This would fail, because one of the steps is to check that there's no tag yet 🤦‍♂️ I forgot to remove that. 
1. the "prepare next version" step had a bug where it would preserve the patch version when determining the next version number. i.e.: the next one to `3.2.5` would have been `3.3.5-SNAPSHOT` instead of `3.3.0-SNAPSHOT`
1. the "create pull request" step was missing the `api_token` param, so it would wait for user input, which can't happen in CI

There was another issue where the user used for CI deploys didn't have write access on `purchases-ios`, I fixed that directly in CI