### PR TITLE
Update issue bot message

### DIFF
--- a/.github/issuecomplete.yml
+++ b/.github/issuecomplete.yml
@@ -12,7 +12,8 @@ commentText: >
   Hello! It doesn't seem like we have quite enough information to send this to 
   a human yet to help out. We would love if you could provide more details about 
   your issue by following the template without modifying any of the pre-filled
-  text.
+  text. If you're looking for support, head over to our [Help Center](https://support.revenuecat.com/hc/en-us)
+  to get in touch with our team directly.
 
 # Whether or not to ensure all checkboxes are checked
 checkCheckboxes: true


### PR DESCRIPTION
Although we have the checklist at the top of the bug template, some developers may delete the entire template without looking at it first. This PR adds a blurb to the issue bot's message to link to the Help Center if they're looking for support help.