### PR TITLE
Migrate to Test Plans

### DIFF
--- a/Purchases.xcodeproj/Purchases.xctestplan
+++ b/Purchases.xcodeproj/Purchases.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "6EE88B1C-2739-4847-85D2-D560E881945B",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:Purchases.xcodeproj",
+        "identifier" : "2DC5621D24EC63430031F69B",
+        "name" : "PurchasesTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Purchases.xcodeproj/project.pbxproj
+++ b/Purchases.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		2CD72947268A828400BFC976 /* Locale+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Locale+Extensions.swift"; sourceTree = "<group>"; };
 		2D11F5E0250FF886005A70E8 /* AttributionStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributionStrings.swift; sourceTree = "<group>"; };
 		2D1C3F3826B9D8B800112626 /* MockBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBundle.swift; sourceTree = "<group>"; };
+		2D343C0726DEC0950049DE09 /* Purchases.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = Purchases.xctestplan; path = Purchases.xcodeproj/Purchases.xctestplan; sourceTree = "<group>"; };
 		2D4E926426990AB1000E10B0 /* StoreKitWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitWrapper.swift; sourceTree = "<group>"; };
 		2D5BB46A24C8E8ED00E27537 /* ReceiptParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptParser.swift; sourceTree = "<group>"; };
 		2D84458826B9CD270033B5A3 /* ReceiptFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptFetcherTests.swift; sourceTree = "<group>"; };
@@ -811,6 +812,7 @@
 		352629F41F7C4B9100C04F2C = {
 			isa = PBXGroup;
 			children = (
+				2D343C0726DEC0950049DE09 /* Purchases.xctestplan */,
 				2DC5621724EC63420031F69B /* Purchases */,
 				2DC5622224EC63430031F69B /* PurchasesTests */,
 				B387F46B2683FD730028701F /* PublicSDKAPITester */,

--- a/Purchases.xcodeproj/xcshareddata/xcschemes/Purchases.xcscheme
+++ b/Purchases.xcodeproj/xcshareddata/xcschemes/Purchases.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1300"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -41,6 +41,12 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Purchases.xcodeproj/Purchases.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO"


### PR DESCRIPTION
Xcode [Test Plans](https://developer.apple.com/videos/play/wwdc2019/413/) make it easy to set up different configuration for tests, like repeating all tests several times, setting up different timeouts, etc. 

This PR migrates our test scheme to Test Plans. This will hopefully make it easier to reproduce the issues in `HTTPClient` for testing, since we can set it up to run several times until it fails. 

I didn't go crazy with configuration yet, the idea is to have this as a starting point. 

<img width="678" alt="image" src="https://user-images.githubusercontent.com/3922667/131568279-2b4ccdc1-e444-4311-9541-906f2629b6cd.png">
