### PR TITLE
remove unused typedef to fix build warning

### DIFF
--- a/Purchases/Networking/RCHTTPClient.m
+++ b/Purchases/Networking/RCHTTPClient.m
@@ -28,8 +28,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation RCHTTPClient
 
-typedef void (^RetryRequestBlock)();
-
 - (instancetype)initWithSystemInfo:(RCSystemInfo *)systemInfo
                        eTagManager:(RCETagManager *)eTagManager {
     if (self = [super init]) {


### PR DESCRIPTION
remove unused typedef to fix build warning. I believe this was introduced in #509, and was unused

<img width="740" alt="image" src="https://user-images.githubusercontent.com/3922667/125520949-e2cc3ee2-5165-474f-9d15-78815dccc382.png">
