### PR TITLE
Remove redundant products by identifier cache

### DIFF
--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -512,16 +512,14 @@ completionBlock:(void (^)(RCPurchaserInfo * _Nullable purchaserInfo, BOOL create
 
 - (void)productsWithIdentifiers:(NSArray<NSString *> *)productIdentifiers
                 completionBlock:(RCReceiveProductsBlock)completion {
-    // TODO: remove this block, and just trust that the ProductsManager's cache should work.
-    NSMutableArray<SKProduct *> *products = [NSMutableArray array];
     NSSet<NSString *> *productIdentifiersSet = [[NSSet alloc] initWithArray:productIdentifiers];
     if (productIdentifiersSet.count > 0) {
         [self.productsManager productsWithIdentifiers:productIdentifiersSet
-                                           completion:^(NSSet<SKProduct *> * _Nonnull newProducts) {
-            CALL_IF_SET_ON_MAIN_THREAD(completion, [products arrayByAddingObjectsFromArray:newProducts.allObjects]);
+                                           completion:^(NSSet<SKProduct *> * _Nonnull products) {
+            CALL_IF_SET_ON_MAIN_THREAD(completion, products.allObjects);
         }];
     } else {
-        CALL_IF_SET_ON_MAIN_THREAD(completion, products);
+        CALL_IF_SET_ON_MAIN_THREAD(completion, @[]);
     }
 }
 

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -604,11 +604,8 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
         [RCLog purchase:[NSString stringWithFormat:RCStrings.purchase.purchasing_product, productIdentifier]];
     }
 
-    // TODO: add to ProductsManager and remove from here
-    @synchronized (self) {
-        self.productsByIdentifier[productIdentifier] = product;
-    }
-
+    [self.productsManager cacheProduct:product];
+    
     @synchronized (self) {
         self.presentedOfferingsByProductIdentifier[productIdentifier] = presentedOfferingIdentifier;
     }
@@ -1178,10 +1175,7 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 - (BOOL)storeKitWrapper:(nonnull RCStoreKitWrapper *)storeKitWrapper
   shouldAddStorePayment:(nonnull SKPayment *)payment
              forProduct:(nonnull SKProduct *)product {
-    // TODO: add to ProductsManager and remove from here
-    @synchronized(self) {
-        self.productsByIdentifier[product.productIdentifier] = product;
-    }
+    [self.productsManager cacheProduct:product];
 
     if ([self.delegate respondsToSelector:@selector(purchases:shouldPurchasePromoProduct:defermentBlock:)]) {
         [self.delegate purchases:self

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -39,8 +39,6 @@ typedef void (^RCReceiveReceiptDataBlock)(NSData *);
 @property (nonatomic) RCStoreKitWrapper *storeKitWrapper;
 @property (nonatomic) NSNotificationCenter *notificationCenter;
 
-// TODO: should be deleted & replaced with ProductsManager
-@property (nonatomic) NSMutableDictionary<NSString *, SKProduct *> *productsByIdentifier;
 // TODO: move to new class PurchasesManager, possibly rename to a name that describes intent?
 @property (nonatomic) NSMutableDictionary<NSString *, NSString *> *presentedOfferingsByProductIdentifier;
 // TODO: move to new class PurchasesManager
@@ -336,8 +334,6 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 
         self.notificationCenter = notificationCenter;
 
-        // TODO: should be deleted & replaced with ProductsManager
-        self.productsByIdentifier = [NSMutableDictionary new];
         self.presentedOfferingsByProductIdentifier = [NSMutableDictionary new];
         self.purchaseCompleteCallbacks = [NSMutableDictionary new];
 
@@ -518,29 +514,10 @@ completionBlock:(void (^)(RCPurchaserInfo * _Nullable purchaserInfo, BOOL create
                 completionBlock:(RCReceiveProductsBlock)completion {
     // TODO: remove this block, and just trust that the ProductsManager's cache should work.
     NSMutableArray<SKProduct *> *products = [NSMutableArray array];
-    NSMutableSet<NSString *> *missingProductIdentifiers = [NSMutableSet set];
-    
-    @synchronized(self) {
-        for (NSString *identifier in productIdentifiers) {
-            SKProduct *product = self.productsByIdentifier[identifier];
-            if (product) {
-                [products addObject:product];
-            } else {
-                [missingProductIdentifiers addObject:identifier];
-            }
-        }
-    }
-
-    if (missingProductIdentifiers.count > 0) {
-        [self.productsManager productsWithIdentifiers:missingProductIdentifiers
+    NSSet<NSString *> *productIdentifiersSet = [[NSSet alloc] initWithArray:productIdentifiers];
+    if (productIdentifiersSet.count > 0) {
+        [self.productsManager productsWithIdentifiers:productIdentifiersSet
                                            completion:^(NSSet<SKProduct *> * _Nonnull newProducts) {
-            @synchronized (self) {
-                for (SKProduct *p in newProducts) {
-                    if (p.productIdentifier) {
-                        self.productsByIdentifier[p.productIdentifier] = p;
-                    }
-                }
-            }
             CALL_IF_SET_ON_MAIN_THREAD(completion, [products arrayByAddingObjectsFromArray:newProducts.allObjects]);
         }];
     } else {

--- a/PurchasesCoreSwift/Purchasing/ProductsManager.swift
+++ b/PurchasesCoreSwift/Purchasing/ProductsManager.swift
@@ -24,6 +24,10 @@ import StoreKit
 
     @objc public func products(withIdentifiers identifiers: Set<String>,
                                completion: @escaping (Set<SKProduct>) -> Void) {
+        guard identifiers.count > 0 else {
+            completion([])
+            return
+        }
         queue.async { [self] in
             let productsAlreadyCached = self.cachedProductsByIdentifier.filter { key, _ in identifiers.contains(key) }
             if productsAlreadyCached.count == identifiers.count {

--- a/PurchasesCoreSwift/Purchasing/ProductsManager.swift
+++ b/PurchasesCoreSwift/Purchasing/ProductsManager.swift
@@ -49,6 +49,12 @@ import StoreKit
             request.start()
         }
     }
+
+    @objc public func cacheProduct(_ product: SKProduct) {
+        queue.async {
+            self.cachedProductsByIdentifier[product.productIdentifier] = product
+        }
+    }
 }
 
 extension ProductsManager: SKProductsRequestDelegate {

--- a/PurchasesCoreSwiftTests/Mocks/MockProductsManager.swift
+++ b/PurchasesCoreSwiftTests/Mocks/MockProductsManager.swift
@@ -36,4 +36,15 @@ class MockProductsManager: ProductsManager {
             completion(Set(products))
         }
     }
+
+    var invokedCacheProduct = false
+    var invokedCacheProductCount = 0
+    var invokedCacheProductParameter: SKProduct?
+
+    override func cacheProduct(_ product: SKProduct) {
+        invokedCacheProduct = true
+        invokedCacheProductCount += 1
+        invokedCacheProductParameter = product
+    }
+
 }

--- a/PurchasesCoreSwiftTests/Mocks/MockProductsManager.swift
+++ b/PurchasesCoreSwiftTests/Mocks/MockProductsManager.swift
@@ -47,4 +47,14 @@ class MockProductsManager: ProductsManager {
         invokedCacheProductParameter = product
     }
 
+    func resetMock() {
+        invokedProducts = false
+        invokedProductsCount = 0
+        invokedProductsParameters = nil
+        invokedProductsParametersList = []
+        stubbedProductsCompletionResult = nil
+        invokedCacheProduct = false
+        invokedCacheProductCount = 0
+        invokedCacheProductParameter = nil
+    }
 }

--- a/PurchasesCoreSwiftTests/Purchasing/ProductsManagerTests.swift
+++ b/PurchasesCoreSwiftTests/Purchasing/ProductsManagerTests.swift
@@ -91,4 +91,25 @@ class ProductsManagerTests: XCTestCase {
         expect(completionCalled).toEventually(beTrue())
         expect(receivedProducts).to(beEmpty())
     }
+    
+    func testCacheProductCachesCorrectly() {
+        let productIdentifiers = Set(["1", "2", "3"])
+        let mockProducts:Set<SKProduct> = Set(productIdentifiers.map {
+            MockSKProduct(mockProductIdentifier: $0)
+        })
+        
+        mockProducts.forEach { productsManager.cacheProduct($0) }
+        
+        var completionCallCount = 0
+        var receivedProducts: Set<SKProduct>?
+        
+        productsManager.products(withIdentifiers: productIdentifiers) { products in
+            completionCallCount += 1
+            receivedProducts = products
+        }
+        
+        expect(completionCallCount).toEventually(equal(1))
+        expect(self.productsRequestFactory.invokedRequestCount).toEventually(equal(0))
+        expect(receivedProducts) == mockProducts
+    }
 }

--- a/PurchasesCoreSwiftTests/Purchasing/ProductsManagerTests.swift
+++ b/PurchasesCoreSwiftTests/Purchasing/ProductsManagerTests.swift
@@ -74,6 +74,11 @@ class ProductsManagerTests: XCTestCase {
         expect(self.productsRequestFactory.invokedRequestParametersList) == [firstCallProducts, secondCallProducts]
     }
 
+    func testProductsWithIdentifiersReturnsDoesntMakeNewRequestIfProductIdentifiersEmpty() {
+        productsManager.products(withIdentifiers: []) { _ in }
+        expect(self.productsRequestFactory.invokedRequestCount).toEventually(equal(0))
+    }
+
     func testProductsWithIdentifiersReturnsErrorAndEmptySetIfRequestFails() {
         let productIdentifiers = Set(["1", "2", "3"])
 

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -533,6 +533,17 @@ class PurchasesTests: XCTestCase {
         expect(self.mockProductsManager.invokedCacheProductParameter) == product
     }
 
+    func testDoesntFetchProductInfoIfEmptyList() {
+        setupPurchases()
+        var completionCalled = false
+        mockProductsManager.resetMock()
+        self.purchases.products([]) { _ in
+            completionCalled = true
+        }
+        expect(completionCalled).toEventually(beTrue())
+        expect(self.mockProductsManager.invokedProducts) == false
+    }
+
     func testTransitioningToPurchasing() {
         setupPurchases()
         let product = MockSKProduct(mockProductIdentifier: "com.product.id1")

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -522,6 +522,17 @@ class PurchasesTests: XCTestCase {
         expect(self.storeKitWrapper.payment?.productIdentifier).to(equal(product.productIdentifier))
     }
 
+    func testPurchaseProductCachesProduct() {
+        setupPurchases()
+        let product = MockSKProduct(mockProductIdentifier: "com.product.id1")
+        self.purchases?.purchaseProduct(product) { (tx, info, error, userCancelled) in
+
+        }
+
+        expect(self.mockProductsManager.invokedCacheProduct) == true
+        expect(self.mockProductsManager.invokedCacheProductParameter) == product
+    }
+
     func testTransitioningToPurchasing() {
         setupPurchases()
         let product = MockSKProduct(mockProductIdentifier: "com.product.id1")
@@ -1308,7 +1319,7 @@ class PurchasesTests: XCTestCase {
         expect(result).to(beFalse())
     }
 
-    func testShouldCacheProductsFromPromoPaymentDelegateMethod() {
+    func testPromoPaymentDelegateMethodMakesRightCalls() {
         setupPurchases()
         let product = MockSKProduct(mockProductIdentifier: "mock_product")
         let payment = SKPayment.init(product: product)
@@ -1329,6 +1340,28 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.postReceiptDataCalled).to(beTrue())
         expect(self.backend.postedProductID).to(equal(product.productIdentifier))
         expect(self.backend.postedPrice).to(equal(product.price))
+    }
+
+    func testPromoPaymentDelegateMethodCachesProduct() {
+        setupPurchases()
+        let product = MockSKProduct(mockProductIdentifier: "mock_product")
+        let payment = SKPayment.init(product: product)
+
+        _ = storeKitWrapper.delegate?.storeKitWrapper(storeKitWrapper,
+                                                      shouldAddStorePayment: payment,
+                                                      for: product)
+
+        let transaction = MockTransaction()
+        transaction.mockPayment = payment
+
+        transaction.mockState = SKPaymentTransactionState.purchasing
+        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+
+        transaction.mockState = SKPaymentTransactionState.purchased
+        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+
+        expect(self.mockProductsManager.invokedCacheProduct) == true
+        expect(self.mockProductsManager.invokedCacheProductParameter) == product
     }
 
     func testDeferBlockMakesPayment() {


### PR DESCRIPTION
fixes #682, as described in #680. 

We had a duplicate `productsByIdentifier` cache between `RCPurchases` and `ProductsManager`. This unifies them and simplifies logic in `RCPurchases`. 