### PR TITLE
Feature: manage subscriptions modal

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,10 @@ func resolveTargets() -> [Target] {
     let infoPlist = "Purchases/Info.plist"
 
     let baseTargets: [Target] = [
+        .target(name: "PurchasesSwift",
+                dependencies: ["PurchasesSwift"],
+                path: ".",
+                sources: ["PurchasesSwift"])),
         .target(name: "Purchases",
                 dependencies: ["PurchasesCoreSwift"],
                 path: ".",
@@ -43,7 +47,7 @@ let package = Package(
     ],
     products: [
         .library(name: "Purchases",
-                 targets: ["Purchases"]),
+                 targets: ["PurchasesSwift"]),
     ],
     dependencies: [],
     targets: resolveTargets()

--- a/Package.swift
+++ b/Package.swift
@@ -23,19 +23,19 @@ func resolveTargets() -> [Target] {
         .target(name: "PurchasesSwift",
                 dependencies: ["PurchasesSwift"],
                 path: ".",
-                sources: ["PurchasesSwift"])),
+                sources: ["PurchasesSwift"]),
         .target(name: "Purchases",
                 dependencies: ["PurchasesCoreSwift"],
                 path: ".",
                 exclude: [infoPlist],
                 sources: ["Purchases"],
                 publicHeadersPath: "Purchases/Public",
-                cSettings: objcSources.map { CSetting.headerSearchPath($0) }
-        ),
+                cSettings: objcSources.map { CSetting.headerSearchPath($0) }),
         .target(name: "PurchasesCoreSwift",
                 dependencies: [],
                 path: ".",
-                sources: ["PurchasesCoreSwift"])]
+                sources: ["PurchasesCoreSwift"])
+    ]
 
     return baseTargets
 }

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -2057,24 +2057,29 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 Purchases. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-all_load";
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecast.PurchasesSwift;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 6.2;
 			};
 			name = Debug;
 		};
@@ -2092,21 +2097,26 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 Purchases. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MARKETING_VERSION = 1.0;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-all_load";
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecast.PurchasesSwift;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = "";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 6.2;
 			};
 			name = Release;
 		};

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -12,6 +12,14 @@
 		2D22679125F2D9AD00E6950C /* PurchasesTests-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 35262A291F7D783F00C04F2C /* PurchasesTests-Bridging-Header.h */; };
 		2D390255259CF46000DB19C0 /* MockPaymentDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D390254259CF46000DB19C0 /* MockPaymentDiscount.swift */; };
 		2D3E29CE25E8009000456FA8 /* MockAttributionTypeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35DA3E083FE37DAF15954 /* MockAttributionTypeFactory.swift */; };
+		2D488A81267A724F00EFF50A /* PurchasesSwift.docc in Sources */ = {isa = PBXBuildFile; fileRef = 2D488A80267A724F00EFF50A /* PurchasesSwift.docc */; };
+		2D488A87267A724F00EFF50A /* PurchasesSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D488A7D267A724F00EFF50A /* PurchasesSwift.framework */; };
+		2D488A8E267A724F00EFF50A /* PurchasesSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D488A8D267A724F00EFF50A /* PurchasesSwiftTests.swift */; };
+		2D488A8F267A724F00EFF50A /* PurchasesSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D488A7F267A724F00EFF50A /* PurchasesSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2D488A92267A724F00EFF50A /* PurchasesSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D488A7D267A724F00EFF50A /* PurchasesSwift.framework */; };
+		2D488A93267A724F00EFF50A /* PurchasesSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2D488A7D267A724F00EFF50A /* PurchasesSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		2D488A9C267A728A00EFF50A /* PurchasesSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D488A9B267A728A00EFF50A /* PurchasesSwift.swift */; };
+		2D488AF3267A756900EFF50A /* Purchases.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 352629FE1F7C4B9100C04F2C /* Purchases.framework */; };
 		2D4C02E426697E490038F877 /* RCLogLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D4C02E326697E490038F877 /* RCLogLevel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2D4C18A924F47E5000F268CD /* Purchases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4C18A824F47E4400F268CD /* Purchases.swift */; };
 		2D4D6AF124F6FEE000B656BE /* MockIntroEligibilityCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DA0068E24E2E515002C59D3 /* MockIntroEligibilityCalculator.swift */; };
