### PR TITLE
auto-update fastlane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,6 +15,7 @@ default_platform(:ios)
 platform :ios do
   before_all do
     setup_circle_ci
+    update_fastlane
   end
 
   desc "Setup development environment"


### PR DESCRIPTION
I ran into an issue today where one of the integration tests projects was using an older version of fastlane. 
It got me thinking that we should just auto-update, since we're already updating fairly often, just manually.

This PR adds the step `update_fastlane` to all lanes. It won't auto-update into a new major version, though. 