### PR TITLE
SwiftStyleGuide: add example for explicit self

### DIFF
--- a/SwiftStyleGuide.swift
+++ b/SwiftStyleGuide.swift
@@ -73,6 +73,13 @@ struct MyStruct {
 
     // public methods in the main declaration
 
+    /// This method prints the planets
+    public func foo() {
+        // use explicit `self` to make it clear that it's accessing a member
+        // versus a global or value in the local context
+        print(self.mercury)
+    }
+
 }
 
 // separate protocol conformance into extension


### PR DESCRIPTION
This came from the conversation [here](https://github.com/RevenueCat/purchases-ios/pull/944/files/b90f989d83d806c2d90223e1b3c9ffaab30fcd99#r749704127).

Still looking for feedback if anyone is opposed to this.