@@ -255,6 +263,34 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		2D488A88267A724F00EFF50A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 352629F51F7C4B9100C04F2C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2D488A7C267A724F00EFF50A;
+			remoteInfo = PurchasesSwift;
+		};
+		2D488A8A267A724F00EFF50A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 352629F51F7C4B9100C04F2C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2DE20B7E26409EB7004C597D;
+			remoteInfo = StoreKitTestApp;
+		};
+		2D488A90267A724F00EFF50A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 352629F51F7C4B9100C04F2C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2D488A7C267A724F00EFF50A;
+			remoteInfo = PurchasesSwift;
+		};
+		2D488AF1267A756200EFF50A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 352629F51F7C4B9100C04F2C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 352629FD1F7C4B9100C04F2C;
+			remoteInfo = Purchases;
+		};
 		2DC5622024EC63430031F69B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 352629F51F7C4B9100C04F2C /* Project object */;
@@ -286,6 +322,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		2D488A94267A724F00EFF50A /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				2D488A93267A724F00EFF50A /* PurchasesSwift.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		350FBDD91F7DFD900065833D /* Copy Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -303,6 +350,12 @@
 		2D11F5E0250FF886005A70E8 /* AttributionStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributionStrings.swift; sourceTree = "<group>"; };
 		2D1FFAD425B8707400367C63 /* RCPurchaserInfoManager+Protected.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCPurchaserInfoManager+Protected.h"; sourceTree = "<group>"; };
 		2D390254259CF46000DB19C0 /* MockPaymentDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPaymentDiscount.swift; sourceTree = "<group>"; };
+		2D488A7D267A724F00EFF50A /* PurchasesSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PurchasesSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2D488A7F267A724F00EFF50A /* PurchasesSwift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PurchasesSwift.h; sourceTree = "<group>"; };
+		2D488A80267A724F00EFF50A /* PurchasesSwift.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = PurchasesSwift.docc; sourceTree = "<group>"; };
+		2D488A86267A724F00EFF50A /* PurchasesSwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PurchasesSwiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		2D488A8D267A724F00EFF50A /* PurchasesSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesSwiftTests.swift; sourceTree = "<group>"; };
+		2D488A9B267A728A00EFF50A /* PurchasesSwift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesSwift.swift; sourceTree = "<group>"; };
 		2D4C02E326697E490038F877 /* RCLogLevel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCLogLevel.h; sourceTree = "<group>"; };
 		2D4C18A824F47E4400F268CD /* Purchases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Purchases.swift; sourceTree = "<group>"; };
 		2D4D6AF224F7172900B656BE /* MockProductsRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockProductsRequest.swift; sourceTree = "<group>"; };
@@ -558,6 +611,22 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		2D488A7A267A724F00EFF50A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D488AF3267A756900EFF50A /* Purchases.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2D488A83267A724F00EFF50A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D488A87267A724F00EFF50A /* PurchasesSwift.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		2DC5621324EC63420031F69B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -591,6 +660,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2DE20B9226409ECF004C597D /* StoreKit.framework in Frameworks */,
+				2D488A92267A724F00EFF50A /* PurchasesSwift.framework in Frameworks */,
 				2DE20B9026409EC7004C597D /* Purchases.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -654,6 +724,24 @@
 				37E35556F2D7B8B28B169C77 /* DataConverters */,
 			);
 			path = LocalReceiptParsing;
