### PR TITLE
Fix/explicit errors on tasks

### DIFF
--- a/Purchases/Purchasing/ProductsManager.swift
+++ b/Purchases/Purchasing/ProductsManager.swift
@@ -31,7 +31,7 @@ class ProductsManager: NSObject {
 
         if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *),
            SystemInfo.useStoreKit2IfAvailable {
-            Task {
+            _ = Task<Void, Never> {
                 let productDetails = await self.sk2ProductDetails(withIdentifiers: identifiers)
                 completion(productDetails)
             }

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -186,7 +186,7 @@ class PurchasesOrchestrator {
         // todo: clean up, move to new class along with the private funcs below
         if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *),
            package.productDetails is SK2ProductDetails {
-            Task {
+            _ = Task<Void, Never> {
                 let result = await purchase(sk2Package: package)
                 DispatchQueue.main.async {
                     switch result {

--- a/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -42,7 +42,7 @@ class TrialOrIntroPriceEligibilityChecker {
     func checkEligibility(productIdentifiers: [String],
                           completion: @escaping ReceiveIntroEligibilityBlock) {
         if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
-            Task {
+            _ = Task<Void, Never> {
                 let eligibility = await sk2CheckEligibility(productIdentifiers)
                 completion(eligibility)
             }

--- a/Purchases/Support/BeginRefundRequestHelper.swift
+++ b/Purchases/Support/BeginRefundRequestHelper.swift
@@ -41,7 +41,7 @@ class BeginRefundRequestHelper {
     @available(tvOS, unavailable)
     func beginRefundRequest(productID: String, completion: @escaping (Result<RefundRequestStatus, Error>) -> Void) {
 #if os(iOS) || targetEnvironment(macCatalyst)
-        Task {
+        _ = Task<Void, Never> {
             let result = await self.beginRefundRequest(productID: productID)
             completion(result)
         }

--- a/Purchases/Support/ManageSubscriptionsModalHelper.swift
+++ b/Purchases/Support/ManageSubscriptionsModalHelper.swift
@@ -78,7 +78,7 @@ private extension ManageSubscriptionsModalHelper {
                                       completion: @escaping (Result<Void, Error>) -> Void) {
 #if os(iOS)
         if #available(iOS 15.0, *) {
-            Task {
+            _ = Task<Void, Never> {
                 let result = await self.showSK2ManageSubscriptions()
                 completion(result)
             }

--- a/SwiftStyleGuide.swift
+++ b/SwiftStyleGuide.swift
@@ -156,3 +156,10 @@ guard 1 == 1,
     print("Universe is broken")
     return
 }
+
+// use _ = Task<Void, Never> for task initialization, so that if a part of the
+// Task throws, the compiler forces us to handle the exception
+// More info here: https://rev.cat/catching-exceptions-from-tasks
+_ = Task<Void, Never> {
+    try await myMethodThatThrows()
+}


### PR DESCRIPTION
Based on discussion here: 
https://rev.cat/catching-exceptions-from-tasks

If a line within a `Task` created using `Task {` throws, it will fail silently, which is never intended. 

So this PR updates the syntax to `_ = Task<Void, Never> {`. Doing this ensures that if an exception _can_ happen within the `Task`, compilation will fail until we handle it. 