### PR TITLE
Cache createAlias and identify calls

### DIFF
--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -63,15 +63,14 @@ class Backend {
             return
         }
 
-        let path = "/subscribers/\(appUserID)/alias"
-        let cacheKey = path + newAppUserID
+        let cacheKey = appUserID + newAppUserID
         if add(createAliasCallback: completion, key: cacheKey) == .addedToExistingInFlightList {
             return
         }
 
         Logger.user(Strings.identity.creating_alias(userA: appUserID, userB: newAppUserID))
         httpClient.performPOSTRequest(serially: true,
-                                      path: path,
+                                      path: "/subscribers/\(appUserID)/alias",
                                       requestBody: ["new_app_user_id": newAppUserID],
                                       headers: authHeaders) { statusCode, response, error in
 
@@ -287,15 +286,14 @@ class Backend {
                newAppUserID: String,
                completion: @escaping IdentifyResponseHandler) {
 
-        let path = "/subscribers/identify"
-        let cacheKey = path + currentAppUserID + newAppUserID
+        let cacheKey = currentAppUserID + newAppUserID
         if add(identifyCallback: completion, key: cacheKey) == .addedToExistingInFlightList {
             return
         }
 
         let requestBody = ["app_user_id": currentAppUserID, "new_app_user_id": newAppUserID]
         httpClient.performPOSTRequest(serially: true,
-                                      path: path,
+                                      path: "/subscribers/identify",
                                       requestBody: requestBody,
                                       headers: authHeaders) { statusCode, response, error in
             for callback in self.getIdentityCallbacksAndClearCache(forKey: cacheKey) {

--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -296,7 +296,7 @@ class Backend {
                                       path: "/subscribers/identify",
                                       requestBody: requestBody,
                                       headers: authHeaders) { statusCode, response, error in
-            for callback in self.getIdentityCallbacksAndClearCache(forKey: cacheKey) {
+            for callback in self.getIdentifyCallbacksAndClearCache(forKey: cacheKey) {
                 self.handleLogin(response: response, statusCode: statusCode, error: error, completion: callback)
             }
         }
@@ -702,7 +702,7 @@ private extension Backend {
         }
     }
 
-    func getIdentityCallbacksAndClearCache(forKey key: String) -> [IdentifyResponseHandler] {
+    func getIdentifyCallbacksAndClearCache(forKey key: String) -> [IdentifyResponseHandler] {
         return callbackQueue.sync { [self] in
             let callbacks = identifyCallbacksCache.removeValue(forKey: key)
             assert(callbacks != nil)

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -1807,7 +1807,6 @@ class BackendTests: XCTestCase {
         expect(receivedError).to(beNil())
     }
 
-
     func testLoginCachesForSameUserIDs() {
         let newAppUserID = "new id"
 
@@ -1869,7 +1868,6 @@ class BackendTests: XCTestCase {
                        newAppUserID: newAppUserID) { _,_,_  in
             completion2Called = true
         }
-
 
         expect(self.httpClient.calls.count).to(equal(1))
         expect(completion1Called).toEventually(beTrue())

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -998,11 +998,17 @@ class BackendTests: XCTestCase {
     }
 
     func testCreateAliasDoesntCacheForDifferentCurrentUserID() {
-        let response = HTTPResponse(statusCode: 200, response: nil, error: nil)
-        httpClient.mock(requestPath: "/subscribers/" + userID + "/alias", response: response)
+        let newAppUserID = "new_alias"
+        let currentAppUserID1 = userID
+        let currentAppUserID2 = userID + "2"
 
-        backend?.createAlias(appUserID: userID, newAppUserID: "new_alias", completion: {_ in })
-        backend?.createAlias(appUserID: "skajfdh", newAppUserID: "new_alias", completion: {_ in })
+        let response = HTTPResponse(statusCode: 200, response: nil, error: nil)
+
+        httpClient.mock(requestPath: "/subscribers/" + currentAppUserID1 + "/alias", response: response)
+        backend?.createAlias(appUserID: currentAppUserID1, newAppUserID: newAppUserID, completion: {_ in })
+
+        httpClient.mock(requestPath: "/subscribers/" + currentAppUserID2 + "/alias", response: response)
+        backend?.createAlias(appUserID: currentAppUserID2, newAppUserID: newAppUserID, completion: {_ in })
 
         expect(self.httpClient.calls.count).to(equal(2))
     }


### PR DESCRIPTION
This is the ios counterpart for https://github.com/RevenueCat/purchases-android/pull/358

This PR prevents the same API calls with the same parameters from being called at the same time.

I made a follow-up ticket (one for android and one for ios) for "genericizing" these kinds of caching functions, since there is as lot of duplicate code, and potentially pulling them out of this class.