### PR TITLE
Fix logging api_request_completed in HTTPClient

### DIFF
--- a/Purchases/Networking/HTTPClient.swift
+++ b/Purchases/Networking/HTTPClient.swift
@@ -193,7 +193,7 @@ private extension HTTPClient {
             if let httpURLResponse = maybeURLResponse as? HTTPURLResponse {
                 statusCode = httpURLResponse.statusCode
                 Logger.debug(Strings.network.api_request_completed(httpMethod: request.httpMethod,
-                                                                   path: request.httpMethod,
+                                                                   path: request.path,
                                                                    httpCode: statusCode))
 
                 if statusCode == HTTPStatusCodes.notModifiedResponseCode.rawValue || maybeData == nil {


### PR DESCRIPTION
Fix passing in `request.httpMethod` for the `path` component of our network strings logging