### PR TITLE
Move logs out of rcpurchases

### DIFF
--- a/Purchases/Attribution/RCAttributionPoster.m
+++ b/Purchases/Attribution/RCAttributionPoster.m
@@ -55,6 +55,7 @@ static NSMutableArray<RCAttributionData *> *_Nullable postponedAttributionData;
 - (void)postAttributionData:(NSDictionary *)data
                 fromNetwork:(RCAttributionNetwork)network
            forNetworkUserId:(nullable NSString *)networkUserId {
+    [RCLog debug:[NSString stringWithFormat:@"%@", RCStrings.attribution.instance_configured_posting_attribution]];
     if (data[@"rc_appsflyer_id"]) {
         [RCLog warn:[NSString stringWithFormat:@"%@", RCStrings.attribution.appsflyer_id_deprecated]];
     }
@@ -144,6 +145,7 @@ static NSMutableArray<RCAttributionData *> *_Nullable postponedAttributionData;
 + (void)storePostponedAttributionData:(NSDictionary *)data
                           fromNetwork:(RCAttributionNetwork)network
                      forNetworkUserId:(nullable NSString *)networkUserId {
+    [RCLog debug:[NSString stringWithFormat:@"%@", RCStrings.attribution.no_instance_configured_caching_attribution]];
     if (postponedAttributionData == nil) {
         postponedAttributionData = [NSMutableArray array];
     }

--- a/Purchases/Identity/RCPurchaserInfoManager.m
+++ b/Purchases/Identity/RCPurchaserInfoManager.m
@@ -181,6 +181,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)clearPurchaserInfoCacheForAppUserID:(NSString *)appUserID {
+    [RCLog debug:[NSString stringWithFormat:@"%@", RCStrings.purchaserInfo.invalidating_purchaserinfo_cache]];
     @synchronized (self) {
         [self.deviceCache clearPurchaserInfoCacheWithAppUserID:appUserID];
         self.lastSentPurchaserInfo = nil;

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -811,93 +811,65 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 }
 
 - (void)setPushToken:(nullable NSData *)pushToken {
-    // todo: move log to relevant class
-    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setPushToken"]];
     [self.subscriberAttributesManager setPushToken:pushToken appUserID:self.appUserID];
 }
 
 - (void)_setPushTokenString:(nullable NSString *)pushToken {
-    // todo: move log to relevant class
-    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setPushTokenString"]];
     [self.subscriberAttributesManager setPushTokenString:pushToken appUserID:self.appUserID];
 }
 
 - (void)setAdjustID:(nullable NSString *)adjustID {
-    // todo: move log to relevant class
-    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setAdjustID"]];
     [self.subscriberAttributesManager setAdjustID:adjustID appUserID:self.appUserID];
 }
 
 - (void)setAppsflyerID:(nullable NSString *)appsflyerID {
-    // todo: move log to relevant class
-    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setAppsflyerID"]];
     [self.subscriberAttributesManager setAppsflyerID:appsflyerID appUserID:self.appUserID];
 }
 
 - (void)setFBAnonymousID:(nullable NSString *)fbAnonymousID {
-    // todo: move log to relevant class
-    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setFBAnonymousID"]];
     [self.subscriberAttributesManager setFBAnonymousID:fbAnonymousID appUserID:self.appUserID];
 }
 
 - (void)setMparticleID:(nullable NSString *)mparticleID {
-    // todo: move log to relevant class
-    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setMparticleID"]];
     [self.subscriberAttributesManager setMparticleID:mparticleID appUserID:self.appUserID];
 }
 
 - (void)setOnesignalID:(nullable NSString *)onesignalID {
-    // todo: move log to relevant class
-    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setOnesignalID"]];
     [self.subscriberAttributesManager setOnesignalID:onesignalID appUserID:self.appUserID];
 }
 
 - (void)setMediaSource:(nullable NSString *)mediaSource {
-    // todo: move log to relevant class
-    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setMediaSource"]];
     [self.subscriberAttributesManager setMediaSource:mediaSource appUserID:self.appUserID];
 }
 
 - (void)setCampaign:(nullable NSString *)campaign {
-    // todo: move log to relevant class
-    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setCampaign"]];
     [self.subscriberAttributesManager setCampaign:campaign appUserID:self.appUserID];
 }
 
 - (void)setAdGroup:(nullable NSString *)adGroup {
-    // todo: move log to relevant class
-    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setAdGroup"]];
     [self.subscriberAttributesManager setAdGroup:adGroup appUserID:self.appUserID];
 }
 
 - (void)setAd:(nullable NSString *)ad {
-    // todo: move log to relevant class
-    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setAd"]];
     [self.subscriberAttributesManager setAd:ad appUserID:self.appUserID];
 }
 
 - (void)setKeyword:(nullable NSString *)keyword {
-    // todo: move log to relevant class
-    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setKeyword"]];
     [self.subscriberAttributesManager setKeyword:keyword appUserID:self.appUserID];
 }
 
 - (void)setCreative:(nullable NSString *)creative {
-    // todo: move log to relevant class
-    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setCreative"]];
     [self.subscriberAttributesManager setCreative:creative appUserID:self.appUserID];
 }
 
 - (void)collectDeviceIdentifiers {
-    // todo: move log to relevant class
-    [RCLog debug:[NSString stringWithFormat:@"collectDeviceIdentifiers called"]];
-    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setAttributes"]];
     [self.subscriberAttributesManager collectDeviceIdentifiersForAppUserID:self.appUserID];
 }
 
 #pragma mark - Private Methods
 
 - (void)applicationDidBecomeActive:(__unused NSNotification *)notif {
+    [RCLog debug:[NSString stringWithFormat:@"%@", RCStrings.configure.application_active]];
     [self updateAllCachesIfNeeded];
     [self syncSubscriberAttributesIfNeeded];
     [self postAppleSearchAddsAttributionCollectionIfNeeded];
@@ -908,8 +880,6 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 }
 
 - (void)updateAllCachesIfNeeded {
-    // todo: move log to relevant class
-    [RCLog debug:[NSString stringWithFormat:@"%@", RCStrings.configure.application_active]];
     [self.systemInfo isApplicationBackgroundedWithCompletion:^(BOOL isAppBackgrounded) {
         [self.purchaserInfoManager fetchAndCachePurchaserInfoIfStaleWithAppUserID:self.appUserID
                                                                 isAppBackgrounded:isAppBackgrounded

--- a/Purchases/Public/RCPurchases.m
+++ b/Purchases/Public/RCPurchases.m
@@ -410,14 +410,9 @@ static BOOL _automaticAppleSearchAdsAttributionCollection = NO;
 + (void)addAttributionData:(NSDictionary *)data
                fromNetwork:(RCAttributionNetwork)network
           forNetworkUserId:(nullable NSString *)networkUserId {
-    // todo: replace this check with `isConfigured`
-    if (_sharedPurchases) {
-        // todo: move log to relevant class
-        [RCLog debug:[NSString stringWithFormat:@"%@", RCStrings.attribution.instance_configured_posting_attribution]];
+    if (self.isConfigured) {
         [_sharedPurchases postAttributionData:data fromNetwork:network forNetworkUserId:networkUserId];
     } else {
-        // todo: move log to relevant class
-        [RCLog debug:[NSString stringWithFormat:@"%@", RCStrings.attribution.no_instance_configured_caching_attribution]];
         [RCAttributionPoster storePostponedAttributionData:data
                                                fromNetwork:network
                                           forNetworkUserId:networkUserId];
@@ -790,40 +785,28 @@ withPresentedOfferingIdentifier:(nullable NSString *)presentedOfferingIdentifier
 }
 
 - (void)invalidatePurchaserInfoCache {
-    // todo: move log to relevant class
-    [RCLog debug:[NSString stringWithFormat:@"%@", RCStrings.purchaserInfo.invalidating_purchaserinfo_cache]];
     [self.purchaserInfoManager clearPurchaserInfoCacheForAppUserID:self.appUserID];
 }
 
 - (void)presentCodeRedemptionSheet API_AVAILABLE(ios(14.0)) API_UNAVAILABLE(tvos, macos, watchos) {
-    // todo: move log to relevant class
-    [RCLog debug:[NSString stringWithFormat:@"%@", RCStrings.purchase.presenting_code_redemption_sheet]];
     [self.storeKitWrapper presentCodeRedemptionSheet];
 }
 
 #pragma mark Subcriber Attributes
 
 - (void)setAttributes:(NSDictionary<NSString *, NSString *> *)attributes {
-    // todo: move log to relevant class
-    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setAttributes"]];
     [self.subscriberAttributesManager setAttributes:attributes appUserID:self.appUserID];
 }
 
 - (void)setEmail:(nullable NSString *)email {
-    // todo: move log to relevant class
-    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setEmail"]];
     [self.subscriberAttributesManager setEmail:email appUserID:self.appUserID];
 }
 
 - (void)setPhoneNumber:(nullable NSString *)phoneNumber {
-    // todo: move log to relevant class
-    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setPhoneNumber"]];
     [self.subscriberAttributesManager setPhoneNumber:phoneNumber appUserID:self.appUserID];
 }
 
 - (void)setDisplayName:(nullable NSString *)displayName {
-    // todo: move log to relevant class
-    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setDisplayName"]];
     [self.subscriberAttributesManager setDisplayName:displayName appUserID:self.appUserID];
 }
 

--- a/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
@@ -43,20 +43,24 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setAttributes:(NSDictionary<NSString *, NSString *> *)attributes appUserID:(NSString *)appUserID {
+    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setAttributes"]];
     [attributes enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
         [self setAttributeWithKey:key value:value appUserID:appUserID];
     }];
 }
 
 - (void)setEmail:(nullable NSString *)email appUserID:(NSString *)appUserID {
+    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setEmail"]];
     [self setAttributeWithKey:RCSpecialSubscriberAttributes.email value:email appUserID:appUserID];
 }
 
 - (void)setPhoneNumber:(nullable NSString *)phoneNumber appUserID:(NSString *)appUserID {
+    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setPhoneNumber"]];
     [self setAttributeWithKey:RCSpecialSubscriberAttributes.phoneNumber value:phoneNumber appUserID:appUserID];
 }
 
 - (void)setDisplayName:(nullable NSString *)displayName appUserID:(NSString *)appUserID {
+    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setDisplayName"]];
     [self setAttributeWithKey:RCSpecialSubscriberAttributes.displayName value:displayName appUserID:appUserID];
 }
 

--- a/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
+++ b/Purchases/SubscriberAttributes/RCSubscriberAttributesManager.m
@@ -65,59 +65,74 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)setPushToken:(nullable NSData *)pushToken appUserID:(NSString *)appUserID {
+    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setPushToken"]];
     NSString *pushTokenString = pushToken ? pushToken.rc_asString : nil;
     [self setPushTokenString:pushTokenString appUserID:appUserID];
 }
 
 - (void)setPushTokenString:(nullable NSString *)pushTokenString appUserID:(NSString *)appUserID {
+    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setPushTokenString"]];
     [self setAttributeWithKey:RCSpecialSubscriberAttributes.pushToken value:pushTokenString appUserID:appUserID];
 }
 
 - (void)setAdjustID:(nullable NSString *)adjustID appUserID:(NSString *)appUserID {
+    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setAdjustID"]];
     [self setAttributionID:adjustID networkKey:RCSpecialSubscriberAttributes.adjustID appUserID:appUserID];
 }
 
 - (void)setAppsflyerID:(nullable NSString *)appsflyerID appUserID:(NSString *)appUserID {
+    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setAppsflyerID"]];
     [self setAttributionID:appsflyerID networkKey:RCSpecialSubscriberAttributes.appsFlyerID appUserID:appUserID];
 }
 
 - (void)setFBAnonymousID:(nullable NSString *)fbAnonymousID appUserID:(NSString *)appUserID {
+    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setFBAnonymousID"]];
     [self setAttributionID:fbAnonymousID networkKey:RCSpecialSubscriberAttributes.fBAnonID appUserID:appUserID];
 }
 
 - (void)setMparticleID:(nullable NSString *)mparticleID appUserID:(NSString *)appUserID {
+    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setMparticleID"]];
     [self setAttributionID:mparticleID networkKey:RCSpecialSubscriberAttributes.mpParticleID appUserID:appUserID];
 }
 
 - (void)setOnesignalID:(nullable NSString *)onesignalID appUserID:(NSString *)appUserID {
+    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setOnesignalID"]];
     [self setAttributionID:onesignalID networkKey:RCSpecialSubscriberAttributes.oneSignalID appUserID:appUserID];
 }
 
 - (void)setMediaSource:(nullable NSString *)mediaSource appUserID:(NSString *)appUserID {
+    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setMediaSource"]];
     [self setAttributeWithKey:RCSpecialSubscriberAttributes.mediaSource value:mediaSource appUserID:appUserID];
 }
 
 - (void)setCampaign:(nullable NSString *)campaign appUserID:(NSString *)appUserID {
+    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setCampaign"]];
     [self setAttributeWithKey:RCSpecialSubscriberAttributes.campaign value:campaign appUserID:appUserID];
 }
 
 - (void)setAdGroup:(nullable NSString *)adGroup appUserID:(NSString *)appUserID {
+    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setAdGroup"]];
     [self setAttributeWithKey:RCSpecialSubscriberAttributes.adGroup value:adGroup appUserID:appUserID];
 }
 
 - (void)setAd:(nullable NSString *)ad appUserID:(NSString *)appUserID {
+    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setAd"]];
     [self setAttributeWithKey:RCSpecialSubscriberAttributes.ad value:ad appUserID:appUserID];
 }
 
 - (void)setKeyword:(nullable NSString *)keyword appUserID:(NSString *)appUserID {
+    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setKeyword"]];
     [self setAttributeWithKey:RCSpecialSubscriberAttributes.keyword value:keyword appUserID:appUserID];
 }
 
 - (void)setCreative:(nullable NSString *)creative appUserID:(NSString *)appUserID {
+    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setCreative"]];
     [self setAttributeWithKey:RCSpecialSubscriberAttributes.creative value:creative appUserID:appUserID];
 }
 
 - (void)collectDeviceIdentifiersForAppUserID:(NSString *)appUserID {
+    [RCLog debug:[NSString stringWithFormat:@"collectDeviceIdentifiers called"]];
+    [RCLog debug:[NSString stringWithFormat:RCStrings.attribution.method_called, "setAttributes"]];
     NSString *identifierForAdvertisers = [self.attributionFetcher identifierForAdvertisers];
     NSString *identifierForVendor = [self.attributionFetcher identifierForVendor];
     [self setAttributeWithKey:RCSpecialSubscriberAttributes.idfa value:identifierForAdvertisers appUserID:appUserID];

--- a/PurchasesCoreSwift/Purchasing/StoreKitWrapper.swift
+++ b/PurchasesCoreSwift/Purchasing/StoreKitWrapper.swift
@@ -71,6 +71,7 @@ import StoreKit
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     @objc public func presentCodeRedemptionSheet() {
+        Logger.debug(Strings.purchase.presenting_code_redemption_sheet)
         paymentQueue.presentCodeRedemptionSheet()
     }
 


### PR DESCRIPTION
Fixes #689 
Moves a few logs away from `RCPurchases`, in the hopes of making that class slightly easier to migrate. 