### PR TITLE
Fix/carthage integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,12 +294,11 @@ workflows:
   version: 2
   build-test:
     jobs:
-      # - runtest
+      - runtest
       - deployment-checks: *release-branches
       - integration-tests-cocoapods: *release-tags-and-branches
       - integration-tests-swift-package-manager: *release-tags-and-branches
-      - integration-tests-carthage
-      # - integration-tests-carthage: *release-tags-and-branches
+      - integration-tests-carthage: *release-tags-and-branches
       - integration-tests-xcode-direct-integration: *release-tags-and-branches
   deploy:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,11 +283,12 @@ workflows:
   version: 2
   build-test:
     jobs:
-      - runtest
+      # - runtest
       - deployment-checks: *release-branches
       - integration-tests-cocoapods: *release-tags-and-branches
       - integration-tests-swift-package-manager: *release-tags-and-branches
-      - integration-tests-carthage: *release-tags-and-branches
+      - integration-tests-carthage
+      # - integration-tests-carthage: *release-tags-and-branches
       - integration-tests-xcode-direct-integration: *release-tags-and-branches
   deploy:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,7 +256,10 @@ jobs:
       - run:
           name: Carthage Update
           working_directory: IntegrationTests/CarthageIntegration/
-          command: ./carthage.sh update --cache-builds
+          command: |
+              ./carthage.sh update --no-build
+              rm -rf Carthage/Checkouts/purchases-root/IntegrationTests/
+              ./carthage.sh build
       - save_cache:
           key: carthage-cache-{{ checksum "Cartfile.resolved" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,15 @@ commands:
           command: |
               bundle exec fastlane update_swift_package_commit
 
+  update-carthage-integration-commit:
+    steps:
+      - install-gems
+      - run:
+          name: Update git commit in Carthage Integration tests
+          working_directory: IntegrationTests/CarthageIntegration/
+          command: |
+              bundle exec fastlane update_carthage_commit
+
 jobs:
   runtest:
     macos:
@@ -248,7 +257,7 @@ jobs:
     steps:
       - checkout
       - trust-github-key
-
+      - update-carthage-integration-commit
       # Carthage
       - restore_cache:
           keys: 
@@ -256,6 +265,8 @@ jobs:
       - run:
           name: Carthage Update
           working_directory: IntegrationTests/CarthageIntegration/
+          # install without building, then remove the tests and build, so that carthage
+          # doesn't try to build the other integration tests
           command: |
               ./carthage.sh update --no-build
               rm -rf Carthage/Checkouts/purchases-root/IntegrationTests/

--- a/IntegrationTests/CarthageIntegration/fastlane/Fastfile
+++ b/IntegrationTests/CarthageIntegration/fastlane/Fastfile
@@ -1,9 +1,9 @@
 import("../../../fastlane/Fastfile")
 
-  desc "Update carthage commit"
+desc "Update carthage commit"
   lane :update_carthage_commit do
-    commit_hash = last_git_commit[:commit_hash]
-    sed_regex = 's|' + "CARTHAGE_INTEGRATION_TESTS_GIT_COMMIT" + '|' + commit_hash + '|'
-    backup_extension = '.bck'
-    sh("sed", '-i', backup_extension, sed_regex, '../Cartfile')
-  end
+  commit_hash = last_git_commit[:commit_hash]
+  sed_regex = 's|' + "CARTHAGE_INTEGRATION_TESTS_GIT_COMMIT" + '|' + commit_hash + '|'
+  backup_extension = '.bck'
+  sh("sed", '-i', backup_extension, sed_regex, '../Cartfile')
+end

--- a/IntegrationTests/CarthageIntegration/fastlane/Fastfile
+++ b/IntegrationTests/CarthageIntegration/fastlane/Fastfile
@@ -1,1 +1,9 @@
 import("../../../fastlane/Fastfile")
+
+  desc "Update carthage commit"
+  lane :update_carthage_commit do
+    commit_hash = last_git_commit[:commit_hash]
+    sed_regex = 's|' + "CARTHAGE_INTEGRATION_TESTS_GIT_COMMIT" + '|' + commit_hash + '|'
+    backup_extension = '.bck'
+    sh("sed", '-i', backup_extension, sed_regex, '../Cartfile')
+  end

--- a/IntegrationTests/SPMIntegration/fastlane/Fastfile
+++ b/IntegrationTests/SPMIntegration/fastlane/Fastfile
@@ -1,9 +1,9 @@
 import("../../../fastlane/Fastfile")
 
-  desc "Update swift package commit"
-  lane :update_swift_package_commit do
-    commit_hash = last_git_commit[:commit_hash]
-    sed_regex = 's|' + "SPM_INTEGRATION_GIT_COMMIT" + '|' + commit_hash + '|'
-    backup_extension = '.bck'
-    sh("sed", '-i', backup_extension, sed_regex, '../SPMIntegration.xcodeproj/project.pbxproj')
-  end
+desc "Update swift package commit"
+lane :update_swift_package_commit do
+  commit_hash = last_git_commit[:commit_hash]
+  sed_regex = 's|' + "SPM_INTEGRATION_GIT_COMMIT" + '|' + commit_hash + '|'
+  backup_extension = '.bck'
+  sh("sed", '-i', backup_extension, sed_regex, '../SPMIntegration.xcodeproj/project.pbxproj')
+end


### PR DESCRIPTION
Our carthage integration tests have a couple of issues: 
- They have a reference to the local project as a git reference, so carthage actually git clones it into its own folder, and uses the default branch. I fixed it by adding an extra step to update the git pointer, very similar to what we did for SPM integration tests. 
- Carthage recursively inspects all folders in search for shared schemes in xcprojects. This means that unfortunately, when doing `carthage build`, it tries to build all other integration tests. And the SPM integration tests **within** the carthage integration tests fail to check out _their_ dependencies, and I'm not 100% sure why that is, since the ssh keys were added in a previous step. But in any case, we don't want to build the other integration tests. 
So I fixed it by doing: 
`carthage update --no-build` - this does the clone
`rm -rf integration tests` - removes all integration tests from the clone, also preventing infinite recursion
`carthage build` from the cloned project

I'm fine, why do you ask? 

![](https://media.giphy.com/media/l0IylOPCNkiqOgMyA/giphy.gif)