### PR TITLE
Fix: Calling `setDebugLogsEnabled(false)` enables debug logs when it should not

### DIFF
--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -96,7 +96,11 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 }
 
 + (void)setDebugLogsEnabled:(BOOL)enabled {
-    [self setLogLevel:RCLogLevelDebug];
+    if (enabled) {
+        [self setLogLevel:RCLogLevelDebug];
+    } else {
+        [self setLogLevel:RCLogLevelInfo];
+    }
 }
 
 + (BOOL)debugLogsEnabled {

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -96,11 +96,8 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 }
 
 + (void)setDebugLogsEnabled:(BOOL)enabled {
-    if (enabled) {
-        [self setLogLevel:RCLogLevelDebug];
-    } else {
-        [self setLogLevel:RCLogLevelInfo];
-    }
+    RCLogLevel level = enabled ? RCLogLevelDebug : RCLogLevelInfo;
+    [self setLogLevel:level];
 }
 
 + (BOOL)debugLogsEnabled {

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -7,6 +7,7 @@ import XCTest
 import Nimble
 
 import Purchases
+import PurchasesCoreSwift
 
 class PurchasesTests: XCTestCase {
 
@@ -2558,6 +2559,16 @@ class PurchasesTests: XCTestCase {
             purchases.storeKitWrapper(storeKitWrapper, didRevokeEntitlementsForProductIdentifiers: ["a", "b"])
             expect(self.backend.postReceiptDataCalled).to(beTrue())
         }
+    }
+
+    func testSetDebugLogsEnabledSetsTheCorrectValue() {
+        Logger.logLevel = .warn
+        
+        Purchases.debugLogsEnabled = true
+        expect(Logger.logLevel) == .debug
+
+        Purchases.debugLogsEnabled = false
+        expect(Logger.logLevel) == .info
     }
 
 


### PR DESCRIPTION
Addresses #662. 

