### PR TITLE
Extract receipt fetcher logic

### DIFF
--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -169,7 +169,7 @@
 		37E35F549AEB655AB6DA83B3 /* MockSKDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35EABF6D7AFE367718784 /* MockSKDiscount.swift */; };
 		37E35F67255A87BD86B39D43 /* MockReceiptParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3558F697A939D2BBD7FEC /* MockReceiptParser.swift */; };
 		37E35FF7952D59C0AE3879D3 /* IdentityManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35294EBC1E5A879C95540 /* IdentityManagerTests.swift */; };
-		80E80EF226970E04008F245A /* RCReceiptFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E80EF026970DC3008F245A /* RCReceiptFetcher.swift */; };
+		80E80EF226970E04008F245A /* ReceiptFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E80EF026970DC3008F245A /* ReceiptFetcher.swift */; };
 		9A65DFDE258AD60A00DE00B0 /* LogIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A65DFDD258AD60A00DE00B0 /* LogIntent.swift */; };
 		9A65E03625918B0500DE00B0 /* ConfigureStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A65E03525918B0500DE00B0 /* ConfigureStrings.swift */; };
 		9A65E03B25918B0900DE00B0 /* PurchaserInfoStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A65E03A25918B0900DE00B0 /* PurchaserInfoStrings.swift */; };
@@ -495,7 +495,7 @@
 		37E35EEE7783629CDE41B70C /* SystemInfoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemInfoTests.swift; sourceTree = "<group>"; };
 		37E35F783903362B65FB7AF3 /* MockProductsRequestFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockProductsRequestFactory.swift; sourceTree = "<group>"; };
 		6B5DC754D48165CE32D8133B /* Pods_PurchasesCoreSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PurchasesCoreSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		80E80EF026970DC3008F245A /* RCReceiptFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RCReceiptFetcher.swift; sourceTree = "<group>"; };
+		80E80EF026970DC3008F245A /* ReceiptFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptFetcher.swift; sourceTree = "<group>"; };
 		84C3F1AC1D7E1E64341D3936 /* Pods_Purchases_PurchasesTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Purchases_PurchasesTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A65DFDD258AD60A00DE00B0 /* LogIntent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogIntent.swift; sourceTree = "<group>"; };
 		9A65E03525918B0500DE00B0 /* ConfigureStrings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigureStrings.swift; sourceTree = "<group>"; };
@@ -974,7 +974,7 @@
 		354235D524C11138008C84EE /* Purchasing */ = {
 			isa = PBXGroup;
 			children = (
-				80E80EF026970DC3008F245A /* RCReceiptFetcher.swift */,
+				80E80EF026970DC3008F245A /* ReceiptFetcher.swift */,
 				B372EC55268FEF020099171E /* ProductInfo.swift */,
 				37E35C7060D7E486F5958BED /* ProductsManager.swift */,
 				37E35E8DCF998D9DB63850F8 /* ProductsRequestFactory.swift */,
@@ -1763,8 +1763,8 @@
 				9A65E07B2591977500DE00B0 /* NetworkStrings.swift in Sources */,
 				F5BE424026962ACF00254A30 /* ReceiptRefreshPolicy.swift in Sources */,
 				9A65E0762591977200DE00B0 /* IdentityStrings.swift in Sources */,
-				80E80EF226970E04008F245A /* RCReceiptFetcher.swift in Sources */,
 				F5BE447D269E4ADB00254A30 /* ASIdentifierManagerProxy.swift in Sources */,
+				80E80EF226970E04008F245A /* ReceiptFetcher.swift in Sources */,
 				F5BE443D26977F9B00254A30 /* HTTPRequest.swift in Sources */,
 				2DDF41AB24F6F37C005BC22D /* AppleReceipt.swift in Sources */,
 				2DDF41BB24F6F392005BC22D /* UInt8+Extensions.swift in Sources */,

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		2D50332A2406EA61009CAE61 /* RCSubscriberAttributesManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D5033272406EA61009CAE61 /* RCSubscriberAttributesManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D50332B2406EA61009CAE61 /* RCSubscriberAttributesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D5033282406EA61009CAE61 /* RCSubscriberAttributesManager.m */; };
 		2D80736A268A691A0072284E /* MockProductsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35C9439E087F63ECC4F59 /* MockProductsManager.swift */; };
