### PR TITLE
Storekit 2: fix tests for iOS 14.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,8 +121,8 @@ jobs:
       - run:
           name: pre-warm simulator
           command:  |
-              open -a /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app --args -CurrentDeviceUDID "iPhone 8"
-              open -a /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app --args -CurrentDeviceUDID "iPhone 12"
+              open -a /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app --args -CurrentDeviceUDID "iPhone 8 (14.5)"
+              open -a /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app --args -CurrentDeviceUDID "iPhone 12 (15.0)"
               open -a /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app --args -CurrentDeviceUDID "Apple TV"
       - install-dependencies
       

--- a/Purchases/Purchasing/ProductDetails.swift
+++ b/Purchases/Purchasing/ProductDetails.swift
@@ -68,10 +68,14 @@ public typealias SK2Product = StoreKit.Product
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 @objc(RCSK2ProductDetails) public class SK2ProductDetails: ProductDetails {
 
-    init(sk2Product: StoreKit.Product) {
+    init(sk2Product: SK2Product) {
         self._underlyingSK2Product = sk2Product
     }
 
+    // We can't directly store instances of StoreKit.Product, since that causes
+    // linking issues in iOS < 15, even with @available checks correctly in place.
+    // So instead, we store the underlying product as Any and wrap it with casting.
+    // https://openradar.appspot.com/radar?id=4970535809187840
     private var _underlyingSK2Product: Any
     public var underlyingSK2Product: SK2Product {
         // swiftlint:disable:next force_cast

--- a/Purchases/Purchasing/ProductDetails.swift
+++ b/Purchases/Purchasing/ProductDetails.swift
@@ -69,10 +69,15 @@ public typealias SK2Product = StoreKit.Product
 @objc(RCSK2ProductDetails) public class SK2ProductDetails: ProductDetails {
 
     init(sk2Product: StoreKit.Product) {
-        self.underlyingSK2Product = sk2Product
+        self._underlyingSK2Product = sk2Product
     }
 
-    public let underlyingSK2Product: StoreKit.Product
+    private var _underlyingSK2Product: Any
+    public var underlyingSK2Product: SK2Product {
+        // swiftlint:disable:next force_cast
+        get { _underlyingSK2Product as! SK2Product }
+        set { _underlyingSK2Product = newValue }
+    }
 
     @objc public override var localizedDescription: String { underlyingSK2Product.description }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -50,7 +50,7 @@ platform :ios do
     # Need to run scan multiple times
     scan(
       step_name: "scan - iPhone", 
-      devices: ["iPhone 8 (15.0)", "iPhone 12 (15.0)"],
+      devices: ["iPhone 8 (14.5)", "iPhone 12 (15.0)"],
       scheme: "UnitTests",
       testplan: "UnitTests",
       prelaunch_simulator: true


### PR DESCRIPTION
When running tests, we were getting a linking error if the device running the tests was using iOS 14.5 (or equivalent OS version for other platforms). 

XCTest doesn't handle availability nicely when it comes to these properties, so the app would crash on start. 

We filed a radar for this, details are available here: https://openradar.appspot.com/radar?id=4970535809187840

The workaround is to store the property as `Any`, and then wrap it for public use. 

This PR does that, and also re-enables tests for iOS 14.5 devices. 