### PR TITLE
migrate StoreKitRequestFetcher: part 1

### DIFF
--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		2D5033262406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5033232406E4E8009CAE61 /* RCSpecialSubscriberAttributes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D50332A2406EA61009CAE61 /* RCSubscriberAttributesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5033272406EA61009CAE61 /* RCSubscriberAttributesManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D50332B2406EA61009CAE61 /* RCSubscriberAttributesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D5033282406EA61009CAE61 /* RCSubscriberAttributesManager.m */; };
+		2D80736A268A691A0072284E /* MockProductsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35C9439E087F63ECC4F59 /* MockProductsManager.swift */; };
 		2D8DB34B24072AAE00BE3D31 /* SubscriberAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8DB34A24072AAE00BE3D31 /* SubscriberAttributeTests.swift */; };
 		2D8E9D482523747D00AFEE11 /* NSDictionaryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD269162522A20A006AC4BC /* NSDictionaryExtensionsTests.swift */; };
 		2DAF814E25B24243002C621E /* RCIdentityManager+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DAF814D25B24243002C621E /* RCIdentityManager+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1836,6 +1837,7 @@
 				37E3524CB70618E6C5F3DB49 /* MockPurchasesDelegate.swift in Sources */,
 				37E35B1F34D1624509012749 /* MockSubscriberAttributesManager.swift in Sources */,
 				37E35AD3BB8E99D2AA325825 /* DeviceCacheSubscriberAttributesTests.swift in Sources */,
+				2D80736A268A691A0072284E /* MockProductsManager.swift in Sources */,
 				37E35F549AEB655AB6DA83B3 /* MockSKDiscount.swift in Sources */,
 				2D4D6AF324F7172900B656BE /* MockProductsRequest.swift in Sources */,
 				37E35D195CD0599FDB381D04 /* HTTPClientTests.swift in Sources */,

--- a/Purchases/ProtectedExtensions/RCPurchases+Protected.h
+++ b/Purchases/ProtectedExtensions/RCPurchases+Protected.h
@@ -21,7 +21,8 @@
     RCOperationDispatcher,
     RCIntroEligibilityCalculator,
     RCReceiptParser,
-    RCPurchaserInfoManager;
+    RCPurchaserInfoManager,
+    RCProductsManager;
 
 #import "RCStoreKitWrapper.h"
 
@@ -45,7 +46,8 @@ NS_ASSUME_NONNULL_BEGIN
               operationDispatcher:(RCOperationDispatcher *)operationDispatcher
        introEligibilityCalculator:(RCIntroEligibilityCalculator *)introEligibilityCalculator
                     receiptParser:(RCReceiptParser *)receiptParser
-             purchaserInfoManager:(RCPurchaserInfoManager *)purchaserInfoManager;
+             purchaserInfoManager:(RCPurchaserInfoManager *)purchaserInfoManager
+                  productsManager:(RCProductsManager *)productsManager;
 
 + (void)setDefaultInstance:(nullable RCPurchases *)instance;
 

--- a/Purchases/Purchasing/RCStoreKitRequestFetcher.h
+++ b/Purchases/Purchasing/RCStoreKitRequestFetcher.h
@@ -15,20 +15,13 @@ typedef void(^RCFetchProductsCompletionHandler)(NSArray<SKProduct *> *products);
 
 typedef void(^RCFetchReceiptCompletionHandler)(void);
 
-@class SKProduct, SKProductsRequest;
-
-@interface RCProductsRequestFactory : NSObject
-- (SKProductsRequest *)requestForProductIdentifiers:(NSSet<NSString *> *)identifiers;
+@interface RCReceiptRefreshRequestFactory : NSObject
 - (SKReceiptRefreshRequest *)receiptRefreshRequest;
 @end
 
-@interface RCStoreKitRequestFetcher : NSObject <SKProductsRequestDelegate>
+@interface RCStoreKitRequestFetcher : NSObject
 
