### PR TITLE
removed test env variable

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,19 +4,6 @@
 import PackageDescription
 import class Foundation.ProcessInfo
 
-let shouldTest = ProcessInfo.processInfo.environment["TEST"] == "1"
-
-func resolveDependencies() -> [Package.Dependency] {
-    if shouldTest {
-        return [
-            .package(url: "https://github.com/AliSoftware/OHHTTPStubs.git", .branch("feature/spm-support")),
-            .package(url: "https://github.com/Quick/Nimble", .exact("8.0.4"))
-        ]
-    }
-
-    return []
-}
-
 func resolveTargets() -> [Target] {
     let objcSources = ["Purchases/Info.plist",
                        "Purchases/Attribution",
@@ -45,32 +32,19 @@ func resolveTargets() -> [Target] {
                 dependencies: [],
                 path: ".",
                 sources: ["PurchasesCoreSwift"])]
-
-    if shouldTest {
-        let testTargets: [Target] = [
-            .testTarget(name: "PurchasesTests",
-                    dependencies: ["Purchases", "OHHTTPStubs", "Nimble"],
-                    path: "PurchasesTests",
-                    exclude: [],
-                    sources: nil)]
-
-        return baseTargets + testTargets
-    }
-
+    
     return baseTargets
 }
 
 let package = Package(
-        name: "Purchases",
-        platforms: [
-            .macOS(.v10_12), .iOS(.v9), .watchOS("6.2"), .tvOS(.v9)
-        ],
-        products: [
-            .library(name: "Purchases",
-                    targets: ["Purchases"]),
-        ],
-        dependencies: resolveDependencies(),
-        targets: resolveTargets()
+    name: "Purchases",
+    platforms: [
+        .macOS(.v10_12), .iOS(.v9), .watchOS("6.2"), .tvOS(.v9)
+    ],
+    products: [
+        .library(name: "Purchases",
+                 targets: ["Purchases"]),
+    ],
+    dependencies: [],
+    targets: resolveTargets()
 )
-
-


### PR DESCRIPTION
Addresses #492 
Removed the "TEST" env variable, as well as the test dependencies, when using Swift Package Manager. 

Discussion: 
- I don't think there's any value in defining the dependencies there, given that they're only useful for running tests on our SDK. If you import the package from SPM I don't think you can even run the tests anyway. 
- Xcode will still pull all of the dev dependencies if they're defined, so you'll see them in your project even if you're not looking to do tests
- The only case I can think of where they'd be useful would be if we were using the dependencies ourselves - i.e.: if instead of using Carthage, we were using SPM for our unit tests dependencies. Which we might wanna do, but that's a story for another day. 
- This is functionally the same as we had before, since we don't actually use the "TEST" env variable, but for folks who do (like the devs on the ticket), it'll prevent some headaches. 

Other libraries do set up the dev dependencies, like [Moya](https://github.com/Moya/Moya/blob/master/Package.swift) and [Auth0](https://github.com/auth0/Auth0.swift/blob/master/Package.swift), but I'm not sure what value they're getting out of them. 

Here's the PR where the env variable was added: https://github.com/RevenueCat/purchases-ios/issues/125
Also, note that tests didn't even run until recently (not sure they do now) if you use solely SPM, because of some assertions from Nimble that don't work in their SPM release