### PR TITLE
Created RawDataContainer

### DIFF
--- a/Purchases/Public/CustomerInfo.swift
+++ b/Purchases/Public/CustomerInfo.swift
@@ -85,6 +85,15 @@ import Foundation
      */
     @objc public let originalApplicationVersion: String?
 
+    /**
+     * The underlying data for this `CustomerInfo`.
+     *
+     * - Note: the content and format of this data isn’t documented and is subject to change.
+     *         it's only meant for debugging purposes or for getting access to future data
+     *         without updating the SDK.
+     */
+    @objc public let rawData: [String: Any]
+
     /// Get the expiration date for a given product identifier. You should use Entitlements though!
     /// - Parameter productIdentifier: Product identifier for product
     /// - Returns:  The expiration date for `productIdentifier`, `nil` if product never purchased
@@ -184,7 +193,7 @@ import Foundation
         }
 
         self.dateFormatter = dateFormatter
-        self.originalData = data
+        self.rawData = data
         self.schemaVersion = data["schema_version"] as? String
         self.requestDate = formattedRequestDate
         self.originalPurchaseDate = subscriberData.originalPurchaseDate
@@ -205,7 +214,7 @@ import Foundation
     static let currentSchemaVersion = "2"
 
     func jsonObject() -> [String: Any] {
-        return originalData.merging(
+        return rawData.merging(
             ["schema_version": CustomerInfo.currentSchemaVersion],
             strategy: .keepOriginalValue
         )
@@ -213,7 +222,6 @@ import Foundation
 
     private let allPurchases: [String: [String: Any]]
     private let subscriptionTransactionsByProductId: [String: [String: Any]]
-    private let originalData: [String: Any]
     private let dateFormatter: DateFormatter
 
     private lazy var expirationDatesByProductId: [String: Date?] = {
@@ -308,6 +316,8 @@ import Foundation
     }
 
 }
+
+extension CustomerInfo: RawDataContainer {}
 
 enum CustomerInfoError: Int, DescribableError {
 

--- a/Purchases/Public/EntitlementInfo.swift
+++ b/Purchases/Public/EntitlementInfo.swift
@@ -137,7 +137,7 @@ import Foundation
     /**
      * The underlying data for this `EntitlementInfo`.
      *
-     * - Note: the content and format of this data isn’t documented and is subject to change.
+     * - Note: the content and format of this data isn’t documented and is subject to change,
      *         it's only meant for debugging purposes or for getting access to future data
      *         without updating the SDK.
      */

--- a/Purchases/Public/EntitlementInfo.swift
+++ b/Purchases/Public/EntitlementInfo.swift
@@ -134,6 +134,15 @@ import Foundation
      */
     @objc public let ownershipType: PurchaseOwnershipType
 
+    /**
+     * The underlying data for this `EntitlementInfo`.
+     *
+     * - Note: the content and format of this data isn’t documented and is subject to change.
+     *         it's only meant for debugging purposes or for getting access to future data
+     *         without updating the SDK.
+     */
+    @objc public let rawData: [String: Any]
+
     public override var description: String {
         return """
             <\(String(describing: EntitlementInfo.self)): "
@@ -282,9 +291,13 @@ import Foundation
                                                           store: store,
                                                           unsubscribeDetectedAt: unsubscribeDetectedAt,
                                                           billingIssueDetectedAt: billingIssueDetectedAt)
+
+        self.rawData = entitlementDataDict
     }
 
 }
+
+extension EntitlementInfo: RawDataContainer {}
 
 private extension EntitlementInfo {
 

--- a/Purchases/Public/RawDataContainer.swift
+++ b/Purchases/Public/RawDataContainer.swift
@@ -14,9 +14,11 @@
 /// A type which exposes its underlying raw data, for debugging purposes or for getting access
 /// to future data while using an older version of the SDK.
 public protocol RawDataContainer {
+
     /// The type of the underlying raw data
     associatedtype Content
 
     /// The underlying data.
     var rawData: Content { get }
+
 }

--- a/Purchases/Public/RawDataContainer.swift
+++ b/Purchases/Public/RawDataContainer.swift
@@ -1,0 +1,22 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  RawDataContainer.swift
+//
+//  Created by Nacho Soto on 11/16/21.
+
+/// A type which exposes its underlying raw data, for debugging purposes or for getting access
+/// to future data while using an older version of the SDK.
+public protocol RawDataContainer {
+    /// The type of the underlying raw data
+    associatedtype Content
+
+    /// The underlying data.
+    var rawData: Content { get }
+}

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 		37E35C8515C5E2D01B0AF5C1 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3507939634ED5A9280544 /* Strings.swift */; };
 		57EAE527274324C60060EB74 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE526274324C60060EB74 /* Lock.swift */; };
 		5791CE80273F26A000E50C4B /* base64encoded_sandboxReceipt.txt in Resources */ = {isa = PBXBuildFile; fileRef = 5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */; };
+		57EAE52D274468900060EB74 /* RawDataContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE52C274468900060EB74 /* RawDataContainer.swift */; };
 		80E80EF226970E04008F245A /* ReceiptFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E80EF026970DC3008F245A /* ReceiptFetcher.swift */; };
 		9A65DFDE258AD60A00DE00B0 /* LogIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A65DFDD258AD60A00DE00B0 /* LogIntent.swift */; };
 		9A65E03625918B0500DE00B0 /* ConfigureStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A65E03525918B0500DE00B0 /* ConfigureStrings.swift */; };
@@ -402,6 +403,7 @@
 		37E35FDA0A44EA03EA12DAA2 /* DateFormatter+ExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DateFormatter+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		57EAE526274324C60060EB74 /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = base64encoded_sandboxReceipt.txt; sourceTree = "<group>"; };
+		57EAE52C274468900060EB74 /* RawDataContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawDataContainer.swift; sourceTree = "<group>"; };
 		80E80EF026970DC3008F245A /* ReceiptFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptFetcher.swift; sourceTree = "<group>"; };
 		84C3F1AC1D7E1E64341D3936 /* Pods_RevenueCat_PurchasesTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RevenueCat_PurchasesTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A65DFDD258AD60A00DE00B0 /* LogIntent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogIntent.swift; sourceTree = "<group>"; };
@@ -1035,6 +1037,7 @@
 				B3DDB55826854865008CCF23 /* PurchaseOwnershipType.swift */,
 				B35042C326CDB79A00905B95 /* Purchases.swift */,
 				B35042C526CDD3B100905B95 /* PurchasesDelegate.swift */,
+				57EAE52C274468900060EB74 /* RawDataContainer.swift */,
 				2DC5621824EC63430031F69B /* RevenueCat.h */,
 				37E355CBB3F3A31A32687B14 /* Transaction.swift */,
 			);
@@ -1372,6 +1375,7 @@
 				2DDF419D24F6F331005BC22D /* IntroEligibilityCalculator.swift in Sources */,
 				A525BF4B26C320D100C354C4 /* SubscriberAttributesManager.swift in Sources */,
 				B3E26A4A26BE0A8E003ACCF3 /* Error+Extensions.swift in Sources */,
+				57EAE52D274468900060EB74 /* RawDataContainer.swift in Sources */,
 				B35042C426CDB79A00905B95 /* Purchases.swift in Sources */,
 				2D22BF6526F3CB31001AE2F9 /* FatalErrorUtil.swift in Sources */,
 				B3B5FBBF269E081E00104A0C /* InMemoryCachedObject.swift in Sources */,


### PR DESCRIPTION
Fixes #708.

This makes `CustomerInfo` and `EntitlementInfo` expose its underlying data so clients can access new backend data without updating the SDK.

Also, as @vegaro [mentioned](https://github.com/RevenueCat/purchases-ios/issues/708#issuecomment-947035327), can be used to simplify implementations in `hybrid-common`.