### PR TITLE
Hotfix: ATTFramework usage rejections

### DIFF
--- a/Purchases/Attribution/RCAttributionFetcher.m
+++ b/Purchases/Attribution/RCAttributionFetcher.m
@@ -131,18 +131,20 @@ static NSMutableArray<RCAttributionData *> *_Nullable postponedAttributionData;
 }
 
 - (BOOL)isAuthorizedToPostSearchAds {
-//#if APP_TRACKING_TRANSPARENCY_REQUIRED
+#if APP_TRACKING_TRANSPARENCY_REQUIRED
     if (@available(iOS 14, macos 11, tvos 14, *)) {
         NSOperatingSystemVersion minimumOSVersionRequiringAuthorization = { .majorVersion = 14, .minorVersion = 5, .patchVersion = 0 };
 
         BOOL needsTrackingAuthorization = [self.systemInfo isOperatingSystemAtLeastVersion:minimumOSVersionRequiringAuthorization];
 
         Class<FakeATTrackingManager> _Nullable trackingManagerClass = [self.attributionFactory atTrackingClass];
-        if (!trackingManagerClass && needsTrackingAuthorization) {
-            RCWarnLog(@"%@", RCStrings.attribution.search_ads_attribution_cancelled_missing_att_framework);
-            return NO;
+        if (!trackingManagerClass) {
+            if (needsTrackingAuthorization) {
+                RCWarnLog(@"%@", RCStrings.attribution.search_ads_attribution_cancelled_missing_att_framework);
+            }
+            return !needsTrackingAuthorization;
         }
-        SEL authStatusSelector = NSSelectorFromString(@"trackingAuthorizationStatus");
+        SEL authStatusSelector = NSSelectorFromString(self.attributionFactory.authorizationStatusPropertyName);
         BOOL canPerformSelector = [trackingManagerClass respondsToSelector:authStatusSelector];
         if (!canPerformSelector) {
             RCWarnLog(@"%@", RCStrings.attribution.att_framework_present_but_couldnt_call_tracking_authorization_status);
@@ -158,7 +160,7 @@ static NSMutableArray<RCAttributionData *> *_Nullable postponedAttributionData;
         }
 
     }
-//#endif
+#endif
     return YES;
 }
 

--- a/Purchases/Attribution/RCAttributionFetcher.m
+++ b/Purchases/Attribution/RCAttributionFetcher.m
@@ -142,7 +142,7 @@ static NSMutableArray<RCAttributionData *> *_Nullable postponedAttributionData;
             RCWarnLog(@"%@", RCStrings.attribution.search_ads_attribution_cancelled_missing_att_framework);
             return NO;
         }
-        NSInteger authorizationStatus = [trackingManagerClass trackingAuthStatusProperty];
+        NSInteger authorizationStatus = [trackingManagerClass trackingAuthorizationStatus];
         BOOL authorized = authorizationStatus == FakeTrackingManagerAuthorizationStatusAuthorized
                           || (!needsTrackingAuthorization
                               && authorizationStatus == FakeTrackingManagerAuthorizationStatusNotDetermined);

--- a/Purchases/Attribution/RCAttributionFetcher.m
+++ b/Purchases/Attribution/RCAttributionFetcher.m
@@ -131,7 +131,7 @@ static NSMutableArray<RCAttributionData *> *_Nullable postponedAttributionData;
 }
 
 - (BOOL)isAuthorizedToPostSearchAds {
-#if APP_TRACKING_TRANSPARENCY_REQUIRED
+//#if APP_TRACKING_TRANSPARENCY_REQUIRED
     if (@available(iOS 14, macos 11, tvos 14, *)) {
         NSOperatingSystemVersion minimumOSVersionRequiringAuthorization = { .majorVersion = 14, .minorVersion = 5, .patchVersion = 0 };
 
@@ -142,7 +142,13 @@ static NSMutableArray<RCAttributionData *> *_Nullable postponedAttributionData;
             RCWarnLog(@"%@", RCStrings.attribution.search_ads_attribution_cancelled_missing_att_framework);
             return NO;
         }
-        NSInteger authorizationStatus = [trackingManagerClass trackingAuthorizationStatus];
+        SEL authStatusSelector = NSSelectorFromString(@"trackingAuthorizationStatus");
+        BOOL canPerformSelector = [trackingManagerClass respondsToSelector:authStatusSelector];
+        if (!canPerformSelector) {
+            RCWarnLog(@"%@", RCStrings.attribution.att_framework_present_but_couldnt_call_tracking_authorization_status);
+            return NO;
+        }
+        NSInteger authorizationStatus = (NSInteger)[trackingManagerClass performSelector:authStatusSelector];
         BOOL authorized = authorizationStatus == FakeTrackingManagerAuthorizationStatusAuthorized
                           || (!needsTrackingAuthorization
                               && authorizationStatus == FakeTrackingManagerAuthorizationStatusNotDetermined);
@@ -152,7 +158,7 @@ static NSMutableArray<RCAttributionData *> *_Nullable postponedAttributionData;
         }
 
     }