+			sourceTree = "<group>";
+		};
+		2D488A7E267A724F00EFF50A /* PurchasesSwift */ = {
+			isa = PBXGroup;
+			children = (
+				2D488A7F267A724F00EFF50A /* PurchasesSwift.h */,
+				2D488A80267A724F00EFF50A /* PurchasesSwift.docc */,
+				2D488A9B267A728A00EFF50A /* PurchasesSwift.swift */,
+			);
+			path = PurchasesSwift;
+			sourceTree = "<group>";
+		};
+		2D488A8C267A724F00EFF50A /* PurchasesSwiftTests */ = {
+			isa = PBXGroup;
+			children = (
+				2D488A8D267A724F00EFF50A /* PurchasesSwiftTests.swift */,
+			);
+			path = PurchasesSwiftTests;
 			sourceTree = "<group>";
 		};
 		2D4C02E52669801D0038F877 /* Logging */ = {
@@ -881,6 +969,8 @@
 				2DC5622224EC63430031F69B /* PurchasesCoreSwiftTests */,
 				2DE20B6D264087FB004C597D /* StoreKitTests */,
 				2DE20B8026409EB7004C597D /* StoreKitTestApp */,
+				2D488A7E267A724F00EFF50A /* PurchasesSwift */,
+				2D488A8C267A724F00EFF50A /* PurchasesSwiftTests */,
 				352629FF1F7C4B9100C04F2C /* Products */,
 				3530C18722653E8F00D6DF52 /* Frameworks */,
 				2DCB85BF2406EC3F003C1260 /* Recovered References */,
@@ -896,6 +986,8 @@
 				2DC5621E24EC63430031F69B /* PurchasesCoreSwiftTests.xctest */,
 				2DE20B6C264087FB004C597D /* StoreKitTests.xctest */,
 				2DE20B7F26409EB7004C597D /* StoreKitTestApp.app */,
+				2D488A7D267A724F00EFF50A /* PurchasesSwift.framework */,
+				2D488A86267A724F00EFF50A /* PurchasesSwiftTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1273,6 +1365,14 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		2D488A78267A724F00EFF50A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D488A8F267A724F00EFF50A /* PurchasesSwift.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		2DC5621124EC63420031F69B /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -1357,6 +1457,44 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		2D488A7C267A724F00EFF50A /* PurchasesSwift */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2D488A99267A724F00EFF50A /* Build configuration list for PBXNativeTarget "PurchasesSwift" */;
+			buildPhases = (
+				2D488A78267A724F00EFF50A /* Headers */,
+				2D488A79267A724F00EFF50A /* Sources */,
+				2D488A7A267A724F00EFF50A /* Frameworks */,
+				2D488A7B267A724F00EFF50A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2D488AF2267A756200EFF50A /* PBXTargetDependency */,
+			);
+			name = PurchasesSwift;
+			productName = PurchasesSwift;
+			productReference = 2D488A7D267A724F00EFF50A /* PurchasesSwift.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		2D488A85267A724F00EFF50A /* PurchasesSwiftTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2D488A9A267A724F00EFF50A /* Build configuration list for PBXNativeTarget "PurchasesSwiftTests" */;
+			buildPhases = (
+				2D488A82267A724F00EFF50A /* Sources */,
+				2D488A83267A724F00EFF50A /* Frameworks */,
+				2D488A84267A724F00EFF50A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2D488A89267A724F00EFF50A /* PBXTargetDependency */,
+				2D488A8B267A724F00EFF50A /* PBXTargetDependency */,
+			);
+			name = PurchasesSwiftTests;
+			productName = PurchasesSwiftTests;
+			productReference = 2D488A86267A724F00EFF50A /* PurchasesSwiftTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		2DC5621524EC63420031F69B /* PurchasesCoreSwift */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2DC5622724EC63430031F69B /* Build configuration list for PBXNativeTarget "PurchasesCoreSwift" */;
@@ -1426,10 +1564,12 @@
 				2DE20B7B26409EB7004C597D /* Sources */,
 				2DE20B7C26409EB7004C597D /* Frameworks */,
 				2DE20B7D26409EB7004C597D /* Resources */,
+				2D488A94267A724F00EFF50A /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				2D488A91267A724F00EFF50A /* PBXTargetDependency */,
 			);
 			name = StoreKitTestApp;
 			productName = StoreKitTestApp;
@@ -1486,10 +1626,17 @@
 		352629F51F7C4B9100C04F2C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1250;
