### PR TITLE
Fix PurchaserInfo date parsing

### DIFF
--- a/Purchases/Public/PurchaserInfo.swift
+++ b/Purchases/Public/PurchaserInfo.swift
@@ -210,7 +210,7 @@ import Foundation
         return parseExpirationDates(transactionsByProductId: subscriptionTransactionsByProductId)
     }()
     private lazy var purchaseDatesByProductId: [String: Date?] = {
-        return parseExpirationDates(transactionsByProductId: allPurchases)
+        return parsePurchaseDates(transactionsByProductId: allPurchases)
     }()
 
     private struct SubscriberData {

--- a/Purchases/Public/PurchaserInfo.swift
+++ b/Purchases/Public/PurchaserInfo.swift
@@ -294,9 +294,8 @@ private extension PurchaserInfo {
 
     func parseDatesIn(transactionsByProductId: [String: [String: Any]], dateLabel: String) -> [String: Date?] {
         // mapValues will keep the key-value pair in the dictionary for nil values, as desired
-        return transactionsByProductId.mapValues { maybeTransaction in
-            if let transactionFieldsByKey = maybeTransaction as? [String: String],
-               let dateString = transactionFieldsByKey[dateLabel] {
+        return transactionsByProductId.mapValues { transaction in
+            if let dateString = transaction[dateLabel] as? String {
                 return dateFormatter.date(fromString: dateString)
             }
             return nil


### PR DESCRIPTION
When attempting to retrieve transaction dates via `expirationDate(forProductIdentifier:) -> Date?` or `purchaseDate(forProductIdentifier:) -> Date?`, PurchaserInfo would always report nil values.

This appears to be due to 1) the `parseDatesIn(transactionsByProductId:dateLabel:) -> [String: Date?]` method attempting to cast transactions to a `[String: String]` dictionary. This always fails as a transaction can contain an `NSNull` amongst other non-String values. 2) the `purchaseDatesByProductId: [String: Date?]` property containing expiration dates rather than purchase dates due to an accidental call to `parseExpirationDates(transactionsByProductId:)` rather than `parsePurchaseDates(transactionsByProductId:)`.
