### PR TITLE
update the cache duration in background from 24 hours to 25

### DIFF
--- a/Purchases/Caching/RCDeviceCache.m
+++ b/Purchases/Caching/RCDeviceCache.m
@@ -30,7 +30,7 @@ NSString *RCLegacySubscriberAttributesKeyBase = RC_CACHE_KEY_PREFIX @".subscribe
 NSString *RCSubscriberAttributesKey = RC_CACHE_KEY_PREFIX @".subscriberAttributes";
 NSString *RCAttributionDataDefaultsKeyBase = RC_CACHE_KEY_PREFIX @".attribution.";
 int cacheDurationInSecondsInForeground = 60 * 5;
-int cacheDurationInSecondsInBackground = 60 * 60 * 24;
+int cacheDurationInSecondsInBackground = 60 * 60 * 25;
 
 @implementation RCDeviceCache
 


### PR DESCRIPTION
iOS equivalent of https://github.com/RevenueCat/purchases-android/pull/255. 

Should alleviate cases where the app gets woken up by remote push notifications every 24 hours exactly, which could make the cache miss depending on the exact timing of the push notification. 