### PR TITLE
fix outdated path reference in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,13 +30,12 @@ func resolveTargets() -> [Target] {
                        "Purchases/SubscriberAttributes",
                        "Purchases/Identity"]
     let infoPlist = "Purchases/Info.plist"
-    let swiftSources = "Purchases/SwiftSources"
     
     let baseTargets: [Target] = [
         .target(name: "Purchases",
                 dependencies: ["PurchasesCoreSwift"],
                 path: ".",
-                exclude: [infoPlist, swiftSources],
+                exclude: [infoPlist],
                 sources: ["Purchases"],
                 publicHeadersPath: "Purchases/Public",
                 cSettings: objcSources.map { CSetting.headerSearchPath($0) }


### PR DESCRIPTION
Addresses https://github.com/RevenueCat/purchases-ios/issues/517

Fixes an outdated path reference in Package.swift