### PR TITLE
fix: introEligibility marked as `eligible` for products that don't have intro pricing

### DIFF
--- a/PurchasesCoreSwift/IntroEligibilityCalculator.swift
+++ b/PurchasesCoreSwift/IntroEligibilityCalculator.swift
@@ -87,7 +87,9 @@ private extension IntroEligibilityCalculator {
                         && candidate.subscriptionGroupIdentifier == purchased.subscriptionGroupIdentifier)
                     return foundByGroupId
                 }
-            result[candidate.productIdentifier] = usedIntroForProductIdentifier
+
+            let hasIntroductoryPrice = candidate.introductoryPrice != nil
+            result[candidate.productIdentifier] = !hasIntroductoryPrice || usedIntroForProductIdentifier
                 ? IntroEligibilityStatus.ineligible.toNSNumber()
                 : IntroEligibilityStatus.eligible.toNSNumber()
         }

--- a/PurchasesCoreSwiftTests/IntroEligibilityCalculatorTests.swift
+++ b/PurchasesCoreSwiftTests/IntroEligibilityCalculatorTests.swift
@@ -98,7 +98,8 @@ class IntroEligibilityCalculatorTests: XCTestCase {
                                         "com.revenuecat.unknownProduct"])
 
         calculator.checkTrialOrIntroductoryPriceEligibility(with: Data(),
-                                                            productIdentifiers: Set(candidateIdentifiers)) { eligibility, error in
+                                                            productIdentifiers: Set(candidateIdentifiers)) { eligibility,
+                                                                                                             error in
             completionCalled = true
             receivedError = error
             receivedEligibility = eligibility
@@ -111,6 +112,38 @@ class IntroEligibilityCalculatorTests: XCTestCase {
             "com.revenuecat.product2": IntroEligibilityStatus.ineligible.toNSNumber(),
             "com.revenuecat.unknownProduct": IntroEligibilityStatus.unknown.toNSNumber(),
         ]
+    }
+
+    func testCheckTrialOrIntroductoryPriceEligibilityForProductWithoutIntroTrialReturnsIneligible() {
+        if #available(iOS 12.2, *) {
+            var receivedError: Error? = nil
+            var receivedEligibility: [String: NSNumber]? = nil
+            var completionCalled = false
+
+            let receipt = mockReceipt()
+            mockReceiptParser.stubbedParseResult = receipt
+            let mockProduct = MockSKProduct(mockProductIdentifier: "com.revenuecat.product1",
+                                            mockSubscriptionGroupIdentifier: "group1")
+            mockProduct.mockDiscount = nil
+            mockProductsManager.stubbedProductsCompletionResult = Set([mockProduct])
+
+            let candidateIdentifiers = Set(["com.revenuecat.product1"])
+
+            calculator.checkTrialOrIntroductoryPriceEligibility(
+                with: Data(),
+                productIdentifiers: Set(candidateIdentifiers)
+            ) { eligibility, error in
+                completionCalled = true
+                receivedError = error
+                receivedEligibility = eligibility
+            }
+
+            expect(completionCalled).toEventually(beTrue())
+            expect(receivedError).to(beNil())
+            expect(receivedEligibility) == [
+                "com.revenuecat.product1": IntroEligibilityStatus.ineligible.toNSNumber()
+            ]
+        }
     }
 }
 

