### PR TITLE
Improve strings formatting part 1: `AttributionStrings`

### DIFF
--- a/Purchases/Logging/Logger.swift
+++ b/Purchases/Logging/Logger.swift
@@ -37,30 +37,36 @@ class Logger {
 
     private static let frameworkDescription = "Purchases"
 
-    static func log(level: LogLevel, message: String) {
-        guard self.logLevel.rawValue <= level.rawValue else { return }
-        logHandler(level, message)
-    }
-
-    static func log(level: LogLevel, intent: LogIntent, message: String) {
-        let messageWithPrefix = "\(intent.suffix) \(message)"
-        Logger.log(level: level, message: messageWithPrefix)
-    }
-
     static func debug(_ message: String) {
         log(level: .debug, intent: .info, message: message)
+    }
+
+    static func debug(_ message: CustomStringConvertible) {
+        log(level: .debug, intent: .info, message: message.description)
     }
 
     static func info(_ message: String) {
         log(level: .info, intent: .info, message: message)
     }
 
+    static func info(_ message: CustomStringConvertible) {
+        log(level: .info, intent: .info, message: message.description)
+    }
+
     static func warn(_ message: String) {
         log(level: .warn, intent: .warning, message: message)
     }
 
+    static func warn(_ message: CustomStringConvertible) {
+        log(level: .warn, intent: .warning, message: message.description)
+    }
+
     static func error(_ message: String) {
         log(level: .error, intent: .rcError, message: message)
+    }
+
+    static func error(_ message: CustomStringConvertible) {
+        log(level: .error, intent: .rcError, message: message.description)
     }
 
 }
@@ -71,24 +77,61 @@ extension Logger {
         log(level: .error, intent: .appleError, message: message)
     }
 
+    static func appleError(_ message: CustomStringConvertible) {
+        log(level: .error, intent: .appleError, message: message.description)
+    }
+
     static func appleWarning(_ message: String) {
         log(level: .warn, intent: .appleError, message: message)
+    }
+
+    static func appleWarning(_ message: CustomStringConvertible) {
+        log(level: .warn, intent: .appleError, message: message.description)
     }
 
     static func purchase(_ message: String) {
         log(level: .debug, intent: .purchase, message: message)
     }
 
+    static func purchase(_ message: CustomStringConvertible) {
+        log(level: .debug, intent: .purchase, message: message.description)
+    }
+
     static func rcPurchaseSuccess(_ message: String) {
         log(level: .info, intent: .rcPurchaseSuccess, message: message)
+    }
+
+    static func rcPurchaseSuccess(_ message: CustomStringConvertible) {
+        log(level: .info, intent: .rcPurchaseSuccess, message: message.description)
     }
 
     static func rcSuccess(_ message: String) {
         log(level: .debug, intent: .rcSuccess, message: message)
     }
 
+    static func rcSuccess(_ message: CustomStringConvertible) {
+        log(level: .debug, intent: .rcSuccess, message: message.description)
+    }
+
     static func user(_ message: String) {
         log(level: .debug, intent: .user, message: message)
     }
 
+    static func user(_ message: CustomStringConvertible) {
+        log(level: .debug, intent: .user, message: message.description)
+    }
+
+}
+
+private extension Logger {
+
+    static func log(level: LogLevel, message: String) {
+        guard self.logLevel.rawValue <= level.rawValue else { return }
+        logHandler(level, message)
+    }
+
+    static func log(level: LogLevel, intent: LogIntent, message: String) {
+        let messageWithPrefix = "\(intent.suffix) \(message)"
+        Logger.log(level: level, message: messageWithPrefix)
+    }
 }

