### PR TITLE
Fix deploy "prepare next version" job bugs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,6 +195,17 @@ jobs:
           name: Deploy new version
           command: bundle exec fastlane deploy
 
+  prepare-next-version:
+    macos:
+      xcode: "12.2.0"
+    working_directory: ~/purchases-ios/
+    shell: /bin/bash --login -o pipefail
+    steps:
+      - checkout
+      - trust-github-key
+      - run:
+          name: Prepare next version
+          command: bundle exec fastlane prepare_next_version
 
   integration-tests-cocoapods:
     macos:
@@ -278,5 +289,6 @@ workflows:
   deploy:
     jobs:
       - make-release: *release-tags
+      - prepare-next-version: *release-tags
       - docs-deploy: *release-tags
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -115,30 +115,31 @@ platform :ios do
     push_pods
     carthage_archive
     github_release(version: version_number)
-    prepare_next_version(version_number)
   end
 
-end
+  desc "Prepare next version"
+  lane :prepare_next_version do |options|
+    current_version_number = get_version_number(target: "Purchases")
+    major, minor, _ = current_version_number.split('.')
+    next_version = "#{major}.#{minor.to_i + 1}.0"
+    next_version_snapshot = "#{next_version}-SNAPSHOT"
 
-def prepare_next_version(current_version)
-  major, minor, _ = current_version.split('.')
-  next_version = "#{major}.#{minor.to_i + 1}.0"
-  next_version_snapshot = "#{next_version}-SNAPSHOT"
+    branch_name = "bump/#{next_version_snapshot}"
+    sh("git", "checkout", "-b", branch_name)
 
-  branch_name = "bump/#{next_version_snapshot}"
-  sh("git", "checkout", "-b", branch_name)
+    bump(version: next_version_snapshot)
 
-  bump(version: next_version_snapshot)
+    sh("git", "commit", "-am", "Preparing for next version")
+    push_to_git_remote
 
-  sh("git", "commit", "-am", "Preparing for next version")
-  push_to_git_remote
+    create_pull_request(
+      repo: "revenuecat/purchases-ios",
+      title: "Prepare next version: #{next_version_snapshot}",
+      base: "develop",
+      api_token: ENV["GITHUB_TOKEN"]
+    )
+  end
 
-  create_pull_request(
-    repo: "revenuecat/purchases-ios",
-    title: "Prepare next version: #{next_version_snapshot}",
-    base: "develop",
-    api_token: ENV["GITHUB_TOKEN"]
-  )
 end
 
 def push_pods

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -123,18 +123,19 @@ end
 def prepare_next_version(current_version)
   major, minor, _ = current_version.split('.')
   next_version = "#{major}.#{minor.to_i + 1}.0"
+  next_version_snapshot = "#{next_version}-SNAPSHOT"
 
-  branch_name = "bump/#{next_version}-SNAPSHOT"
+  branch_name = "bump/#{next_version_snapshot}"
   sh("git", "checkout", "-b", branch_name)
 
-  bump(version: next_version)
+  bump(version: next_version_snapshot)
 
   sh("git", "commit", "-am", "Preparing for next version")
   push_to_git_remote
 
   create_pull_request(
     repo: "revenuecat/purchases-ios",
-    title: "Prepare next version: #{next_version}",
+    title: "Prepare next version: #{next_version_snapshot}",
     base: "develop",
     api_token: ENV["GITHUB_TOKEN"]
   )


### PR DESCRIPTION
The automation that prepares the next version snapshot has a couple of bugs: 
- it was missing the "-SNAPSHOT" suffix in the version number
- it was automatically committing changes that weren't meant to be committed, like the sample API key that was embedded into the SPM integration tests project. 

The fixes here are: 
- pass in the suffix correctly
- separate the `prepare_next_version` job into its own fastlane job, so that it runs from a clean checkout, and it can even run in parallel, making the overall deploy a little quicker