### PR TITLE
Use current commit in api testers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,7 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
+      - install-dependencies
       - run:
           name: Update Swift Package Commit
           command: bundle exec fastlane update_swift_package_commit
@@ -166,6 +167,7 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
+      - install-dependencies
       - run:
           name: Update Swift Package Commit
           command: bundle exec fastlane update_swift_package_commit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,6 +153,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Update Swift Package Commit
+          command: bundle exec fastlane update_swift_package_commit
+      - run:
           name: Build SwiftAPITester
           command: xcodebuild -workspace APITesters/APITesters.xcworkspace -scheme SwiftAPITester
 
@@ -163,6 +166,9 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
+      - run:
+          name: Update Swift Package Commit
+          command: bundle exec fastlane update_swift_package_commit
       - run:
           name: Build ObjCAPITester
           command: xcodebuild -workspace APITesters/APITesters.xcworkspace -scheme ObjCAPITester

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -234,6 +234,8 @@ platform :ios do
       '../IntegrationTests/SPMIntegration/SPMIntegration.xcodeproj/project.pbxproj',
       '../Examples/MagicWeather/MagicWeather.xcodeproj/project.pbxproj',
       '../Examples/MagicWeatherSwiftUI/Magic Weather SwiftUI.xcodeproj/project.pbxproj',
+      '../APITesters/ObjCAPITester/ObjCAPITester.xcodeproj/project.pbxproj',
+      '../APITesters/SwiftAPITester/SwiftAPITester.xcodeproj/project.pbxproj',
     ]
 
     old_kind_line = "kind = branch;"


### PR DESCRIPTION
Automatically updates the API tester's git commit to the current one before running them in CI. 
When running them locally, they'll still be pointing to `main`, but at least we'll be able to catch issues in CI early. 