-#endif
+//#endif
     return YES;
 }
 

--- a/Purchases/Attribution/RCAttributionFetcher.m
+++ b/Purchases/Attribution/RCAttributionFetcher.m
@@ -142,7 +142,7 @@ static NSMutableArray<RCAttributionData *> *_Nullable postponedAttributionData;
             RCWarnLog(@"%@", RCStrings.attribution.search_ads_attribution_cancelled_missing_att_framework);
             return NO;
         }
-        NSInteger authorizationStatus = [trackingManagerClass trackingAuthorizationStatus];
+        NSInteger authorizationStatus = [trackingManagerClass trackingAuthStatusProperty];
         BOOL authorized = authorizationStatus == FakeATTrackingManagerAuthorizationStatusAuthorized
                           || (!needsTrackingAuthorization
                               && authorizationStatus == FakeATTrackingManagerAuthorizationStatusNotDetermined);

--- a/Purchases/Attribution/RCAttributionFetcher.m
+++ b/Purchases/Attribution/RCAttributionFetcher.m
@@ -137,7 +137,7 @@ static NSMutableArray<RCAttributionData *> *_Nullable postponedAttributionData;
 
         BOOL needsTrackingAuthorization = [self.systemInfo isOperatingSystemAtLeastVersion:minimumOSVersionRequiringAuthorization];
 
-        Class<FakeATTrackingManager> _Nullable trackingManagerClass = [self.attributionFactory atTrackingManagerClass];
+        Class<FakeATTrackingManager> _Nullable trackingManagerClass = [self.attributionFactory atTrackingClass];
         if (!trackingManagerClass && needsTrackingAuthorization) {
             RCWarnLog(@"%@", RCStrings.attribution.search_ads_attribution_cancelled_missing_att_framework);
             return NO;

--- a/Purchases/Attribution/RCAttributionFetcher.m
+++ b/Purchases/Attribution/RCAttributionFetcher.m
@@ -143,9 +143,9 @@ static NSMutableArray<RCAttributionData *> *_Nullable postponedAttributionData;
             return NO;
         }
         NSInteger authorizationStatus = [trackingManagerClass trackingAuthStatusProperty];
-        BOOL authorized = authorizationStatus == FakeATTrackingManagerAuthorizationStatusAuthorized
+        BOOL authorized = authorizationStatus == FakeTrackingManagerAuthorizationStatusAuthorized
                           || (!needsTrackingAuthorization
-                              && authorizationStatus == FakeATTrackingManagerAuthorizationStatusNotDetermined);
+                              && authorizationStatus == FakeTrackingManagerAuthorizationStatusNotDetermined);
         if (!authorized) {
             RCLog(@"%@", RCStrings.attribution.search_ads_attribution_cancelled_not_authorized);
             return NO;

--- a/Purchases/Attribution/RCAttributionFetcher.m
+++ b/Purchases/Attribution/RCAttributionFetcher.m
@@ -150,7 +150,8 @@ static NSMutableArray<RCAttributionData *> *_Nullable postponedAttributionData;
             RCWarnLog(@"%@", RCStrings.attribution.att_framework_present_but_couldnt_call_tracking_authorization_status);
             return NO;
         }
