### PR TITLE
Replace macro with direct calls to operation dispatcher

### DIFF
--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -479,7 +479,7 @@ completionBlock:(void (^)(RCPurchaserInfo * _Nullable purchaserInfo, BOOL create
                                                                     BOOL created,
                                                                     NSError * _Nullable error) {
         [self.operationDispatcher dispatchOnMainThread:^{ completion(purchaserInfo, created, error); }];
-    
+
         if (error == nil) {
             [self.systemInfo isApplicationBackgroundedWithCompletion:^(BOOL isAppBackgrounded) {
                 [self.offeringsManager updateOfferingsCacheWithAppUserID:self.appUserID

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -662,7 +662,11 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
             if (RCSystemInfo.isSandbox) {
                 [RCLog appleWarning:[NSString stringWithFormat:@"%@", RCStrings.receipt.no_sandbox_receipt_restore]];
             }
-            CALL_IF_SET_ON_MAIN_THREAD(completion, nil, [RCPurchasesErrorUtils missingReceiptFileError]);
+            if (completion) {
+                [self.operationDispatcher dispatchOnMainThread:^{
+                    completion(nil, RCPurchasesErrorUtils.missingReceiptFileError);
+                }];
+            }
             return;
         }
 
@@ -671,7 +675,9 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
         BOOL hasOriginalPurchaseDate = cachedPurchaserInfo != nil && cachedPurchaserInfo.originalPurchaseDate != nil;
         BOOL receiptHasTransactions = [self.receiptParser receiptHasTransactionsWithReceiptData:data];
         if (!receiptHasTransactions && hasOriginalPurchaseDate) {
-            CALL_IF_SET_ON_MAIN_THREAD(completion, cachedPurchaserInfo, nil);
+            if (completion) {
+                [self.operationDispatcher dispatchOnMainThread:^{ completion(cachedPurchaserInfo, nil); }];
+            }
             return;
         }
 
@@ -765,7 +771,7 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
                                                    completion:^(NSDictionary<NSString *, RCIntroEligibility *> *_Nonnull result, NSError * _Nullable error) {
                     [RCLog error:[NSString stringWithFormat:@"Unable to getIntroEligibilityForAppUserID: %@",
                                   error.localizedDescription]];
-                    CALL_IF_SET_ON_MAIN_THREAD(receiveEligibility, result);
+                    [self.operationDispatcher dispatchOnMainThread:^{ receiveEligibility(result); }];
                 }];
             }
         } else {
@@ -775,7 +781,7 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
                                                completion:^(NSDictionary<NSString *,RCIntroEligibility *> * _Nonnull result, NSError * _Nullable error) {
                 [RCLog error:[NSString stringWithFormat:@"Unable to getIntroEligibilityForAppUserID: %@",
                               error.localizedDescription]];
-                CALL_IF_SET_ON_MAIN_THREAD(receiveEligibility, result);
+                [self.operationDispatcher dispatchOnMainThread:^{ receiveEligibility(result); }];
             }];
         }
     }];

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -940,22 +940,29 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
         RCPurchaseCompletedBlock _Nullable completion = [self getAndRemovePurchaseCompletedBlockFor:transaction];
         if (info) {
             [self.purchaserInfoManager cachePurchaserInfo:info forAppUserID:self.appUserID];
-
-            CALL_IF_SET_ON_SAME_THREAD(completion, transaction, info, nil, false);
+            if (completion) {
+                completion(transaction, info, nil, false);
+            }
 
             if (self.finishTransactions) {
                 [self.storeKitWrapper finishTransaction:transaction];
             }
         } else if ([error.userInfo[RCErrorDetails.RCFinishableKey] boolValue]) {
-            CALL_IF_SET_ON_SAME_THREAD(completion, transaction, nil, error, false);
+            if (completion) {
+                completion(transaction, nil, error, false);
+            }
             if (self.finishTransactions) {
                 [self.storeKitWrapper finishTransaction:transaction];
             }
         } else if (![error.userInfo[RCErrorDetails.RCFinishableKey] boolValue]) {
-            CALL_IF_SET_ON_SAME_THREAD(completion, transaction, nil, error, false);
+            if (completion) {
+                completion(transaction, nil, error, false);
+            }
         } else {
             [RCLog error:[NSString stringWithFormat:@"%@", RCStrings.receipt.unknown_backend_error]];
-            CALL_IF_SET_ON_SAME_THREAD(completion, transaction, nil, error, false);
+            if (completion) {
+                completion(transaction, nil, error, false);
+            }
         }
     }];
 }


### PR DESCRIPTION
replaced a couple of macros: 
- `CALL_IF_SET_ON_MAIN_THREAD`
- `CALL_IF_SET_ON_SAME_THREAD`

with direct calls to operation dispatcher. 

Also cleaned up the nullability specifiers for a few private methods. 

I figured this is a good thing to do before trying to migrate the full class, since it'll be easier to translate. 

Fixes #681 
