### PR TITLE
Fix: add prefix to foundation extensions

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "AliSoftware/OHHTTPStubs" "9.1.0"
-github "Quick/Nimble" "v9.0.0"
+github "Quick/Nimble" "v9.0.1"

--- a/Purchases/FoundationExtensions/NSData+RCExtensions.h
+++ b/Purchases/FoundationExtensions/NSData+RCExtensions.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSData (RCExtensions)
 
-- (NSString *)asString;
+- (NSString *)rc_asString;
 
 @end
 

--- a/Purchases/FoundationExtensions/NSData+RCExtensions.m
+++ b/Purchases/FoundationExtensions/NSData+RCExtensions.m
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation NSData (RCExtensions)
 
-- (NSString *)asString {
+- (NSString *)rc_asString {
     NSMutableString *deviceTokenString = [NSMutableString string];
     [self enumerateByteRangesUsingBlock:^(const void *bytes,
                                           NSRange byteRange,

--- a/Purchases/FoundationExtensions/NSDate+RCExtensions.h
+++ b/Purchases/FoundationExtensions/NSDate+RCExtensions.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSDate (RCExtensions)
 
-- (UInt64)millisecondsSince1970;
+- (UInt64)rc_millisecondsSince1970InUInt64;
 
 @end
 

--- a/Purchases/FoundationExtensions/NSDate+RCExtensions.h
+++ b/Purchases/FoundationExtensions/NSDate+RCExtensions.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSDate (RCExtensions)
 
-- (UInt64)rc_UInt64MillisecondsSince1970;
+- (UInt64)rc_uint64MillisecondsSince1970;
 
 @end
 

--- a/Purchases/FoundationExtensions/NSDate+RCExtensions.h
+++ b/Purchases/FoundationExtensions/NSDate+RCExtensions.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSDate (RCExtensions)
 
-- (UInt64)rc_millisecondsSince1970InUInt64;
+- (UInt64)rc_UInt64MillisecondsSince1970;
 
 @end
 

--- a/Purchases/FoundationExtensions/NSDate+RCExtensions.h
+++ b/Purchases/FoundationExtensions/NSDate+RCExtensions.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSDate (RCExtensions)
 
-- (UInt64)rc_uint64MillisecondsSince1970;
+- (UInt64)rc_millisecondsSince1970AsUInt64;
 
 @end
 

--- a/Purchases/FoundationExtensions/NSDate+RCExtensions.m
+++ b/Purchases/FoundationExtensions/NSDate+RCExtensions.m
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation NSDate (RCExtensions)
 
-- (UInt64)rc_millisecondsSince1970InUInt64 {
+- (UInt64)rc_UInt64MillisecondsSince1970 {
     return (UInt64)([self timeIntervalSince1970] * 1000.0);
 }
 

--- a/Purchases/FoundationExtensions/NSDate+RCExtensions.m
+++ b/Purchases/FoundationExtensions/NSDate+RCExtensions.m
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation NSDate (RCExtensions)
 
-- (UInt64)rc_UInt64MillisecondsSince1970 {
+- (UInt64)rc_uint64MillisecondsSince1970 {
     return (UInt64)([self timeIntervalSince1970] * 1000.0);
 }
 

--- a/Purchases/FoundationExtensions/NSDate+RCExtensions.m
+++ b/Purchases/FoundationExtensions/NSDate+RCExtensions.m
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation NSDate (RCExtensions)
 
-- (UInt64)millisecondsSince1970 {
+- (UInt64)rc_millisecondsSince1970InUInt64 {
     return (UInt64)([self timeIntervalSince1970] * 1000.0);
 }
 

--- a/Purchases/FoundationExtensions/NSDate+RCExtensions.m
+++ b/Purchases/FoundationExtensions/NSDate+RCExtensions.m
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation NSDate (RCExtensions)
 
-- (UInt64)rc_uint64MillisecondsSince1970 {
+- (UInt64)rc_millisecondsSince1970AsUInt64 {
     return (UInt64)([self timeIntervalSince1970] * 1000.0);
 }
 

--- a/Purchases/FoundationExtensions/NSDictionary+RCExtensions.h
+++ b/Purchases/FoundationExtensions/NSDictionary+RCExtensions.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSDictionary (RCExtensions)
 
-- (NSDictionary *)removingNSNullValues;
+- (NSDictionary *)rc_removingNSNullValues;
 
 @end
 

--- a/Purchases/FoundationExtensions/NSDictionary+RCExtensions.m
+++ b/Purchases/FoundationExtensions/NSDictionary+RCExtensions.m
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation NSDictionary (RCExtensions)
 
-- (NSDictionary *)removingNSNullValues {
+- (NSDictionary *)rc_removingNSNullValues {
     NSMutableDictionary *result = [[NSMutableDictionary alloc] init];
     
     NSEnumerator *enumerator = [self keyEnumerator];

--- a/Purchases/FoundationExtensions/NSError+RCExtensions.h
+++ b/Purchases/FoundationExtensions/NSError+RCExtensions.h
@@ -10,8 +10,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSError (RCExtensions)
 
-- (BOOL)successfullySynced;
-- (nullable NSDictionary *)subscriberAttributesErrors;
+- (BOOL)rc_successfullySynced;
+- (nullable NSDictionary *)rc_subscriberAttributesErrors;
 
 @end
 

--- a/Purchases/FoundationExtensions/NSError+RCExtensions.m
+++ b/Purchases/FoundationExtensions/NSError+RCExtensions.m
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation NSError (RCExtensions)
 
-- (BOOL)successfullySynced {
+- (BOOL)rc_successfullySynced {
     if (self.code == RCNetworkError) {
         return NO;
     }
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
     return successfullySyncedNumber.boolValue;
 }
 
-- (nullable NSDictionary *)subscriberAttributesErrors {
+- (nullable NSDictionary *)rc_subscriberAttributesErrors {
     return self.userInfo[RCAttributeErrorsKey];
 }
 

--- a/Purchases/Networking/RCBackend.m
+++ b/Purchases/Networking/RCBackend.m
@@ -20,7 +20,7 @@
 @import PurchasesCoreSwift;
 
 #define RC_HAS_KEY(dictionary, key) (dictionary[key] == nil || dictionary[key] != [NSNull null])
-NSErrorUserInfoKey const RCSuccessfullySyncedKey = @"successfullySynced";
+NSErrorUserInfoKey const RCSuccessfullySyncedKey = @"rc_successfullySynced";
 NSString *const RCAttributeErrorsKey = @"attribute_errors";
 NSString *const RCAttributeErrorsResponseKey = @"attributes_error_response";
 

--- a/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.m
+++ b/Purchases/SubscriberAttributes/RCPurchases+SubscriberAttributes.m
@@ -35,12 +35,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)markAttributesAsSyncedIfNeeded:(nullable RCSubscriberAttributeDict)syncedAttributes
                              appUserID:(NSString *)appUserID
                                  error:(nullable NSError *)error {
-    if (error && !error.successfullySynced) {
+    if (error && !error.rc_successfullySynced) {
         return;
     }
 
-    if (error.subscriberAttributesErrors) {
-        RCErrorLog(RCStrings.attribution.subscriber_attributes_error, error.subscriberAttributesErrors);
+    if (error.rc_subscriberAttributesErrors) {
+        RCErrorLog(RCStrings.attribution.subscriber_attributes_error, error.rc_subscriberAttributesErrors);
     }
     [self.subscriberAttributesManager markAttributesAsSynced:syncedAttributes appUserID:appUserID];
 }

--- a/Purchases/SubscriberAttributes/RCSubscriberAttribute.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttribute.m
@@ -80,7 +80,7 @@ NS_ASSUME_NONNULL_END
 - (NSDictionary <NSString *, NSObject *> *)asBackendDictionary {
     return @{
         BACKEND_VALUE_KEY: self.value ?: @"",
-        BACKEND_TIMESTAMP_KEY: @(self.setTime.millisecondsSince1970)
+        BACKEND_TIMESTAMP_KEY: @(self.setTime.rc_millisecondsSince1970InUInt64)
     };
 }
 

--- a/Purchases/SubscriberAttributes/RCSubscriberAttribute.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttribute.m
@@ -80,7 +80,7 @@ NS_ASSUME_NONNULL_END
 - (NSDictionary <NSString *, NSObject *> *)asBackendDictionary {
     return @{
         BACKEND_VALUE_KEY: self.value ?: @"",
-        BACKEND_TIMESTAMP_KEY: @(self.setTime.rc_uint64MillisecondsSince1970)
+        BACKEND_TIMESTAMP_KEY: @(self.setTime.rc_millisecondsSince1970AsUInt64)
     };
 }
 

--- a/Purchases/SubscriberAttributes/RCSubscriberAttribute.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttribute.m
@@ -80,7 +80,7 @@ NS_ASSUME_NONNULL_END
 - (NSDictionary <NSString *, NSObject *> *)asBackendDictionary {
     return @{
         BACKEND_VALUE_KEY: self.value ?: @"",
-        BACKEND_TIMESTAMP_KEY: @(self.setTime.rc_millisecondsSince1970InUInt64)
+        BACKEND_TIMESTAMP_KEY: @(self.setTime.rc_UInt64MillisecondsSince1970)
     };
 }
 

--- a/Purchases/SubscriberAttributes/RCSubscriberAttribute.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttribute.m
@@ -80,7 +80,7 @@ NS_ASSUME_NONNULL_END
 - (NSDictionary <NSString *, NSObject *> *)asBackendDictionary {
     return @{
         BACKEND_VALUE_KEY: self.value ?: @"",
-        BACKEND_TIMESTAMP_KEY: @(self.setTime.rc_UInt64MillisecondsSince1970)
+        BACKEND_TIMESTAMP_KEY: @(self.setTime.rc_uint64MillisecondsSince1970)
     };
 }
 

--- a/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setPushToken:(nullable NSData *)pushToken appUserID:(NSString *)appUserID {
-    NSString *pushTokenString = pushToken ? pushToken.asString : nil;
+    NSString *pushTokenString = pushToken ? pushToken.rc_asString : nil;
     [self setPushTokenString:pushTokenString appUserID:appUserID];
 }
 
@@ -170,7 +170,7 @@ NS_ASSUME_NONNULL_BEGIN
           forAppUserID:(NSString *)appUserID
             completion:(void (^)(NSError *))completion {
     [self.backend postSubscriberAttributes:attributes appUserID:appUserID completion:^(NSError *error) {
-        BOOL didBackendReceiveValues = (error == nil || error.successfullySynced);
+        BOOL didBackendReceiveValues = (error == nil || error.rc_successfullySynced);
 
         if (didBackendReceiveValues) {
             [self markAttributesAsSynced:attributes appUserID:appUserID];

--- a/PurchasesTests/FoundationExtensions/NSData+RCExtensionsTests.swift
+++ b/PurchasesTests/FoundationExtensions/NSData+RCExtensionsTests.swift
@@ -24,6 +24,6 @@ class NSDataExtensionsTests: XCTestCase {
 
         let nsData = data as NSData
 
-        expect(nsData.asString()) == "e388152d6c67f4d5f7a78edf073946f158357f89a1dc74dff80a796740fd9d91"
+        expect(nsData.rc_asString()) == "e388152d6c67f4d5f7a78edf073946f158357f89a1dc74dff80a796740fd9d91"
     }
 }

--- a/PurchasesTests/FoundationExtensions/NSDate+RCExtensionsTests.swift
+++ b/PurchasesTests/FoundationExtensions/NSDate+RCExtensionsTests.swift
@@ -11,13 +11,13 @@ import Purchases
 class NSDateExtensionsTests: XCTestCase {
     func testMillisecondsSince1970ConvertsCorrectlyWithCurrentTime() {
         let date = NSDate()
-        expect(date.rc_uint64MillisecondsSince1970()) == (UInt64)(date.timeIntervalSince1970 * 1000)
+        expect(date.rc_millisecondsSince1970AsUInt64()) == (UInt64)(date.timeIntervalSince1970 * 1000)
     }
 
     func testMillisecondsSince1970ConvertsCorrectlyWithFixedTime() {
         let secondsSince1970: TimeInterval = 1619555571.0
         let millisecondsSince1970UInt64: UInt64 = 1619555571000
         let date = NSDate(timeIntervalSince1970: secondsSince1970)
-        expect(date.rc_uint64MillisecondsSince1970()) == millisecondsSince1970UInt64
+        expect(date.rc_millisecondsSince1970AsUInt64()) == millisecondsSince1970UInt64
     }
 }

--- a/PurchasesTests/FoundationExtensions/NSDate+RCExtensionsTests.swift
+++ b/PurchasesTests/FoundationExtensions/NSDate+RCExtensionsTests.swift
@@ -11,13 +11,13 @@ import Purchases
 class NSDateExtensionsTests: XCTestCase {
     func testMillisecondsSince1970ConvertsCorrectlyWithCurrentTime() {
         let date = NSDate()
-        expect(date.rc_UInt64MillisecondsSince1970()) == (UInt64)(date.timeIntervalSince1970 * 1000)
+        expect(date.rc_uint64MillisecondsSince1970()) == (UInt64)(date.timeIntervalSince1970 * 1000)
     }
 
     func testMillisecondsSince1970ConvertsCorrectlyWithFixedTime() {
         let secondsSince1970: TimeInterval = 1619555571.0
         let millisecondsSince1970UInt64: UInt64 = 1619555571000
         let date = NSDate(timeIntervalSince1970: secondsSince1970)
-        expect(date.rc_UInt64MillisecondsSince1970()) == millisecondsSince1970UInt64
+        expect(date.rc_uint64MillisecondsSince1970()) == millisecondsSince1970UInt64
     }
 }

--- a/PurchasesTests/FoundationExtensions/NSDate+RCExtensionsTests.swift
+++ b/PurchasesTests/FoundationExtensions/NSDate+RCExtensionsTests.swift
@@ -9,8 +9,15 @@ import XCTest
 import Purchases
 
 class NSDateExtensionsTests: XCTestCase {
-    func testMillisecondsSince1970PerformsCorrectConversion() {
+    func testMillisecondsSince1970ConvertsCorrectlyWithCurrentTime() {
         let date = NSDate()
         expect(date.rc_millisecondsSince1970InUInt64()) == (UInt64)(date.timeIntervalSince1970 * 1000)
+    }
+
+    func testMillisecondsSince1970ConvertsCorrectlyWithFixedTime() {
+        let secondsSince1970: TimeInterval = 1619555571.0
+        let millisecondsSince1970UInt64: UInt64 = 1619555571000
+        let date = NSDate(timeIntervalSince1970: secondsSince1970)
+        expect(date.rc_millisecondsSince1970InUInt64()) == millisecondsSince1970UInt64
     }
 }

--- a/PurchasesTests/FoundationExtensions/NSDate+RCExtensionsTests.swift
+++ b/PurchasesTests/FoundationExtensions/NSDate+RCExtensionsTests.swift
@@ -11,13 +11,13 @@ import Purchases
 class NSDateExtensionsTests: XCTestCase {
     func testMillisecondsSince1970ConvertsCorrectlyWithCurrentTime() {
         let date = NSDate()
-        expect(date.rc_millisecondsSince1970InUInt64()) == (UInt64)(date.timeIntervalSince1970 * 1000)
+        expect(date.rc_UInt64MillisecondsSince1970()) == (UInt64)(date.timeIntervalSince1970 * 1000)
     }
 
     func testMillisecondsSince1970ConvertsCorrectlyWithFixedTime() {
         let secondsSince1970: TimeInterval = 1619555571.0
         let millisecondsSince1970UInt64: UInt64 = 1619555571000
         let date = NSDate(timeIntervalSince1970: secondsSince1970)
-        expect(date.rc_millisecondsSince1970InUInt64()) == millisecondsSince1970UInt64
+        expect(date.rc_UInt64MillisecondsSince1970()) == millisecondsSince1970UInt64
     }
 }

--- a/PurchasesTests/FoundationExtensions/NSDate+RCExtensionsTests.swift
+++ b/PurchasesTests/FoundationExtensions/NSDate+RCExtensionsTests.swift
@@ -9,8 +9,8 @@ import XCTest
 import Purchases
 
 class NSDateExtensionsTests: XCTestCase {
-    func testMillisecondsSince1970() {
+    func testMillisecondsSince1970PerformsCorrectConversion() {
         let date = NSDate()
-        expect(date.millisecondsSince1970()) == (UInt64)(date.timeIntervalSince1970 * 1000)
+        expect(date.rc_millisecondsSince1970InUInt64()) == (UInt64)(date.timeIntervalSince1970 * 1000)
     }
 }

--- a/PurchasesTests/FoundationExtensions/NSError+RCExtensionsTests.swift
+++ b/PurchasesTests/FoundationExtensions/NSError+RCExtensionsTests.swift
@@ -14,31 +14,31 @@ class NSErrorRCExtensionsTests: XCTestCase {
     func testSuccessfullySyncedFalseIfCodeIsNetworkError() {
         let errorCode = Purchases.ErrorCode.networkError.rawValue
         let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [:])
-        expect(error.successfullySynced()) == false
+        expect(error.rc_successfullySynced()) == false
     }
 
     func testSuccessfullySyncedFalseIfNotShouldMarkSynced() {
         let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
         let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [RCSuccessfullySyncedKey: false])
-        expect(error.successfullySynced()) == false
+        expect(error.rc_successfullySynced()) == false
     }
 
     func testSuccessfullySyncedFalseIfShouldMarkSyncedNotPresent() {
         let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
         let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [:])
-        expect(error.successfullySynced()) == false
+        expect(error.rc_successfullySynced()) == false
     }
 
     func testSuccessfullySyncedTrueIfShouldMarkSynced() {
         let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
         let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [RCSuccessfullySyncedKey: true])
-        expect(error.successfullySynced()) == true
+        expect(error.rc_successfullySynced()) == true
     }
 
     func testSubscriberAttributesErrorsNilIfNoAttributesErrors() {
         let errorCode = Purchases.ErrorCode.purchaseNotAllowedError.rawValue
         let error = NSError(domain: Purchases.ErrorDomain, code: errorCode, userInfo: [RCSuccessfullySyncedKey: true])
-        expect(error.subscriberAttributesErrors()).to(beNil())
+        expect(error.rc_subscriberAttributesErrors()).to(beNil())
     }
 
     func testSubscriberAttributesErrorsReturnsAttributesErrorsInUserInfo() {
@@ -48,7 +48,7 @@ class NSErrorRCExtensionsTests: XCTestCase {
         let error = NSError(domain: Purchases.ErrorDomain,
                             code: errorCode,
                             userInfo: [RCAttributeErrorsKey: attributeErrors])
-        expect(error.subscriberAttributesErrors()).toNot(beNil())
-        expect(error.subscriberAttributesErrors() as? [String: String]) == attributeErrors
+        expect(error.rc_subscriberAttributesErrors()).toNot(beNil())
+        expect(error.rc_subscriberAttributesErrors() as? [String: String]) == attributeErrors
     }
 }

--- a/PurchasesTests/Misc/NSDictionaryExtensionsTests.swift
+++ b/PurchasesTests/Misc/NSDictionaryExtensionsTests.swift
@@ -23,12 +23,12 @@ class NSDictionaryExtensionsTests: XCTestCase {
             "type": 1
         ]
         
-        expect(testValues.removingNSNullValues() as NSDictionary) == expectedValues
+        expect(testValues.rc_removingNSNullValues() as NSDictionary) == expectedValues
     }
     
     func testRemovingNSNullValuesReturnsEmptyIfOriginalIsEmpty() {
         let testValues = NSDictionary()
         
-        expect(testValues.removingNSNullValues() as NSDictionary) == testValues
+        expect(testValues.rc_removingNSNullValues() as NSDictionary) == testValues
     }
 }

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -69,11 +69,11 @@ class BackendSubscriberAttributesTests: XCTestCase {
         let expectedBody: [String: [String: NSObject]] = [
             "attributes": [
                 subscriberAttribute1.key: [
-                    "updated_at_ms": (subscriberAttribute1.setTime as NSDate).rc_UInt64MillisecondsSince1970(),
+                    "updated_at_ms": (subscriberAttribute1.setTime as NSDate).rc_uint64MillisecondsSince1970(),
                     "value": subscriberAttribute1.value
                 ] as NSObject,
                 subscriberAttribute2.key: [
-                    "updated_at_ms": (subscriberAttribute2.setTime as NSDate).rc_UInt64MillisecondsSince1970(),
+                    "updated_at_ms": (subscriberAttribute2.setTime as NSDate).rc_uint64MillisecondsSince1970(),
                     "value": subscriberAttribute2.value
                 ] as NSObject,
             ]
@@ -291,11 +291,11 @@ class BackendSubscriberAttributesTests: XCTestCase {
 
         let expectedBody: [String: NSObject] = [
             subscriberAttribute1.key: [
-                "updated_at_ms": (subscriberAttribute1.setTime as NSDate).rc_UInt64MillisecondsSince1970(),
+                "updated_at_ms": (subscriberAttribute1.setTime as NSDate).rc_uint64MillisecondsSince1970(),
                 "value": subscriberAttribute1.value
             ] as NSObject,
             subscriberAttribute2.key: [
-                "updated_at_ms": (subscriberAttribute2.setTime as NSDate).rc_UInt64MillisecondsSince1970(),
+                "updated_at_ms": (subscriberAttribute2.setTime as NSDate).rc_uint64MillisecondsSince1970(),
                 "value": subscriberAttribute2.value
             ] as NSObject
         ]

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -69,11 +69,11 @@ class BackendSubscriberAttributesTests: XCTestCase {
         let expectedBody: [String: [String: NSObject]] = [
             "attributes": [
                 subscriberAttribute1.key: [
-                    "updated_at_ms": (subscriberAttribute1.setTime as NSDate).millisecondsSince1970(),
+                    "updated_at_ms": (subscriberAttribute1.setTime as NSDate).rc_millisecondsSince1970InUInt64(),
                     "value": subscriberAttribute1.value
                 ] as NSObject,
                 subscriberAttribute2.key: [
-                    "updated_at_ms": (subscriberAttribute2.setTime as NSDate).millisecondsSince1970(),
+                    "updated_at_ms": (subscriberAttribute2.setTime as NSDate).rc_millisecondsSince1970InUInt64(),
                     "value": subscriberAttribute2.value
                 ] as NSObject,
             ]
@@ -125,7 +125,7 @@ class BackendSubscriberAttributesTests: XCTestCase {
         let receivedNSError = receivedError! as NSError
 
         expect(receivedNSError.code) == Purchases.ErrorCode.networkError.rawValue
-        expect(receivedNSError.successfullySynced()) == false
+        expect(receivedNSError.rc_successfullySynced()) == false
     }
 
     func testPostSubscriberAttributesCallsCompletionWithErrorInBackendErrorCase() {
@@ -152,7 +152,7 @@ class BackendSubscriberAttributesTests: XCTestCase {
 
         let receivedNSError = receivedError! as NSError
         expect(receivedNSError.code) == Purchases.ErrorCode.unknownBackendError.rawValue
-        expect(receivedNSError.successfullySynced()) == false
+        expect(receivedNSError.rc_successfullySynced()) == false
         expect(receivedNSError.userInfo[RCSuccessfullySyncedKey]).toNot(beNil())
         expect((receivedNSError.userInfo[RCSuccessfullySyncedKey] as! NSNumber).boolValue) == false
     }
@@ -215,7 +215,7 @@ class BackendSubscriberAttributesTests: XCTestCase {
 
         let receivedNSError = receivedError! as NSError
         expect(receivedNSError.code) == Purchases.ErrorCode.unknownBackendError.rawValue
-        expect(receivedNSError.successfullySynced()) == true
+        expect(receivedNSError.rc_successfullySynced()) == true
         expect(receivedNSError.userInfo[RCSuccessfullySyncedKey]).toNot(beNil())
         expect((receivedNSError.userInfo[RCSuccessfullySyncedKey] as! NSNumber).boolValue) == true
     }
@@ -254,7 +254,7 @@ class BackendSubscriberAttributesTests: XCTestCase {
 
        let receivedNSError = receivedError! as NSError
        expect(receivedNSError.code) == Purchases.ErrorCode.unknownBackendError.rawValue
-       expect(receivedNSError.successfullySynced()) == false
+       expect(receivedNSError.rc_successfullySynced()) == false
        expect(receivedNSError.userInfo[RCSuccessfullySyncedKey]).toNot(beNil())
        expect((receivedNSError.userInfo[RCSuccessfullySyncedKey] as! NSNumber).boolValue) == false
     }
@@ -291,11 +291,11 @@ class BackendSubscriberAttributesTests: XCTestCase {
 
         let expectedBody: [String: NSObject] = [
             subscriberAttribute1.key: [
-                "updated_at_ms": (subscriberAttribute1.setTime as NSDate).millisecondsSince1970(),
+                "updated_at_ms": (subscriberAttribute1.setTime as NSDate).rc_millisecondsSince1970InUInt64(),
                 "value": subscriberAttribute1.value
             ] as NSObject,
             subscriberAttribute2.key: [
-                "updated_at_ms": (subscriberAttribute2.setTime as NSDate).millisecondsSince1970(),
+                "updated_at_ms": (subscriberAttribute2.setTime as NSDate).rc_millisecondsSince1970InUInt64(),
                 "value": subscriberAttribute2.value
             ] as NSObject
         ]
@@ -360,8 +360,8 @@ class BackendSubscriberAttributesTests: XCTestCase {
 
         expect(receivedError).toNot(beNil())
         guard let nonNilReceivedError = receivedError else { fatalError() }
-        expect(nonNilReceivedError.successfullySynced()) == true
-        expect(nonNilReceivedError.subscriberAttributesErrors() as? [String: String])
+        expect(nonNilReceivedError.rc_successfullySynced()) == true
+        expect(nonNilReceivedError.rc_subscriberAttributesErrors() as? [String: String])
             == attributeErrors[RCAttributeErrorsKey]
     }
 
@@ -397,8 +397,8 @@ class BackendSubscriberAttributesTests: XCTestCase {
 
         expect(receivedError).toNot(beNil())
         guard let nonNilReceivedError = receivedError else { fatalError() }
-        expect(nonNilReceivedError.successfullySynced()) == true
-        expect(nonNilReceivedError.subscriberAttributesErrors() as? [String: String])
+        expect(nonNilReceivedError.rc_successfullySynced()) == true
+        expect(nonNilReceivedError.rc_subscriberAttributesErrors() as? [String: String])
             == attributeErrors[RCAttributeErrorsKey]
     }
 }

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -69,11 +69,11 @@ class BackendSubscriberAttributesTests: XCTestCase {
         let expectedBody: [String: [String: NSObject]] = [
             "attributes": [
                 subscriberAttribute1.key: [
-                    "updated_at_ms": (subscriberAttribute1.setTime as NSDate).rc_uint64MillisecondsSince1970(),
+                    "updated_at_ms": (subscriberAttribute1.setTime as NSDate).rc_millisecondsSince1970AsUInt64(),
                     "value": subscriberAttribute1.value
                 ] as NSObject,
                 subscriberAttribute2.key: [
-                    "updated_at_ms": (subscriberAttribute2.setTime as NSDate).rc_uint64MillisecondsSince1970(),
+                    "updated_at_ms": (subscriberAttribute2.setTime as NSDate).rc_millisecondsSince1970AsUInt64(),
                     "value": subscriberAttribute2.value
                 ] as NSObject,
             ]
@@ -291,11 +291,11 @@ class BackendSubscriberAttributesTests: XCTestCase {
 
         let expectedBody: [String: NSObject] = [
             subscriberAttribute1.key: [
-                "updated_at_ms": (subscriberAttribute1.setTime as NSDate).rc_uint64MillisecondsSince1970(),
+                "updated_at_ms": (subscriberAttribute1.setTime as NSDate).rc_millisecondsSince1970AsUInt64(),
                 "value": subscriberAttribute1.value
             ] as NSObject,
             subscriberAttribute2.key: [
-                "updated_at_ms": (subscriberAttribute2.setTime as NSDate).rc_uint64MillisecondsSince1970(),
+                "updated_at_ms": (subscriberAttribute2.setTime as NSDate).rc_millisecondsSince1970AsUInt64(),
                 "value": subscriberAttribute2.value
             ] as NSObject
         ]

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -69,11 +69,11 @@ class BackendSubscriberAttributesTests: XCTestCase {
         let expectedBody: [String: [String: NSObject]] = [
             "attributes": [
                 subscriberAttribute1.key: [
-                    "updated_at_ms": (subscriberAttribute1.setTime as NSDate).rc_millisecondsSince1970InUInt64(),
+                    "updated_at_ms": (subscriberAttribute1.setTime as NSDate).rc_UInt64MillisecondsSince1970(),
                     "value": subscriberAttribute1.value
                 ] as NSObject,
                 subscriberAttribute2.key: [
-                    "updated_at_ms": (subscriberAttribute2.setTime as NSDate).rc_millisecondsSince1970InUInt64(),
+                    "updated_at_ms": (subscriberAttribute2.setTime as NSDate).rc_UInt64MillisecondsSince1970(),
                     "value": subscriberAttribute2.value
                 ] as NSObject,
             ]
@@ -291,11 +291,11 @@ class BackendSubscriberAttributesTests: XCTestCase {
 
         let expectedBody: [String: NSObject] = [
             subscriberAttribute1.key: [
-                "updated_at_ms": (subscriberAttribute1.setTime as NSDate).rc_millisecondsSince1970InUInt64(),
+                "updated_at_ms": (subscriberAttribute1.setTime as NSDate).rc_UInt64MillisecondsSince1970(),
                 "value": subscriberAttribute1.value
             ] as NSObject,
             subscriberAttribute2.key: [
-                "updated_at_ms": (subscriberAttribute2.setTime as NSDate).rc_millisecondsSince1970InUInt64(),
+                "updated_at_ms": (subscriberAttribute2.setTime as NSDate).rc_UInt64MillisecondsSince1970(),
                 "value": subscriberAttribute2.value
             ] as NSObject
         ]

--- a/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -207,14 +207,14 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
     func testSetPushTokenMakesRightCalls() {
         setupPurchases()
         let tokenData = Data("ligai32g32ig".data(using: .utf8)!)
-        let tokenString = (tokenData as NSData).asString()
+        let tokenString = (tokenData as NSData).rc_asString()
 
         Purchases.shared.setPushToken(tokenData)
         expect(self.mockSubscriberAttributesManager.invokedSetPushTokenCount) == 1
 
         let receivedPushToken = self.mockSubscriberAttributesManager.invokedSetPushTokenParameters!.pushToken!
 
-        expect((receivedPushToken as NSData).asString()) == tokenString
+        expect((receivedPushToken as NSData).rc_asString()) == tokenString
         expect(self.mockSubscriberAttributesManager.invokedSetPushTokenParameters?.appUserID) == mockIdentityManager
             .currentAppUserID
     }

--- a/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
@@ -76,6 +76,6 @@ class SubscriberAttributeTests: XCTestCase {
 
         expect(receivedDictionary["value"] as? String) == value
         let updatedAtEpoch = (receivedDictionary["updated_at_ms"] as! NSNumber).uint64Value
-        expect(updatedAtEpoch) == (now as NSDate).millisecondsSince1970()
+        expect(updatedAtEpoch) == (now as NSDate).rc_millisecondsSince1970InUInt64()
     }
 }

--- a/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
@@ -76,6 +76,6 @@ class SubscriberAttributeTests: XCTestCase {
 
         expect(receivedDictionary["value"] as? String) == value
         let updatedAtEpoch = (receivedDictionary["updated_at_ms"] as! NSNumber).uint64Value
-        expect(updatedAtEpoch) == (now as NSDate).rc_UInt64MillisecondsSince1970()
+        expect(updatedAtEpoch) == (now as NSDate).rc_uint64MillisecondsSince1970()
     }
 }

--- a/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
@@ -76,6 +76,6 @@ class SubscriberAttributeTests: XCTestCase {
 
         expect(receivedDictionary["value"] as? String) == value
         let updatedAtEpoch = (receivedDictionary["updated_at_ms"] as! NSNumber).uint64Value
-        expect(updatedAtEpoch) == (now as NSDate).rc_millisecondsSince1970InUInt64()
+        expect(updatedAtEpoch) == (now as NSDate).rc_UInt64MillisecondsSince1970()
     }
 }

--- a/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SubscriberAttributeTests.swift
@@ -76,6 +76,6 @@ class SubscriberAttributeTests: XCTestCase {
 
         expect(receivedDictionary["value"] as? String) == value
         let updatedAtEpoch = (receivedDictionary["updated_at_ms"] as! NSNumber).uint64Value
-        expect(updatedAtEpoch) == (now as NSDate).rc_uint64MillisecondsSince1970()
+        expect(updatedAtEpoch) == (now as NSDate).rc_millisecondsSince1970AsUInt64()
     }
 }

--- a/PurchasesTests/SubscriberAttributes/SusbcriberAttributesManagerTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SusbcriberAttributesManagerTests.swift
@@ -306,7 +306,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
         let receivedAttribute = invokedParams.attribute
         expect(receivedAttribute.key) == "$apnsTokens"
 
-        let tokenString = (tokenData as NSData).asString()
+        let tokenString = (tokenData as NSData).rc_asString()
         expect(receivedAttribute.value) == tokenString
         expect(receivedAttribute.isSynced) == false
     }
@@ -329,7 +329,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
 
     func testSetPushTokenSkipsIfSameValue() {
         let tokenData = "ligai32g32ig".data(using: .utf8)!
-        let tokenString = (tokenData as NSData).asString()
+        let tokenString = (tokenData as NSData).rc_asString()
         self.mockDeviceCache.stubbedSubscriberAttributeResult = RCSubscriberAttribute(key: "$apnsTokens",
                                                                                       value: tokenString)
 
@@ -340,7 +340,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
 
     func testSetPushTokenOverwritesIfNewValue() {
         let tokenData = "ligai32g32ig".data(using: .utf8)!
-        let tokenString = (tokenData as NSData).asString()
+        let tokenString = (tokenData as NSData).rc_asString()
         let oldSyncTime = Date()
 
         self.mockDeviceCache.stubbedSubscriberAttributeResult = RCSubscriberAttribute(key: "$apnsTokens",


### PR DESCRIPTION
Adds an `rc_` prefix to all foundation extensions, to prevent naming collisions. 
Also does some extra renaming to `millisecondsSince1970`, since it would conflict with another extension in `purchases-hybrid-common`


It should fix the following warning in hybrid sdks:
![image](https://user-images.githubusercontent.com/3922667/116309664-6c06c400-a77f-11eb-934b-2c7009a7e655.png)
