### PR TITLE
identity v3: public-facing changes

### DIFF
--- a/Examples/MagicWeather/MagicWeather/Sources/Controllers/UserViewController.swift
+++ b/Examples/MagicWeather/MagicWeather/Sources/Controllers/UserViewController.swift
@@ -69,7 +69,7 @@ extension UserViewController {
                 
                 #warning("Public-facing usernames aren't optimal for user ID's - you should use something non-guessable, like a non-public database ID. For more information, visit https://docs.revenuecat.com/docs/user-ids.")
                 /// - Call `identify` with the Purchases SDK with the unique user ID
-                Purchases.shared.identify(username) { (purchaserInfo, error) in
+                Purchases.shared.logIn(username) { (purchaserInfo, created, error) in
                     if let error = error {
                         self.present(UIAlertController.errorAlert(message: error.localizedDescription), animated: true, completion: nil)
                     }
@@ -92,7 +92,7 @@ extension UserViewController {
          
          Note: Each time you call `reset`, a new installation will be logged in the RevenueCat dashboard as that metric tracks unique user ID's that are in-use. Since this method generates a new anonymous ID, it counts as a new user ID in-use.
          */
-        Purchases.shared.reset { (purchaserInfo, error) in
+        Purchases.shared.logOut { (purchaserInfo, error) in
             if let error = error {
                 self.present(UIAlertController.errorAlert(message: error.localizedDescription), animated: true, completion: nil)
             } else {

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
-  s.dependency 'PurchasesCoreSwift', '3.12.0-SNAPSHOT'
+  s.dependency 'PurchasesCoreSwift'
 
 
   s.source_files = ['Purchases/**/*.{h,m}']

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
-  s.dependency 'PurchasesCoreSwift'
+  s.dependency 'PurchasesCoreSwift', '3.12.0-SNAPSHOT'
 
 
   s.source_files = ['Purchases/**/*.{h,m}']

--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -167,6 +167,7 @@ NS_SWIFT_NAME(Purchases)
 /** Set this to true if you are passing in an appUserID but it is anonymous, this is true by default if you didn't pass an appUserID
  If a user tries to purchase a product that is active on the current app store account, we will treat it as a restore and alias
  the new ID with the previous id.
+ See https://docs.revenuecat.com/docs/user-ids
  */
 @property (nonatomic) BOOL allowSharingAppStoreAccount
     __attribute((deprecated("Configure behavior through the RevenueCat dashboard instead.")));
@@ -197,8 +198,8 @@ NS_SWIFT_NAME(Purchases)
 NS_SWIFT_NAME(createAlias(_:_:));
 
 /**
- This function will identify the current user with an appUserID. Typically this would be used after a logout to identify a new user without calling configure
- @param appUserID The appUserID that should be linked to the currently user
+ This function will identify the current user with an appUserID. Typically this would be used after a logout to identify a new user without calling configure.
+ @param appUserID The appUserID that should be linked to the current user.
  */
 - (void)identify:(NSString *)appUserID completionBlock:(nullable RCReceivePurchaserInfoBlock)completion
 NS_SWIFT_NAME(identify(_:_:)) __attribute((deprecated("Use logIn instead.")));
@@ -210,15 +211,21 @@ NS_SWIFT_NAME(identify(_:_:)) __attribute((deprecated("Use logIn instead.")));
 NS_SWIFT_NAME(reset(_:)) __attribute((deprecated("Use logOut instead.")));
 
 /**
- This function will identify the current user with an appUserID.
- @param appUserID The appUserID that should be linked to the currently user
+ This function will logIn the current user with an appUserID.
+ @param appUserID The appUserID that should be linked to the current user.
+ The callback will be called with the latest PurchaserInfo for the user, as well as a boolean indicating whether the user was created for the first
+ time in the RevenueCat backend.
+ See https://docs.revenuecat.com/docs/user-ids
  */
 - (void)  logIn:(NSString *)appUserID
 completionBlock:(void (^)(RCPurchaserInfo * _Nullable purchaserInfo, BOOL created, NSError * _Nullable error))completion
 NS_SWIFT_NAME(logIn(_:_:));
 
 /**
- Resets the Purchases client clearing the saved appUserID. This will generate a random user id and save it in the cache.*/
+ Logs out the Purchases client clearing the saved appUserID. This will generate a random user id and save it in the cache.
+ If this method is called and the current user is anonymous, it will return an error.
+ See https://docs.revenuecat.com/docs/user-ids
+ */
 - (void)logOutWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion
 NS_SWIFT_NAME(logOut(_:));
 

--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -168,7 +168,8 @@ NS_SWIFT_NAME(Purchases)
  If a user tries to purchase a product that is active on the current app store account, we will treat it as a restore and alias
  the new ID with the previous id.
  */
-@property (nonatomic) BOOL allowSharingAppStoreAccount;
+@property (nonatomic) BOOL allowSharingAppStoreAccount
+    __attribute((deprecated("Configure behavior through the RevenueCat dashboard instead.")));
 
 /// Default to YES, set this to NO if you are finishing transactions with your own StoreKit queue listener
 @property (nonatomic) BOOL finishTransactions;
@@ -200,13 +201,26 @@ NS_SWIFT_NAME(createAlias(_:_:));
  @param appUserID The appUserID that should be linked to the currently user
  */
 - (void)identify:(NSString *)appUserID completionBlock:(nullable RCReceivePurchaserInfoBlock)completion
-NS_SWIFT_NAME(identify(_:_:));
+NS_SWIFT_NAME(identify(_:_:)) __attribute((deprecated("Use logIn instead.")));
 
 /**
  * Resets the Purchases client clearing the saved appUserID. This will generate a random user id and save it in the cache.
  */
 - (void)resetWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion
-NS_SWIFT_NAME(reset(_:));
+NS_SWIFT_NAME(reset(_:)) __attribute((deprecated("Use logOut instead.")));
+
+/**
+ This function will identify the current user with an appUserID.
+ @param appUserID The appUserID that should be linked to the currently user
+ */
+- (void)  logIn:(NSString *)appUserID
+completionBlock:(void (^)(RCPurchaserInfo *_Nullable purchaserInfo, BOOL created, NSError *error))completion
+NS_SWIFT_NAME(logIn(_:_:));
+
+/**
+ Resets the Purchases client clearing the saved appUserID. This will generate a random user id and save it in the cache.*/
+- (void)logOutWithCompletionBlock:(nullable RCReceivePurchaserInfoBlock)completion
+NS_SWIFT_NAME(logOut(_:));
 
 #pragma mark Attribution
 

--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -214,7 +214,7 @@ NS_SWIFT_NAME(reset(_:)) __attribute((deprecated("Use logOut instead.")));
  @param appUserID The appUserID that should be linked to the currently user
  */
 - (void)  logIn:(NSString *)appUserID
-completionBlock:(void (^)(RCPurchaserInfo *_Nullable purchaserInfo, BOOL created, NSError *error))completion
+completionBlock:(void (^)(RCPurchaserInfo * _Nullable purchaserInfo, BOOL created, NSError * _Nullable error))completion
 NS_SWIFT_NAME(logIn(_:_:));
 
 /**


### PR DESCRIPTION

Based on #438 

This adds only the public-facing changes, so that we can integrate the main identity v3 PR without worrying about making changes available publicly through the SDK until we're ready. 

### Public changes overview

#### New methods
- Introduces `logIn`, a new way of identifying users, which also returns whether a new user has been registered in the system. 
`logIn` uses a new backend endpoint. 
- Introduces `logOut`, a replacement for `reset`. 

#### Deprecations / removals
- removes `createAlias`
- deprecates `identify` in favor of `logIn`
- deprecates `reset` in favor of `logOut`
- deprecates `allowSharingAppStoreAccount` in favor of dashboard-side configuration