-- (nullable instancetype)initWithRequestFactory:(RCProductsRequestFactory *)requestFactory;
-
-- (void)fetchProducts:(NSSet<NSString *> *)identifiers
-           completion:(RCFetchProductsCompletionHandler)completion;
-
+- (nullable instancetype)initWithRequestFactory:(RCReceiptRefreshRequestFactory *)requestFactory;
 - (void)fetchReceiptData:(RCFetchReceiptCompletionHandler)completion;
 
 @end

--- a/Purchases/Purchasing/RCStoreKitRequestFetcher.m
+++ b/Purchases/Purchasing/RCStoreKitRequestFetcher.m
@@ -23,9 +23,6 @@
 @interface RCStoreKitRequestFetcher () <SKRequestDelegate>
 @property (nonatomic) RCReceiptRefreshRequestFactory *requestFactory;
 
-@property (nonatomic) NSMutableDictionary<NSSet *, SKRequest *> *productsRequests;
-@property (nonatomic) NSMutableDictionary<NSSet *, NSMutableArray<RCFetchProductsCompletionHandler> *> *productsCompletionHandlers;
-
 @property (nonatomic) SKRequest *receiptRefreshRequest;
 @property (nonatomic) NSMutableArray<RCFetchReceiptCompletionHandler> *receiptRefreshCompletionHandlers;
 
