### PR TITLE
Remove more "ADClient" words

### DIFF
--- a/Purchases/Attribution/ASIdManagerProxy.swift
+++ b/Purchases/Attribution/ASIdManagerProxy.swift
@@ -7,7 +7,7 @@
 //
 //      https://opensource.org/licenses/MIT
 //
-//  ASIdentifierManagerProxy.swift
+//  ASIdManagerProxy.swift
 //
 //  Created by Juanpe Catalán on 14/7/21.
 //
@@ -18,16 +18,16 @@ import Foundation
 // Review uses some grep to find the class names, so we ended up creating a fake class that
 // exposes the same methods we're looking for in ASIdentifierManager to call the same methods and mangling
 // the class names. So that Apple can't find them during the review, but we can still access them on runtime.
-class FakeASIdentifierManager: NSObject {
+class FakeASIdManager: NSObject {
 
     // We need this method to be available as an optional implicitly unwrapped method for `AnyClass`.
-    @objc static func sharedManager() -> FakeASIdentifierManager {
-        FakeASIdentifierManager()
+    @objc static func sharedManager() -> FakeASIdManager {
+        FakeASIdManager()
     }
 
 }
 
-class ASIdentifierManagerProxy {
+class ASIdManagerProxy {
 
     static let mangledIdentifierClassName = "NFVqragvsvreZnantre"
     static let mangledIdentifierPropertyName = "nqiregvfvatVqragvsvre"

--- a/Purchases/Attribution/AfficheClientProxy.swift
+++ b/Purchases/Attribution/AfficheClientProxy.swift
@@ -20,6 +20,7 @@ typealias AttributionDetailsBlock = ([String: NSObject]?, Error?) -> Void
 // Review uses some grep to find the class names, so we ended up creating a fake class that
 // exposes the same methods we're looking for in ADClient to call the same methods and mangling
 // the class names. So that Apple can't find them during the review, but we can still access them on runtime.
+// You can see the class here: https://rev.cat/fake-affiche-client
 class FakeAfficheClient: NSObject {
 
     // We need this method to be available as an optional implicitly unwrapped method for `AnyClass`.

--- a/Purchases/Attribution/AfficheClientProxy.swift
+++ b/Purchases/Attribution/AfficheClientProxy.swift
@@ -7,7 +7,7 @@
 //
 //      https://opensource.org/licenses/MIT
 //
-//  AdClientProxy.swift
+//  AfficheClientProxy.swift
 //
 //  Created by Juanpe Catalán on 14/7/21.
 //
@@ -20,39 +20,39 @@ typealias AttributionDetailsBlock = ([String: NSObject]?, Error?) -> Void
 // Review uses some grep to find the class names, so we ended up creating a fake class that
 // exposes the same methods we're looking for in ADClient to call the same methods and mangling
 // the class names. So that Apple can't find them during the review, but we can still access them on runtime.
-class FakeAdClient: NSObject {
+class FakeAfficheClient: NSObject {
 
     // We need this method to be available as an optional implicitly unwrapped method for `AnyClass`.
-    @objc static func sharedClient() -> FakeAdClient {
-        FakeAdClient()
+    @objc static func sharedClient() -> FakeAfficheClient {
+        FakeAfficheClient()
     }
 
     // We need this method to be available as an optional implicitly unwrapped method for `AnyClass`.
     @objc(requestAttributionDetailsWithBlock:)
     func requestAttributionDetails(_ completionHandler: @escaping AttributionDetailsBlock) {
-        Logger.warn(Strings.attribution.iad_framework_present_but_couldnt_call_request_attribution_details)
+        Logger.warn(Strings.attribution.apple_affiche_framework_present_but_couldnt_call_request_attribution_details)
     }
 
 }
 
-class AdClientProxy {
+class AfficheClientProxy {
 
-    private static let className = "ADClient"
+    private static let mangledClassName = "NQPyvrag"
 
-    static var adClientClass: AnyClass? {
-        NSClassFromString(Self.className)
+    static var afficheClientClass: AnyClass? {
+        NSClassFromString(Self.mangledClassName.rot13())
     }
 
     func requestAttributionDetails(_ completionHandler: @escaping AttributionDetailsBlock) {
         let client: AnyObject
-        if let klass = Self.adClientClass, let clientClass = klass as AnyObject as? NSObjectProtocol {
+        if let klass = Self.afficheClientClass, let clientClass = klass as AnyObject as? NSObjectProtocol {
             // This looks strange, but #selector() does fun things to create a selector. If the selector for the given
             // function matches the selector on another class, it can be used in place. Results:
             // If ADClient class is instantiated above, then +sharedClient selector is performed even though you can see
-            // that we're using #selector(FakeAdClient.sharedClient) to instantiate a Selector object.
-            client = clientClass.perform(#selector(FakeAdClient.sharedClient)).takeUnretainedValue()
+            // that we're using #selector(FakeAfficheClient.sharedClient) to instantiate a Selector object.
+            client = clientClass.perform(#selector(FakeAfficheClient.sharedClient)).takeUnretainedValue()
         } else {
-            client = FakeAdClient.sharedClient()
+            client = FakeAfficheClient.sharedClient()
         }
 
         client.requestAttributionDetails(completionHandler)

--- a/Purchases/Attribution/AttributionFetcher.swift
+++ b/Purchases/Attribution/AttributionFetcher.swift
@@ -60,7 +60,7 @@ class AttributionFetcher {
         // https://developer.apple.com/documentation/adsupport/asidentifiermanager/1614151-advertisingidentifier
 #if os(iOS) || os(tvOS) || os(macOS)
         if #available(macOS 10.14, *) {
-            let maybeIdentifierManagerProxy = attributionFactory.asIdentifierProxy()
+            let maybeIdentifierManagerProxy = attributionFactory.asIdProxy()
             guard let identifierManagerProxy = maybeIdentifierManagerProxy else {
                 Logger.warn(Strings.configure.adsupport_not_imported)
                 return nil
@@ -76,16 +76,16 @@ class AttributionFetcher {
         return nil
     }
 
-    func adClientAttributionDetails(completion: @escaping ([String: NSObject]?, Error?) -> Void) {
+    func afficheClientAttributionDetails(completion: @escaping ([String: NSObject]?, Error?) -> Void) {
         // Should match available platforms in
         // https://developer.apple.com/documentation/iad/adclient?language=swift
 #if os(iOS)
-        guard let adClientProxy = attributionFactory.adClientProxy() else {
-            Logger.warn(Strings.attribution.search_ads_attribution_cancelled_missing_iad_framework)
+        guard let afficheClientProxy = attributionFactory.afficheClientProxy() else {
+            Logger.warn(Strings.attribution.search_ads_attribution_cancelled_missing_ad_framework)
             completion(nil, AttributionFetcherError.identifierForAdvertiserFrameworksUnavailable)
             return
         }
-        adClientProxy.requestAttributionDetails(completion)
+        afficheClientProxy.requestAttributionDetails(completion)
 #else
         completion(nil, AttributionFetcherError.identifierForAdvertiserUnavailableForPlatform)
 #endif
@@ -117,7 +117,7 @@ private extension AttributionFetcher {
         let needsTrackingAuthorization = systemInfo
             .isOperatingSystemAtLeastVersion(minimumOSVersionRequiringAuthorization)
 
-        guard let trackingManagerProxy = attributionFactory.atTrackingProxy() else {
+        guard let trackingManagerProxy = attributionFactory.atFollowingProxy() else {
             if needsTrackingAuthorization {
                 Logger.warn(Strings.attribution.search_ads_attribution_cancelled_missing_att_framework)
             }

--- a/Purchases/Attribution/AttributionPoster.swift
+++ b/Purchases/Attribution/AttributionPoster.swift
@@ -113,7 +113,7 @@ class AttributionPoster {
             return
         }
 
-        attributionFetcher.adClientAttributionDetails { maybeAttributionDetails, maybeError in
+        attributionFetcher.afficheClientAttributionDetails { maybeAttributionDetails, maybeError in
             guard let attributionDetails = maybeAttributionDetails,
                   maybeError == nil else {
                 return

--- a/Purchases/Attribution/AttributionTypeFactory.swift
+++ b/Purchases/Attribution/AttributionTypeFactory.swift
@@ -16,8 +16,8 @@ import Foundation
 
 class AttributionTypeFactory {
 
-    func adClientProxy() -> AdClientProxy? {
-        return AdClientProxy.adClientClass == nil ? nil : AdClientProxy()
+    func adClientProxy() -> AfficheClientProxy? {
+        return AfficheClientProxy.afficheClientClass == nil ? nil : AfficheClientProxy()
     }
 
     func atTrackingProxy() -> TrackingManagerProxy? {

--- a/Purchases/Attribution/AttributionTypeFactory.swift
+++ b/Purchases/Attribution/AttributionTypeFactory.swift
@@ -16,16 +16,16 @@ import Foundation
 
 class AttributionTypeFactory {
 
-    func adClientProxy() -> AfficheClientProxy? {
+    func afficheClientProxy() -> AfficheClientProxy? {
         return AfficheClientProxy.afficheClientClass == nil ? nil : AfficheClientProxy()
     }
 
-    func atTrackingProxy() -> TrackingManagerProxy? {
+    func atFollowingProxy() -> TrackingManagerProxy? {
         return TrackingManagerProxy.trackingClass == nil ? nil : TrackingManagerProxy()
     }
 
-    func asIdentifierProxy() -> ASIdentifierManagerProxy? {
-        return ASIdentifierManagerProxy.identifierClass == nil ? nil : ASIdentifierManagerProxy()
+    func asIdProxy() -> ASIdManagerProxy? {
+        return ASIdManagerProxy.identifierClass == nil ? nil : ASIdManagerProxy()
     }
 
 }

--- a/Purchases/Logging/Strings/AttributionStrings.swift
+++ b/Purchases/Logging/Strings/AttributionStrings.swift
@@ -29,7 +29,7 @@ enum AttributionStrings {
     case instance_configured_posting_attribution
     case search_ads_attribution_cancelled_missing_att_framework
     case att_framework_present_but_couldnt_call_tracking_authorization_status
-    case iad_framework_present_but_couldnt_call_request_attribution_details
+    case apple_affiche_framework_present_but_couldnt_call_request_attribution_details
     case search_ads_attribution_cancelled_missing_iad_framework
     case search_ads_attribution_cancelled_not_authorized
     case skip_same_attributes
@@ -84,7 +84,7 @@ extension AttributionStrings: CustomStringConvertible {
         case .att_framework_present_but_couldnt_call_tracking_authorization_status:
             return "ATT Framework was found but it didn't respond to authorization status selector!"
 
-        case .iad_framework_present_but_couldnt_call_request_attribution_details:
+        case .apple_affiche_framework_present_but_couldnt_call_request_attribution_details:
             return "iAd Framework was found but it didn't respond to attribution details request!"
 
         case .search_ads_attribution_cancelled_missing_iad_framework:

--- a/Purchases/Logging/Strings/AttributionStrings.swift
+++ b/Purchases/Logging/Strings/AttributionStrings.swift
@@ -30,7 +30,7 @@ enum AttributionStrings {
     case search_ads_attribution_cancelled_missing_att_framework
     case att_framework_present_but_couldnt_call_tracking_authorization_status
     case apple_affiche_framework_present_but_couldnt_call_request_attribution_details
-    case search_ads_attribution_cancelled_missing_iad_framework
+    case search_ads_attribution_cancelled_missing_ad_framework
     case search_ads_attribution_cancelled_not_authorized
     case skip_same_attributes
     case subscriber_attributes_error(errors: [String: String]?)
@@ -85,11 +85,11 @@ extension AttributionStrings: CustomStringConvertible {
             return "ATT Framework was found but it didn't respond to authorization status selector!"
 
         case .apple_affiche_framework_present_but_couldnt_call_request_attribution_details:
-            return "iAd Framework was found but it didn't respond to attribution details request!"
+            return "Apple Ad Framework was found but it didn't respond to attribution details request!"
 
-        case .search_ads_attribution_cancelled_missing_iad_framework:
+        case .search_ads_attribution_cancelled_missing_ad_framework:
             return "Tried to post Apple Search Ads Attribution, " +
-            "but iAd Framework is is required for it and it isn't included"
+            "but Apple Ad Framework is is required for it and it isn't included"
 
         case .search_ads_attribution_cancelled_not_authorized:
             return "Tried to post Apple Search Ads Attribution, but " +

--- a/PurchasesTests/Attribution/AttributionTypeFactoryTests.swift
+++ b/PurchasesTests/Attribution/AttributionTypeFactoryTests.swift
@@ -27,7 +27,7 @@ class AttributionTypeFactoryTests: XCTestCase {
 
     func testCanRotateASIdentifierManagerBack() {
         let expected = "ASIdentifierManager"
-        let randomized = ASIdentifierManagerProxy.mangledIdentifierClassName
+        let randomized = ASIdManagerProxy.mangledIdentifierClassName
 
         expect { randomized.rot13() }.to(equal(expected))
     }
@@ -42,7 +42,7 @@ class AttributionTypeFactoryTests: XCTestCase {
 
     func testCanRotateAdvertisingIdentifierBack() {
         let expected = "advertisingIdentifier"
-        let randomized = ASIdentifierManagerProxy.mangledIdentifierPropertyName
+        let randomized = ASIdManagerProxy.mangledIdentifierPropertyName
 
         expect { randomized.rot13() }.to(equal(expected))
     }

--- a/PurchasesTests/Mocks/MockAttributionFetcher.swift
+++ b/PurchasesTests/Mocks/MockAttributionFetcher.swift
@@ -15,7 +15,7 @@ class MockAttributionFetcher: AttributionFetcher {
         return "rc_idfv"
     }
 
-    override func adClientAttributionDetails(completion completionHandler: @escaping ([String: NSObject]?, Error?) -> Void) {
+    override func afficheClientAttributionDetails(completion completionHandler: @escaping ([String: NSObject]?, Error?) -> Void) {
         completionHandler(["Version3.1": ["iad-campaign-id": 15292426, "iad-attribution": true] as NSObject], nil)
     }
 }

--- a/PurchasesTests/Mocks/MockAttributionTypeFactory.swift
+++ b/PurchasesTests/Mocks/MockAttributionTypeFactory.swift
@@ -16,7 +16,7 @@ import Foundation
 #endif
 @testable import RevenueCat
 
-class MockAdClientProxy: AdClientProxy {
+class MockAdClientProxy: AfficheClientProxy {
 
     static var mockAttributionDetails: [String: NSObject] = [
         "Version3.1":
@@ -50,7 +50,7 @@ class MockAttributionTypeFactory: AttributionTypeFactory {
 
     static var shouldReturnAdClientProxy = true
 
-    override func adClientProxy() -> AdClientProxy? {
+    override func adClientProxy() -> AfficheClientProxy? {
         Self.shouldReturnAdClientProxy ? MockAdClientProxy() : nil
     }
 

--- a/PurchasesTests/Mocks/MockAttributionTypeFactory.swift
+++ b/PurchasesTests/Mocks/MockAttributionTypeFactory.swift
@@ -50,13 +50,13 @@ class MockAttributionTypeFactory: AttributionTypeFactory {
 
     static var shouldReturnAdClientProxy = true
 
-    override func adClientProxy() -> AfficheClientProxy? {
+    override func afficheClientProxy() -> AfficheClientProxy? {
         Self.shouldReturnAdClientProxy ? MockAdClientProxy() : nil
     }
 
     static var shouldReturnTrackingManagerProxy = true
 
-    override func atTrackingProxy() -> TrackingManagerProxy? {
+    override func atFollowingProxy() -> TrackingManagerProxy? {
         if #available(iOS 14, macOS 11, tvOS 14, *) {
             return Self.shouldReturnTrackingManagerProxy ? MockTrackingManagerProxy() : nil
         } else {

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -221,7 +221,7 @@
 		F5BE443D26977F9B00254A30 /* HTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BE443C26977F9B00254A30 /* HTTPRequest.swift */; };
 		F5BE44432698581100254A30 /* AttributionTypeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BE44422698581100254A30 /* AttributionTypeFactory.swift */; };
 		F5BE444726985E7B00254A30 /* AttributionTypeFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E350420D54B99BB39448E0 /* AttributionTypeFactoryTests.swift */; };
-		F5BE4479269E4A4C00254A30 /* AdClientProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BE4478269E4A4C00254A30 /* AdClientProxy.swift */; };
+		F5BE4479269E4A4C00254A30 /* AfficheClientProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BE4478269E4A4C00254A30 /* AfficheClientProxy.swift */; };
 		F5BE447B269E4A7500254A30 /* TrackingManagerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BE447A269E4A7500254A30 /* TrackingManagerProxy.swift */; };
 		F5BE447D269E4ADB00254A30 /* ASIdentifierManagerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BE447C269E4ADB00254A30 /* ASIdentifierManagerProxy.swift */; };
 		F5C0196926E880800005D61E /* StoreKitStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C0196826E880800005D61E /* StoreKitStrings.swift */; };
@@ -465,7 +465,7 @@
 		F5BE4244269676E200254A30 /* StoreKitRequestFetcherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreKitRequestFetcherTests.swift; sourceTree = "<group>"; };
 		F5BE443C26977F9B00254A30 /* HTTPRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequest.swift; sourceTree = "<group>"; };
 		F5BE44422698581100254A30 /* AttributionTypeFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributionTypeFactory.swift; sourceTree = "<group>"; };
-		F5BE4478269E4A4C00254A30 /* AdClientProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdClientProxy.swift; sourceTree = "<group>"; };
+		F5BE4478269E4A4C00254A30 /* AfficheClientProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfficheClientProxy.swift; sourceTree = "<group>"; };
 		F5BE447A269E4A7500254A30 /* TrackingManagerProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingManagerProxy.swift; sourceTree = "<group>"; };
 		F5BE447C269E4ADB00254A30 /* ASIdentifierManagerProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASIdentifierManagerProxy.swift; sourceTree = "<group>"; };
 		F5C0196826E880800005D61E /* StoreKitStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitStrings.swift; sourceTree = "<group>"; };
@@ -1058,7 +1058,7 @@
 		F5BE44412698580200254A30 /* Attribution */ = {
 			isa = PBXGroup;
 			children = (
-				F5BE4478269E4A4C00254A30 /* AdClientProxy.swift */,
+				F5BE4478269E4A4C00254A30 /* AfficheClientProxy.swift */,
 				F5BE447C269E4ADB00254A30 /* ASIdentifierManagerProxy.swift */,
 				37E35CD16BB73BB091E64D9A /* AttributionData.swift */,
 				37E3521731D8DC16873F55F3 /* AttributionFetcher.swift */,
@@ -1351,7 +1351,7 @@
 				B3C4AAD526B8911300E1B3C8 /* Backend.swift in Sources */,
 				B34D2AA626976FC700D88C3A /* ErrorCode.swift in Sources */,
 				B39E811D268E887500D31189 /* SubscriberAttribute.swift in Sources */,
-				F5BE4479269E4A4C00254A30 /* AdClientProxy.swift in Sources */,
+				F5BE4479269E4A4C00254A30 /* AfficheClientProxy.swift in Sources */,
 				B33CEAA0268CDCC9008A3144 /* ISOPeriodFormatter.swift in Sources */,
 				2DDF41A324F6F331005BC22D /* ReceiptParser.swift in Sources */,
 				35D832F4262E606500E60AC5 /* HTTPResponse.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -223,7 +223,7 @@
 		F5BE444726985E7B00254A30 /* AttributionTypeFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E350420D54B99BB39448E0 /* AttributionTypeFactoryTests.swift */; };
 		F5BE4479269E4A4C00254A30 /* AfficheClientProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BE4478269E4A4C00254A30 /* AfficheClientProxy.swift */; };
 		F5BE447B269E4A7500254A30 /* TrackingManagerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BE447A269E4A7500254A30 /* TrackingManagerProxy.swift */; };
-		F5BE447D269E4ADB00254A30 /* ASIdentifierManagerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BE447C269E4ADB00254A30 /* ASIdentifierManagerProxy.swift */; };
+		F5BE447D269E4ADB00254A30 /* ASIdManagerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BE447C269E4ADB00254A30 /* ASIdManagerProxy.swift */; };
 		F5C0196926E880800005D61E /* StoreKitStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C0196826E880800005D61E /* StoreKitStrings.swift */; };
 		F5E4383826B8530700841CC8 /* SKPaymentTransaction+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E4383726B8530700841CC8 /* SKPaymentTransaction+Extensions.swift */; };
 /* End PBXBuildFile section */
@@ -467,7 +467,7 @@
 		F5BE44422698581100254A30 /* AttributionTypeFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributionTypeFactory.swift; sourceTree = "<group>"; };
 		F5BE4478269E4A4C00254A30 /* AfficheClientProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AfficheClientProxy.swift; sourceTree = "<group>"; };
 		F5BE447A269E4A7500254A30 /* TrackingManagerProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingManagerProxy.swift; sourceTree = "<group>"; };
-		F5BE447C269E4ADB00254A30 /* ASIdentifierManagerProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASIdentifierManagerProxy.swift; sourceTree = "<group>"; };
+		F5BE447C269E4ADB00254A30 /* ASIdManagerProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASIdManagerProxy.swift; sourceTree = "<group>"; };
 		F5C0196826E880800005D61E /* StoreKitStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitStrings.swift; sourceTree = "<group>"; };
 		F5E4383726B8530700841CC8 /* SKPaymentTransaction+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SKPaymentTransaction+Extensions.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1059,7 +1059,7 @@
 			isa = PBXGroup;
 			children = (
 				F5BE4478269E4A4C00254A30 /* AfficheClientProxy.swift */,
-				F5BE447C269E4ADB00254A30 /* ASIdentifierManagerProxy.swift */,
+				F5BE447C269E4ADB00254A30 /* ASIdManagerProxy.swift */,
 				37E35CD16BB73BB091E64D9A /* AttributionData.swift */,
 				37E3521731D8DC16873F55F3 /* AttributionFetcher.swift */,
 				B3A55B7C26C452A7007EFC56 /* AttributionPoster.swift */,
@@ -1379,7 +1379,7 @@
 				F5BE424026962ACF00254A30 /* ReceiptRefreshPolicy.swift in Sources */,
 				9A65E0762591977200DE00B0 /* IdentityStrings.swift in Sources */,
 				F5714EAA26D7A85D00635477 /* PeriodType+Extensions.swift in Sources */,
-				F5BE447D269E4ADB00254A30 /* ASIdentifierManagerProxy.swift in Sources */,
+				F5BE447D269E4ADB00254A30 /* ASIdManagerProxy.swift in Sources */,
 				80E80EF226970E04008F245A /* ReceiptFetcher.swift in Sources */,
 				F5BE443D26977F9B00254A30 /* HTTPRequest.swift in Sources */,
 				2DDF41AB24F6F37C005BC22D /* AppleReceipt.swift in Sources */,


### PR DESCRIPTION
Rename `ad` to `affiche`
Apple might have gotten more paranoid about Ad tracking classes being available in children's apps.