### PR TITLE
added missing field in create_pull_request call

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -138,7 +138,8 @@ platform :ios do
       repo: "revenuecat/purchases-ios",
       title: "Prepare next version: #{next_version_snapshot}",
       base: "develop",
-      api_token: ENV["GITHUB_TOKEN"]
+      api_token: ENV["GITHUB_TOKEN"],
+      head: branch_name
     )
   end
 


### PR DESCRIPTION
From #503 , it looks like the `create_pull_request` method now requires `head` to be passed in as a field. Fastlane hasn't updated [their docs yet](https://docs.fastlane.tools/actions/create_pull_request/), it's still marked as optional, so I'll open up a bug report. 

In the meantime, this just adds the field.