@@ -41,9 +38,6 @@
 {
     if (self = [super init]) {
         self.requestFactory = requestFactory;
-        self.productsRequests = [NSMutableDictionary new];
-        self.productsCompletionHandlers = [NSMutableDictionary new];
-        
         self.receiptRefreshRequest = nil;
         self.receiptRefreshCompletionHandlers = [NSMutableArray new];
     }
@@ -86,7 +80,7 @@
 
 - (void)request:(SKRequest *)request didFailWithError:(NSError *)error
 {
-    RCAppleErrorLog(RCStrings.offering.fetching_products_failed, error.localizedDescription);
+    RCAppleErrorLog(RCStrings.offering.sk_request_failed, error.localizedDescription);
     if ([request isKindOfClass:SKReceiptRefreshRequest.class]) {
         NSArray<RCFetchReceiptCompletionHandler> *receiptHandlers = [self finishReceiptRequest:request];
         for (RCFetchReceiptCompletionHandler receiptHandler in receiptHandlers) {

--- a/Purchases/Purchasing/RCStoreKitRequestFetcher.m
+++ b/Purchases/Purchasing/RCStoreKitRequestFetcher.m
@@ -1,5 +1,5 @@
 //
-//  RCProductFetcher.m
+//  RCStoreKitRequestFetcher.m
 //  Purchases
 //
 //  Created by RevenueCat.
@@ -11,11 +11,7 @@
 #import "RCLogUtils.h"
 @import PurchasesCoreSwift;
 
-@implementation RCProductsRequestFactory : NSObject
-- (SKProductsRequest *)requestForProductIdentifiers:(NSSet<NSString *> *)identifiers
-{
-    return [[SKProductsRequest alloc] initWithProductIdentifiers:identifiers];
-}
+@implementation RCReceiptRefreshRequestFactory : NSObject
 
 - (SKReceiptRefreshRequest *)receiptRefreshRequest
 {
@@ -24,8 +20,8 @@
 
 @end
 
-@interface RCStoreKitRequestFetcher ()
-@property (nonatomic) RCProductsRequestFactory *requestFactory;
+@interface RCStoreKitRequestFetcher () <SKRequestDelegate>
+@property (nonatomic) RCReceiptRefreshRequestFactory *requestFactory;
 
 @property (nonatomic) NSMutableDictionary<NSSet *, SKRequest *> *productsRequests;
 @property (nonatomic) NSMutableDictionary<NSSet *, NSMutableArray<RCFetchProductsCompletionHandler> *> *productsCompletionHandlers;
@@ -38,10 +34,10 @@
 @implementation RCStoreKitRequestFetcher
 
 - (nullable instancetype)init {
-    return [self initWithRequestFactory:[RCProductsRequestFactory new]];
+    return [self initWithRequestFactory:[RCReceiptRefreshRequestFactory new]];
 }
 
-- (nullable instancetype)initWithRequestFactory:(RCProductsRequestFactory *)requestFactory;
+- (nullable instancetype)initWithRequestFactory:(RCReceiptRefreshRequestFactory *)requestFactory;
 {
     if (self = [super init]) {
         self.requestFactory = requestFactory;
@@ -52,34 +48,6 @@
         self.receiptRefreshCompletionHandlers = [NSMutableArray new];
     }
     return self;
-}
-
-- (void)fetchProducts:(NSSet<NSString *> *)identifiers
-           completion:(RCFetchProductsCompletionHandler)completion;
-{
-    
-    @synchronized(self) {
-        SKProductsRequest *newRequest = nil;
-        
-        if (self.productsRequests[identifiers] == nil) {
-            RCDebugLog(RCStrings.offering.fetching_products, identifiers);
-            newRequest = [self.requestFactory requestForProductIdentifiers:identifiers];
-            newRequest.delegate = self;
-            
-            self.productsRequests[identifiers] = newRequest;
-            self.productsCompletionHandlers[identifiers] = [NSMutableArray new];
-        }
-        
-        NSMutableArray *handlers = self.productsCompletionHandlers[identifiers];
-        NSAssert(handlers != nil, @"Corrupted handler storage");
-        
-        [handlers addObject:completion];
-        
-        
-        [newRequest start];
-    }
-    
-    NSAssert(self.productsRequests.count == self.productsCompletionHandlers.count, @"Corrupted handler storage");
 }
 
 - (void)fetchReceiptData:(void (^ _Nonnull)(void))completion
@@ -93,28 +61,6 @@
             [self.receiptRefreshRequest start];
         }
     }
-}
-
-- (NSArray<RCFetchProductsCompletionHandler> *)finishProductsRequest:(SKRequest *)request
-{
-    NSMutableArray<RCFetchProductsCompletionHandler> *handlers;
-    @synchronized(self) {
-        NSSet *associatedProductIdentifiers = nil;
-        for (NSSet *productIdentifiers in self.productsRequests) {
-            SKRequest *r = self.productsRequests[productIdentifiers];
-            if (r == request) {
-                NSAssert(associatedProductIdentifiers == nil, @"Request maps to multiple product sets");
-                associatedProductIdentifiers = productIdentifiers;
-            }
-        }
-        NSAssert(associatedProductIdentifiers != nil, @"Could not find request in storage");
-        
-        handlers = self.productsCompletionHandlers[associatedProductIdentifiers];
-        [self.productsRequests removeObjectForKey:associatedProductIdentifiers];
-        [self.productsCompletionHandlers removeObjectForKey:associatedProductIdentifiers];
-    }
-    NSAssert(self.productsRequests.count == self.productsCompletionHandlers.count, @"Corrupted handler storage");
-    return handlers;
 }
 
 - (NSArray<RCFetchReceiptCompletionHandler> *)finishReceiptRequest:(SKRequest *)request
@@ -146,34 +92,8 @@
         for (RCFetchReceiptCompletionHandler receiptHandler in receiptHandlers) {
             receiptHandler();
         }
-    } else if ([request isKindOfClass:SKProductsRequest.class]) {
-        NSArray<RCFetchProductsCompletionHandler> *productsHandlers = [self finishProductsRequest:request];
-        for (RCFetchProductsCompletionHandler handler in productsHandlers)
-        {
-            handler(@[]);
-        }
     }
     [request cancel];
-}
-
-- (void)productsRequest:(SKProductsRequest *)request didReceiveResponse:(SKProductsResponse *)response
-{
-    RCDebugLog(@"%@", RCStrings.offering.fetching_products_finished);
-    RCPurchaseLog(@"%@", RCStrings.offering.retrieved_products);
-    for (SKProduct *p in response.products)
-    {
-        RCPurchaseLog(RCStrings.offering.list_products, p.productIdentifier, p);
-    }
-    if (response.invalidProductIdentifiers.count > 0) {
-        RCAppleWarningLog(RCStrings.offering.invalid_product_identifiers, response.invalidProductIdentifiers);        
-    }
-
-    NSArray<RCFetchProductsCompletionHandler> *handlers = [self finishProductsRequest:request];
-    RCDebugLog(RCStrings.offering.completion_handlers_waiting_on_products, (unsigned long)handlers.count);
-    for (RCFetchProductsCompletionHandler handler in handlers)
-    {
-        handler(response.products);
-    }
 }
 
 @end