+				LastSwiftUpdateCheck = 1300;
 				LastUpgradeCheck = 0930;
 				ORGANIZATIONNAME = Purchases;
 				TargetAttributes = {
+					2D488A7C267A724F00EFF50A = {
+						CreatedOnToolsVersion = 13.0;
+					};
+					2D488A85267A724F00EFF50A = {
+						CreatedOnToolsVersion = 13.0;
+						TestTargetID = 2DE20B7E26409EB7004C597D;
+					};
 					2DC5621524EC63420031F69B = {
 						CreatedOnToolsVersion = 12.0;
 						ProvisioningStyle = Automatic;
@@ -1542,11 +1689,27 @@
 				2DC5621D24EC63430031F69B /* PurchasesCoreSwiftTests */,
 				2DE20B7E26409EB7004C597D /* StoreKitTestApp */,
 				2DE20B6B264087FB004C597D /* StoreKitTests */,
+				2D488A7C267A724F00EFF50A /* PurchasesSwift */,
+				2D488A85267A724F00EFF50A /* PurchasesSwiftTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		2D488A7B267A724F00EFF50A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2D488A84267A724F00EFF50A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		2DC5621424EC63420031F69B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1617,6 +1780,23 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		2D488A79267A724F00EFF50A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D488A9C267A728A00EFF50A /* PurchasesSwift.swift in Sources */,
+				2D488A81267A724F00EFF50A /* PurchasesSwift.docc in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2D488A82267A724F00EFF50A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D488A8E267A724F00EFF50A /* PurchasesSwiftTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		2DC5621224EC63420031F69B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1820,6 +2000,26 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		2D488A89267A724F00EFF50A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2D488A7C267A724F00EFF50A /* PurchasesSwift */;
+			targetProxy = 2D488A88267A724F00EFF50A /* PBXContainerItemProxy */;
+		};
+		2D488A8B267A724F00EFF50A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2DE20B7E26409EB7004C597D /* StoreKitTestApp */;
+			targetProxy = 2D488A8A267A724F00EFF50A /* PBXContainerItemProxy */;
+		};
+		2D488A91267A724F00EFF50A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2D488A7C267A724F00EFF50A /* PurchasesSwift */;
+			targetProxy = 2D488A90267A724F00EFF50A /* PBXContainerItemProxy */;
+		};
+		2D488AF2267A756200EFF50A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 352629FD1F7C4B9100C04F2C /* Purchases */;
+			targetProxy = 2D488AF1267A756200EFF50A /* PBXContainerItemProxy */;
+		};
 		2DC5622124EC63430031F69B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 2DC5621524EC63420031F69B /* PurchasesCoreSwift */;
@@ -1843,6 +2043,130 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		2D488A95267A724F00EFF50A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 Purchases. All rights reserved.";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				OTHER_LDFLAGS = "-all_load";
+				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecast.PurchasesSwift;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		2D488A96267A724F00EFF50A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 Purchases. All rights reserved.";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				OTHER_LDFLAGS = "-all_load";
+				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecast.PurchasesSwift;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		2D488A97267A724F00EFF50A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8SXR2327BM;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecast.PurchasesSwiftTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StoreKitTestApp.app/StoreKitTestApp";
+			};
+			name = Debug;
+		};
+		2D488A98267A724F00EFF50A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8SXR2327BM;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecast.PurchasesSwiftTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StoreKitTestApp.app/StoreKitTestApp";
+			};
+			name = Release;
+		};
 		2DC5622824EC63430031F69B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2031,6 +2355,7 @@
 		2DE20B8C26409EB8004C597D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_OBJC_WEAK = YES;
@@ -2058,6 +2383,7 @@
 		2DE20B8D26409EB8004C597D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_OBJC_WEAK = YES;
@@ -2210,6 +2536,7 @@
 				INFOPLIST_FILE = Purchases/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MACH_O_TYPE = staticlib;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				OTHER_LDFLAGS = "-all_load";
 				PRODUCT_BUNDLE_IDENTIFIER = com.purchases.Purchases;
@@ -2243,6 +2570,7 @@
 				INFOPLIST_FILE = Purchases/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MACH_O_TYPE = staticlib;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				OTHER_LDFLAGS = "-all_load";
 				PRODUCT_BUNDLE_IDENTIFIER = com.purchases.Purchases;