-
+        // we use NSInvocation to prevent direct references to tracking frameworks, which cause issues for
+        // kids apps when going through app review, even if they don't actually use them at all. 
         NSMethodSignature *methodSignature = [trackingManagerClass methodSignatureForSelector:authStatusSelector];
         NSInvocation *myInvocation = [NSInvocation invocationWithMethodSignature:methodSignature];
         [myInvocation setTarget:trackingManagerClass];

--- a/Purchases/Attribution/RCAttributionTypeFactory.h
+++ b/Purchases/Attribution/RCAttributionTypeFactory.h
@@ -31,7 +31,7 @@ typedef NS_ENUM(NSUInteger, FakeTrackingManagerAuthorizationStatus) {
 
 @end
 
-@protocol FakeATTrackingManager <NSObject>
+@protocol FakeTrackingManager <NSObject>
 
 + (NSInteger)trackingAuthorizationStatus;
 
@@ -42,7 +42,7 @@ NS_SWIFT_NAME(AttributionTypeFactory)
 @interface RCAttributionTypeFactory : NSObject
 
 - (Class<FakeAdClient> _Nullable)adClientClass;
-- (Class<FakeATTrackingManager> _Nullable)atTrackingClass;
+- (Class<FakeTrackingManager> _Nullable)atTrackingClass;
 - (Class<FakeASIdentifierManager> _Nullable)asIdentifierClass;
 
 - (NSString *)asIdentifierPropertyName;

--- a/Purchases/Attribution/RCAttributionTypeFactory.h
+++ b/Purchases/Attribution/RCAttributionTypeFactory.h
@@ -42,10 +42,14 @@ NS_SWIFT_NAME(AttributionTypeFactory)
 @interface RCAttributionTypeFactory : NSObject
 
 - (Class<FakeAdClient> _Nullable)adClientClass;
-- (Class<FakeATTrackingManager> _Nullable)atTrackingManagerClass;
+- (Class<FakeATTrackingManager> _Nullable)atTrackingClass;
 - (Class<FakeASIdentifierManager> _Nullable)asIdentifierClass;
 
 - (NSString *)asIdentifierPropertyName;
+
+@property (readonly) NSString *mangledIdentifierClassName;
+@property (readonly) NSString *mangledIdentifierPropertyName;
+@property (readonly) NSString *mangledTrackingClassName;
 
 @end
 

--- a/Purchases/Attribution/RCAttributionTypeFactory.h
+++ b/Purchases/Attribution/RCAttributionTypeFactory.h
@@ -33,7 +33,7 @@ typedef NS_ENUM(NSUInteger, FakeTrackingManagerAuthorizationStatus) {
 
 @protocol FakeATTrackingManager <NSObject>
 
-+ (NSInteger)trackingAuthStatusProperty;
++ (NSInteger)trackingAuthorizationStatus;
 
 @end
 

--- a/Purchases/Attribution/RCAttributionTypeFactory.h
+++ b/Purchases/Attribution/RCAttributionTypeFactory.h
@@ -46,10 +46,12 @@ NS_SWIFT_NAME(AttributionTypeFactory)
 - (Class<FakeASIdentifierManager> _Nullable)asIdentifierClass;
 
 - (NSString *)asIdentifierPropertyName;
+- (NSString *)authorizationStatusPropertyName;
 
 @property (readonly) NSString *mangledIdentifierClassName;
 @property (readonly) NSString *mangledIdentifierPropertyName;
 @property (readonly) NSString *mangledTrackingClassName;
+@property (readonly) NSString *mangledAuthStatusPropertyName;
 
 @end
 

--- a/Purchases/Attribution/RCAttributionTypeFactory.h
+++ b/Purchases/Attribution/RCAttributionTypeFactory.h
@@ -10,11 +10,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^RCAttributionDetailsBlock)(NSDictionary<NSString *, NSObject *> *_Nullable, NSError *_Nullable);
 
-typedef NS_ENUM(NSUInteger, FakeATTrackingManagerAuthorizationStatus) {
-    FakeATTrackingManagerAuthorizationStatusNotDetermined = 0,
-    FakeATTrackingManagerAuthorizationStatusRestricted,
-    FakeATTrackingManagerAuthorizationStatusDenied,
-    FakeATTrackingManagerAuthorizationStatusAuthorized
+typedef NS_ENUM(NSUInteger, FakeTrackingManagerAuthorizationStatus) {
+    FakeTrackingManagerAuthorizationStatusNotDetermined = 0,
+    FakeTrackingManagerAuthorizationStatusRestricted,
+    FakeTrackingManagerAuthorizationStatusDenied,
+    FakeTrackingManagerAuthorizationStatusAuthorized
 };
 
 @protocol FakeAdClient <NSObject>

--- a/Purchases/Attribution/RCAttributionTypeFactory.h
+++ b/Purchases/Attribution/RCAttributionTypeFactory.h
@@ -33,7 +33,7 @@ typedef NS_ENUM(NSUInteger, FakeATTrackingManagerAuthorizationStatus) {
 
 @protocol FakeATTrackingManager <NSObject>
 
-+ (NSInteger)trackingAuthorizationStatus;
++ (NSInteger)trackingAuthStatusProperty;
 
 @end
 

--- a/Purchases/Attribution/RCAttributionTypeFactory.m
+++ b/Purchases/Attribution/RCAttributionTypeFactory.m
@@ -13,8 +13,26 @@ NS_ASSUME_NONNULL_BEGIN
     return (Class<FakeAdClient> _Nullable)NSClassFromString(@"ADClient");
 }
 
-- (Class<FakeATTrackingManager> _Nullable)atTrackingManagerClass {
-    return (Class<FakeATTrackingManager> _Nullable)NSClassFromString(@"ATTrackingManager");
+- (NSString *)mangledIdentifierClassName {
+    return @"NFVqragvsvreZnantre";
+}
+
+- (NSString *)mangledIdentifierPropertyName {
+    return @"nqiregvfvatVqragvsvre";
+}
+
+- (NSString *)mangledTrackingClassName {
+    return @"NGGenpxvatZnantre";
+}
+
+- (Class<FakeATTrackingManager> _Nullable)atTrackingClass {
+    // We need to do this mangling to avoid Kid apps being rejected for getting idfa.
+    // It looks like during the app review process Apple does some string matching looking for
+    // functions in ATTrackingTransparency. We apply rot13 on these functions and classes names
+    // so that Apple can't find them during the review, but we can still access them on runtime.
+    NSString *className = [self rot13:self.mangledTrackingClassName];
+
+    return (Class<FakeATTrackingManager> _Nullable)NSClassFromString(className);
 }
 
 - (Class<FakeASIdentifierManager> _Nullable)asIdentifierClass {
@@ -22,16 +40,13 @@ NS_ASSUME_NONNULL_BEGIN
     // It looks like during the app review process Apple does some string matching looking for
     // functions in the AdSupport.framework. We apply rot13 on these functions and classes names
     // so that Apple can't find them during the review, but we can still access them on runtime.
-    NSString *mangledClassName = @"NFVqragvsvreZnantre";
-
-    NSString *className = [self rot13:mangledClassName];
+    NSString *className = [self rot13:self.mangledIdentifierClassName];
 
     return (Class<FakeASIdentifierManager> _Nullable)NSClassFromString(className);
 }
 
 - (NSString *)asIdentifierPropertyName {
-    NSString *mangledIdentifierPropertyName = @"nqiregvfvatVqragvsvre";
-    return [self rot13:mangledIdentifierPropertyName];
+    return [self rot13:self.mangledIdentifierPropertyName];
 }
 
 - (NSString *)rot13:(NSString *)string {

--- a/Purchases/Attribution/RCAttributionTypeFactory.m
+++ b/Purchases/Attribution/RCAttributionTypeFactory.m
@@ -21,6 +21,10 @@ NS_ASSUME_NONNULL_BEGIN
     return @"nqiregvfvatVqragvsvre";
 }
 
+- (NSString *)mangledAuthStatusPropertyName {
+    return @"genpxvatNhgubevmngvbaFgnghf";
+}
+
 - (NSString *)mangledTrackingClassName {
     return @"NGGenpxvatZnantre";
 }
@@ -47,6 +51,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)asIdentifierPropertyName {
     return [self rot13:self.mangledIdentifierPropertyName];
+}
+
+- (NSString *)authorizationStatusPropertyName {
+    return [self rot13:self.mangledAuthStatusPropertyName];
 }
 
 - (NSString *)rot13:(NSString *)string {

--- a/Purchases/Attribution/RCAttributionTypeFactory.m
+++ b/Purchases/Attribution/RCAttributionTypeFactory.m
@@ -29,14 +29,14 @@ NS_ASSUME_NONNULL_BEGIN
     return @"NGGenpxvatZnantre";
 }
 
-- (Class<FakeATTrackingManager> _Nullable)atTrackingClass {
+- (Class<FakeTrackingManager> _Nullable)atTrackingClass {
     // We need to do this mangling to avoid Kid apps being rejected for getting idfa.
     // It looks like during the app review process Apple does some string matching looking for
     // functions in ATTrackingTransparency. We apply rot13 on these functions and classes names
     // so that Apple can't find them during the review, but we can still access them on runtime.
     NSString *className = [self rot13:self.mangledTrackingClassName];
 
-    return (Class<FakeATTrackingManager> _Nullable)NSClassFromString(className);
+    return (Class<FakeTrackingManager> _Nullable)NSClassFromString(className);
 }
 
 - (Class<FakeASIdentifierManager> _Nullable)asIdentifierClass {

--- a/PurchasesCoreSwift/Logging/Strings/AttributionStrings.swift
+++ b/PurchasesCoreSwift/Logging/Strings/AttributionStrings.swift
@@ -19,11 +19,11 @@ import Foundation
     @objc public var no_instance_configured_caching_attribution: String { "There is no purchase instance configured, caching attribution" }
     @objc public var instance_configured_posting_attribution: String { "There is a purchase instance configured, posting attribution" }
     @objc public var search_ads_attribution_cancelled_missing_att_framework: String {
-        "Tried to post Apple Search Ads Attribution, but AppTrackingTransparency is required on this OS" +
+        "Tried to post Apple Search Ads Attribution, but ATT Framework is required on this OS" +
             " and it isn't included";
     }
     @objc public var att_framework_present_but_couldnt_call_tracking_authorization_status: String {
-        "AppTrackingTransparency framework was found but it didn't respond to authorization status selector!";
+        "ATT Framework was found but it didn't respond to authorization status selector!";
     }
     @objc public var search_ads_attribution_cancelled_missing_iad_framework: String {
         "Tried to post Apple Search Ads Attribution, but iAd Framework is is required for it" +

--- a/PurchasesCoreSwift/Logging/Strings/AttributionStrings.swift
+++ b/PurchasesCoreSwift/Logging/Strings/AttributionStrings.swift
@@ -22,6 +22,9 @@ import Foundation
         "Tried to post Apple Search Ads Attribution, but AppTrackingTransparency is required on this OS" +
             " and it isn't included";
     }
+    @objc public var att_framework_present_but_couldnt_call_tracking_authorization_status: String {
+        "AppTrackingTransparency framework was found but it didn't respond to authorization status selector!";
+    }
     @objc public var search_ads_attribution_cancelled_missing_iad_framework: String {
         "Tried to post Apple Search Ads Attribution, but iAd Framework is is required for it" +
             " and it isn't included";

--- a/PurchasesTests/Attribution/AttributionFetcherTests.swift
+++ b/PurchasesTests/Attribution/AttributionFetcherTests.swift
@@ -42,7 +42,7 @@ class AttributionFetcherTests: XCTestCase {
 
     private func resetAttributionStaticProperties() {
         if #available(iOS 14, macOS 11, tvOS 14, *) {
-            MockATTrackingManager.mockAuthorizationStatus = .authorized
+            MockTrackingManager.mockAuthorizationStatus = .authorized
         }
         MockAttributionTypeFactory.shouldReturnAdClientClass = true
         MockAttributionTypeFactory.shouldReturnTrackingManagerClass = true
@@ -140,7 +140,7 @@ class AttributionFetcherTests: XCTestCase {
     func testPostAppleSearchAdsAttributionIfNeededPostsIfAuthorizedOnNewOS() {
         if #available(iOS 14, macOS 11, tvOS 14, *) {
             systemInfo.stubbedIsOperatingSystemAtLeastVersion = true
-            MockATTrackingManager.mockAuthorizationStatus = .authorized
+            MockTrackingManager.mockAuthorizationStatus = .authorized
             MockAttributionTypeFactory.shouldReturnAdClientClass = true
             MockAttributionTypeFactory.shouldReturnTrackingManagerClass = true
 
@@ -153,7 +153,7 @@ class AttributionFetcherTests: XCTestCase {
     func testPostAppleSearchAdsAttributionIfNeededPostsIfAuthorizedOnOldOS() {
         if #available(iOS 14, macOS 11, tvOS 14, *) {
             systemInfo.stubbedIsOperatingSystemAtLeastVersion = false
-            MockATTrackingManager.mockAuthorizationStatus = .authorized
+            MockTrackingManager.mockAuthorizationStatus = .authorized
             MockAttributionTypeFactory.shouldReturnAdClientClass = true
             MockAttributionTypeFactory.shouldReturnTrackingManagerClass = true
 
@@ -166,7 +166,7 @@ class AttributionFetcherTests: XCTestCase {
     func testPostAppleSearchAdsAttributionIfNeededPostsIfAuthNotDeterminedOnOldOS() {
         if #available(iOS 14, macOS 11, tvOS 14, *) {
             systemInfo.stubbedIsOperatingSystemAtLeastVersion = false
-            MockATTrackingManager.mockAuthorizationStatus = .notDetermined
+            MockTrackingManager.mockAuthorizationStatus = .notDetermined
             MockAttributionTypeFactory.shouldReturnAdClientClass = true
             MockAttributionTypeFactory.shouldReturnTrackingManagerClass = true
 
@@ -180,7 +180,7 @@ class AttributionFetcherTests: XCTestCase {
         if #available(iOS 14, macOS 11, tvOS 14, *) {
             systemInfo.stubbedIsOperatingSystemAtLeastVersion = true
 
-            MockATTrackingManager.mockAuthorizationStatus = .notDetermined
+            MockTrackingManager.mockAuthorizationStatus = .notDetermined
             MockAttributionTypeFactory.shouldReturnAdClientClass = true
             MockAttributionTypeFactory.shouldReturnTrackingManagerClass = true
 
@@ -194,7 +194,7 @@ class AttributionFetcherTests: XCTestCase {
     func testPostAppleSearchAdsAttributionIfNeededSkipsIfNotAuthorizedOnOldOS() {
         if #available(iOS 14, macOS 11, tvOS 14, *) {
             systemInfo.stubbedIsOperatingSystemAtLeastVersion = false
-            MockATTrackingManager.mockAuthorizationStatus = .denied
+            MockTrackingManager.mockAuthorizationStatus = .denied
             MockAttributionTypeFactory.shouldReturnAdClientClass = true
             MockAttributionTypeFactory.shouldReturnTrackingManagerClass = true
 
@@ -207,7 +207,7 @@ class AttributionFetcherTests: XCTestCase {
     func testPostAppleSearchAdsAttributionIfNeededSkipsIfNotAuthorizedOnNewOS() {
         if #available(iOS 14, macOS 11, tvOS 14, *) {
             systemInfo.stubbedIsOperatingSystemAtLeastVersion = true
-            MockATTrackingManager.mockAuthorizationStatus = .denied
+            MockTrackingManager.mockAuthorizationStatus = .denied
             MockAttributionTypeFactory.shouldReturnAdClientClass = true
             MockAttributionTypeFactory.shouldReturnTrackingManagerClass = true
 
@@ -219,7 +219,7 @@ class AttributionFetcherTests: XCTestCase {
 
     func testPostAppleSearchAdsAttributionIfNeededSkipsIfAlreadySent() {
         if #available(iOS 14, macOS 11, tvOS 14, *) {
-            MockATTrackingManager.mockAuthorizationStatus = .authorized
+            MockTrackingManager.mockAuthorizationStatus = .authorized
             MockAttributionTypeFactory.shouldReturnAdClientClass = true
             MockAttributionTypeFactory.shouldReturnTrackingManagerClass = true
 

--- a/PurchasesTests/Attribution/AttributionTypeFactoryTests.swift
+++ b/PurchasesTests/Attribution/AttributionTypeFactoryTests.swift
@@ -27,7 +27,7 @@ class AttributionTypeFactoryTests: XCTestCase {
 
     func testCanRotateASIdentifierManagerBack() {
         let expected = "ASIdentifierManager"
-        let randomized = "NFVqragvsvreZnantre"
+        let randomized = self.attributionTypeFactory.mangledIdentifierClassName
 
         expect { self.attributionTypeFactory.rot13(randomized) }.to(equal(expected))
     }
@@ -42,7 +42,22 @@ class AttributionTypeFactoryTests: XCTestCase {
 
     func testCanRotateAdvertisingIdentifierBack() {
         let expected = "advertisingIdentifier"
-        let randomized = "nqiregvfvatVqragvsvre"
+        let randomized = self.attributionTypeFactory.mangledIdentifierPropertyName
+
+        expect { self.attributionTypeFactory.rot13(randomized) }.to(equal(expected))
+    }
+
+    func testCanRotateATTrackingManager() {
+        let expected = "ATTrackingManager"
+        let randomized = attributionTypeFactory.rot13(expected)
+
+        expect { randomized }.notTo(equal(expected))
+        expect { self.attributionTypeFactory.rot13(randomized) }.to(equal(expected))
+    }
+
+    func testCanRotateATTrackingManagerBack() {
+        let expected = "ATTrackingManager"
+        let randomized = self.attributionTypeFactory.mangledTrackingClassName
 
         expect { self.attributionTypeFactory.rot13(randomized) }.to(equal(expected))
     }

--- a/PurchasesTests/Attribution/AttributionTypeFactoryTests.swift
+++ b/PurchasesTests/Attribution/AttributionTypeFactoryTests.swift
@@ -61,4 +61,19 @@ class AttributionTypeFactoryTests: XCTestCase {
 
         expect { self.attributionTypeFactory.rot13(randomized) }.to(equal(expected))
     }
+
+    func testCanRotateTrackingAuthorizationStatus() {
+        let expected = "trackingAuthorizationStatus"
+
+        let randomized = attributionTypeFactory.rot13(expected)
+        expect { randomized }.notTo(equal(expected))
+        expect { self.attributionTypeFactory.rot13(randomized) }.to(equal(expected))
+    }
+
+    func testCanRotateTrackingAuthorizationStatusBack() {
+        let expected = "trackingAuthorizationStatus"
+        let randomized = self.attributionTypeFactory.mangledAuthStatusPropertyName
+
+        expect { self.attributionTypeFactory.rot13(randomized) }.to(equal(expected))
+    }
 }

--- a/PurchasesTests/Attribution/AttributionTypeFactoryTests.swift
+++ b/PurchasesTests/Attribution/AttributionTypeFactoryTests.swift
@@ -47,7 +47,7 @@ class AttributionTypeFactoryTests: XCTestCase {
         expect { self.attributionTypeFactory.rot13(randomized) }.to(equal(expected))
     }
 
-    func testCanRotateATTrackingManager() {
+    func testCanRotateTrackingManager() {
         let expected = "ATTrackingManager"
         let randomized = attributionTypeFactory.rot13(expected)
 
@@ -55,7 +55,7 @@ class AttributionTypeFactoryTests: XCTestCase {
         expect { self.attributionTypeFactory.rot13(randomized) }.to(equal(expected))
     }
 
-    func testCanRotateATTrackingManagerBack() {
+    func testCanRotateTrackingManagerBack() {
         let expected = "ATTrackingManager"
         let randomized = self.attributionTypeFactory.mangledTrackingClassName
 

--- a/PurchasesTests/Mocks/MockAttributionTypeFactory.swift
+++ b/PurchasesTests/Mocks/MockAttributionTypeFactory.swift
@@ -34,7 +34,7 @@ class MockAdClient: NSObject, FakeAdClient {
 class MockATTrackingManager: NSObject, FakeATTrackingManager {
     static var mockAuthorizationStatus: ATTrackingManager.AuthorizationStatus = .authorized
 
-    static func trackingAuthStatusProperty() -> Int {
+    static func trackingAuthorizationStatus() -> Int {
         return Int(mockAuthorizationStatus.rawValue)
     }
 }

--- a/PurchasesTests/Mocks/MockAttributionTypeFactory.swift
+++ b/PurchasesTests/Mocks/MockAttributionTypeFactory.swift
@@ -34,7 +34,7 @@ class MockAdClient: NSObject, FakeAdClient {
 class MockATTrackingManager: NSObject, FakeATTrackingManager {
     static var mockAuthorizationStatus: ATTrackingManager.AuthorizationStatus = .authorized
 
-    static func trackingAuthorizationStatus() -> Int {
+    static func trackingAuthStatusProperty() -> Int {
         return Int(mockAuthorizationStatus.rawValue)
     }
 }

--- a/PurchasesTests/Mocks/MockAttributionTypeFactory.swift
+++ b/PurchasesTests/Mocks/MockAttributionTypeFactory.swift
@@ -31,7 +31,7 @@ class MockAdClient: NSObject, FakeAdClient {
 }
 
 @available(iOS 14, macOS 11, tvOS 14, *)
-class MockATTrackingManager: NSObject, FakeATTrackingManager {
+class MockTrackingManager: NSObject, FakeTrackingManager {
     static var mockAuthorizationStatus: ATTrackingManager.AuthorizationStatus = .authorized
 
     static func trackingAuthorizationStatus() -> Int {
@@ -48,9 +48,9 @@ class MockAttributionTypeFactory: AttributionTypeFactory {
 
     static var shouldReturnTrackingManagerClass = true
 
-    override func atTrackingClass() -> FakeATTrackingManager.Type? {
+    override func atTrackingClass() -> FakeTrackingManager.Type? {
         if #available(iOS 14, macOS 11, tvOS 14, *) {
-            return Self.shouldReturnTrackingManagerClass ? MockATTrackingManager.self : nil
+            return Self.shouldReturnTrackingManagerClass ? MockTrackingManager.self : nil
         } else {
             return nil
         }

--- a/PurchasesTests/Mocks/MockAttributionTypeFactory.swift
+++ b/PurchasesTests/Mocks/MockAttributionTypeFactory.swift
@@ -48,7 +48,7 @@ class MockAttributionTypeFactory: AttributionTypeFactory {
 
     static var shouldReturnTrackingManagerClass = true
 
-    override func atTrackingManagerClass() -> FakeATTrackingManager.Type? {
+    override func atTrackingClass() -> FakeATTrackingManager.Type? {
         if #available(iOS 14, macOS 11, tvOS 14, *) {
             return Self.shouldReturnTrackingManagerClass ? MockATTrackingManager.self : nil
         } else {


### PR DESCRIPTION
Obfuscates our soft-linking of the `AppAtrackingTransparency` framework, since Apple seems to be doing string searches for `ATTrackingManager` and rejecting apps even if they don't actually use `AppAtrackingTransparency`. 

Changes summary: 

Replaced the strings for ATT framework with ROT13 versions. 

Since we can't reference the property directly and it's a class property, calling it through KVC isn't possible, because the class itself isn't KVC-compatible (although all _instances of it would be). 

Since KVC won't work, I first tried with `performSelector`... but because the selector is created from a string, this actually [creates possible leaks](https://stackoverflow.com/a/20058585/5074358), because ARC isn't sure how to manage the return value. Note that the solution described in that SO reply doesn't actually work correctly anymore. 

So this left me with `NSInvocation`, which is sort of a more cumbersome version of the same idea. This one seems to work correctly on device. 

It did however force me to replace 

```objective-c
Class<FakeATTrackingManager> _Nullable trackingManagerClass
```

with 

```objective-c
Class _Nullable trackingManagerClass
```

Otherwise `methodSignatureForSelector` wouldn't be found for `trackingManagerClass`, but I'm not sure why. 
