### PR TITLE
Fix: sharedPurchases nullability

### DIFF
--- a/Purchases/Public/RCPurchases.h
+++ b/Purchases/Public/RCPurchases.h
@@ -152,10 +152,17 @@ NS_SWIFT_NAME(Purchases)
 
 /**
  @return A singleton `RCPurchases` object. Call this after a configure method to access the singleton.
+ @note: If the SDK has not been configured, calls to sharedPurchases will raise an exception. Make sure to configure the SDK before making calls to sharedPurchases.
  */
 @property (class, nonatomic, readonly) RCPurchases *sharedPurchases;
 
 #pragma mark Configuration
+
+/**
+ @note True if the SDK has been configured, false otherwise. This property should only be used in special circumstances. If the shared instance has not been configured,
+ calls made to it will raise an exception.
+ */
+@property (class, nonatomic, readonly) BOOL isConfigured;
 
 /** Set this to true if you are passing in an appUserID but it is anonymous, this is true by default if you didn't pass an appUserID
  If a user tries to purchase a product that is active on the current app store account, we will treat it as a restore and alias

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -140,7 +140,9 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 
 + (instancetype)sharedPurchases {
     if (!_sharedPurchases) {
-        RCWarnLog(@"%@", RCStrings.configure.no_singleton_instance);
+        NSString *errorMessage = RCStrings.configure.no_singleton_instance;
+        RCWarnLog(@"%@", errorMessage);
+        @throw([NSException exceptionWithName:@"UninitializedPurchasesSDKException" reason:errorMessage userInfo:nil]);
     }
     return _sharedPurchases;
 }

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -138,12 +138,12 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
     self.systemInfo.finishTransactions = finishTransactions;
 }
 
++ (BOOL)isConfigured {
+    return _sharedPurchases != nil;
+}
+
 + (instancetype)sharedPurchases {
-    if (!_sharedPurchases) {
-        NSString *errorMessage = RCStrings.configure.no_singleton_instance;
-        RCWarnLog(@"%@", errorMessage);
-        @throw([NSException exceptionWithName:@"UninitializedPurchasesSDKException" reason:errorMessage userInfo:nil]);
-    }
+    NSCAssert(_sharedPurchases, RCStrings.configure.no_singleton_instance);
     return _sharedPurchases;
 }
 

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -250,6 +250,12 @@ class PurchasesTests: XCTestCase {
         setupPurchases()
         expect(self.purchases).toNot(beNil())
     }
+    
+    func testUsingSharedInstanceWithoutInitializingRaisesException() {
+        expect{ Purchases.shared }.to(raiseException())
+        setupPurchases()
+        expect{ Purchases.shared }.toNot(raiseException())
+    }
 
     func testFirstInitializationCallDelegate() {
         setupPurchases()

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -257,6 +257,12 @@ class PurchasesTests: XCTestCase {
         expect{ Purchases.shared }.toNot(raiseException())
     }
 
+    func testIsConfiguredReturnsCorrectvalue() {
+        expect(Purchases.isConfigured) == false
+        setupPurchases()
+        expect(Purchases.isConfigured) == true
+    }
+    
     func testFirstInitializationCallDelegate() {
         setupPurchases()
         expect(self.purchasesDelegate.purchaserInfoReceivedCount).toEventually(equal(1))


### PR DESCRIPTION
As mentioned in https://github.com/RevenueCat/purchases-ios/issues/490, the value of `sharedPurchases` can be `nil`, but it's marked as `non-nullable`. 

This can lead to some awkward behavior, particularly in Swift, where the compiler will assume that the value is not `nil` and will not let you check against it. 

To solve this, this PR does 2 things: 
- adds an `assert` when calling `sharedPurchases`, since calls to it will no-op, which is unexpected behavior the vast majority of the time. 
- adds a new property, `isConfigured`, that you can use to know whether it's safe to call `sharedPurchases`. I added this so that if someone is indiscriminately calling a method and relying on no-ops, they can use the new property to keep their code compatible with this behavior. However, this should _only_ ever be used in very specific circumstances. 