### PR TITLE
Fix: pod structure

### DIFF
--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -967,6 +967,7 @@
 		354235D524C11138008C84EE /* Purchasing */ = {
 			isa = PBXGroup;
 			children = (
+				80E80EF026970DC3008F245A /* RCReceiptFetcher.swift */,
 				B372EC55268FEF020099171E /* ProductInfo.swift */,
 				37E35C7060D7E486F5958BED /* ProductsManager.swift */,
 				37E35E8DCF998D9DB63850F8 /* ProductsRequestFactory.swift */,
@@ -1159,7 +1160,6 @@
 				37E35105C5C36A30D084954C /* RCOfferingsFactory.m */,
 				37E359B77C1E588C9C009D2B /* RCStoreKitWrapper.h */,
 				37E35CE6628D07BD2C4A07C0 /* RCStoreKitWrapper.m */,
-				80E80EF026970DC3008F245A /* RCReceiptFetcher.swift */,
 			);
 			path = Purchasing;
 			sourceTree = "<group>";

--- a/PurchasesCoreSwift/Purchasing/RCReceiptFetcher.swift
+++ b/PurchasesCoreSwift/Purchasing/RCReceiptFetcher.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 // TODO: Make internal after migration to Swift is complete
-@objc open class RCReceiptFetcher: NSObject {
+@objc(RCReceiptFetcher) open class ReceiptFetcher: NSObject {
 
     // TODO: Make internal after migration to Swift is complete
     @objc open func receiptData() -> Data? {

--- a/PurchasesTests/Mocks/MockReceiptFetcher.swift
+++ b/PurchasesTests/Mocks/MockReceiptFetcher.swift
@@ -3,7 +3,7 @@
 // Copyright (c) 2020 Purchases. All rights reserved.
 //
 
-class MockReceiptFetcher: RCReceiptFetcher {
+class MockReceiptFetcher: ReceiptFetcher {
     var receiptDataCalled = false
     var shouldReturnReceipt = true
     var shouldReturnZeroBytesReceipt = false


### PR DESCRIPTION
The PR where `RCReceiptFetcher` [was migrated](https://github.com/RevenueCat/purchases-ios/pull/628) introduced a swift file in the `Purchases` folder, instead of `PurchasesCoreSwift`. 

However, both our Podspecs and our SPM setup assume that all of the Swift files will be located in `PurchasesCoreSwift`, so the SDK could no longer be integrated, with a compilation failure. 

This fixes that compilation error by moving the file to the correct folder, and also updates the naming a little bit. 