### PR TITLE
install gems when preparing next version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,6 +211,7 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
+      - install-gems
       - trust-github-key
       - run:
           name: Prepare next version


### PR DESCRIPTION
Facepalm. 

forgot to add "install gems" step to `prepare_next_version`. I tested it locally, but of course, I already had the gems. 