### PR TITLE
Joshdholtz circleci remove bundler deprecations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,9 @@ commands:
           name: Bundle install
           working_directory: << parameters.directory >>
           command: |
+              bundle config set --local clean 'true'
               bundle config set --local path 'vendor/bundle'
-              bundle install --clean
+              bundle install
       - save_cache:
           key: v1-gem-cache-{{ checksum "Gemfile.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,14 +28,16 @@ commands:
         type: string
         default: .
     steps:
-       # Bundler
+      # Bundler
       - restore_cache:
           keys: 
             - v1-gem-cache-{{ checksum "Gemfile.lock" }}
       - run: 
           name: Bundle install
           working_directory: << parameters.directory >>
-          command: bundle install --clean --path vendor/bundle
+          command: |
+              bundle config set --local path 'vendor/bundle'
+              bundle install --clean
       - save_cache:
           key: v1-gem-cache-{{ checksum "Gemfile.lock" }}
           paths:


### PR DESCRIPTION
Thank you for contributing to Purchases. Before pressing the "Create Pull Request" button, please provide the following:

  - [x] A description about what and why you are contributing, even if it's trivial.

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [x] If applicable, unit tests.

---

## Motivation

Small PR but wanted to remove some deprecation warnings when using `bundler --clean` and `bundler --path` 🤷‍♂️ 

👇  This is what was appearing in the "Bundle install" command from on CircleCI

```sh
#!/bin/bash --login -o pipefail
bundle install --clean --path vendor/bundle
[DEPRECATED] The `--clean` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local clean 'true'`, and stop using this flag
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local path 'vendor/bundle'`, and stop using this flag
Using rake 13.0.6
Using CFPropertyList 3.0.3
Using concurrent-ruby 1.1.9
```

## Description

Now using...

```sh
bundle config set --local clean 'true'
bundle config set --local path 'vendor/bundle'
```

cc: @taquitos 
