### PR TITLE
version 3.10.6

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -5,9 +5,9 @@ objc: true
 sdk: iphonesimulator
 module: Purchases
 umbrella_header: Purchases/Public/Purchases.h
-module_version: 3.11.0-SNAPSHOT
+module_version: 3.10.6
 github_url: https://github.com/revenuecat/purchases-ios
-github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.11.0-SNAPSHOT
+github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.10.6
 output: docs
 # Leaving this commented out. We used to specify this before, but now it's working without it
 # xcodebuild_arguments: [--objc,Purchases/Public/Purchases.h,--,-x,objective-c,-isysroot,$(xcrun --show-sdk-path),-I,$(pwd)]

--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,4 +1,4 @@
-- Fix automatic Appl Search Ads Attribution collection for iOS 14.5
+- Fix automatic Apple Search Ads Attribution collection for iOS 14.5
     https://github.com/RevenueCat/purchases-ios/pull/473
 - Fixed `willRenew` values for consumables and promotionals
     https://github.com/RevenueCat/purchases-ios/pull/475

--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,5 +1,6 @@
-- Fixed a couple of issues with `.xcframework` output in releases
-    https://github.com/RevenueCat/purchases-ios/pull/470
-    https://github.com/RevenueCat/purchases-ios/pull/469
-- Fix Carthage builds from source, so that end customers can start leveraging XCFramework support for Carthage >= 0.37
-    https://github.com/RevenueCat/purchases-ios/pull/471
+- Fix automatic Appl Search Ads Attribution collection for iOS 14.5
+    https://github.com/RevenueCat/purchases-ios/pull/473
+- Fixed `willRenew` values for consumables and promotionals
+    https://github.com/RevenueCat/purchases-ios/pull/475
+- Improves tests for EntitlementInfos
+    https://github.com/RevenueCat/purchases-ios/pull/476

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 3.10.6
+- Fix automatic Appl Search Ads Attribution collection for iOS 14.5
+    https://github.com/RevenueCat/purchases-ios/pull/473
+- Fixed `willRenew` values for consumables and promotionals
+    https://github.com/RevenueCat/purchases-ios/pull/475
+- Improves tests for EntitlementInfos
+    https://github.com/RevenueCat/purchases-ios/pull/476
+
 ## 3.10.5
 - Fixed a couple of issues with `.xcframework` output in releases
     https://github.com/RevenueCat/purchases-ios/pull/470

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.10.6
-- Fix automatic Appl Search Ads Attribution collection for iOS 14.5
+- Fix automatic Apple Search Ads Attribution collection for iOS 14.5
     https://github.com/RevenueCat/purchases-ios/pull/473
 - Fixed `willRenew` values for consumables and promotionals
     https://github.com/RevenueCat/purchases-ios/pull/475

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Purchases"
-  s.version          = "3.11.0-SNAPSHOT"
+  s.version          = "3.10.6"
   s.summary          = "Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
-  s.dependency 'PurchasesCoreSwift', '3.11.0-SNAPSHOT'
+  s.dependency 'PurchasesCoreSwift', '3.10.6'
 
 
   s.source_files = ['Purchases/**/*.{h,m}']

--- a/Purchases/Info.plist
+++ b/Purchases/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11.0-SNAPSHOT</string>
+	<string>3.10.6</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Purchases/Misc/RCSystemInfo.m
+++ b/Purchases/Misc/RCSystemInfo.m
@@ -49,7 +49,7 @@ static BOOL _forceUniversalAppStore = NO;
 }
 
 + (NSString *)frameworkVersion {
-    return @"3.11.0-SNAPSHOT";
+    return @"3.10.6";
 }
 
 + (NSString *)systemVersion {

--- a/PurchasesCoreSwift.podspec
+++ b/PurchasesCoreSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesCoreSwift"
-  s.version          = "3.11.0-SNAPSHOT"
+  s.version          = "3.10.6"
   s.summary          = "Swift portion of RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/PurchasesCoreSwift/Info.plist
+++ b/PurchasesCoreSwift/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11.0-SNAPSHOT</string>
+	<string>3.10.6</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/PurchasesCoreSwiftTests/Info.plist
+++ b/PurchasesCoreSwiftTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11.0-SNAPSHOT</string>
+	<string>3.10.6</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/PurchasesTests/Info.plist
+++ b/PurchasesTests/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11.0-SNAPSHOT</string>
+	<string>3.10.6</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
- Fix automatic Apple Search Ads Attribution collection for iOS 14.5
    https://github.com/RevenueCat/purchases-ios/pull/473
- Fixed `willRenew` values for consumables and promotionals
    https://github.com/RevenueCat/purchases-ios/pull/475
- Improves tests for EntitlementInfos
    https://github.com/RevenueCat/purchases-ios/pull/476
