### PR TITLE
Extract platform checks for notification names

### DIFF
--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -371,26 +371,14 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
     return self;
 }
 
-// todo: move somewhere else, maybe PlatformInfo? maybe extension? maybe SystemInfo?
-// see example of how to do it in SystemInfo.platformHeaderConstant
-#if TARGET_OS_IOS || TARGET_OS_TV
-#define APP_DID_BECOME_ACTIVE_NOTIFICATION_NAME UIApplicationDidBecomeActiveNotification
-#define APP_WILL_RESIGN_ACTIVE_NOTIFICATION_NAME UIApplicationWillResignActiveNotification
-#elif TARGET_OS_OSX
-#define APP_DID_BECOME_ACTIVE_NOTIFICATION_NAME NSApplicationDidBecomeActiveNotification
-#define APP_WILL_RESIGN_ACTIVE_NOTIFICATION_NAME NSApplicationWillResignActiveNotification
-#elif TARGET_OS_WATCH
-#define APP_DID_BECOME_ACTIVE_NOTIFICATION_NAME NSExtensionHostDidBecomeActiveNotification
-#define APP_WILL_RESIGN_ACTIVE_NOTIFICATION_NAME NSExtensionHostWillResignActiveNotification
-#endif
-
 - (void)subscribeToAppStateNotifications {
     [self.notificationCenter addObserver:self
                                 selector:@selector(applicationDidBecomeActive:)
-                                    name:APP_DID_BECOME_ACTIVE_NOTIFICATION_NAME object:nil];
+                                    name:RCSystemInfo.applicationDidBecomeActiveNotification
+                                  object:nil];
     [self.notificationCenter addObserver:self
                                 selector:@selector(applicationWillResignActive:)
-                                    name:APP_WILL_RESIGN_ACTIVE_NOTIFICATION_NAME
+                                    name:RCSystemInfo.applicationWillResignActiveNotification
                                   object:nil];
 }
 

--- a/PurchasesCoreSwift/Misc/SystemInfo.swift
+++ b/PurchasesCoreSwift/Misc/SystemInfo.swift
@@ -123,6 +123,30 @@ import AppKit
 
 }
 
+extension SystemInfo {
+
+    @objc static var applicationDidBecomeActiveNotification: Notification.Name {
+        #if os(iOS) || os(tvOS)
+            UIApplication.didBecomeActiveNotification
+        #elseif os(macOS)
+            NSApplication.didBecomeActiveNotification
+        #elseif os(watchOS)
+            Notification.Name.NSExtensionHostDidBecomeActive
+        #endif
+    }
+
+    @objc static var applicationWillResignActiveNotification: Notification.Name {
+        #if os(iOS) || os(tvOS)
+            UIApplication.willResignActiveNotification
+        #elseif os(macOS)
+            NSApplication.willResignActiveNotification
+        #elseif os(watchOS)
+            Notification.Name.NSExtensionHostWillResignActive
+        #endif
+    }
+
+}
+
 private extension SystemInfo {
 
     var isApplicationBackgrounded: Bool {


### PR DESCRIPTION
Resolves #687 

Tiny PR that extracts the platform checks to find the application lifecycle notification names. There are a lot of approaches but considering that we are only using two notifications and we still have ObjC code, I think we could use the `SystemInfo` class to do the platform checks.

Maybe we could use the Apple approach in the future, creating a [`Notification.Name` extension with constants](https://developer.apple.com/documentation/foundation/nsnotification/name/1616519-nsextensionhostwillresignactive).