--- a/PurchasesCoreSwiftTests/IntroEligibilityCalculatorTests.swift
+++ b/PurchasesCoreSwiftTests/IntroEligibilityCalculatorTests.swift
@@ -5,17 +5,17 @@ import Nimble
 
 @available(iOS 12.0, macOS 10.14, macCatalyst 13.0, tvOS 12.0, watchOS 6.2, *)
 class IntroEligibilityCalculatorTests: XCTestCase {
-    
+
     var calculator: IntroEligibilityCalculator!
     let mockProductsManager = MockProductsManager()
     let mockReceiptParser = MockReceiptParser()
-    
+
     override func setUp() {
         super.setUp()
         calculator = IntroEligibilityCalculator(productsManager: mockProductsManager,
                                                 receiptParser: mockReceiptParser)
     }
-    
+
     func testCheckTrialOrIntroductoryPriceEligibilityReturnsEmptyIfNoProductIds() {
         var receivedError: Error? = nil
         var receivedEligibility: [String: NSNumber]? = nil
@@ -27,21 +27,21 @@ class IntroEligibilityCalculatorTests: XCTestCase {
             receivedError = error
             receivedEligibility = eligibilityByProductId
         }
-        
+
         expect(completionCalled).toEventually(beTrue())
         expect(receivedError).to(beNil())
         expect(receivedEligibility).toNot(beNil())
         expect(receivedEligibility).to(beEmpty())
     }
-    
+
     func testCheckTrialOrIntroductoryPriceEligibilityReturnsErrorIfReceiptParserThrows() {
         var receivedError: Error? = nil
         var receivedEligibility: [String: NSNumber]? = nil
         var completionCalled = false
         let productIdentifiers = Set(["com.revenuecat.test"])
-        
+
         mockReceiptParser.stubbedParseError = ReceiptReadingError.receiptParsingError
-        
+
         calculator.checkTrialOrIntroductoryPriceEligibility(with: Data(),
                                                             productIdentifiers: productIdentifiers) {
             eligibilityByProductId,
@@ -50,56 +50,56 @@ class IntroEligibilityCalculatorTests: XCTestCase {
             receivedError = error
             receivedEligibility = eligibilityByProductId
         }
-        
+
         expect(completionCalled).toEventually(beTrue())
         expect(receivedError).to(matchError(ReceiptReadingError.receiptParsingError))
         expect(receivedEligibility).toNot(beNil())
         expect(receivedEligibility).to(beEmpty())
     }
-    
+
     func testCheckTrialOrIntroductoryPriceEligibilityMakesOnlyOneProductsRequest() {
         var completionCalled = false
-        
+
         let receipt = mockReceipt()
         mockReceiptParser.stubbedParseResult = receipt
         let receiptIdentifiers = receipt.purchasedIntroOfferOrFreeTrialProductIdentifiers()
-        
+
         mockProductsManager.stubbedProductsCompletionResult = Set(["a", "b"].map {
             MockSKProduct(mockProductIdentifier: $0)
         })
-        
+
         let candidateIdentifiers = Set(["a", "b", "c"])
         calculator.checkTrialOrIntroductoryPriceEligibility(with: Data(),
                                                             productIdentifiers: Set(candidateIdentifiers)) { _, _ in
             completionCalled = true
         }
-        
+
         expect(completionCalled).toEventually(beTrue())
         expect(self.mockProductsManager.invokedProductsCount) == 1
         expect(self.mockProductsManager.invokedProductsParameters) == candidateIdentifiers.union(receiptIdentifiers)
     }
-    
+
     func testCheckTrialOrIntroductoryPriceEligibilityGetsCorrectResult() {
         var receivedError: Error? = nil
         var receivedEligibility: [String: NSNumber]? = nil
         var completionCalled = false
-        
+
         let receipt = mockReceipt()
         mockReceiptParser.stubbedParseResult = receipt
-        
+
         let product1 = MockSKProduct(mockProductIdentifier: "com.revenuecat.product1",
                                      mockSubscriptionGroupIdentifier: "group1")
         product1.mockDiscount = MockDiscount()
         let product2 = MockSKProduct(mockProductIdentifier: "com.revenuecat.product2",
                                      mockSubscriptionGroupIdentifier: "group2")
         product2.mockDiscount = MockDiscount()
-        
+
         mockProductsManager.stubbedProductsCompletionResult = Set([product1, product2])
-        
+
         let candidateIdentifiers = Set(["com.revenuecat.product1",
                                         "com.revenuecat.product2",
                                         "com.revenuecat.unknownProduct"])
-        
+
         calculator.checkTrialOrIntroductoryPriceEligibility(with: Data(),
                                                             productIdentifiers: Set(candidateIdentifiers)) { eligibility,
                                                                                                              error in
@@ -107,7 +107,7 @@ class IntroEligibilityCalculatorTests: XCTestCase {
             receivedError = error
             receivedEligibility = eligibility
         }
-        
+
         expect(completionCalled).toEventually(beTrue())
         expect(receivedError).to(beNil())
         expect(receivedEligibility) == [
@@ -116,21 +116,21 @@ class IntroEligibilityCalculatorTests: XCTestCase {
             "com.revenuecat.unknownProduct": IntroEligibilityStatus.unknown.toNSNumber(),
         ]
     }
-    
+
     func testCheckTrialOrIntroductoryPriceEligibilityForProductWithoutIntroTrialReturnsIneligible() {
         var receivedError: Error? = nil
         var receivedEligibility: [String: NSNumber]? = nil
         var completionCalled = false
-        
+
         let receipt = mockReceipt()
         mockReceiptParser.stubbedParseResult = receipt
         let mockProduct = MockSKProduct(mockProductIdentifier: "com.revenuecat.product1",
                                         mockSubscriptionGroupIdentifier: "group1")
         mockProduct.mockDiscount = nil
         mockProductsManager.stubbedProductsCompletionResult = Set([mockProduct])
-        
+
         let candidateIdentifiers = Set(["com.revenuecat.product1"])
-        
+
         calculator.checkTrialOrIntroductoryPriceEligibility(
             with: Data(),
             productIdentifiers: Set(candidateIdentifiers)
@@ -139,7 +139,7 @@ class IntroEligibilityCalculatorTests: XCTestCase {
             receivedError = error
             receivedEligibility = eligibility
         }
-        
+
         expect(completionCalled).toEventually(beTrue())
         expect(receivedError).to(beNil())
         expect(receivedEligibility) == [
@@ -193,7 +193,7 @@ private extension IntroEligibilityCalculatorTests {
                           promotionalOfferIdentifier: nil)
         ]
     }
-    
+
     func mockReceipt() -> AppleReceipt {
         return AppleReceipt(bundleId: "com.revenuecat.test",
                             applicationVersion: "3.4.5",

--- a/PurchasesCoreSwiftTests/Mocks/MockSKDiscount.swift
+++ b/PurchasesCoreSwiftTests/Mocks/MockSKDiscount.swift
@@ -6,7 +6,7 @@
 import Foundation
 import StoreKit
 
-@available(iOS 11.2, *)
+@available(iOS 11.2, macCatalyst 13.0, macOS 10.13.2, tvOS 11.2, *)
 class MockDiscount: SKProductDiscount {
     var mockPaymentMode: SKProductDiscount.PaymentMode?
     override var paymentMode: SKProductDiscount.PaymentMode {

--- a/PurchasesCoreSwiftTests/Mocks/MockSKProduct.swift
+++ b/PurchasesCoreSwiftTests/Mocks/MockSKProduct.swift
@@ -32,7 +32,7 @@ class MockSKProduct: SKProduct {
         return mockPrice ?? 2.99 as NSDecimalNumber
     }
 
-    @available(iOS 11.2, *)
+    @available(iOS 11.2, macCatalyst 13.0, macOS 10.13.2, tvOS 11.2, *)
     override var introductoryPrice: SKProductDiscount? {
         if #available(iOS 12.2, *) {
             return mockDiscount
@@ -40,18 +40,18 @@ class MockSKProduct: SKProduct {
         return nil
     }
 
-    @available(iOS 12.2, *)
+    @available(iOS 11.2, macCatalyst 13.0, macOS 10.13.2, tvOS 11.2, *)
     lazy var mockDiscount: SKProductDiscount? = nil
 
-    @available(iOS 12.2, *)
+    @available(iOS 11.2, macCatalyst 13.0, macOS 10.13.2, tvOS 11.2, *)
     override var discounts: [SKProductDiscount] {
         return (mockDiscount != nil) ? [mockDiscount!] : []
     }
 
-    @available(iOS 11.2, *)
+    @available(iOS 11.2, macCatalyst 13.0, macOS 10.13.2, tvOS 11.2, *)
     lazy var mockSubscriptionPeriod: SKProductSubscriptionPeriod? = nil
 
-    @available(iOS 11.2, *)
+    @available(iOS 11.2, macCatalyst 13.0, macOS 10.13.2, tvOS 11.2, *)
     override var subscriptionPeriod: SKProductSubscriptionPeriod {
         return mockSubscriptionPeriod ?? SKProductSubscriptionPeriod(numberOfUnits: 1, unit:.month)
     }

--- a/PurchasesCoreSwiftTests/Mocks/MockSKProduct.swift
+++ b/PurchasesCoreSwiftTests/Mocks/MockSKProduct.swift
@@ -35,10 +35,9 @@ class MockSKProduct: SKProduct {
     @available(iOS 11.2, *)
     override var introductoryPrice: SKProductDiscount? {
         if #available(iOS 12.2, *) {
-            return mockDiscount ?? MockDiscount()
-        } else {
-            return MockDiscount()
+            return mockDiscount
         }
+        return nil
     }
 
     @available(iOS 12.2, *)


### PR DESCRIPTION
Our intro eligibility calculation is considering the status for all products that don't have any intro pricing set up as `eligible`, when they should be `ineligible` if no intro pricing exists. 
This only affects calls to `checkTrialOrIntroductoryPriceEligibility:` that include product identifiers for products that don't have intro pricing set up. 

Fixed by adding an extra check. 