### PR TITLE
Preparing for next version: 3.12.0

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -5,9 +5,9 @@ objc: true
 sdk: iphonesimulator
 module: Purchases
 umbrella_header: Purchases/Public/Purchases.h
-module_version: 3.11.1
+module_version: 3.12.0-SNAPSHOT
 github_url: https://github.com/revenuecat/purchases-ios
-github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.11.1
+github_file_prefix: https://github.com/revenuecat/purchases-ios/tree/3.12.0-SNAPSHOT
 output: docs
 # Leaving this commented out. We used to specify this before, but now it's working without it
 # xcodebuild_arguments: [--objc,Purchases/Public/Purchases.h,--,-x,objective-c,-isysroot,$(xcrun --show-sdk-path),-I,$(pwd)]

--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Purchases"
-  s.version          = "3.11.1"
+  s.version          = "3.12.0-SNAPSHOT"
   s.summary          = "Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
-  s.dependency 'PurchasesCoreSwift', '3.11.1'
+  s.dependency 'PurchasesCoreSwift', '3.12.0-SNAPSHOT'
 
 
   s.source_files = ['Purchases/**/*.{h,m}']

--- a/Purchases/Info.plist
+++ b/Purchases/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11.1</string>
+	<string>3.12.0-SNAPSHOT</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>

--- a/Purchases/Misc/RCSystemInfo.m
+++ b/Purchases/Misc/RCSystemInfo.m
@@ -49,7 +49,7 @@ static BOOL _forceUniversalAppStore = NO;
 }
 
 + (NSString *)frameworkVersion {
-    return @"3.11.1";
+    return @"3.12.0-SNAPSHOT";
 }
 
 + (NSString *)systemVersion {

--- a/PurchasesCoreSwift.podspec
+++ b/PurchasesCoreSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PurchasesCoreSwift"
-  s.version          = "3.11.1"
+  s.version          = "3.12.0-SNAPSHOT"
   s.summary          = "Swift portion of RevenueCat's Subscription and in-app-purchase backend service."
 
   s.description      = <<-DESC

--- a/PurchasesCoreSwift/Info.plist
+++ b/PurchasesCoreSwift/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11.1</string>
+	<string>3.12.0-SNAPSHOT</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/PurchasesCoreSwiftTests/Info.plist
+++ b/PurchasesCoreSwiftTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11.1</string>
+	<string>3.12.0-SNAPSHOT</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/PurchasesTests/Info.plist
+++ b/PurchasesTests/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.11.1</string>
+	<string>3.12.0-SNAPSHOT</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
Bumps version number to 3.12.0-SNAPSHOT. 

Our fancy fastlane automation failed so I'm doing this manually. 
```
[18:29:59]: GitHub responded with 422: {"message":"Validation Failed","errors":[{"resource":"PullRequest","code":"missing_field","field":"head"}],"documentation_url":"https://docs.github.com/rest/reference/pulls#create-a-pull-request"}
```