### PR TITLE
Split HTTPClient method

### DIFF
--- a/Purchases/Networking/RCBackend.m
+++ b/Purchases/Networking/RCBackend.m
@@ -194,20 +194,19 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
         body[@"presented_offering_identifier"] = offeringIdentifier;
     }
 
-    [self.httpClient performRequest:@"POST"
-                    performSerially:YES
-                               path:@"/receipts"
-                        requestBody:body
-                            headers:self.authHeaders
-                  completionHandler:^(NSInteger status, NSDictionary *response, NSError *error) {
-                      NSArray *callbacks = [self getCallbacksAndClearForKey:cacheKey];
-                      for (RCBackendPurchaserInfoResponseHandler callback in callbacks) {
-                          [self handlePurchaserInfoWithResponse:response
-                                                     statusCode:status
-                                                          error:error
-                                                     completion:callback];
-                      }
-                  }];
+    [self.httpClient performPOSTRequestSerially:YES
+                                           path:@"/receipts"
+                                    requestBody:body
+                                        headers:self.authHeaders
+                              completionHandler:^(NSInteger status, NSDictionary *response, NSError *error) {
+                                  NSArray *callbacks = [self getCallbacksAndClearForKey:cacheKey];
+                                  for (RCBackendPurchaserInfoResponseHandler callback in callbacks) {
+                                      [self handlePurchaserInfoWithResponse:response
+                                                                 statusCode:status
+                                                                      error:error
+                                                                 completion:callback];
+                                  }
+                              }];
 }
 
 - (void)getSubscriberDataWithAppUserID:(NSString *)appUserID
@@ -219,19 +218,17 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
         return;
     }
 
-    [self.httpClient performRequest:@"GET"
-                    performSerially:YES
-                               path:path
-                        requestBody:nil
-                            headers:self.authHeaders
-                  completionHandler:^(NSInteger status, NSDictionary *response, NSError *error) {
-                      for (RCBackendPurchaserInfoResponseHandler completion in [self getCallbacksAndClearForKey:path]) {
-                          [self handlePurchaserInfoWithResponse:response
-                                                     statusCode:status
-                                                          error:error
-                                                     completion:completion];
-                      }
-                  }];
+    [self.httpClient performGETRequestSerially:YES
+                                          path:path
+                                       headers:self.authHeaders
+                             completionHandler:^(NSInteger status, NSDictionary *response, NSError *error) {
+                                  for (RCBackendPurchaserInfoResponseHandler completion in [self getCallbacksAndClearForKey:path]) {
+                                      [self handlePurchaserInfoWithResponse:response
+                                                                 statusCode:status
+                                                                      error:error
+                                                                 completion:completion];
+                                  }
+                             }];
 }
 
 - (void)getIntroEligibilityForAppUserID:(NSString *)appUserID
@@ -259,36 +256,35 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
 
     NSString *escapedAppUserID = [self escapedAppUserID:appUserID];
     NSString *path = [NSString stringWithFormat:@"/subscribers/%@/intro_eligibility", escapedAppUserID];
-    [self.httpClient performRequest:@"POST"
-                    performSerially:YES
-                               path:path
-                        requestBody:@{
-                                      @"product_identifiers": productIdentifiers,
-                                      @"fetch_token": fetchToken
+    [self.httpClient performPOSTRequestSerially:YES
+                                           path:path
+                                    requestBody:@{
+                                            @"product_identifiers": productIdentifiers,
+                                            @"fetch_token": fetchToken
+                                        }
+                                        headers:self.authHeaders
+                              completionHandler:^(NSInteger statusCode, NSDictionary * _Nullable response, NSError * _Nullable error) {
+                                  if (statusCode >= RCHTTPStatusCodesRedirect || error != nil) {
+                                      response = @{};
+                                  }
+
+                                  NSMutableDictionary *eligibilities = [NSMutableDictionary new];
+                                  for (NSString *productID in productIdentifiers) {
+                                      NSNumber *e = response[productID];
+                                      RCIntroEligibilityStatus status;
+                                      if (e == nil || [e isKindOfClass:[NSNull class]]) {
+                                          status = RCIntroEligibilityStatusUnknown;
+                                      } else if ([e boolValue]) {
+                                          status = RCIntroEligibilityStatusEligible;
+                                      } else {
+                                          status = RCIntroEligibilityStatusIneligible;
                                       }
-                            headers:self.authHeaders
-                  completionHandler:^(NSInteger statusCode, NSDictionary * _Nullable response, NSError * _Nullable error) {
-                      if (statusCode >= RCHTTPStatusCodesRedirect || error != nil) {
-                          response = @{};
-                      }
 
-                      NSMutableDictionary *eligibilities = [NSMutableDictionary new];
-                      for (NSString *productID in productIdentifiers) {
-                          NSNumber *e = response[productID];
-                          RCIntroEligibilityStatus status;
-                          if (e == nil || [e isKindOfClass:[NSNull class]]) {
-                              status = RCIntroEligibilityStatusUnknown;
-                          } else if ([e boolValue]) {
-                              status = RCIntroEligibilityStatusEligible;
-                          } else {
-                              status = RCIntroEligibilityStatusIneligible;
-                          }
+                                      eligibilities[productID] = [[RCIntroEligibility alloc] initWithEligibilityStatus:status];
+                                  }
 
-                          eligibilities[productID] = [[RCIntroEligibility alloc] initWithEligibilityStatus:status];
-                      }
-
-                      completion([NSDictionary dictionaryWithDictionary:eligibilities]);
-    }];
+                                  completion([NSDictionary dictionaryWithDictionary:eligibilities]);
+                               }];
 }
 
 - (void)getOfferingsForAppUserID:(NSString *)appUserID
@@ -306,29 +302,27 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
         return;
     }
 
-    [self.httpClient performRequest:@"GET"
-                    performSerially:NO
-                               path:path
-                        requestBody:nil
-                            headers:self.authHeaders
-                  completionHandler:^(NSInteger statusCode, NSDictionary * _Nullable response, NSError * _Nullable error) {
-                      if (error == nil && statusCode < RCHTTPStatusCodesRedirect) {
-                          for (RCOfferingsResponseHandler callback in [self getCallbacksAndClearForKey:path]) {
-                              callback(response, nil);
-                          }
-                          return;
-                      }
+    [self.httpClient performGETRequestSerially:NO
+                                          path:path
+                                       headers:self.authHeaders
+                             completionHandler:^(NSInteger statusCode, NSDictionary * _Nullable response, NSError * _Nullable error) {
+                                  if (error == nil && statusCode < RCHTTPStatusCodesRedirect) {
+                                      for (RCOfferingsResponseHandler callback in [self getCallbacksAndClearForKey:path]) {
+                                          callback(response, nil);
+                                      }
+                                      return;
+                                  }
 
-                      if (error != nil) {
-                          error = [RCPurchasesErrorUtils networkErrorWithUnderlyingError:error];
-                      } else if (statusCode > RCHTTPStatusCodesRedirect) {
-                          error = [RCPurchasesErrorUtils backendErrorWithBackendCode:response[@"code"]
-                                                                      backendMessage:response[@"message"]];
-                      }
-                      for (RCOfferingsResponseHandler callback in [self getCallbacksAndClearForKey:path]) {
-                          callback(nil, error);
-                      }
-                  }];
+                                  if (error != nil) {
+                                      error = [RCPurchasesErrorUtils networkErrorWithUnderlyingError:error];
+                                  } else if (statusCode > RCHTTPStatusCodesRedirect) {
+                                      error = [RCPurchasesErrorUtils backendErrorWithBackendCode:response[@"code"]
+                                                                                  backendMessage:response[@"message"]];
+                                  }
+                                  for (RCOfferingsResponseHandler callback in [self getCallbacksAndClearForKey:path]) {
+                                      callback(nil, error);
+                                  }
+                              }];
 }
 
 - (void)postAttributionData:(NSDictionary *)data
