### PR TITLE
Re-enable macOS builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ commands:
 jobs:
   runtest:
     macos:
-      xcode: "13.0.1"
+      xcode: "13.1.0"
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
     steps:
@@ -129,9 +129,9 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-  buildTvAndWatch:
+  buildTvWatchAndMac:
     macos:
-      xcode: "13.0.1"
+      xcode: "13.1.0"
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
     steps:
@@ -142,11 +142,11 @@ jobs:
       - install-dependencies
       - run:
           name: Build tvOS and watchOS
-          command: bundle exec fastlane build_tv_watch
+          command: bundle exec fastlane build_tv_watch_mac
 
   swift_apitest:
     macos:
-      xcode: "13.0.1"
+      xcode: "13.1.0"
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
     steps:
@@ -159,7 +159,7 @@ jobs:
 
   objc_apitest:
     macos:
-      xcode: "13.0.1"
+      xcode: "13.1.0"
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
     steps:
@@ -172,7 +172,7 @@ jobs:
 
   backend_integration_tests:
     macos:
-      xcode: "13.0.1"
+      xcode: "13.1.0"
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
     steps:
@@ -193,7 +193,7 @@ jobs:
 
   deployment-checks: 
     macos:
-      xcode: "13.0.1"
+      xcode: "13.1.0"
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
     steps:
@@ -225,7 +225,7 @@ jobs:
           
   docs-deploy:
     macos:
-      xcode: "13.0.1"
+      xcode: "13.1.0"
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
     steps:
@@ -249,7 +249,7 @@ jobs:
   
   make-release:
     macos:
-      xcode: "13.0.1"
+      xcode: "13.1.0"
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -262,7 +262,7 @@ jobs:
 
   prepare-next-version:
     macos:
-      xcode: "13.0.1"
+      xcode: "13.1.0"
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -275,7 +275,7 @@ jobs:
 
   integration-tests-cocoapods:
     macos:
-      xcode: "13.0.1"
+      xcode: "13.1.0"
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -296,7 +296,7 @@ jobs:
       
   integration-tests-swift-package-manager:
     macos:
-      xcode: "13.0.1"
+      xcode: "13.1.0"
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -308,7 +308,7 @@ jobs:
 
   integration-tests-carthage:
     macos:
-      xcode: "13.0.1"
+      xcode: "13.1.0"
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -338,7 +338,7 @@ jobs:
 
   integration-tests-xcode-direct-integration:
     macos:
-      xcode: "13.0.1"
+      xcode: "13.1.0"
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -349,7 +349,7 @@ jobs:
 
   lint:
     macos:
-      xcode: "13.0.1"
+      xcode: "13.1.0"
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -375,7 +375,7 @@ workflows:
       - runtest
       - swift_apitest
       - objc_apitest
-      - buildTvAndWatch
+      - buildTvWatchAndMac
       - backend_integration_tests
       - deployment-checks: *release-branches
       - integration-tests-cocoapods: *release-tags-and-branches

--- a/RevenueCat.podspec
+++ b/RevenueCat.podspec
@@ -23,8 +23,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '12.0'
   s.watchos.deployment_target = '6.2'
   s.tvos.deployment_target = '9.0'
-  # temporarily disabling macOS, since Xcode 13 isn't compatible with macOS 12.
-  # s.osx.deployment_target = '10.12'
+  s.osx.deployment_target = '10.12'
   
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -149,10 +149,10 @@ platform :ios do
     check_no_github_release_exists(version_number)
   end
 
-  desc "tvOS, watchOS"
-  lane :build_tv_watch do |options|
+  desc "build tvOS, watchOS, macOS"
+  lane :build_tv_watch_mac do |options|
     check_pods(ignore_warnings: in_beta)
-    carthage(command: "build", no_skip_current: true, platform: "watchOS,tvOS", use_xcframeworks: true)
+    carthage(command: "build", no_skip_current: true, platform: "watchOS,tvOS,Mac", use_xcframeworks: true)
   end
 
   desc "macOS build"
@@ -182,6 +182,7 @@ platform :ios do
         app_identifier: ["com.revenuecat.SwiftAPITesterIOS"],
         username: ENV["FASTLANE_USER"])
       sh('xcodebuild', '-workspace', '../APITesters/APITesters.xcworkspace', '-scheme', 'SwiftAPITesterIOS')
+      sh('xcodebuild', '-workspace', '../APITesters/APITesters.xcworkspace', '-scheme', 'SwiftAPITester')
   end
   
   desc "build ObjC API tester"
@@ -194,6 +195,7 @@ platform :ios do
         app_identifier: ["com.revenuecat.ObjCAPITesterIOS"],
         username: ENV["FASTLANE_USER"])
       sh('xcodebuild', '-workspace', '../APITesters/APITesters.xcworkspace', '-scheme', 'ObjCAPITesterIOS')
+      sh('xcodebuild', '-workspace', '../APITesters/APITesters.xcworkspace', '-scheme', 'ObjCAPITester')
   end
 
   desc "replace API KEY for integration tests"


### PR DESCRIPTION
macOS was temporarily disabled because Xcode 13 wasn't compatible with macOS 12 and Swift 5.5, which caused build issues, even when gating the logic with `@available`. 

This re-enables macOS in the podspec, and our test builds, including API testers. 