### PR TITLE
Better error message when attempting to replace a nonexistent string

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -244,6 +244,9 @@ def attach_changelog_to_master(version_number)
 end
 
 def replace_in(previous_text, new_text, path)
+  if new_text.to_s.strip.empty?
+    fail "Missing `new_text` in call to `replace_in`, looking for replacement for #{previous_text} 😵."
+  end
   sed_regex = 's|' + previous_text + '|' + new_text + '|'
   backup_extension = '.bck'
   sh("sed", '-i', backup_extension, sed_regex, path)


### PR DESCRIPTION
- When running fastlane-based tests, we need to ensure that the environment variables are setup, added `ensure_testing_enviroment` function
- `sed` gives a message that requires you to track down the source of pain, so added some messaging around that to better find the source of your problem.
- Removed DEVELOPMENT_TEAM from projects, set to empty
