### PR TITLE
expose `ownershipType` in purchaserInfo

### DIFF
--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		2D5033262406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5033232406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D50332A2406EA61009CAE61 /* RCSubscriberAttributesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5033272406EA61009CAE61 /* RCSubscriberAttributesManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D50332B2406EA61009CAE61 /* RCSubscriberAttributesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D5033282406EA61009CAE61 /* RCSubscriberAttributesManager.m */; };
+		2D540CD72601509000A7475D /* RCPurchaseOwnershipType.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D540CD62601509000A7475D /* RCPurchaseOwnershipType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2D8DB34B24072AAE00BE3D31 /* SubscriberAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8DB34A24072AAE00BE3D31 /* SubscriberAttributeTests.swift */; };
 		2D8E9D482523747D00AFEE11 /* NSDictionaryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD269162522A20A006AC4BC /* NSDictionaryExtensionsTests.swift */; };
 		2D8E9D54252374A600AFEE11 /* NSDictionary+RCExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D8E9D52252374A600AFEE11 /* NSDictionary+RCExtensions.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -284,6 +285,7 @@
 		2D5033232406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCSpecialSubscriberAttributes.h; path = Purchases/SubscriberAttributes/RCSpecialSubscriberAttributes.h; sourceTree = SOURCE_ROOT; };
 		2D5033272406EA61009CAE61 /* RCSubscriberAttributesManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCSubscriberAttributesManager.h; path = Purchases/SubscriberAttributes/RCSubscriberAttributesManager.h; sourceTree = SOURCE_ROOT; };
 		2D5033282406EA61009CAE61 /* RCSubscriberAttributesManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCSubscriberAttributesManager.m; path = Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m; sourceTree = SOURCE_ROOT; };
+		2D540CD62601509000A7475D /* RCPurchaseOwnershipType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCPurchaseOwnershipType.h; sourceTree = "<group>"; };
 		2D5BB46A24C8E8ED00E27537 /* ReceiptParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptParser.swift; sourceTree = "<group>"; };
 		2D604CA224E5BF37004821DC /* RCTransaction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTransaction.h; sourceTree = "<group>"; };
 		2D8DB34A24072AAE00BE3D31 /* SubscriberAttributeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriberAttributeTests.swift; sourceTree = "<group>"; };
@@ -760,6 +762,7 @@
 				35B54E4B22EA6FD3005918B1 /* RCEntitlementInfos.m */,
 				2D604CA224E5BF37004821DC /* RCTransaction.h */,
 				37E357903E469CF42667760C /* RCAttributionNetwork.h */,
+				2D540CD62601509000A7475D /* RCPurchaseOwnershipType.h */,
 			);
 			path = Public;
 			sourceTree = "<group>";
@@ -1209,6 +1212,7 @@
 				2DC5623824EC7DF70031F69B /* RCTransaction.h in Headers */,
 				37E354AFE06A9723230E47B8 /* RCInMemoryCachedObject+Protected.h in Headers */,
 				37E35C7C3BADD6D1BBAE7129 /* RCSubscriberAttribute+Protected.h in Headers */,
+				2D540CD72601509000A7475D /* RCPurchaseOwnershipType.h in Headers */,
 				2DAF814E25B24243002C621E /* RCIdentityManager+Protected.h in Headers */,
 				37E358D3F3C7C0388FF5C2BD /* RCOfferingsFactory.h in Headers */,
 				37E35DB1E991055497D18044 /* RCPromotionalOffer.h in Headers */,

--- a/Purchases/Public/RCEntitlementInfo.h
+++ b/Purchases/Public/RCEntitlementInfo.h
@@ -4,6 +4,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "RCPurchaseOwnershipType.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -113,6 +114,13 @@ NS_SWIFT_NAME(Purchases.EntitlementInfo)
  Check the `isActive` property.
  */
 @property (readonly, nullable) NSDate *billingIssueDetectedAt;
+
+/**
+ Use this property to determine whether a purchase was made by the current user
+ or shared to them by a family member. This can be useful for onboarding users who have had
+ an entitlement shared with them, but might not be entirely aware of the benefits they now have.
+ */
+@property (readonly) RCPurchaseOwnershipType ownershipType;
 
 @end
 

--- a/Purchases/Public/RCEntitlementInfo.m
+++ b/Purchases/Public/RCEntitlementInfo.m
@@ -130,7 +130,7 @@
     [description appendFormat:@"isSandbox=%d,\n", self.isSandbox];
     [description appendFormat:@"unsubscribeDetectedAt=%@,\n", self.unsubscribeDetectedAt];
     [description appendFormat:@"billingIssueDetectedAt=%@,\n", self.billingIssueDetectedAt];
-    [description appendFormat:@"ownershipType=%@,\n", self.ownershipType];
+    [description appendFormat:@"ownershipType=%@,\n", (long) self.ownershipType];
     [description appendString:@">"];
     return description;
 }