--- a/Purchases/Logging/Strings/AttributionStrings.swift
+++ b/Purchases/Logging/Strings/AttributionStrings.swift
@@ -46,17 +46,21 @@ enum AttributionStrings {
     case search_ads_attribution_cancelled_not_authorized
 
     case skip_same_attributes
+
     case subscriber_attributes_error(errors: [String: String]?)
-    static let unsynced_attributes_count = "Found %lu unsynced attributes for App User ID: %@"
-    static let unsynced_attributes = "Unsynced attributes: %@"
-    static let attribute_set_locally = "Attribute set locally: %@. It will be synced to the backend" +
-        "when the app backgrounds/foregrounds or when a purchase is made."
-    static let missing_advertiser_identifiers = "Attribution error: identifierForAdvertisers is missing"
-    static let missing_app_user_id = "Attribution error: can't post attribution, missing appUserId"
+
+    case unsynced_attributes_count(unsyncedAttributesCount: Int, appUserID: String)
+
+    case unsynced_attributes(unsyncedAttributes: SubscriberAttributeDict)
+
+    case attribute_set_locally(attribute: String)
+
+    case missing_advertiser_identifiers
 
 }
 
 extension AttributionStrings: CustomStringConvertible {
+
     var description: String {
         switch self {
         case .appsflyer_id_deprecated:
@@ -110,6 +114,21 @@ extension AttributionStrings: CustomStringConvertible {
 
         case .subscriber_attributes_error(let errors):
             return "Subscriber attributes errors: \((errors?.description ?? ""))"
+
+        case .unsynced_attributes_count(let unsyncedAttributesCount, let appUserID):
+            return "Found \(unsyncedAttributesCount) unsynced attributes for App User ID: \(appUserID)"
+
+        case .unsynced_attributes(let unsyncedAttributes):
+            return "Unsynced attributes: \(unsyncedAttributes)"
+
+        case .attribute_set_locally(let attribute):
+            return "Attribute set locally: \(attribute). It will be synced to the backend" +
+            "when the app backgrounds/foregrounds or when a purchase is made."
+
+        case .missing_advertiser_identifiers:
+            return "Attribution error: identifierForAdvertisers is missing"
+
         }
     }
+
 }

--- a/Purchases/Logging/Strings/AttributionStrings.swift
+++ b/Purchases/Logging/Strings/AttributionStrings.swift
@@ -27,28 +27,23 @@ enum AttributionStrings {
 
     case marking_attributes_synced(appUserID: String, attributes: SubscriberAttributeDict)
 
-    static let method_called = "%@ called"
-    static let networkuserid_required_for_appsflyer = "The parameter networkUserId is REQUIRED for AppsFlyer."
+    case method_called(methodName: String)
 
-    static let no_instance_configured_caching_attribution = "There is no purchase instance configured, " +
-        "caching attribution"
+    case networkuserid_required_for_appsflyer
 
-    static let instance_configured_posting_attribution = "There is a purchase instance configured, posting attribution"
+    case no_instance_configured_caching_attribution
 
-    static let search_ads_attribution_cancelled_missing_att_framework = "Tried to post Apple Search Ads Attribution, " +
-        "but ATT Framework is required on this OS and it isn't included"
+    case instance_configured_posting_attribution
 
-    static let att_framework_present_but_couldnt_call_tracking_authorization_status = "ATT Framework was found but " +
-        "it didn't respond to authorization status selector!"
+    case search_ads_attribution_cancelled_missing_att_framework
 
-    static let iad_framework_present_but_couldnt_call_request_attribution_details = "iAd Framework was found but " +
-        "it didn't respond to attribution details request!"
+    case att_framework_present_but_couldnt_call_tracking_authorization_status
 
-    static let search_ads_attribution_cancelled_missing_iad_framework = "Tried to post Apple Search Ads Attribution, " +
-        "but iAd Framework is is required for it and it isn't included"
+    case iad_framework_present_but_couldnt_call_request_attribution_details
 
-    static let search_ads_attribution_cancelled_not_authorized = "Tried to post Apple Search Ads Attribution, but " +
-        "authorization hasn't been granted. Will automatically retry if authorization gets granted."
+    case search_ads_attribution_cancelled_missing_iad_framework
+
+    case search_ads_attribution_cancelled_not_authorized
 
     static let skip_same_attributes = "Attribution data is the same as latest. Skipping."
     static let subscriber_attributes_error = "Subscriber attributes errors: %@"
@@ -67,14 +62,49 @@ extension AttributionStrings: CustomStringConvertible {
         case .appsflyer_id_deprecated:
             return "The parameter key rc_appsflyer_id is deprecated." +
             " Pass networkUserId to addAttribution instead."
+
         case .attributes_sync_error(let details, let userInfo):
             return "Error when syncing subscriber attributes. Details: \(details ?? "")\n UserInfo: \(userInfo ?? [:])"
+
         case .attributes_sync_success(let appUserID):
             return "Subscriber attributes synced successfully for App User ID: \(appUserID)"
+
         case .empty_subscriber_attributes:
             return "Called post subscriber attributes with an empty attributes dictionary!"
+
         case .marking_attributes_synced(let appUserID, let attributes):
             return "Marking attributes as synced for App User ID: \(appUserID):\n attributes: \(attributes.description)"
+
+        case .method_called(let methodName):
+            return "\(methodName) called"
+
+        case .networkuserid_required_for_appsflyer:
+            return "The parameter networkUserId is REQUIRED for AppsFlyer."
+
+        case .no_instance_configured_caching_attribution:
+            return "There is no purchase instance configured, caching attribution"
+
+        case .instance_configured_posting_attribution:
+            return "There is a purchase instance configured, posting attribution"
+
+        case .search_ads_attribution_cancelled_missing_att_framework:
+            return "Tried to post Apple Search Ads Attribution, " +
+            "but ATT Framework is required on this OS and it isn't included"
+
+        case .att_framework_present_but_couldnt_call_tracking_authorization_status:
+            return "ATT Framework was found but it didn't respond to authorization status selector!"
+
+        case .iad_framework_present_but_couldnt_call_request_attribution_details:
+            return "iAd Framework was found but it didn't respond to attribution details request!"
+
+        case .search_ads_attribution_cancelled_missing_iad_framework:
+            return "Tried to post Apple Search Ads Attribution, " +
+            "but iAd Framework is is required for it and it isn't included"
+
+        case .search_ads_attribution_cancelled_not_authorized:
+            return "Tried to post Apple Search Ads Attribution, but " +
+            "authorization hasn't been granted. Will automatically retry if authorization gets granted."
+
         }
     }
 }

