### PR TITLE
Updates willRenew logic

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "AliSoftware/OHHTTPStubs" "9.0.0"
+github "AliSoftware/OHHTTPStubs" "9.1.0"
 github "Quick/Nimble" "v9.0.0"

--- a/Purchases/Public/RCEntitlementInfo.m
+++ b/Purchases/Public/RCEntitlementInfo.m
@@ -39,13 +39,19 @@
         self.isSandbox = [productData[@"is_sandbox"] boolValue];
         self.unsubscribeDetectedAt = [self parseDate:productData[@"unsubscribe_detected_at"] withDateFormatter:dateFormatter];
         self.billingIssueDetectedAt = [self parseDate:productData[@"billing_issues_detected_at"] withDateFormatter:dateFormatter];
-        if ([entitlementData[@"expires_date"] isKindOfClass:NSNull.class]) {
-            self.willRenew = true;
-        } else {
-            self.willRenew = self.unsubscribeDetectedAt == nil && self.billingIssueDetectedAt == nil;
-        }
+        self.willRenew = [self willRenewWith:self.expirationDate store:self.store unsubscribeDetectedAt:self.unsubscribeDetectedAt billingIssueDetectedAt:self.billingIssueDetectedAt];
     }
     return self;
+}
+
+- (BOOL)willRenewWith:(NSDate *)expirationDate store:(RCStore)store unsubscribeDetectedAt:(NSDate *)unsubscribeDetectedAt billingIssueDetectedAt:(NSDate *)billingIssueDetectedAt
+{
+    BOOL isPromo = store == RCPromotional;
+    BOOL isLifetime = expirationDate == nil;
+    BOOL hasUnsubscribed = unsubscribeDetectedAt != nil;
+    BOOL hasBillingIssues = billingIssueDetectedAt != nil;
+    
+    return !(isPromo || isLifetime || hasUnsubscribed || hasBillingIssues);
 }
 
 - (BOOL)isDateActive:(nullable NSDate *)expirationDate forRequestDate:(NSDate *)requestDate

--- a/Purchases/Public/RCEntitlementInfo.m
+++ b/Purchases/Public/RCEntitlementInfo.m
@@ -39,12 +39,15 @@
         self.isSandbox = [productData[@"is_sandbox"] boolValue];
         self.unsubscribeDetectedAt = [self parseDate:productData[@"unsubscribe_detected_at"] withDateFormatter:dateFormatter];
         self.billingIssueDetectedAt = [self parseDate:productData[@"billing_issues_detected_at"] withDateFormatter:dateFormatter];
-        self.willRenew = [self willRenewWith:self.expirationDate store:self.store unsubscribeDetectedAt:self.unsubscribeDetectedAt billingIssueDetectedAt:self.billingIssueDetectedAt];
+        self.willRenew = [self willRenewWithExpirationDate:self.expirationDate
+                                                     store:self.store
+                                     unsubscribeDetectedAt:self.unsubscribeDetectedAt
+                                    billingIssueDetectedAt:self.billingIssueDetectedAt];
     }
     return self;
 }
 
-- (BOOL)willRenewWith:(NSDate *)expirationDate store:(RCStore)store unsubscribeDetectedAt:(NSDate *)unsubscribeDetectedAt billingIssueDetectedAt:(NSDate *)billingIssueDetectedAt
+- (BOOL)willRenewWithExpirationDate:(NSDate *)expirationDate store:(RCStore)store unsubscribeDetectedAt:(NSDate *)unsubscribeDetectedAt billingIssueDetectedAt:(NSDate *)billingIssueDetectedAt
 {
     BOOL isPromo = store == RCPromotional;
     BOOL isLifetime = expirationDate == nil;

--- a/PurchasesTests/Purchasing/EntitlementInfosTests.swift
+++ b/PurchasesTests/Purchasing/EntitlementInfosTests.swift
@@ -97,7 +97,7 @@ class EntitlementInfosTests: XCTestCase {
         verifyProduct()
         // Check for "lifetime_cat" entitlement
         verifyEntitlementActive(beTrue(), entitlement: "lifetime_cat")
-        verifyRenewal(beTrue(), unsubscribeDetectedAt: beNil(), billingIssueDetectedAt: beNil(), entitlement: "lifetime_cat")
+        verifyRenewal(beFalse(), unsubscribeDetectedAt: beNil(), billingIssueDetectedAt: beNil(), entitlement: "lifetime_cat")
         verifyPeriodType(equal(Purchases.PeriodType.normal.rawValue), entitlement: "lifetime_cat")
         verifyStore(equal(Purchases.Store.appStore.rawValue), entitlement: "lifetime_cat")
         verifySandbox(beFalse(), entitlement: "lifetime_cat")
@@ -274,7 +274,7 @@ class EntitlementInfosTests: XCTestCase {
 
         verifySubscriberInfo()
         verifyEntitlementActive()
-        verifyRenewal()
+        verifyRenewal(beFalse())
         verifyPeriodType()
         verifyStore()
         verifySandbox()
@@ -472,7 +472,7 @@ class EntitlementInfosTests: XCTestCase {
 
         verifySubscriberInfo()
         verifyEntitlementActive()
-        verifyRenewal()
+        verifyRenewal(beFalse())
         verifyPeriodType()
         verifyStore()
         verifySandbox()
@@ -921,6 +921,31 @@ class EntitlementInfosTests: XCTestCase {
             subscriptions: [:]
         )
         verifyPeriodType(equal(Purchases.PeriodType.normal.rawValue))
+    }
+
+    func testPromoWillRenew() {
+        stubResponse(
+                entitlements: [
+                    "pro_cat": [
+                        "expires_date": "2221-01-10T02:35:25Z",
+                        "product_identifier": "rc_promo_pro_cat_lifetime",
+                        "purchase_date": "2021-02-27T02:35:25Z"
+                    ]
+                ],
+                subscriptions: [
+                    "rc_promo_pro_cat_lifetime": [
+                        "billing_issues_detected_at": nil,
+                        "expires_date": "2221-01-10T02:35:25Z",
+                        "is_sandbox": false,
+                        "original_purchase_date": "2021-02-27T02:35:25Z",
+                        "period_type": "normal",
+                        "purchase_date": "2021-02-27T02:35:25Z",
+                        "store": "promotional",
+                        "unsubscribe_detected_at": nil
+                    ]
+                ])
+
+        verifyRenewal(beFalse())
     }
 
     func verifySubscriberInfo() {


### PR DESCRIPTION
Right now consumables and promotionals return willRenew as true. We should update so that:

1. Consumables always return willRenew as false
1. Promotionals always return willRenew as false
1. Subscriptions return willRenew as true if they don't have unsubscribe detected or billing issues.