### PR TITLE
Pass a message to NSLog as an argument instead of format

### DIFF
--- a/Purchases/Logging/Logger.swift
+++ b/Purchases/Logging/Logger.swift
@@ -33,7 +33,7 @@ class Logger {
 
     static var logLevel: LogLevel = .info
     static var logHandler: (LogLevel, String) -> Void = { level, message in
-        NSLog("[\(frameworkDescription)] - \(level.description): \(message)")
+        NSLog("%@", "[\(frameworkDescription)] - \(level.description): \(message)")
     }
 
     private static let frameworkDescription = "Purchases"


### PR DESCRIPTION
Hello RC team!

According to common programming practices it is insecure to pass dynamically generated strings as a format into printf-like methods. We use `purchases-ios` framework a lot and have a visible amount of crashes when something containing `%@` literal is being logged by the following method. That would be nice to have such a fix 😄 

Thanks!