### PR TITLE
fix: logging 'invalid product identifiers' even when the list is empty

### DIFF
--- a/Purchases/Purchasing/RCStoreKitRequestFetcher.m
+++ b/Purchases/Purchasing/RCStoreKitRequestFetcher.m
@@ -164,8 +164,10 @@
     {
         RCPurchaseLog(RCStrings.offering.list_products, p.productIdentifier, p);
     }
-    RCAppleWarningLog(RCStrings.offering.invalid_product_identifiers, response.invalidProductIdentifiers);
-    
+    if (response.invalidProductIdentifiers.count > 0) {
+        RCAppleWarningLog(RCStrings.offering.invalid_product_identifiers, response.invalidProductIdentifiers);        
+    }
+
     NSArray<RCFetchProductsCompletionHandler> *handlers = [self finishProductsRequest:request];
     RCDebugLog(RCStrings.offering.completion_handlers_waiting_on_products, (unsigned long)handlers.count);
     for (RCFetchProductsCompletionHandler handler in handlers)


### PR DESCRIPTION
we were always logging ":apple::bangbang: Invalid Product Identifiers" even when there were none, so that looked unnecessarily alarming. This prevents the warning if all product identifiers are valid. 