@@ -2322,6 +2650,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		2D488A99267A724F00EFF50A /* Build configuration list for PBXNativeTarget "PurchasesSwift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2D488A95267A724F00EFF50A /* Debug */,
+				2D488A96267A724F00EFF50A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2D488A9A267A724F00EFF50A /* Build configuration list for PBXNativeTarget "PurchasesSwiftTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2D488A97267A724F00EFF50A /* Debug */,
+				2D488A98267A724F00EFF50A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		2DC5622724EC63430031F69B /* Build configuration list for PBXNativeTarget "PurchasesCoreSwift" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Purchases.xcodeproj/xcshareddata/xcschemes/StoreKitTests.xcscheme
+++ b/Purchases.xcodeproj/xcshareddata/xcschemes/StoreKitTests.xcscheme
@@ -38,6 +38,16 @@
                ReferencedContainer = "container:Purchases.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2D488A85267A724F00EFF50A"
+               BuildableName = "PurchasesSwiftTests.xctest"
+               BlueprintName = "PurchasesSwiftTests"
+               ReferencedContainer = "container:Purchases.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -70,15 +80,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "2DE20B7E26409EB7004C597D"
-            BuildableName = "StoreKitTestApp.app"
-            BlueprintName = "StoreKitTestApp"
-            ReferencedContainer = "container:Purchases.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/PurchasesSwift.podspec
+++ b/PurchasesSwift.podspec
@@ -1,0 +1,29 @@
+Pod::Spec.new do |s|
+  s.name             = "PurchasesSwift"
+  s.version          = "3.12.0-SNAPSHOT"
+  s.summary          = "Subscription and in-app-purchase backend service."
+
+  s.description      = <<-DESC
+                       Save yourself the hastle of implementing a subscriptions backend. Use RevenueCat instead https://www.revenuecat.com/
+                       DESC
+
+  s.homepage         = "https://www.revenuecat.com/"
+  s.license          =  { :type => 'MIT' }
+  s.author           = { "RevenueCat, Inc." => "support@revenuecat.com" }
+  s.source           = { :git => "https://github.com/revenuecat/purchases-ios.git", :tag => s.version.to_s }
+  s.documentation_url = "https://docs.revenuecat.com/"
+
+  s.framework      = 'StoreKit'
+  s.swift_version       = '5.0'
+
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.12'
+  s.watchos.deployment_target = '6.2'
+  s.tvos.deployment_target = '9.0'
+
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+  s.dependency 'Purchases', '3.12.0-SNAPSHOT'
+
+  s.source_files = ['PurchasesSwift/**/*.{swift}']
+
+end

--- a/PurchasesSwift/PurchasesSwift.docc/PurchasesSwift.md
+++ b/PurchasesSwift/PurchasesSwift.docc/PurchasesSwift.md
@@ -1,0 +1,14 @@
+# ``PurchasesSwift``
+
+<!--@START_MENU_TOKEN@-->Summary<!--@END_MENU_TOKEN@-->
+
+## Overview
+
+<!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->
+
+## Topics
+
+### <!--@START_MENU_TOKEN@-->Group<!--@END_MENU_TOKEN@-->
+
+- <!--@START_MENU_TOKEN@-->``Symbol``<!--@END_MENU_TOKEN@-->
+

--- a/PurchasesSwift/PurchasesSwift.h
+++ b/PurchasesSwift/PurchasesSwift.h
@@ -1,0 +1,19 @@
+//
+//  PurchasesSwift.h
+//  PurchasesSwift
+//
+//  Created by Andrés Boedo on 6/16/21.
+//  Copyright © 2021 Purchases. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for PurchasesSwift.
+FOUNDATION_EXPORT double PurchasesSwiftVersionNumber;
+
+//! Project version string for PurchasesSwift.
+FOUNDATION_EXPORT const unsigned char PurchasesSwiftVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <PurchasesSwift/PublicHeader.h>
+
+