--- a/Purchases/Logging/Strings/AttributionStrings.swift
+++ b/Purchases/Logging/Strings/AttributionStrings.swift
@@ -21,10 +21,11 @@ enum AttributionStrings {
 
     case attributes_sync_error(details: String?, userInfo: [String: Any]?)
 
-    static let attributes_sync_success = "Subscriber attributes synced successfully for App User ID: %@"
-    static let empty_subscriber_attributes = "Called post subscriber attributes with an empty attributes dictionary!"
+    case attributes_sync_success(appUserID: String)
 
-    static let marking_attributes_synced = "Marking the following attributes as synced for App User ID: %@: %@"
+    case empty_subscriber_attributes
+
+    case marking_attributes_synced(appUserID: String, attributes: SubscriberAttributeDict)
 
     static let method_called = "%@ called"
     static let networkuserid_required_for_appsflyer = "The parameter networkUserId is REQUIRED for AppsFlyer."
@@ -68,6 +69,12 @@ extension AttributionStrings: CustomStringConvertible {
             " Pass networkUserId to addAttribution instead."
         case .attributes_sync_error(let details, let userInfo):
             return "Error when syncing subscriber attributes. Details: \(details ?? "")\n UserInfo: \(userInfo ?? [:])"
+        case .attributes_sync_success(let appUserID):
+            return "Subscriber attributes synced successfully for App User ID: \(appUserID)"
+        case .empty_subscriber_attributes:
+            return "Called post subscriber attributes with an empty attributes dictionary!"
+        case .marking_attributes_synced(let appUserID, let attributes):
+            return "Marking attributes as synced for App User ID: \(appUserID):\n attributes: \(attributes.description)"
         }
     }
 }

