### PR TITLE
Update LegacySwiftExample to use RevenueCat instead of Purchases

### DIFF
--- a/Examples/LegacySwiftExample/Podfile.lock
+++ b/Examples/LegacySwiftExample/Podfile.lock
@@ -1,22 +1,16 @@
 PODS:
-  - Purchases (3.12.0-SNAPSHOT):
-    - PurchasesCoreSwift (= 3.12.0-SNAPSHOT)
-  - PurchasesCoreSwift (3.12.0-SNAPSHOT)
+  - RevenueCat (4.0.0-beta.1)
 
 DEPENDENCIES:
-  - Purchases (from `../../`)
-  - PurchasesCoreSwift (from `../../`)
+  - RevenueCat (from `../../`)
 
 EXTERNAL SOURCES:
-  Purchases:
-    :path: "../../"
-  PurchasesCoreSwift:
+  RevenueCat:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  Purchases: 4fc5778252b9a53a9e8933c69c7c90d61ea3ba03
-  PurchasesCoreSwift: ab847be1cfcc8c34c4a11d6fc0c90bdc86e7d812
+  RevenueCat: 76c389734f648f31278ccefc1c713fefccd53067
 
-PODFILE CHECKSUM: 1a5412316b168a76eeadb16a7a1691a6c5c8a015
+PODFILE CHECKSUM: 9b366bd379bbf3f55bc20631d8212cb2796cbab2
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.10.2

--- a/Examples/LegacySwiftExample/SwiftExample/CatsViewController.swift
+++ b/Examples/LegacySwiftExample/SwiftExample/CatsViewController.swift
@@ -29,7 +29,7 @@ class CatsViewController: UIViewController {
 
     }
     
-    func configureCatContentFor(purchaserInfo: Purchases.PurchaserInfo?) {
+    func configureCatContentFor(purchaserInfo: PurchaserInfo?) {
         
         // set the content based on the user subscription status
         if let purchaserInfo = purchaserInfo {

--- a/Examples/LegacySwiftExample/SwiftExample/SwiftPaywall.swift
+++ b/Examples/LegacySwiftExample/SwiftExample/SwiftPaywall.swift
@@ -16,9 +16,9 @@ enum PayWallEdgeStyle : String {
 }
 
 @objc protocol SwiftPaywallDelegate {
-    func purchaseCompleted(paywall: SwiftPaywall, transaction: SKPaymentTransaction, purchaserInfo: Purchases.PurchaserInfo)
-    @objc optional func purchaseFailed(paywall: SwiftPaywall, purchaserInfo: Purchases.PurchaserInfo?, error: Error, userCancelled: Bool)
-    @objc optional func purchaseRestored(paywall: SwiftPaywall, purchaserInfo: Purchases.PurchaserInfo?, error: Error?)
+    func purchaseCompleted(paywall: SwiftPaywall, purchaserInfo: PurchaserInfo)
+    @objc optional func purchaseFailed(paywall: SwiftPaywall, purchaserInfo: PurchaserInfo?, error: Error, userCancelled: Bool)
+    @objc optional func purchaseRestored(paywall: SwiftPaywall, purchaserInfo: PurchaserInfo?, error: Error?)
 }
 
 class SwiftPaywall: UIViewController {
@@ -48,7 +48,7 @@ class SwiftPaywall: UIViewController {
     
     // Internal variables
     private var scrollView : UIScrollView!
-    private var offering : Purchases.Offering?
+    private var offering : Offering?
     private var offeringCollectionView : UICollectionView!
     private let maxItemsPerRow : CGFloat = 3
     private let aspectRatio : CGFloat = 1.3
@@ -163,7 +163,7 @@ class SwiftPaywall: UIViewController {
         }
         
         setState(loading: true)
-        Purchases.shared.purchasePackage(package) { (trans, info, error, cancelled) in
+        Purchases.shared.purchase(package: package) { (trans, info, error, cancelled) in
 
             self.setState(loading: false)
 
@@ -177,7 +177,7 @@ class SwiftPaywall: UIViewController {
                 }
             } else {
                 if let purchaseCompletedHandler = self.delegate?.purchaseCompleted {
-                    purchaseCompletedHandler(self, trans!, info!)
+                    purchaseCompletedHandler(self, info!)
                 } else {
                     self.close()
                 }
@@ -269,13 +269,13 @@ class SwiftPaywall: UIViewController {
         }
     }
     
-    private func shouldShowDiscount(package: Purchases.Package?) -> (Bool, Purchases.Package?) {
+    private func shouldShowDiscount(package: Package?) -> (Bool, Package?) {
         return (showDiscountPercentage == true
             && mostAffordablePackages.count > 1
             && mostAffordablePackages.first?.product.productIdentifier == package?.product.productIdentifier, mostAffordablePackages.last)
     }
     
-    private var mostAffordablePackages : [Purchases.Package] {
+    private var mostAffordablePackages : [Package] {
         guard let sorted = offering?.availablePackages
             .filter({$0.packageType != .lifetime && $0.packageType != .custom})
             .sorted(by: { $1.annualCost() > $0.annualCost() }) else {
@@ -693,8 +693,8 @@ private class PackageCell : UICollectionViewCell {
     }
     
     func setupWith(
-        package: Purchases.Package?,
-        discount: (Bool, Purchases.Package?),
+        package: Package?,
+        discount: (Bool, Package?),
         edgeStyle: PayWallEdgeStyle = .round,
         productSelectedColor: UIColor? = nil,
         productDeselectedColor: UIColor? = nil) {
@@ -765,7 +765,7 @@ private class PackageCell : UICollectionViewCell {
         }
     }
     
-    func discountBetween(highest: Purchases.Package, current: Purchases.Package) -> NSNumber {
+    func discountBetween(highest: Package, current: Package) -> NSNumber {
         let highestAnnualCost : NSNumber!
         switch highest.packageType {
         case .annual:
@@ -854,7 +854,7 @@ private class PackageCell : UICollectionViewCell {
     }
 }
 
-fileprivate extension Purchases.Package {
+fileprivate extension Package {
     
     func annualCost() -> Double {
         switch self.packageType {

--- a/Examples/LegacySwiftExample/WatchExample Extension/InterfaceController.swift
+++ b/Examples/LegacySwiftExample/WatchExample Extension/InterfaceController.swift
@@ -11,7 +11,7 @@ import Foundation
 import RevenueCat
 
 class InterfaceController: WKInterfaceController {
-    private var offering : Purchases.Offering?
+    private var offering : Offering?
     
     @IBOutlet weak var expiryDateLabel: WKInterfaceLabel!
     @IBOutlet weak var purchaseDateLabel: WKInterfaceLabel!
@@ -51,7 +51,7 @@ private extension InterfaceController {
         let package = offering.availablePackages[0]
         
         proStatusLabel.setText("purchasing...")
-        Purchases.shared.purchasePackage(package) { [weak self] (trans, info, error, cancelled) in
+        Purchases.shared.purchase(package: package) { [weak self] (trans, info, error, cancelled) in
             guard let self = self else { return }
             
             if let error = error {


### PR DESCRIPTION
There were still some references to `Purchases.` in the LegacySwiftExample, this PR updates them.