### PR TITLE
Adds missing changes from #679 (bugfix on check intro eligibility)

### DIFF
--- a/Purchases/Purchasing/IntroEligibilityCalculator.swift
+++ b/Purchases/Purchasing/IntroEligibilityCalculator.swift
@@ -88,7 +88,9 @@ private extension IntroEligibilityCalculator {
                         && candidate.subscriptionGroupIdentifier == purchased.subscriptionGroupIdentifier)
                     return foundByGroupId
                 }
-            result[candidate.productIdentifier] = usedIntroForProductIdentifier
+
+            let hasIntroductoryPrice = candidate.introductoryPrice != nil
+            result[candidate.productIdentifier] = !hasIntroductoryPrice || usedIntroForProductIdentifier
                 ? IntroEligibilityStatus.ineligible.toNSNumber()
                 : IntroEligibilityStatus.eligible.toNSNumber()
         }

--- a/PurchasesTests/Mocks/MockSKDiscount.swift
+++ b/PurchasesTests/Mocks/MockSKDiscount.swift
@@ -6,7 +6,7 @@
 import Foundation
 import StoreKit
 
-@available(iOS 11.2, tvOS 11.2, macOS 10.13.2, *)
+@available(iOS 11.2, macCatalyst 13.0, tvOS 11.2, macOS 10.13.2, *)
 class MockDiscount: SKProductDiscount {
     var mockPaymentMode: SKProductDiscount.PaymentMode?
     override var paymentMode: SKProductDiscount.PaymentMode {

--- a/PurchasesTests/Mocks/MockSKProduct.swift
+++ b/PurchasesTests/Mocks/MockSKProduct.swift
@@ -34,7 +34,10 @@ class MockSKProduct: SKProduct {
 
     @available(iOS 11.2, macCatalyst 13.0, tvOS 11.2, macOS 10.13.2, *)
     override var introductoryPrice: SKProductDiscount? {
-        mockDiscount ?? MockDiscount()
+        if #available(iOS 12.2, *) {
+            return mockDiscount
+        }
+        return nil
     }
 
     @available(iOS 11.2, macCatalyst 13.0, tvOS 11.2, macOS 10.13.2, *)

--- a/PurchasesTests/Mocks/MockSKProduct.swift
+++ b/PurchasesTests/Mocks/MockSKProduct.swift
@@ -32,23 +32,23 @@ class MockSKProduct: SKProduct {
         return mockPrice ?? 2.99 as NSDecimalNumber
     }
 
-    @available(iOS 11.2, tvOS 11.2, macOS 10.13.2, *)
+    @available(iOS 11.2, macCatalyst 13.0, tvOS 11.2, macOS 10.13.2, *)
     override var introductoryPrice: SKProductDiscount? {
         mockDiscount ?? MockDiscount()
     }
 
-    @available(iOS 11.2, tvOS 11.2, macOS 10.13.2, *)
+    @available(iOS 11.2, macCatalyst 13.0, tvOS 11.2, macOS 10.13.2, *)
     lazy var mockDiscount: SKProductDiscount? = nil
 
-    @available(iOS 12.2, tvOS 12.2, macOS 10.13.2, *)
+    @available(iOS 12.2, macCatalyst 13.0, tvOS 12.2, macOS 10.13.2, *)
     override var discounts: [SKProductDiscount] {
         return (mockDiscount != nil) ? [mockDiscount!] : []
     }
 
-    @available(iOS 11.2, tvOS 11.2, macOS 10.13.2, *)
+    @available(iOS 11.2, macCatalyst 13.0, tvOS 11.2, macOS 10.13.2, *)
     lazy var mockSubscriptionPeriod: SKProductSubscriptionPeriod? = nil
 
-    @available(iOS 11.2, tvOS 11.2, macOS 10.13.2, *)
+    @available(iOS 11.2, macCatalyst 13.0, tvOS 11.2, macOS 10.13.2, *)
     override var subscriptionPeriod: SKProductSubscriptionPeriod {
         return mockSubscriptionPeriod ?? SKProductSubscriptionPeriod(numberOfUnits: 1, unit:.month)
     }


### PR DESCRIPTION
The changes from #679 were lost during the swift migration so this PR brings the changes back