### PR TITLE
fix: flaky test in `StoreKitRequestFetcherTests`

### DIFF
--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -263,7 +263,8 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
     RCProductsRequestFactory *productsRequestFactory = [[RCProductsRequestFactory alloc] init];
     RCProductsManager *productsManager = [[RCProductsManager alloc] initWithProductsRequestFactory:productsRequestFactory];
     RCReceiptRefreshRequestFactory *receiptRefreshRequestFactory = [[RCReceiptRefreshRequestFactory alloc] init];
-    RCStoreKitRequestFetcher *fetcher = [[RCStoreKitRequestFetcher alloc] initWithRequestFactory:receiptRefreshRequestFactory];
+    RCStoreKitRequestFetcher *fetcher = [[RCStoreKitRequestFetcher alloc] initWithRequestFactory:receiptRefreshRequestFactory
+                                                                             operationDispatcher:operationDispatcher];
     return [self initWithAppUserID:appUserID
                     requestFetcher:fetcher
                     receiptFetcher:receiptFetcher

--- a/PurchasesTests/Mocks/MockRequestFetcher.swift
+++ b/PurchasesTests/Mocks/MockRequestFetcher.swift
@@ -12,4 +12,8 @@ class MockRequestFetcher: StoreKitRequestFetcher {
         refreshReceiptCalled = true
         completion()
     }
+
+    convenience init() {
+        self.init(operationDispatcher: OperationDispatcher())
+    }
 }

--- a/PurchasesTests/Purchasing/StoreKitRequestFetcherTests.swift
+++ b/PurchasesTests/Purchasing/StoreKitRequestFetcherTests.swift
@@ -49,12 +49,14 @@ class StoreKitRequestFetcherTests: XCTestCase {
 
     var fetcher: StoreKitRequestFetcher?
     var factory: MockRequestsFactory?
+    var operationDispatcher = MockOperationDispatcher()
     var receiptFetched = false
     var receiptFetchedCallbackCount = 0
 
     func setupFetcher(fails: Bool) {
+        self.operationDispatcher = MockOperationDispatcher()
         self.factory = MockRequestsFactory(fails: fails)
-        self.fetcher = StoreKitRequestFetcher(requestFactory: self.factory!)
+        self.fetcher = StoreKitRequestFetcher(requestFactory: self.factory!, operationDispatcher: operationDispatcher)
 
         self.fetcher!.fetchReceiptData {
             self.receiptFetched = true
@@ -82,7 +84,7 @@ class StoreKitRequestFetcherTests: XCTestCase {
 
     func testCallsStartOnRequest() {
         setupFetcher(fails: false)
-        expect((self.factory!.requests[0] as! MockReceiptRequest).startCalled).toEventually(beTrue(), timeout: .seconds(2))
+        expect((self.factory!.requests[0] as! MockReceiptRequest).startCalled).toEventually(beTrue(), timeout: .seconds(1))
     }
     func testFetchesReceipt() {
         setupFetcher(fails: false)


### PR DESCRIPTION
`StoreKitRequestFetcherTests` were failing, because the new version in swift uses GCD for thread management, which might take a little longer to queue up than the old `@syncrhonized` blocks. 
This wasn't a problem locally, but on slow CI machines tests became flaky. 

This PR replaces the queue in `StoreKitRequestFetcher` by using `OperationDispatcher`. 
This is functionally the same, since `OperationDispatcher` will just forward to its own worker queue. However, we already have some mocks in place to have the tests execute the queued-up work straight away, so this should eliminate the flakiness. 

It's also best practice to [avoid creating too many private queues](https://developer.apple.com/documentation/dispatch/dispatchqueue), so this also helps by unifying to a single queue. 