### PR TITLE
Use subtraction instead of intersection to find missing product IDs

### DIFF
--- a/Purchases/Purchasing/OfferingsManager.swift
+++ b/Purchases/Purchasing/OfferingsManager.swift
@@ -93,11 +93,10 @@ private extension OfferingsManager {
                 result[product.productIdentifier] = product
             }
 
-            if let createdOfferings = self.offeringsFactory.createOfferings(withProducts: productsByID, data: data) {
-                self.logMissingProductsIfAppropriate(products: productsByID,
-                                                     productIdentifiers: productIdentifiers,
-                                                     offeringsData: data)
+            self.logMissingProductsIfAppropriate(products: productsByID,
+                                                 productIdentifiers: productIdentifiers)
 
+            if let createdOfferings = self.offeringsFactory.createOfferings(withProducts: productsByID, data: data) {
                 self.deviceCache.cache(offerings: createdOfferings)
                 self.dispatchCompletionOnMainThreadIfPossible(completion,
                                                               offerings: createdOfferings,
@@ -130,10 +129,8 @@ private extension OfferingsManager {
     }
 
     func logMissingProductsIfAppropriate(products: [String: SKProduct],
-                                         productIdentifiers: Set<String>,
-                                         offeringsData: [String: Any]) {
-        guard !productIdentifiers.isEmpty,
-              !offeringsData.isEmpty else {
+                                         productIdentifiers: Set<String>) {
+        guard !productIdentifiers.isEmpty else {
             return
         }
 

--- a/Purchases/Purchasing/OfferingsManager.swift
+++ b/Purchases/Purchasing/OfferingsManager.swift
@@ -137,12 +137,11 @@ private extension OfferingsManager {
             return
         }
 
-        var mutableProductIdentifiers = Set(productIdentifiers)
-        mutableProductIdentifiers.subtract(Set(products.keys))
+        let missingProductIdentifiers = productIdentifiers.subtracting(Set(products.keys))
 
-        if !mutableProductIdentifiers.isEmpty {
+        if !missingProductIdentifiers.isEmpty {
             Logger.appleWarning(
-                Strings.offering.cannot_find_product_configuration_error(identifiers: mutableProductIdentifiers))
+                Strings.offering.cannot_find_product_configuration_error(identifiers: missingProductIdentifiers))
         }
     }
 

--- a/Purchases/Purchasing/OfferingsManager.swift
+++ b/Purchases/Purchasing/OfferingsManager.swift
@@ -93,8 +93,8 @@ private extension OfferingsManager {
                 result[product.productIdentifier] = product
             }
 
-            self.logMissingProductsIfAppropriate(products: productsByID,
-                                                 productIdentifiers: productIdentifiers)
+            self.logMissingProductIDsIfAppropriate(productsFromStore: productsByID,
+                                                   productIDsFromRC: productIdentifiers)
 
             if let createdOfferings = self.offeringsFactory.createOfferings(withProducts: productsByID, data: data) {
                 self.deviceCache.cache(offerings: createdOfferings)
@@ -128,13 +128,13 @@ private extension OfferingsManager {
         return Set(productIdenfitiersArray)
     }
 
-    func logMissingProductsIfAppropriate(products: [String: SKProduct],
-                                         productIdentifiers: Set<String>) {
-        guard !productIdentifiers.isEmpty else {
+    func logMissingProductIDsIfAppropriate(productsFromStore: [String: SKProduct],
+                                           productIDsFromRC: Set<String>) {
+        guard !productIDsFromRC.isEmpty else {
             return
         }
 
-        let missingProductIdentifiers = productIdentifiers.subtracting(Set(products.keys))
+        let missingProductIdentifiers = productIDsFromRC.subtracting(productsFromStore.keys)
 
         if !missingProductIdentifiers.isEmpty {
             Logger.appleWarning(

--- a/Purchases/Purchasing/OfferingsManager.swift
+++ b/Purchases/Purchasing/OfferingsManager.swift
@@ -94,7 +94,9 @@ private extension OfferingsManager {
             }
 
             if let createdOfferings = self.offeringsFactory.createOfferings(withProducts: productsByID, data: data) {
-                self.logMissingProductsIfAppropriate(products: productsByID, offeringsData: data)
+                self.logMissingProductsIfAppropriate(products: productsByID,
+                                                     productIdentifiers: productIdentifiers,
+                                                     offeringsData: data)
 
                 self.deviceCache.cache(offerings: createdOfferings)
                 self.dispatchCompletionOnMainThreadIfPossible(completion,
@@ -127,17 +129,20 @@ private extension OfferingsManager {
         return Set(productIdenfitiersArray)
     }
 
-    func logMissingProductsIfAppropriate(products: [String: SKProduct], offeringsData: [String: Any]) {
+    func logMissingProductsIfAppropriate(products: [String: SKProduct],
+                                         productIdentifiers: Set<String>,
+                                         offeringsData: [String: Any]) {
         guard !products.isEmpty,
               !offeringsData.isEmpty else {
             return
         }
 
-        let productIdentifiers = extractProductIdentifiers(fromOfferingsData: offeringsData)
-        let missingProducts = Set(products.keys).intersection(productIdentifiers)
+        var mutableProductIdentifiers = Set(productIdentifiers)
+        mutableProductIdentifiers.subtract(Set(products.keys))
 
-        if !missingProducts.isEmpty {
-            Logger.appleWarning(Strings.offering.cannot_find_product_configuration_error(identifiers: missingProducts))
+        if !mutableProductIdentifiers.isEmpty {
+            Logger.appleWarning(
+                Strings.offering.cannot_find_product_configuration_error(identifiers: mutableProductIdentifiers))
         }
     }
 

--- a/Purchases/Purchasing/OfferingsManager.swift
+++ b/Purchases/Purchasing/OfferingsManager.swift
@@ -132,7 +132,7 @@ private extension OfferingsManager {
     func logMissingProductsIfAppropriate(products: [String: SKProduct],
                                          productIdentifiers: Set<String>,
                                          offeringsData: [String: Any]) {
-        guard !products.isEmpty,
+        guard !productIdentifiers.isEmpty,
               !offeringsData.isEmpty else {
             return
         }

--- a/Purchases/Purchasing/OfferingsManager.swift
+++ b/Purchases/Purchasing/OfferingsManager.swift
@@ -82,12 +82,12 @@ class OfferingsManager {
     }
 
     internal func getMissingProductIDs(productsFromStore: [String: SKProduct],
-                                       productIDsFromRC: Set<String>) -> Set<String> {
-        guard !productIDsFromRC.isEmpty else {
+                                       productIDsFromBackend: Set<String>) -> Set<String> {
+        guard !productIDsFromBackend.isEmpty else {
             return []
         }
 
-        return productIDsFromRC.subtracting(productsFromStore.keys)
+        return productIDsFromBackend.subtracting(productsFromStore.keys)
     }
 
 }
@@ -103,7 +103,7 @@ private extension OfferingsManager {
             }
 
             let missingProductIDs = self.getMissingProductIDs(productsFromStore: productsByID,
-                                                                           productIDsFromRC: productIdentifiers)
+                                                                           productIDsFromBackend: productIdentifiers)
             if !missingProductIDs.isEmpty {
                 Logger.appleWarning(
                     Strings.offering.cannot_find_product_configuration_error(identifiers: missingProductIDs))

--- a/PurchasesTests/Purchasing/OfferingsManagerTests.swift
+++ b/PurchasesTests/Purchasing/OfferingsManagerTests.swift
@@ -149,6 +149,18 @@ extension OfferingsManagerTests {
         expect(self.mockDeviceCache.cacheOfferingsCount).toEventually(equal(expectedCallCount))
     }
 
+    func testGetMissingProductIDs() {
+        let productIDs: Set<String> = ["a", "b", "c"]
+        let skProducts = ["a" : SKProduct(), "b" : SKProduct()]
+
+        expect(self.offeringsManager.getMissingProductIDs(productsFromStore: [:],
+                                                          productIDsFromRC: productIDs)).to(equal(productIDs))
+        expect(self.offeringsManager.getMissingProductIDs(productsFromStore: skProducts,
+                                                          productIDsFromRC: [])).to(equal([]))
+        expect(self.offeringsManager.getMissingProductIDs(productsFromStore: skProducts,
+                                                          productIDsFromRC:productIDs)).to(equal(["c"]))
+    }
+
 }
 
 private extension OfferingsManagerTests {

--- a/PurchasesTests/Purchasing/OfferingsManagerTests.swift
+++ b/PurchasesTests/Purchasing/OfferingsManagerTests.swift
@@ -154,11 +154,11 @@ extension OfferingsManagerTests {
         let skProducts = ["a" : SKProduct(), "b" : SKProduct()]
 
         expect(self.offeringsManager.getMissingProductIDs(productsFromStore: [:],
-                                                          productIDsFromRC: productIDs)).to(equal(productIDs))
+                                                          productIDsFromBackend: productIDs)).to(equal(productIDs))
         expect(self.offeringsManager.getMissingProductIDs(productsFromStore: skProducts,
-                                                          productIDsFromRC: [])).to(equal([]))
+                                                          productIDsFromBackend: [])).to(equal([]))
         expect(self.offeringsManager.getMissingProductIDs(productsFromStore: skProducts,
-                                                          productIDsFromRC:productIDs)).to(equal(["c"]))
+                                                          productIDsFromBackend:productIDs)).to(equal(["c"]))
     }
 
 }


### PR DESCRIPTION
Thanks to our beta community, we've found a bug around our logging of missing product identifiers. This log is intended to inform developers of product IDs created in RevenueCat that are not found in the Apple Store.

We had a regression in our logic for determining which IDs were missing -- using the intersection of RC/ASC products rather than the difference. 

Also includes:
* optimization to re-use extracted product IDs
* minor bug fix - checking the wrong empty list for an early return