### PR TITLE
Solve the error of Purchases.Package in SwiftUI's ForEach.

### DIFF
--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/Views/PaywallView.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/Views/PaywallView.swift
@@ -32,7 +32,7 @@ struct PaywallView: View {
                 /// - The paywall view list displaying each package
                 List {
                     Section(header: Text("\nMagic Weather Premium"), footer: Text(footerText)) {
-                        ForEach(offering?.availablePackages ?? []) { package in
+                        ForEach(offering?.availablePackages ?? [], id: \.self) { package in
                             PackageCellView(package: package) { (package) in
                                 
                                 /// - Set 'isPurchasing' state to `true`


### PR DESCRIPTION
Solve the problem that SwiftUI's ForEach requires that Purchases.Package conforms to the Identifiable protocol.

Before the fix, Xcode would not compile, reporting the following error:
Referencing initializer 'init(_:content:)' on 'ForEach' requires that 'Purchases.Package' conform to 'Identifiable'
