### PR TITLE
version 3.10.1

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -5,9 +5,9 @@ objc: true
 sdk: iphonesimulator
 module: Purchases
 umbrella_header: Purchases/Public/Purchases.h
-module_version: 3.11.0-SNAPSHOT
+module_version: 3.10.1
 github_url: https://github.com/revenuecat/purchases-ios
-github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.11.0-SNAPSHOT
+github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.10.1
 output: docs
 # Leaving this commented out. We used to specify this before, but now it's working without it
 # xcodebuild_arguments: [--objc,Purchases/Public/Purchases.h,--,-x,objective-c,-isysroot,$(xcrun --show-sdk-path),-I,$(pwd)]

--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,15 +1,4 @@
-- Adds a new property `simulateAsksToBuyInSandbox`, that allows developers to test deferred purchases easily.
-    https://github.com/RevenueCat/purchases-ios/pull/432
-    https://github.com/RevenueCat/purchases-ios/pull/436
-- Slight optimization so that offerings and purchaserInfo are returned faster if they're cached.
-    https://github.com/RevenueCat/purchases-ios/pull/433
-    https://github.com/RevenueCat/purchases-ios/issues/401
-- Revamped logging strings, makes log messages from `Purchases` easier to spot and understand.
-    https://github.com/RevenueCat/purchases-ios/pull/426
-    https://github.com/RevenueCat/purchases-ios/pull/428
-    https://github.com/RevenueCat/purchases-ios/pull/430
-    https://github.com/RevenueCat/purchases-ios/pull/431
-    https://github.com/RevenueCat/purchases-ios/pull/422
-- Fix deploy automation bugs when preparing the next version PR
-    https://github.com/RevenueCat/purchases-ios/pull/434
-    https://github.com/RevenueCat/purchases-ios/pull/437
+- Enables improved logging prefixes so they're easier to locate.
+    https://github.com/RevenueCat/purchases-ios/pull/441
+- Fixed issue with Prepare next version CI job, which was missing the install gems step. 
+    https://github.com/RevenueCat/purchases-ios/pull/440

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.10.1
+- Enables improved logging prefixes so they're easier to locate.
+    https://github.com/RevenueCat/purchases-ios/pull/441
+- Fixed issue with Prepare next version CI job, which was missing the install gems step. 
+    https://github.com/RevenueCat/purchases-ios/pull/440
+
 ## 3.10.0
 - Adds a new property `simulateAsksToBuyInSandbox`, that allows developers to test deferred purchases easily.
     https://github.com/RevenueCat/purchases-ios/pull/432

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Purchases"
-  s.version          = "3.11.0-SNAPSHOT"
+  s.version          = "3.10.1"
   s.summary          = "Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
-  s.dependency 'PurchasesCoreSwift', '3.11.0-SNAPSHOT'
+  s.dependency 'PurchasesCoreSwift', '3.10.1'
 
 
   s.source_files = ['Purchases/**/*.{h,m}']

--- a/Purchases/Info.plist
+++ b/Purchases/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11.0-SNAPSHOT</string>
+	<string>3.10.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Purchases/Misc/RCSystemInfo.m
+++ b/Purchases/Misc/RCSystemInfo.m
@@ -49,7 +49,7 @@ static BOOL _forceUniversalAppStore = NO;
 }
 
 + (NSString *)frameworkVersion {
-    return @"3.11.0-SNAPSHOT";
+    return @"3.10.1";
 }
 
 + (NSString *)systemVersion {

--- a/PurchasesCoreSwift.podspec
+++ b/PurchasesCoreSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesCoreSwift"
-  s.version          = "3.11.0-SNAPSHOT"
+  s.version          = "3.10.1"
   s.summary          = "Swift portion of RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/PurchasesCoreSwift/Info.plist
+++ b/PurchasesCoreSwift/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11.0-SNAPSHOT</string>
+	<string>3.10.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/PurchasesCoreSwiftTests/Info.plist
+++ b/PurchasesCoreSwiftTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11.0-SNAPSHOT</string>
+	<string>3.10.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/PurchasesTests/Info.plist
+++ b/PurchasesTests/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11.0-SNAPSHOT</string>
+	<string>3.10.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
### 3.10.1

- Enables improved logging prefixes so they're easier to locate.
    https://github.com/RevenueCat/purchases-ios/pull/441
- Fixed issue with Prepare next version CI job, which was missing the install gems step. 
    https://github.com/RevenueCat/purchases-ios/pull/440
