### PR TITLE
Update purchase tester

### DIFF
--- a/IntegrationTests/PurchaseTester/Podfile.lock
+++ b/IntegrationTests/PurchaseTester/Podfile.lock
@@ -1,22 +1,16 @@
 PODS:
-  - Purchases (3.13.0-SNAPSHOT):
-    - PurchasesCoreSwift (= 3.13.0-SNAPSHOT)
-  - PurchasesCoreSwift (3.13.0-SNAPSHOT)
+  - Purchases (3.13.0-SNAPSHOT)
 
 DEPENDENCIES:
   - Purchases (from `../../`)
-  - PurchasesCoreSwift (from `../../`)
 
 EXTERNAL SOURCES:
   Purchases:
     :path: "../../"
-  PurchasesCoreSwift:
-    :path: "../../"
 
 SPEC CHECKSUMS:
-  Purchases: 84b25fa06a09f7dc1583985c850bc3d8d40469ca
-  PurchasesCoreSwift: 188ac805aa07acd191a9dd14ea5e61fc76c0b0ce
+  Purchases: 76743d41cfb64f6960a78438959c58f80065c342
 
-PODFILE CHECKSUM: d5822b076e715d248ef4648005449c1282626fd5
+PODFILE CHECKSUM: 22d943618b2bd4ab6b523cc4829b24647d202c09
 
 COCOAPODS: 1.10.2

--- a/IntegrationTests/PurchaseTester/PurchaseTester/SwiftPaywall.swift
+++ b/IntegrationTests/PurchaseTester/PurchaseTester/SwiftPaywall.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import Purchases
+import StoreKit
 
 enum PayWallEdgeStyle : String {
     case square
@@ -163,7 +164,7 @@ class SwiftPaywall: UIViewController {
         }
         
         setState(loading: true)
-        Purchases.shared.purchasePackage(package) { (trans, info, error, cancelled) in
+        Purchases.shared.purchase(package: package) { (trans, info, error, cancelled) in
 
             self.setState(loading: false)
 

--- a/IntegrationTests/PurchaseTester/PurchaseTester/SwiftPaywall.swift
+++ b/IntegrationTests/PurchaseTester/PurchaseTester/SwiftPaywall.swift
@@ -363,7 +363,7 @@ class SwiftPaywall: UIViewController {
             ])
         
         // The offerings loading indicator
-        offeringLoadingIndicator = UIActivityIndicatorView(style: .gray)
+        offeringLoadingIndicator = UIActivityIndicatorView(style: .medium)
         offeringLoadingIndicator.hidesWhenStopped = true
         offeringLoadingIndicator.translatesAutoresizingMaskIntoConstraints = false
         offeringCollectionView.addSubview(offeringLoadingIndicator)
@@ -416,7 +416,7 @@ class SwiftPaywall: UIViewController {
             ])
         
         // The buy button loading indicator
-        buyButtonLoadingIndicator = UIActivityIndicatorView(style: .gray)
+        buyButtonLoadingIndicator = UIActivityIndicatorView(style: .medium)
         buyButtonLoadingIndicator.hidesWhenStopped = true
         buyButtonLoadingIndicator.translatesAutoresizingMaskIntoConstraints = false
         buyButton.addSubview(buyButtonLoadingIndicator)
@@ -558,6 +558,8 @@ extension SwiftPaywall: UICollectionViewDelegate, UICollectionViewDataSource, UI
                     trialLength = "\(numUnits)-year"
                     cancelDate = Calendar.current.date(byAdding: .year, value: numUnits, to: Date())
                     cancelDate = Calendar.current.date(byAdding: .day, value: -1, to: cancelDate ?? Date())
+                @unknown default:
+                    fatalError()
                 }
                 
                 let dateFormatter = DateFormatter()


### PR DESCRIPTION
Updated the `PurchaseTester` app to the latest syntax. 
Also, it looks like we now require importing StoreKit manually, perhaps that's something that we can improve. 
Reminder that this app is for our internal testing only, so we should just make it work as we fix issues along the way. 