--- a/Purchases/Logging/Strings/AttributionStrings.swift
+++ b/Purchases/Logging/Strings/AttributionStrings.swift
@@ -19,7 +19,7 @@ enum AttributionStrings {
 
     case appsflyer_id_deprecated
 
-    static let attributes_sync_error = "Error when syncing subscriber attributes. Details: %@\n UserInfo:%@"
+    case attributes_sync_error(details: String?, userInfo: [String: Any]?)
 
     static let attributes_sync_success = "Subscriber attributes synced successfully for App User ID: %@"
     static let empty_subscriber_attributes = "Called post subscriber attributes with an empty attributes dictionary!"
@@ -66,6 +66,8 @@ extension AttributionStrings: CustomStringConvertible {
         case .appsflyer_id_deprecated:
             return "The parameter key rc_appsflyer_id is deprecated." +
             " Pass networkUserId to addAttribution instead."
+        case .attributes_sync_error(let details, let userInfo):
+            return "Error when syncing subscriber attributes. Details: \(details ?? "")\n UserInfo: \(userInfo ?? [:])"
         }
     }
 }

--- a/Purchases/Logging/Strings/AttributionStrings.swift
+++ b/Purchases/Logging/Strings/AttributionStrings.swift
@@ -17,8 +17,7 @@ import Foundation
 // swiftlint:disable identifier_name
 enum AttributionStrings {
 
-    static let appsflyer_id_deprecated = "The parameter key rc_appsflyer_id is deprecated." +
-        " Pass networkUserId to addAttribution instead."
+    case appsflyer_id_deprecated
 
     static let attributes_sync_error = "Error when syncing subscriber attributes. Details: %@\n UserInfo:%@"
 
@@ -59,4 +58,14 @@ enum AttributionStrings {
     static let missing_advertiser_identifiers = "Attribution error: identifierForAdvertisers is missing"
     static let missing_app_user_id = "Attribution error: can't post attribution, missing appUserId"
 
+}
+
+extension AttributionStrings: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .appsflyer_id_deprecated:
+            return "The parameter key rc_appsflyer_id is deprecated." +
+            " Pass networkUserId to addAttribution instead."
+        }
+    }
 }

--- a/Purchases/Logging/Strings/AttributionStrings.swift
+++ b/Purchases/Logging/Strings/AttributionStrings.swift
@@ -45,8 +45,8 @@ enum AttributionStrings {
 
     case search_ads_attribution_cancelled_not_authorized
 
-    static let skip_same_attributes = "Attribution data is the same as latest. Skipping."
-    static let subscriber_attributes_error = "Subscriber attributes errors: %@"
+    case skip_same_attributes
+    case subscriber_attributes_error(errors: [String: String]?)
     static let unsynced_attributes_count = "Found %lu unsynced attributes for App User ID: %@"
     static let unsynced_attributes = "Unsynced attributes: %@"
     static let attribute_set_locally = "Attribute set locally: %@. It will be synced to the backend" +
@@ -105,6 +105,11 @@ extension AttributionStrings: CustomStringConvertible {
             return "Tried to post Apple Search Ads Attribution, but " +
             "authorization hasn't been granted. Will automatically retry if authorization gets granted."
 
+        case .skip_same_attributes:
+            return "Attribution data is the same as latest. Skipping."
+
+        case .subscriber_attributes_error(let errors):
+            return "Subscriber attributes errors: \((errors?.description ?? ""))"
         }
     }
 }

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -401,8 +401,7 @@ private extension PurchasesOrchestrator {
             if !error.successfullySynced {
                 return
             }
-            let attributeErrors = (error.subscriberAttributesErrors?.debugDescription ?? "None") as NSString
-            Logger.error(String(format: Strings.attribution.subscriber_attributes_error, attributeErrors))
+            Logger.error(Strings.attribution.subscriber_attributes_error(errors: error.subscriberAttributesErrors))
         }
 
         subscriberAttributesManager.markAttributesAsSynced(subscriberAttributes, appUserID: appUserID)

