### PR TITLE
simulatesAskToBuyInSandbox fixes

### DIFF
--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -84,7 +84,7 @@ NS_SWIFT_NAME(Purchases)
  Set this property to true *only* when testing the ask-to-buy / SCA purchases flow. More information:
  http://errors.rev.cat/ask-to-buy
  */
-@property (class, nonatomic, assign) BOOL simulatesAskToBuyInSandbox;
+@property (class, nonatomic, assign) BOOL simulatesAskToBuyInSandbox API_AVAILABLE(ios(8.0), macos(10.14), watchos(6.2), macCatalyst(13.0), tvos(9.0));
 
 /**
  Configures an instance of the Purchases SDK with a specified API key. The instance will be set as a singleton. You should access the singleton instance using [RCPurchases sharedPurchases]

--- a/Purchases/Purchasing/RCStoreKitWrapper.h
+++ b/Purchases/Purchasing/RCStoreKitWrapper.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable instancetype)initWithPaymentQueue:(SKPaymentQueue *)paymentQueue;
 
 @property (nonatomic, weak, nullable) id<RCStoreKitWrapperDelegate> delegate;
-@property (class, nonatomic, assign) BOOL simulatesAskToBuyInSandbox;
+@property (class, nonatomic, assign) BOOL simulatesAskToBuyInSandbox API_AVAILABLE(ios(8.0), macos(10.14), watchos(6.2), macCatalyst(13.0), tvos(9.0));
 
 - (void)addPayment:(SKPayment *)payment;
 - (void)finishTransaction:(SKPaymentTransaction *)transaction;

--- a/Purchases/Purchasing/RCStoreKitWrapper.m
+++ b/Purchases/Purchasing/RCStoreKitWrapper.m
@@ -83,7 +83,7 @@ static BOOL _simulatesAskToBuyInSandbox = NO;
 
 - (SKMutablePayment *)paymentWithProduct:(SKProduct *)product {
     SKMutablePayment *payment = [SKMutablePayment paymentWithProduct:product];
-    if (@available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvos 12.2)) {
+    if (@available(iOS 8.0, macOS 10.14, watchOS 6.2, macCatalyst 13.0, tvos 9.0, *)) {
         payment.simulatesAskToBuyInSandbox = self.class.simulatesAskToBuyInSandbox;
     }
     return payment;

--- a/Purchases/Purchasing/RCStoreKitWrapper.m
+++ b/Purchases/Purchasing/RCStoreKitWrapper.m
@@ -83,7 +83,9 @@ static BOOL _simulatesAskToBuyInSandbox = NO;
 
 - (SKMutablePayment *)paymentWithProduct:(SKProduct *)product {
     SKMutablePayment *payment = [SKMutablePayment paymentWithProduct:product];
-    payment.simulatesAskToBuyInSandbox = self.class.simulatesAskToBuyInSandbox;
+    if (@available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvos 12.2)) {
+        payment.simulatesAskToBuyInSandbox = self.class.simulatesAskToBuyInSandbox;
+    }
     return payment;
 }
 


### PR DESCRIPTION
Fixes an issue with `simulatesAskToBuyInSandbox` where we made the API available, but didn't check the OS version of the underlying API in `SKPayment`. 

This was caught by deployment checks 🎉 