@@ -338,17 +332,16 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
     NSString *escapedAppUserID = [self escapedAppUserID:appUserID];
     NSString *path = [NSString stringWithFormat:@"/subscribers/%@/attribution", escapedAppUserID];
 
-    [self.httpClient performRequest:@"POST"
-                    performSerially:YES
-                               path:path
-                        requestBody:@{
-                                      @"network": @(network),
-                                      @"data": data
-                                      }
-                            headers:self.authHeaders
-                  completionHandler:^(NSInteger status, NSDictionary *_Nullable response, NSError *_Nullable error) {
-                      [self handleResponse:response statusCode:status error:error completion:completion];
-                  }];
+    [self.httpClient performPOSTRequestSerially:YES
+                                           path:path
+                                    requestBody:@{
+                                            @"network": @(network),
+                                            @"data": data
+                                        }
+                                        headers:self.authHeaders
+                              completionHandler:^(NSInteger status, NSDictionary *_Nullable response, NSError *_Nullable error) {
+                                [self handleResponse:response statusCode:status error:error completion:completion];
+                              }];
 }
 
 - (void)logInWithCurrentAppUserID:(NSString *)currentAppUserID
@@ -359,20 +352,19 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
     NSParameterAssert(currentAppUserID);
     NSParameterAssert(newAppUserID);
     NSString *path = @"/subscribers/identify";
-    [self.httpClient performRequest:@"POST"
-                    performSerially:YES
-                               path:path
-                        requestBody:@{
-                                   @"app_user_id": currentAppUserID,
-                                   @"new_app_user_id": newAppUserID
-                               }
-                            headers:self.authHeaders
-                  completionHandler:^(NSInteger status, NSDictionary *_Nullable response, NSError *_Nullable error) {
-                      [self handleLoginWithResponse:response
-                                         statusCode:status
-                                              error:error
-                                         completion:completion];
-                  }];
+    [self.httpClient performPOSTRequestSerially:YES
+                                           path:path
+                                    requestBody:@{
+                                            @"app_user_id": currentAppUserID,
+                                            @"new_app_user_id": newAppUserID
+                                    }
+                                        headers:self.authHeaders
+                              completionHandler:^(NSInteger status, NSDictionary *_Nullable response, NSError *_Nullable error) {
+                                  [self handleLoginWithResponse:response
+                                                     statusCode:status
+                                                          error:error
+                                                     completion:completion];
+                              }];
 }
 
 - (void)handleLoginWithResponse:(nullable NSDictionary *)response
@@ -413,16 +405,15 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
                      completion:(nullable void (^)(NSError * _Nullable error))completion {
     NSString *escapedAppUserID = [self escapedAppUserID:appUserID];
     NSString *path = [NSString stringWithFormat:@"/subscribers/%@/alias", escapedAppUserID];
-    [self.httpClient performRequest:@"POST"
-                    performSerially:YES
-                               path:path
-                        requestBody:@{
-                                       @"new_app_user_id": newAppUserID
-                               }
-                            headers:self.authHeaders
-                  completionHandler:^(NSInteger status, NSDictionary *_Nullable response, NSError *_Nullable error) {
-                      [self handleResponse:response statusCode:status error:error completion:completion];
-                  }];
+    [self.httpClient performPOSTRequestSerially:YES
+                                           path:path
+                                    requestBody:@{
+                                        @"new_app_user_id": newAppUserID
+                                    }
+                                        headers:self.authHeaders
+                              completionHandler:^(NSInteger status, NSDictionary *_Nullable response, NSError *_Nullable error) {
+                                  [self handleResponse:response statusCode:status error:error completion:completion];
+                              }];
 }
 
 - (void)postOfferForSigning:(NSString *)offerIdentifier
@@ -432,53 +423,52 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
                   appUserID:(NSString *)appUserID
                  completion:(RCOfferSigningResponseHandler)completion {
     NSString *fetchToken = [receiptData base64EncodedStringWithOptions:0];
-    [self.httpClient performRequest:@"POST"
-                    performSerially:YES
-                               path:@"/offers"
-                        requestBody:@{
-                                       @"app_user_id": appUserID,
-                                       @"fetch_token": fetchToken,
-                                       @"generate_offers": @[@{
-                                               @"offer_id": offerIdentifier,
-                                               @"product_id": productIdentifier,
-                                               @"subscription_group": subscriptionGroup
-                                       }],
-                               }
-                            headers:self.authHeaders
-                  completionHandler:^(NSInteger statusCode, NSDictionary *_Nullable response, NSError *_Nullable error) {
-                      if (error != nil) {
-                          completion(nil, nil, nil, nil, [RCPurchasesErrorUtils networkErrorWithUnderlyingError:error]);
-                          return;
-                      }
+    [self.httpClient performPOSTRequestSerially:YES
+                                           path:@"/offers"
+                                    requestBody:@{
+                                           @"app_user_id": appUserID,
+                                           @"fetch_token": fetchToken,
+                                           @"generate_offers": @[@{
+                                                   @"offer_id": offerIdentifier,
+                                                   @"product_id": productIdentifier,
+                                                   @"subscription_group": subscriptionGroup
+                                           }],
+                                        }
+                                        headers:self.authHeaders
+                              completionHandler:^(NSInteger statusCode, NSDictionary *_Nullable response, NSError *_Nullable error) {
+                                  if (error != nil) {
+                                      completion(nil, nil, nil, nil, [RCPurchasesErrorUtils networkErrorWithUnderlyingError:error]);
+                                      return;
+                                  }
 
-                      NSArray *offers = nil;
+                                  NSArray *offers = nil;
 
-                      if (statusCode < RCHTTPStatusCodesRedirect) {
-                          offers = response[@"offers"];
-                          if (offers == nil || offers.count == 0) {
-                              error = [RCPurchasesErrorUtils unexpectedBackendResponseError];
-                          } else {
-                            NSDictionary *offer = offers[0];
-                            if (RC_HAS_KEY(offer, @"signature_error")) {
-                                error = [RCPurchasesErrorUtils backendErrorWithBackendCode:offer[@"signature_error"][@"code"] backendMessage:offer[@"signature_error"][@"message"]];
-                            } else if (RC_HAS_KEY(offer, @"signature_data")) {
-                                NSDictionary *signatureData = offer[@"signature_data"];
-                                NSString *signature = signatureData[@"signature"];
-                                NSString *keyIdentifier = offer[@"key_id"];
-                                NSUUID *nonce = [[NSUUID alloc] initWithUUIDString:signatureData[@"nonce"]];
-                                NSNumber *timestamp = signatureData[@"timestamp"];
-                                completion(signature, keyIdentifier, nonce, timestamp, nil);
-                                return;
-                            } else {
-                                error = [RCPurchasesErrorUtils unexpectedBackendResponseError];
-                            }
-                          }
-                      } else {
-                          error = [RCPurchasesErrorUtils backendErrorWithBackendCode:response[@"code"] backendMessage:response[@"message"]];
-                      }
+                                  if (statusCode < RCHTTPStatusCodesRedirect) {
+                                      offers = response[@"offers"];
+                                      if (offers == nil || offers.count == 0) {
+                                          error = [RCPurchasesErrorUtils unexpectedBackendResponseError];
+                                      } else {
+                                        NSDictionary *offer = offers[0];
+                                        if (RC_HAS_KEY(offer, @"signature_error")) {
+                                            error = [RCPurchasesErrorUtils backendErrorWithBackendCode:offer[@"signature_error"][@"code"] backendMessage:offer[@"signature_error"][@"message"]];
+                                        } else if (RC_HAS_KEY(offer, @"signature_data")) {
+                                            NSDictionary *signatureData = offer[@"signature_data"];
+                                            NSString *signature = signatureData[@"signature"];
+                                            NSString *keyIdentifier = offer[@"key_id"];
+                                            NSUUID *nonce = [[NSUUID alloc] initWithUUIDString:signatureData[@"nonce"]];
+                                            NSNumber *timestamp = signatureData[@"timestamp"];
+                                            completion(signature, keyIdentifier, nonce, timestamp, nil);
+                                            return;
+                                        } else {
+                                            error = [RCPurchasesErrorUtils unexpectedBackendResponseError];
+                                        }
+                                      }
+                                  } else {
+                                      error = [RCPurchasesErrorUtils backendErrorWithBackendCode:response[@"code"] backendMessage:response[@"message"]];
+                                  }
 
-                      completion(nil, nil, nil, nil, error);
-                  }];
+                                  completion(nil, nil, nil, nil, error);
+                              }];
 }
 
 - (void)postSubscriberAttributes:(RCSubscriberAttributeDict)subscriberAttributes