--- a/PurchasesCoreSwift/Logging/Strings/OfferingStrings.swift
+++ b/PurchasesCoreSwift/Logging/Strings/OfferingStrings.swift
@@ -15,7 +15,7 @@ import Foundation
         "\nMore info here: https://errors.rev.cat/configuring-products"}
     @objc public var completion_handlers_waiting_on_products: String { "%lu completion handlers waiting on products" }
     @objc public var fetching_offerings_error: String { "Error fetching offerings - %@" }
-    @objc public var fetching_products_failed: String { "SKRequest failed: %@" }
+    @objc public var sk_request_failed: String { "SKRequest failed: %@" }
     @objc public var fetching_products_finished: String { "Products request finished." }
     @objc public var fetching_products: String { "Requesting products from the store with identifiers: %@" }
     @objc public var found_existing_product_request: String { "Found an existing request for products: %@, appending " +

--- a/PurchasesCoreSwift/Purchasing/ProductsManager.swift
+++ b/PurchasesCoreSwift/Purchasing/ProductsManager.swift
@@ -9,7 +9,8 @@
 import Foundation
 import StoreKit
 
-internal class ProductsManager: NSObject {
+// TODO: make internal
+@objc(RCProductsManager) public class ProductsManager: NSObject {
     private let productsRequestFactory: ProductsRequestFactory
 
     private var cachedProductsByIdentifier: [String: SKProduct] = [:]
@@ -17,11 +18,12 @@ internal class ProductsManager: NSObject {
     private var productsByRequests: [SKRequest: Set<String>] = [:]
     private var completionHandlers: [Set<String>: [(Set<SKProduct>) -> Void]] = [:]
 
-    init(productsRequestFactory: ProductsRequestFactory = ProductsRequestFactory()) {
+    @objc public init(productsRequestFactory: ProductsRequestFactory = ProductsRequestFactory()) {
         self.productsRequestFactory = productsRequestFactory
     }
 
-    func products(withIdentifiers identifiers: Set<String>, completion: @escaping (Set<SKProduct>) -> Void) {
+    @objc public func products(withIdentifiers identifiers: Set<String>,
+                               completion: @escaping (Set<SKProduct>) -> Void) {
         queue.async { [self] in
             let productsAlreadyCached = self.cachedProductsByIdentifier.filter { key, _ in identifiers.contains(key) }
             if productsAlreadyCached.count == identifiers.count {
@@ -51,7 +53,7 @@ internal class ProductsManager: NSObject {
 
 extension ProductsManager: SKProductsRequestDelegate {
 
-    func productsRequest(_ request: SKProductsRequest, didReceive response: SKProductsResponse) {
+    public func productsRequest(_ request: SKProductsRequest, didReceive response: SKProductsResponse) {
         queue.async { [self] in
             Logger.rcSuccess(Strings.network.skproductsrequest_received_response)
             guard let requestProducts = self.productsByRequests[request] else {
@@ -73,12 +75,12 @@ extension ProductsManager: SKProductsRequestDelegate {
         }
     }
 
-    func requestDidFinish(_ request: SKRequest) {
+    public func requestDidFinish(_ request: SKRequest) {
         Logger.rcSuccess(Strings.network.skproductsrequest_finished)
         request.cancel()
     }
 
-    func request(_ request: SKRequest, didFailWithError error: Error) {
+    public func request(_ request: SKRequest, didFailWithError error: Error) {
         queue.async { [self] in
             Logger.appleError(String(format: Strings.network.skproductsrequest_failed, error.localizedDescription))
             guard let products = self.productsByRequests[request] else {

--- a/PurchasesCoreSwift/Purchasing/ProductsRequestFactory.swift
+++ b/PurchasesCoreSwift/Purchasing/ProductsRequestFactory.swift
@@ -6,7 +6,8 @@
 import Foundation
 import StoreKit
 
-class ProductsRequestFactory {
+// todo: make internal
+@objc(RCProductsRequestFactory) public class ProductsRequestFactory: NSObject {
     func request(productIdentifiers: Set<String>) -> SKProductsRequest {
         return SKProductsRequest(productIdentifiers: productIdentifiers)
     }

--- a/PurchasesCoreSwiftTests/Mocks/MockProductsManager.swift
+++ b/PurchasesCoreSwiftTests/Mocks/MockProductsManager.swift
@@ -22,6 +22,18 @@ class MockProductsManager: ProductsManager {
         invokedProductsParametersList.append(identifiers)
         if let result = stubbedProductsCompletionResult {
             completion(result)
+        } else {
+            let products: [SKProduct] = identifiers.map { (identifier) -> MockSKProduct in
+                let p = MockSKProduct(mockProductIdentifier: identifier)
+                p.mockSubscriptionGroupIdentifier = "1234567"
+                if #available(iOS 12.2, *) {
+                    let mockDiscount = MockDiscount()
+                    mockDiscount.mockIdentifier = "discount_id"
+                    p.mockDiscount = mockDiscount
+                }
+                return p
+            }
+            completion(Set(products))
         }
     }
 }

--- a/PurchasesTests/Mocks/MockRequestFetcher.swift
+++ b/PurchasesTests/Mocks/MockRequestFetcher.swift
@@ -5,27 +5,6 @@
 
 class MockRequestFetcher: RCStoreKitRequestFetcher {
     var refreshReceiptCalled = false
-    var failProducts = false
-    var requestedProducts: Set<String?>?
-
-    override func fetchProducts(_ identifiers: Set<String>, completion: @escaping RCFetchProductsCompletionHandler) {
-        if (failProducts) {
-            completion([SKProduct]())
-            return
-        }
-        requestedProducts = identifiers
-        let products = identifiers.map { (identifier) -> MockSKProduct in
-            let p = MockSKProduct(mockProductIdentifier: identifier)
-            p.mockSubscriptionGroupIdentifier = "1234567"
-            if #available(iOS 12.2, *) {
-                let mockDiscount = MockDiscount()
-                mockDiscount.mockIdentifier = "discount_id"
-                p.mockDiscount = mockDiscount
-            }
-            return p
-        }
-        completion(products)
-    }
 
     override func fetchReceiptData(_ completion: @escaping RCFetchReceiptCompletionHandler) {
         refreshReceiptCalled = true

--- a/PurchasesTests/Mocks/MockSKProduct.swift
+++ b/PurchasesTests/Mocks/MockSKProduct.swift
@@ -2,6 +2,7 @@
 // Created by RevenueCat on 3/2/20.
 // Copyright (c) 2020 Purchases. All rights reserved.
 //
+import StoreKit
 
 class MockSKProduct: SKProduct {
     var mockProductIdentifier: String

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -13,6 +13,7 @@ class PurchasesTests: XCTestCase {
     override func setUp() {
         self.userDefaults = UserDefaults(suiteName: "TestDefaults")
         requestFetcher = MockRequestFetcher()
+        mockProductsManager = MockProductsManager()
         systemInfo = MockSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: true)
         mockOperationDispatcher = MockOperationDispatcher()
         mockIntroEligibilityCalculator = MockIntroEligibilityCalculator()
@@ -187,6 +188,7 @@ class PurchasesTests: XCTestCase {
 
     let receiptFetcher = MockReceiptFetcher()
     var requestFetcher: MockRequestFetcher!
+    var mockProductsManager: MockProductsManager!
     let backend = MockBackend()
     let storeKitWrapper = MockStoreKitWrapper()
     let notificationCenter = MockNotificationCenter()
@@ -240,7 +242,8 @@ class PurchasesTests: XCTestCase {
                               operationDispatcher: mockOperationDispatcher,
                               introEligibilityCalculator: mockIntroEligibilityCalculator,
                               receiptParser: mockReceiptParser,
-                              purchaserInfoManager: purchaserInfoManager)
+                              purchaserInfoManager: purchaserInfoManager,
+                              productsManager: mockProductsManager)
 
         purchases!.delegate = purchasesDelegate
         Purchases.setDefaultInstance(purchases!)
@@ -703,7 +706,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        expect(self.requestFetcher.requestedProducts! as NSSet).toEventually(contain([product.productIdentifier]))
+        expect(self.mockProductsManager.invokedProductsParameters).toEventually(contain([product.productIdentifier]))
 
         expect(self.backend.postedProductID).toNot(beNil())
         expect(self.backend.postedPrice).toNot(beNil())
@@ -1647,7 +1650,8 @@ class PurchasesTests: XCTestCase {
     }
 
     func testMissingProductDetailsReturnsNil() {
-        requestFetcher.failProducts = true
+        self.mockProductsManager.stubbedProductsCompletionResult = Set<SKProduct>()
+
         offeringsFactory.emptyOfferings = true
         setupPurchases()
 
@@ -2354,7 +2358,7 @@ class PurchasesTests: XCTestCase {
     }
 
     func testProductIsRemovedButPresentInTheQueuedTransaction() {
-        self.requestFetcher.failProducts = true
+        self.mockProductsManager.stubbedProductsCompletionResult = Set<SKProduct>()
         setupPurchases()
         let product = MockSKProduct(mockProductIdentifier: "product")
 

--- a/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -12,6 +12,7 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
 
     let mockReceiptFetcher = MockReceiptFetcher()
     let mockRequestFetcher = MockRequestFetcher()
+    let mockProductsManager = MockProductsManager()
     let mockBackend = MockBackend()
     let mockStoreKitWrapper = MockStoreKitWrapper()
     let mockNotificationCenter = MockNotificationCenter()
@@ -89,7 +90,8 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
                               operationDispatcher: mockOperationDispatcher,
                               introEligibilityCalculator: mockIntroEligibilityCalculator,
                               receiptParser: mockReceiptParser,
-                              purchaserInfoManager: purchaserInfoManager)
+                              purchaserInfoManager: purchaserInfoManager,
+                              productsManager: mockProductsManager)
         purchases!.delegate = purchasesDelegate
         Purchases.setDefaultInstance(purchases!)
     }


### PR DESCRIPTION
This migration is split into 2 parts:
- Part 1: migrate the fetching of products into the **already existing code** in `ProductsManager.swift`, and update its usage
- Part 2: migrate fetching of receipts following the standard procedure described in the [Swift Migration Project docs](https://github.com/RevenueCat/purchases-ios/blob/swift_migration/CONTRIBUTING.md#-objc-to-swift-migration)

The reason I separated them is that they're pretty different in execution, both likely large, and can be done atomically. 

As for the `ProductsManager.swift` bit: 
This was done as a part of the project to parse local receipt files, and it's been used and tested for a while. So it's not exactly new code, it was actually duplicated logic in Swift and Obj-C. The reason that we had this duplicated is that this was one of the first things we ever added in Swift alongside doing modularization in the first place, and I wanted to de-risk by having that part as isolated as possible at first, since fetching products is very critical to the SDK. 

However, enough time has passed with this code working that we should be able to trust the Swift implementation. 