### PR TITLE
fixed name of reserved attribute `$airshipChannelId`

### DIFF
--- a/Purchases/SubscriberAttributes/ReservedSubscriberAttributes.swift
+++ b/Purchases/SubscriberAttributes/ReservedSubscriberAttributes.swift
@@ -35,7 +35,7 @@ enum ReservedSubscriberAttribute: String {
     case fBAnonID = "$fbAnonId"
     case mpParticleID = "$mparticleId"
     case oneSignalID = "$onesignalId"
-    case airshipChannelID = "$airshipChannelID"
+    case airshipChannelID = "$airshipChannelId"
 
     case mediaSource = "$mediaSource"
     case campaign = "$campaign"

--- a/PurchasesTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -926,7 +926,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
         let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
         let receivedAttribute = invokedParams.attribute
 
-        expect(receivedAttribute.key) == "$airshipChannelID"
+        expect(receivedAttribute.key) == "$airshipChannelId"
         expect(receivedAttribute.value) == airshipChannelID
         expect(receivedAttribute.isSynced) == false
     }
@@ -942,7 +942,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
         let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
         let receivedAttribute = invokedParams.attribute
 
-        expect(receivedAttribute.key) == "$airshipChannelID"
+        expect(receivedAttribute.key) == "$airshipChannelId"
         expect(receivedAttribute.value) == ""
         expect(receivedAttribute.isSynced) == false
     }
@@ -950,7 +950,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
     func testSetAirshipChannelIDSkipsIfSameValue() {
         let airshipChannelID = "airshipChannelID"
 
-        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$airshipChannelID",
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$airshipChannelId",
                                                                                     value: airshipChannelID)
         self.subscriberAttributesManager.setAirshipChannelID(airshipChannelID, appUserID: "kratos")
 
@@ -961,7 +961,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
         let oldSyncTime = Date()
         let airshipChannelID = "airshipChannelID"
 
-        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$airshipChannelID",
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$airshipChannelId",
                                                                                     value: "old_id",
                                                                                     isSynced: true,
                                                                                     setTime: oldSyncTime)
@@ -973,7 +973,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
         let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
         let receivedAttribute = invokedParams.attribute
 
-        expect(receivedAttribute.key) == "$airshipChannelID"
+        expect(receivedAttribute.key) == "$airshipChannelId"
         expect(receivedAttribute.value) == airshipChannelID
         expect(receivedAttribute.isSynced) == false
         expect(receivedAttribute.setTime) > oldSyncTime


### PR DESCRIPTION
The name of the reserved attribute for AirshipChannelID was wrong, so this updates it. 

| Before | After |
| :-: | :-: |
| `$airshipChannelID` | `$airshipChannelId` |