### PR TITLE
Add more specific backend error subcodes

### DIFF
--- a/Purchases/Error Handling/DescribableError.swift
+++ b/Purchases/Error Handling/DescribableError.swift
@@ -13,8 +13,4 @@
 
 import Foundation
 
-protocol DescribableError: Error {
-
-    var description: String { get }
-
-}
+protocol DescribableError: Error, CustomStringConvertible { }

--- a/Purchases/Error Handling/DescribableError.swift
+++ b/Purchases/Error Handling/DescribableError.swift
@@ -1,0 +1,20 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  DescribableError.swift
+//
+//  Created by Joshua Liebowitz on 10/28/21.
+
+import Foundation
+
+protocol DescribableError: Error {
+
+    var description: String { get }
+
+}

--- a/Purchases/Error Handling/ErrorDetails.swift
+++ b/Purchases/Error Handling/ErrorDetails.swift
@@ -19,5 +19,6 @@ class ErrorDetails: NSObject {
     static let finishableKey: NSError.UserInfoKey = "finishable"
     static let readableErrorCodeKey: NSError.UserInfoKey = "readable_error_code"
     static let generatedByKey: NSError.UserInfoKey = "generated_by"
+    static let extraContextKey: NSError.UserInfoKey = "extra_context"
 
 }

--- a/Purchases/Error Handling/ErrorDetails.swift
+++ b/Purchases/Error Handling/ErrorDetails.swift
@@ -20,6 +20,5 @@ class ErrorDetails: NSObject {
     static let readableErrorCodeKey: NSError.UserInfoKey = "readable_error_code"
     static let generatedByKey: NSError.UserInfoKey = "generated_by"
     static let extraContextKey: NSError.UserInfoKey = "extra_context"
-    static let attachedErrorKey: NSError.UserInfoKey = "attached_error"
 
 }

--- a/Purchases/Error Handling/ErrorDetails.swift
+++ b/Purchases/Error Handling/ErrorDetails.swift
@@ -20,5 +20,6 @@ class ErrorDetails: NSObject {
     static let readableErrorCodeKey: NSError.UserInfoKey = "readable_error_code"
     static let generatedByKey: NSError.UserInfoKey = "generated_by"
     static let extraContextKey: NSError.UserInfoKey = "extra_context"
+    static let attachedErrorKey: NSError.UserInfoKey = "attached_error"
 
 }

