### PR TITLE
fix tests in Xcode 13 beta

### DIFF
--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -308,7 +308,7 @@ class HTTPClientTests: XCTestCase {
         let path = "/a_random_path"
         var headerPresent = false
         
-        let version = "" // for unit tests the version will empty
+        let version = RCSystemInfo.appVersion()
 
         stub(condition: hasHeaderNamed("X-Client-Version", value: version )) { request in
             headerPresent = true


### PR DESCRIPTION
Tests were failing in Xcode 13 beta. 

The cause is that in the beta, getting `NSBundle.mainBundle.infoDictionary[@"CFBundleShortVersionString"];` has a different behavior than usual. 

In other versions of Xcode, if you obtain `BundleShortVersionString` through that, by calling it inside a framework target, but within a unit tests target, you'd get `""`. 

In Xcode 13, it instead returns `13.0`. This looks like an Xcode bug. Curiously, if you get the value *within* the unit tests target, it returns `""` instead of `13.0`, so the trick to the bug is to call it from the unit tests target, but within a framework target. 

Hope that makes sense and doesn't sound like the ramblings of a mad person. 
