### PR TITLE
clean up naming convention for optionals

### DIFF
--- a/SwiftStyleGuide.swift
+++ b/SwiftStyleGuide.swift
@@ -47,9 +47,14 @@ struct MyStruct {
     // public properties, then internal, then private.
     /// mercury is used for ...
     public let mercury = false
+    // don't use `maybe` for public properties, since it might be confusing to developers
+    // unfamiliar with our naming convention
+    /// maybeVenus is used for ...
+    public var saturn: String?
+
     // use `maybe` prefix for optionals
     /// maybeVenus is used for ...
-    public var maybeVenus: String?
+    internal var maybeVenus: String?
 
     /// eath is used for ...
     public static var Earth = "earth"


### PR DESCRIPTION
Updated the naming convention for optionals in `SwiftStyleGuide`, so that `public` properties don't use the `maybe` prefix. 

Open for discussion, though!! Would love to know what others think