### PR TITLE
Fix: storekit 2 tests on older OS versions

### DIFF
--- a/PurchasesTests/Mocks/MockSK2BeginRefundRequestHelper.swift
+++ b/PurchasesTests/Mocks/MockSK2BeginRefundRequestHelper.swift
@@ -22,7 +22,21 @@ import StoreKit
 class MockSK2BeginRefundRequestHelper: SK2BeginRefundRequestHelper {
 
     var maybeMockSK2Error: Error?
-    var maybeMockSK2Status: StoreKit.Transaction.RefundRequestStatus?
+
+    // We can't directly store instances of StoreKit.Product, since that causes
+    // linking issues in iOS < 15, even with @available checks correctly in place.
+    // So instead, we store the underlying product as Any and wrap it with casting.
+    // https://openradar.appspot.com/radar?id=4970535809187840
+    private var untypedSK2Status: Any?
+    var maybeMockSK2Status: StoreKit.Transaction.RefundRequestStatus? {
+        get {
+            return untypedSK2Status as! StoreKit.Transaction.RefundRequestStatus?
+        }
+        set {
+            untypedSK2Status = newValue
+        }
+    }
+
     var transactionVerified = true
     var refundRequestCalled = false
     var verifyTransactionCalled = false

--- a/PurchasesTests/Mocks/MockSK2BeginRefundRequestHelper.swift
+++ b/PurchasesTests/Mocks/MockSK2BeginRefundRequestHelper.swift
@@ -23,7 +23,7 @@ class MockSK2BeginRefundRequestHelper: SK2BeginRefundRequestHelper {
 
     var maybeMockSK2Error: Error?
 
-    // We can't directly store instances of StoreKit.Product, since that causes
+    // We can't directly store instances of StoreKit.Transaction.RefundRequestStatus, since that causes
     // linking issues in iOS < 15, even with @available checks correctly in place.
     // So instead, we store the underlying product as Any and wrap it with casting.
     // https://openradar.appspot.com/radar?id=4970535809187840

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -47,7 +47,6 @@ platform :ios do
       scheme: "UnitTests",
       testplan: "UnitTests",
       prelaunch_simulator: true,
-      devices: ["iPhone 8", "iPhone 12"],
       scheme: "UnitTests",
       output_types: '',
       fail_build: false,


### PR DESCRIPTION
Tests are currently crashing on iOS < 15.0. 
This is related to a known issue with linking in XCTest. There's a more detailed description of the issue in a code comment in the changes. 

They weren't failing in CI, but this was because of a bug on our Fastfile, where we weren't actually testing on older OS versions. 
