### PR TITLE
PurchasesOrchestrator.paymentDiscount(forProductDiscount:product:completion:): improved error information

### DIFF
--- a/Purchases/Error Handling/ErrorUtils.swift
+++ b/Purchases/Error Handling/ErrorUtils.swift
@@ -74,8 +74,8 @@ class ErrorUtils: NSObject {
      *
      * - Note: This error is used when a network request returns an unexpected response.
      */
-    static func unexpectedBackendResponseError() -> Error {
-        return error(with: ErrorCode.unexpectedBackendResponseError)
+    static func unexpectedBackendResponseError(extraUserInfo: [NSError.UserInfoKey: Any]? = nil) -> Error {
+        return error(with: ErrorCode.unexpectedBackendResponseError, extraUserInfo: extraUserInfo)
     }
 
     /**

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -125,22 +125,30 @@ class PurchasesOrchestrator {
                       return
                   }
 
-            // swiftlint:disable line_length
-            self.backend.post(offerIdForSigning: discountIdentifier,
-                              productIdentifier: product.productIdentifier,
-                              subscriptionGroup: subscriptionGroupIdentifier,
-                              receiptData: receiptData,
-                              appUserID: self.appUserID) { maybeSignature, maybeKeyIdentifier, maybeNonce, maybeTimestamp, maybeError in
+            self.backend.post(
+                offerIdForSigning: discountIdentifier,
+                productIdentifier: product.productIdentifier,
+                subscriptionGroup: subscriptionGroupIdentifier,
+                receiptData: receiptData,
+                appUserID: self.appUserID
+            ) { maybeSignature, maybeKeyIdentifier, maybeNonce, maybeTimestamp, maybeError in
                 if let error = maybeError {
                     completion(nil, error)
                     return
                 }
-            // swiftlint:enable line_length
                 guard let keyIdentifier = maybeKeyIdentifier,
                       let nonce = maybeNonce,
                       let signature = maybeSignature,
                       let timestamp = maybeTimestamp else {
-                          completion(nil, ErrorUtils.unexpectedBackendResponseError())
+                          completion(
+                            nil,
+                            ErrorUtils.unexpectedBackendResponseError(extraUserInfo: [
+                                "keyIdentifier": String(describing: maybeKeyIdentifier),
+                                "nonce": String(describing: maybeNonce),
+                                "signature": String(describing: maybeSignature),
+                                "timestamp": String(describing: maybeTimestamp)
+                            ])
+                          )
                           return
                       }
 


### PR DESCRIPTION
Fixes #751.

All the other branches seem to already have adequate errors. This one was pretty ambiguous (what was wrong with the response?) so the extra data should show us what was `nil`.