### PR TITLE
Fix: offerings completion not called in some cases

### DIFF
--- a/Purchases/Logging/Strings/OfferingStrings.swift
+++ b/Purchases/Logging/Strings/OfferingStrings.swift
@@ -36,6 +36,7 @@ enum OfferingStrings {
     case completion_handlers_waiting_on_products(handlersCount: Int)
     case configuration_error_skproducts_not_found
     case configuration_error_no_products_for_offering
+    case offering_empty(offeringIdentifier: String)
 
 }
 
@@ -107,6 +108,13 @@ extension OfferingStrings: CustomStringConvertible {
         case .configuration_error_no_products_for_offering:
             return "Three's a problem with your configuration. There are no products registered in the RevenueCat " +
             "dashboard for your offerings. To configure products, follow the instructions in " +
+            "https://rev.cat/how-to-configure-offerings. \nMore information: https://rev.cat/why-are-offerings-empty"
+
+        case .offering_empty(let offeringIdentifier):
+            return "Three's a problem with your configuration. No packages could be found for offering with  " +
+            "identifier \(offeringIdentifier). This could be due to Products not being configured correctly in the " +
+            "RevenueCat dashboard, App Store Connect (or the StoreKit Configuration file " +
+            "if one is being used). \nTo configure products, follow the instructions in " +
             "https://rev.cat/how-to-configure-offerings. \nMore information: https://rev.cat/why-are-offerings-empty"
 
         }

--- a/Purchases/Logging/Strings/OfferingStrings.swift
+++ b/Purchases/Logging/Strings/OfferingStrings.swift
@@ -101,17 +101,17 @@ extension OfferingStrings: CustomStringConvertible {
             return "\(handlersCount) completion handlers waiting on products"
 
         case .configuration_error_skproducts_not_found:
-            return "Three's a problem with your configuration. None of the products registered in the RevenueCat " +
+            return "There's a problem with your configuration. None of the products registered in the RevenueCat " +
             "dashboard could be fetched from App Store Connect (or the StoreKit Configuration file " +
             "if one is being used). \nMore information: https://rev.cat/why-are-offerings-empty"
 
         case .configuration_error_no_products_for_offering:
-            return "Three's a problem with your configuration. There are no products registered in the RevenueCat " +
+            return "There's a problem with your configuration. There are no products registered in the RevenueCat " +
             "dashboard for your offerings. To configure products, follow the instructions in " +
             "https://rev.cat/how-to-configure-offerings. \nMore information: https://rev.cat/why-are-offerings-empty"
 
         case .offering_empty(let offeringIdentifier):
-            return "Three's a problem with your configuration. No packages could be found for offering with  " +
+            return "There's a problem with your configuration. No packages could be found for offering with  " +
             "identifier \(offeringIdentifier). This could be due to Products not being configured correctly in the " +
             "RevenueCat dashboard, App Store Connect (or the StoreKit Configuration file " +
             "if one is being used). \nTo configure products, follow the instructions in " +

--- a/Purchases/Logging/Strings/OfferingStrings.swift
+++ b/Purchases/Logging/Strings/OfferingStrings.swift
@@ -106,7 +106,7 @@ extension OfferingStrings: CustomStringConvertible {
 
         case .configuration_error_no_products_for_offering:
             return "Three's a problem with your configuration. There are no products registered in the RevenueCat " +
-            "dashboard for this offering. To configure products, follow the instructions in " +
+            "dashboard for your offerings. To configure products, follow the instructions in " +
             "https://rev.cat/how-to-configure-offerings. \nMore information: https://rev.cat/why-are-offerings-empty"
 
         }

--- a/Purchases/Logging/Strings/OfferingStrings.swift
+++ b/Purchases/Logging/Strings/OfferingStrings.swift
@@ -34,6 +34,8 @@ enum OfferingStrings {
     case fetching_products_finished
     case fetching_products(identifiers: Set<String>)
     case completion_handlers_waiting_on_products(handlersCount: Int)
+    case configuration_error_skproducts_not_found
+    case configuration_error_no_products_for_offering
 
 }
 
@@ -96,6 +98,16 @@ extension OfferingStrings: CustomStringConvertible {
 
         case .completion_handlers_waiting_on_products(let handlersCount):
             return "\(handlersCount) completion handlers waiting on products"
+
+        case .configuration_error_skproducts_not_found:
+            return "Three's a problem with your configuration. None of the products registered in the RevenueCat " +
+            "dashboard could be fetched from App Store Connect (or the StoreKit Configuration file " +
+            "if one is being used). \nMore information: https://rev.cat/why-are-offerings-empty"
+
+        case .configuration_error_no_products_for_offering:
+            return "Three's a problem with your configuration. There are no products registered in the RevenueCat " +
+            "dashboard for this offering. To configure products, follow the instructions in " +
+            "https://rev.cat/how-to-configure-offerings. \nMore information: https://rev.cat/why-are-offerings-empty"
 
         }
     }

