### PR TITLE
Update ObjC visibility for proxies

### DIFF
--- a/PurchasesCoreSwift/Attribution/ASIdentifierManagerProxy.swift
+++ b/PurchasesCoreSwift/Attribution/ASIdentifierManagerProxy.swift
@@ -27,7 +27,7 @@ class FakeASIdentifierManager: NSObject {
 
 }
 
-@objc class ASIdentifierManagerProxy: NSObject {
+class ASIdentifierManagerProxy {
 
     static let mangledIdentifierClassName = "NFVqragvsvreZnantre"
     static let mangledIdentifierPropertyName = "nqiregvfvatVqragvsvre"
@@ -40,7 +40,7 @@ class FakeASIdentifierManager: NSObject {
         NSClassFromString(Self.mangledIdentifierClassName.rot13())
     }
 
-    @objc var adsIdentifier: UUID? {
+    var adsIdentifier: UUID? {
         guard let classType: AnyClass = Self.identifierClass else {
             return nil
         }

--- a/PurchasesCoreSwift/Attribution/AdClientProxy.swift
+++ b/PurchasesCoreSwift/Attribution/AdClientProxy.swift
@@ -35,7 +35,7 @@ class FakeAdClient: NSObject {
 
 }
 
-@objc class AdClientProxy: NSObject {
+class AdClientProxy {
 
     private static let className = "ADClient"
 
@@ -43,7 +43,6 @@ class FakeAdClient: NSObject {
         NSClassFromString(Self.className)
     }
 
-    @objc(requestAttributionDetailsWithBlock:)
     func requestAttributionDetails(_ completionHandler: @escaping AttributionDetailsBlock) {
         let client: AnyObject
         if let klass = Self.adClientClass, let clientClass = klass as AnyObject as? NSObjectProtocol {

--- a/PurchasesCoreSwift/Attribution/TrackingManagerProxy.swift
+++ b/PurchasesCoreSwift/Attribution/TrackingManagerProxy.swift
@@ -37,7 +37,7 @@ class FakeTrackingManager: NSObject {
 
 }
 
-@objc class TrackingManagerProxy: NSObject {
+class TrackingManagerProxy: NSObject {
 
     static let mangledTrackingClassName = "NGGenpxvatZnantre"
     static let mangledAuthStatusPropertyName = "genpxvatNhgubevmngvbaFgnghf"


### PR DESCRIPTION
Resolves #779, Resolves #780, Resolves #781;

The goal of this PR is to update the ObjC visibility of some helper proxies that were created during the migration.

I've used the app called `PurchaseTester` in the `IntegrationsTests` folder. Although I did some updates on some method signatures due to the migration changes.

This is a video showing how the app works after the changes:



https://user-images.githubusercontent.com/1409041/130956647-84c6de84-8ca4-4f87-b85e-16e902c211d4.mp4



Thank you for contributing to Purchases. Before pressing the "Create Pull Request" button, please provide the following:
  - [x] A description about what and why you are contributing, even if it's trivial.
  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.
  - [x] If applicable, unit tests.