+		2D84458926B9CD270033B5A3 /* ReceiptFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D84458826B9CD270033B5A3 /* ReceiptFetcherTests.swift */; };
 		2D8E9D482523747D00AFEE11 /* DictionaryExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD269162522A20A006AC4BC /* DictionaryExtensionsTests.swift */; };
 		2D991ACA268BA56900085481 /* StoreKitRequestFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D991AC9268BA56900085481 /* StoreKitRequestFetcher.swift */; };
 		2D991ACC268BBCD600085481 /* MockRequestFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35609E46E869675A466C1 /* MockRequestFetcher.swift */; };
@@ -322,6 +323,7 @@
 		2D5033272406EA61009CAE61 /* RCSubscriberAttributesManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCSubscriberAttributesManager.h; path = Purchases/SubscriberAttributes/RCSubscriberAttributesManager.h; sourceTree = SOURCE_ROOT; };
 		2D5033282406EA61009CAE61 /* RCSubscriberAttributesManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCSubscriberAttributesManager.m; path = Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m; sourceTree = SOURCE_ROOT; };
 		2D5BB46A24C8E8ED00E27537 /* ReceiptParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptParser.swift; sourceTree = "<group>"; };
+		2D84458826B9CD270033B5A3 /* ReceiptFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptFetcherTests.swift; sourceTree = "<group>"; };
 		2D8DB34A24072AAE00BE3D31 /* SubscriberAttributeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriberAttributeTests.swift; sourceTree = "<group>"; };
 		2D8F622224D30F9D00F993AA /* ReceiptParsingError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptParsingError.swift; sourceTree = "<group>"; };
 		2D97458E24BDFCEF006245E9 /* IntroEligibilityCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroEligibilityCalculator.swift; sourceTree = "<group>"; };
@@ -999,6 +1001,7 @@
 				37E351F0E21361EAEC078A0D /* ProductsManagerTests.swift */,
 				37E352F86A0A8EB05BAD77C4 /* StoreKitWrapperTests.swift */,
 				3597021124BF6AAC0010506E /* TransactionsFactoryTests.swift */,
+				2D84458826B9CD270033B5A3 /* ReceiptFetcherTests.swift */,
 			);
 			path = Purchasing;
 			sourceTree = "<group>";
@@ -1805,6 +1808,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2D84458926B9CD270033B5A3 /* ReceiptFetcherTests.swift in Sources */,
 				2DDF41E824F6F61B005BC22D /* MockSKDiscount.swift in Sources */,
 				2DDF41CB24F6F4C3005BC22D /* ASN1ObjectIdentifierBuilderTests.swift in Sources */,
 				B36824BF268FBC8700957E4C /* SubscriberAttributeTests.swift in Sources */,

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		2CD72944268A826F00BFC976 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD72943268A826F00BFC976 /* Date+Extensions.swift */; };
 		2CD72948268A828400BFC976 /* Locale+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD72947268A828400BFC976 /* Locale+Extensions.swift */; };
 		2D11F5E1250FF886005A70E8 /* AttributionStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D11F5E0250FF886005A70E8 /* AttributionStrings.swift */; };
+		2D1C3F3926B9D8B800112626 /* MockBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1C3F3826B9D8B800112626 /* MockBundle.swift */; };
 		2D1FFAD525B8707400367C63 /* RCPurchaserInfoManager+Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D1FFAD425B8707400367C63 /* RCPurchaserInfoManager+Protected.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2D22679125F2D9AD00E6950C /* PurchasesTests-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 35262A291F7D783F00C04F2C /* PurchasesTests-Bridging-Header.h */; };
 		2D390255259CF46000DB19C0 /* MockPaymentDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D390254259CF46000DB19C0 /* MockPaymentDiscount.swift */; };
@@ -314,6 +315,7 @@
 		2CD72943268A826F00BFC976 /* Date+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; };
 		2CD72947268A828400BFC976 /* Locale+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Locale+Extensions.swift"; sourceTree = "<group>"; };
 		2D11F5E0250FF886005A70E8 /* AttributionStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributionStrings.swift; sourceTree = "<group>"; };
+		2D1C3F3826B9D8B800112626 /* MockBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBundle.swift; sourceTree = "<group>"; };
 		2D1FFAD425B8707400367C63 /* RCPurchaserInfoManager+Protected.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCPurchaserInfoManager+Protected.h"; sourceTree = "<group>"; };
 		2D390254259CF46000DB19C0 /* MockPaymentDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPaymentDiscount.swift; sourceTree = "<group>"; };
 		2D4C18A824F47E4400F268CD /* Purchases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Purchases.swift; sourceTree = "<group>"; };
@@ -835,6 +837,7 @@
 				37E357D16038F07915D7825D /* MockUserDefaults.swift */,
 				2DDF41E924F6F844005BC22D /* SKProductSubscriptionDurationExtensions.swift */,
 				F591492726B9956C00D32E58 /* MockTransaction.swift */,
