### PR TITLE
make getOfferings perform serially in RCv3

### DIFF
--- a/Purchases/Networking/RCBackend.m
+++ b/Purchases/Networking/RCBackend.m
@@ -311,7 +311,7 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
     }
 
     [self.httpClient performRequest:@"GET"
-                           serially:NO
+                           serially:YES
                                path:path
                                body:nil
                             headers:self.headers

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -733,6 +733,17 @@ class BackendTests: XCTestCase {
         expect(self.httpClient.calls.count).toNot(equal(0))
         expect(offeringsData).toEventuallyNot(beNil())
     }
+
+    func testGetOfferingsCallsHTTPMethodSerially() {
+        let response = HTTPResponse(statusCode: 200, response: noOfferingsResponse as [String : Any], error: nil)
+        let path = "/subscribers/" + userID + "/offerings"
+        httpClient.mock(requestPath: path, response: response)
+
+        backend?.getOfferingsForAppUserID(userID) { _, _ in }
+
+        expect(self.httpClient.calls.count).to(equal(1))
+        expect(self.httpClient.calls[0].serially).to(beTrue())
+    }
     
     func testGetOfferingsCachesForSameUserID() {
         let response = HTTPResponse(statusCode: 200, response: noOfferingsResponse as [AnyHashable : Any], error: nil)


### PR DESCRIPTION
Same as https://github.com/RevenueCat/purchases-ios/pull/829 for versions 3.x.x of the SDK