### PR TITLE
Create a build step to check TARGET_OS macro

### DIFF
--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -1393,6 +1393,7 @@
 				2DC5621224EC63420031F69B /* Sources */,
 				2DC5621324EC63420031F69B /* Frameworks */,
 				2DC5621424EC63420031F69B /* Resources */,
+				F578415E26A0407A00EA3D8A /* Check TARGET_OS macro */,
 			);
 			buildRules = (
 			);
@@ -1666,6 +1667,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "scripts/swiftlint.sh\n";
+		};
+		F578415E26A0407A00EA3D8A /* Check TARGET_OS macro */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Check TARGET_OS macro";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if grep -rl 2>/dev/null --include=\"*.swift\" \"TARGET_OS\" \"${SRCROOT}\"; then\n  echo \"error: TARGET_OS macro has been found in some files\"\n  exit 1\nfi\n\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -1684,7 +1684,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if grep -rl 2>/dev/null --include=\"*.swift\" \"TARGET_OS\" \"${SRCROOT}\"; then\n  echo \"error: TARGET_OS macro has been found in some files\"\n  exit 1\nfi\n\n";
+			shellScript = "if grep -rl 2>/dev/null --include=\"*.swift\" \"TARGET_OS\" \"${SRCROOT}\"; then\n  echo \"error: TARGET_OS macro has been found in some Swift files\"\n  exit 1\nfi\n\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Resolves #629

>This PR already included the suggested changes by @taquitos in PR #653

This PR aims to create a new build phase that runs a script to validate that some macros, like `TARGET_OS_ (TARGET_OS_IPHONE, TARGET_OS_SIMULATOR)`, are not included in any Swift file.

The script checks all the swift files in the project folder to find the specified tag.
If the script found some files, the project will not compile, and the developer can see this error:

![Screenshot 2021-07-15 at 15 42 10](https://user-images.githubusercontent.com/1409041/125798189-4bbce12d-b636-4fd7-9648-791d37cf5d83.png)
![Screenshot 2021-07-15 at 15 42 53](https://user-images.githubusercontent.com/1409041/125798195-3684e757-3701-4f3b-90e8-098f3c9ea116.png)