+				2D1C3F3826B9D8B800112626 /* MockBundle.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -1845,6 +1848,7 @@
 				B36824C1268FBCE000957E4C /* MockDateProvider.swift in Sources */,
 				2DDF41CE24F6F4C3005BC22D /* InAppPurchaseBuilderTests.swift in Sources */,
 				F591492626B994B400D32E58 /* SKPaymentTransactionExtensionsTests.swift in Sources */,
+				2D1C3F3926B9D8B800112626 /* MockBundle.swift in Sources */,
 				2DDF41E424F6F527005BC22D /* MockProductsRequestFactory.swift in Sources */,
 				2DDF41E024F6F527005BC22D /* MockInAppPurchaseBuilder.swift in Sources */,
 			);

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -218,7 +218,12 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
                   observerMode:(BOOL)observerMode
                 platformFlavor:(nullable NSString *)platformFlavor
          platformFlavorVersion:(nullable NSString *)platformFlavorVersion {
-    RCReceiptFetcher *receiptFetcher = [[RCReceiptFetcher alloc] init];
+    RCOperationDispatcher *operationDispatcher = [[RCOperationDispatcher alloc] init];
+    RCReceiptRefreshRequestFactory *receiptRefreshRequestFactory = [[RCReceiptRefreshRequestFactory alloc] init];
+    RCStoreKitRequestFetcher *fetcher = [[RCStoreKitRequestFetcher alloc]
+                                         initWithRequestFactory:receiptRefreshRequestFactory
+                                         operationDispatcher:operationDispatcher];
+    RCReceiptFetcher *receiptFetcher = [[RCReceiptFetcher alloc] initWithRequestFetcher:fetcher];
     NSError *error = nil;
     RCSystemInfo *systemInfo = [[RCSystemInfo alloc] initWithPlatformFlavor:platformFlavor
                                                       platformFlavorVersion:platformFlavorVersion
@@ -227,7 +232,6 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
     NSAssert(systemInfo, error.localizedDescription);
 
     RCETagManager *eTagManager = [[RCETagManager alloc] init];
-    RCOperationDispatcher *operationDispatcher = [[RCOperationDispatcher alloc] init];
 
     RCBackend *backend = [[RCBackend alloc] initWithAPIKey:APIKey
                                                 systemInfo:systemInfo
@@ -271,9 +275,6 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 
     RCProductsRequestFactory *productsRequestFactory = [[RCProductsRequestFactory alloc] init];
     RCProductsManager *productsManager = [[RCProductsManager alloc] initWithProductsRequestFactory:productsRequestFactory];
-    RCReceiptRefreshRequestFactory *receiptRefreshRequestFactory = [[RCReceiptRefreshRequestFactory alloc] init];
-    RCStoreKitRequestFetcher *fetcher = [[RCStoreKitRequestFetcher alloc] initWithRequestFactory:receiptRefreshRequestFactory
-                                                                             operationDispatcher:operationDispatcher];
     return [self initWithAppUserID:appUserID
                     requestFetcher:fetcher
                     receiptFetcher:receiptFetcher

--- a/PurchasesCoreSwift/Purchasing/ReceiptFetcher.swift
+++ b/PurchasesCoreSwift/Purchasing/ReceiptFetcher.swift
@@ -1,5 +1,5 @@
 //
-//  RCReceiptFetcher.swift
+//  ReceiptFetcher.swift
 //  Purchases
 //
 //  Created by Javier de Martín Gil on 8/7/21.
@@ -9,10 +9,10 @@
 import Foundation
 
 // TODO: Make internal after migration to Swift is complete
-@objc(RCReceiptFetcher) open class ReceiptFetcher: NSObject {
+@objc(RCReceiptFetcher) public class ReceiptFetcher: NSObject {
 
     // TODO: Make internal after migration to Swift is complete
-    @objc open func receiptData() -> Data? {
+    @objc public func receiptData() -> Data? {
 
         guard var receiptURL: URL = Bundle.main.appStoreReceiptURL else {
             Logger.debug(Strings.receipt.no_sandbox_receipt_restore)

--- a/PurchasesCoreSwift/Purchasing/ReceiptFetcher.swift
+++ b/PurchasesCoreSwift/Purchasing/ReceiptFetcher.swift
@@ -12,7 +12,7 @@ import Foundation
 @objc(RCReceiptFetcher) public class ReceiptFetcher: NSObject {
     private let requestFetcher: StoreKitRequestFetcher
 
-    public init(requestFetcher: StoreKitRequestFetcher) {
+    @objc public init(requestFetcher: StoreKitRequestFetcher) {
         self.requestFetcher = requestFetcher
     }
 

--- a/PurchasesCoreSwift/Purchasing/ReceiptFetcher.swift
+++ b/PurchasesCoreSwift/Purchasing/ReceiptFetcher.swift
@@ -11,12 +11,19 @@ import Foundation
 // TODO: Make internal after migration to Swift is complete
 @objc(RCReceiptFetcher) public class ReceiptFetcher: NSObject {
     private let requestFetcher: StoreKitRequestFetcher
+    private let receiptBundle: Bundle
 
-    @objc public init(requestFetcher: StoreKitRequestFetcher) {
-        self.requestFetcher = requestFetcher
+    @objc public convenience init(requestFetcher: StoreKitRequestFetcher) {
+        self.init(requestFetcher: requestFetcher, bundle: .main)
     }
 
-    @objc public func receiptData(refreshPolicy: ReceiptRefreshPolicy, completion: @escaping ((Data?) -> Void)) {
+    init(requestFetcher: StoreKitRequestFetcher, bundle: Bundle) {
+        self.requestFetcher = requestFetcher
+        self.receiptBundle = bundle
+    }
+
+    @objc public func receiptData(refreshPolicy: ReceiptRefreshPolicy,
+                                  completion: @escaping ((Data?) -> Void)) {
         if refreshPolicy == .always {
             Logger.debug(String(format: Strings.receipt.force_refreshing_receipt))
             self.refreshReceipt(completion)
@@ -39,7 +46,7 @@ import Foundation
 private extension ReceiptFetcher {
 
     func receiptData() -> Data? {
-        guard var receiptURL: URL = Bundle.main.appStoreReceiptURL else {
+        guard var receiptURL: URL = self.receiptBundle.appStoreReceiptURL else {
             Logger.debug(Strings.receipt.no_sandbox_receipt_restore)
             return nil
         }

--- a/PurchasesCoreSwift/Purchasing/ReceiptFetcher.swift
+++ b/PurchasesCoreSwift/Purchasing/ReceiptFetcher.swift
@@ -23,10 +23,10 @@ import Foundation
     }
 
     @objc public func receiptData(refreshPolicy: ReceiptRefreshPolicy,
-                                  completion: @escaping ((Data?) -> Void)) {
+                                  completion: @escaping (Data?) -> Void) {
         if refreshPolicy == .always {
             Logger.debug(String(format: Strings.receipt.force_refreshing_receipt))
-            self.refreshReceipt(completion)
+            refreshReceipt(completion)
             return
         }
 
@@ -35,7 +35,7 @@ import Foundation
 
         if isReceiptEmpty && refreshPolicy == .onlyIfEmpty {
             Logger.debug(Strings.receipt.refreshing_empty_receipt)
-            self.refreshReceipt(completion)
+            refreshReceipt(completion)
         } else {
             completion(receiptData)
         }
@@ -46,7 +46,7 @@ import Foundation
 private extension ReceiptFetcher {
 
     func receiptData() -> Data? {
-        guard var receiptURL: URL = self.receiptBundle.appStoreReceiptURL else {
+        guard var receiptURL: URL = receiptBundle.appStoreReceiptURL else {
             Logger.debug(Strings.receipt.no_sandbox_receipt_restore)
             return nil
         }
@@ -78,7 +78,7 @@ private extension ReceiptFetcher {
         return data
     }
 
-    func refreshReceipt(_ completion: @escaping ((Data) -> Void)) {
+    func refreshReceipt(_ completion: @escaping (Data) -> Void) {
         requestFetcher.fetchReceiptData {
             let maybeData = self.receiptData()
             guard let receiptData = maybeData,

--- a/PurchasesCoreSwift/Purchasing/ReceiptFetcher.swift
+++ b/PurchasesCoreSwift/Purchasing/ReceiptFetcher.swift
@@ -34,9 +34,11 @@ import Foundation
         }
     }
 
-    // TODO: Make internal after migration to Swift is complete
-    @objc public func receiptData() -> Data? {
+}
 
+private extension ReceiptFetcher {
+
+    func receiptData() -> Data? {
         guard var receiptURL: URL = Bundle.main.appStoreReceiptURL else {
             Logger.debug(Strings.receipt.no_sandbox_receipt_restore)
             return nil
@@ -68,9 +70,6 @@ import Foundation
 
         return data
     }
-}
-
-private extension ReceiptFetcher {
 
     func refreshReceipt(_ completion: @escaping ((Data) -> Void)) {
         requestFetcher.fetchReceiptData {

--- a/PurchasesCoreSwiftTests/Mocks/MockBundle.swift
+++ b/PurchasesCoreSwiftTests/Mocks/MockBundle.swift
@@ -14,18 +14,24 @@
 import Foundation
 
 class MockBundle: Bundle {
-    var mockAppStoreReceiptFileName = "base64encodedreceiptsample1"
-    var shouldReturnNilURL = false
-    
-    var mockAppStoreReceiptURL: URL? {
-        guard !shouldReturnNilURL else { return nil }
-        
-        return Bundle(for: type(of: self))
-            .url(forResource: mockAppStoreReceiptFileName, withExtension: "txt")
+    enum MockAppStoreReceiptURLResult {
+        case receiptWithData, emptyReceipt, nilURL
     }
     
+    var mockAppStoreReceiptURLResult: MockAppStoreReceiptURLResult = .receiptWithData
+    
+    var mockAppStoreReceiptFileName = "base64encodedreceiptsample1"
+    
     override var appStoreReceiptURL: URL? {
-        return mockAppStoreReceiptURL
+        switch mockAppStoreReceiptURLResult {
+        case .receiptWithData:
+            return Bundle(for: type(of: self))
+                .url(forResource: mockAppStoreReceiptFileName, withExtension: "txt")
+        case .emptyReceipt:
+            return Bundle.main.appStoreReceiptURL
+        case .nilURL:
+            return nil
+        }
     }
     
 }

--- a/PurchasesCoreSwiftTests/Mocks/MockBundle.swift
+++ b/PurchasesCoreSwiftTests/Mocks/MockBundle.swift
@@ -20,7 +20,7 @@ class MockBundle: Bundle {
     
     var mockAppStoreReceiptURLResult: MockAppStoreReceiptURLResult = .receiptWithData
     
-    var mockAppStoreReceiptFileName = "base64encodedreceiptsample1"
+    private let mockAppStoreReceiptFileName = "base64encodedreceiptsample1"
     
     override var appStoreReceiptURL: URL? {
         switch mockAppStoreReceiptURLResult {

--- a/PurchasesCoreSwiftTests/Mocks/MockBundle.swift
+++ b/PurchasesCoreSwiftTests/Mocks/MockBundle.swift
@@ -1,0 +1,31 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockBundle.swift
+//
+//  Created by Andrés Boedo on 3/8/21.
+
+import Foundation
+
+class MockBundle: Bundle {
+    var mockAppStoreReceiptFileName = "base64encodedreceiptsample1"
+    var shouldReturnNilURL = false
+    
+    var mockAppStoreReceiptURL: URL? {
+        guard !shouldReturnNilURL else { return nil }
+        
+        return Bundle(for: type(of: self))
+            .url(forResource: mockAppStoreReceiptFileName, withExtension: "txt")
+    }
+    
+    override var appStoreReceiptURL: URL? {
+        return mockAppStoreReceiptURL
+    }
+    
+}

--- a/PurchasesCoreSwiftTests/Purchasing/ReceiptFetcherTests.swift
+++ b/PurchasesCoreSwiftTests/Purchasing/ReceiptFetcherTests.swift
@@ -29,19 +29,6 @@ class ReceiptFetcherTests: XCTestCase {
         receiptFetcher = ReceiptFetcher(requestFetcher: mockRequestFetcher, bundle: mockBundle)
     }
     
-    func testReceiptDataWithRefreshPolicyNeverDoesntRefreshIfEmpty() {
-        var completionCalled = false
-        mockBundle.shouldReturnNilURL = true
-        var receivedData: Data?
-        receiptFetcher.receiptData(refreshPolicy: .never) { maybeData in
-            completionCalled = true
-            receivedData = maybeData
-        }
-        expect(completionCalled).toEventually(beTrue())
-        expect(self.mockRequestFetcher.refreshReceiptCalled) == false
-        expect(receivedData).to(beNil())
-    }
-
     func testReceiptDataWithRefreshPolicyNeverReturnsReceiptData() {
         var completionCalled = false
         var receivedData: Data?
@@ -53,24 +40,97 @@ class ReceiptFetcherTests: XCTestCase {
         expect(receivedData).toNot(beNil())
     }
 
-    func testReceiptDataWithRefreshPolicyOnlyIfEmptyRefreshesIfEmpty() {
-        
-    }
-
-    func testReceiptDataWithRefreshPolicyOnlyIfEmptyDoesntRefreshIfTheresData() {
-        
-    }
-
     func testReceiptDataWithRefreshPolicyOnlyIfEmptyReturnsReceiptData() {
-        
+        var completionCalled = false
+        var receivedData: Data?
+        receiptFetcher.receiptData(refreshPolicy: .onlyIfEmpty) { maybeData in
+            completionCalled = true
+            receivedData = maybeData
+        }
+        expect(completionCalled).toEventually(beTrue())
+        expect(receivedData).toNot(beNil())
     }
 
     func testReceiptDataWithRefreshPolicyAlwaysReturnsReceiptData() {
-        
+        var completionCalled = false
+        var receivedData: Data?
+        receiptFetcher.receiptData(refreshPolicy: .always) { maybeData in
+            completionCalled = true
+            receivedData = maybeData
+        }
+        expect(completionCalled).toEventually(beTrue())
+        expect(receivedData).toNot(beNil())
+    }
+    
+    func testReceiptDataWithRefreshPolicyNeverDoesntRefreshIfEmpty() {
+        var completionCalled = false
+        mockBundle.mockAppStoreReceiptURLResult = .emptyReceipt
+        var receivedData: Data?
+        receiptFetcher.receiptData(refreshPolicy: .never) { maybeData in
+            completionCalled = true
+            receivedData = maybeData
+        }
+        expect(completionCalled).toEventually(beTrue())
+        expect(self.mockRequestFetcher.refreshReceiptCalled) == false
+        expect(receivedData).to(beNil())
     }
 
+    func testReceiptDataWithRefreshPolicyOnlyIfEmptyRefreshesIfEmpty() {
+        var completionCalled = false
+        mockBundle.mockAppStoreReceiptURLResult = .emptyReceipt
+        var receivedData: Data?
+        receiptFetcher.receiptData(refreshPolicy: .onlyIfEmpty) { maybeData in
+            completionCalled = true
+            receivedData = maybeData
+        }
+        expect(completionCalled).toEventually(beTrue())
+        expect(self.mockRequestFetcher.refreshReceiptCalled) == true
+        expect(receivedData).toNot(beNil())
+        expect(receivedData).to(beEmpty())
+    }
+    
+    func testReceiptDataWithRefreshPolicyOnlyIfEmptyRefreshesIfNil() {
+        var completionCalled = false
+        mockBundle.mockAppStoreReceiptURLResult = .nilURL
+        var receivedData: Data?
+        receiptFetcher.receiptData(refreshPolicy: .onlyIfEmpty) { maybeData in
+            completionCalled = true
+            receivedData = maybeData
+        }
+        expect(completionCalled).toEventually(beTrue())
+        expect(self.mockRequestFetcher.refreshReceiptCalled) == true
+        expect(receivedData).toNot(beNil())
+        expect(receivedData).to(beEmpty())
+    }
+
+
+    func testReceiptDataWithRefreshPolicyOnlyIfEmptyDoesntRefreshIfTheresData() {
+        var completionCalled = false
+        mockBundle.mockAppStoreReceiptURLResult = .receiptWithData
+        var receivedData: Data?
+        receiptFetcher.receiptData(refreshPolicy: .onlyIfEmpty) { maybeData in
+            completionCalled = true
+            receivedData = maybeData
+        }
+        expect(completionCalled).toEventually(beTrue())
+        expect(self.mockRequestFetcher.refreshReceiptCalled) == false
+        expect(receivedData).toNot(beNil())
+        expect(receivedData).toNot(beEmpty())
+    }
+
+
     func testReceiptDataWithRefreshPolicyAlwaysRefreshesEvenIfTheresData() {
-        
+        var completionCalled = false
+        mockBundle.mockAppStoreReceiptURLResult = .receiptWithData
+        var receivedData: Data?
+        receiptFetcher.receiptData(refreshPolicy: .always) { maybeData in
+            completionCalled = true
+            receivedData = maybeData
+        }
+        expect(completionCalled).toEventually(beTrue())
+        expect(self.mockRequestFetcher.refreshReceiptCalled) == true
+        expect(receivedData).toNot(beNil())
+        expect(receivedData).toNot(beEmpty())
     }
     
 }

--- a/PurchasesCoreSwiftTests/Purchasing/ReceiptFetcherTests.swift
+++ b/PurchasesCoreSwiftTests/Purchasing/ReceiptFetcherTests.swift
@@ -12,3 +12,65 @@
 //  Created by Andrés Boedo on 8/3/21.
 
 import Foundation
+import XCTest
+
+@testable import PurchasesCoreSwift
+import Nimble
+
+
+class ReceiptFetcherTests: XCTestCase {
+    var receiptFetcher: ReceiptFetcher!
+    var mockRequestFetcher: MockRequestFetcher!
+    var mockBundle: MockBundle!
+    
+    override func setUp() {
+        mockBundle = MockBundle()
+        mockRequestFetcher = MockRequestFetcher()
+        receiptFetcher = ReceiptFetcher(requestFetcher: mockRequestFetcher, bundle: mockBundle)
+    }
+    
+    func testReceiptDataWithRefreshPolicyNeverDoesntRefreshIfEmpty() {
+        var completionCalled = false
+        mockBundle.shouldReturnNilURL = true
+        var receivedData: Data?
+        receiptFetcher.receiptData(refreshPolicy: .never) { maybeData in
+            completionCalled = true
+            receivedData = maybeData
+        }
+        expect(completionCalled).toEventually(beTrue())
+        expect(self.mockRequestFetcher.refreshReceiptCalled) == false
+        expect(receivedData).to(beNil())
+    }
+
+    func testReceiptDataWithRefreshPolicyNeverReturnsReceiptData() {
+        var completionCalled = false
+        var receivedData: Data?
+        receiptFetcher.receiptData(refreshPolicy: .never) { maybeData in
+            completionCalled = true
+            receivedData = maybeData
+        }
+        expect(completionCalled).toEventually(beTrue())
+        expect(receivedData).toNot(beNil())
+    }
+
+    func testReceiptDataWithRefreshPolicyOnlyIfEmptyRefreshesIfEmpty() {
+        
+    }
+
+    func testReceiptDataWithRefreshPolicyOnlyIfEmptyDoesntRefreshIfTheresData() {
+        
+    }
+
+    func testReceiptDataWithRefreshPolicyOnlyIfEmptyReturnsReceiptData() {
+        
+    }
+
+    func testReceiptDataWithRefreshPolicyAlwaysReturnsReceiptData() {
+        
+    }
+
+    func testReceiptDataWithRefreshPolicyAlwaysRefreshesEvenIfTheresData() {
+        
+    }
+    
+}

--- a/PurchasesCoreSwiftTests/Purchasing/ReceiptFetcherTests.swift
+++ b/PurchasesCoreSwiftTests/Purchasing/ReceiptFetcherTests.swift
@@ -1,0 +1,14 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ReceiptFetcherTests.swift
+//
+//  Created by Andrés Boedo on 8/3/21.
+
+import Foundation

--- a/PurchasesTests/Mocks/MockReceiptFetcher.swift
+++ b/PurchasesTests/Mocks/MockReceiptFetcher.swift
@@ -10,17 +10,21 @@ class MockReceiptFetcher: ReceiptFetcher {
     var shouldReturnReceipt = true
     var shouldReturnZeroBytesReceipt = false
     var receiptDataTimesCalled = 0
+    var receiptDataReceivedRefreshPolicy: ReceiptRefreshPolicy?
 
-    override func receiptData() -> Data? {
+    @objc override public func receiptData(refreshPolicy: ReceiptRefreshPolicy,
+                                           completion: @escaping ((Data?) -> Void)) {
+        receiptDataReceivedRefreshPolicy = refreshPolicy
         receiptDataCalled = true
         receiptDataTimesCalled += 1
         if (shouldReturnReceipt) {
             if (shouldReturnZeroBytesReceipt) {
-                return Data()
+                completion(Data())
+            } else {
+                completion(Data(1...3))
             }
-            return Data(1...3)
         } else {
-            return nil
+            completion(nil)
         }
     }
 }

--- a/PurchasesTests/Mocks/MockReceiptFetcher.swift
+++ b/PurchasesTests/Mocks/MockReceiptFetcher.swift
@@ -12,6 +12,10 @@ class MockReceiptFetcher: ReceiptFetcher {
     var receiptDataTimesCalled = 0
     var receiptDataReceivedRefreshPolicy: ReceiptRefreshPolicy?
 
+    convenience init(requestFetcher: StoreKitRequestFetcher) {
+        self.init(requestFetcher: requestFetcher, bundle: .main)
+    }
+
     @objc override public func receiptData(refreshPolicy: ReceiptRefreshPolicy,
                                            completion: @escaping ((Data?) -> Void)) {
         receiptDataReceivedRefreshPolicy = refreshPolicy

--- a/PurchasesTests/Mocks/MockReceiptFetcher.swift
+++ b/PurchasesTests/Mocks/MockReceiptFetcher.swift
@@ -3,6 +3,8 @@
 // Copyright (c) 2020 Purchases. All rights reserved.
 //
 
+@testable import PurchasesCoreSwift
+
 class MockReceiptFetcher: ReceiptFetcher {
     var receiptDataCalled = false
     var shouldReturnReceipt = true

--- a/PurchasesTests/Mocks/MockSystemInfo.swift
+++ b/PurchasesTests/Mocks/MockSystemInfo.swift
@@ -7,6 +7,8 @@
 //
 
 import Foundation
+@testable import PurchasesCoreSwift
+
 
 class MockSystemInfo: SystemInfo {
     var stubbedIsApplicationBackgrounded: Bool?

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -1162,7 +1162,6 @@ class PurchasesTests: XCTestCase {
         purchases!.restoreTransactions()
 
         expect(self.receiptFetcher.receiptDataTimesCalled).to(equal(1))
-        expect(self.requestFetcher.refreshReceiptCalled).to(beTrue())
     }
 
     func testRestoringPurchasesSetsIsRestore() {
@@ -2057,8 +2056,9 @@ class PurchasesTests: XCTestCase {
         receiptFetcher.shouldReturnZeroBytesReceipt = true
 
         makeAPurchase()
-
-        expect(self.requestFetcher.refreshReceiptCalled).to(beTrue())
+        
+        expect(self.receiptFetcher.receiptDataCalled) == true
+        expect(self.receiptFetcher.receiptDataReceivedRefreshPolicy) == .onlyIfEmpty
     }
 
     private func makeAPurchase() {

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -2041,15 +2041,6 @@ class PurchasesTests: XCTestCase {
         expect(info).toEventuallyNot(beNil())
     }
 
-    func testWhenNoReceiptReceiptIsRefreshed() {
-        setupPurchases()
-        receiptFetcher.shouldReturnReceipt = false
-
-        makeAPurchase()
-
-        expect(self.requestFetcher.refreshReceiptCalled).to(beTrue())
-    }
-
     func testWhenNoReceiptDataReceiptIsRefreshed() {
         setupPurchases()
         receiptFetcher.shouldReturnReceipt = true

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -30,6 +30,7 @@ class PurchasesTests: XCTestCase {
         mockOperationDispatcher = MockOperationDispatcher()
         mockIntroEligibilityCalculator = MockIntroEligibilityCalculator()
         mockReceiptParser = MockReceiptParser()
+        receiptFetcher = MockReceiptFetcher(requestFetcher: requestFetcher)
         let systemInfoAttribution = try! MockSystemInfo(platformFlavor: "iOS",
                                                    platformFlavorVersion: "3.2.1",
                                                    finishTransactions: true)
@@ -226,7 +227,7 @@ class PurchasesTests: XCTestCase {
     }
 
 
-    let receiptFetcher = MockReceiptFetcher()
+    var receiptFetcher: MockReceiptFetcher!
     var requestFetcher: MockRequestFetcher!
     var mockProductsManager: MockProductsManager!
     let backend = MockBackend(httpClient: MockHTTPClient(systemInfo: try! MockSystemInfo(platformFlavor: nil,

--- a/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -18,7 +18,7 @@ import Nimble
 
 class PurchasesSubscriberAttributesTests: XCTestCase {
 
-    let mockReceiptFetcher = MockReceiptFetcher()
+    var mockReceiptFetcher: MockReceiptFetcher!
     let mockRequestFetcher = MockRequestFetcher()
     let mockProductsManager = MockProductsManager()
     let mockBackend = MockBackend()
@@ -86,6 +86,7 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
                                                          deviceCache: mockDeviceCache,
                                                          backend: mockBackend,
                                                          systemInfo: systemInfo)
+        self.mockReceiptFetcher = MockReceiptFetcher(requestFetcher: mockRequestFetcher)
 
     }
 


### PR DESCRIPTION
Moved some logic away from `RCPurchases.m` and into `ReceiptFetcher`, as described in #680. 

Fixes #692 