### PR TITLE
Uses UserViewModel property for entitlement check.

### DIFF
--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/Lifecycle/PurchasesDelegateHandler.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/Lifecycle/PurchasesDelegateHandler.swift
@@ -18,9 +18,12 @@ class PurchasesDelegateHandler: NSObject, ObservableObject {
 
 extension PurchasesDelegateHandler: PurchasesDelegate {
     
-    /* Whenever the `shared` instance of Purchases updates the PurchaserInfo cache, this method will be called.
+    /* 
+     Whenever the `shared` instance of Purchases updates the PurchaserInfo cache, this method will be called.
     
-     Note: PurchaserInfo is not pushed to each Purchases client, it has to be fetched. This delegate method is only called when the SDK updates its cache after an app launch, purchase, restore, or fetch. You still need to call `Purchases.shared.purchaserInfo` to fetch PurchaserInfo regularly.
+     Note: PurchaserInfo is not pushed to each Purchases client, it has to be fetched. 
+     This delegate method is only called when the SDK updates its cache after an app launch, purchase, restore, or fetch. 
+     You still need to call `Purchases.shared.purchaserInfo` to fetch PurchaserInfo regularly.
      */
     func purchases(_ purchases: Purchases, didReceiveUpdated purchaserInfo: Purchases.PurchaserInfo) {
         

--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/Lifecycle/PurchasesDelegateHandler.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/Lifecycle/PurchasesDelegateHandler.swift
@@ -18,7 +18,10 @@ class PurchasesDelegateHandler: NSObject, ObservableObject {
 
 extension PurchasesDelegateHandler: PurchasesDelegate {
     
-    /// -  Whenever the `shared` instance of Purchases updates the PurchaserInfo cache, this method will be called.
+    /* Whenever the `shared` instance of Purchases updates the PurchaserInfo cache, this method will be called.
+    
+     Note: PurchaserInfo is not pushed to each Purchases client, it has to be fetched. This delegate method is only called when the SDK updates its cache after an app launch, purchase, restore, or fetch. You still need to call `Purchases.shared.purchaserInfo` to fetch PurchaserInfo regularly.
+     */
     func purchases(_ purchases: Purchases, didReceiveUpdated purchaserInfo: Purchases.PurchaserInfo) {
         
         /// - Update our published purchaserInfo object

--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/Views/WeatherView.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/Views/WeatherView.swift
@@ -15,7 +15,8 @@ import Purchases
 struct WeatherView: View {
     @Binding var paywallPresented: Bool
     @ObservedObject var model = WeatherViewModel.shared
-    
+    @ObservedObject var userModel = UserViewModel.shared
+
     var body: some View {
         VStack {
             /// - Sample weather details
@@ -59,8 +60,8 @@ struct WeatherView: View {
         /*
          We should check if we can magically change the weather (subscription active) and if not, display the paywall.
          */
-        Purchases.shared.purchaserInfo { (purchaserInfo, error) in
-            if purchaserInfo?.entitlements[Constants.entitlementID]?.isActive == true {
+        Purchases.shared.purchaserInfo { (_, _) in
+            if userModel.subscriptionActive {
                 self.model.currentData = SampleWeatherData.generateSampleData(for: self.model.currentEnvironment)
             } else {
                 self.paywallPresented.toggle()


### PR DESCRIPTION
Instead of checking for entitlement access in two places, this uses the UserViewModel property to check for an active subscription. Note: You must still fetch PurchaserInfo regularly (Purchases.shared.purchaserInfo) to update the SDK's cache and reflect the latest subscription status.

Additionally, this adds some comments to PurchasesDelegateHandler to clarify how PurchaserInfo is fetched/cached.