--- a/Purchases/Public/RCEntitlementInfo.m
+++ b/Purchases/Public/RCEntitlementInfo.m
@@ -20,6 +20,7 @@
 @property (readwrite, nullable) NSDate *unsubscribeDetectedAt;
 @property (readwrite, nullable) NSDate *billingIssueDetectedAt;
 @property (readwrite) BOOL willRenew;
+@property (readwrite) RCPurchaseOwnershipType ownershipType;
 
 @end
 
@@ -43,8 +44,23 @@
                                                      store:self.store
                                      unsubscribeDetectedAt:self.unsubscribeDetectedAt
                                     billingIssueDetectedAt:self.billingIssueDetectedAt];
+        self.ownershipType = [self parseOwnershipType:productData[@"ownership_type"]];
+
     }
     return self;
+}
+
+- (RCPurchaseOwnershipType)parseOwnershipType:(NSString * _Nullable)ownershipType {
+    if (!ownershipType) {
+        return RCPurchaseOwnershipTypePurchased;
+    }
+    if ([ownershipType isEqualToString:@"PURCHASED"]) {
+        return RCPurchaseOwnershipTypePurchased;
+    } else if ([ownershipType isEqualToString:@"FAMILY_SHARED"]) {
+            return RCPurchaseOwnershipTypeFamilyShared;
+    } else {
+        return RCPurchaseOwnershipTypeUnknown;
+    }
 }
 
 - (BOOL)willRenewWithExpirationDate:(NSDate *)expirationDate store:(RCStore)store unsubscribeDetectedAt:(NSDate *)unsubscribeDetectedAt billingIssueDetectedAt:(NSDate *)billingIssueDetectedAt
@@ -114,6 +130,7 @@
     [description appendFormat:@"isSandbox=%d,\n", self.isSandbox];
     [description appendFormat:@"unsubscribeDetectedAt=%@,\n", self.unsubscribeDetectedAt];
     [description appendFormat:@"billingIssueDetectedAt=%@,\n", self.billingIssueDetectedAt];
+    [description appendFormat:@"ownershipType=%@,\n", self.ownershipType];
     [description appendString:@">"];
     return description;
 }
@@ -158,6 +175,8 @@
         return NO;
     if (self.billingIssueDetectedAt != info.billingIssueDetectedAt && ![self.billingIssueDetectedAt isEqualToDate:info.billingIssueDetectedAt])
         return NO;
+    if (self.ownershipType != info.ownershipType)
+        return NO;
     return YES;
 }
 
@@ -175,6 +194,7 @@
     hash = hash * 31u + self.isSandbox;
     hash = hash * 31u + [self.unsubscribeDetectedAt hash];
     hash = hash * 31u + [self.billingIssueDetectedAt hash];
+    hash = hash * 31u + (NSUInteger)self.ownershipType;
     return hash;
 }
 

--- a/Purchases/Public/RCEntitlementInfo.m
+++ b/Purchases/Public/RCEntitlementInfo.m
@@ -130,7 +130,7 @@
     [description appendFormat:@"isSandbox=%d,\n", self.isSandbox];
     [description appendFormat:@"unsubscribeDetectedAt=%@,\n", self.unsubscribeDetectedAt];
     [description appendFormat:@"billingIssueDetectedAt=%@,\n", self.billingIssueDetectedAt];
-    [description appendFormat:@"ownershipType=%@,\n", (long) self.ownershipType];
+    [description appendFormat:@"ownershipType=%li,\n", (long) self.ownershipType];
     [description appendString:@">"];
     return description;
 }

--- a/Purchases/Public/RCPurchaseOwnershipType.h
+++ b/Purchases/Public/RCPurchaseOwnershipType.h
@@ -1,0 +1,22 @@
+//
+//  RCPurchaseOwnershipType.h
+//  Purchases
+//
+//  Created by Andrés Boedo on 3/16/21.
+//  Copyright © 2021 Purchases. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSInteger, RCPurchaseOwnershipType) {
+    /**
+     The purchase was made directly by this user.
+     */
+    RCPurchaseOwnershipTypePurchased = 0,
+    /**
+     The purchase has been shared to this user by a family member.
+     */
+    RCPurchaseOwnershipTypeFamilyShared = 1,
+
+    RCPurchaseOwnershipTypeUnknown = 2,
+};

--- a/PurchasesTests/PurchasesTests-Bridging-Header.h
+++ b/PurchasesTests/PurchasesTests-Bridging-Header.h
@@ -46,4 +46,5 @@
 #include <Purchases/NSDictionary+RCExtensions.h>
 #include <Purchases/RCPurchaserInfoManager.h>
 #include <Purchases/RCAttributionTypeFactory.h>
+#include <Purchases/RCPurchaseOwnershipType.h>
 #include <Purchases/RCPurchaserInfoManager+Protected.h>


### PR DESCRIPTION
This is a new field, that allows customers to know whether a given subscription was purchased by the user or was shared to them by a member of their family. 
This in turn allows for apps to provide a custom onboarding for users who've had a subscription shared with them, but might not be aware of the benefits of the subscription, or that they even have one. 