### PR TITLE
Ensure order of operations for HTTPClient

### DIFF
--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -40,9 +40,7 @@ class Backend {
                      systemInfo: SystemInfo,
                      eTagManager: ETagManager,
                      operationDispatcher: OperationDispatcher) {
-        let httpClient = HTTPClient(systemInfo: systemInfo,
-                                    eTagManager: eTagManager,
-                                    operationDispatcher: operationDispatcher)
+        let httpClient = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
         self.init(httpClient: httpClient, apiKey: apiKey)
     }
 

--- a/Purchases/Networking/HTTPClient.swift
+++ b/Purchases/Networking/HTTPClient.swift
@@ -20,16 +20,14 @@ class HTTPClient {
     private var queuedRequests: [HTTPRequest] = []
     private var currentSerialRequest: HTTPRequest?
     private var eTagManager: ETagManager
-    private let operationDispatcher: OperationDispatcher
     private let recursiveLock = NSRecursiveLock()
 
-    init(systemInfo: SystemInfo, eTagManager: ETagManager, operationDispatcher: OperationDispatcher) {
+    init(systemInfo: SystemInfo, eTagManager: ETagManager) {
         let config = URLSessionConfiguration.ephemeral
         config.httpMaximumConnectionsPerHost = 1
         self.session = URLSession(configuration: config)
         self.systemInfo = systemInfo
         self.eTagManager = eTagManager
-        self.operationDispatcher = operationDispatcher
     }
 
     func performGETRequest(serially: Bool = false,

--- a/PurchasesTests/Mocks/MockBackend.swift
+++ b/PurchasesTests/Mocks/MockBackend.swift
@@ -32,8 +32,7 @@ class MockBackend: Backend {
         self.init(httpClient: MockHTTPClient(systemInfo: try! MockSystemInfo(platformFlavor: nil,
                                                                              platformFlavorVersion: nil,
                                                                              finishTransactions: false),
-                                             eTagManager: MockETagManager(),
-                                             operationDispatcher: MockOperationDispatcher()),
+                                             eTagManager: MockETagManager()),
                   apiKey: "mockAPIKey")
     }
 

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -118,12 +118,8 @@ class BackendTests: XCTestCase {
 
     override func setUp() {
         let eTagManager = MockETagManager(userDefaults: MockUserDefaults())
-        let operationDispatcher = MockOperationDispatcher()
-        httpClient = MockHTTPClient(systemInfo: systemInfo,
-                                    eTagManager: eTagManager,
-                                    operationDispatcher: operationDispatcher)
-        backend = Backend.init(httpClient: httpClient,
-                                 apiKey: apiKey)
+        httpClient = MockHTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
+        backend = Backend.init(httpClient: httpClient, apiKey: apiKey)
     }
 
     func testPostsReceiptDataCorrectly() {

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -616,6 +616,62 @@ class HTTPClientTests: XCTestCase {
         expect(secondRequestFinished).toEventually(beTrue())
     }
 
+    func testPerformSerialRequestWaitsUntilRequestsAreDoneBeforeStartingNext() {
+        let path = "/a_random_path"
+        var firstRequestFinished = false
+        var secondRequestFinished = false
+        var thirdRequestFinished = false
+
+        stub(condition: isPath("/v1" + path)) { request in
+            let requestData = request.ohhttpStubs_httpBody!
+            let requestBodyDict = try! JSONSerialization.jsonObject(with: requestData, options: []) as! [String: Any]
+
+            let requestNumber = requestBodyDict["requestNumber"] as! Int
+            var responseTime = 0.5
+            if requestNumber == 1 {
+                expect(secondRequestFinished) == false
+                expect(thirdRequestFinished) == false
+            } else if requestNumber == 2 {
+                expect(firstRequestFinished) == true
+                expect(thirdRequestFinished) == false
+                responseTime = 0.3
+            } else if requestNumber == 3 {
+                expect(firstRequestFinished) == true
+                expect(secondRequestFinished) == true
+                responseTime = 0.1
+            }
+
+            let json = "{\"message\": \"something is great up in the cloud\"}"
+            return HTTPStubsResponse(data: json.data(using: String.Encoding.utf8)!, statusCode: 200, headers: nil)
+                .responseTime(responseTime)
+        }
+
+        self.client.performPOSTRequest(serially: true,
+                                       path: path,
+                                       requestBody: ["requestNumber": 1],
+                                       headers: [:]) { (status, data, error) in
+            firstRequestFinished = true
+        }
+
+        self.client.performPOSTRequest(serially: true,
+                                       path: path,
+                                       requestBody: ["requestNumber": 2],
+                                       headers: [:]) { (status, data, error) in
+            secondRequestFinished = true
+        }
+
+        self.client.performPOSTRequest(serially: true,
+                                       path: path,
+                                       requestBody: ["requestNumber": 3],
+                                       headers: [:]) { (status, data, error) in
+            thirdRequestFinished = true
+        }
+
+        expect(firstRequestFinished).toEventually(beTrue(), timeout: .seconds(1))
+        expect(secondRequestFinished).toEventually(beTrue(), timeout: .seconds(2))
+        expect(thirdRequestFinished).toEventually(beTrue(), timeout: .seconds(3))
+    }
+
     func testPerformSerialRequestDoesntWaitForConcurrentRequestsBeforeStarting() {
         let path = "/a_random_path"
         var firstRequestFinished = false

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -26,7 +26,7 @@ class HTTPClientTests: XCTestCase {
         userDefaults = MockUserDefaults()
         eTagManager = MockETagManager(userDefaults: userDefaults)
         operationDispatcher = OperationDispatcher()
-        client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager, operationDispatcher: operationDispatcher)
+        client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
     }
 
     override func tearDown() {
@@ -406,7 +406,7 @@ class HTTPClientTests: XCTestCase {
         let systemInfo = try! SystemInfo(platformFlavor: "react-native",
                                          platformFlavorVersion: "3.2.1",
                                          finishTransactions: true)
-        let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager, operationDispatcher: operationDispatcher)
+        let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
         client.performPOSTRequest(serially: true,
                                   path: path,
                                   requestBody: Dictionary.init(),
@@ -427,7 +427,7 @@ class HTTPClientTests: XCTestCase {
         let systemInfo = try! SystemInfo(platformFlavor: "react-native",
                                          platformFlavorVersion: "1.2.3",
                                          finishTransactions: true)
-        let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager, operationDispatcher: operationDispatcher)
+        let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
         
         client.performPOSTRequest(serially: true,
                                   path: path,
@@ -447,7 +447,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode: 200, headers: nil)
         }
         let systemInfo = try! SystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: true)
-        let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager, operationDispatcher: operationDispatcher)
+        let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
         client.performPOSTRequest(serially: true,
                                   path: path,
                                   requestBody: Dictionary.init(),
@@ -466,7 +466,7 @@ class HTTPClientTests: XCTestCase {
             return HTTPStubsResponse(data: Data.init(), statusCode: 200, headers: nil)
         }
         let systemInfo = try! SystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: false)
-        let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager, operationDispatcher: operationDispatcher)
+        let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
         client.performPOSTRequest(serially: true,
                                   path: path,
                                   requestBody: Dictionary.init(),

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -2354,7 +2354,7 @@ class PurchasesTests: XCTestCase {
         setupPurchases()
 
         for key in data.keys {
-            expect(self.backend.invokedPostAttributionDataParameters?.data?.keys.contains(key)) == true
+            expect(self.backend.invokedPostAttributionDataParameters?.data?.keys.contains(key)).toEventually(beTrue())
         }
 
         expect(self.backend.invokedPostAttributionDataParameters?.data?.keys.contains("rc_idfa")) == true

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -249,8 +249,7 @@ class PurchasesTests: XCTestCase {
     let backend = MockBackend(httpClient: MockHTTPClient(systemInfo: try! MockSystemInfo(platformFlavor: nil,
                                                                                          platformFlavorVersion: nil,
                                                                                          finishTransactions: false),
-                                                         eTagManager: MockETagManager(),
-                                                         operationDispatcher: MockOperationDispatcher()),
+                                                         eTagManager: MockETagManager()),
                               apiKey: "mockAPIKey")
     let storeKitWrapper = MockStoreKitWrapper()
     let notificationCenter = MockNotificationCenter()

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -2352,8 +2352,9 @@ class PurchasesTests: XCTestCase {
 
         setupPurchases()
 
+        expect(self.backend.invokedPostAttributionData).toEventually(beTrue())
         for key in data.keys {
-            expect(self.backend.invokedPostAttributionDataParameters?.data?.keys.contains(key)).toEventually(beTrue())
+            expect(self.backend.invokedPostAttributionDataParameters?.data?.keys.contains(key)).to(beTrue())
         }
 
         expect(self.backend.invokedPostAttributionDataParameters?.data?.keys.contains("rc_idfa")) == true

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -37,9 +37,8 @@ class BackendSubscriberAttributesTests: XCTestCase {
     let systemInfo = try! SystemInfo(platformFlavor: "Unity", platformFlavorVersion: "2.3.3", finishTransactions: true)
 
     override func setUp() {
-        let mockOperationDispatcher = MockOperationDispatcher()
         mockETagManager = MockETagManager(userDefaults: MockUserDefaults())
-        mockHTTPClient = MockHTTPClient(systemInfo: systemInfo, eTagManager: mockETagManager, operationDispatcher: mockOperationDispatcher)
+        mockHTTPClient = MockHTTPClient(systemInfo: systemInfo, eTagManager: mockETagManager)
         self.backend = Backend(httpClient: mockHTTPClient, apiKey: "key")
         dateProvider = MockDateProvider(stubbedNow: now)
         subscriberAttribute1 = SubscriberAttribute(withKey: "a key",


### PR DESCRIPTION
There were a few places where we were queue-hopping a bit. The original implementation locked in just a few places. With the Swift migration we introduced a couple changes, like always dispatching `completion` to the main queue and wrapping the `handler` and `perform` methods in a dispatch work item. The data task we create dispatches the completion to the Session's own internal queue (we don't have a delegate), so we end up potentially using 4 queues here, original caller, serial http, internal session, then main. I reduced the queue usage to just two, the original caller and the internal queue on Session. I also used NSRecursiveLock for access control (to replace the original `@synchronized`).

resolves #750 