### PR TITLE
Detect ErrorCode.productAlreadyPurchasedError when SKError.unknown is actually cased by it

### DIFF
--- a/Purchases/Error Handling/ErrorUtils.swift
+++ b/Purchases/Error Handling/ErrorUtils.swift
@@ -211,10 +211,10 @@ class ErrorUtils: NSObject {
 
 private extension SKError {
 
+    // swiftlint:disable:next cyclomatic_complexity
     func toPurchasesErrorCode() -> ErrorCode {
         switch self.code {
-        case .unknown,
-             .cloudServiceNetworkConnectionFailed,
+        case .cloudServiceNetworkConnectionFailed,
              .cloudServiceRevoked,
              .overlayTimeout,
              .overlayPresentedInBackgroundScene:
@@ -240,6 +240,19 @@ private extension SKError {
              .overlayInvalidConfiguration,
              .unsupportedPlatform:
             return .purchaseNotAllowedError
+        case .unknown:
+            if let error = self.userInfo[NSUnderlyingErrorKey] as? NSError {
+                switch (error.domain, error.code) {
+                case ("ASDServerErrorDomain", 3532): // "You’re currently subscribed to this"
+                    // See https://github.com/RevenueCat/purchases-ios/issues/392
+                    return .productAlreadyPurchasedError
+
+                default: break
+                }
+            }
+
+            return .storeProblemError
+
         @unknown default:
             return .unknownError
         }


### PR DESCRIPTION
Fixes #392.

As per the conversation in that issue, this introspects and checks for the undocumented error domain and code.