### PR TITLE
fixed issues with Xcode 13 in carthage script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@
     100% Swift framework + ObjC support.
 - See our [RevenueCat V4 API update doc](docs/V4_API_Updates.md) for API updates.
 
+## 3.12.5
+- Cache callbacks for `createAlias` and `identify` to avoid sending multiple calls with same parameters at the same time
+    https://github.com/RevenueCat/purchases-ios/pull/874
+
+## 3.12.4
+- Updated `getOfferings` call to be performed serially instead of concurrently.
+    https://github.com/RevenueCat/purchases-ios/pull/831
+
 ## 3.12.3
 - Fixed a bug where checkTrialOrIntroductoryPriceEligibility would return `eligible` for products that don't have intro pricing
     https://github.com/RevenueCat/purchases-ios/pull/679

--- a/scripts/carthage.sh
+++ b/scripts/carthage.sh
@@ -11,10 +11,12 @@ trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
 # For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
 # the build will fail on lipo due to duplicate architectures.
 
-CURRENT_XCODE_VERSION=$(xcodebuild -version | grep "Build version" | cut -d' ' -f3)
-echo "EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$CURRENT_XCODE_VERSION = arm64 arm64e armv7 armv7s armv6 armv8" >> $xcconfig
+CURRENT_XCODE_VERSION="$(xcodebuild -version | grep "Xcode" | cut -d' ' -f2 | cut -d'.' -f1)00"
+CURRENT_XCODE_BUILD=$(xcodebuild -version | grep "Build version" | cut -d' ' -f3)
 
-echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$(XCODE_PRODUCT_BUILD_VERSION))' >> $xcconfig
+echo "EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_${CURRENT_XCODE_VERSION}__BUILD_${CURRENT_XCODE_BUILD} = arm64 arm64e armv7 armv7s armv6 armv8" >> $xcconfig
+
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_'${CURRENT_XCODE_VERSION}' = $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_$(XCODE_VERSION_MAJOR)__BUILD_$(XCODE_PRODUCT_BUILD_VERSION))' >> $xcconfig
 echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
 
 export XCODE_XCCONFIG_FILE="$xcconfig"


### PR DESCRIPTION
Updates the carthage deploy script for Xcode 13 compatibility:
https://github.com/Carthage/Carthage/issues/3201
This doesn't need to be back-ported to 3.x.x, since we're as of right now using Xcode 12 for that one. 

Updates the changelog to include the latest 3.x.x releases. 
