### PR TITLE
Fix: tests on older OS versions

### DIFF
--- a/PurchasesTests/Caching/DeviceCacheTests.swift
+++ b/PurchasesTests/Caching/DeviceCacheTests.swift
@@ -226,13 +226,13 @@ class DeviceCacheTests: XCTestCase {
         // Here we check that the expectation has not been fulfilled
         wait(for: [assertionDidNotHappen], timeout: TimeInterval(1))
 
-        #else
+        #elseif arch(x86_64) && canImport(Darwin)
         self.deviceCache = DeviceCache(userDefaults: mockUserDefaults,
                                        offeringsCachedObject: nil,
                                        notificationCenter: mockNotificationCenter)
 
         // Only check the assertion for the valid archs.
-        expect(mockNotificationCenter.fireNotifications()).toNot(throwAssertion())
+        expect { mockNotificationCenter.fireNotifications() }.toNot(throwAssertion())
         #endif
 
         mockUserDefaults.mockValues["com.revenuecat.userdefaults.appUserID.new"] = nil
@@ -240,8 +240,8 @@ class DeviceCacheTests: XCTestCase {
         #if arch(arm64)
         mockNotificationCenter.fireNotifications()
         wait(for: [assertionHappened], timeout: TimeInterval(1))
-        #else
-        expect(mockNotificationCenter.fireNotifications()).to(throwAssertion())
+        #elseif arch(x86_64) && canImport(Darwin)
+        expect { mockNotificationCenter.fireNotifications() }.to(throwAssertion())
         #endif
     }
 
@@ -262,12 +262,12 @@ class DeviceCacheTests: XCTestCase {
 
         // Here we check that the expectation has not been fulfilled
         wait(for: [assertionDidNotHappen], timeout: TimeInterval(1))
-        #else
+        #elseif arch(x86_64) && canImport(Darwin)
         self.deviceCache = DeviceCache(userDefaults: mockUserDefaults,
                                          offeringsCachedObject: nil,
                                          notificationCenter: mockNotificationCenter)
 
-        expect(mockNotificationCenter.fireNotifications).toNot(throwAssertion())
+        expect { mockNotificationCenter.fireNotifications }.toNot(throwAssertion())
         #endif
     }
 

--- a/PurchasesTests/Identity/IdentityManagerTests.swift
+++ b/PurchasesTests/Identity/IdentityManagerTests.swift
@@ -87,13 +87,13 @@ class IdentityManagerTests: XCTestCase {
         expect(self.mockBackend.invokedCreateAlias).toEventually(beTrue())
     }
 
-    #if arch(x86_64)
+    #if arch(x86_64) && canImport(Darwin)
     //  Also, Nimble's throwAssertion() matcher doesn't work for ARM64.
     //  See https://github.com/Quick/Nimble/blob/main/Sources/Nimble/Matchers/ThrowAssertion.swift#L125
     func testCreateAliasFatalErrorsIfCurrentAppUserIDIsNil() {
         self.mockBackend.invokedCreateAlias = false
         self.mockDeviceCache.stubbedAppUserID = nil
-        expect(self.identityManager.createAlias(appUserID: "cesar"){ _ in }).to(throwAssertion())
+        expect { self.identityManager.createAlias(appUserID: "cesar"){ _ in } }.to(throwAssertion())
     }
     #endif
 

--- a/PurchasesTests/Purchasing/ProductInfoExtractorTests.swift
+++ b/PurchasesTests/Purchasing/ProductInfoExtractorTests.swift
@@ -168,7 +168,7 @@ class ProductInfoExtractorTests: XCTestCase {
 
     func testExtractInfoFromProductExtractsSubscriptionGroup() {
         let product = MockSKProduct(mockProductIdentifier: "cool_product")
-        if #available(iOS 11.2, *) {
+        if #available(iOS 12.0, macCatalyst 13.0, macOS 10.14, tvOS 12.0, watchOS 6.2, *) {
             let group = "mock_group"
             product.mockSubscriptionGroupIdentifier = group
             let productInfoExtractor = ProductInfoExtractor()

--- a/PurchasesTests/Purchasing/ProductInfoTests.swift
+++ b/PurchasesTests/Purchasing/ProductInfoTests.swift
@@ -122,6 +122,8 @@ class ProductInfoTests: XCTestCase {
     }
     
     func testCacheKey() {
+        guard #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *) else { return }
+        
         let discount1 = PromotionalOffer(offerIdentifier: "offerid1",
                                          price: NSDecimalNumber(decimal: 11),
                                          paymentMode: .payAsYouGo)

--- a/PurchasesTests/Purchasing/ProductInfoTests.swift
+++ b/PurchasesTests/Purchasing/ProductInfoTests.swift
@@ -3,7 +3,6 @@ import Nimble
 
 @testable import Purchases
 
-@available(iOS 12.2, *)
 class ProductInfoTests: XCTestCase {
     func testAsDictionaryConvertsProductIdentifierCorrectly() {
         let productIdentifier = "cool_product"
@@ -88,8 +87,9 @@ class ProductInfoTests: XCTestCase {
         let productInfo: ProductInfo = .createMockProductInfo(subscriptionGroup: subscriptionGroup)
         expect(productInfo.asDictionary()["subscription_group_id"] as? String) == subscriptionGroup
     }
-    
-    func testAsDictionaryConvertsDiscountsCorrectly() {
+
+    func testAsDictionaryConvertsDiscountsCorrectly() throws {
+        guard #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *) else { return }
         let discount1 = PromotionalOffer(offerIdentifier: "offerid1",
                                          price: NSDecimalNumber(decimal: 11),
                                          paymentMode: .payAsYouGo)
@@ -105,7 +105,7 @@ class ProductInfoTests: XCTestCase {
         let productInfo: ProductInfo = .createMockProductInfo(discounts: [discount1, discount2, discount3])
         
         expect(productInfo.asDictionary()["offers"] as? [[String: NSObject]]).toNot(beNil())
-        guard let receivedOffers = productInfo.asDictionary()["offers"] as? [[String: NSObject]] else { fatalError() }
+        let receivedOffers = try XCTUnwrap(productInfo.asDictionary()["offers"] as? [[String: NSObject]])
         
         expect(receivedOffers[0]["offer_identifier"] as? String) == discount1.offerIdentifier
         expect(receivedOffers[0]["price"] as? NSDecimalNumber) == discount1.price

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -336,7 +336,10 @@ class PurchasesTests: XCTestCase {
     }
 
     func testUsingSharedInstanceWithoutInitializingThrowsAssertion() {
-        #if arch(arm64)
+        #if arch(x86_64) && canImport(Darwin)
+        expect { Purchases.shared } .to(throwAssertion())
+
+        #else
         let assertionHappened = expectation(description: "Assertion happened")
         Purchases.notConfiguredAssertionFunction = {
             assertionHappened.fulfill()
@@ -345,13 +348,13 @@ class PurchasesTests: XCTestCase {
         _ = Purchases.shared
 
         wait(for: [assertionHappened], timeout: TimeInterval(1))
-        #elseif arch(x86_64) && canImport(Darwin)
-        expect { Purchases.shared } .to(throwAssertion())
         #endif
 
         setupPurchases()
 
-        #if arch(arm64)
+        #if arch(x86_64) && canImport(Darwin)
+        expect { _ = Purchases.shared }.toNot(throwAssertion())
+        #else
         // Create an inverted expectation. So, it'll fail if fulfilled.
         let assertionDidNotHappen = expectation(description: "Assertion did not happen")
         assertionDidNotHappen.isInverted = true
@@ -362,8 +365,6 @@ class PurchasesTests: XCTestCase {
         _ = Purchases.shared
 
         wait(for: [assertionDidNotHappen], timeout: TimeInterval(1))
-        #elseif arch(x86_64) && canImport(Darwin)
-        expect { _ = Purchases.shared }.toNot(throwAssertion())
         #endif
     }
 

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -345,8 +345,8 @@ class PurchasesTests: XCTestCase {
         _ = Purchases.shared
 
         wait(for: [assertionHappened], timeout: TimeInterval(1))
-        #else
-        expect(Purchases.shared).to(throwAssertion())
+        #elseif arch(x86_64) && canImport(Darwin)
+        expect { Purchases.shared } .to(throwAssertion())
         #endif
 
         setupPurchases()
@@ -362,7 +362,7 @@ class PurchasesTests: XCTestCase {
         _ = Purchases.shared
 
         wait(for: [assertionDidNotHappen], timeout: TimeInterval(1))
-        #else
+        #elseif arch(x86_64) && canImport(Darwin)
         expect { _ = Purchases.shared }.toNot(throwAssertion())
         #endif
     }


### PR DESCRIPTION
Tests are crashing on older OS versions (for example, iPhone running iOS 11.4)
One reason this is happening is that when testing for something to throw, you need to use the following syntax:
```swift
expect { mockNotificationCenter.fireNotifications() } .toNot(throwAssertion())
```
instead of 
```swift
expect(mockNotificationCenter.fireNotifications()).toNot(throwAssertion())
```
this is because the inside of expect() gets evaluated before the expect method itself, so if something throws, it crashes the test suite. 

There are a couple of other updates here, like cleaning up the architecture checks for `throwAssertion` to match those in the actual implementation in Nimble, cleaning up availability checks in a few places, and updating force unwraps to use `XCTUnwrap` (but there are still a ton more around). 
