### PR TITLE
Update PR template to remind about android and hybrid follow-ups

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,3 +5,5 @@ Thank you for contributing to Purchases. Before pressing the "Create Pull Reques
   - [ ] The issue number(s) or PR number(s) in the description if you are contributing in response to those.
 
   - [ ] If applicable, unit tests.
+  
+  - [ ] If applicable, create follow-up tickets for `purchases-android` and hybrids.


### PR DESCRIPTION
Idk how to make this open-source agnostic... do we want open-source contributors making Github issues?
