### PR TITLE
Remove extra call to add error message

### DIFF
--- a/Purchases/Purchasing/StoreKit2/SK2BeginRefundRequestHelper.swift
+++ b/Purchases/Purchasing/StoreKit2/SK2BeginRefundRequestHelper.swift
@@ -107,8 +107,7 @@ private extension SK2BeginRefundRequestHelper {
             }
             return .success(rcStatus)
         case .failure(let error):
-            let message = getErrorMessage(from: error)
-            return .failure(ErrorUtils.beginRefundRequestError(withMessage: message))
+            return .failure(error)
         }
     }
 


### PR DESCRIPTION
While adding the begin refund button to PurchaseTester, I realized we append an error message to the refund error one extra time. It was wasteful and also not recognizing the error type correctly the second time, resulting in an extra "unknown error type" prefix.

