### PR TITLE
Make getOfferings execute serially

### DIFF
--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -293,7 +293,7 @@ class Backend {
             return
         }
 
-        httpClient.performGETRequest(serially: false,
+        httpClient.performGETRequest(serially: true,
                                      path: path,
                                      headers: authHeaders) { [weak self] (statusCode, response, error) in
             guard let self = self else {

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -830,6 +830,17 @@ class BackendTests: XCTestCase {
         expect(self.httpClient.calls.count).toNot(equal(0))
         expect(offeringsData).toEventuallyNot(beNil())
     }
+
+    func testGetOfferingsCallsHTTPMethodSerially() {
+        let response = HTTPResponse(statusCode: 200, response: noOfferingsResponse as [String : Any], error: nil)
+        let path = "/subscribers/" + userID + "/offerings"
+        httpClient.mock(requestPath: path, response: response)
+
+        backend?.getOfferings(appUserID: userID) { _, _ in }
+
+        expect(self.httpClient.calls.count).to(equal(1))
+        expect(self.httpClient.calls[0].serially).to(beTrue())
+    }
     
     func testGetOfferingsCachesForSameUserID() {
         let response = HTTPResponse(statusCode: 200, response: noOfferingsResponse as [String : Any], error: nil)


### PR DESCRIPTION
getOfferings can sometimes trigger creation of a user. In that case, there can be a race condition if another request is in process and it happens to also create a user.