### PR TITLE
replace `#file` with `#fileID`

### DIFF
--- a/Purchases/LocalReceiptParsing/ReceiptParser.swift
+++ b/Purchases/LocalReceiptParsing/ReceiptParser.swift
@@ -34,7 +34,7 @@ class ReceiptParser {
             return receipt.inAppPurchases.count > 0
         }
 
-        Logger.warn(Strings.receipt.parsing_receipt_failed(fileName: #file, functionName: #function))
+        Logger.warn(Strings.receipt.parsing_receipt_failed(fileName: #fileID, functionName: #function))
         return true
     }
 


### PR DESCRIPTION
Fixes #920. 
Replaces `#file` with `#fileID`, which is more secure, as it doesn't include the full path to the file in the file system. 