--- a/PurchasesSwift/PurchasesSwift.swift
+++ b/PurchasesSwift/PurchasesSwift.swift
@@ -1,0 +1,32 @@
+//
+//  PurchasesSwift.swift
+//  PurchasesSwift
+//
+//  Created by Andrés Boedo on 6/16/21.
+//  Copyright © 2021 Purchases. All rights reserved.
+//
+
+import Foundation
+import StoreKit
+
+@_exported import Purchases
+
+public extension Purchases {
+    @inlinable public func showManageSubscriptionModal() {
+        if let windowScene = self.view.window?.windowScene {
+            do {
+                try await AppStore.showManageSubscriptions(in: windowScene)
+            } catch {
+                // handle error
+            }
+        }
+    }
+}
+
+public class Foo {
+    public init() { }
+
+    public func bar() {
+        print("totally foobar")
+    }
+}

--- a/PurchasesSwift/PurchasesSwift.swift
+++ b/PurchasesSwift/PurchasesSwift.swift
@@ -11,6 +11,8 @@ import StoreKit
 
 @_exported import Purchases
 
+#if os(iOS)
+
 @objc public extension Purchases {
     func showManageSubscriptionModal() {
 
@@ -36,8 +38,8 @@ import StoreKit
                     detach {
                         await self.showSK2ManageSubscriptions()
                     }
-                    return
                 }
+                return
             }
 
             self.openURL(managementURL)
