### PR TITLE
Initial configuration of bots

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,7 +13,7 @@ assignees: ""
 - [ ] I have searched for [existing Github issues](https://github.com/RevenueCat/purchases-ios/issues)
 
 **Describe the bug**
-A clear and concise description of what the bug is. The more detail you can provide the faster our team will be able to triage and resolve the issue. If Debug logs are not applicable to this issue, please do not remove step 2 when submitting the issue.
+A clear and concise description of what the bug is. The more detail you can provide the faster our team will be able to triage and resolve the issue. If debug logs are not applicable to this issue, please do not remove step 2 when submitting the issue.
 
 1. Environment
    1. Platform:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,33 +1,26 @@
 ---
 name: Bug report
 about: Filling a bug report
-title: ''
+title: ""
 labels: bug
-assignees: ''
-
+assignees: ""
 ---
 
-## Common project specific issues
-
-There are certain project specific issues that are commonly misinterpreted as bugs.
-
-- [Offerings, products, or available packages are empty](https://support.revenuecat.com/hc/en-us/articles/360041793174)
-- [Invalid Play Store credentials errors](https://support.revenuecat.com/hc/en-us/articles/360046398913)
-- [Unable to connect to the App Store (STORE_PROBLEM) errors](https://support.revenuecat.com/hc/en-us/articles/360046399333)
-
-For support I'd recommend our [online community](https://spectrum.chat/revenuecat), [StackOverflow](https://stackoverflow.com/tags/revenuecat/) and/or [Help Center](https://support.revenuecat.com/hc/en-us) 👍
-
-If you have a clearly defined bug (with a [Minimal, Complete, and Reproducible example](https://stackoverflow.com/help/minimal-reproducible-example)) that is not specific to your project, follow the steps below to file it with RevenueCat. For SDK-related bugs, make sure they can be reproduced on a physical device, not a simulator (there are simulator-specific problems that prevent purchases from working).
+- [ ] I have Updated Purchases SDK to the latest version
+- [ ] I have read the [Contribution Guidelines](https://github.com/RevenueCat/purchases-ios/blob/develop/CONTRIBUTING.md)
+- [ ] I have read the [Help Center](https://support.revenuecat.com/hc/en-us)
+- [ ] I have read [docs.revenuecat.com](https://docs.revenuecat.com/)
+- [ ] I have searched for [existing Github issues](https://github.com/RevenueCat/purchases-ios/issues)
 
 **Describe the bug**
-A clear and concise description of what the bug is. The more detail you can provide the faster our team will be able to triage and resolve the issue.
+A clear and concise description of what the bug is. The more detail you can provide the faster our team will be able to triage and resolve the issue. If Debug logs are not applicable to this issue, please do not remove step 2 when submitting the issue.
 
 1. Environment
-    1. Platform:
-    2. SDK version:
-    3. OS version:
-    4. Xcode version:
-    5. How widespread is the issue. Percentage of devices affected.
+   1. Platform:
+   2. SDK version:
+   3. OS version:
+   4. Xcode version:
+   5. How widespread is the issue. Percentage of devices affected.
 2. [Debug logs](https://docs.revenuecat.com/docs/debugging) that reproduce the issue
 3. Steps to reproduce, with a description of expected vs. actual behavior
 4. **Other information** (e.g. stacktraces, related issues, suggestions how to fix, links for us to have context, eg. stackoverflow, etc.)

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ labels: bug
 assignees: ""
 ---
 
-- [ ] I have Updated Purchases SDK to the latest version
+- [ ] I have updated Purchases SDK to the latest version
 - [ ] I have read the [Contribution Guidelines](https://github.com/RevenueCat/purchases-ios/blob/develop/CONTRIBUTING.md)
 - [ ] I have read the [Help Center](https://support.revenuecat.com/hc/en-us)
 - [ ] I have read [docs.revenuecat.com](https://docs.revenuecat.com/)

--- a/.github/issuecomplete.yml
+++ b/.github/issuecomplete.yml
@@ -1,0 +1,27 @@
+# Configuration for Issue Check: https://github.com/stevenzeck/issue-check
+
+# The name of the label to apply when an issue does not have all tasks checked
+labelName: "status: needs-additional-info"
+
+# The color of the label in hex format (without #). Will use the label color configured
+# in Issues settings.
+labelColor:
+
+# The text of the comment to add to the issue in addition to the label
+commentText: >
+  Hello! It doesn't seem like we have quite enough information to send this to 
+  a human yet to help out. We would love if you could provide more details about 
+  your issue by following the template without modifying any of the pre-filled
+  text.
+
+# Whether or not to ensure all checkboxes are checked
+checkCheckboxes: true
+
+# Keywords to look for in the body of the issue
+keywords:
+  - Platform
+  - SDK version
+  - OS version
+  - Xcode version
+  - Debug logs
+  - Steps to reproduce, with a description of expected vs. actual behavior

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,7 +8,8 @@ daysUntilStale: 30
 daysUntilClose: 7
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
-onlyLabels: [bug]
+onlyLabels:
+  - bug
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,49 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 30
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: [bug, investigating]
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - enhancement
+  - next-release
+
+# Set to true to ignore issues in a project (defaults to false)
+#exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+#exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false). Setting to true won't mark issues as stale
+# or auto-close if there is an assignee.
+exemptAssignees: true
+
+# Label to use when marking as stale
+staleLabel: "status: waiting-for-reply"
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale due to inactivity. It will 
+  be closed if no further activity occurs. Please reach out if you have 
+  additional information to help us investigate further!
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+only: issues

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,12 +8,13 @@ daysUntilStale: 30
 daysUntilClose: 7
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
-onlyLabels: [bug, investigating]
+onlyLabels: [bug]
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
   - enhancement
   - next-release
+  - investigating
 
 # Set to true to ignore issues in a project (defaults to false)
 #exemptProjects: false

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,22 @@
+# Configuration for Lock Threads: https://github.com/dessant/lock-threads
+
+name: "Lock Threads"
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # runs at 00:00 UTC every day
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2.0.1
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-inactive-days: "7"
+          issue-exclude-created-before: "2021-03-01T00:00:00Z"
+          issue-lock-comment: >
+            This issue has been automatically locked due to no recent activity after it 
+            was closed. Please open a new issue for related reports.
+          issue-lock-reason: ""
+          process-only: "issues"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,8 @@ Be sure to adhere to the prevailing style of the project.
 
 #### 4. Write tests for your fix/new functionality.
 
-You can run the tests by hitting Cmd+U. The tests are written swift
+You can run the tests by selecting the All Tests Scheme in Xcode and hitting `Cmd+U`.
+The tests are written in Swift, using XCTest and [Nimble](https://github.com/quick/nimble).
 
 #### 5. Create a pull request to revenuecat/master and request review
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,14 +2,34 @@
 
 #### 1. Create an issue to make sure its something that should be done.
 
+Before submitting a Github issue, please make sure to
+
+- Take a look at https://docs.revenuecat.com/
+- Search for [existing Github issues](https://github.com/RevenueCat/purchases-ios/issues)
+- Review our [Help Center](https://support.revenuecat.com/hc/en-us)
+- Read our [docs.revenuecat.com](https://docs.revenuecat.com/)
+
+## Common project specific issues
+
+There are certain project specific issues that are commonly misinterpreted as bugs.
+
+- [Offerings, products, or available packages are empty](https://support.revenuecat.com/hc/en-us/articles/360041793174)
+- [Invalid Play Store credentials errors](https://support.revenuecat.com/hc/en-us/articles/360046398913)
+- [Unable to connect to the App Store (STORE_PROBLEM) errors](https://support.revenuecat.com/hc/en-us/articles/360046399333)
+
+For support I'd recommend our [online community](https://spectrum.chat/revenuecat), [StackOverflow](https://stackoverflow.com/tags/revenuecat/) and/or [Help Center](https://support.revenuecat.com/hc/en-us) 👍
+
+If you have a clearly defined bug (with a [Minimal, Complete, and Reproducible example](https://stackoverflow.com/help/minimal-reproducible-example)) that is not specific to your project, follow the steps in the GitHub Issue template to file it with RevenueCat without removing any of the steps. For SDK-related bugs, make sure they can be reproduced on a physical device, not a simulator (there are simulator-specific problems that prevent purchases from working).
+
 #### 2. Create a fork/branch.
 
 #### 3. Do your work.
+
 Be sure to adhere to the prevailing style of the project.
 
 #### 4. Write tests for your fix/new functionality.
 
-You can run the tests by hitting Cmd+U. The tests are written swift 
+You can run the tests by hitting Cmd+U. The tests are written swift
 
 #### 5. Create a pull request to revenuecat/master and request review
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,6 @@
 
 Before submitting a Github issue, please make sure to
 
-- Take a look at https://docs.revenuecat.com/
 - Search for [existing Github issues](https://github.com/RevenueCat/purchases-ios/issues)
 - Review our [Help Center](https://support.revenuecat.com/hc/en-us)
 - Read our [docs.revenuecat.com](https://docs.revenuecat.com/)


### PR DESCRIPTION
This PR configures the follow Bots / Github Action:
- https://github.com/probot/stale
- https://github.com/stevenzeck/issue-check
- https://github.com/dessant/lock-threads

### Stale:
- Mark issues as stale after 30 days of no activity
- Close stale issues after 7 days of no activity
- Adds label `status: waiting-for-reply` for issues marked as stale
- Only check issues with `bug` label
- Does not check issues with `enhancement`, `next-release`, or `investigating` labels
- Does not check if issue has an assignee 

### Issue-check:
- Adds label `status: needs-additional-info` for issues that did not follow Issue template

### Lock Threads
- Runs at 00:00 UTC every day
- Excludes issues created before March 1st, 2021 (for the purpose of not creating noise for old issues)
- Will lock a closed issue after 7 days of no activity. 

This PR also modifies the following files:
- `bug_report.md` to include a checklist at the beginning
- `CONTRIBUTING.md` to include the top blurb from bug_report.md and places to check before opening an issue.

### Next steps
Once this is approved, I will open duplicate PRs specific to the rest of the Purchase SDKs. Before merging I will create the [labels](https://github.com/RevenueCat/purchases-ios/labels) the bots will use.