### PR TITLE
fix method not available to obj-c

### DIFF
--- a/PurchasesCoreSwift/Misc/SystemInfo.swift
+++ b/PurchasesCoreSwift/Misc/SystemInfo.swift
@@ -123,9 +123,9 @@ import AppKit
 
 }
 
-extension SystemInfo {
+@objc public extension SystemInfo {
 
-    @objc static var applicationDidBecomeActiveNotification: Notification.Name {
+    static var applicationDidBecomeActiveNotification: Notification.Name {
         #if os(iOS) || os(tvOS)
             UIApplication.didBecomeActiveNotification
         #elseif os(macOS)
@@ -135,7 +135,7 @@ extension SystemInfo {
         #endif
     }
 
-    @objc static var applicationWillResignActiveNotification: Notification.Name {
+    static var applicationWillResignActiveNotification: Notification.Name {
         #if os(iOS) || os(tvOS)
             UIApplication.willResignActiveNotification
         #elseif os(macOS)


### PR DESCRIPTION
follow-up to https://github.com/RevenueCat/purchases-ios/pull/701. 
Our tests were failing because the new methods were missing a `public`, so they weren't actually available to obj-c (but tests would still pass on `debug` schemes)