--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -315,24 +315,24 @@ class Backend {
 
         httpClient.performGETRequest(serially: true,
                                      path: path,
-                                     headers: authHeaders) { [weak self] (statusCode, response, error) in
+                                     headers: authHeaders) { [weak self] (statusCode, maybeResponse, maybeError) in
             guard let self = self else {
                 return
             }
 
-            if error == nil && statusCode < HTTPStatusCodes.redirect.rawValue {
+            if maybeError == nil && statusCode < HTTPStatusCodes.redirect.rawValue {
                 for callback in self.getOfferingsCallbacksAndClearCache(forKey: path) {
-                    callback(response, nil)
+                    callback(maybeResponse, nil)
                 }
                 return
             }
 
             let errorForCallbacks: Error
-            if let error = error {
+            if let error = maybeError {
                 errorForCallbacks = ErrorUtils.networkError(withUnderlyingError: error)
             } else if statusCode > HTTPStatusCodes.redirect.rawValue {
-                let backendCode = self.maybeNumberFromError(code: response?["code"])
-                let backendMessage = response?["message"] as? String
+                let backendCode = self.maybeNumberFromError(code: maybeResponse?["code"])
+                let backendMessage = maybeResponse?["message"] as? String
                 errorForCallbacks = ErrorUtils.backendError(withBackendCode: backendCode as NSNumber?,
                                                             backendMessage: backendMessage)
             } else {

--- a/Purchases/Public/Error Handling/ErrorUtils.swift
+++ b/Purchases/Public/Error Handling/ErrorUtils.swift
@@ -179,8 +179,8 @@ import StoreKit
      * - Note: This error is used when the configuration in App Store Connect doesn't match the configuration
      * in the RevenueCat dashboard.
      */
-    @objc public static func configurationError() -> Error {
-        return error(with: ErrorCode.configurationError)
+    @objc public static func configurationError(message: String? = nil) -> Error {
+        return error(with: ErrorCode.configurationError, message: message)
     }
 
     /**

--- a/Purchases/Public/Error Handling/ErrorUtils.swift
+++ b/Purchases/Public/Error Handling/ErrorUtils.swift
@@ -174,6 +174,16 @@ import StoreKit
     }
 
     /**
+     * Constructs an Error with the ``ErrorCode/configurationError`` code.
+     *
+     * - Note: This error is used when the configuration in App Store Connect doesn't match the configuration
+     * in the RevenueCat dashboard.
+     */
+    @objc public static func configurationError() -> Error {
+        return error(with: ErrorCode.configurationError)
+    }
+
+    /**
      * Maps an `SKError` to a Error with a ``ErrorCode``. Adds a underlying error in the `NSError.userInfo` dictionary.
      *
      * - Parameter skError: The originating `SKError`.

--- a/Purchases/Purchasing/OfferingsFactory.swift
+++ b/Purchases/Purchasing/OfferingsFactory.swift
@@ -27,6 +27,9 @@ class OfferingsFactory {
             var dict = dict
             if let offering = createOffering(withProducts: products, offeringData: offeringData) {
                 dict[offering.identifier] = offering
+                if offering.availablePackages.isEmpty {
+                    Logger.warn(Strings.offering.offering_empty(offeringIdentifier: offering.identifier))
+                }
             }
             return dict
         }

--- a/Purchases/Purchasing/OfferingsFactory.swift
+++ b/Purchases/Purchasing/OfferingsFactory.swift
@@ -30,6 +30,11 @@ class OfferingsFactory {
             }
             return dict
         }
+
+        guard !offerings.isEmpty else {
+            return nil
+        }
+
         let currentOfferingID = data["current_offering_id"] as? String
 
         return Offerings(offerings: offerings, currentOfferingID: currentOfferingID)

--- a/Purchases/Purchasing/OfferingsManager.swift
+++ b/Purchases/Purchasing/OfferingsManager.swift
@@ -103,10 +103,15 @@ private extension OfferingsManager {
             }
 
             let missingProductIDs = self.getMissingProductIDs(productsFromStore: productsByID,
-                                                                           productIDsFromBackend: productIdentifiers)
+                                                              productIDsFromBackend: productIdentifiers)
             if !missingProductIDs.isEmpty {
                 Logger.appleWarning(
                     Strings.offering.cannot_find_product_configuration_error(identifiers: missingProductIDs))
+            }
+
+            guard !products.isEmpty else {
+                self.handleOfferingsUpdateError(ErrorUtils.configurationError(), completion: completion)
+                return
             }
 
             if let createdOfferings = self.offeringsFactory.createOfferings(withProducts: productsByID, data: data) {

--- a/Purchases/Purchasing/OfferingsManager.swift
+++ b/Purchases/Purchasing/OfferingsManager.swift
@@ -99,7 +99,9 @@ private extension OfferingsManager {
     func handleOfferingsBackendResult(with data: [String: Any], completion: ((Offerings?, Error?) -> Void)?) {
         let productIdentifiers = extractProductIdentifiers(fromOfferingsData: data)
         guard !productIdentifiers.isEmpty else {
-            self.handleOfferingsUpdateError(ErrorUtils.configurationError(), completion: completion)
+            let errorMessage = Strings.offering.configuration_error_no_products_for_offering.description
+            self.handleOfferingsUpdateError(ErrorUtils.configurationError(message: errorMessage),
+                                            completion: completion)
             return
         }
 
@@ -116,7 +118,9 @@ private extension OfferingsManager {
             }
 
             guard !products.isEmpty else {
-                self.handleOfferingsUpdateError(ErrorUtils.configurationError(), completion: completion)
+                let errorMessage = Strings.offering.configuration_error_skproducts_not_found.description
+                self.handleOfferingsUpdateError(ErrorUtils.configurationError(message: errorMessage),
+                                                completion: completion)
                 return
             }
 

--- a/Purchases/Purchasing/OfferingsManager.swift
+++ b/Purchases/Purchasing/OfferingsManager.swift
@@ -74,9 +74,11 @@ class OfferingsManager {
             self.backend.getOfferings(appUserID: appUserID) { maybeData, maybeError in
                 if let data = maybeData {
                     self.handleOfferingsBackendResult(with: data, completion: completion)
-                } else if let error = maybeError {
-                    self.handleOfferingsUpdateError(error, completion: completion)
+                    return
                 }
+
+                let error = maybeError ?? ErrorUtils.unexpectedBackendResponseError()
+                self.handleOfferingsUpdateError(error, completion: completion)
             }
         }
     }

--- a/Purchases/Purchasing/OfferingsManager.swift
+++ b/Purchases/Purchasing/OfferingsManager.swift
@@ -96,6 +96,10 @@ private extension OfferingsManager {
 
     func handleOfferingsBackendResult(with data: [String: Any], completion: ((Offerings?, Error?) -> Void)?) {
         let productIdentifiers = extractProductIdentifiers(fromOfferingsData: data)
+        guard !productIdentifiers.isEmpty else {
+            self.handleOfferingsUpdateError(ErrorUtils.configurationError(), completion: completion)
+            return
+        }
 
         productsManager.products(withIdentifiers: productIdentifiers) { products in
             let productsByID = products.reduce(into: [:]) { result, product in

--- a/Purchases/Purchasing/OfferingsManager.swift
+++ b/Purchases/Purchasing/OfferingsManager.swift
@@ -106,6 +106,13 @@ private extension OfferingsManager {
         }
 
         productsManager.products(withIdentifiers: productIdentifiers) { products in
+            guard !products.isEmpty else {
+                let errorMessage = Strings.offering.configuration_error_skproducts_not_found.description
+                self.handleOfferingsUpdateError(ErrorUtils.configurationError(message: errorMessage),
+                                                completion: completion)
+                return
+            }
+
             let productsByID = products.reduce(into: [:]) { result, product in
                 result[product.productIdentifier] = product
             }
@@ -115,13 +122,6 @@ private extension OfferingsManager {
             if !missingProductIDs.isEmpty {
                 Logger.appleWarning(
                     Strings.offering.cannot_find_product_configuration_error(identifiers: missingProductIDs))
-            }
-
-            guard !products.isEmpty else {
-                let errorMessage = Strings.offering.configuration_error_skproducts_not_found.description
-                self.handleOfferingsUpdateError(ErrorUtils.configurationError(message: errorMessage),
-                                                completion: completion)
-                return
             }
 
             if let createdOfferings = self.offeringsFactory.createOfferings(withProducts: productsByID, data: data) {

--- a/PurchasesTests/Mocks/MockOfferingsFactory.swift
+++ b/PurchasesTests/Mocks/MockOfferingsFactory.swift
@@ -8,14 +8,14 @@ import StoreKit
 class MockOfferingsFactory: OfferingsFactory {
 
     var emptyOfferings = false
-    var badOfferings = false
+    var nilOfferings = false
 
     override func createOfferings(withProducts products: [String: SKProduct],
                                   data: [String: Any]) -> Offerings? {
         if (emptyOfferings) {
             return Offerings(offerings: [:], currentOfferingID: "base")
         }
-        if (badOfferings) {
+        if (nilOfferings) {
             return nil
         }
         return Offerings(

--- a/PurchasesTests/Purchasing/OfferingsManagerTests.swift
+++ b/PurchasesTests/Purchasing/OfferingsManagerTests.swift
@@ -100,6 +100,28 @@ extension OfferingsManagerTests {
         expect(obtainedOfferings).to(beNil())
     }
 
+    func testOfferingsForAppUserIDReturnsConfigurationErrorIfBackendReturnsEmpty() throws {
+        // given
+        mockBackend.stubbedGetOfferingsCompletionResult = ([:], nil)
+        mockOfferingsFactory.emptyOfferings = true
+
+        // when
+        var obtainedOfferings: Offerings?
+        var completionCalled = false
+        var obtainedError: Error?
+        offeringsManager.offerings(appUserID: MockData.anyAppUserID) { maybeOfferings, maybeError in
+            obtainedOfferings = maybeOfferings
+            completionCalled = true
+            obtainedError = maybeError
+        }
+
+        // then
+        expect(completionCalled).toEventually(beTrue())
+        expect(obtainedOfferings).to(beNil())
+        let error = try XCTUnwrap(obtainedError)
+        expect((error as NSError).code) == (ErrorUtils.configurationError() as NSError).code
+    }
+
     func testOfferingsForAppUserIDReturnsNilIfBackendReturnsNilDataAndNilOfferings() {
         // given
         mockBackend.stubbedGetOfferingsCompletionResult = (nil, nil)
@@ -117,7 +139,6 @@ extension OfferingsManagerTests {
         expect(completionCalled).toEventually(beTrue())
         expect(obtainedOfferings).to(beNil())
     }
-
 
     func testOfferingsForAppUserIDReturnsUnexpectedBackendErrorIfBadBackendRequest() {
         // given

--- a/PurchasesTests/Purchasing/OfferingsManagerTests.swift
+++ b/PurchasesTests/Purchasing/OfferingsManagerTests.swift
@@ -100,6 +100,25 @@ extension OfferingsManagerTests {
         expect(obtainedOfferings).to(beNil())
     }
 
+    func testOfferingsForAppUserIDReturnsNilIfBackendReturnsNilDataAndNilOfferings() {
+        // given
+        mockBackend.stubbedGetOfferingsCompletionResult = (nil, nil)
+        mockOfferingsFactory.emptyOfferings = true
+
+        // when
+        var obtainedOfferings: Offerings?
+        var completionCalled = false
+        offeringsManager.offerings(appUserID: MockData.anyAppUserID) { offerings, _ in
+            obtainedOfferings = offerings
+            completionCalled = true
+        }
+
+        // then
+        expect(completionCalled).toEventually(beTrue())
+        expect(obtainedOfferings).to(beNil())
+    }
+
+
     func testOfferingsForAppUserIDReturnsUnexpectedBackendErrorIfBadBackendRequest() {
         // given
         mockBackend.stubbedGetOfferingsCompletionResult = (nil, MockData.unexpectedBackendResponseError)

--- a/PurchasesTests/Purchasing/OfferingsManagerTests.swift
+++ b/PurchasesTests/Purchasing/OfferingsManagerTests.swift
@@ -43,43 +43,43 @@ class OfferingsManagerTests: XCTestCase {
 
 extension OfferingsManagerTests {
 
-    func testOfferingsForAppUserIDReturnsNilIfMissingProductDetails() {
+    func testOfferingsForAppUserIDReturnsNilIfMissingProductDetails() throws {
         // given
         mockOfferingsFactory.emptyOfferings = true
         mockBackend.stubbedGetOfferingsCompletionResult = (MockData.anyBackendOfferingsData, nil)
 
         // when
-        var obtainedOfferings: Offerings?
+        var maybeObtainedOfferings: Offerings?
         var completionCalled = false
         offeringsManager.offerings(appUserID: MockData.anyAppUserID) { offerings, _ in
-            obtainedOfferings = offerings
+            maybeObtainedOfferings = offerings
             completionCalled = true
         }
 
         // then
         expect(completionCalled).toEventually(beTrue())
-        expect(obtainedOfferings).toNot(beNil())
-        expect(obtainedOfferings!["base"]).to(beNil())
+        let obtainedOfferings = try XCTUnwrap(maybeObtainedOfferings)
+        expect(obtainedOfferings["base"]).to(beNil())
     }
 
-    func testOfferingsForAppUserIDReturnsOfferingsIfSuccessBackendRequest() {
+    func testOfferingsForAppUserIDReturnsOfferingsIfSuccessBackendRequest() throws {
         // given
         mockBackend.stubbedGetOfferingsCompletionResult = (MockData.anyBackendOfferingsData, nil)
 
         // when
-        var obtainedOfferings: Offerings?
+        var maybeObtainedOfferings: Offerings?
         var completionCalled = false
         offeringsManager.offerings(appUserID: MockData.anyAppUserID) { offerings, _ in
-            obtainedOfferings = offerings
+            maybeObtainedOfferings = offerings
             completionCalled = true
         }
 
         // then
         expect(completionCalled).toEventually(beTrue())
-        expect(obtainedOfferings).toNot(beNil())
-        expect(obtainedOfferings!["base"]).toNot(beNil())
-        expect(obtainedOfferings!["base"]!.monthly).toNot(beNil())
-        expect(obtainedOfferings!["base"]!.monthly?.product).toNot(beNil())
+        let obtainedOfferings = try XCTUnwrap(maybeObtainedOfferings)
+        expect(obtainedOfferings["base"]).toNot(beNil())
+        expect(obtainedOfferings["base"]!.monthly).toNot(beNil())
+        expect(obtainedOfferings["base"]!.monthly?.product).toNot(beNil())
     }
 
     func testOfferingsForAppUserIDReturnsNilIfFailBackendRequest() {
@@ -190,24 +190,24 @@ extension OfferingsManagerTests {
         expect((obtainedError as NSError).code) == ErrorCode.unexpectedBackendResponseError.rawValue
     }
 
-    func testOfferingsForAppUserIDReturnsUnexpectedBackendErrorIfBadBackendRequest() {
+    func testOfferingsForAppUserIDReturnsUnexpectedBackendErrorIfBadBackendRequest() throws {
         // given
         mockBackend.stubbedGetOfferingsCompletionResult = (nil, MockData.unexpectedBackendResponseError)
         mockOfferingsFactory.nilOfferings = true
 
         // when
-        var receivedError: NSError?
+        var maybeReceivedError: NSError?
         var completionCalled = false
         offeringsManager.offerings(appUserID: MockData.anyAppUserID) { _, error in
-            receivedError = error as NSError?
+            maybeReceivedError = error as NSError?
             completionCalled = true
         }
 
         // then
         expect(completionCalled).toEventually(beTrue())
-        expect(receivedError).toNot(beNil())
-        expect(receivedError?.domain).to(equal(RCPurchasesErrorCodeDomain))
-        expect(receivedError?.code).to(be(ErrorCode.unexpectedBackendResponseError.rawValue))
+        let receivedError = try XCTUnwrap(maybeReceivedError)
+        expect(receivedError.domain).to(equal(RCPurchasesErrorCodeDomain))
+        expect(receivedError.code).to(be(ErrorCode.unexpectedBackendResponseError.rawValue))
     }
 
     func testFailBackendDeviceCacheClearsOfferingsCache() {

--- a/PurchasesTests/Purchasing/OfferingsTests.swift
+++ b/PurchasesTests/Purchasing/OfferingsTests.swift
@@ -89,7 +89,7 @@ class OfferingsTests: XCTestCase {
         expect(offering?.sixMonth).to(beNil())
     }
 
-    func testListOfOfferingsIsEmptyIfNoValidOffering() {
+    func testListOfOfferingsIsNilIfNoValidOffering() {
         let offerings = offeringsFactory.createOfferings(withProducts: [:], data: [
             "offerings": [
                 [
@@ -112,10 +112,7 @@ class OfferingsTests: XCTestCase {
             "current_offering_id": "offering_a"
         ])
 
-        expect(offerings).toNot(beNil())
-        expect(offerings?.current).to(beNil())
-        expect(offerings?["offering_a"]).to(beNil())
-        expect(offerings?["offering_b"]).to(beNil())
+        expect(offerings).to(beNil())
     }
 
     func testOfferingsIsCreated() {
@@ -187,26 +184,38 @@ class OfferingsTests: XCTestCase {
         testPackageType(packageType: PackageType.unknown)
     }
 
-    func testNoOfferings() {
+    func testOfferingsIsNilIfNoOfferingCanBeCreated() throws {
         let data = [
             "offerings": [],
             "current_offering_id": nil
         ]
-        let offerings = offeringsFactory.createOfferings(withProducts: [:], data: data as [String : Any])
+        let maybeOfferings = offeringsFactory.createOfferings(withProducts: [:], data: data as [String : Any])
 
-        expect(offerings).toNot(beNil())
-        expect(offerings!.current).to(beNil())
+        expect(maybeOfferings).to(beNil())
     }
 
-    func testCurrentOfferingWithBrokenProduct() {
+    func testCurrentOfferingWithBrokenProductReturnsNilForCurrentOfferingButContainsOtherOfferings() throws {
+        let products = [
+            "com.myproduct.annual": MockSKProduct(mockProductIdentifier: "com.myproduct.annual"),
+        ]
+
         let data = [
-            "offerings": [],
+            "offerings": [
+                [
+                    "identifier": "offering_a",
+                    "description": "This is the base offering",
+                    "packages": [
+                        ["identifier": "$rc_six_month",
+                         "platform_product_identifier": "com.myproduct.annual"]
+                    ]
+                ]
+            ],
             "current_offering_id": "offering_with_broken_product"
         ] as [String : Any]
-        let offerings = offeringsFactory.createOfferings(withProducts: [:], data: data as [String : Any])
+        let maybeOfferings = offeringsFactory.createOfferings(withProducts: products, data: data as [String : Any])
 
-        expect(offerings).toNot(beNil())
-        expect(offerings!.current).to(beNil())
+        let offerings = try XCTUnwrap(maybeOfferings)
+        expect(offerings.current).to(beNil())
     }
 
     func testBadOfferingsDataReturnsNil() {


### PR DESCRIPTION
Fixed a couple of cases where we're not calling completion block. 

First up is this case: 
https://community.revenuecat.com/sdks-51/ios-bug-rcpurchases-offeringswithcompletionblock-offerings-and-error-are-both-nil-442?postid=1328#post1328

This is very easy to reproduce, and happens whenever you have a bad configuration: 
- no offerings in the backend
- offerings exist in the backend, but no corresponding skproducts exist. 

In both of those cases, we're returning `error = nil` && `offerings.current = nil`, which seems very confusing for developers. 

So I'm updating so that in those cases we return `configurationError`.  