--- a/Purchases/Error Handling/ErrorUtils.swift
+++ b/Purchases/Error Handling/ErrorUtils.swift
@@ -262,13 +262,14 @@ extension ErrorUtils {
     // Addes a sub-error to the userInfo of the `error` object as some extra context. Sometimes we have multiple error
     // Conditions but only a single place to surface them. This adds the second error as extra context to help during
     // debugging.
-    static func attach(subError: Error?, toError error: Error) -> Error {
+    static func attach(subError: Error?, toError error: Error, extraContext: String? = nil) -> Error {
         guard let subError = subError else {
             return error
         }
 
         var userInfo = (error as NSError).userInfo as [NSError.UserInfoKey: Any]
-        userInfo[ErrorDetails.extraContextKey] = subError
+        userInfo[ErrorDetails.attachedErrorKey] = subError
+        userInfo[ErrorDetails.extraContextKey] = extraContext
         let ogError = error as NSError
         let nsErrorWithUserInfo = NSError(domain: ogError.domain,
                                           code: ogError.code,

--- a/Purchases/Error Handling/ErrorUtils.swift
+++ b/Purchases/Error Handling/ErrorUtils.swift
@@ -332,10 +332,6 @@ private extension ErrorUtils {
         userInfo[ErrorDetails.generatedByKey] = maybeGeneratedBy
         userInfo[ErrorDetails.extraContextKey] = maybeExtraContext
 
-        if let describableSubError = describableSubError {
-            Logger.error(describableSubError.description)
-        }
-
         let nsError = ErrorCode.unexpectedBackendResponseError as NSError
         let nsErrorWithUserInfo = NSError(domain: nsError.domain,
                                           code: nsError.code,

--- a/Purchases/Error Handling/ErrorUtils.swift
+++ b/Purchases/Error Handling/ErrorUtils.swift
@@ -261,24 +261,6 @@ extension ErrorUtils {
                      extraUserInfo: extraUserInfo)
     }
 
-    // Addes a sub-error to the userInfo of the `error` object as some extra context. Sometimes we have multiple error
-    // Conditions but only a single place to surface them. This adds the second error as extra context to help during
-    // debugging.
-    static func attach(error maybeError: Error?, toError error: Error, extraContext: String? = nil) -> Error {
-        guard let attachedError = maybeError else {
-            return error
-        }
-
-        var userInfo = (error as NSError).userInfo as [NSError.UserInfoKey: Any]
-        userInfo[ErrorDetails.attachedErrorKey] = attachedError
-        userInfo[ErrorDetails.extraContextKey] = extraContext
-        let ogError = error as NSError
-        let nsErrorWithUserInfo = NSError(domain: ogError.domain,
-                                          code: ogError.code,
-                                          userInfo: userInfo as [String: Any])
-        return nsErrorWithUserInfo as Error
-    }
-
 }
 
 private extension ErrorUtils {

--- a/Purchases/Error Handling/ErrorUtils.swift
+++ b/Purchases/Error Handling/ErrorUtils.swift
@@ -85,8 +85,10 @@ class ErrorUtils: NSObject {
      * - Note: This error is used when a network request returns an unexpected response and we can determine some
      * of what went wrong with the response.
      */
-    static func unexpectedBackendResponse(withSubError subError: UnexpectedBackendResponseSubErrorCode) -> Error {
-        return backendResponseError(withSubError: subError)
+    static func unexpectedBackendResponse(withSubError subError: UnexpectedBackendResponseSubErrorCode,
+                                          generatedBy: String? = nil,
+                                          extraContext: String? = nil) -> Error {
+        return backendResponseError(withSubError: subError, generatedBy: generatedBy, extraContext: extraContext)
     }
 
     /**
@@ -316,11 +318,15 @@ private extension ErrorUtils {
         return nsErrorWithUserInfo as Error
     }
 
-    static func backendResponseError(withSubError subError: UnexpectedBackendResponseSubErrorCode) -> Error {
+    static func backendResponseError(withSubError subError: UnexpectedBackendResponseSubErrorCode,
+                                     generatedBy: String?,
+                                     extraContext: String?) -> Error {
         var userInfo: [NSError.UserInfoKey: Any] = [:]
         userInfo[NSLocalizedDescriptionKey as NSError.UserInfoKey] = subError.description
         userInfo[NSUnderlyingErrorKey as NSError.UserInfoKey] = subError
         userInfo[ErrorDetails.readableErrorCodeKey] = ErrorCode.unexpectedBackendResponseError.codeName
+        userInfo[ErrorDetails.generatedByKey] = generatedBy
+        userInfo[ErrorDetails.extraContextKey] = extraContext
         Logger.error(subError.description)
 
         let nsError = ErrorCode.unexpectedBackendResponseError as NSError

--- a/Purchases/Error Handling/UnexpectedBackendResponseSubErrorCode.swift
+++ b/Purchases/Error Handling/UnexpectedBackendResponseSubErrorCode.swift
@@ -36,8 +36,11 @@ enum UnexpectedBackendResponseSubErrorCode: Int, Error {
     // getOffer call failed with an invalid response.
     case getOfferUnexpectedResponse
 
-    // A call that is supposed to retrieve a CustomerInfo failed and we're not sure why.
-    case customerInfoResponse
+    // A call that is supposed to retrieve a CustomerInfo failed because the response object was missing.
+    case customerInfoResponseMissing
+
+    // A call that is supposed to retrieve a CustomerInfo failed because the json object couldn't be parsed.
+    case customerInfoResponseParsing
 
     var description: String {
         switch self {
@@ -55,8 +58,10 @@ enum UnexpectedBackendResponseSubErrorCode: Int, Error {
             return "Signature error encountered in response returned from posting offer for signing."
         case .getOfferUnexpectedResponse:
             return "Unknown error encountered while getting offerings."
-        case .customerInfoResponse:
-            return "Unable to instantiate a CustomerInfoResponse."
+        case .customerInfoResponseMissing:
+            return "Unable to instantiate a CustomerInfoResponse, backend response missing."
+        case .customerInfoResponseParsing:
+            return "Unable to instantiate a CustomerInfoResponse due to malformed json."
         }
     }
 

--- a/Purchases/Error Handling/UnexpectedBackendResponseSubErrorCode.swift
+++ b/Purchases/Error Handling/UnexpectedBackendResponseSubErrorCode.swift
@@ -36,11 +36,15 @@ enum UnexpectedBackendResponseSubErrorCode: Int, Error {
     // getOffer call failed with an invalid response.
     case getOfferUnexpectedResponse
 
-    // A call that is supposed to retrieve a CustomerInfo failed because the response object was missing.
-    case customerInfoResponseMissing
+    // A call that is supposed to retrieve a CustomerInfo failed because the response object was malformed.
+    case customerInfoResponseMalformed
 
     // A call that is supposed to retrieve a CustomerInfo failed because the json object couldn't be parsed.
     case customerInfoResponseParsing
+
+}
+
+extension UnexpectedBackendResponseSubErrorCode: DescribableError {
 
     var description: String {
         switch self {
@@ -58,8 +62,8 @@ enum UnexpectedBackendResponseSubErrorCode: Int, Error {
             return "Signature error encountered in response returned from posting offer for signing."
         case .getOfferUnexpectedResponse:
             return "Unknown error encountered while getting offerings."
-        case .customerInfoResponseMissing:
-            return "Unable to instantiate a CustomerInfoResponse, backend response missing."
+        case .customerInfoResponseMalformed:
+            return "Unable to instantiate a CustomerInfoResponse, backend response is malformed."
         case .customerInfoResponseParsing:
             return "Unable to instantiate a CustomerInfoResponse due to malformed json."
         }

--- a/Purchases/FoundationExtensions/Dictionary+Extensions.swift
+++ b/Purchases/FoundationExtensions/Dictionary+Extensions.swift
@@ -16,8 +16,14 @@ import Foundation
 
 extension Dictionary {
 
+    var stringRepresentation: String {
+        compactMap { "\($0)=\($1)" }
+        .sorted()
+        .joined(separator: ",")
+    }
+
     func removingNSNullValues() -> Dictionary {
-        self.filter { !($0.value is NSNull) }
+        filter { !($0.value is NSNull) }
     }
 
 }

--- a/Purchases/FoundationExtensions/Error+Extensions.swift
+++ b/Purchases/FoundationExtensions/Error+Extensions.swift
@@ -21,14 +21,14 @@ extension Error {
      * debugging.
      * - Returns: a new error matching `self` but with the `extraContext` and `error` added.
      */
-    func attaching(error maybeError: Error?, extraContext: String? = nil) -> Error {
+    func addingUnderlyingError(_ maybeError: Error?, extraContext: String? = nil) -> Error {
         guard let attachedError = maybeError else {
             return self
         }
 
         let asNSError = self as NSError
         var userInfo = asNSError.userInfo as [NSError.UserInfoKey: Any]
-        userInfo[ErrorDetails.attachedErrorKey] = attachedError
+        userInfo[NSUnderlyingErrorKey as NSString] = attachedError
         userInfo[ErrorDetails.extraContextKey] = extraContext
         let nsErrorWithUserInfo = NSError(domain: asNSError.domain,
                                           code: asNSError.code,

--- a/Purchases/FoundationExtensions/Error+Extensions.swift
+++ b/Purchases/FoundationExtensions/Error+Extensions.swift
@@ -13,6 +13,31 @@
 
 import Foundation
 
+extension Error {
+
+    /**
+     * Addes a sub-error to the userInfo of a new `error` object as some extra context. Sometimes we have multiple error
+     * Conditions but only a single place to surface them. This adds the second error as extra context to help during
+     * debugging.
+     * - Returns: a new error matching `self` but with the `extraContext` and `error` added.
+     */
+    func attaching(error maybeError: Error?, extraContext: String? = nil) -> Error {
+        guard let attachedError = maybeError else {
+            return self
+        }
+
+        let asNSError = self as NSError
+        var userInfo = asNSError.userInfo as [NSError.UserInfoKey: Any]
+        userInfo[ErrorDetails.attachedErrorKey] = attachedError
+        userInfo[ErrorDetails.extraContextKey] = extraContext
+        let nsErrorWithUserInfo = NSError(domain: asNSError.domain,
+                                          code: asNSError.code,
+                                          userInfo: userInfo as [String: Any])
+        return nsErrorWithUserInfo as Error
+    }
+
+}
+
 extension NSError {
 
     var successfullySynced: Bool {

--- a/Purchases/FoundationExtensions/JSONDecoder+Extensions.swift
+++ b/Purchases/FoundationExtensions/JSONDecoder+Extensions.swift
@@ -103,9 +103,10 @@ private extension ErrorUtils {
         case .dataCorrupted(let context):
             Logger.error(Strings.codable.corrupted_data_error(context: context))
         case .keyNotFound(let key, let context):
-            Logger.error(Strings.codable.keyNotFoundError(key: key, context: context))
+            // This is expected to happen occasionally, the backend doesn't always populate all key/values.
+            Logger.debug(Strings.codable.keyNotFoundError(key: key, context: context))
         case .valueNotFound(let value, let context):
-            Logger.error(Strings.codable.valueNotFoundError(value: value, context: context))
+            Logger.debug(Strings.codable.valueNotFoundError(value: value, context: context))
         case .typeMismatch(let type, let context):
             Logger.error(Strings.codable.typeMismatch(type: type, context: context))
         default:

--- a/Purchases/Identity/CustomerInfoManager.swift
+++ b/Purchases/Identity/CustomerInfoManager.swift
@@ -126,8 +126,19 @@ class CustomerInfoManager {
 
         do {
             let maybeInfoDict = try JSONSerialization.jsonObject(with: customerInfoData) as? [String: Any]
-            guard let customerInfoDict = maybeInfoDict,
-                  let info = CustomerInfo(data: customerInfoDict) else {
+            guard let customerInfoDict = maybeInfoDict else {
+                return nil
+            }
+
+            let info: CustomerInfo
+            do {
+                info = try CustomerInfo(data: customerInfoDict)
+            } catch {
+                if let customerInfoError = error as? CustomerInfoError {
+                    Logger.error(customerInfoError.description)
+                } else {
+                    Logger.error("Error loading customer info from cache: \(error)")
+                }
                 return nil
             }
 

--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -588,7 +588,7 @@ private extension Backend {
             return try CustomerInfo(data: customerJson)
         } catch {
             let parsingError = UnexpectedBackendResponseSubErrorCode.customerInfoResponseParsing
-            let subError = ErrorUtils.attach(subError: error,
+            let subError = ErrorUtils.attach(error: error,
                                              toError: parsingError,
                                              extraContext: customerJson.stringRepresentation)
             throw subError
@@ -639,7 +639,7 @@ private extension Backend {
             var responseError = ErrorUtils.backendError(withBackendCode: backendErrorCode,
                                                         backendMessage: message,
                                                         extraUserInfo: extraUserInfo as [NSError.UserInfoKey: Any])
-            responseError = ErrorUtils.attach(subError: maybeError,
+            responseError = ErrorUtils.attach(error: maybeError,
                                               toError: responseError,
                                               extraContext: maybeResponse?.stringRepresentation)
             completion(maybeCustomerInfo, responseError)

--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -242,8 +242,9 @@ class Backend {
                 let keyIdentifier = offer["key_id"] as? String
                 let nonceString = signatureData["nonce"] as? String
                 let maybeNonce = nonceString.flatMap { UUID(uuidString: $0) }
+                let timestamp = signatureData["timestamp"] as? Int
 
-                completion(signature, keyIdentifier, maybeNonce, signatureData["timestamp"] as? Int, nil)
+                completion(signature, keyIdentifier, maybeNonce, timestamp, nil)
                 return
             } else {
                 Logger.error(Strings.backendError.signature_error(maybeSignatureDataString: offer["signature_data"]))

--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -588,9 +588,7 @@ private extension Backend {
             return try CustomerInfo(data: customerJson)
         } catch {
             let parsingError = UnexpectedBackendResponseSubErrorCode.customerInfoResponseParsing
-            let subError = ErrorUtils.attach(error: error,
-                                             toError: parsingError,
-                                             extraContext: customerJson.stringRepresentation)
+            let subError = parsingError.attaching(error: error, extraContext: customerJson.stringRepresentation)
             throw subError
         }
     }
@@ -639,9 +637,8 @@ private extension Backend {
             var responseError = ErrorUtils.backendError(withBackendCode: backendErrorCode,
                                                         backendMessage: message,
                                                         extraUserInfo: extraUserInfo as [NSError.UserInfoKey: Any])
-            responseError = ErrorUtils.attach(error: maybeError,
-                                              toError: responseError,
-                                              extraContext: maybeResponse?.stringRepresentation)
+            responseError = responseError.attaching(error: maybeError,
+                                                    extraContext: maybeResponse?.stringRepresentation)
             completion(maybeCustomerInfo, responseError)
             return
         }

--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -511,7 +511,6 @@ private extension Backend {
             let subErrorCode = UnexpectedBackendResponseSubErrorCode.loginResponseDecoding
             let responseError = ErrorUtils.unexpectedBackendResponse(withSubError: subErrorCode)
             completion(nil, false, responseError)
-            return
         }
     }
 
@@ -613,16 +612,16 @@ private extension Backend {
         let isErrorStatusCode = statusCode >= HTTPStatusCodes.redirect.rawValue
 
         let maybeError: Error?
-        let customerInfo: CustomerInfo?
+        let maybeCustomerInfo: CustomerInfo?
         do {
-            customerInfo = try self.parseCustomerInfo(fromMaybeResponse: maybeResponse)
+            maybeCustomerInfo = try self.parseCustomerInfo(fromMaybeResponse: maybeResponse)
             maybeError = nil
         } catch let customerInfoError {
-            customerInfo = nil
+            maybeCustomerInfo = nil
             maybeError = customerInfoError
         }
 
-        if !isErrorStatusCode && customerInfo == nil {
+        if !isErrorStatusCode && maybeCustomerInfo == nil {
             let extraContext = "statusCode: \(statusCode), json:\(maybeResponse.debugDescription)"
             completion(nil, ErrorUtils.unexpectedBackendResponse(withSubError: maybeError,
                                                                  generatedBy: "\(file) \(function)",
@@ -645,11 +644,11 @@ private extension Backend {
                                                         backendMessage: message,
                                                         extraUserInfo: extraUserInfo as [NSError.UserInfoKey: Any])
             responseError = ErrorUtils.attach(subError: maybeError, toError: responseError)
-            completion(customerInfo, responseError)
+            completion(maybeCustomerInfo, responseError)
             return
         }
 
-        completion(customerInfo, nil)
+        completion(maybeCustomerInfo, nil)
     }
 
     func escapedAppUserID(appUserID: String) throws -> String {
@@ -772,13 +771,6 @@ private extension Backend {
             return callbacks ?? []
         }
     }
-
-}
-
-private struct CustomerInfoResponseTuple {
-
-    let maybeCustomerInfo: CustomerInfo?
-    let maybeError: Error?
 
 }
 

--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -594,7 +594,9 @@ private extension Backend {
             return try CustomerInfo(data: customerJson)
         } catch {
             let parsingError = UnexpectedBackendResponseSubErrorCode.customerInfoResponseParsing
-            let subError = ErrorUtils.attach(subError: error, toError: parsingError)
+            let subError = ErrorUtils.attach(subError: error,
+                                             toError: parsingError,
+                                             extraContext: customerJson.stringRepresentation)
             throw subError
         }
     }
@@ -614,7 +616,7 @@ private extension Backend {
         let maybeError: Error?
         let maybeCustomerInfo: CustomerInfo?
         do {
-            maybeCustomerInfo = try self.parseCustomerInfo(fromMaybeResponse: maybeResponse)
+            maybeCustomerInfo = try parseCustomerInfo(fromMaybeResponse: maybeResponse)
             maybeError = nil
         } catch let customerInfoError {
             maybeCustomerInfo = nil
@@ -643,7 +645,9 @@ private extension Backend {
             var responseError = ErrorUtils.backendError(withBackendCode: backendErrorCode,
                                                         backendMessage: message,
                                                         extraUserInfo: extraUserInfo as [NSError.UserInfoKey: Any])
-            responseError = ErrorUtils.attach(subError: maybeError, toError: responseError)
+            responseError = ErrorUtils.attach(subError: maybeError,
+                                              toError: responseError,
+                                              extraContext: maybeResponse?.stringRepresentation)
             completion(maybeCustomerInfo, responseError)
             return
         }

--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -241,7 +241,7 @@ class Backend {
                 let signature = signatureData["signature"] as? String
                 let keyIdentifier = offer["key_id"] as? String
                 let nonceString = signatureData["nonce"] as? String
-                let maybeNonce: UUID? = nonceString.flatMap { UUID(uuidString: $0) }
+                let maybeNonce = nonceString.flatMap { UUID(uuidString: $0) }
 
                 completion(signature, keyIdentifier, maybeNonce, signatureData["timestamp"] as? Int, nil)
                 return
@@ -580,8 +580,7 @@ private extension Backend {
 
     func parseCustomerInfo(fromMaybeResponse maybeResponse: [String: Any]?) throws -> CustomerInfo {
         guard let customerJson = maybeResponse else {
-            let subError = UnexpectedBackendResponseSubErrorCode.customerInfoResponseMalformed
-            throw subError
+            throw UnexpectedBackendResponseSubErrorCode.customerInfoResponseMalformed
         }
 
         do {

--- a/Purchases/Public/CustomerInfo.swift
+++ b/Purchases/Public/CustomerInfo.swift
@@ -281,7 +281,7 @@ import Foundation
 
 }
 
-enum CustomerInfoError: Int, Error, DescribableError {
+enum CustomerInfoError: Int, DescribableError {
 
     case missingJsonObject
     case cantInstantiateJsonObject

--- a/Purchases/Public/Errors/ErrorCode.swift
+++ b/Purchases/Public/Errors/ErrorCode.swift
@@ -54,10 +54,9 @@ import Foundation
 
 extension ErrorCode: CaseIterable { }
 
-extension ErrorCode {
+extension ErrorCode: DescribableError {
 
     var description: String {
-
         switch self {
         case .networkError:
             return "Error performing request."
@@ -127,8 +126,11 @@ extension ErrorCode {
         @unknown default:
             return "Something went wrong."
         }
-
     }
+
+}
+
+extension ErrorCode {
 
     /**
      * The error short string, based on the error code.

--- a/Purchases/Public/Errors/ErrorCode.swift
+++ b/Purchases/Public/Errors/ErrorCode.swift
@@ -56,7 +56,7 @@ extension ErrorCode: CaseIterable { }
 
 extension ErrorCode: DescribableError {
 
-    var description: String {
+    public var description: String {
         switch self {
         case .networkError:
             return "Error performing request."

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -148,7 +148,7 @@ class PurchasesOrchestrator {
                                                         keyIdentifier: keyIdentifier,
                                                         nonce: nonce,
                                                         signature: signature,
-                                                        timestamp: timestamp)
+                                                        timestamp: timestamp as NSNumber)
                 completion(paymentDiscount, nil)
             }
         }

--- a/PurchasesTests/Identity/CustomerInfoManagerTests.swift
+++ b/PurchasesTests/Identity/CustomerInfoManagerTests.swift
@@ -8,7 +8,7 @@ class CustomerInfoManagerTests: XCTestCase {
     var mockOperationDispatcher = MockOperationDispatcher()
     var mockDeviceCache: MockDeviceCache!
     var mockSystemInfo = try! MockSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: true)
-    let mockCustomerInfo = CustomerInfo(data: [
+    let mockCustomerInfo = CustomerInfo(testData: [
         "request_date": "2018-12-21T02:40:36Z",
         "subscriber": [
             "original_app_user_id": "app_user_id",
@@ -185,7 +185,7 @@ class CustomerInfoManagerTests: XCTestCase {
     }
 
     func testSendCachedCustomerInfoIfAvailableForAppUserIDSendsIfNeverSent() {
-        let info = CustomerInfo(data: [
+        let info = CustomerInfo(testData: [
         "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "original_app_user_id": "app_user_id",
@@ -206,7 +206,7 @@ class CustomerInfoManagerTests: XCTestCase {
     }
 
     func testSendCachedCustomerInfoIfAvailableForAppUserIDSendsIfDifferent() {
-        let oldInfo = CustomerInfo(data: [
+        let oldInfo = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "original_app_user_id": "app_user_id",
@@ -223,7 +223,7 @@ class CustomerInfoManagerTests: XCTestCase {
 
         customerInfoManager.sendCachedCustomerInfoIfAvailable(appUserID: appUserID)
 
-        let newInfo = CustomerInfo(data: [
+        let newInfo = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "original_app_user_id": "app_user_id",
@@ -242,7 +242,7 @@ class CustomerInfoManagerTests: XCTestCase {
     }
 
     func testSendCachedCustomerInfoIfAvailableForAppUserIDSendsOnMainThread() {
-        let oldInfo = CustomerInfo(data: [
+        let oldInfo = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "original_app_user_id": "app_user_id",
@@ -311,7 +311,7 @@ class CustomerInfoManagerTests: XCTestCase {
 
     func testCachedCustomerInfoParsesCorrectly() {
         let appUserID = "myUser"
-        let info = CustomerInfo(data: [
+        let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "original_app_user_id": "app_user_id",
@@ -337,7 +337,7 @@ class CustomerInfoManagerTests: XCTestCase {
     }
 
     func testCachedCustomerInfoReturnsNilIfNotAvailableForTheAppUserID() {
-        let info = CustomerInfo(data: [
+        let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "original_app_user_id": "app_user_id",
@@ -396,7 +396,7 @@ class CustomerInfoManagerTests: XCTestCase {
     func testCachePurchaserDoesntStoreIfCantBeSerialized() {
         // infinity can't be cast into JSON, so we use it to force a parsing exception. See:
         // https://developer.apple.com/documentation/foundation/nsjsonserialization?language=objc
-        let invalidCustomerInfo = CustomerInfo(data: [
+        let invalidCustomerInfo = CustomerInfo(testData: [
             "something": Double.infinity,
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [

--- a/PurchasesTests/Identity/IdentityManagerTests.swift
+++ b/PurchasesTests/Identity/IdentityManagerTests.swift
@@ -20,7 +20,7 @@ class IdentityManagerTests: XCTestCase {
                                                                                                platformFlavorVersion: nil,
                                                                                                finishTransactions: false))
 
-    let mockCustomerInfo = CustomerInfo(data: [
+    let mockCustomerInfo = CustomerInfo(testData: [
         "request_date": "2019-08-16T10:30:42Z",
         "subscriber": [
             "first_seen": "2019-07-17T00:05:54Z",

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -528,8 +528,8 @@ class BackendTests: XCTestCase {
         let customerInfoError = unexpectedBackendError?.userInfo[attachedErrorKey] as! CustomerInfoError
         let extraContextString = unexpectedBackendError?.userInfo[ErrorDetails.extraContextKey as String] as! String
 
-        expect(extraContextString).to(equal("code=7225,message=something is bad up in the cloud"))
-        expect(customerInfoError.rawValue).to(equal(CustomerInfoError.missingJsonObject.rawValue))
+        expect(extraContextString) == "code=7225,message=something is bad up in the cloud"
+        expect(customerInfoError.rawValue) == CustomerInfoError.missingJsonObject.rawValue
         expect(error?.code).toEventually(equal(ErrorCode.invalidCredentialsError.rawValue))
         expect(error?.userInfo["finishable"]).to(be(false))
 

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -523,13 +523,6 @@ class BackendTests: XCTestCase {
         })
 
         expect(error).toEventuallyNot(beNil())
-        let attachedErrorKey = ErrorDetails.attachedErrorKey as String
-        let unexpectedBackendError = error?.userInfo[attachedErrorKey] as? NSError
-        let customerInfoError = unexpectedBackendError?.userInfo[attachedErrorKey] as! CustomerInfoError
-        let extraContextString = unexpectedBackendError?.userInfo[ErrorDetails.extraContextKey as String] as! String
-
-        expect(extraContextString) == "code=7225,message=something is bad up in the cloud"
-        expect(customerInfoError.rawValue) == CustomerInfoError.missingJsonObject.rawValue
         expect(error?.code).toEventually(equal(ErrorCode.invalidCredentialsError.rawValue))
         expect(error?.userInfo["finishable"]).to(be(false))
 

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -523,7 +523,11 @@ class BackendTests: XCTestCase {
         })
 
         expect(error).toEventuallyNot(beNil())
-        expect(error?.code).toEventually(be(ErrorCode.invalidCredentialsError.rawValue))
+        let unexpectedBackendError = error?.userInfo[ErrorDetails.extraContextKey as String] as? NSError
+        let customerInfoError = unexpectedBackendError?.userInfo[ErrorDetails.extraContextKey as String] as! CustomerInfoError
+
+        expect(customerInfoError.rawValue).to(equal(CustomerInfoError.missingJsonObject.rawValue))
+        expect(error?.code).toEventually(equal(ErrorCode.invalidCredentialsError.rawValue))
         expect(error?.userInfo["finishable"]).to(be(false))
 
         expect(underlyingError).toEventuallyNot(beNil())
@@ -1773,9 +1777,8 @@ class BackendTests: XCTestCase {
         }
 
         expect(completionCalled).toEventually(beTrue())
-
         expect(receivedCreated) == true
-        expect(receivedCustomerInfo) == CustomerInfo(data: mockCustomerInfoDict)
+        expect(receivedCustomerInfo) == CustomerInfo(testData: mockCustomerInfoDict)
         expect(receivedError).to(beNil())
     }
 
@@ -1805,7 +1808,7 @@ class BackendTests: XCTestCase {
         expect(completionCalled).toEventually(beTrue())
 
         expect(receivedCreated) == false
-        expect(receivedCustomerInfo) == CustomerInfo(data: mockCustomerInfoDict)
+        expect(receivedCustomerInfo) == CustomerInfo(testData: mockCustomerInfoDict)
         expect(receivedError).to(beNil())
     }
 

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -523,9 +523,12 @@ class BackendTests: XCTestCase {
         })
 
         expect(error).toEventuallyNot(beNil())
-        let unexpectedBackendError = error?.userInfo[ErrorDetails.extraContextKey as String] as? NSError
-        let customerInfoError = unexpectedBackendError?.userInfo[ErrorDetails.extraContextKey as String] as! CustomerInfoError
+        let attachedErrorKey = ErrorDetails.attachedErrorKey as String
+        let unexpectedBackendError = error?.userInfo[attachedErrorKey] as? NSError
+        let customerInfoError = unexpectedBackendError?.userInfo[attachedErrorKey] as! CustomerInfoError
+        let extraContextString = unexpectedBackendError?.userInfo[ErrorDetails.extraContextKey as String] as! String
 
+        expect(extraContextString).to(equal("code=7225,message=something is bad up in the cloud"))
         expect(customerInfoError.rawValue).to(equal(CustomerInfoError.missingJsonObject.rawValue))
         expect(error?.code).toEventually(equal(ErrorCode.invalidCredentialsError.rawValue))
         expect(error?.userInfo["finishable"]).to(be(false))

--- a/PurchasesTests/Purchasing/CustomerInfoTests.swift
+++ b/PurchasesTests/Purchasing/CustomerInfoTests.swift
@@ -759,7 +759,7 @@ extension CustomerInfo {
                           transactionsFactory: TransactionsFactory())
         } catch {
             let errorDescription = (error as? DescribableError)?.description ?? error.localizedDescription
-            Logger.error("Caught error created testData, this is probably expected, right? \(errorDescription).")
+            Logger.error("Caught error creating testData, this is probably expected, right? \(errorDescription).")
             return nil
         }
     }

--- a/PurchasesTests/Purchasing/CustomerInfoTests.swift
+++ b/PurchasesTests/Purchasing/CustomerInfoTests.swift
@@ -13,7 +13,7 @@ import Nimble
 @testable import RevenueCat
 
 class EmptyCustomerInfoTests: XCTestCase {
-    let customerInfo = CustomerInfo(data: [String : Any]())
+    let customerInfo = CustomerInfo(testData: [String : Any]())
 
     func testEmptyDataYieldsANilInfo() {
         expect(self.customerInfo).to(beNil())
@@ -88,7 +88,7 @@ class BasicCustomerInfoTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        customerInfo = CustomerInfo(data: validSubscriberResponse)
+        customerInfo = CustomerInfo(testData: validSubscriberResponse)
     }
 
     func testParsesSubscriptions() {
@@ -135,7 +135,7 @@ class BasicCustomerInfoTests: XCTestCase {
     }
 
     func testOriginalApplicationVersionNilIfNotPresent() {
-        let customerInfo = CustomerInfo(data: [
+        let customerInfo = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "original_app_user_id": "app_user_id",
@@ -147,7 +147,7 @@ class BasicCustomerInfoTests: XCTestCase {
     }
 
     func testOriginalApplicationVersionNilIfNull() {
-        let customerInfo = CustomerInfo(data: [
+        let customerInfo = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "original_app_user_id": "app_user_id",
@@ -160,7 +160,7 @@ class BasicCustomerInfoTests: XCTestCase {
     }
 
     func testOriginalApplicationVersion() {
-        let customerInfo = CustomerInfo(data: [
+        let customerInfo = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -173,7 +173,7 @@ class BasicCustomerInfoTests: XCTestCase {
     }
 
     func testOriginalPurchaseDate() {
-        let customerInfo = CustomerInfo(data: [
+        let customerInfo = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -188,7 +188,7 @@ class BasicCustomerInfoTests: XCTestCase {
 
 
     func testManagementURLNullIfNotPresent() {
-        let customerInfo = CustomerInfo(data: [
+        let customerInfo = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -200,7 +200,7 @@ class BasicCustomerInfoTests: XCTestCase {
     }
 
     func testManagementURLIsPresentWithValidURL() {
-        let customerInfo = CustomerInfo(data: [
+        let customerInfo = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -214,7 +214,7 @@ class BasicCustomerInfoTests: XCTestCase {
     }
 
     func testManagementURLIsNullWithInvalidURL() {
-        var customerInfo = CustomerInfo(data: [
+        var customerInfo = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "management_url": "this isnt' a URL!",
@@ -225,7 +225,7 @@ class BasicCustomerInfoTests: XCTestCase {
             ]])
         expect(customerInfo!.managementURL).to(beNil())
 
-        customerInfo = CustomerInfo(data: [
+        customerInfo = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "management_url": 68546984,
@@ -240,13 +240,13 @@ class BasicCustomerInfoTests: XCTestCase {
 
     func testPreservesOriginalJSONSerializableObject() {
         let json = customerInfo?.jsonObject()
-        let newInfo = CustomerInfo(data: json!)
+        let newInfo = CustomerInfo(testData: json!)
         expect(newInfo).toNot(beNil())
     }
 
     func testTwoProductJson() {
         let json = try! JSONSerialization.jsonObject(with: validTwoProductsJSON.data(using: String.Encoding.utf8)!, options: [])
-        let info = CustomerInfo(data: json as! [String : Any])
+        let info = CustomerInfo(testData: json as! [String : Any])
         expect(info?.latestExpirationDate).toNot(beNil())
     }
 
@@ -343,7 +343,7 @@ class BasicCustomerInfoTests: XCTestCase {
                 ]
             ]
         ] as [String : Any]
-        let customerInfoWithoutRequestData = CustomerInfo(data: response)
+        let customerInfoWithoutRequestData = CustomerInfo(testData: response)
 
         let entitlements: [String : EntitlementInfo] = customerInfoWithoutRequestData!.entitlements.active
         expect(entitlements["pro"]).toNot(beNil());
@@ -394,13 +394,13 @@ class BasicCustomerInfoTests: XCTestCase {
                 ]
             ]
         ] as [String : Any]
-        let customerInfoWithoutRequestData = CustomerInfo(data: response)
+        let customerInfoWithoutRequestData = CustomerInfo(testData: response)
         let purchaseDate = customerInfoWithoutRequestData!.purchaseDate(forEntitlement: "pro")
         expect(purchaseDate).to(beNil())
     }
     
     func testEmptyInfosEqual() {
-        let info1 = CustomerInfo(data: [
+        let info1 = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -408,7 +408,7 @@ class BasicCustomerInfoTests: XCTestCase {
                 "subscriptions": [:],
                 "other_purchases": [:]
             ]])
-        let info2 = CustomerInfo(data: [
+        let info2 = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -420,7 +420,7 @@ class BasicCustomerInfoTests: XCTestCase {
     }
     
     func testDifferentFetchDatesStillEqual() {
-        let info1 = CustomerInfo(data: [
+        let info1 = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -428,7 +428,7 @@ class BasicCustomerInfoTests: XCTestCase {
                 "subscriptions": [:],
                 "other_purchases": [:]
             ]])
-        let info2 = CustomerInfo(data: [
+        let info2 = CustomerInfo(testData: [
             "request_date": "2018-11-19T02:40:36Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -440,7 +440,7 @@ class BasicCustomerInfoTests: XCTestCase {
     }
     
     func testDifferentActiveEntitlementsNotEqual() {
-        let info1 = CustomerInfo(data: [
+        let info1 = CustomerInfo(testData: [
             "request_date": "2018-12-20T02:40:36Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -457,7 +457,7 @@ class BasicCustomerInfoTests: XCTestCase {
                     ]
                 ]
             ]])
-        let info2 = CustomerInfo(data: [
+        let info2 = CustomerInfo(testData: [
             "request_date": "2018-11-19T02:40:36Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -479,7 +479,7 @@ class BasicCustomerInfoTests: XCTestCase {
     }
     
     func testDifferentEntitlementsNotEqual() {
-        let info1 = CustomerInfo(data: [
+        let info1 = CustomerInfo(testData: [
             "request_date": "2018-12-20T02:40:36Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -505,7 +505,7 @@ class BasicCustomerInfoTests: XCTestCase {
                     ]
                 ]
             ]])
-        let info2 = CustomerInfo(data: [
+        let info2 = CustomerInfo(testData: [
             "request_date": "2018-12-20T02:40:36Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -535,7 +535,7 @@ class BasicCustomerInfoTests: XCTestCase {
     }
     
     func testSameEntitlementsDifferentRequestDateEqual() {
-        let info1 = CustomerInfo(data: [
+        let info1 = CustomerInfo(testData: [
             "request_date": "2018-12-21T02:40:36Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -561,7 +561,7 @@ class BasicCustomerInfoTests: XCTestCase {
                     ]
                 ]
             ]])
-        let info2 = CustomerInfo(data: [
+        let info2 = CustomerInfo(testData: [
             "request_date": "2018-12-20T02:40:36Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -591,7 +591,7 @@ class BasicCustomerInfoTests: XCTestCase {
     }
     
     func testInitFailsIfNoRequestDate() {
-        let info = CustomerInfo(data: [
+        let info = CustomerInfo(testData: [
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
                 "management_url": "https://apple.com/manage_subscription",
@@ -603,7 +603,7 @@ class BasicCustomerInfoTests: XCTestCase {
     }
     
     func testInitFailsIfNoSubscriberOriginalAppUserId() {
-        let info = CustomerInfo(data: [
+        let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -615,14 +615,14 @@ class BasicCustomerInfoTests: XCTestCase {
     }
     
     func testInitFailsIfNoSubscriber() {
-        let info = CustomerInfo(data: [
+        let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
            ])
         expect(info).to(beNil());
     }
 
     func testInitFailsIfNoSubscriberFirstSeen() {
-        let info = CustomerInfo(data: [
+        let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "management_url": "https://apple.com/manage_subscription",
@@ -634,7 +634,7 @@ class BasicCustomerInfoTests: XCTestCase {
     }
     
     func testInitFailsIfMalformedRequestDate() {
-        let info = CustomerInfo(data: [
+        let info = CustomerInfo(testData: [
             "request_date": "2019-08-110:30:42Z",
             "subscriber": [
                 "original_app_user_id": "app_user_id",
@@ -647,7 +647,7 @@ class BasicCustomerInfoTests: XCTestCase {
     }
     
     func testInitFailsIfMalformedFirstSeenDate() {
-        let info = CustomerInfo(data: [
+        let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "original_app_user_id": "app_user_id",
@@ -698,7 +698,7 @@ class BasicCustomerInfoTests: XCTestCase {
             ]
         ] as [String : Any]
 
-        let info = CustomerInfo(data: response)
+        let info = CustomerInfo(testData: response)
         XCTAssertEqual(Set(["onemonth_freetrial", "twomonth_freetrial"]), info!.activeSubscriptions)
 
     }
@@ -743,9 +743,25 @@ class BasicCustomerInfoTests: XCTestCase {
             ]
         ] as [String : Any]
 
-        let info = CustomerInfo(data: response)
+        let info = CustomerInfo(testData: response)
         XCTAssertEqual(Set(["onemonth_freetrial", "twomonth_freetrial", "threemonth_freetrial"]),
                        info!.allPurchasedProductIdentifiers)
+    }
+
+}
+
+extension CustomerInfo {
+
+    convenience init?(testData: [String: Any]) {
+        do {
+            try self.init(data: testData,
+                          dateFormatter: .iso8601SecondsDateFormatter,
+                          transactionsFactory: TransactionsFactory())
+        } catch {
+            let errorDescription = (error as? DescribableError)?.description ?? error.localizedDescription
+            Logger.error("Caught error created testData, this is probably expected, right? \(errorDescription).")
+            return nil
+        }
     }
 
 }

--- a/PurchasesTests/Purchasing/EntitlementInfosTests.swift
+++ b/PurchasesTests/Purchasing/EntitlementInfosTests.swift
@@ -86,7 +86,7 @@ class EntitlementInfosTests: XCTestCase {
             ]
         )
         
-        let subscriberInfo: CustomerInfo = CustomerInfo(data: response)!
+        let subscriberInfo: CustomerInfo = CustomerInfo(testData: response)!
         expect(subscriberInfo.entitlements.all.count).to(equal(2))
         // The default is "pro_cat"
         verifySubscriberInfo()
@@ -133,7 +133,7 @@ class EntitlementInfosTests: XCTestCase {
             ]
         )
         
-        let subscriberInfo: CustomerInfo = CustomerInfo(data: response)!
+        let subscriberInfo: CustomerInfo = CustomerInfo(testData: response)!
         
         expect(subscriberInfo.entitlements["pro_cat"]).toNot(beNil())
         expect(subscriberInfo.entitlements.active["pro_cat"]).toNot(beNil())
@@ -193,7 +193,7 @@ class EntitlementInfosTests: XCTestCase {
 
     func testGetsEmptySubscriberInfo() {
         stubResponse()
-        let subscriberInfo = CustomerInfo(data: response)
+        let subscriberInfo = CustomerInfo(testData: response)
 
         expect(subscriberInfo?.firstSeen).toNot(beNil())
         expect(subscriberInfo?.originalAppUserId).to(equal("cesarsandbox1"))
@@ -471,7 +471,7 @@ class EntitlementInfosTests: XCTestCase {
         stubResponse(entitlements: mockEntitlements,
                      subscriptions: mockSubscriptions(ownershipType: "PURCHASED"))
 
-        var subscriberInfo = CustomerInfo(data: response)!
+        var subscriberInfo = CustomerInfo(testData: response)!
         var entitlement: EntitlementInfo? = subscriberInfo.entitlements.active["pro_cat"]
         expect(entitlement).toNot(beNil())
         expect(entitlement!.ownershipType) == .purchased
@@ -479,7 +479,7 @@ class EntitlementInfosTests: XCTestCase {
         stubResponse(entitlements: mockEntitlements,
                      subscriptions: mockSubscriptions(ownershipType: "FAMILY_SHARED"))
 
-        subscriberInfo = CustomerInfo(data: response)!
+        subscriberInfo = CustomerInfo(testData: response)!
         entitlement = subscriberInfo.entitlements.active["pro_cat"]
         expect(entitlement).toNot(beNil())
         expect(entitlement!.ownershipType) == .familyShared
@@ -487,7 +487,7 @@ class EntitlementInfosTests: XCTestCase {
         stubResponse(entitlements: mockEntitlements,
                      subscriptions: mockSubscriptions(ownershipType: "BOATY_MCBOATFACE"))
 
-        subscriberInfo = CustomerInfo(data: response)!
+        subscriberInfo = CustomerInfo(testData: response)!
         entitlement = subscriberInfo.entitlements.active["pro_cat"]
         expect(entitlement).toNot(beNil())
         expect(entitlement!.ownershipType) == .unknown
@@ -504,7 +504,7 @@ class EntitlementInfosTests: XCTestCase {
         stubResponse(entitlements: mockEntitlements,
                      subscriptions: mockSubscriptions(ownershipType: nil))
 
-        let subscriberInfo = CustomerInfo(data: response)!
+        let subscriberInfo = CustomerInfo(testData: response)!
         let entitlement: EntitlementInfo? = subscriberInfo.entitlements.active["pro_cat"]
         expect(entitlement).toNot(beNil())
         expect(entitlement!.ownershipType) == .purchased
@@ -1019,7 +1019,7 @@ class EntitlementInfosTests: XCTestCase {
     }
 
     func verifySubscriberInfo() {
-        let subscriberInfo: CustomerInfo = CustomerInfo(data: response)!
+        let subscriberInfo: CustomerInfo = CustomerInfo(testData: response)!
 
         expect(subscriberInfo).toNot(beNil())
         expect(subscriberInfo.firstSeen).to(equal(formatter.date(from: "2019-07-26T23:29:50Z")))
@@ -1027,7 +1027,7 @@ class EntitlementInfosTests: XCTestCase {
     }
 
     func verifyEntitlementActive(_ expectedEntitlementActive: Bool = true, entitlement: String = "pro_cat") {
-        let subscriberInfo: CustomerInfo = CustomerInfo(data: response)!
+        let subscriberInfo: CustomerInfo = CustomerInfo(testData: response)!
         let proCat: EntitlementInfo = subscriberInfo.entitlements[entitlement]!
 
         expect(proCat.identifier) == entitlement
@@ -1040,7 +1040,7 @@ class EntitlementInfosTests: XCTestCase {
                        expectedUnsubscribeDetectedAt: Date? = nil,
                        expectedBillingIssueDetectedAt: Date? = nil,
                        entitlement: String = "pro_cat") {
-        let subscriberInfo: CustomerInfo = CustomerInfo(data: response)!
+        let subscriberInfo: CustomerInfo = CustomerInfo(testData: response)!
         let proCat: EntitlementInfo = subscriberInfo.entitlements[entitlement]!
 
         expect(proCat.willRenew) == expectedWillRenew
@@ -1059,21 +1059,21 @@ class EntitlementInfosTests: XCTestCase {
     }
 
     func verifyPeriodType(_ expectedPeriodType: PeriodType = PeriodType.normal, expectedEntitlement: String = "pro_cat") {
-        let subscriberInfo: CustomerInfo = CustomerInfo(data: response)!
+        let subscriberInfo: CustomerInfo = CustomerInfo(testData: response)!
         let proCat: EntitlementInfo = subscriberInfo.entitlements[expectedEntitlement]!
 
         expect(proCat.periodType) == expectedPeriodType
     }
 
     func verifyStore(_ expectedStore: Store = Store.appStore, expectedEntitlement: String = "pro_cat") {
-        let subscriberInfo: CustomerInfo = CustomerInfo(data: response)!
+        let subscriberInfo: CustomerInfo = CustomerInfo(testData: response)!
         let proCat: EntitlementInfo = subscriberInfo.entitlements[expectedEntitlement]!
 
         expect(proCat.store) == expectedStore
     }
 
     func verifySandbox(_ expectedIsSandbox: Bool = false, expectedEntitlement: String = "pro_cat") {
-        let subscriberInfo: CustomerInfo = CustomerInfo(data: response)!
+        let subscriberInfo: CustomerInfo = CustomerInfo(testData: response)!
         let proCat: EntitlementInfo = subscriberInfo.entitlements[expectedEntitlement]!
 
         expect(proCat.isSandbox) == expectedIsSandbox
@@ -1093,7 +1093,7 @@ class EntitlementInfosTests: XCTestCase {
                        expectedOriginalPurchaseDate: Date?,
                        expectedExpirationDate: Date?,
                        expectedEntitlement: String = "pro_cat") {
-        let subscriberInfo: CustomerInfo = CustomerInfo(data: response)!
+        let subscriberInfo: CustomerInfo = CustomerInfo(testData: response)!
         let proCat: EntitlementInfo = subscriberInfo.entitlements[expectedEntitlement]!
 
         if (expectedLatestPurchaseDate != nil) {

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -239,7 +239,11 @@ class PurchasesTests: XCTestCase {
                            appUserID: String,
                            completion: @escaping OfferSigningResponseHandler) {
             postOfferForSigningCalled = true
-            completion(postOfferForSigningPaymentDiscountResponse["signature"] as? String, postOfferForSigningPaymentDiscountResponse["keyIdentifier"] as? String, postOfferForSigningPaymentDiscountResponse["nonce"] as? UUID, postOfferForSigningPaymentDiscountResponse["timestamp"] as? NSNumber, postOfferForSigningError)
+            completion(postOfferForSigningPaymentDiscountResponse["signature"] as? String,
+                       postOfferForSigningPaymentDiscountResponse["keyIdentifier"] as? String,
+                       postOfferForSigningPaymentDiscountResponse["nonce"] as? UUID,
+                       postOfferForSigningPaymentDiscountResponse["timestamp"] as? Int,
+                       postOfferForSigningError)
         }
     }
 

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -79,7 +79,7 @@ class PurchasesTests: XCTestCase {
         var timeout = false
         var getSubscriberCallCount = 0
         var overrideCustomerInfoError: Error? = nil
-        var overrideCustomerInfo = CustomerInfo(data: [
+        var overrideCustomerInfo = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -171,7 +171,8 @@ class PurchasesTests: XCTestCase {
         override func getOfferings(appUserID: String, completion: @escaping OfferingsResponseHandler) {
             gotOfferings += 1
             if (failOfferings) {
-                completion(nil, ErrorUtils.unexpectedBackendResponse(withSubError: .getOfferUnexpectedResponse))
+                let subError = UnexpectedBackendResponseSubErrorCode.getOfferUnexpectedResponse
+                completion(nil, ErrorUtils.unexpectedBackendResponse(withSubError: subError))
                 return
             }
             if (badOfferingsResponse) {
@@ -369,7 +370,7 @@ class PurchasesTests: XCTestCase {
 
     func testFirstInitializationFromBackgroundCallsDelegateForAnonIfInfoCached() {
         systemInfo.stubbedIsApplicationBackgrounded = true
-        let info = CustomerInfo(data: [
+        let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -425,13 +426,13 @@ class PurchasesTests: XCTestCase {
     func testDelegateIsCalledForRandomPurchaseSuccess() {
         setupPurchases()
 
-        let customerInfo = CustomerInfo(data: emptyCustomerInfoData)
+        let customerInfo = CustomerInfo(testData: emptyCustomerInfoData)
         self.backend.postReceiptCustomerInfo = customerInfo
 
         let product = MockSKProduct(mockProductIdentifier: "product")
         let payment = SKPayment(product: product)
 
-        let customerInfoBeforePurchase = CustomerInfo(data: [
+        let customerInfoBeforePurchase = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -439,7 +440,7 @@ class PurchasesTests: XCTestCase {
                 "subscriptions": [:],
                 "non_subscriptions": [:]
             ]])
-        let customerInfoAfterPurchase = CustomerInfo(data: [
+        let customerInfoAfterPurchase = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -467,7 +468,7 @@ class PurchasesTests: XCTestCase {
     func testDelegateIsOnlyCalledOnceIfCustomerInfoTheSame() {
         setupPurchases()
 
-        let customerInfo1 = CustomerInfo(data: [
+        let customerInfo1 = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -505,7 +506,7 @@ class PurchasesTests: XCTestCase {
     func testDelegateIsCalledTwiceIfCustomerInfoTheDifferent() {
         setupPurchases()
 
-        let customerInfo1 = CustomerInfo(data: [
+        let customerInfo1 = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -516,7 +517,7 @@ class PurchasesTests: XCTestCase {
             ]
             ])
 
-        let customerInfo2 = CustomerInfo(data: [
+        let customerInfo2 = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -733,7 +734,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        self.backend.postReceiptCustomerInfo = CustomerInfo(data: emptyCustomerInfoData)
+        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: emptyCustomerInfoData)
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -756,7 +757,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        self.backend.postReceiptCustomerInfo = CustomerInfo(data: self.emptyCustomerInfoData)
+        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -780,7 +781,7 @@ class PurchasesTests: XCTestCase {
             transaction.mockState = SKPaymentTransactionState.purchasing
             self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-            self.backend.postReceiptCustomerInfo = CustomerInfo(data: self.emptyCustomerInfoData)
+            self.backend.postReceiptCustomerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
 
             transaction.mockState = SKPaymentTransactionState.purchased
             self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -829,7 +830,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        self.backend.postReceiptCustomerInfo = CustomerInfo(data: emptyCustomerInfoData)
+        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: emptyCustomerInfoData)
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -941,7 +942,7 @@ class PurchasesTests: XCTestCase {
         var receivedError: Error?
         var receivedUserCancelled: Bool?
 
-        let customerInfoBeforePurchase = CustomerInfo(data: [
+        let customerInfoBeforePurchase = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -949,7 +950,7 @@ class PurchasesTests: XCTestCase {
                 "subscriptions": [:],
                 "non_subscriptions": [:]
             ]])
-        let customerInfoAfterPurchase = CustomerInfo(data: [
+        let customerInfoAfterPurchase = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -991,7 +992,7 @@ class PurchasesTests: XCTestCase {
         let transaction = MockTransaction()
         transaction.mockPayment = self.storeKitWrapper.payment!
 
-        self.backend.postReceiptCustomerInfo = CustomerInfo(data: emptyCustomerInfoData)
+        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: emptyCustomerInfoData)
 
         transaction.mockState = SKPaymentTransactionState.purchased
 
@@ -1015,7 +1016,7 @@ class PurchasesTests: XCTestCase {
         let transaction = MockTransaction()
         transaction.mockPayment = SKPayment.init(product: otherProduct)
 
-        self.backend.postReceiptCustomerInfo = CustomerInfo(data: self.emptyCustomerInfoData)
+        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
 
         transaction.mockState = SKPaymentTransactionState.purchased
 
@@ -1134,7 +1135,7 @@ class PurchasesTests: XCTestCase {
     }
 
     func testRestoringPurchasesDoesntPostIfReceiptEmptyAndCustomerInfoLoaded() {
-        let info = CustomerInfo(data: [
+        let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "original_app_user_id": "app_user_id",
@@ -1168,7 +1169,7 @@ class PurchasesTests: XCTestCase {
     }
 
     func testRestoringPurchasesPostsIfReceiptHasTransactionsAndCustomerInfoLoaded() {
-        let info = CustomerInfo(data: [
+        let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -1225,7 +1226,7 @@ class PurchasesTests: XCTestCase {
     func testRestoringPurchasesCallsSuccessDelegateMethod() {
         setupPurchases()
 
-        let customerInfo = CustomerInfo(data: self.emptyCustomerInfoData)
+        let customerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
         self.backend.postReceiptCustomerInfo = customerInfo
 
         var receivedCustomerInfo: CustomerInfo?
@@ -1264,7 +1265,7 @@ class PurchasesTests: XCTestCase {
     }
 
     func testSyncPurchasesDoesntPostIfReceiptEmptyAndCustomerInfoLoaded() {
-        let info = CustomerInfo(data: [
+        let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -1298,7 +1299,7 @@ class PurchasesTests: XCTestCase {
     }
 
     func testSyncPurchasesPostsIfReceiptHasTransactionsAndCustomerInfoLoaded() {
-        let info = CustomerInfo(data: [
+        let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -1378,7 +1379,7 @@ class PurchasesTests: XCTestCase {
     func testSyncPurchasesCallsSuccessDelegateMethod() {
         setupPurchases()
 
-        let customerInfo = CustomerInfo(data: self.emptyCustomerInfoData)
+        let customerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
         self.backend.postReceiptCustomerInfo = customerInfo
 
         var receivedCustomerInfo: CustomerInfo?
@@ -1534,7 +1535,7 @@ class PurchasesTests: XCTestCase {
     func testFetchVersionSendsAReceiptIfNoVersion() {
         setupPurchases()
 
-        self.backend.postReceiptCustomerInfo = CustomerInfo(data: [
+        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -1580,7 +1581,7 @@ class PurchasesTests: XCTestCase {
 
         expect(self.deviceCache.cachedCustomerInfo.count).toEventually(equal(1))
 
-        self.backend.postReceiptCustomerInfo = CustomerInfo(data: [
+        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -1609,7 +1610,7 @@ class PurchasesTests: XCTestCase {
     }
 
     func testCachedCustomerInfoHasSchemaVersion() {
-        let info = CustomerInfo(data: [
+        let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -1636,7 +1637,7 @@ class PurchasesTests: XCTestCase {
     }
 
     func testCachedCustomerInfoHandlesNullSchema() {
-        let info = CustomerInfo(data: [
+        let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -1665,7 +1666,7 @@ class PurchasesTests: XCTestCase {
     }
 
     func testSendsCachedCustomerInfoToGetter() {
-        let info = CustomerInfo(data: [
+        let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -1689,7 +1690,7 @@ class PurchasesTests: XCTestCase {
     }
 
     func testCustomerInfoCompletionBlockCalledExactlyOnceWhenInfoCached() {
-        let info = CustomerInfo(data: [
+        let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -1714,7 +1715,7 @@ class PurchasesTests: XCTestCase {
     }
 
     func testDoesntSendsCachedCustomerInfoToGetterIfSchemaVersionDiffers() {
-        let info = CustomerInfo(data: [
+        let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -1741,7 +1742,7 @@ class PurchasesTests: XCTestCase {
     }
 
     func testDoesntSendsCachedCustomerInfoToGetterIfNoSchemaVersionInCached() {
-        let info = CustomerInfo(data: [
+        let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -1807,7 +1808,7 @@ class PurchasesTests: XCTestCase {
             transaction.mockState = SKPaymentTransactionState.purchasing
             self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-            self.backend.postReceiptCustomerInfo = CustomerInfo(data: self.emptyCustomerInfoData)
+            self.backend.postReceiptCustomerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
 
             transaction.mockState = SKPaymentTransactionState.purchased
             self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -1900,7 +1901,7 @@ class PurchasesTests: XCTestCase {
 
     func testCreateAliasUpdatesCaches() {
         setupPurchases()
-        self.backend.overrideCustomerInfo = CustomerInfo(data: [
+        self.backend.overrideCustomerInfo = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -1951,7 +1952,7 @@ class PurchasesTests: XCTestCase {
     func testIdentifyUpdatesCaches() {
         setupPurchases()
 
-        self.backend.overrideCustomerInfo = CustomerInfo(data: [
+        self.backend.overrideCustomerInfo = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -1988,7 +1989,7 @@ class PurchasesTests: XCTestCase {
 
     func testResetUpdatesCaches() {
         setupPurchases()
-        self.backend.overrideCustomerInfo = CustomerInfo(data: [
+        self.backend.overrideCustomerInfo = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -2422,7 +2423,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        self.backend.postReceiptCustomerInfo = CustomerInfo(data: self.emptyCustomerInfoData)
+        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -2444,7 +2445,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        self.backend.postReceiptCustomerInfo = CustomerInfo(data: self.emptyCustomerInfoData)
+        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -2524,7 +2525,7 @@ class PurchasesTests: XCTestCase {
             transaction.mockState = SKPaymentTransactionState.purchasing
             self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-            self.backend.postReceiptCustomerInfo = CustomerInfo(data: self.emptyCustomerInfoData)
+            self.backend.postReceiptCustomerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
 
             transaction.mockState = SKPaymentTransactionState.purchased
             self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -2584,7 +2585,7 @@ class PurchasesTests: XCTestCase {
 
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
-        self.backend.postReceiptCustomerInfo = CustomerInfo(data: self.emptyCustomerInfoData)
+        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
     }
@@ -2615,7 +2616,7 @@ class PurchasesTests: XCTestCase {
         setupPurchases()
         let product = MockSKProduct(mockProductIdentifier: "product")
 
-        let customerInfoBeforePurchase = CustomerInfo(data: [
+        let customerInfoBeforePurchase = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -2623,7 +2624,7 @@ class PurchasesTests: XCTestCase {
                 "subscriptions": [:],
                 "non_subscriptions": [:]
             ]])
-        let customerInfoAfterPurchase = CustomerInfo(data: [
+        let customerInfoAfterPurchase = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -2710,7 +2711,7 @@ class PurchasesTests: XCTestCase {
         let appUserID = identityManager.currentAppUserID
         let oldAppUserInfo = Data()
         self.deviceCache.cache(customerInfo: oldAppUserInfo, appUserID: appUserID)
-        let overrideCustomerInfo = CustomerInfo(data: [
+        let overrideCustomerInfo = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -368,11 +368,14 @@ class BackendSubscriberAttributesTests: XCTestCase {
 
         expect(self.mockHTTPClient.invokedPerformRequestCount) == 1
 
+
+        let unexpectedBackendError = receivedError?.userInfo[ErrorDetails.extraContextKey as String] as? NSError
+        let customerInfoError = unexpectedBackendError?.userInfo[ErrorDetails.extraContextKey as String] as? NSError
+        expect(customerInfoError as? CustomerInfoError).to(equal(CustomerInfoError.missingJsonObject))
         expect(receivedError).toNot(beNil())
         guard let nonNilReceivedError = receivedError else { fatalError() }
-        expect(nonNilReceivedError.successfullySynced) == true
-        expect(nonNilReceivedError.subscriberAttributesErrors)
-            == attributeErrors[Backend.RCAttributeErrorsKey]
+        expect(nonNilReceivedError.successfullySynced).to(equal(true))
+        expect(nonNilReceivedError.subscriberAttributesErrors).to(equal(attributeErrors[Backend.RCAttributeErrorsKey]))
     }
 
     func testPostReceiptWithSubscriberAttributesPassesErrorsToCallbackIfStatusCodeIsSuccess() {

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -371,11 +371,11 @@ class BackendSubscriberAttributesTests: XCTestCase {
 
         let unexpectedBackendError = receivedError?.userInfo[ErrorDetails.attachedErrorKey as String] as? NSError
         let customerInfoError = unexpectedBackendError?.userInfo[ErrorDetails.attachedErrorKey as String] as? NSError
-        expect(customerInfoError as? CustomerInfoError).to(equal(CustomerInfoError.missingJsonObject))
+        expect(customerInfoError as? CustomerInfoError) == CustomerInfoError.missingJsonObject
         expect(receivedError).toNot(beNil())
         guard let nonNilReceivedError = receivedError else { fatalError() }
-        expect(nonNilReceivedError.successfullySynced).to(equal(true))
-        expect(nonNilReceivedError.subscriberAttributesErrors).to(equal(attributeErrors[Backend.RCAttributeErrorsKey]))
+        expect(nonNilReceivedError.successfullySynced) == true
+        expect(nonNilReceivedError.subscriberAttributesErrors) == attributeErrors[Backend.RCAttributeErrorsKey]
     }
 
     func testPostReceiptWithSubscriberAttributesPassesErrorsToCallbackIfStatusCodeIsSuccess() {

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -369,8 +369,8 @@ class BackendSubscriberAttributesTests: XCTestCase {
         expect(self.mockHTTPClient.invokedPerformRequestCount) == 1
 
 
-        let unexpectedBackendError = receivedError?.userInfo[ErrorDetails.extraContextKey as String] as? NSError
-        let customerInfoError = unexpectedBackendError?.userInfo[ErrorDetails.extraContextKey as String] as? NSError
+        let unexpectedBackendError = receivedError?.userInfo[ErrorDetails.attachedErrorKey as String] as? NSError
+        let customerInfoError = unexpectedBackendError?.userInfo[ErrorDetails.attachedErrorKey as String] as? NSError
         expect(customerInfoError as? CustomerInfoError).to(equal(CustomerInfoError.missingJsonObject))
         expect(receivedError).toNot(beNil())
         guard let nonNilReceivedError = receivedError else { fatalError() }

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -313,6 +313,53 @@ class BackendSubscriberAttributesTests: XCTestCase {
         expect(requestBody["attributes"] as? [String: NSObject]) == expectedBody
     }
 
+    func testPostReceiptWithSubscriberAttributesReturnsBadJson() {
+        let subscriberAttributesByKey: [String: SubscriberAttribute] = [
+            subscriberAttribute1.key: subscriberAttribute1,
+            subscriberAttribute2.key: subscriberAttribute2
+        ]
+
+        var maybeReceivedError: Error? = nil
+        var maybeCustomerInfo: CustomerInfo? = nil
+        backend.post(receiptData: receiptData,
+                     appUserID: appUserID,
+                     isRestore: false,
+                     productInfo: nil,
+                     presentedOfferingIdentifier: nil,
+                     observerMode: false,
+                     subscriberAttributes: subscriberAttributesByKey,
+                     completion: { (customerInfo, error) in
+            maybeReceivedError = error
+            maybeCustomerInfo = customerInfo
+        })
+
+        expect(maybeCustomerInfo).toEventually(beNil())
+
+        guard let nsError = maybeReceivedError as NSError? else {
+            fail("receivedError is nil")
+            return
+        }
+
+        expect(nsError.domain) == RevenueCat.ErrorCode._nsErrorDomain
+        expect(nsError.code) == ErrorCode.unexpectedBackendResponseError.rawValue
+
+        guard let underlyingError = nsError.userInfo[NSUnderlyingErrorKey] as? NSError else {
+            fail("Underlying error missing")
+            return
+        }
+
+        expect(underlyingError.domain) == "RevenueCat.UnexpectedBackendResponseSubErrorCode"
+        expect(underlyingError.code) == UnexpectedBackendResponseSubErrorCode.customerInfoResponseParsing.rawValue
+
+        guard let parsingError = underlyingError.userInfo[NSUnderlyingErrorKey] as? NSError else {
+            fail("Additional error details missing")
+            return
+        }
+
+        expect(parsingError.domain) == "RevenueCat.CustomerInfoError"
+        expect(parsingError.code) == CustomerInfoError.missingJsonObject.rawValue
+    }
+
     func testPostReceiptWithoutSubscriberAttributesSkipsThem() {
         var completionCallCount = 0
 
@@ -367,15 +414,20 @@ class BackendSubscriberAttributesTests: XCTestCase {
                                 })
 
         expect(self.mockHTTPClient.invokedPerformRequestCount) == 1
-
-
-        let unexpectedBackendError = receivedError?.userInfo[ErrorDetails.attachedErrorKey as String] as? NSError
-        let customerInfoError = unexpectedBackendError?.userInfo[ErrorDetails.attachedErrorKey as String] as? NSError
-        expect(customerInfoError as? CustomerInfoError) == CustomerInfoError.missingJsonObject
         expect(receivedError).toNot(beNil())
-        guard let nonNilReceivedError = receivedError else { fatalError() }
+        guard let nonNilReceivedError = receivedError else {
+            fail("missing receivedError")
+            return
+        }
         expect(nonNilReceivedError.successfullySynced) == true
         expect(nonNilReceivedError.subscriberAttributesErrors) == attributeErrors[Backend.RCAttributeErrorsKey]
+
+        guard let underlyingError = (nonNilReceivedError as NSError).userInfo[NSUnderlyingErrorKey] as? NSError else {
+            fail("Missing underlying error")
+            return
+        }
+
+        expect(underlyingError.userInfo[NSUnderlyingErrorKey]).to(beNil())
     }
 
     func testPostReceiptWithSubscriberAttributesPassesErrorsToCallbackIfStatusCodeIsSuccess() {

--- a/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -187,7 +187,7 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
     }
 
     func testSubscriberAttributesSyncIsPerformedAfterCustomerInfoSync() {
-        mockBackend.stubbedGetSubscriberDataCustomerInfo = CustomerInfo(data: [
+        mockBackend.stubbedGetSubscriberDataCustomerInfo = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -577,7 +577,7 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.mockStoreKitWrapper.delegate?.storeKitWrapper(self.mockStoreKitWrapper, updatedTransaction: transaction)
 
-        self.mockBackend.stubbedPostReceiptCustomerInfo = CustomerInfo(data: emptyCustomerInfoData)
+        self.mockBackend.stubbedPostReceiptCustomerInfo = CustomerInfo(testData: emptyCustomerInfoData)
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.mockStoreKitWrapper.delegate?.storeKitWrapper(self.mockStoreKitWrapper, updatedTransaction: transaction)

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -166,6 +166,7 @@
 		B302206A27271BCB008F1A0D /* Decoder+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B302206927271BCB008F1A0D /* Decoder+Extensions.swift */; };
 		B302206C2727436F008F1A0D /* UnexpectedBackendResponseSubErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B302206B2727436F008F1A0D /* UnexpectedBackendResponseSubErrorCode.swift */; };
 		B302206E2728B798008F1A0D /* BackendErrorStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B302206D2728B798008F1A0D /* BackendErrorStrings.swift */; };
+		B3022072272B3DDC008F1A0D /* DescribableError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3022071272B3DDC008F1A0D /* DescribableError.swift */; };
 		B3083A132699334C007B5503 /* Offering.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3083A122699334C007B5503 /* Offering.swift */; };
 		B319514926C19856002CA9AC /* NSData+RCExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35ABEE9FD79CCA64E4F8B /* NSData+RCExtensionsTests.swift */; };
 		B319514B26C1991E002CA9AC /* base64EncodedReceiptSampleForDataExtension.txt in Resources */ = {isa = PBXBuildFile; fileRef = B319514A26C1991E002CA9AC /* base64EncodedReceiptSampleForDataExtension.txt */; };
@@ -413,6 +414,7 @@
 		B302206927271BCB008F1A0D /* Decoder+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decoder+Extensions.swift"; sourceTree = "<group>"; };
 		B302206B2727436F008F1A0D /* UnexpectedBackendResponseSubErrorCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnexpectedBackendResponseSubErrorCode.swift; sourceTree = "<group>"; };
 		B302206D2728B798008F1A0D /* BackendErrorStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendErrorStrings.swift; sourceTree = "<group>"; };
+		B3022071272B3DDC008F1A0D /* DescribableError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescribableError.swift; sourceTree = "<group>"; };
 		B3083A122699334C007B5503 /* Offering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Offering.swift; sourceTree = "<group>"; };
 		B319514A26C1991E002CA9AC /* base64EncodedReceiptSampleForDataExtension.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = base64EncodedReceiptSampleForDataExtension.txt; sourceTree = "<group>"; };
 		B32B750026868C1D005647BF /* EntitlementInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EntitlementInfo.swift; sourceTree = "<group>"; };
@@ -965,6 +967,7 @@
 			isa = PBXGroup;
 			children = (
 				B3B5FBB3269CED4B00104A0C /* BackendErrorCode.swift */,
+				B3022071272B3DDC008F1A0D /* DescribableError.swift */,
 				B3B5FBB5269CED6400104A0C /* ErrorDetails.swift */,
 				35D0E5CF26A5886C0099EAD8 /* ErrorUtils.swift */,
 				B302206B2727436F008F1A0D /* UnexpectedBackendResponseSubErrorCode.swift */,
@@ -1185,7 +1188,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1300;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1310;
 				ORGANIZATIONNAME = RevenueCat;
 				TargetAttributes = {
 					2DC5621524EC63420031F69B = {
@@ -1326,6 +1329,7 @@
 				2DDF41B624F6F387005BC22D /* ASN1ObjectIdentifierBuilder.swift in Sources */,
 				35D832D2262E56DB00E60AC5 /* HTTPStatusCodes.swift in Sources */,
 				F5E4383826B8530700841CC8 /* SKPaymentTransaction+Extensions.swift in Sources */,
+				B3022072272B3DDC008F1A0D /* DescribableError.swift in Sources */,
 				F5C0196926E880800005D61E /* StoreKitStrings.swift in Sources */,
 				B302206C2727436F008F1A0D /* UnexpectedBackendResponseSubErrorCode.swift in Sources */,
 				2D4E926526990AB1000E10B0 /* StoreKitWrapper.swift in Sources */,


### PR DESCRIPTION
Distinguish between missing json/response and malformed data.
Add extra context to those error states including
- statusCode
- responseData
- which method called `handle`