@@ -47,6 +49,10 @@ import StoreKit
 
 public extension Purchases {
 
+    @available(iOS 9.0, *)
+    @available(macOS, unavailable)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
     func showAppleManageSubscriptions() {
         if #available(iOS 15.0, *) {
             detach {
@@ -59,6 +65,9 @@ public extension Purchases {
 
     @MainActor
     @available(iOS 15.0, *)
+    @available(macOS, unavailable)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
     func showSK2ManageSubscriptions() async {
         let windowScene = UIApplication.shared
             .connectedScenes
@@ -93,3 +102,4 @@ private extension URL {
 
     static let appleSubscriptionsURL = URL(string: "https://apps.apple.com/account/subscriptions")!
 }
+#endif

--- a/PurchasesSwift/PurchasesSwift.swift
+++ b/PurchasesSwift/PurchasesSwift.swift
@@ -11,10 +11,9 @@ import StoreKit
 
 @_exported import Purchases
 
-#if os(iOS)
 
 @objc public extension Purchases {
-    func showManageSubscriptionModal() {
+    @objc func showManageSubscriptionModal() {
 
         self.purchaserInfo { purchaserInfo, error in
             if let error = error {
@@ -33,6 +32,7 @@ import StoreKit
                 return
             }
 
+            #if os(iOS)
             if managementURL.isAppleSubscription() {
                 if #available(iOS 15.0, *) {
                     detach {
@@ -41,7 +41,7 @@ import StoreKit
                 }
                 return
             }
-
+            #endif
             self.openURL(managementURL)
         }
     }
@@ -50,10 +50,11 @@ import StoreKit
 public extension Purchases {
 
     @available(iOS 9.0, *)
-    @available(macOS, unavailable)
+    @available(macOS 10.12, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     func showAppleManageSubscriptions() {
+#if os(iOS)
         if #available(iOS 15.0, *) {
             detach {
                 await self.showSK2ManageSubscriptions()
@@ -61,6 +62,9 @@ public extension Purchases {
         } else {
             self.openURL(.appleSubscriptionsURL)
         }
+#elseif os(macOS)
+        self.openURL(.appleSubscriptionsURL)
+#endif
     }
 
     @MainActor
@@ -69,6 +73,7 @@ public extension Purchases {
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     func showSK2ManageSubscriptions() async {
+        #if os(iOS)
         let windowScene = UIApplication.shared
             .connectedScenes
             .filter { $0.activationState == .foregroundActive }
@@ -84,14 +89,19 @@ public extension Purchases {
         } else {
             print("couldn't get window")
         }
+        #endif
     }
 
     func openURL(_ url: URL) {
+#if os(iOS)
         if #available(iOS 10.0, *) {
             UIApplication.shared.open(url)
         } else {
             UIApplication.shared.openURL(url)
         }
+#elseif os(macOS)
+        NSWorkspace.shared.open(url)
+#endif
     }
 }
 
@@ -102,4 +112,3 @@ private extension URL {
 
     static let appleSubscriptionsURL = URL(string: "https://apps.apple.com/account/subscriptions")!
 }
-#endif

--- a/PurchasesSwift/PurchasesSwift.swift
+++ b/PurchasesSwift/PurchasesSwift.swift
@@ -55,9 +55,9 @@ public extension Purchases {
                let managementURL = purchaserInfo.managementURL {
                 self.openURL(managementURL)
             } else {
-                print("no management URL avaialable, opening support instead")
-                let supportURL = URL(string: "https://support.revenuecat.com")!
-                self.openURL(supportURL)
+                print("no management URL avaialable, opening generic settings instead")
+                let subscriptionsURL = URL(string: "https://apps.apple.com/account/subscriptions")!
+                self.openURL(subscriptionsURL)
             }
         }
     }

--- a/PurchasesSwift/PurchasesSwift.swift
+++ b/PurchasesSwift/PurchasesSwift.swift
@@ -11,14 +11,62 @@ import StoreKit
 
 @_exported import Purchases
 
+@objc public extension Purchases {
+    func showManageSubscriptionModal() {
+        if #available(iOS 15.0, *) {
+            detach {
+                await self.showSK2ManageSubscriptions()
+            }
+        } else {
+            self.showSK1ManageSubscriptions()
+        }
+    }
+}
+
 public extension Purchases {
-    @inlinable public func showManageSubscriptionModal() {
-        if let windowScene = self.view.window?.windowScene {
+    @MainActor
+    @available(iOS 15.0, *)
+    func showSK2ManageSubscriptions() async {
+        let windowScene = UIApplication.shared
+            .connectedScenes
+            .filter { $0.activationState == .foregroundActive }
+            .first
+
+        if let windowScene = windowScene as? UIWindowScene {
+
             do {
                 try await AppStore.showManageSubscriptions(in: windowScene)
-            } catch {
-                // handle error
+            } catch let error {
+                print("error when trying to show manage subscription: \(error.localizedDescription)")
             }
+        } else {
+            print("couldn't get window")
+        }
+    }
+
+    func showSK1ManageSubscriptions() {
+        self.purchaserInfo { purchaserInfo, error in
+            if let error = error {
+                print("there was an error getting purchaserInfo: \(error.localizedDescription)")
+                return
+            }
+
+            if let purchaserInfo = purchaserInfo,
+               let managementURL = purchaserInfo.managementURL {
+                self.openURL(managementURL)
+            } else {
+                print("no management URL avaialable, opening support instead")
+                let supportURL = URL(string: "https://support.revenuecat.com")!
+                self.openURL(supportURL)
+            }
+        }
+    }
+
+    func openURL(_ url: URL) {
+        if #available(iOS 10.0, *) {
+            UIApplication.shared.open(url)
+        } else {
+            UIApplication.shared.openURL(url)
         }
     }
 }

--- a/PurchasesSwiftTests/PurchasesSwiftTests.swift
+++ b/PurchasesSwiftTests/PurchasesSwiftTests.swift
@@ -1,0 +1,34 @@
+//
+//  PurchasesSwiftTests.swift
+//  PurchasesSwiftTests
+//
+//  Created by Andrés Boedo on 6/16/21.
+//  Copyright © 2021 Purchases. All rights reserved.
+//
+
+import XCTest
+@testable import PurchasesSwift
+
+class PurchasesSwiftTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}


### PR DESCRIPTION
This is a PoC. 

It adds a new method, `showManageSubscriptionsModal`, which will show the SK2 manage subscriptions modal if available, and otherwise will open up the `manageSubscriptionsURL` from RC.

The logic is a bit more nuanced, but that's the basic stuff. 

To achieve this and keep all the rest, this adds a new module `PurchasesSwift` (name will absolutely change before merging), which imports all of the original `Purchases`, while adding Swift extensions. 

I tested that this can be used from objective-c and Swift (which is a clear win over SK2), as well as macOS and iOS (SK2's version only supports iOS). 
Also, this takes into account the `managementURL`, so if a user purchased a subscription through Android, they'll go to the corresponding `managementURL` instead. 

If there's no `managementURL`, I'm currently defaulting to the native one in the OS, but that's subject to change. That also conflicts with a[ known bug in managementURL](https://github.com/RevenueCat/purchases-android/issues/290) for purchases on HOLD status in Android. 