@@ -491,20 +481,18 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
     NSString *escapedAppUserID = [self escapedAppUserID:appUserID];
     NSString *path = [NSString stringWithFormat:@"/subscribers/%@/attributes", escapedAppUserID];
     NSDictionary *attributesInBackendFormat = [self subscriberAttributesByKey:subscriberAttributes];
-    [self.httpClient performRequest:@"POST"
-                    performSerially:YES
-                               path:path
-                        requestBody:@{
-                                   @"attributes": attributesInBackendFormat
-                               }
-                            headers:self.authHeaders
-                  completionHandler:^(NSInteger status, NSDictionary *_Nullable response, NSError *_Nullable error) {
-                      [self handleSubscriberAttributesResultWithStatusCode:status
-                                                                  response:response
-                                                                     error:error
-                                                                completion:completion];
-                  }];
-
+    [self.httpClient performPOSTRequestSerially:YES
+                                           path:path
+                                    requestBody:@{
+                                            @"attributes": attributesInBackendFormat
+                                        }
+                                        headers:self.authHeaders
+                              completionHandler:^(NSInteger status, NSDictionary *_Nullable response, NSError *_Nullable error) {
+                                    [self handleSubscriberAttributesResultWithStatusCode:status
+                                                                                response:response
+                                                                                   error:error
+                                                                              completion:completion];
+                              }];
 }
 
 - (NSDictionary<NSString *, NSDictionary *> *)subscriberAttributesByKey:(RCSubscriberAttributeDict)subscriberAttributes {

--- a/PurchasesCoreSwift/Networking/HTTPClient.swift
+++ b/PurchasesCoreSwift/Networking/HTTPClient.swift
@@ -32,14 +32,27 @@ import Foundation
         self.operationDispatcher = operationDispatcher
     }
 
-    // TODO:(post-migration) remove and use only the private performRequest
-    @objc public func performRequest(_ httpMethod: String,
-                                     performSerially: Bool = false,
-                                     path: String,
-                                     requestBody: [String: Any]?,
-                                     headers authHeaders: [String: String],
-                                     completionHandler: ((Int, [AnyHashable: Any]?, Error?) -> Void)?) {
-        performRequest(httpMethod,
+    @objc(performGETRequestSerially:path:headers:completionHandler:)
+    public func performGETRequest(performSerially: Bool = false,
+                                  path: String,
+                                  headers authHeaders: [String: String],
+                                  completionHandler: ((Int, [AnyHashable: Any]?, Error?) -> Void)?) {
+        performRequest("GET",
+                       performSerially: performSerially,
+                       path: path,
+                       requestBody: nil,
+                       authHeaders: authHeaders,
+                       retried: false,
+                       completionHandler: completionHandler)
+    }
+
+    @objc(performPOSTRequestSerially:path:requestBody:headers:completionHandler:)
+    public func performPOSTRequest(performSerially: Bool = false,
+                                   path: String,
+                                   requestBody: [String: Any],
+                                   headers authHeaders: [String: String],
+                                   completionHandler: ((Int, [AnyHashable: Any]?, Error?) -> Void)?) {
+        performRequest("POST",
                        performSerially: performSerially,
                        path: path,
                        requestBody: requestBody,
@@ -125,17 +138,6 @@ private extension HTTPClient {
                                     authHeaders: [String: String],
                                     retried: Bool,
                                     completionHandler maybeCompletionHandler: ((Int, [AnyHashable: Any]?, Error?) -> Void)?) {
-        do {
-            try self.assertIsValidRequest(httpMethod: httpMethod, requestBody: maybeRequestBody)
-        } catch let error {
-            if let completionHandler = maybeCompletionHandler {
-                self.operationDispatcher.dispatchOnMainThread {
-                    completionHandler(-1, nil, error)
-                }
-                return
-            }
-        }
-
         let requestHeaders = self.defaultHeaders.merging(authHeaders, uniquingKeysWith: { (_, last) in last })
 
         let maybeURLRequest = self.createRequest(httpMethod: httpMethod,
@@ -274,7 +276,8 @@ private extension HTTPClient {
                                     performSerially: true,
                                     path: nextRequest.path,
                                     requestBody: nextRequest.requestBody,
-                                    headers: nextRequest.authHeaders,
+                                    authHeaders: nextRequest.authHeaders,
+                                    retried: false,
                                     completionHandler: nextRequest.completionHandler)
             }
         }
@@ -315,31 +318,5 @@ private extension HTTPClient {
             }
         }
         return urlRequest
-    }
-
-    func assertIsValidRequest(httpMethod: String, requestBody: [String: Any]?) throws {
-        if (httpMethod != "GET" && httpMethod != "POST") ||
-            (httpMethod == "GET" && requestBody != nil) ||
-            (httpMethod == "POST" && requestBody == nil) {
-            throw HTTPClientError.invalidNetworkCall(httpMethod, requestBody: requestBody)
-        }
-    }
-
-}
-
-enum HTTPClientError: Error {
-    case invalidNetworkCall(_ httpMethod: String, requestBody: [String: Any]?)
-}
-
-extension HTTPClientError: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case .invalidNetworkCall(let httpMethod, let requestBody):
-            if requestBody == nil {
-                return "invalid network call with method \(httpMethod) and empty body"
-            } else {
-                return "invalid network call with method \(httpMethod) and not an empty body"
-            }
-        }
     }
 }

--- a/PurchasesCoreSwift/Networking/HTTPClient.swift
+++ b/PurchasesCoreSwift/Networking/HTTPClient.swift
@@ -33,7 +33,7 @@ import Foundation
     }
 
     @objc(performGETRequestSerially:path:headers:completionHandler:)