--- a/Purchases/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Purchases/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -159,9 +159,8 @@ class SubscriberAttributesManager {
             }
         } else {
             let receivedNSError = error as NSError?
-            Logger.error(String(format: Strings.attribution.attributes_sync_error,
-                                receivedNSError?.localizedDescription ?? "",
-                                receivedNSError?.userInfo ?? ""))
+            Logger.error(Strings.attribution.attributes_sync_error(details: receivedNSError?.localizedDescription,
+                                                                   userInfo: receivedNSError?.userInfo))
         }
     }
 

--- a/Purchases/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Purchases/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -256,7 +256,7 @@ private extension SubscriberAttributesManager {
     }
 
     func logAttributionMethodCalled(functionName: String) {
-        Logger.debug(String(format: Strings.attribution.method_called, functionName))
+        Logger.debug(Strings.attribution.method_called(methodName: functionName))
     }
 
 }

--- a/Purchases/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Purchases/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -166,11 +166,10 @@ class SubscriberAttributesManager {
 
     func unsyncedAttributesByKey(appUserID: String) -> SubscriberAttributeDict {
         let unsyncedAttributes = deviceCache.unsyncedAttributesByKey(appUserID: appUserID)
-        Logger.debug(String(format: Strings.attribution.unsynced_attributes_count,
-                            unsyncedAttributes.count,
-                            appUserID))
+        Logger.debug(Strings.attribution.unsynced_attributes_count(unsyncedAttributesCount: unsyncedAttributes.count,
+                                                                   appUserID: appUserID))
         if !unsyncedAttributes.isEmpty {
-            Logger.debug(String(format: Strings.attribution.unsynced_attributes, unsyncedAttributes))
+            Logger.debug(Strings.attribution.unsynced_attributes(unsyncedAttributes: unsyncedAttributes))
         }
 
         return unsyncedAttributes
@@ -241,7 +240,7 @@ private extension SubscriberAttributesManager {
 
     func storeAttributeLocally(key: String, value: String, appUserID: String) {
         let subscriberAttribute = SubscriberAttribute.init(withKey: key, value: value)
-        Logger.debug(String(format: Strings.attribution.attribute_set_locally, subscriberAttribute.description))
+        Logger.debug(Strings.attribution.attribute_set_locally(attribute: subscriberAttribute.description))
         deviceCache.store(subscriberAttribute: subscriberAttribute, appUserID: appUserID)
     }
 

--- a/Purchases/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Purchases/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -153,7 +153,7 @@ class SubscriberAttributesManager {
 
     func handleAttributesSynced(syncingAppUserId: String, currentAppUserId: String, error: Error?) {
         if error == nil {
-            Logger.rcSuccess(String(format: Strings.attribution.attributes_sync_success, syncingAppUserId))
+            Logger.rcSuccess(Strings.attribution.attributes_sync_success(appUserID: syncingAppUserId))
             if syncingAppUserId != currentAppUserId {
                 deviceCache.deleteAttributesIfSynced(appUserID: syncingAppUserId)
             }
@@ -186,9 +186,7 @@ class SubscriberAttributesManager {
             return
         }
 
-        Logger.info(String(format: Strings.attribution.marking_attributes_synced,
-                           appUserID,
-                           attributesToSync.description))
+        Logger.info(Strings.attribution.marking_attributes_synced(appUserID: appUserID, attributes: attributesToSync))
 
         lock.lock()
         var unsyncedAttributes = unsyncedAttributesByKey(appUserID: appUserID)


### PR DESCRIPTION
We're currently storing all logging strings as `static let`. 
This has the unfortunate side-effect of eagerly loading them all into memory. 

In addition, formatting them isn't very type-safe, and is difficult to do, because when using the strings, you don't know what each parameter does, in which order. 

This PR improves upon this by transforming them into enum cases with labels. 

This means we can move from this syntax: 
```swift
Logger.info(String(format: Strings.whatever.purchasing_product, productId))
```

into this one: 

```swift
Logger.info(Strings.whatever.purchasing_product(productIdentifier: productId))
```

which gets a lot better when there are multiple parameters. 