### PR TITLE
Add hook to customize the way logs are emitted

### DIFF
--- a/Purchases/Misc/RCLogUtils.h
+++ b/Purchases/Misc/RCLogUtils.h
@@ -14,33 +14,33 @@ void RCSetShowDebugLogs(BOOL showDebugLogs);
 BOOL RCShowDebugLogs(void);
 
 #define RCDebugLog(args, ...) \
-    [RCLogger debug: [NSString stringWithFormat: args, ##__VA_ARGS__]]
+    [RCLog debug: [NSString stringWithFormat: args, ##__VA_ARGS__]]
 
 #define RCLog(args, ...) \
-    [RCLogger info: [NSString stringWithFormat: args, ##__VA_ARGS__]]
+    [RCLog info: [NSString stringWithFormat: args, ##__VA_ARGS__]]
 
 #define RCWarnLog(args, ...) \
-    [RCLogger warn: [NSString stringWithFormat: args, ##__VA_ARGS__]]
+    [RCLog warn: [NSString stringWithFormat: args, ##__VA_ARGS__]]
 
 #define RCErrorLog(args, ...) \
-    [RCLogger error: [NSString stringWithFormat: args, ##__VA_ARGS__]]
+    [RCLog error: [NSString stringWithFormat: args, ##__VA_ARGS__]]
 
 #define RCAppleErrorLog(args, ...) \
-    [RCLogger appleError: [NSString stringWithFormat: args, ##__VA_ARGS__]]
+    [RCLog appleError: [NSString stringWithFormat: args, ##__VA_ARGS__]]
 
 #define RCAppleWarningLog(args, ...) \
-    [RCLogger appleWarning: [NSString stringWithFormat: args, ##__VA_ARGS__]]
+    [RCLog appleWarning: [NSString stringWithFormat: args, ##__VA_ARGS__]]
 
 #define RCPurchaseLog(args, ...) \
-    [RCLogger purchase: [NSString stringWithFormat: args, ##__VA_ARGS__]]
+    [RCLog purchase: [NSString stringWithFormat: args, ##__VA_ARGS__]]
 
 #define RCPurchaseSuccessLog(args, ...) \
-    [RCLogger rcPurchaseSuccess: [NSString stringWithFormat: args, ##__VA_ARGS__]]
+    [RCLog rcPurchaseSuccess: [NSString stringWithFormat: args, ##__VA_ARGS__]]
 
 #define RCSuccessLog(args, ...) \
-    [RCLogger rcSuccess: [NSString stringWithFormat: args, ##__VA_ARGS__]]
+    [RCLog rcSuccess: [NSString stringWithFormat: args, ##__VA_ARGS__]]
 
 #define RCUserLog(args, ...) \
-    [RCLogger user: [NSString stringWithFormat: args, ##__VA_ARGS__]]
+    [RCLog user: [NSString stringWithFormat: args, ##__VA_ARGS__]]
 
 NS_ASSUME_NONNULL_END

--- a/Purchases/Misc/RCLogUtils.m
+++ b/Purchases/Misc/RCLogUtils.m
@@ -10,9 +10,9 @@
 @import PurchasesCoreSwift;
 
 void RCSetShowDebugLogs(BOOL showDebugLogs) {
-    RCLogger.shouldShowDebugLogs = showDebugLogs;
+    RCLog.shouldShowDebugLogs = showDebugLogs;
 }
 
 BOOL RCShowDebugLogs() {
-    return RCLogger.shouldShowDebugLogs;
+    return RCLog.shouldShowDebugLogs;
 }

--- a/Purchases/Public/Purchases.h
+++ b/Purchases/Public/Purchases.h
@@ -28,3 +28,4 @@ FOUNDATION_EXPORT const unsigned char PurchasesVersionString[];
 #import "RCEntitlementInfo.h"
 #import "RCEntitlementInfos.h"
 #import "RCTransaction.h"
+#import "RCLogger.h"

--- a/Purchases/Public/RCLogger.h
+++ b/Purchases/Public/RCLogger.h
@@ -1,0 +1,39 @@
+//
+//  RCLogger.h
+//  Purchases
+//
+//  Created by RevenueCat.
+//  Copyright © 2021 RevenueCat. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, RCLogLevel) {
+    RCLogLevelDebug,
+    RCLogLevelInfo,
+    RCLogLevelWarn,
+    RCLogLevelError,
+} NS_SWIFT_NAME(Purchases.LogLevel);
+
+NS_SWIFT_NAME(Purchases.Logger)
+@interface RCLogger : NSObject
+
+/**
+ Set a custom log handler for redirecting logs to your own logging system.
+ 
+ By default, this sends Info, Warn, and Error messages. If you wish to receive Debug level messages, you must enable debug logs.
+ */
++ (void)setLogHandler:(void(^)(RCLogLevel, NSString * _Nonnull))logHandler;
+
+/**
+ Enable debug logging. Useful for debugging issues with the lovely team @RevenueCat
+*/
+@property (class, nonatomic) BOOL debugLogsEnabled;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Purchases/Public/RCLogger.m
+++ b/Purchases/Public/RCLogger.m
@@ -1,0 +1,30 @@
+//
+//  RCLogger.m
+//  Purchases
+//
+//  Created by RevenueCat.
+//  Copyright © 2021 RevenueCat. All rights reserved.
+//
+
+#import "RCLogger.h"
+#import "RCLogUtils.h"
+
+@import PurchasesCoreSwift;
+
+@implementation RCLogger
+
++ (void)setDebugLogsEnabled:(BOOL)enabled {
+    RCSetShowDebugLogs(enabled);
+}
+
++ (BOOL)debugLogsEnabled {
+    return RCShowDebugLogs();
+}
+
++ (void)setLogHandler:(void(^)(RCLogLevel, NSString * _Nonnull))handler {
+    RCLog.logHandler = ^(NSInteger level, NSString *message) {
+        handler((RCLogLevel)level, message);
+    };
+}
+
+@end

--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -67,7 +67,7 @@ NS_SWIFT_NAME(Purchases)
 /**
  Enable debug logging. Useful for debugging issues with the lovely team @RevenueCat
 */
-@property (class, nonatomic, assign) BOOL debugLogsEnabled;
+@property (class, nonatomic, assign) BOOL debugLogsEnabled DEPRECATED_MSG_ATTRIBUTE("use RCLogger.debugLogsEnabled");
 
 /**
  Set this property to your proxy URL before configuring Purchases *only* if you've received a proxy key value from your RevenueCat contact.

--- a/PurchasesCoreSwift/Logging/Logger.swift
+++ b/PurchasesCoreSwift/Logging/Logger.swift
@@ -8,7 +8,8 @@
 
 import Foundation
 
-@objc(RCLogLevel) public enum LogLevel: Int {
+// NOTE: this must exactly match the enum in RCLogging.h
+@objc(RCInternalLogLevel) public enum LogLevel: Int {
     case debug, info, warn, error
 
     func description() -> String {
@@ -21,7 +22,7 @@ import Foundation
     }
 }
 
-@objc(RCLogger) public class Logger: NSObject {
+@objc(RCLog) public class Logger: NSObject {
     @objc public static var shouldShowDebugLogs = false
     @objc public static var logHandler: (LogLevel, String) -> Void = { level, message in
         NSLog("[\(frameworkDescription)] - \(level.description()): \(message)")

--- a/PurchasesCoreSwift/Logging/Logger.swift
+++ b/PurchasesCoreSwift/Logging/Logger.swift
@@ -23,11 +23,15 @@ import Foundation
 
 @objc(RCLogger) public class Logger: NSObject {
     @objc public static var shouldShowDebugLogs = false
+    @objc public static var logHandler: (LogLevel, String) -> Void = { level, message in
+        NSLog("[\(frameworkDescription)] - \(level.description()): \(message)")
+    }
+    
     private static let frameworkDescription = "Purchases"
 
     @objc public static func log(level: LogLevel, message: String) {
         guard level != .debug || shouldShowDebugLogs else { return }
-        NSLog("[\(frameworkDescription)] - \(level.description()): \(message)")
+        logHandler(level, message)
     }
     
     @objc public static func log(level: LogLevel, intent: LogIntent, message: String) {


### PR DESCRIPTION
This changes adds the ability to set a new handler on the `RCLogger` type. By default, the handler is the current implementation of `NSLog` that emits the framework description.

The log handler provides the parameters of the log level and the message, and then anyone providing a custom handler can interpret those parameters however they wish and/or redirect them to their own logging system.