### PR TITLE
updated link to rev.cat link, points to more complete article

### DIFF
--- a/Purchases/Caching/RCDeviceCache.m
+++ b/Purchases/Caching/RCDeviceCache.m
@@ -79,7 +79,7 @@ int cacheDurationInSecondsInBackground = 60 * 60 * 25;
             NSAssert(false, @"[Purchases] - Cached appUserID has been deleted from user defaults. "
                             "This leaves the SDK in an undetermined state. Please make sure that RevenueCat "
                             "entries in user defaults don't get deleted by anything other than the SDK. "
-                            "More info: https://support.revenuecat.com/hc/en-us/articles/360047927393");
+                            "More info: https://rev.cat/userdefaults-crash");
         }
     }
 }


### PR DESCRIPTION
When a developer deletes the userDefaults entry for appUserID that revenueCat uses, the SDK crashes with an error, and a link pointing to an article that explains the issue. 

The article was previously private, @beylmk caught that (👏 ) and we fixed it to make it public, but we also have a better article with more info to point to. 

I updated the link to the more complete article, and also used a rebrandly link so that we can update without issuing an SDK update in the future. 

| Before | After |
| :-: | :-: |
| https://support.revenuecat.com/hc/en-us/articles/360047927393 | https://rev.cat/userdefaults-crash |