### PR TITLE
Hotfix to cache createAlias and identify

### DIFF
--- a/Purchases/Networking/RCBackend.h
+++ b/Purchases/Networking/RCBackend.h
@@ -37,6 +37,12 @@ typedef void(^RCOfferSigningResponseHandler)(NSString * _Nullable signature,
                                              NSNumber * _Nullable timestamp,
                                              NSError * _Nullable error);
 
+typedef void(^PostRequestResponseHandler)(NSError * _Nullable error);
+
+typedef void(^IdentifyResponseHandler)(RCPurchaserInfo * _Nullable purchaserInfo,
+                                       BOOL created,
+                                       NSError * _Nullable error);
+
 @interface RCBackend : NSObject
 
 - (nullable instancetype)initWithAPIKey:(NSString *)APIKey

--- a/Purchases/Networking/RCBackend.m
+++ b/Purchases/Networking/RCBackend.m
@@ -109,7 +109,6 @@ NSString *const RCAttributeErrorsResponseKey = @"attributes_error_response";
     if (completion == nil || [completion isKindOfClass:NSNull.class]) return;
 
     if (error != nil) {
-        // TODO check completion nil?
         completion([RCPurchasesErrorUtils networkErrorWithUnderlyingError:error]);
         return;
     }
@@ -344,7 +343,7 @@ presentedOfferingIdentifier:(nullable NSString *)offeringIdentifier
 - (void)postAttributionData:(NSDictionary *)data
                 fromNetwork:(RCAttributionNetwork)network
                forAppUserID:(NSString *)appUserID
