### PR TITLE
Logger: added filename / function / line information

### DIFF
--- a/Purchases/Caching/DeviceCache.swift
+++ b/Purchases/Caching/DeviceCache.swift
@@ -63,7 +63,7 @@ class DeviceCache {
         if appUserIDHasBeenSet && threadUnsafeCachedAppUserID == nil {
             fatalError(
                 """
-                [Purchases] - Cached appUserID has been deleted from user defaults.
+                [\(Logger.frameworkDescription)] - Cached appUserID has been deleted from user defaults.
                 This leaves the SDK in an undetermined state. Please make sure that RevenueCat
                 entries in user defaults don't get deleted by anything other than the SDK.
                 More info: https://rev.cat/userdefaults-crash

--- a/Purchases/Logging/Logger.swift
+++ b/Purchases/Logging/Logger.swift
@@ -29,19 +29,22 @@ import Foundation
 
 }
 
-/// A function that can handle a log message
+/// A function that can handle a log message including file and method information.
+public typealias VerboseLogHandler = (_ level: LogLevel,
+                                      _ message: String,
+                                      _ file: String?,
+                                      _ function: String?,
+                                      _ line: UInt) -> Void
+
+/// A function that can handle a log message.
 public typealias LogHandler = (_ level: LogLevel,
-                               _ message: String,
-                               _ file: String?,
-                               _ function: String?,
-                               _ line: UInt
-) -> Void
+                               _ message: String) -> Void
 
 class Logger {
     static var logLevel: LogLevel = .info
-    static var logHandler: LogHandler = { level, message, file, functionName, line in
+    static var logHandler: VerboseLogHandler = { level, message, file, functionName, line in
         let fileContext: String
-        if let file = file, let functionName = functionName {
+        if Logger.verbose, let file = file, let functionName = functionName {
             let fileName = (file as NSString)
                 .lastPathComponent
                 .replacingOccurrences(of: ".swift", with: "")
@@ -55,7 +58,9 @@ class Logger {
         NSLog("%@", "[\(frameworkDescription)] - \(level.description)\(fileContext): \(message)")
     }
 
-    private static let frameworkDescription = "Purchases"
+    static var verbose: Bool = false
+
+    internal static let frameworkDescription = "Purchases"
 
     static func debug(_ message: CustomStringConvertible,
                       fileName: String? = #fileID,

--- a/Purchases/Logging/Logger.swift
+++ b/Purchases/Logging/Logger.swift
@@ -29,71 +29,145 @@ import Foundation
 
 }
 
-class Logger {
+/// A function that can handle a log message
+public typealias LogHandler = (_ level: LogLevel,
+                               _ message: String,
+                               _ file: String?,
+                               _ function: String?,
+                               _ line: UInt
+) -> Void
 
+class Logger {
     static var logLevel: LogLevel = .info
-    static var logHandler: (LogLevel, String) -> Void = { level, message in
-        NSLog("%@", "[\(frameworkDescription)] - \(level.description): \(message)")
+    static var logHandler: LogHandler = { level, message, file, functionName, line in
+        let fileContext: String
+        if let file = file, let functionName = functionName {
+            let fileName = (file as NSString)
+                .lastPathComponent
+                .replacingOccurrences(of: ".swift", with: "")
+                .trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+
+            fileContext = "\t\(fileName).\(functionName):\(line)"
+        } else {
+            fileContext = ""
+        }
+
+        NSLog("%@", "[\(frameworkDescription)] - \(level.description)\(fileContext): \(message)")
     }
 
     private static let frameworkDescription = "Purchases"
 
-    static func debug(_ message: CustomStringConvertible) {
-        log(level: .debug, intent: .info, message: message.description)
+    static func debug(_ message: CustomStringConvertible,
+                      fileName: String? = #fileID,
+                      functionName: String? = #function,
+                      line: UInt = #line) {
+        log(level: .debug, intent: .info, message: message.description,
+            fileName: fileName, functionName: functionName, line: line)
     }
 
-    static func info(_ message: CustomStringConvertible) {
-        log(level: .info, intent: .info, message: message.description)
+    static func info(_ message: CustomStringConvertible,
+                     fileName: String? = #fileID,
+                     functionName: String? = #function,
+                     line: UInt = #line) {
+        log(level: .info, intent: .info, message: message.description,
+            fileName: fileName, functionName: functionName, line: line)
     }
 
-    static func warn(_ message: CustomStringConvertible) {
-        log(level: .warn, intent: .warning, message: message.description)
+    static func warn(_ message: CustomStringConvertible,
+                     fileName: String? = #fileID,
+                     functionName: String? = #function,
+                     line: UInt = #line) {
+        log(level: .warn, intent: .warning, message: message.description,
+            fileName: fileName, functionName: functionName, line: line)
     }
 
-    static func error(_ message: CustomStringConvertible) {
-        log(level: .error, intent: .rcError, message: message.description)
+    static func error(_ message: CustomStringConvertible,
+                      fileName: String = #fileID,
+                      functionName: String = #function,
+                      line: UInt = #line) {
+        log(level: .error, intent: .rcError, message: message.description,
+            fileName: fileName, functionName: functionName, line: line)
     }
 
 }
 
 extension Logger {
 
-    static func appleError(_ message: CustomStringConvertible) {
-        log(level: .error, intent: .appleError, message: message.description)
+    static func appleError(_ message: CustomStringConvertible,
+                           fileName: String = #fileID,
+                           functionName: String = #function,
+                           line: UInt = #line) {
+        log(level: .error, intent: .appleError, message: message.description,
+            fileName: fileName,
+            functionName: functionName,
+            line: line)
     }
 
-    static func appleWarning(_ message: CustomStringConvertible) {
-        log(level: .warn, intent: .appleError, message: message.description)
+    static func appleWarning(_ message: CustomStringConvertible,
+                             fileName: String = #fileID,
+                             functionName: String = #function,
+                             line: UInt = #line) {
+        log(level: .warn, intent: .appleError, message: message.description,
+            fileName: fileName, functionName: functionName, line: line)
     }
 
-    static func purchase(_ message: CustomStringConvertible) {
-        log(level: .debug, intent: .purchase, message: message.description)
+    static func purchase(_ message: CustomStringConvertible,
+                         fileName: String = #fileID,
+                         functionName: String = #function,
+                         line: UInt = #line) {
+        log(level: .debug, intent: .purchase, message: message.description,
+            fileName: fileName, functionName: functionName, line: line)
     }
 
-    static func rcPurchaseSuccess(_ message: CustomStringConvertible) {
-        log(level: .info, intent: .rcPurchaseSuccess, message: message.description)
+    static func rcPurchaseSuccess(_ message: CustomStringConvertible,
+                                  fileName: String = #fileID,
+                                  functionName: String = #function,
+                                  line: UInt = #line) {
+        log(level: .info, intent: .rcPurchaseSuccess, message: message.description,
+            fileName: fileName, functionName: functionName, line: line)
     }
 
-    static func rcSuccess(_ message: CustomStringConvertible) {
-        log(level: .debug, intent: .rcSuccess, message: message.description)
+    static func rcSuccess(_ message: CustomStringConvertible,
+                          fileName: String = #fileID,
+                          functionName: String = #function,
+                          line: UInt = #line) {
+        log(level: .debug, intent: .rcSuccess, message: message.description,
+            fileName: fileName, functionName: functionName, line: line)
     }
 
-    static func user(_ message: CustomStringConvertible) {
-        log(level: .debug, intent: .user, message: message.description)
+    static func user(_ message: CustomStringConvertible,
+                     fileName: String? = #fileID,
+                     functionName: String? = #function,
+                     line: UInt = #line) {
+        log(level: .debug, intent: .user, message: message.description,
+            fileName: fileName, functionName: functionName, line: line)
     }
 
 }
 
 private extension Logger {
 
-    static func log(level: LogLevel, message: String) {
+    static func log(level: LogLevel,
+                    message: String,
+                    fileName: String? = #fileID,
+                    functionName: String? = #function,
+                    line: UInt = #line) {
         guard self.logLevel.rawValue <= level.rawValue else { return }
-        logHandler(level, message)
+        logHandler(level, message, fileName, functionName, line)
     }
 
-    static func log(level: LogLevel, intent: LogIntent, message: String) {
+    static func log(level: LogLevel,
+                    intent: LogIntent,
+                    message: String,
+                    fileName: String? = #fileID,
+                    functionName: String? = #function,
+                    line: UInt = #line) {
         let messageWithPrefix = "\(intent.prefix) \(message)"
-        Logger.log(level: level, message: messageWithPrefix)
+        Logger.log(level: level,
+                   message: messageWithPrefix,
+                   fileName: fileName,
+                   functionName: functionName,
+                   line: line)
     }
 
 }

--- a/Purchases/Misc/FatalErrorUtil.swift
+++ b/Purchases/Misc/FatalErrorUtil.swift
@@ -28,6 +28,6 @@ struct FatalErrorUtil {
     }
 }
 
-func fatalError(_ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line) -> Never {
+func fatalError(_ message: @autoclosure () -> String = "", file: StaticString = #fileID, line: UInt = #line) -> Never {
     FatalErrorUtil.fatalErrorClosure(message(), file, line)
 }

--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -596,7 +596,7 @@ private extension Backend {
     func handle(customerInfoResponse maybeResponse: [String: Any]?,
                 statusCode: Int,
                 maybeError: Error?,
-                file: String = #file,
+                file: String = #fileID,
                 function: String = #function,
                 completion: BackendCustomerInfoResponseHandler) {
         if let error = maybeError {

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -290,9 +290,9 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
          offeringsManager: OfferingsManager,
          purchasesOrchestrator: PurchasesOrchestrator) {
 
-        Logger.debug(Strings.configure.debug_enabled)
-        Logger.debug(Strings.configure.sdk_version(sdkVersion: Self.frameworkVersion))
-        Logger.user(Strings.configure.initial_app_user_id(appUserID: appUserID))
+        Logger.debug(Strings.configure.debug_enabled, fileName: nil)
+        Logger.debug(Strings.configure.sdk_version(sdkVersion: Self.frameworkVersion), fileName: nil)
+        Logger.user(Strings.configure.initial_app_user_id(appUserID: appUserID), fileName: nil)
 
         self.requestFetcher = requestFetcher
         self.receiptFetcher = receiptFetcher

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -134,7 +134,7 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
      * By default, this sends Info, Warn, and Error messages. If you wish to receive Debug level messages,
      * you must enable debug logs.
      */
-    @objc public static var logHandler: (LogLevel, String) -> Void {
+    @objc public static var logHandler: LogHandler {
         get { Logger.logHandler }
         set { Logger.logHandler = newValue }
     }

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -89,6 +89,9 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
 
     /**
      * Used to set the log level. Useful for debugging issues with the lovely team @RevenueCat
+     *
+     * - Seealso ``logHandler``
+     * - Seealso ``verboseLogHandler``
      */
     @objc public static var logLevel: LogLevel {
         get { Logger.logLevel }
@@ -133,10 +136,52 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
      * Set a custom log handler for redirecting logs to your own logging system.
      * By default, this sends Info, Warn, and Error messages. If you wish to receive Debug level messages,
      * you must enable debug logs.
+     *
+     * - Note:``verboseLogHandler`` provides additional information.
+     *
+     * - Seealso: ``verboseLogHandler``
+     * - Seealso: ``logLevel``
      */
     @objc public static var logHandler: LogHandler {
+        get {
+            return { level, message in
+                self.verboseLogHandler(level, message, nil, nil, 0)
+            }
+        }
+
+        set {
+            self.verboseLogHandler = { level, message, _, _, _ in
+                newValue(level, message)
+            }
+        }
+    }
+
+    /**
+     * Set a custom log handler for redirecting logs to your own logging system.
+     * By default, this sends Info, Warn, and Error messages. If you wish to receive Debug level messages,
+     * you must enable debug logs.
+     *
+     * - Note: you can use ``logHandler`` if you don't need filename information.
+     *
+     * - Seealso: ``logHandler``
+     * - Seealso: ``logLevel``
+     */
+    @objc public static var verboseLogHandler: VerboseLogHandler {
         get { Logger.logHandler }
         set { Logger.logHandler = newValue }
+    }
+
+    /**
+     * Setting this to `true` adds additional information to the default log handler:
+     *  Filename, line, and method data.
+     * You can also access that information for your own logging system by using ``verboseLogHandler``.
+     *
+     * - Seealso: ``verboseLogHandler``
+     * - Seealso: ``logLevel``
+     */
+    @objc public static var verboseLogs: Bool {
+        get { return Logger.verbose }
+        set { Logger.verbose = newValue }
     }
 
     /// Current version of the Purchases framework.

--- a/PurchasesTests/Caching/DeviceCacheTests.swift
+++ b/PurchasesTests/Caching/DeviceCacheTests.swift
@@ -216,7 +216,7 @@ class DeviceCacheTests: XCTestCase {
 
         mockUserDefaults.mockValues["com.revenuecat.userdefaults.appUserID.new"] = nil
 
-        let expectedMessage = "[Purchases] - Cached appUserID has been deleted from user defaults.\n" +
+        let expectedMessage = "[\(Logger.frameworkDescription)] - Cached appUserID has been deleted from user defaults.\n" +
         "This leaves the SDK in an undetermined state. Please make sure that RevenueCat\n" +
         "entries in user defaults don\'t get deleted by anything other than the SDK.\n" +
         "More info: https://rev.cat/userdefaults-crash"


### PR DESCRIPTION
### Example:

```
2021-11-16 17:39:54.345436-0800 [Purchases] - DEBUG: ℹ️ Debug logging enabled
2021-11-16 17:39:54.345837-0800 [Purchases] - DEBUG: ℹ️ SDK Version - 4.0.0-beta.6
2021-11-16 17:39:54.346042-0800 [Purchases] - DEBUG: 👤 Initial App User ID - nil appUserID
2021-11-16 17:39:54.346582-0800 [Purchases] - DEBUG	IdentityManager.configure(appUserID:):53: 👤 Identifying App User ID: $RCAnonymousID:xxxx
2021-11-16 17:39:54.358750-0800 [Purchases] - DEBUG	CustomerInfoManager.sendUpdateIfChanged(customerInfo:):186: ℹ️ Sending latest CustomerInfo to delegate.
2021-11-16 17:39:54.360017-0800 [Purchases] - DEBUG	Purchases.delegate:78: ℹ️ Delegate set
2021-11-16 17:39:54.360377-0800 [Purchases] - DEBUG	OfferingsManager.offerings(appUserID:completion:):42: ℹ️ No cached Offerings, fetching from network
2021-11-16 17:39:54.861103-0800 [Purchases] - DEBUG	Purchases.applicationDidBecomeActive(notification:):1310: ℹ️ applicationDidBecomeActive
2021-11-16 17:39:54.865619-0800 [Purchases] - DEBUG	HTTPClient.performRequest(_:serially:path:requestBody:authHeaders:retried:completionHandler:):138: ℹ️ There are no requests currently running, starting request GET /subscribers/$RCAnonymousID%xxxx/offerings
2021-11-16 17:39:54.865972-0800 [Purchases] - DEBUG	HTTPClient.performRequest(_:serially:path:requestBody:authHeaders:retried:completionHandler:):144: ℹ️ API request started: GET /v1/subscribers/$RCAnonymousID:xxxxx/offerings
2021-11-16 17:39:54.869508-0800 [Purchases] - DEBUG	HTTPClient.performRequest(_:serially:path:requestBody:authHeaders:retried:completionHandler:):131: ℹ️ There's a request currently running and 0 requests left in the queue, queueing GET /subscribers/$RCAnonymousID%xxxxx
2021-11-16 17:39:55.541730-0800 [boringssl] boringssl_metrics_log_metric_block_invoke(144) Failed to log metrics
2021-11-16 17:39:55.638582-0800 [Purchases] - DEBUG	HTTPClient.threadUnsafeHandleResponse(urlResponse:request:data:error:completionHandler:beginNextRequestWhenFinished:retried:):195: ℹ️ API request completed with status: GET /subscribers/$RCAnonymousID%xxxxx/offerings 304
2021-11-16 17:39:55.640057-0800 [Purchases] - DEBUG	HTTPClient.threadUnsafeHandleResponse(urlResponse:request:data:error:completionHandler:beginNextRequestWhenFinished:retried:):238: ℹ️ Serial request done: GET /subscribers/$RCAnonymousID%xxxxx/offerings, 1 requests left in the queue
2021-11-16 17:39:55.640280-0800 [Purchases] - DEBUG	ProductsManager.products(withIdentifiers:completion:):54: ℹ️ No existing requests and products not cached, starting SKProducts request for: ["com.nachosoto.magic-weather-swift-ui.pro.weekly"]
2021-11-16 17:39:55.640458-0800 [Purchases] - DEBUG	HTTPClient.threadUnsafeHandleResponse(urlResponse:request:data:error:completionHandler:beginNextRequestWhenFinished:retried:):244: ℹ️ Starting the next request in the queue, <HTTPRequest: httpMethod=GET
path=/subscribers/$RCAnonymousID%xxxxx
requestBody=(null)
headers=["Authorization": "Bearer xxxxx"]
retried=false
urlRequest=https://api.revenuecat.com/v1/subscribers/$RCAnonymousID%xxxxx
>
2021-11-16 17:39:55.642772-0800 [Purchases] - DEBUG	ProductsManager.products(withIdentifiers:completion:):49: ℹ️ Found an existing request for products: ["com.nachosoto.magic-weather-swift-ui.pro.weekly"], appending to completion
2021-11-16 17:39:55.659954-0800 [Purchases] - DEBUG	HTTPClient.performRequest(_:serially:path:requestBody:authHeaders:retried:completionHandler:):138: ℹ️ There are no requests currently running, starting request GET /subscribers/$RCAnonymousID%xxxxx
2021-11-16 17:39:55.660610-0800 [Purchases] - DEBUG	HTTPClient.performRequest(_:serially:path:requestBody:authHeaders:retried:completionHandler:):144: ℹ️ API request started: GET /v1/subscribers/$RCAnonymousID:xxxxxx
2021-11-16 17:39:55.688234-0800 [Purchases] - DEBUG	ProductsManager.productsRequest(_:didReceive:):78: 😻 SKProductsRequest request received response
2021-11-16 17:39:55.688257-0800 [Purchases] - DEBUG	ProductsManager.requestDidFinish(_:):99: 😻 SKProductsRequest did finish
2021-11-16 17:39:55.689360-0800 [Purchases] - ERROR	OfferingsManager.handleOfferingsUpdateError(_:completion:):139: 🍎‼️ Error fetching offerings - There's a problem with your configuration. None of the products registered in the RevenueCat dashboard could be fetched from App Store Connect (or the StoreKit Configuration file if one is being used). 
More information: https://rev.cat/why-are-offerings-empty
2021-11-16 17:39:55.689725-0800 [Purchases] - ERROR	OfferingsManager.handleOfferingsUpdateError(_:completion:):139: 🍎‼️ Error fetching offerings - There's a problem with your configuration. None of the products registered in the RevenueCat dashboard could be fetched from App Store Connect (or the StoreKit Configuration file if one is being used). 
More information: https://rev.cat/why-are-offerings-empty
2021-11-16 17:39:55.772937-0800 [Purchases] - DEBUG	HTTPClient.threadUnsafeHandleResponse(urlResponse:request:data:error:completionHandler:beginNextRequestWhenFinished:retried:):195: ℹ️ API request completed with status: GET /subscribers/$RCAnonymousID%xxxxx 304
2021-11-16 17:39:55.776777-0800 [Purchases] - DEBUG	CustomerInfoManager.fetchAndCacheCustomerInfo(appUserID:isAppBackgrounded:completion:):54: 😻 CustomerInfo updated from network.
2021-11-16 17:39:55.777072-0800 [Purchases] - DEBUG	HTTPClient.threadUnsafeHandleResponse(urlResponse:request:data:error:completionHandler:beginNextRequestWhenFinished:retried:):238: ℹ️ Serial request done: GET /subscribers/$RCAnonymousID%xxxxx, 0 requests left in the queue
```

### Issues:

- I don't love that the `LogIntent` is displayed after the log context. If others agree, we could expose this to clients and have it formatted better.
- `LogHandler`'s type has changed to add the new information, which means that this isn't a backwards compatible change and clients of this will have to add the new parameters to their `Purchases.logHandler` value. Should we just document that in the release notes?