-    public func performGETRequest(performSerially: Bool = false,
+    public func performGETRequest(serially performSerially: Bool = false,
                                   path: String,
                                   headers authHeaders: [String: String],
                                   completionHandler: ((Int, [AnyHashable: Any]?, Error?) -> Void)?) {
@@ -47,7 +47,7 @@ import Foundation
     }
 
     @objc(performPOSTRequestSerially:path:requestBody:headers:completionHandler:)
-    public func performPOSTRequest(performSerially: Bool = false,
+    public func performPOSTRequest(serially performSerially: Bool = false,
                                    path: String,
                                    requestBody: [String: Any],
                                    headers authHeaders: [String: String],

--- a/PurchasesTests/Mocks/MockHTTPClient.swift
+++ b/PurchasesTests/Mocks/MockHTTPClient.swift
@@ -25,19 +25,19 @@ class MockHTTPClient: HTTPClient {
          headers: [String: String]?,
          completionHandler: ((Int, [AnyHashable: Any]?, Error?) -> Void)?)]()
     
-    override func performGETRequest(performSerially: Bool = false,
+    override func performGETRequest(serially: Bool = false,
                                     path: String,
                                     headers: [String : String],
                                     completionHandler: ((Int, [AnyHashable : Any]?, Error?) -> Void)?) {
-        performRequest("GET", performSerially: performSerially, path: path, requestBody: nil, headers: headers, completionHandler: completionHandler)
+        performRequest("GET", performSerially: serially, path: path, requestBody: nil, headers: headers, completionHandler: completionHandler)
     }
     
-    override func performPOSTRequest(performSerially: Bool = false,
+    override func performPOSTRequest(serially: Bool = false,
                                      path: String,
                                      requestBody: [String: Any],
                                      headers: [String : String],
                                      completionHandler: ((Int, [AnyHashable : Any]?, Error?) -> Void)?) {
-        performRequest("POST", performSerially: performSerially, path: path, requestBody: requestBody, headers: headers, completionHandler: completionHandler)
+        performRequest("POST", performSerially: serially, path: path, requestBody: requestBody, headers: headers, completionHandler: completionHandler)
     }
 }
 

--- a/PurchasesTests/Mocks/MockHTTPClient.swift
+++ b/PurchasesTests/Mocks/MockHTTPClient.swift
@@ -24,13 +24,30 @@ class MockHTTPClient: HTTPClient {
          requestBody: [AnyHashable: Any]?,
          headers: [String: String]?,
          completionHandler: ((Int, [AnyHashable: Any]?, Error?) -> Void)?)]()
+    
+    override func performGETRequest(performSerially: Bool = false,
+                                    path: String,
+                                    headers: [String : String],
+                                    completionHandler: ((Int, [AnyHashable : Any]?, Error?) -> Void)?) {
+        performRequest("GET", performSerially: performSerially, path: path, requestBody: nil, headers: headers, completionHandler: completionHandler)
+    }
+    
+    override func performPOSTRequest(performSerially: Bool = false,
+                                     path: String,
+                                     requestBody: [String: Any],
+                                     headers: [String : String],
+                                     completionHandler: ((Int, [AnyHashable : Any]?, Error?) -> Void)?) {
+        performRequest("POST", performSerially: performSerially, path: path, requestBody: requestBody, headers: headers, completionHandler: completionHandler)
+    }
+}
 
-    override func performRequest(_ httpMethod: String,
-                                 performSerially: Bool = false,
-                                 path: String,
-                                 requestBody: [String : Any]?,
-                                 headers: [String : String]?,
-                                 completionHandler: ((Int, [AnyHashable: Any]?, Error?) -> Void)?) {
+private extension MockHTTPClient {
+    func performRequest(_ httpMethod: String,
+                        performSerially: Bool,
+                        path: String,
+                        requestBody: [String : Any]?,
+                        headers: [String : String]?,
+                        completionHandler: ((Int, [AnyHashable: Any]?, Error?) -> Void)?) {
         invokedPerformRequest = true
         invokedPerformRequestCount += 1
         invokedPerformRequestParameters = (httpMethod, performSerially, path, requestBody, headers, completionHandler)

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -36,19 +36,19 @@ class BackendTests: XCTestCase {
 
         var shouldFinish = true
         
-        override func performGETRequest(performSerially: Bool = false,
+        override func performGETRequest(serially: Bool = false,
                                         path: String,
                                         headers: [String : String],
                                         completionHandler: ((Int, [AnyHashable : Any]?, Error?) -> Void)?) {
-            performRequest("GET", performSerially: performSerially, path: path, requestBody: nil, headers: headers, completionHandler: completionHandler)
+            performRequest("GET", performSerially: serially, path: path, requestBody: nil, headers: headers, completionHandler: completionHandler)
         }
         
-        override func performPOSTRequest(performSerially: Bool = false,
+        override func performPOSTRequest(serially: Bool = false,
                                          path: String,
                                          requestBody: [String: Any],
                                          headers: [String : String],
                                          completionHandler: ((Int, [AnyHashable : Any]?, Error?) -> Void)?) {
-            performRequest("POST", performSerially: performSerially, path: path, requestBody: requestBody, headers: headers, completionHandler: completionHandler)
+            performRequest("POST", performSerially: serially, path: path, requestBody: requestBody, headers: headers, completionHandler: completionHandler)
         }
         
         private func performRequest(_ httpMethod: String,

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -35,22 +35,37 @@ class BackendTests: XCTestCase {
         var calls: [HTTPRequest] = []
 
         var shouldFinish = true
-
-        override func performRequest(_ httpMethod: String,
-                                     performSerially: Bool = false,
-                                     path: String,
-                                     requestBody: [String : Any]?,
-                                     headers: [String : String],
-                                     completionHandler: ((Int, [AnyHashable: Any]?, Error?) -> Void)?) {
+        
+        override func performGETRequest(performSerially: Bool = false,
+                                        path: String,
+                                        headers: [String : String],
+                                        completionHandler: ((Int, [AnyHashable : Any]?, Error?) -> Void)?) {
+            performRequest("GET", performSerially: performSerially, path: path, requestBody: nil, headers: headers, completionHandler: completionHandler)
+        }
+        
+        override func performPOSTRequest(performSerially: Bool = false,
+                                         path: String,
+                                         requestBody: [String: Any],
+                                         headers: [String : String],
+                                         completionHandler: ((Int, [AnyHashable : Any]?, Error?) -> Void)?) {
+            performRequest("POST", performSerially: performSerially, path: path, requestBody: requestBody, headers: headers, completionHandler: completionHandler)
+        }
+        
+        private func performRequest(_ httpMethod: String,
+                                    performSerially: Bool,
+                                    path: String,
+                                    requestBody: [String : Any]?,
+                                    headers: [String : String],
+                                    completionHandler: ((Int, [AnyHashable: Any]?, Error?) -> Void)?) {
             assert(mocks[path] != nil, "Path " + path + " not mocked")
             let response = mocks[path]!
-
+            
             calls.append(HTTPRequest(HTTPMethod: httpMethod,
                                      serially: performSerially,
                                      path: path,
                                      body: requestBody,
                                      headers: headers))
-
+            
             if shouldFinish {
                 DispatchQueue.main.async {
                     if completionHandler != nil {
@@ -59,7 +74,7 @@ class BackendTests: XCTestCase {
                 }
             }
         }
-
+        
         func mock(requestPath: String, response:HTTPResponse) {
             mocks[requestPath] = response
         }

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -59,13 +59,13 @@ class BackendTests: XCTestCase {
                                     completionHandler: ((Int, [AnyHashable: Any]?, Error?) -> Void)?) {
             assert(mocks[path] != nil, "Path " + path + " not mocked")
             let response = mocks[path]!
-            
+
             calls.append(HTTPRequest(HTTPMethod: httpMethod,
                                      serially: performSerially,
                                      path: path,
                                      body: requestBody,
                                      headers: headers))
-            
+
             if shouldFinish {
                 DispatchQueue.main.async {
                     if completionHandler != nil {
@@ -74,7 +74,7 @@ class BackendTests: XCTestCase {
                 }
             }
         }
-        
+
         func mock(requestPath: String, response:HTTPResponse) {
             mocks[requestPath] = response
         }

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -44,7 +44,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
         
-        self.client.performPOSTRequest(performSerially: true,
+        self.client.performPOSTRequest(serially: true,
                                        path: path,
                                        requestBody: Dictionary.init(),
                                        headers: [:],
@@ -62,7 +62,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
         
-        self.client.performPOSTRequest(performSerially: true,
+        self.client.performPOSTRequest(serially: true,
                                        path: path,
                                        requestBody: Dictionary.init(),
                                        headers: ["test_header": "value"],
@@ -80,7 +80,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
         
-        self.client.performPOSTRequest(performSerially: true,
+        self.client.performPOSTRequest(serially: true,
                                        path: path,
                                        requestBody: Dictionary.init(),
                                        headers: ["test_header": "value"],
@@ -98,7 +98,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
         
-        self.client.performPOSTRequest(performSerially: true,
+        self.client.performPOSTRequest(serially: true,
                                        path: path,
                                        requestBody: Dictionary.init(),
                                        headers: ["test_header": "value"],
@@ -116,7 +116,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
         
-        self.client.performPOSTRequest(performSerially: true,
+        self.client.performPOSTRequest(serially: true,
                                        path: path,
                                        requestBody: Dictionary.init(),
                                        headers: ["test_header": "value"],
@@ -134,7 +134,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
         
-        self.client.performPOSTRequest(performSerially: true,
+        self.client.performPOSTRequest(serially: true,
                                        path: path,
                                        requestBody: Dictionary.init(),
                                        headers: ["test_header": "value"],
@@ -152,7 +152,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
         
-        self.client.performPOSTRequest(performSerially: true,
+        self.client.performPOSTRequest(serially: true,
                                        path: path,
                                        requestBody: Dictionary.init(),
                                        headers: [:],
@@ -173,7 +173,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
 
-        self.client.performPOSTRequest(performSerially: true,
+        self.client.performPOSTRequest(serially: true,
                                        path: path,
                                        requestBody: body,
                                        headers: [:],
@@ -190,7 +190,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
 
-        self.client.performGETRequest(performSerially: true,
+        self.client.performGETRequest(serially: true,
                                       path: path,
                                       headers: [:]) { (status, data, error) in
             completionCalled = true
@@ -209,7 +209,7 @@ class HTTPClientTests: XCTestCase {
             response.error = error
             return response
         }
-        self.client.performGETRequest(performSerially: true,
+        self.client.performGETRequest(serially: true,
                                       path: path,
                                       headers: [:]) { (status, data, responseError) in
             if let responseNSError = responseError as NSError? {
@@ -236,7 +236,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: json.data(using: String.Encoding.utf8)!, statusCode:Int32(errorCode), headers: nil)
         }
         
-        self.client.performGETRequest(performSerially: true,
+        self.client.performGETRequest(serially: true,
                                       path: path,
                                       headers: [:]) { (status, data, error) in
             correctResponse = (status == errorCode) && (data != nil) && (error == nil);
@@ -260,7 +260,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: json.data(using: String.Encoding.utf8)!, statusCode:Int32(errorCode), headers: nil)
         }
 
-        self.client.performGETRequest(performSerially: true,
+        self.client.performGETRequest(serially: true,
                                       path: path,
                                       headers: [:]) { (status, data, error) in
             correctResponse = (status == errorCode) && (data != nil) && (error == nil);
@@ -283,7 +283,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: json.data(using: String.Encoding.utf8)!, statusCode:Int32(errorCode), headers: nil)
         }
         
-        self.client.performGETRequest(performSerially: true,
+        self.client.performGETRequest(serially: true,
                                       path: path,
                                       headers: [:]) { (status, data, error) in
             correctResponse = (status == errorCode) && (data == nil) && (error != nil);
@@ -303,7 +303,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: json.data(using: String.Encoding.utf8)!, statusCode:200, headers: nil)
         }
         
-        self.client.performGETRequest(performSerially: true,
+        self.client.performGETRequest(serially: true,
                                       path: path,
                                       headers: [:]) { (status, data, error) in
             successIsTrue = (status == 200) && (error == nil);
@@ -327,7 +327,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
         
-        self.client.performPOSTRequest(performSerially: true,
+        self.client.performPOSTRequest(serially: true,
                                        path: path,
                                        requestBody: Dictionary.init(),
                                        headers: ["test_header": "value"],
@@ -347,7 +347,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
         
-        self.client.performPOSTRequest(performSerially: true,
+        self.client.performPOSTRequest(serially: true,
                                        path: path,
                                        requestBody: Dictionary.init(),
                                        headers: ["test_header": "value"],
@@ -367,7 +367,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
 
-        self.client.performPOSTRequest(performSerially: true,
+        self.client.performPOSTRequest(serially: true,
                                        path: path,
                                        requestBody: Dictionary.init(),
                                        headers: ["test_header": "value"],
@@ -385,7 +385,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
 
-        self.client.performPOSTRequest(performSerially: true,
+        self.client.performPOSTRequest(serially: true,
                                        path: path,
                                        requestBody: Dictionary.init(),
                                        headers: ["test_header": "value"],
@@ -406,7 +406,7 @@ class HTTPClientTests: XCTestCase {
                                          platformFlavorVersion: "3.2.1",
                                          finishTransactions: true)
         let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager, operationDispatcher: operationDispatcher)
-        client.performPOSTRequest(performSerially: true,
+        client.performPOSTRequest(serially: true,
                                   path: path,
                                   requestBody: Dictionary.init(),
                                   headers: ["test_header": "value"],
@@ -428,7 +428,7 @@ class HTTPClientTests: XCTestCase {
                                          finishTransactions: true)
         let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager, operationDispatcher: operationDispatcher)
         
-        client.performPOSTRequest(performSerially: true,
+        client.performPOSTRequest(serially: true,
                                   path: path,
                                   requestBody: Dictionary.init(),
                                   headers: ["test_header": "value"],
@@ -447,7 +447,7 @@ class HTTPClientTests: XCTestCase {
         }
         let systemInfo = try! SystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: true)
         let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager, operationDispatcher: operationDispatcher)
-        client.performPOSTRequest(performSerially: true,
+        client.performPOSTRequest(serially: true,
                                   path: path,
                                   requestBody: Dictionary.init(),
                                   headers: ["test_header": "value"],
@@ -466,7 +466,7 @@ class HTTPClientTests: XCTestCase {
         }
         let systemInfo = try! SystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: false)
         let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager, operationDispatcher: operationDispatcher)
-        client.performPOSTRequest(performSerially: true,
+        client.performPOSTRequest(serially: true,
                                   path: path,
                                   requestBody: Dictionary.init(),
                                   headers: ["test_header": "value"],
@@ -493,7 +493,7 @@ class HTTPClientTests: XCTestCase {
 
         let totalRequests = Int.random(in: 50..<100)
         for requestNumber in 0..<totalRequests {
-            self.client.performPOSTRequest(performSerially: true,
+            self.client.performPOSTRequest(serially: true,
                                            path: path,
                                            requestBody: ["requestNumber": requestNumber],
                                            headers: [:]) { (status, data, error) in
@@ -523,14 +523,14 @@ class HTTPClientTests: XCTestCase {
                 .responseTime(0.1)
         }
         
-        self.client.performPOSTRequest(performSerially: true,
+        self.client.performPOSTRequest(serially: true,
                                        path: path,
                                        requestBody: ["requestNumber": 1],
                                        headers: [:]) { (status, data, error) in
             firstRequestFinished = true
         }
         
-        self.client.performPOSTRequest(performSerially: true,
+        self.client.performPOSTRequest(serially: true,
                                        path: path,
                                        requestBody: ["requestNumber": 2],
                                        headers: [:]) { (status, data, error) in
@@ -560,14 +560,14 @@ class HTTPClientTests: XCTestCase {
                 .responseTime(0.1)
         }
         
-        self.client.performPOSTRequest(performSerially: false,
+        self.client.performPOSTRequest(serially: false,
                                        path: path,
                                        requestBody: ["requestNumber": 1],
                                        headers: [:]) { (status, data, error) in
             firstRequestFinished = true
         }
         
-        self.client.performPOSTRequest(performSerially: false,
+        self.client.performPOSTRequest(serially: false,
                                        path: path,
                                        requestBody: ["requestNumber": 2],
                                        headers: [:]) { (status, data, error) in
@@ -597,14 +597,14 @@ class HTTPClientTests: XCTestCase {
                 .responseTime(0.1)
         }
 
-        self.client.performPOSTRequest(performSerially: true,
+        self.client.performPOSTRequest(serially: true,
                                        path: path,
                                        requestBody: ["requestNumber": 1],
                                        headers: [:]) { (status, data, error) in
             firstRequestFinished = true
         }
         
-        self.client.performPOSTRequest(performSerially: false,
+        self.client.performPOSTRequest(serially: false,
                                        path: path,
                                        requestBody: ["requestNumber": 2],
                                        headers: [:]) { (status, data, error) in
@@ -634,14 +634,14 @@ class HTTPClientTests: XCTestCase {
                 .responseTime(0.1)
         }
 
-        self.client.performPOSTRequest(performSerially: false,
+        self.client.performPOSTRequest(serially: false,
                                        path: path,
                                        requestBody: ["requestNumber": 1],
                                        headers: [:]) { (status, data, error) in
             firstRequestFinished = true
         }
         
-        self.client.performPOSTRequest(performSerially: true,
+        self.client.performPOSTRequest(serially: true,
                                        path: path,
                                        requestBody: ["requestNumber": 2],
                                        headers: [:]) { (status, data, error) in
@@ -662,7 +662,7 @@ class HTTPClientTests: XCTestCase {
         var receivedError: Error? = nil
         var receivedStatus: Int? = nil
         var receivedData: [AnyHashable: Any]? = nil
-        self.client.performPOSTRequest(performSerially: true,
+        self.client.performPOSTRequest(serially: true,
                                        path: path,
                                        requestBody: nonJSONBody,
                                        headers: [:]) { (status, data, error) in
@@ -694,7 +694,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data(), statusCode:200, headers: nil)
         }
         
-        self.client.performPOSTRequest(performSerially: true,
+        self.client.performPOSTRequest(serially: true,
                                        path: path,
                                        requestBody: nonJSONBody,
                                        headers: [:]) { (status, data, error) in
@@ -720,7 +720,7 @@ class HTTPClientTests: XCTestCase {
 
         self.eTagManager.shouldReturnResultFromBackend = false
         self.eTagManager.stubbedHTTPResultFromCacheOrBackendResult = nil
-        self.client.performGETRequest(performSerially: true,
+        self.client.performGETRequest(serially: true,
                                       path: path,
                                       headers: [:]) { (status, data, error) in
             completionCalled = true

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -34,30 +34,6 @@ class HTTPClientTests: XCTestCase {
         HTTPStubs.removeAllStubs()
     }
 
-    func testCantPostABodyWithGet() {
-        var maybeError: Error? = nil
-        self.client.performRequest("GET",
-                                   performSerially: true,
-                                   path: "/",
-                                   requestBody: Dictionary.init(),
-                                   headers: [:]) { _, _, error in
-            maybeError = error
-        }
-        expect(maybeError).toEventuallyNot(beNil())
-    }
-
-    func testUnrecognizedMethodFails() {
-        var maybeError: Error? = nil
-        self.client.performRequest("GE",
-                                   performSerially: true,
-                                   path: "/",
-                                   requestBody: Dictionary.init(),
-                                   headers: [:]) { _, _, error in
-            maybeError = error
-        }
-        expect(maybeError).toEventuallyNot(beNil())
-    }
-
     func testUsesTheCorrectHost() {
         let path = "/a_random_path"
         var hostCorrect = false
@@ -67,14 +43,13 @@ class HTTPClientTests: XCTestCase {
             hostCorrect = true
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
-
-        self.client.performRequest("POST",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: Dictionary.init(),
-                                   headers: [:],
-                                   completionHandler: nil)
-
+        
+        self.client.performPOSTRequest(performSerially: true,
+                                       path: path,
+                                       requestBody: Dictionary.init(),
+                                       headers: [:],
+                                       completionHandler: nil)
+        
         expect(hostCorrect).toEventually(equal(true), timeout: .seconds(1))
     }
 
@@ -86,13 +61,12 @@ class HTTPClientTests: XCTestCase {
             headerPresent = true
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
-
-        self.client.performRequest("POST",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: Dictionary.init(),
-                                   headers: ["test_header": "value"],
-                                   completionHandler: nil)
+        
+        self.client.performPOSTRequest(performSerially: true,
+                                       path: path,
+                                       requestBody: Dictionary.init(),
+                                       headers: ["test_header": "value"],
+                                       completionHandler: nil)
 
         expect(headerPresent).toEventually(equal(true), timeout: .seconds(1))
     }
@@ -100,19 +74,18 @@ class HTTPClientTests: XCTestCase {
     func testAlwaysSetsContentTypeHeader() {
         let path = "/a_random_path"
         var headerPresent = false
-
+        
         stub(condition: hasHeaderNamed("content-type", value: "application/json")) { request in
             headerPresent = true
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
-
-        self.client.performRequest("POST",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: Dictionary.init(),
-                                   headers: ["test_header": "value"],
-                                   completionHandler: nil)
-
+        
+        self.client.performPOSTRequest(performSerially: true,
+                                       path: path,
+                                       requestBody: Dictionary.init(),
+                                       headers: ["test_header": "value"],
+                                       completionHandler: nil)
+        
         expect(headerPresent).toEventually(equal(true), timeout: .seconds(1))
     }
 
@@ -124,13 +97,12 @@ class HTTPClientTests: XCTestCase {
             headerPresent = true
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
-
-        self.client.performRequest("POST",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: Dictionary.init(),
-                                   headers: ["test_header": "value"],
-                                   completionHandler: nil)
+        
+        self.client.performPOSTRequest(performSerially: true,
+                                       path: path,
+                                       requestBody: Dictionary.init(),
+                                       headers: ["test_header": "value"],
+                                       completionHandler: nil)
 
         expect(headerPresent).toEventually(equal(true))
     }
@@ -143,14 +115,13 @@ class HTTPClientTests: XCTestCase {
             headerPresent = true
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
-
-        self.client.performRequest("POST",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: Dictionary.init(),
-                                   headers: ["test_header": "value"],
-                                   completionHandler: nil)
-
+        
+        self.client.performPOSTRequest(performSerially: true,
+                                       path: path,
+                                       requestBody: Dictionary.init(),
+                                       headers: ["test_header": "value"],
+                                       completionHandler: nil)
+        
         expect(headerPresent).toEventually(equal(true))
     }
 
@@ -162,13 +133,12 @@ class HTTPClientTests: XCTestCase {
             headerPresent = true
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
-
-        self.client.performRequest("POST",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: Dictionary.init(),
-                                   headers: ["test_header": "value"],
-                                   completionHandler: nil)
+        
+        self.client.performPOSTRequest(performSerially: true,
+                                       path: path,
+                                       requestBody: Dictionary.init(),
+                                       headers: ["test_header": "value"],
+                                       completionHandler: nil)
 
         expect(headerPresent).toEventually(equal(true))
     }
@@ -182,39 +152,18 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
         
-        self.client.performRequest("POST",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: Dictionary.init(),
-                                   headers: [:],
-                                   completionHandler: nil)
-
-        expect(pathHit).toEventually(equal(true), timeout: .seconds(1))
-    }
-
-    func testCallsWithCorrectMethod() {
-        let path = "/a_random_path"
-        let (method, body) = [("POST", Dictionary<String, String>.init()), ("GET", nil)][Int(arc4random() % 2)]
-        var pathHit = false
-
-        stub(condition: isPath("/v1" + path)) { request in
-            pathHit = request.httpMethod == method
-            return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
-        }
-
-        self.client.performRequest(method,
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: body,
-                                   headers: [:],
-                                   completionHandler: nil)
+        self.client.performPOSTRequest(performSerially: true,
+                                       path: path,
+                                       requestBody: Dictionary.init(),
+                                       headers: [:],
+                                       completionHandler: nil)
 
         expect(pathHit).toEventually(equal(true), timeout: .seconds(1))
     }
 
     func testSendsBodyData() {
         let path = "/a_random_path"
-        let (method, body) = ("POST", ["arg": "value"])
+        let body = ["arg": "value"]
         var pathHit = false
 
         let bodyData = try! JSONSerialization.data(withJSONObject: body)
@@ -224,12 +173,11 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
 
-        self.client.performRequest(method,
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: body,
-                                   headers: [:],
-                                   completionHandler: nil)
+        self.client.performPOSTRequest(performSerially: true,
+                                       path: path,
+                                       requestBody: body,
+                                       headers: [:],
+                                       completionHandler: nil)
 
         expect(pathHit).toEventually(equal(true))
     }
@@ -242,11 +190,9 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
 
-        self.client.performRequest("GET",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: nil,
-                                   headers: [:]) { (status, data, error) in
+        self.client.performGETRequest(performSerially: true,
+                                      path: path,
+                                      headers: [:]) { (status, data, error) in
             completionCalled = true
         }
 
@@ -263,11 +209,9 @@ class HTTPClientTests: XCTestCase {
             response.error = error
             return response
         }
-        self.client.performRequest("GET",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: nil,
-                                   headers: [:]) { (status, data, responseError) in
+        self.client.performGETRequest(performSerially: true,
+                                      path: path,
+                                      headers: [:]) { (status, data, responseError) in
             if let responseNSError = responseError as NSError? {
                 successFailed = (status >= 500
                                     && data == nil
@@ -292,11 +236,9 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: json.data(using: String.Encoding.utf8)!, statusCode:Int32(errorCode), headers: nil)
         }
         
-        self.client.performRequest("GET",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: nil,
-                                   headers: [:]) { (status, data, error) in
+        self.client.performGETRequest(performSerially: true,
+                                      path: path,
+                                      headers: [:]) { (status, data, error) in
             correctResponse = (status == errorCode) && (data != nil) && (error == nil);
             if data != nil {
                 message = data!["message"] as! String?
@@ -318,11 +260,9 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: json.data(using: String.Encoding.utf8)!, statusCode:Int32(errorCode), headers: nil)
         }
 
-        self.client.performRequest("GET",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: nil,
-                                   headers: [:]) { (status, data, error) in
+        self.client.performGETRequest(performSerially: true,
+                                      path: path,
+                                      headers: [:]) { (status, data, error) in
             correctResponse = (status == errorCode) && (data != nil) && (error == nil);
             if data != nil {
                 message = data!["message"] as! String?
@@ -342,18 +282,16 @@ class HTTPClientTests: XCTestCase {
             let json = "{this is not JSON.csdsd"
             return HTTPStubsResponse(data: json.data(using: String.Encoding.utf8)!, statusCode:Int32(errorCode), headers: nil)
         }
-
-        self.client.performRequest("GET",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: nil,
-                                   headers: [:]) { (status, data, error) in
+        
+        self.client.performGETRequest(performSerially: true,
+                                      path: path,
+                                      headers: [:]) { (status, data, error) in
             correctResponse = (status == errorCode) && (data == nil) && (error != nil);
         }
-
+        
         expect(correctResponse).toEventually(beTrue(), timeout: .seconds(1))
     }
-
+    
     func testServerSide200s() {
         let path = "/a_random_path"
 
@@ -364,12 +302,10 @@ class HTTPClientTests: XCTestCase {
             let json = "{\"message\": \"something is great up in the cloud\"}"
             return HTTPStubsResponse(data: json.data(using: String.Encoding.utf8)!, statusCode:200, headers: nil)
         }
-
-        self.client.performRequest("GET",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: nil,
-                                   headers: [:]) { (status, data, error) in
+        
+        self.client.performGETRequest(performSerially: true,
+                                      path: path,
+                                      headers: [:]) { (status, data, error) in
             successIsTrue = (status == 200) && (error == nil);
             if data != nil {
                 message = data!["message"] as! String?
@@ -391,12 +327,11 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
         
-        self.client.performRequest("POST",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: Dictionary.init(),
-                                   headers: ["test_header": "value"],
-                                   completionHandler: nil)
+        self.client.performPOSTRequest(performSerially: true,
+                                       path: path,
+                                       requestBody: Dictionary.init(),
+                                       headers: ["test_header": "value"],
+                                       completionHandler: nil)
         
         expect(headerPresent).toEventually(equal(true))
     }
@@ -411,14 +346,13 @@ class HTTPClientTests: XCTestCase {
             headerPresent = true
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
-
-        self.client.performRequest("POST",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: Dictionary.init(),
-                                   headers: ["test_header": "value"],
-                                   completionHandler: nil)
-
+        
+        self.client.performPOSTRequest(performSerially: true,
+                                       path: path,
+                                       requestBody: Dictionary.init(),
+                                       headers: ["test_header": "value"],
+                                       completionHandler: nil)
+        
         expect(headerPresent).toEventually(equal(true))
     }
 
@@ -433,13 +367,12 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
 
-        self.client.performRequest("POST",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: Dictionary.init(),
-                                   headers: ["test_header": "value"],
-                                   completionHandler: nil)
-
+        self.client.performPOSTRequest(performSerially: true,
+                                       path: path,
+                                       requestBody: Dictionary.init(),
+                                       headers: ["test_header": "value"],
+                                       completionHandler: nil)
+        
         expect(headerPresent).toEventually(equal(true))
     }
 
@@ -452,12 +385,11 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode:200, headers: nil)
         }
 
-        self.client.performRequest("POST",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: Dictionary.init(),
-                                   headers: ["test_header": "value"],
-                                   completionHandler: nil)
+        self.client.performPOSTRequest(performSerially: true,
+                                       path: path,
+                                       requestBody: Dictionary.init(),
+                                       headers: ["test_header": "value"],
+                                       completionHandler: nil)
 
         expect(headerPresent).toEventually(equal(true))
     }
@@ -474,12 +406,11 @@ class HTTPClientTests: XCTestCase {
                                          platformFlavorVersion: "3.2.1",
                                          finishTransactions: true)
         let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager, operationDispatcher: operationDispatcher)
-        client.performRequest("POST",
-                              performSerially: true,
-                              path: path,
-                              requestBody: Dictionary.init(),
-                              headers: ["test_header": "value"],
-                              completionHandler: nil)
+        client.performPOSTRequest(performSerially: true,
+                                  path: path,
+                                  requestBody: Dictionary.init(),
+                                  headers: ["test_header": "value"],
+                                  completionHandler: nil)
 
         expect(headerPresent).toEventually(equal(true))
     }
@@ -497,12 +428,11 @@ class HTTPClientTests: XCTestCase {
                                          finishTransactions: true)
         let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager, operationDispatcher: operationDispatcher)
         
-        client.performRequest("POST",
-                              performSerially: true,
-                              path: path,
-                              requestBody: Dictionary.init(),
-                              headers: ["test_header": "value"],
-                              completionHandler: nil)
+        client.performPOSTRequest(performSerially: true,
+                                  path: path,
+                                  requestBody: Dictionary.init(),
+                                  headers: ["test_header": "value"],
+                                  completionHandler: nil)
 
         expect(headerPresent).toEventually(equal(true))
     }
@@ -517,13 +447,12 @@ class HTTPClientTests: XCTestCase {
         }
         let systemInfo = try! SystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: true)
         let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager, operationDispatcher: operationDispatcher)
-        client.performRequest("POST",
-                              performSerially: true,
-                              path: path,
-                              requestBody: Dictionary.init(),
-                              headers: ["test_header": "value"],
-                              completionHandler: nil)
-
+        client.performPOSTRequest(performSerially: true,
+                                  path: path,
+                                  requestBody: Dictionary.init(),
+                                  headers: ["test_header": "value"],
+                                  completionHandler: nil)
+        
         expect(headerPresent).toEventually(equal(true))
     }
 
@@ -537,13 +466,12 @@ class HTTPClientTests: XCTestCase {
         }
         let systemInfo = try! SystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: false)
         let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager, operationDispatcher: operationDispatcher)
-        client.performRequest("POST",
-                              performSerially: true,
-                              path: path,
-                              requestBody: Dictionary.init(),
-                              headers: ["test_header": "value"],
-                              completionHandler: nil)
-
+        client.performPOSTRequest(performSerially: true,
+                                  path: path,
+                                  requestBody: Dictionary.init(),
+                                  headers: ["test_header": "value"],
+                                  completionHandler: nil)
+        
         expect(headerPresent).toEventually(equal(true))
     }
 
@@ -565,11 +493,10 @@ class HTTPClientTests: XCTestCase {
 
         let totalRequests = Int.random(in: 50..<100)
         for requestNumber in 0..<totalRequests {
-            self.client.performRequest("POST",
-                                       performSerially: true,
-                                       path: path,
-                                       requestBody: ["requestNumber": requestNumber],
-                                       headers: [:]) { (status, data, error) in
+            self.client.performPOSTRequest(performSerially: true,
+                                           path: path,
+                                           requestBody: ["requestNumber": requestNumber],
+                                           headers: [:]) { (status, data, error) in
                 completionCallCount += 1
             }
         }
@@ -595,23 +522,21 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: json.data(using: String.Encoding.utf8)!, statusCode:200, headers: nil)
                 .responseTime(0.1)
         }
-
-        self.client.performRequest("POST",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: ["requestNumber": 1],
-                                   headers: [:]) { (status, data, error) in
+        
+        self.client.performPOSTRequest(performSerially: true,
+                                       path: path,
+                                       requestBody: ["requestNumber": 1],
+                                       headers: [:]) { (status, data, error) in
             firstRequestFinished = true
         }
-
-        self.client.performRequest("POST",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: ["requestNumber": 2],
-                                   headers: [:]) { (status, data, error) in
+        
+        self.client.performPOSTRequest(performSerially: true,
+                                       path: path,
+                                       requestBody: ["requestNumber": 2],
+                                       headers: [:]) { (status, data, error) in
             secondRequestFinished = true
         }
-
+        
         expect(firstRequestFinished).toEventually(beTrue())
         expect(secondRequestFinished).toEventually(beTrue())
     }
@@ -634,23 +559,21 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: json.data(using: String.Encoding.utf8)!, statusCode:200, headers: nil)
                 .responseTime(0.1)
         }
-
-        self.client.performRequest("POST",
-                                   performSerially: false,
-                                   path: path,
-                                   requestBody: ["requestNumber": 1],
-                                   headers: [:]) { (status, data, error) in
+        
+        self.client.performPOSTRequest(performSerially: false,
+                                       path: path,
+                                       requestBody: ["requestNumber": 1],
+                                       headers: [:]) { (status, data, error) in
             firstRequestFinished = true
         }
-
-        self.client.performRequest("POST",
-                                   performSerially: false,
-                                   path: path,
-                                   requestBody: ["requestNumber": 2],
-                                   headers: [:]) { (status, data, error) in
+        
+        self.client.performPOSTRequest(performSerially: false,
+                                       path: path,
+                                       requestBody: ["requestNumber": 2],
+                                       headers: [:]) { (status, data, error) in
             secondRequestFinished = true
         }
-
+        
         expect(firstRequestFinished).toEventually(beTrue())
         expect(secondRequestFinished).toEventually(beTrue())
     }
@@ -674,19 +597,17 @@ class HTTPClientTests: XCTestCase {
                 .responseTime(0.1)
         }
 
-        self.client.performRequest("POST",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: ["requestNumber": 1],
-                                   headers: [:]) { (status, data, error) in
+        self.client.performPOSTRequest(performSerially: true,
+                                       path: path,
+                                       requestBody: ["requestNumber": 1],
+                                       headers: [:]) { (status, data, error) in
             firstRequestFinished = true
         }
-
-        self.client.performRequest("POST",
-                                   performSerially: false,
-                                   path: path,
-                                   requestBody: ["requestNumber": 2],
-                                   headers: [:]) { (status, data, error) in
+        
+        self.client.performPOSTRequest(performSerially: false,
+                                       path: path,
+                                       requestBody: ["requestNumber": 2],
+                                       headers: [:]) { (status, data, error) in
             secondRequestFinished = true
         }
 
@@ -713,38 +634,22 @@ class HTTPClientTests: XCTestCase {
                 .responseTime(0.1)
         }
 
-        self.client.performRequest("POST",
-                                   performSerially: false,
-                                   path: path,
-                                   requestBody: ["requestNumber": 1],
-                                   headers: [:]) { (status, data, error) in
+        self.client.performPOSTRequest(performSerially: false,
+                                       path: path,
+                                       requestBody: ["requestNumber": 1],
+                                       headers: [:]) { (status, data, error) in
             firstRequestFinished = true
         }
-
-        self.client.performRequest("POST",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: ["requestNumber": 2],
-                                   headers: [:]) { (status, data, error) in
+        
+        self.client.performPOSTRequest(performSerially: true,
+                                       path: path,
+                                       requestBody: ["requestNumber": 2],
+                                       headers: [:]) { (status, data, error) in
             secondRequestFinished = true
         }
 
         expect(firstRequestFinished).toEventually(beTrue())
         expect(secondRequestFinished).toEventually(beTrue())
-    }
-
-    func testPerformRequestFailsAssertionIfPostWithNilBody() {
-        let path = "/a_random_path"
-        
-        var maybeError: Error? = nil
-        self.client.performRequest("POST",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: nil,
-                                   headers: [:]) { _, _, error in
-            maybeError = error
-        }
-        expect(maybeError).toEventuallyNot(beNil())
     }
 
     func testPerformRequestExitsWithErrorIfBodyCouldntBeParsedIntoJSON() {
@@ -757,11 +662,10 @@ class HTTPClientTests: XCTestCase {
         var receivedError: Error? = nil
         var receivedStatus: Int? = nil
         var receivedData: [AnyHashable: Any]? = nil
-        self.client.performRequest("POST",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: nonJSONBody,
-                                   headers: [:]) { (status, data, error) in
+        self.client.performPOSTRequest(performSerially: true,
+                                       path: path,
+                                       requestBody: nonJSONBody,
+                                       headers: [:]) { (status, data, error) in
             completionCalled = true
             receivedError = error
             receivedStatus = status
@@ -789,12 +693,11 @@ class HTTPClientTests: XCTestCase {
             httpCallMade = true
             return HTTPStubsResponse(data: Data(), statusCode:200, headers: nil)
         }
-
-        self.client.performRequest("POST",
-                                   performSerially: true,
-                                   path: path,
-                                   requestBody: nonJSONBody,
-                                   headers: [:]) { (status, data, error) in
+        
+        self.client.performPOSTRequest(performSerially: true,
+                                       path: path,
+                                       requestBody: nonJSONBody,
+                                       headers: [:]) { (status, data, error) in
             completionCalled = true
         }
 
@@ -817,7 +720,9 @@ class HTTPClientTests: XCTestCase {
 
         self.eTagManager.shouldReturnResultFromBackend = false
         self.eTagManager.stubbedHTTPResultFromCacheOrBackendResult = nil
-        self.client.performRequest("GET", performSerially: true, path: path, requestBody: nil, headers: [:]) { (status, data, error) in
+        self.client.performGETRequest(performSerially: true,
+                                      path: path,
+                                      headers: [:]) { (status, data, error) in
             completionCalled = true
         }
 


### PR DESCRIPTION
Solves #694 

This PR aims to create separate method signatures in the `HTTPClient` for both GET and POST requests to make sure that gets aren't called with a body and posts are called with a body.

BTW, although there is a task for doing all the post-migration TODOs, I think the `HTTPRequest` class is ready to be internal and remove the **ObjC** compatibility :)