-                 completion:(nullable void (^)(NSError * _Nullable error))completion {
+                 completion:(nullable PostRequestResponseHandler)completion {
     NSString *escapedAppUserID = [self escapedAppUserID:appUserID];
     NSString *path = [NSString stringWithFormat:@"/subscribers/%@/attribution", escapedAppUserID];
 

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -1574,8 +1574,8 @@ class BackendTests: XCTestCase {
         }
 
         expect(self.httpClient.calls.count).to(equal(1))
-//        expect(completion1Called).toEventually(beTrue())
-//        expect(completion2Called).toEventually(beTrue())
+        expect(completion1Called).toEventually(beTrue())
+        expect(completion2Called).toEventually(beTrue())
     }
 
     func testLoginPassesNetworkErrorIfCouldntCommunicate() {

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -878,6 +878,72 @@ class BackendTests: XCTestCase {
         expect(completionCalled).toEventually(beTrue())
     }
 
+    func testCreateAliasCachesForSameUserIDs() {
+        let response = HTTPResponse(statusCode: 200, response: nil, error: nil)
+        httpClient.mock(requestPath: "/subscribers/" + userID + "/alias", response: response)
+
+        backend?.createAlias(forAppUserID: userID, withNewAppUserID: "new_alias", completion: {_ in })
+        backend?.createAlias(forAppUserID: userID, withNewAppUserID: "new_alias", completion: {_ in })
+
+        expect(self.httpClient.calls.count).to(equal(1))
+    }
+
+    func testCreateAliasDoesntCacheForDifferentNewUserID() {
+        let response = HTTPResponse(statusCode: 200, response: nil, error: nil)
+        httpClient.mock(requestPath: "/subscribers/" + userID + "/alias", response: response)
+
+        backend?.createAlias(forAppUserID: userID, withNewAppUserID: "new_alias", completion: {_ in })
+        backend?.createAlias(forAppUserID: userID, withNewAppUserID: "another_new_alias", completion: {_ in })
+
+        expect(self.httpClient.calls.count).to(equal(2))
+    }
+
+    func testCreateAliasCachesWhenCallbackNil() {
+        let response = HTTPResponse(statusCode: 200, response: nil, error: nil)
+        httpClient.mock(requestPath: "/subscribers/" + userID + "/alias", response: response)
+
+        backend?.createAlias(forAppUserID: userID, withNewAppUserID: "new_alias", completion: nil)
+        backend?.createAlias(forAppUserID: userID, withNewAppUserID: "new_alias", completion: { _ in })
+
+        expect(self.httpClient.calls.count).to(equal(1))
+    }
+
+    func testCreateAliasCallsAllCompletionBlocksInCache() {
+        let response = HTTPResponse(statusCode: 200, response: nil, error: nil)
+        httpClient.mock(requestPath: "/subscribers/" + userID + "/alias", response: response)
+
+        var completion1Called = false
+        var completion2Called = false
+
+        backend?.createAlias(forAppUserID: userID, withNewAppUserID: "new_alias", completion: nil)
+        backend?.createAlias(forAppUserID: userID, withNewAppUserID: "new_alias", completion: { (error) in
+            completion1Called = true
+        })
+        backend?.createAlias(forAppUserID: userID, withNewAppUserID: "new_alias", completion: { (error) in
+            completion2Called = true
+        })
+
+        expect(self.httpClient.calls.count).to(equal(1))
+        expect(completion1Called).toEventually(beTrue())
+        expect(completion2Called).toEventually(beTrue())
+    }
+
+    func testCreateAliasDoesntCacheForDifferentCurrentUserID() {
+        let newAppUserID = "new_alias"
+        let currentAppUserID1 = userID
+        let currentAppUserID2 = userID + "2"
+
+        let response = HTTPResponse(statusCode: 200, response: nil, error: nil)
+
+        httpClient.mock(requestPath: "/subscribers/" + currentAppUserID1 + "/alias", response: response)
+        backend?.createAlias(forAppUserID: currentAppUserID1, withNewAppUserID: newAppUserID, completion: {_ in })
+
+        httpClient.mock(requestPath: "/subscribers/" + currentAppUserID2 + "/alias", response: response)
+        backend?.createAlias(forAppUserID: currentAppUserID2, withNewAppUserID: newAppUserID, completion: {_ in })
+
+        expect(self.httpClient.calls.count).to(equal(2))
+    }
+
     func testNetworkErrorIsForwardedForPurchaserInfoCalls() {
         let response = HTTPResponse(statusCode: 200, response: nil, error: NSError(domain: NSURLErrorDomain, code: -1009))
         httpClient.mock(requestPath: "/receipts", response: response)
@@ -1443,6 +1509,73 @@ class BackendTests: XCTestCase {
         expect(receivedCall.body as? [String: String]) == ["new_app_user_id": newAppUserID,
                                                            "app_user_id": currentAppUserID]
         expect(receivedCall.headers) == ["Authorization": "Bearer asharedsecret"]
+    }
+
+    func testLoginCachesForSameUserIDs() {
+        let newAppUserID = "new id"
+
+        let currentAppUserID = "old id"
+        let _ = mockLoginRequest(appUserID: currentAppUserID, statusCode: 201, response: mockPurchaserInfoDict)
+
+        backend?.logIn(withCurrentAppUserID: currentAppUserID,
+                       newAppUserID: newAppUserID) { _,_,_  in }
+        backend?.logIn(withCurrentAppUserID: currentAppUserID,
+                       newAppUserID: newAppUserID) { _,_,_  in }
+
+        expect(self.httpClient.calls.count).to(equal(1))
+    }
+
+    func testLoginDoesntCacheForDifferentNewUserID() {
+        let newAppUserID = "new id"
+        let secondNewAppUserID = "new id 2"
+
+        let currentAppUserID = "old id"
+        let _ = mockLoginRequest(appUserID: currentAppUserID, statusCode: 201, response: mockPurchaserInfoDict)
+
+        backend?.logIn(withCurrentAppUserID: currentAppUserID,
+                       newAppUserID: newAppUserID) { _,_,_  in }
+        backend?.logIn(withCurrentAppUserID: currentAppUserID,
+                       newAppUserID: secondNewAppUserID) { _,_,_  in }
+
+        expect(self.httpClient.calls.count).to(equal(2))
+    }
+
+    func testLoginDoesntCacheForDifferentCurrentUserID() {
+        let newAppUserID = "new id"
+
+        let currentAppUserID = "old id"
+        let currentAppUserID2 = "old id 2"
+        let _ = mockLoginRequest(appUserID: currentAppUserID, statusCode: 201, response: mockPurchaserInfoDict)
+
+        backend?.logIn(withCurrentAppUserID: currentAppUserID,
+                       newAppUserID: newAppUserID) { _,_,_  in }
+        backend?.logIn(withCurrentAppUserID: currentAppUserID2,
+                       newAppUserID: newAppUserID) { _,_,_  in }
+
+        expect(self.httpClient.calls.count).to(equal(2))
+    }
+
+    func testLoginCallsAllCompletionBlocksInCache() {
+        let newAppUserID = "new id"
+
+        let currentAppUserID = "old id"
+        let _ = mockLoginRequest(appUserID: currentAppUserID, statusCode: 201, response: mockPurchaserInfoDict)
+
+        var completion1Called = false
+        var completion2Called = false
+
+        backend?.logIn(withCurrentAppUserID: currentAppUserID,
+                       newAppUserID: newAppUserID) { _,_,_  in
+            completion1Called = true
+        }
+        backend?.logIn(withCurrentAppUserID: currentAppUserID,
+                       newAppUserID: newAppUserID) { _,_,_  in
+            completion2Called = true
+        }
+
+        expect(self.httpClient.calls.count).to(equal(1))
+//        expect(completion1Called).toEventually(beTrue())
+//        expect(completion2Called).toEventually(beTrue())
     }
 
     func testLoginPassesNetworkErrorIfCouldntCommunicate() {


### PR DESCRIPTION
This is the hotfix equivalent for https://github.com/RevenueCat/purchases-ios/pull/867

I just made the release/3.12.5 branch off of the 3.12.4 tag...but still have to see how we will do a hotfix release?


