### PR TITLE
Update Fastfile `test` lane to run scan for iOS and tvOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
       
       - run:
           name: Run tests
-          command: bundle exec fastlane scan
+          command: bundle exec fastlane test
           environment:
             SCAN_SCHEME: Unit Tests
       - store_test_results:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -42,8 +42,10 @@ platform :ios do
 
   desc "Runs all the tests"
   lane :test do
-    scan
-    snapshot
+    # Need to run iOS and tvOS in two differen
+    # Scan can't target two different platforms in devices
+    scan(devices: ["iPhone 6", "iPhone 12"])
+    scan(devices: ["Apple TV"])
   end
 
   desc "Increment build number"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,9 +10,6 @@
 #     https://docs.fastlane.tools/plugins/available-plugins
 #
 
-# Uncomment the line if you want fastlane to automatically update itself
-# update_fastlane
-
 default_platform(:ios)
 
 platform :ios do
@@ -42,10 +39,16 @@ platform :ios do
 
   desc "Runs all the tests"
   lane :test do
-    # Need to run iOS and tvOS in two differen
     # Scan can't target two different platforms in devices
-    scan(devices: ["iPhone 6", "iPhone 12"])
-    scan(devices: ["Apple TV"])
+    # Need to run scan multiple times
+    scan(
+      step_name: "scan - iPhone", 
+      devices: ["iPhone 6", "iPhone 12"]
+    )
+    scan(
+      step_name: "scan - Apple TV",
+      devices: ["Apple TV"]
+    )
   end
 
   desc "Increment build number"

--- a/fastlane/Scanfile
+++ b/fastlane/Scanfile
@@ -5,5 +5,10 @@
 # fastlane scan --help
 
 scheme("Unit Tests")
-devices(["iPhone 6", "iPhone 12"])
 
+# Commenting out devices in Scanfile as of fastlane 2.191.0
+# Scan cannot handle running multiple platform type (iOS and tvOS)
+# in the same run but might in the future
+# Future version of fastlane might allow this
+
+# devices(["iPhone 6", "iPhone 12", "Apple TV"])


### PR DESCRIPTION
Thank you for contributing to Purchases. Before pressing the "Create Pull Request" button, please provide the following:

  - [x] A description about what and why you are contributing, even if it's trivial.

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [x] If applicable, unit tests.

---

Follow up to #728
cc: @aboedo @taquitos 

## Motivation
Add support to test both iOS and tvOS with _fastlane_

## Description
`scan` cannot run with devices of different types (ie: iPhone and Apple TV). These are both iOS-ish but are different platforms. `scan` forwards these devices to the `xcodebuild` CLI tool and that is what gets confused. This was essentially like telling Xcode to run tests on iPhone and Apple TV within the same build which you cannot do (to my knowledge 😅)

This changes does two things:
1) Removes the devices from the `Scanfile` since we need to change the devices per platform
2) Adds two `scan` calls in the `test` lane to test both iOS and tVOS separately 

## How to test

‼️ `fastlane scan` should not be called directly anymore

👉  All testing should be done with `fastlane test` instead (or `fastlane <platform> test` once other platforms get added to the `Fastfile`)

So.... just run `bundle exec fastlane test` and you'll see this at the end of your run 👇 

```
+------+------------------+-------------+
|           fastlane summary            |
+------+------------------+-------------+
| Step | Action           | Time (in s) |
+------+------------------+-------------+
| 1    | default_platform | 0           |
| 2    | setup_circle_ci  | 0           |
| 3    | scan - iPhone    | 24          |
| 4    | scan - Apple TV  | 19          |
+------+------------------+-------------+

[20:52:25]: fastlane.tools finished successfully 🎉
```

## Future changes
There are some other changes I'd like to see done to this `Fastfile` at some point 😊  The `Fastfile` currently only has `platform :ios` defined right now but this should probably be split up into multiple platforms. And with that, the two `scan` calls I added sequentially could be moved into their own respective platform groups (and so could macOS and watchOS tests).

Sooooo... I believe what I added is good for now but I'll be back to make other changes after we have some discussion in an issue about this 😉 
