### PR TITLE
CicrcleCI seems to have a stale cache, updating cache keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,13 +31,13 @@ commands:
        # Bundler
       - restore_cache:
           keys: 
-            - gem-cache-{{ checksum "Gemfile.lock" }}
+            - v1-gem-cache-{{ checksum "Gemfile.lock" }}
       - run: 
           name: Bundle install
           working_directory: << parameters.directory >>
           command: bundle install --clean --path vendor/bundle
       - save_cache:
-          key: gem-cache-{{ checksum "Gemfile.lock" }}
+          key: v1-gem-cache-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
   scan-and-archive:
@@ -115,13 +115,13 @@ jobs:
       # Carthage
       - restore_cache:
           keys: 
-            - carthage-cache-{{ checksum "Cartfile.resolved" }}
+            - v1-carthage-cache-{{ checksum "Cartfile.resolved" }}
       - run:
           name: Carthage Bootstrap
           command: |
               ./carthage.sh bootstrap --cache-builds
       - save_cache:
-          key: carthage-cache-{{ checksum "Cartfile.resolved" }}
+          key: v1-carthage-cache-{{ checksum "Cartfile.resolved" }}
           paths:
             - Carthage
       
@@ -152,13 +152,13 @@ jobs:
       # Carthage
       - restore_cache:
           keys: 
-            - carthage-cache-{{ checksum "Cartfile.resolved" }}
+            - v1-carthage-cache-{{ checksum "Cartfile.resolved" }}
       - run:
           name: Carthage Bootstrap
           command: |
               ./carthage.sh bootstrap --cache-builds
       - save_cache:
-          key: carthage-cache-{{ checksum "Cartfile.resolved" }}
+          key: v1-carthage-cache-{{ checksum "Cartfile.resolved" }}
           paths:
             - Carthage
       
@@ -188,10 +188,10 @@ jobs:
       # Bundler
       - restore_cache:
           keys: 
-            - gem-cache-{{ checksum "Gemfile.lock" }}
+            - v1-gem-cache-{{ checksum "Gemfile.lock" }}
       - run: bundle install --clean --path vendor/bundle
       - save_cache:
-          key: gem-cache-{{ checksum "Gemfile.lock" }}
+          key: v1-gem-cache-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
       
@@ -300,7 +300,7 @@ jobs:
       # Carthage
       - restore_cache:
           keys: 
-            - carthage-cache-{{ checksum "Cartfile.resolved" }}
+            - v1-carthage-cache-{{ checksum "Cartfile.resolved" }}
       - run:
           name: Carthage Update
           working_directory: IntegrationTests/CarthageIntegration/
@@ -311,7 +311,7 @@ jobs:
               rm -rf Carthage/Checkouts/purchases-root/IntegrationTests/
               ./carthage.sh build
       - save_cache:
-          key: carthage-cache-{{ checksum "Cartfile.resolved" }}
+          key: v1-carthage-cache-{{ checksum "Cartfile.resolved" }}
           paths:
             - Carthage
       


### PR DESCRIPTION
I'm getting failed CircleCI builds since updating to Xcode 12.5. The build cache is from 6/2 and the update after that.

`module compiled with Swift 5.3.1 cannot be imported by the Swift 5.4 compiler: /Users/distiller/purchases-ios/Carthage/Build/iOS/OHHTTPStubs.framework/Modules/OHHTTPStubs.swiftmodule/x86_64-apple-ios-simulator.swiftmodule`

Versioning the cache keys will make killing the build caches easier in the future, too.