### PR TITLE
Version 3.10.5

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -5,9 +5,9 @@ objc: true
 sdk: iphonesimulator
 module: Purchases
 umbrella_header: Purchases/Public/Purchases.h
-module_version: 3.11.0-SNAPSHOT
+module_version: 3.10.5
 github_url: https://github.com/revenuecat/purchases-ios
-github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.11.0-SNAPSHOT
+github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.10.5
 output: docs
 # Leaving this commented out. We used to specify this before, but now it's working without it
 # xcodebuild_arguments: [--objc,Purchases/Public/Purchases.h,--,-x,objective-c,-isysroot,$(xcrun --show-sdk-path),-I,$(pwd)]

--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,8 +1,5 @@
-- Added .xcframework output to Releases, alongside the usual fat frameworks.
-    https://github.com/RevenueCat/purchases-ios/pull/466
-- Added PurchaseTester project, useful to test features while working on `purchases-ios`.
-    https://github.com/RevenueCat/purchases-ios/pull/464
-- Renamed the old `SwiftExample` project to `LegacySwiftExample` to encourage developers to use the new MagicWeather apps
-    https://github.com/RevenueCat/purchases-ios/pull/461
-- Updated the cache duration in background from 24 hours to 25 to prevent cache misses when the app is woken every 24 hours exactly by remote push notifications.
-    https://github.com/RevenueCat/purchases-ios/pull/463
+- Fixed a couple of issues with `.xcframework` output in releases
+    https://github.com/RevenueCat/purchases-ios/pull/470
+    https://github.com/RevenueCat/purchases-ios/pull/469
+- Fix Carthage builds from source, so that end customers can start leveraging XCFramework support for Carthage >= 0.37
+    https://github.com/RevenueCat/purchases-ios/pull/471

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.10.5
+- Fixed a couple of issues with `.xcframework` output in releases
+    https://github.com/RevenueCat/purchases-ios/pull/470
+    https://github.com/RevenueCat/purchases-ios/pull/469
+- Fix Carthage builds from source, so that end customers can start leveraging XCFramework support for Carthage >= 0.37
+    https://github.com/RevenueCat/purchases-ios/pull/471
+
 ## 3.10.4
 - Added .xcframework output to Releases, alongside the usual fat frameworks.
     https://github.com/RevenueCat/purchases-ios/pull/466

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Purchases"
-  s.version          = "3.11.0-SNAPSHOT"
+  s.version          = "3.10.5"
   s.summary          = "Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
-  s.dependency 'PurchasesCoreSwift', '3.11.0-SNAPSHOT'
+  s.dependency 'PurchasesCoreSwift', '3.10.5'
 
 
   s.source_files = ['Purchases/**/*.{h,m}']

--- a/Purchases/Info.plist
+++ b/Purchases/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11.0-SNAPSHOT</string>
+	<string>3.10.5</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Purchases/Misc/RCSystemInfo.m
+++ b/Purchases/Misc/RCSystemInfo.m
@@ -49,7 +49,7 @@ static BOOL _forceUniversalAppStore = NO;
 }
 
 + (NSString *)frameworkVersion {
-    return @"3.11.0-SNAPSHOT";
+    return @"3.10.5";
 }
 
 + (NSString *)systemVersion {

--- a/PurchasesCoreSwift.podspec
+++ b/PurchasesCoreSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesCoreSwift"
-  s.version          = "3.11.0-SNAPSHOT"
+  s.version          = "3.10.5"
   s.summary          = "Swift portion of RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/PurchasesCoreSwift/Info.plist
+++ b/PurchasesCoreSwift/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11.0-SNAPSHOT</string>
+	<string>3.10.5</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/PurchasesCoreSwiftTests/Info.plist
+++ b/PurchasesCoreSwiftTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11.0-SNAPSHOT</string>
+	<string>3.10.5</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/PurchasesTests/Info.plist
+++ b/PurchasesTests/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11.0-SNAPSHOT</string>
+	<string>3.10.5</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -92,6 +92,7 @@ platform :ios do
     check_no_git_tag_exists(version_number)
     check_pods
     carthage_archive
+    export_xcframework
     check_no_github_release_exists(version_number)
   end
 


### PR DESCRIPTION
- Fixed a couple of issues with `.xcframework` output in releases
    https://github.com/RevenueCat/purchases-ios/pull/470
    https://github.com/RevenueCat/purchases-ios/pull/469
- Fix Carthage builds from source, so that end customers can start leveraging XCFramework support for Carthage >= 0.37
    https://github.com/RevenueCat/purchases-ios/pull/471
