### PR TITLE
fix: carthage build from source issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,11 +296,15 @@ workflows:
   build-test:
     jobs:
       - runtest
-      - deployment-checks: *release-branches
-      - integration-tests-cocoapods: *release-tags-and-branches
-      - integration-tests-swift-package-manager: *release-tags-and-branches
-      - integration-tests-carthage: *release-tags-and-branches
-      - integration-tests-xcode-direct-integration: *release-tags-and-branches
+      - deployment-checks
+      - integration-tests-swift-package-manager
+      - integration-tests-carthage
+
+      # - deployment-checks: *release-branches
+      # - integration-tests-cocoapods: *release-tags-and-branches
+      # - integration-tests-swift-package-manager: *release-tags-and-branches
+      # - integration-tests-carthage: *release-tags-and-branches
+      # - integration-tests-xcode-direct-integration: *release-tags-and-branches
   deploy:
     jobs:
       - make-release: *release-tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,15 +296,11 @@ workflows:
   build-test:
     jobs:
       - runtest
-      - deployment-checks
-      - integration-tests-swift-package-manager
-      - integration-tests-carthage
-
-      # - deployment-checks: *release-branches
-      # - integration-tests-cocoapods: *release-tags-and-branches
-      # - integration-tests-swift-package-manager: *release-tags-and-branches
-      # - integration-tests-carthage: *release-tags-and-branches
-      # - integration-tests-xcode-direct-integration: *release-tags-and-branches
+      - deployment-checks: *release-branches
+      - integration-tests-cocoapods: *release-tags-and-branches
+      - integration-tests-swift-package-manager: *release-tags-and-branches
+      - integration-tests-carthage: *release-tags-and-branches
+      - integration-tests-xcode-direct-integration: *release-tags-and-branches
   deploy:
     jobs:
       - make-release: *release-tags

--- a/IntegrationTests/SPMIntegration/SPMIntegration.xcodeproj/project.pbxproj
+++ b/IntegrationTests/SPMIntegration/SPMIntegration.xcodeproj/project.pbxproj
@@ -557,7 +557,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/RevenueCat/purchases-ios.git";
 			requirement = {
-				branch = SPM_INTEGRATION_GIT_COMMIT;
+				branch = develop;
 				kind = branch;
 			};
 		};

--- a/IntegrationTests/SPMIntegration/fastlane/Fastfile
+++ b/IntegrationTests/SPMIntegration/fastlane/Fastfile
@@ -2,8 +2,18 @@ import("../../../fastlane/Fastfile")
 
 desc "Update swift package commit"
 lane :update_swift_package_commit do
-  commit_hash = last_git_commit[:commit_hash]
-  sed_regex = 's|' + "SPM_INTEGRATION_GIT_COMMIT" + '|' + commit_hash + '|'
   backup_extension = '.bck'
+
+  commit_hash = last_git_commit[:commit_hash]
+  old_kind_line = "kind = branch;"
+  new_kind_line = "kind = revision;"
+
+  sed_regex = 's|' + old_kind_line + '|' + new_kind_line + '|'
+  sh("sed", '-i', backup_extension, sed_regex, '../SPMIntegration.xcodeproj/project.pbxproj')
+
+  old_branch_line = "branch = develop;"
+  new_revision_line = "revision = #{commit_hash};"
+
+  sed_regex = 's|' + old_branch_line + '|' + new_revision_line + '|'
   sh("sed", '-i', backup_extension, sed_regex, '../SPMIntegration.xcodeproj/project.pbxproj')
 end

--- a/IntegrationTests/SPMIntegration/fastlane/Fastfile
+++ b/IntegrationTests/SPMIntegration/fastlane/Fastfile
@@ -2,18 +2,22 @@ import("../../../fastlane/Fastfile")
 
 desc "Update swift package commit"
 lane :update_swift_package_commit do
-  backup_extension = '.bck'
+  project_file_location = '../SPMIntegration.xcodeproj/project.pbxproj'
 
-  commit_hash = last_git_commit[:commit_hash]
   old_kind_line = "kind = branch;"
   new_kind_line = "kind = revision;"
 
-  sed_regex = 's|' + old_kind_line + '|' + new_kind_line + '|'
-  sh("sed", '-i', backup_extension, sed_regex, '../SPMIntegration.xcodeproj/project.pbxproj')
+  replace_string_in_path(old_kind_line, new_kind_line, project_file_location)
 
+  commit_hash = last_git_commit[:commit_hash]
   old_branch_line = "branch = develop;"
   new_revision_line = "revision = #{commit_hash};"
 
-  sed_regex = 's|' + old_branch_line + '|' + new_revision_line + '|'
-  sh("sed", '-i', backup_extension, sed_regex, '../SPMIntegration.xcodeproj/project.pbxproj')
+  replace_string_in_path(old_branch_line, new_revision_line, project_file_location)
+end
+
+def replace_string_in_path(old_string, new_string, path)
+  backup_extension = '.bck'
+  sed_regex = 's|' + old_string + '|' + new_string + '|'  
+  sh("sed", '-i', backup_extension, sed_regex, path)
 end


### PR DESCRIPTION
In current builds, doing `carthage update purchases-ios --no-use-binaries` will produce an error. 
The issue is caused by the fact that Carthage will try to build every single scheme it finds within a repository, even if it's not needed for a dependency. 

[There's a promising PR](https://github.com/Carthage/Carthage/pull/3055) for adding support to selecting which Schemes Carthage builds, but I'm not sure how long that'll take to ship, or if it will end up moving the responsibility of deciding which schemes to build to the end user, which we should not do, as it would add a ton of friction and complexity to an already-difficult process. 

In the meantime, the issue is that the SPMIntegration scheme in our IntegrationTests won't build from Carthage. The reason is that this integration test relies on CI updating a git pointer before running, which won't happen when building from Carthage. 

This PR updates the dependency management, so that instead of having a placeholder pointer `SPM_INTEGRATION_COMMIT`, SPMIntegrationTests always point to `develop`, and then CI replaces that pointer to develop with the one needed for each test. 

This should fix the issues when doing `carthage update --no-use-binaries`, and in turn allow users who use Carthage >= 0.37 to leverage the new `XCFrameworks` support for it. 

Fixes https://github.com/RevenueCat/purchases-ios/issues/450