### PR TITLE
added style guide for strong and weak self references

### DIFF
--- a/SwiftStyleGuide.swift
+++ b/SwiftStyleGuide.swift
@@ -106,7 +106,7 @@ private extension MyStruct {
 
     func methodThatNeedsToCaptureSelf() {
         // great guide on when and when not to capture self strongly
-        // https://www.avanderlee.com/swift/weak-self/
+        // https://docs.swift.org/swift-book/LanguageGuide/AutomaticReferenceCounting.html#ID56
 
         // no need to explicitly capture self if you need a strong reference
         foo.methodThatNeedsStrongCapture {

--- a/SwiftStyleGuide.swift
+++ b/SwiftStyleGuide.swift
@@ -109,12 +109,12 @@ private extension MyStruct {
         // https://medium.com/flawless-app-stories/you-dont-always-need-weak-self-a778bec505ef
 
         // no need to explicitly capture self if you need a strong reference
-        foo.methodThatNeedsStrongCapture() {
+        foo.methodThatNeedsStrongCapture {
             // ...
         }
 
         // but of course we do add it for weak references
-        foo.methodThatNeedsWeakCapture() { [weak self] in
+        foo.methodThatNeedsWeakCapture { [weak self] in
             guard let `self` = self else { return }
             // from this point on, you can use self as usual
             self.doThings()

--- a/SwiftStyleGuide.swift
+++ b/SwiftStyleGuide.swift
@@ -106,7 +106,7 @@ private extension MyStruct {
 
     func methodThatNeedsToCaptureSelf() {
         // great guide on when and when not to capture self strongly
-        // https://medium.com/flawless-app-stories/you-dont-always-need-weak-self-a778bec505ef
+        // https://www.avanderlee.com/swift/weak-self/
 
         // no need to explicitly capture self if you need a strong reference
         foo.methodThatNeedsStrongCapture {

--- a/SwiftStyleGuide.swift
+++ b/SwiftStyleGuide.swift
@@ -111,6 +111,7 @@ private extension MyStruct {
         // no need to explicitly capture self if you need a strong reference
         foo.methodThatNeedsStrongCapture {
             // ...
+            self.bar()
         }
 
         // but of course we do add it for weak references

--- a/SwiftStyleGuide.swift
+++ b/SwiftStyleGuide.swift
@@ -115,6 +115,9 @@ private extension MyStruct {
 
         // but of course we do add it for weak references
         foo.methodThatNeedsWeakCapture() { [weak self] in
+            guard let `self` = self else { return }
+            // from this point on, you can use self as usual
+            self.doThings()
             // ...
         }
     }

--- a/SwiftStyleGuide.swift
+++ b/SwiftStyleGuide.swift
@@ -115,7 +115,10 @@ private extension MyStruct {
 
         // but of course we do add it for weak references
         foo.methodThatNeedsWeakCapture { [weak self] in
-            guard let `self` = self else { return }
+            // we need to make self strong again, because the object could be dealloc'ed while
+            // this completion block is running.
+            // so we capture it strongly only within the scope of this completion block.
+            guard let self = self else { return }
             // from this point on, you can use self as usual
             self.doThings()
             // ...

--- a/SwiftStyleGuide.swift
+++ b/SwiftStyleGuide.swift
@@ -104,6 +104,21 @@ private extension MyStruct {
                             : MyCustomError.networkError
     }
 
+    func methodThatNeedsToCaptureSelf() {
+        // great guide on when and when not to capture self strongly
+        // https://medium.com/flawless-app-stories/you-dont-always-need-weak-self-a778bec505ef
+
+        // no need to explicitly capture self if you need a strong reference
+        foo.methodThatNeedsStrongCapture() {
+            // ...
+        }
+
+        // but of course we do add it for weak references
+        foo.methodThatNeedsWeakCapture() { [weak self] in
+            // ...
+        }
+    }
+
 }
 
 // use private extensions of basic types to define constants


### PR DESCRIPTION
added sample code for capturing self weakly and strongly, and link to guide for when to do one or the other. 
Inspired by [this comment](https://github.com/RevenueCat/purchases-ios/pull/705#discussion_r683580830)