### PR TITLE
Replaced `try!` in tests with `throws`

### DIFF
--- a/PurchasesTests/Identity/CustomerInfoManagerTests.swift
+++ b/PurchasesTests/Identity/CustomerInfoManagerTests.swift
@@ -184,7 +184,7 @@ class CustomerInfoManagerTests: XCTestCase {
         expect(self.mockBackend.invokedGetSubscriberDataCount).toEventually(equal(1))
     }
 
-    func testSendCachedCustomerInfoIfAvailableForAppUserIDSendsIfNeverSent() {
+    func testSendCachedCustomerInfoIfAvailableForAppUserIDSendsIfNeverSent() throws {
         let info = CustomerInfo(testData: [
         "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
@@ -196,7 +196,7 @@ class CustomerInfoManagerTests: XCTestCase {
 
         let jsonObject = info!.jsonObject()
 
-        let object = try! JSONSerialization.data(withJSONObject: jsonObject, options: [])
+        let object = try JSONSerialization.data(withJSONObject: jsonObject, options: [])
         let appUserID = "myUser"
         self.mockDeviceCache.cachedCustomerInfo[appUserID] = object
 
@@ -205,7 +205,7 @@ class CustomerInfoManagerTests: XCTestCase {
         expect(self.customerInfoManagerDelegateCallCount) == 1
     }
 
-    func testSendCachedCustomerInfoIfAvailableForAppUserIDSendsIfDifferent() {
+    func testSendCachedCustomerInfoIfAvailableForAppUserIDSendsIfDifferent() throws {
         let oldInfo = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
@@ -217,7 +217,7 @@ class CustomerInfoManagerTests: XCTestCase {
 
         var jsonObject = oldInfo!.jsonObject()
 
-        var object = try! JSONSerialization.data(withJSONObject: jsonObject, options: [])
+        var object = try JSONSerialization.data(withJSONObject: jsonObject, options: [])
         let appUserID = "myUser"
         mockDeviceCache.cachedCustomerInfo[appUserID] = object
 
@@ -234,14 +234,14 @@ class CustomerInfoManagerTests: XCTestCase {
 
         jsonObject = newInfo!.jsonObject()
 
-        object = try! JSONSerialization.data(withJSONObject: jsonObject, options: [])
+        object = try JSONSerialization.data(withJSONObject: jsonObject, options: [])
         mockDeviceCache.cachedCustomerInfo[appUserID] = object
 
         customerInfoManager.sendCachedCustomerInfoIfAvailable(appUserID: appUserID)
         expect(self.customerInfoManagerDelegateCallCount) == 2
     }
 
-    func testSendCachedCustomerInfoIfAvailableForAppUserIDSendsOnMainThread() {
+    func testSendCachedCustomerInfoIfAvailableForAppUserIDSendsOnMainThread() throws {
         let oldInfo = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
@@ -253,7 +253,7 @@ class CustomerInfoManagerTests: XCTestCase {
 
         let jsonObject = oldInfo!.jsonObject()
 
-        let object = try! JSONSerialization.data(withJSONObject: jsonObject, options: [])
+        let object = try JSONSerialization.data(withJSONObject: jsonObject, options: [])
         let appUserID = "myUser"
         mockDeviceCache.cachedCustomerInfo[appUserID] = object
 
@@ -309,7 +309,7 @@ class CustomerInfoManagerTests: XCTestCase {
         expect(completionCalled).toEventually(beTrue())
     }
 
-    func testCachedCustomerInfoParsesCorrectly() {
+    func testCachedCustomerInfoParsesCorrectly() throws {
         let appUserID = "myUser"
         let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
@@ -322,7 +322,7 @@ class CustomerInfoManagerTests: XCTestCase {
 
         let jsonObject = info!.jsonObject()
 
-        let object = try! JSONSerialization.data(withJSONObject: jsonObject, options: [])
+        let object = try JSONSerialization.data(withJSONObject: jsonObject, options: [])
         mockDeviceCache.cachedCustomerInfo[appUserID] = object
 
         let receivedCustomerInfo = customerInfoManager.cachedCustomerInfo(appUserID: appUserID)
@@ -336,7 +336,7 @@ class CustomerInfoManagerTests: XCTestCase {
         expect(receivedCustomerInfo).to(beNil())
     }
 
-    func testCachedCustomerInfoReturnsNilIfNotAvailableForTheAppUserID() {
+    func testCachedCustomerInfoReturnsNilIfNotAvailableForTheAppUserID() throws {
         let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
@@ -348,7 +348,7 @@ class CustomerInfoManagerTests: XCTestCase {
 
         let jsonObject = info!.jsonObject()
 
-        let object = try! JSONSerialization.data(withJSONObject: jsonObject, options: [])
+        let object = try JSONSerialization.data(withJSONObject: jsonObject, options: [])
         mockDeviceCache.cachedCustomerInfo["firstUser"] = object
 
         let receivedCustomerInfo = customerInfoManager.cachedCustomerInfo(appUserID: "secondUser")
@@ -364,7 +364,7 @@ class CustomerInfoManagerTests: XCTestCase {
         expect(receivedCustomerInfo).to(beNil())
     }
 
-    func testCachedCustomerInfoReturnsNilIfDifferentSchema() {
+    func testCachedCustomerInfoReturnsNilIfDifferentSchema() throws {
         let oldSchemaVersion = Int(CustomerInfo.currentSchemaVersion)! - 1
         let data: [String: Any] = [
             "request_date": "2019-08-16T10:30:42Z",
@@ -377,7 +377,7 @@ class CustomerInfoManagerTests: XCTestCase {
             ]
         ]
 
-        let object = try! JSONSerialization.data(withJSONObject: data, options: [])
+        let object = try JSONSerialization.data(withJSONObject: data, options: [])
         let appUserID = "myUser"
         mockDeviceCache.cachedCustomerInfo[appUserID] = object
 

--- a/PurchasesTests/LocalReceiptParsing/Builders/AppleReceiptBuilderTests.swift
+++ b/PurchasesTests/LocalReceiptParsing/Builders/AppleReceiptBuilderTests.swift
@@ -24,55 +24,55 @@ class AppleReceiptBuilderTests: XCTestCase {
         expect { try self.appleReceiptBuilder.build(fromContainer: sampleReceiptContainer) }.notTo(throwError())
     }
 
-    func testBuildGetsCorrectBundleId() {
+    func testBuildGetsCorrectBundleId() throws {
         let sampleReceiptContainer = sampleReceiptContainerWithMinimalAttributes()
-        let receipt = try! self.appleReceiptBuilder.build(fromContainer: sampleReceiptContainer)
+        let receipt = try self.appleReceiptBuilder.build(fromContainer: sampleReceiptContainer)
         expect(receipt.bundleId) == bundleId
     }
 
-    func testBuildGetsCorrectApplicationVersion() {
+    func testBuildGetsCorrectApplicationVersion() throws {
         let sampleReceiptContainer = sampleReceiptContainerWithMinimalAttributes()
-        let receipt = try! self.appleReceiptBuilder.build(fromContainer: sampleReceiptContainer)
+        let receipt = try self.appleReceiptBuilder.build(fromContainer: sampleReceiptContainer)
         expect(receipt.applicationVersion) == applicationVersion
     }
 
-    func testBuildGetsCorrectOriginalApplicationVersion() {
+    func testBuildGetsCorrectOriginalApplicationVersion() throws {
         let sampleReceiptContainer = sampleReceiptContainerWithMinimalAttributes()
-        let receipt = try! self.appleReceiptBuilder.build(fromContainer: sampleReceiptContainer)
+        let receipt = try self.appleReceiptBuilder.build(fromContainer: sampleReceiptContainer)
         expect(receipt.originalApplicationVersion) == originalApplicationVersion
     }
 
-    func testBuildGetsCorrectCreationDate() {
+    func testBuildGetsCorrectCreationDate() throws {
         let sampleReceiptContainer = sampleReceiptContainerWithMinimalAttributes()
-        let receipt = try! self.appleReceiptBuilder.build(fromContainer: sampleReceiptContainer)
+        let receipt = try self.appleReceiptBuilder.build(fromContainer: sampleReceiptContainer)
         expect(receipt.creationDate) == creationDate
     }
 
-    func testBuildGetsSha1Hash() {
+    func testBuildGetsSha1Hash() throws {
         let sampleReceiptContainer = sampleReceiptContainerWithMinimalAttributes()
-        let receipt = try! self.appleReceiptBuilder.build(fromContainer: sampleReceiptContainer)
+        let receipt = try self.appleReceiptBuilder.build(fromContainer: sampleReceiptContainer)
         expect(receipt.sha1Hash).toNot(beNil())
     }
 
-    func testBuildGetsOpaqueValue() {
+    func testBuildGetsOpaqueValue() throws {
         let sampleReceiptContainer = sampleReceiptContainerWithMinimalAttributes()
-        let receipt = try! self.appleReceiptBuilder.build(fromContainer: sampleReceiptContainer)
+        let receipt = try self.appleReceiptBuilder.build(fromContainer: sampleReceiptContainer)
         expect(receipt.opaqueValue).toNot(beNil())
     }
 
-    func testBuildGetsExpiresDate() {
-        let expirationDate = try! Date.from(year: 2020, month: 7, day: 4, hour: 5, minute: 3, second: 2)
+    func testBuildGetsExpiresDate() throws {
+        let expirationDate = try Date.from(year: 2020, month: 7, day: 4, hour: 5, minute: 3, second: 2)
         let expirationDateContainer =
             containerFactory.receiptAttributeContainer(attributeType: ReceiptAttributeType.expirationDate,
                                                        expirationDate)
         let receiptContainer =
             containerFactory.receiptContainerFromContainers(containers: minimalAttributes() + [expirationDateContainer])
 
-        let receipt = try! self.appleReceiptBuilder.build(fromContainer: receiptContainer)
+        let receipt = try self.appleReceiptBuilder.build(fromContainer: receiptContainer)
         expect(receipt.expirationDate) == expirationDate
     }
 
-    func testBuildGetsInAppPurchases() {
+    func testBuildGetsInAppPurchases() throws {
         let totalInAppPurchases = Int.random(in: 5..<20)
         let inAppContainers = (Int(0)..<totalInAppPurchases).map { _ in
             containerFactory.receiptDataAttributeContainer(attributeType: ReceiptAttributeType.inAppPurchase)
@@ -95,7 +95,7 @@ class AppleReceiptBuilderTests: XCTestCase {
                                                                     webOrderLineItemId: Int64(658464),
                                                                     promotionalOfferIdentifier: nil)
 
-        let receipt = try! self.appleReceiptBuilder.build(fromContainer: receiptContainer)
+        let receipt = try self.appleReceiptBuilder.build(fromContainer: receiptContainer)
         expect(receipt.inAppPurchases.count) == totalInAppPurchases
         expect(self.mockInAppPurchaseBuilder.invokedBuildCount) == totalInAppPurchases
 

--- a/PurchasesTests/LocalReceiptParsing/Builders/InAppPurchaseBuilderTests.swift
+++ b/PurchasesTests/LocalReceiptParsing/Builders/InAppPurchaseBuilderTests.swift
@@ -48,90 +48,90 @@ class InAppPurchaseBuilderTests: XCTestCase {
         expect { try self.inAppPurchaseBuilder.build(fromContainer: inAppPurchaseContainer) }.to(throwError())
     }
 
-    func testBuildGetsCorrectQuantity() {
+    func testBuildGetsCorrectQuantity() throws {
         let sampleInAppPurchaseContainer = sampleInAppPurchaseContainerWithMinimalAttributes()
-        let inAppPurchase = try! self.inAppPurchaseBuilder.build(fromContainer: sampleInAppPurchaseContainer)
+        let inAppPurchase = try self.inAppPurchaseBuilder.build(fromContainer: sampleInAppPurchaseContainer)
         expect(inAppPurchase.quantity) == quantity
     }
 
-    func testBuildGetsCorrectProductId() {
+    func testBuildGetsCorrectProductId() throws {
         let sampleInAppPurchaseContainer = sampleInAppPurchaseContainerWithMinimalAttributes()
-        let inAppPurchase = try! self.inAppPurchaseBuilder.build(fromContainer: sampleInAppPurchaseContainer)
+        let inAppPurchase = try self.inAppPurchaseBuilder.build(fromContainer: sampleInAppPurchaseContainer)
         expect(inAppPurchase.productId) == productId
     }
 
-    func testBuildGetsCorrectTransactionId() {
+    func testBuildGetsCorrectTransactionId() throws {
         let sampleInAppPurchaseContainer = sampleInAppPurchaseContainerWithMinimalAttributes()
-        let inAppPurchase = try! self.inAppPurchaseBuilder.build(fromContainer: sampleInAppPurchaseContainer)
+        let inAppPurchase = try self.inAppPurchaseBuilder.build(fromContainer: sampleInAppPurchaseContainer)
         expect(inAppPurchase.transactionId) == transactionId
     }
 
-    func testBuildGetsCorrectOriginalTransactionId() {
+    func testBuildGetsCorrectOriginalTransactionId() throws {
         let sampleInAppPurchaseContainer = sampleInAppPurchaseContainerWithMinimalAttributes()
-        let inAppPurchase = try! self.inAppPurchaseBuilder.build(fromContainer: sampleInAppPurchaseContainer)
+        let inAppPurchase = try self.inAppPurchaseBuilder.build(fromContainer: sampleInAppPurchaseContainer)
         expect(inAppPurchase.originalTransactionId) == originalTransactionId
     }
 
-    func testBuildGetsCorrectPurchaseDate() {
+    func testBuildGetsCorrectPurchaseDate() throws {
         let sampleInAppPurchaseContainer = sampleInAppPurchaseContainerWithMinimalAttributes()
-        let inAppPurchase = try! self.inAppPurchaseBuilder.build(fromContainer: sampleInAppPurchaseContainer)
+        let inAppPurchase = try self.inAppPurchaseBuilder.build(fromContainer: sampleInAppPurchaseContainer)
         expect(inAppPurchase.purchaseDate) == purchaseDate
     }
 
-    func testBuildGetsCorrectOriginalPurchaseDate() {
+    func testBuildGetsCorrectOriginalPurchaseDate() throws {
         let sampleInAppPurchaseContainer = sampleInAppPurchaseContainerWithMinimalAttributes()
-        let inAppPurchase = try! self.inAppPurchaseBuilder.build(fromContainer: sampleInAppPurchaseContainer)
+        let inAppPurchase = try self.inAppPurchaseBuilder.build(fromContainer: sampleInAppPurchaseContainer)
         expect(inAppPurchase.originalPurchaseDate) == originalPurchaseDate
     }
 
-    func testBuildGetsCorrectIsInIntroOfferPeriod() {
+    func testBuildGetsCorrectIsInIntroOfferPeriod() throws {
         let sampleInAppPurchaseContainer = sampleInAppPurchaseContainerWithMinimalAttributes()
-        let inAppPurchase = try! self.inAppPurchaseBuilder.build(fromContainer: sampleInAppPurchaseContainer)
+        let inAppPurchase = try self.inAppPurchaseBuilder.build(fromContainer: sampleInAppPurchaseContainer)
         expect(inAppPurchase.isInIntroOfferPeriod) == isInIntroOfferPeriod
     }
 
-    func testBuildGetsCorrectWebOrderLineItemId() {
+    func testBuildGetsCorrectWebOrderLineItemId() throws {
         let sampleInAppPurchaseContainer = sampleInAppPurchaseContainerWithMinimalAttributes()
-        let inAppPurchase = try! self.inAppPurchaseBuilder.build(fromContainer: sampleInAppPurchaseContainer)
+        let inAppPurchase = try self.inAppPurchaseBuilder.build(fromContainer: sampleInAppPurchaseContainer)
         expect(inAppPurchase.webOrderLineItemId) == webOrderLineItemId
     }
 
-    func testBuildGetsCorrectProductType() {
+    func testBuildGetsCorrectProductType() throws {
         let inAppPurchaseContainer = containerFactory
             .inAppPurchaseContainerFromContainers(containers: minimalAttributes() + [productTypeContainer()])
-        let inAppPurchase = try! self.inAppPurchaseBuilder.build(fromContainer: inAppPurchaseContainer)
+        let inAppPurchase = try self.inAppPurchaseBuilder.build(fromContainer: inAppPurchaseContainer)
 
         expect(inAppPurchase.productType) == productType
     }
 
-    func testBuildGetsCorrectExpiresDate() {
+    func testBuildGetsCorrectExpiresDate() throws {
         let inAppPurchaseContainer = containerFactory
             .inAppPurchaseContainerFromContainers(containers: minimalAttributes() + [expiresDateContainer()])
-        let inAppPurchase = try! self.inAppPurchaseBuilder.build(fromContainer: inAppPurchaseContainer)
+        let inAppPurchase = try self.inAppPurchaseBuilder.build(fromContainer: inAppPurchaseContainer)
 
         expect(inAppPurchase.expiresDate) == expiresDate
     }
 
-    func testBuildGetsCorrectCancellationDate() {
+    func testBuildGetsCorrectCancellationDate() throws {
         let inAppPurchaseContainer = containerFactory
             .inAppPurchaseContainerFromContainers(containers: minimalAttributes() + [cancellationDateContainer()])
-        let inAppPurchase = try! self.inAppPurchaseBuilder.build(fromContainer: inAppPurchaseContainer)
+        let inAppPurchase = try self.inAppPurchaseBuilder.build(fromContainer: inAppPurchaseContainer)
 
         expect(inAppPurchase.cancellationDate) == cancellationDate
     }
 
-    func testBuildGetsCorrectIsInTrialPeriod() {
+    func testBuildGetsCorrectIsInTrialPeriod() throws {
         let inAppPurchaseContainer = containerFactory
             .inAppPurchaseContainerFromContainers(containers: minimalAttributes() + [isInTrialPeriodContainer()])
-        let inAppPurchase = try! self.inAppPurchaseBuilder.build(fromContainer: inAppPurchaseContainer)
+        let inAppPurchase = try self.inAppPurchaseBuilder.build(fromContainer: inAppPurchaseContainer)
 
         expect(inAppPurchase.isInTrialPeriod) == isInTrialPeriod
     }
 
-    func testBuildGetsCorrectPromotionalOfferIdentifier() {
+    func testBuildGetsCorrectPromotionalOfferIdentifier() throws {
         let inAppPurchaseContainer = containerFactory
             .inAppPurchaseContainerFromContainers(containers: minimalAttributes() + [promotionalOfferIdentifierContainer()])
-        let inAppPurchase = try! self.inAppPurchaseBuilder.build(fromContainer: inAppPurchaseContainer)
+        let inAppPurchase = try self.inAppPurchaseBuilder.build(fromContainer: inAppPurchaseContainer)
 
         expect(inAppPurchase.promotionalOfferIdentifier) == promotionalOfferIdentifier
     }

--- a/PurchasesTests/LocalReceiptParsing/ReceiptParserTests.swift
+++ b/PurchasesTests/LocalReceiptParsing/ReceiptParserTests.swift
@@ -19,7 +19,7 @@ class ReceiptParserTests: XCTestCase {
                                       receiptBuilder: mockAppleReceiptBuilder)
     }
 
-    func testParseFromReceiptDataBuildsContainerAfterObjectIdentifier() {
+    func testParseFromReceiptDataBuildsContainerAfterObjectIdentifier() throws {
         let receiptContainer = containerFactory.receiptContainerFromContainers(containers: [])
         let dataObjectIdentifierContainer = containerFactory.objectIdentifierContainer(.data)
         let constructedContainer = containerFactory.constructedContainer(containers: [
@@ -31,14 +31,14 @@ class ReceiptParserTests: XCTestCase {
         let expectedReceipt = mockAppleReceiptWithoutPurchases()
         mockAppleReceiptBuilder.stubbedBuildResult = expectedReceipt
 
-        let receivedReceipt = try! self.receiptParser.parse(from: Data())
+        let receivedReceipt = try self.receiptParser.parse(from: Data())
 
         expect(self.mockAppleReceiptBuilder.invokedBuildCount) == 1
         expect(self.mockAppleReceiptBuilder.invokedBuildParameters) == receiptContainer
         expect(receivedReceipt) == expectedReceipt
     }
 
-    func testParseFromReceiptDataBuildsContainerAfterObjectIdentifierInComplexContainer() {
+    func testParseFromReceiptDataBuildsContainerAfterObjectIdentifierInComplexContainer() throws {
         let receiptContainer = containerFactory.receiptContainerFromContainers(containers: [])
         let dataObjectIdentifierContainer = containerFactory.objectIdentifierContainer(.data)
 
@@ -67,7 +67,7 @@ class ReceiptParserTests: XCTestCase {
         let expectedReceipt = mockAppleReceiptWithoutPurchases()
         mockAppleReceiptBuilder.stubbedBuildResult = expectedReceipt
 
-        let receivedReceipt = try! self.receiptParser.parse(from: Data())
+        let receivedReceipt = try self.receiptParser.parse(from: Data())
 
         expect(self.mockAppleReceiptBuilder.invokedBuildCount) == 1
         expect(self.mockAppleReceiptBuilder.invokedBuildParameters) == receiptContainer

--- a/PurchasesTests/LocalReceiptParsing/TestsAgainstRealReceipts/ReceiptParsing+TestsWithRealReceipts.swift
+++ b/PurchasesTests/LocalReceiptParsing/TestsAgainstRealReceipts/ReceiptParsing+TestsWithRealReceipts.swift
@@ -16,22 +16,20 @@ class ReceiptParsingRealReceiptTests: XCTestCase {
     
     let receipt1Name = "base64encodedreceiptsample1"
 
-    func testBasicReceiptAttributesForSample1() {
+    func testBasicReceiptAttributesForSample1() throws {
         let receiptData = sampleReceiptData(receiptName: receipt1Name)
-        let receipt = try! ReceiptParser().parse(from: receiptData)
+        let receipt = try ReceiptParser().parse(from: receiptData)
         
         expect(receipt.applicationVersion) == "4"
         expect(receipt.bundleId) == "com.revenuecat.sampleapp"
         expect(receipt.originalApplicationVersion) == "1.0"
         expect(receipt.creationDate) == Date(timeIntervalSince1970: 1595439548)
         expect(receipt.expirationDate).to(beNil())
-        
-        
     }
     
-    func testInAppPurchasesAttributesForSample1() {
+    func testInAppPurchasesAttributesForSample1() throws {
         let receiptData = sampleReceiptData(receiptName: receipt1Name)
-        let receipt = try! ReceiptParser().parse(from: receiptData)
+        let receipt = try ReceiptParser().parse(from: receiptData)
         let inAppPurchases = receipt.inAppPurchases
         
         expect(inAppPurchases.count) == 9

--- a/PurchasesTests/Misc/SystemInfoTests.swift
+++ b/PurchasesTests/Misc/SystemInfoTests.swift
@@ -25,19 +25,19 @@ class SystemInfoTests: XCTestCase {
         expect(SystemInfo.systemVersion) == ProcessInfo().operatingSystemVersionString
     }
 
-    func testPlatformFlavor() {
+    func testPlatformFlavor() throws {
         let flavor = "flavor"
-        let systemInfo = try! SystemInfo(platformFlavor: flavor,
-                                           platformFlavorVersion: "foo",
-                                           finishTransactions: false)
+        let systemInfo = try SystemInfo(platformFlavor: flavor,
+                                        platformFlavorVersion: "foo",
+                                        finishTransactions: false)
         expect(systemInfo.platformFlavor) == flavor
     }
 
-    func testPlatformFlavorVersion() {
+    func testPlatformFlavorVersion() throws {
         let flavorVersion = "flavorVersion"
-        let systemInfo = try! SystemInfo(platformFlavor: "foo",
-                                           platformFlavorVersion: flavorVersion,
-                                           finishTransactions: false)
+        let systemInfo = try SystemInfo(platformFlavor: "foo",
+                                        platformFlavorVersion: flavorVersion,
+                                        finishTransactions: false)
         expect(systemInfo.platformFlavorVersion) == flavorVersion
     }
 
@@ -63,44 +63,44 @@ class SystemInfoTests: XCTestCase {
             .toNot(throwError(SystemInfo.SystemInfoError.invalidInitializationData))
     }
 
-    func testFinishTransactions() {
+    func testFinishTransactions() throws {
         var finishTransactions = false
-        var systemInfo = try! SystemInfo(platformFlavor: nil,
-                                           platformFlavorVersion: nil,
-                                           finishTransactions: finishTransactions)
+        var systemInfo = try SystemInfo(platformFlavor: nil,
+                                        platformFlavorVersion: nil,
+                                        finishTransactions: finishTransactions)
         expect(systemInfo.finishTransactions) == finishTransactions
 
         finishTransactions = true
 
-        systemInfo = try! SystemInfo(platformFlavor: nil,
-                                       platformFlavorVersion: nil,
-                                       finishTransactions: finishTransactions)
+        systemInfo = try SystemInfo(platformFlavor: nil,
+                                    platformFlavorVersion: nil,
+                                    finishTransactions: finishTransactions)
         expect(systemInfo.finishTransactions) == finishTransactions
     }
     
-    func testIsSandbox() {
-        expect(SystemInfo.withReceiptResult(.sandboxReceipt).isSandbox) == true
+    func testIsSandbox() throws {
+        expect(try SystemInfo.withReceiptResult(.sandboxReceipt).isSandbox) == true
     }
     
-    func testIsNotSandbox() {
-        expect(SystemInfo.withReceiptResult(.receiptWithData).isSandbox) == false
+    func testIsNotSandbox() throws {
+        expect(try SystemInfo.withReceiptResult(.receiptWithData).isSandbox) == false
     }
     
-    func testIsNotSandboxIfNoReceiptURL() {
-        expect(SystemInfo.withReceiptResult(.nilURL).isSandbox) == false
+    func testIsNotSandboxIfNoReceiptURL() throws {
+        expect(try SystemInfo.withReceiptResult(.nilURL).isSandbox) == false
     }
 }
 
 private extension SystemInfo {
     
-    static func withReceiptResult(_ result: MockBundle.ReceiptURLResult) -> SystemInfo {
+    static func withReceiptResult(_ result: MockBundle.ReceiptURLResult) throws -> SystemInfo {
         let bundle = MockBundle()
         bundle.receiptURLResult = result
         
-        return try! SystemInfo(platformFlavor: nil,
-                               platformFlavorVersion: nil,
-                               finishTransactions: false,
-                               bundle: bundle)
+        return try SystemInfo(platformFlavor: nil,
+                              platformFlavorVersion: nil,
+                              finishTransactions: false,
+                              bundle: bundle)
     }
     
 }

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -160,12 +160,12 @@ class HTTPClientTests: XCTestCase {
         expect(pathHit).toEventually(equal(true), timeout: .seconds(1))
     }
 
-    func testSendsBodyData() {
+    func testSendsBodyData() throws {
         let path = "/a_random_path"
         let body = ["arg": "value"]
         var pathHit = false
 
-        let bodyData = try! JSONSerialization.data(withJSONObject: body)
+        let bodyData = try JSONSerialization.data(withJSONObject: body)
 
         stub(condition: hasBody(bodyData)) { _ in
             pathHit = true
@@ -395,7 +395,7 @@ class HTTPClientTests: XCTestCase {
         expect(headerPresent).toEventually(equal(true))
     }
     
-    func testPassesPlatformFlavorHeader() {
+    func testPassesPlatformFlavorHeader() throws {
         let path = "/a_random_path"
         var headerPresent = false
 
@@ -403,9 +403,9 @@ class HTTPClientTests: XCTestCase {
             headerPresent = true
             return HTTPStubsResponse(data: Data.init(), statusCode: 200, headers: nil)
         }
-        let systemInfo = try! SystemInfo(platformFlavor: "react-native",
-                                         platformFlavorVersion: "3.2.1",
-                                         finishTransactions: true)
+        let systemInfo = try SystemInfo(platformFlavor: "react-native",
+                                        platformFlavorVersion: "3.2.1",
+                                        finishTransactions: true)
         let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
         client.performPOSTRequest(serially: true,
                                   path: path,
@@ -416,7 +416,7 @@ class HTTPClientTests: XCTestCase {
         expect(headerPresent).toEventually(equal(true))
     }
 
-    func testPassesPlatformFlavorVersionHeader() {
+    func testPassesPlatformFlavorVersionHeader() throws {
         let path = "/a_random_path"
         var headerPresent = false
 
@@ -424,9 +424,9 @@ class HTTPClientTests: XCTestCase {
             headerPresent = true
             return HTTPStubsResponse(data: Data.init(), statusCode: 200, headers: nil)
         }
-        let systemInfo = try! SystemInfo(platformFlavor: "react-native",
-                                         platformFlavorVersion: "1.2.3",
-                                         finishTransactions: true)
+        let systemInfo = try SystemInfo(platformFlavor: "react-native",
+                                        platformFlavorVersion: "1.2.3",
+                                        finishTransactions: true)
         let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
         
         client.performPOSTRequest(serially: true,
@@ -438,7 +438,7 @@ class HTTPClientTests: XCTestCase {
         expect(headerPresent).toEventually(equal(true))
     }
 
-    func testPassesObserverModeHeaderCorrectlyWhenEnabled() {
+    func testPassesObserverModeHeaderCorrectlyWhenEnabled() throws {
         let path = "/a_random_path"
         var headerPresent = false
 
@@ -446,7 +446,7 @@ class HTTPClientTests: XCTestCase {
             headerPresent = true
             return HTTPStubsResponse(data: Data.init(), statusCode: 200, headers: nil)
         }
-        let systemInfo = try! SystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: true)
+        let systemInfo = try SystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: true)
         let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
         client.performPOSTRequest(serially: true,
                                   path: path,
@@ -457,7 +457,7 @@ class HTTPClientTests: XCTestCase {
         expect(headerPresent).toEventually(equal(true))
     }
 
-    func testPassesObserverModeHeaderCorrectlyWhenDisabled() {
+    func testPassesObserverModeHeaderCorrectlyWhenDisabled() throws {
         let path = "/a_random_path"
         var headerPresent = false
 
@@ -465,7 +465,7 @@ class HTTPClientTests: XCTestCase {
             headerPresent = true
             return HTTPStubsResponse(data: Data.init(), statusCode: 200, headers: nil)
         }
-        let systemInfo = try! SystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: false)
+        let systemInfo = try SystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: false)
         let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
         client.performPOSTRequest(serially: true,
                                   path: path,

--- a/PurchasesTests/Purchasing/CustomerInfoTests.swift
+++ b/PurchasesTests/Purchasing/CustomerInfoTests.swift
@@ -244,8 +244,8 @@ class BasicCustomerInfoTests: XCTestCase {
         expect(newInfo).toNot(beNil())
     }
 
-    func testTwoProductJson() {
-        let json = try! JSONSerialization.jsonObject(with: validTwoProductsJSON.data(using: String.Encoding.utf8)!, options: [])
+    func testTwoProductJson() throws {
+        let json = try JSONSerialization.jsonObject(with: validTwoProductsJSON.data(using: String.Encoding.utf8)!, options: [])
         let info = CustomerInfo(testData: json as! [String : Any])
         expect(info?.latestExpirationDate).toNot(beNil())
     }

--- a/PurchasesTests/Purchasing/OfferingsTests.swift
+++ b/PurchasesTests/Purchasing/OfferingsTests.swift
@@ -115,73 +115,74 @@ class OfferingsTests: XCTestCase {
         expect(offerings).to(beNil())
     }
 
-    func testOfferingsIsCreated() {
+    func testOfferingsIsCreated() throws {
         let products = [
             "com.myproduct.annual": MockSKProduct(mockProductIdentifier: "com.myproduct.annual"),
             "com.myproduct.monthly": MockSKProduct(mockProductIdentifier: "com.myproduct.monthly")
         ]
-        let offerings = offeringsFactory.createOfferings(withProducts: products, data: [
-            "offerings": [
-                [
-                    "identifier": "offering_a",
-                    "description": "This is the base offering",
-                    "packages": [
-                        ["identifier": "$rc_six_month",
-                         "platform_product_identifier": "com.myproduct.annual"]
-                    ]
+        let offerings = try XCTUnwrap(
+            offeringsFactory.createOfferings(withProducts: products, data: [
+                "offerings": [
+                    [
+                        "identifier": "offering_a",
+                        "description": "This is the base offering",
+                        "packages": [
+                            ["identifier": "$rc_six_month",
+                             "platform_product_identifier": "com.myproduct.annual"]
+                        ]
+                    ],
+                    [
+                        "identifier": "offering_b",
+                        "description": "This is the base offering b",
+                        "packages": [
+                            ["identifier": "$rc_monthly",
+                             "platform_product_identifier": "com.myproduct.monthly"]
+                        ]
+                    ],
                 ],
-                [
-                    "identifier": "offering_b",
-                    "description": "This is the base offering b",
-                    "packages": [
-                        ["identifier": "$rc_monthly",
-                         "platform_product_identifier": "com.myproduct.monthly"]
-                    ]
-                ],
-            ],
-            "current_offering_id": "offering_a"
-        ])
+                "current_offering_id": "offering_a"
+            ])
+        )
 
-        expect(offerings).toNot(beNil())
-        expect(offerings?["offering_a"]).toNot(beNil())
-        expect(offerings?["offering_b"]).toNot(beNil())
-        expect(offerings?.current).to(be(offerings?["offering_a"]))
+        expect(offerings["offering_a"]).toNot(beNil())
+        expect(offerings["offering_b"]).toNot(beNil())
+        expect(offerings.current).to(be(offerings["offering_a"]))
     }
 
-    func testLifetimePackage() {
-        testPackageType(packageType: PackageType.lifetime)
+    func testLifetimePackage() throws {
+        try testPackageType(packageType: PackageType.lifetime)
     }
 
-    func testAnnualPackage() {
-        testPackageType(packageType: PackageType.annual)
+    func testAnnualPackage() throws {
+        try testPackageType(packageType: PackageType.annual)
     }
 
-    func testSixMonthPackage() {
-        testPackageType(packageType: PackageType.sixMonth)
+    func testSixMonthPackage() throws {
+        try testPackageType(packageType: PackageType.sixMonth)
     }
 
-    func testThreeMonthPackage() {
-        testPackageType(packageType: PackageType.threeMonth)
+    func testThreeMonthPackage() throws {
+        try testPackageType(packageType: PackageType.threeMonth)
     }
 
-    func testTwoMonthPackage() {
-        testPackageType(packageType: PackageType.twoMonth)
+    func testTwoMonthPackage() throws {
+        try testPackageType(packageType: PackageType.twoMonth)
     }
 
-    func testMonthlyPackage() {
-        testPackageType(packageType: PackageType.monthly)
+    func testMonthlyPackage() throws {
+        try testPackageType(packageType: PackageType.monthly)
     }
 
-    func testWeeklyPackage() {
-        testPackageType(packageType: PackageType.weekly)
+    func testWeeklyPackage() throws {
+        try testPackageType(packageType: PackageType.weekly)
     }
 
-    func testCustomPackage() {
-        testPackageType(packageType: PackageType.custom)
+    func testCustomPackage() throws {
+        try testPackageType(packageType: PackageType.custom)
     }
 
-    func testUnknownPackageType() {
-        testPackageType(packageType: PackageType.unknown)
+    func testUnknownPackageType() throws {
+        try testPackageType(packageType: PackageType.unknown)
     }
 
     func testOfferingsIsNilIfNoOfferingCanBeCreated() throws {
@@ -225,7 +226,7 @@ class OfferingsTests: XCTestCase {
         expect(offerings).to(beNil())
     }
 
-    private func testPackageType(packageType: PackageType) {
+    private func testPackageType(packageType: PackageType) throws {
         var identifier = Package.string(from: packageType)
         if (identifier == nil) {
             if (packageType == PackageType.unknown) {
@@ -238,58 +239,59 @@ class OfferingsTests: XCTestCase {
         let products = [
             productIdentifier: MockSKProduct(mockProductIdentifier: productIdentifier)
         ]
-        let offerings = offeringsFactory.createOfferings(withProducts: products, data: [
-            "offerings": [
-                [
-                    "identifier": "offering_a",
-                    "description": "This is the base offering",
-                    "packages": [
-                        ["identifier": identifier,
-                         "platform_product_identifier": "com.myproduct"]
+        let offerings = try XCTUnwrap(
+            offeringsFactory.createOfferings(withProducts: products, data: [
+                "offerings": [
+                    [
+                        "identifier": "offering_a",
+                        "description": "This is the base offering",
+                        "packages": [
+                            ["identifier": identifier,
+                             "platform_product_identifier": "com.myproduct"]
+                        ]
                     ]
-                ]
-            ],
-            "current_offering_id": "offering_a"
-        ])
+                ],
+                "current_offering_id": "offering_a"
+            ])
+        )
 
-        expect(offerings).toNot(beNil())
-        expect(offerings?.current).toNot(beNil())
+        expect(offerings.current).toNot(beNil())
         if (packageType == PackageType.lifetime) {
-            expect(offerings?.current?.lifetime).toNot(beNil())
+            expect(offerings.current?.lifetime).toNot(beNil())
         } else {
-            expect(offerings?.current?.lifetime).to(beNil())
+            expect(offerings.current?.lifetime).to(beNil())
         }
         if (packageType == PackageType.annual) {
-            expect(offerings?.current?.annual).toNot(beNil())
+            expect(offerings.current?.annual).toNot(beNil())
         } else {
-            expect(offerings?.current?.annual).to(beNil())
+            expect(offerings.current?.annual).to(beNil())
         }
         if (packageType == PackageType.sixMonth) {
-            expect(offerings?.current?.sixMonth).toNot(beNil())
+            expect(offerings.current?.sixMonth).toNot(beNil())
         } else {
-            expect(offerings?.current?.sixMonth).to(beNil())
+            expect(offerings.current?.sixMonth).to(beNil())
         }
         if (packageType == PackageType.threeMonth) {
-            expect(offerings?.current?.threeMonth).toNot(beNil())
+            expect(offerings.current?.threeMonth).toNot(beNil())
         } else {
-            expect(offerings?.current?.threeMonth).to(beNil())
+            expect(offerings.current?.threeMonth).to(beNil())
         }
         if (packageType == PackageType.twoMonth) {
-            expect(offerings?.current?.twoMonth).toNot(beNil())
+            expect(offerings.current?.twoMonth).toNot(beNil())
         } else {
-            expect(offerings?.current?.twoMonth).to(beNil())
+            expect(offerings.current?.twoMonth).to(beNil())
         }
         if (packageType == PackageType.monthly) {
-            expect(offerings?.current?.monthly).toNot(beNil())
+            expect(offerings.current?.monthly).toNot(beNil())
         } else {
-            expect(offerings?.current?.monthly).to(beNil())
+            expect(offerings.current?.monthly).to(beNil())
         }
         if (packageType == PackageType.weekly) {
-            expect(offerings?.current?.weekly).toNot(beNil())
+            expect(offerings.current?.weekly).toNot(beNil())
         } else {
-            expect(offerings?.current?.weekly).to(beNil())
+            expect(offerings.current?.weekly).to(beNil())
         }
-        let package = offerings?["offering_a"]?.package(identifier: identifier)
+        let package = offerings["offering_a"]?.package(identifier: identifier)
         expect(package?.packageType).to(equal(packageType))
     }
 

--- a/PurchasesTests/Purchasing/OfferingsTests.swift
+++ b/PurchasesTests/Purchasing/OfferingsTests.swift
@@ -143,9 +143,9 @@ class OfferingsTests: XCTestCase {
         ])
 
         expect(offerings).toNot(beNil())
-        expect(offerings!["offering_a"]).toNot(beNil())
-        expect(offerings!["offering_b"]).toNot(beNil())
-        expect(offerings!.current).to(be(offerings!["offering_a"]))
+        expect(offerings?["offering_a"]).toNot(beNil())
+        expect(offerings?["offering_b"]).toNot(beNil())
+        expect(offerings?.current).to(be(offerings?["offering_a"]))
     }
 
     func testLifetimePackage() {
@@ -253,43 +253,43 @@ class OfferingsTests: XCTestCase {
         ])
 
         expect(offerings).toNot(beNil())
-        expect(offerings!.current).toNot(beNil())
+        expect(offerings?.current).toNot(beNil())
         if (packageType == PackageType.lifetime) {
-            expect(offerings!.current?.lifetime).toNot(beNil())
+            expect(offerings?.current?.lifetime).toNot(beNil())
         } else {
-            expect(offerings!.current?.lifetime).to(beNil())
+            expect(offerings?.current?.lifetime).to(beNil())
         }
         if (packageType == PackageType.annual) {
-            expect(offerings!.current?.annual).toNot(beNil())
+            expect(offerings?.current?.annual).toNot(beNil())
         } else {
-            expect(offerings!.current?.annual).to(beNil())
+            expect(offerings?.current?.annual).to(beNil())
         }
         if (packageType == PackageType.sixMonth) {
-            expect(offerings!.current?.sixMonth).toNot(beNil())
+            expect(offerings?.current?.sixMonth).toNot(beNil())
         } else {
-            expect(offerings!.current?.sixMonth).to(beNil())
+            expect(offerings?.current?.sixMonth).to(beNil())
         }
         if (packageType == PackageType.threeMonth) {
-            expect(offerings!.current?.threeMonth).toNot(beNil())
+            expect(offerings?.current?.threeMonth).toNot(beNil())
         } else {
-            expect(offerings!.current?.threeMonth).to(beNil())
+            expect(offerings?.current?.threeMonth).to(beNil())
         }
         if (packageType == PackageType.twoMonth) {
-            expect(offerings!.current?.twoMonth).toNot(beNil())
+            expect(offerings?.current?.twoMonth).toNot(beNil())
         } else {
-            expect(offerings!.current?.twoMonth).to(beNil())
+            expect(offerings?.current?.twoMonth).to(beNil())
         }
         if (packageType == PackageType.monthly) {
-            expect(offerings!.current?.monthly).toNot(beNil())
+            expect(offerings?.current?.monthly).toNot(beNil())
         } else {
-            expect(offerings!.current?.monthly).to(beNil())
+            expect(offerings?.current?.monthly).to(beNil())
         }
         if (packageType == PackageType.weekly) {
-            expect(offerings!.current?.weekly).toNot(beNil())
+            expect(offerings?.current?.weekly).toNot(beNil())
         } else {
-            expect(offerings!.current?.weekly).to(beNil())
+            expect(offerings?.current?.weekly).to(beNil())
         }
-        let package = offerings!["offering_a"]?.package(identifier: identifier)
+        let package = offerings?["offering_a"]?.package(identifier: identifier)
         expect(package?.packageType).to(equal(packageType))
     }
 

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -28,18 +28,20 @@ class PurchasesTests: XCTestCase {
             "original_application_version": NSNull()
     ]]
 
-    override func setUp() {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
         userDefaults = UserDefaults(suiteName: "TestDefaults")
         deviceCache = MockDeviceCache(userDefaults: userDefaults)
         requestFetcher = MockRequestFetcher()
-        systemInfo = try! MockSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: true)
+        systemInfo = try MockSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: true)
         mockProductsManager = MockProductsManager()
         mockOperationDispatcher = MockOperationDispatcher()
         mockIntroEligibilityCalculator = MockIntroEligibilityCalculator()
         mockReceiptParser = MockReceiptParser()
-        let systemInfoAttribution = try! MockSystemInfo(platformFlavor: "iOS",
-                                                   platformFlavorVersion: "3.2.1",
-                                                   finishTransactions: true)
+        let systemInfoAttribution = try MockSystemInfo(platformFlavor: "iOS",
+                                                       platformFlavorVersion: "3.2.1",
+                                                       finishTransactions: true)
         receiptFetcher = MockReceiptFetcher(requestFetcher: requestFetcher, systemInfo: systemInfoAttribution)
         attributionFetcher = MockAttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
                                                     systemInfo: systemInfoAttribution)
@@ -290,8 +292,8 @@ class PurchasesTests: XCTestCase {
         initializePurchasesInstance(appUserId: nil)
     }
 
-    func setupPurchasesObserverModeOn() {
-        systemInfo = try! MockSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: false)
+    func setupPurchasesObserverModeOn() throws {
+        systemInfo = try MockSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: false)
         initializePurchasesInstance(appUserId: nil)
     }
 
@@ -372,7 +374,7 @@ class PurchasesTests: XCTestCase {
         expect(self.purchasesDelegate.customerInfoReceivedCount).toEventually(equal(0))
     }
 
-    func testFirstInitializationFromBackgroundCallsDelegateForAnonIfInfoCached() {
+    func testFirstInitializationFromBackgroundCallsDelegateForAnonIfInfoCached() throws {
         systemInfo.stubbedIsApplicationBackgrounded = true
         let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
@@ -385,7 +387,7 @@ class PurchasesTests: XCTestCase {
 
         let jsonObject = info!.jsonObject()
 
-        let object = try! JSONSerialization.data(withJSONObject: jsonObject, options: []);
+        let object = try JSONSerialization.data(withJSONObject: jsonObject, options: []);
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
 
         setupPurchases()
@@ -1138,7 +1140,7 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.postReceiptDataCalled).to(beTrue())
     }
 
-    func testRestoringPurchasesDoesntPostIfReceiptEmptyAndCustomerInfoLoaded() {
+    func testRestoringPurchasesDoesntPostIfReceiptEmptyAndCustomerInfoLoaded() throws {
         let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
@@ -1152,7 +1154,7 @@ class PurchasesTests: XCTestCase {
 
         let jsonObject = info!.jsonObject()
 
-        let object = try! JSONSerialization.data(withJSONObject: jsonObject, options: []);
+        let object = try JSONSerialization.data(withJSONObject: jsonObject, options: []);
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
 
         mockReceiptParser.stubbedReceiptHasTransactionsResult = false
@@ -1172,7 +1174,7 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.postReceiptDataCalled) == true
     }
 
-    func testRestoringPurchasesPostsIfReceiptHasTransactionsAndCustomerInfoLoaded() {
+    func testRestoringPurchasesPostsIfReceiptHasTransactionsAndCustomerInfoLoaded() throws {
         let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
@@ -1186,7 +1188,7 @@ class PurchasesTests: XCTestCase {
 
         let jsonObject = info!.jsonObject()
 
-        let object = try! JSONSerialization.data(withJSONObject: jsonObject, options: []);
+        let object = try JSONSerialization.data(withJSONObject: jsonObject, options: []);
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
 
         mockReceiptParser.stubbedReceiptHasTransactionsResult = true
@@ -1268,7 +1270,7 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.postReceiptDataCalled).to(beTrue())
     }
 
-    func testSyncPurchasesDoesntPostIfReceiptEmptyAndCustomerInfoLoaded() {
+    func testSyncPurchasesDoesntPostIfReceiptEmptyAndCustomerInfoLoaded() throws {
         let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
@@ -1282,7 +1284,7 @@ class PurchasesTests: XCTestCase {
 
         let jsonObject = info!.jsonObject()
 
-        let object = try! JSONSerialization.data(withJSONObject: jsonObject, options: []);
+        let object = try JSONSerialization.data(withJSONObject: jsonObject, options: []);
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
 
         mockReceiptParser.stubbedReceiptHasTransactionsResult = false
@@ -1302,7 +1304,7 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.postReceiptDataCalled) == true
     }
 
-    func testSyncPurchasesPostsIfReceiptHasTransactionsAndCustomerInfoLoaded() {
+    func testSyncPurchasesPostsIfReceiptHasTransactionsAndCustomerInfoLoaded() throws {
         let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
@@ -1316,7 +1318,7 @@ class PurchasesTests: XCTestCase {
 
         let jsonObject = info!.jsonObject()
 
-        let object = try! JSONSerialization.data(withJSONObject: jsonObject, options: []);
+        let object = try JSONSerialization.data(withJSONObject: jsonObject, options: []);
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
 
         mockReceiptParser.stubbedReceiptHasTransactionsResult = true
@@ -1613,7 +1615,7 @@ class PurchasesTests: XCTestCase {
         expect(self.deviceCache.cacheCustomerInfoCount).toEventually(equal(2))
     }
 
-    func testCachedCustomerInfoHasSchemaVersion() {
+    func testCachedCustomerInfoHasSchemaVersion() throws {
         let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
@@ -1624,7 +1626,7 @@ class PurchasesTests: XCTestCase {
             ]]);
         let jsonObject = info!.jsonObject()
 
-        let object = try! JSONSerialization.data(withJSONObject: jsonObject, options: []);
+        let object = try JSONSerialization.data(withJSONObject: jsonObject, options: []);
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
         self.backend.timeout = true
 
@@ -1640,7 +1642,7 @@ class PurchasesTests: XCTestCase {
         expect(receivedInfo?.schemaVersion).toNot(beNil())
     }
 
-    func testCachedCustomerInfoHandlesNullSchema() {
+    func testCachedCustomerInfoHandlesNullSchema() throws {
         let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
@@ -1654,7 +1656,7 @@ class PurchasesTests: XCTestCase {
 
         jsonObject["schema_version"] = NSNull()
 
-        let object = try! JSONSerialization.data(withJSONObject: jsonObject, options: []);
+        let object = try JSONSerialization.data(withJSONObject: jsonObject, options: []);
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
         self.backend.timeout = true
 
@@ -1669,7 +1671,7 @@ class PurchasesTests: XCTestCase {
         expect(receivedInfo).to(beNil())
     }
 
-    func testSendsCachedCustomerInfoToGetter() {
+    func testSendsCachedCustomerInfoToGetter() throws {
         let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
@@ -1678,7 +1680,7 @@ class PurchasesTests: XCTestCase {
                 "subscriptions": [:],
                 "other_purchases": [:]
             ]]);
-        let object = try! JSONSerialization.data(withJSONObject: info!.jsonObject(), options: []);
+        let object = try JSONSerialization.data(withJSONObject: info!.jsonObject(), options: []);
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
         self.backend.timeout = true
 
@@ -1693,7 +1695,7 @@ class PurchasesTests: XCTestCase {
         expect(receivedInfo).toNot(beNil())
     }
 
-    func testCustomerInfoCompletionBlockCalledExactlyOnceWhenInfoCached() {
+    func testCustomerInfoCompletionBlockCalledExactlyOnceWhenInfoCached() throws {
         let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
@@ -1702,7 +1704,7 @@ class PurchasesTests: XCTestCase {
                 "subscriptions": [:],
                 "other_purchases": [:]
             ]]);
-        let object = try! JSONSerialization.data(withJSONObject: info!.jsonObject(), options: []);
+        let object = try JSONSerialization.data(withJSONObject: info!.jsonObject(), options: []);
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
         self.deviceCache.stubbedIsCustomerInfoCacheStale = true
         self.backend.timeout = false
@@ -1718,7 +1720,7 @@ class PurchasesTests: XCTestCase {
         expect(callCount).toEventually(equal(1))
     }
 
-    func testDoesntSendsCachedCustomerInfoToGetterIfSchemaVersionDiffers() {
+    func testDoesntSendsCachedCustomerInfoToGetterIfSchemaVersionDiffers() throws {
         let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
@@ -1729,7 +1731,7 @@ class PurchasesTests: XCTestCase {
             ]]);
         var jsonObject = info!.jsonObject()
         jsonObject["schema_version"] = "bad_version"
-        let object = try! JSONSerialization.data(withJSONObject: jsonObject, options: []);
+        let object = try JSONSerialization.data(withJSONObject: jsonObject, options: []);
 
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
         self.backend.timeout = true
@@ -1745,7 +1747,7 @@ class PurchasesTests: XCTestCase {
         expect(receivedInfo).to(beNil())
     }
 
-    func testDoesntSendsCachedCustomerInfoToGetterIfNoSchemaVersionInCached() {
+    func testDoesntSendsCachedCustomerInfoToGetterIfNoSchemaVersionInCached() throws {
         let info = CustomerInfo(testData: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
@@ -1756,7 +1758,7 @@ class PurchasesTests: XCTestCase {
             ]]);
         var jsonObject = info!.jsonObject()
         jsonObject.removeValue(forKey: "schema_version")
-        let object = try! JSONSerialization.data(withJSONObject: jsonObject, options: []);
+        let object = try JSONSerialization.data(withJSONObject: jsonObject, options: []);
 
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
         self.backend.timeout = true
@@ -2475,8 +2477,8 @@ class PurchasesTests: XCTestCase {
         expect(self.storeKitWrapper.finishCalled).toEventually(beTrue())
     }
 
-    func testDoesntFinishTransactionsIfObserverModeIsSet() {
-        setupPurchasesObserverModeOn()
+    func testDoesntFinishTransactionsIfObserverModeIsSet() throws {
+        try setupPurchasesObserverModeOn()
         let product = MockSKProduct(mockProductIdentifier: "com.product.id1")
         self.purchases?.purchase(product: product) { (tx, info, error, userCancelled) in
 
@@ -2497,8 +2499,8 @@ class PurchasesTests: XCTestCase {
         expect(self.storeKitWrapper.finishCalled).toEventually(beFalse())
     }
 
-    func testRestoredPurchasesArePosted() {
-        setupPurchasesObserverModeOn()
+    func testRestoredPurchasesArePosted() throws {
+        try setupPurchasesObserverModeOn()
         let product = MockSKProduct(mockProductIdentifier: "com.product.id1")
         self.purchases?.purchase(product: product) { (tx, info, error, userCancelled) in
 
@@ -2694,8 +2696,8 @@ class PurchasesTests: XCTestCase {
         expect(self.purchasesDelegate.customerInfoReceivedCount).toEventually(equal(2))
     }
 
-    func testReceiptsSendsObserverModeWhenObserverMode() {
-        setupPurchasesObserverModeOn()
+    func testReceiptsSendsObserverModeWhenObserverMode() throws {
+        try setupPurchasesObserverModeOn()
         let product = MockSKProduct(mockProductIdentifier: "com.product.id1")
         self.purchases?.purchase(product: product) { (tx, info, error, userCancelled) in
 

--- a/PurchasesTests/Purchasing/RCIntroEligibilityTests.swift
+++ b/PurchasesTests/Purchasing/RCIntroEligibilityTests.swift
@@ -12,19 +12,16 @@ import Nimble
 @testable import RevenueCat
 
 class IntroEligibilityTests: XCTestCase {
-    func testInitWithEligibilityStatusCodeUnknown() {
-        let introElegibility = try! IntroEligibility(eligibilityStatusCode: NSNumber(value: IntroEligibilityStatus.unknown.rawValue))
-        expect(introElegibility.status) == IntroEligibilityStatus.unknown
+    func testInitWithEligibilityStatusCodeUnknown() throws {
+        expect(try self.create(.unknown).status) == IntroEligibilityStatus.unknown
     }
     
-    func testInitWithEligibilityStatusCodeIneligible() {
-        let introElegibility = try! IntroEligibility(eligibilityStatusCode: NSNumber(value: IntroEligibilityStatus.ineligible.rawValue))
-        expect(introElegibility.status) == IntroEligibilityStatus.ineligible
+    func testInitWithEligibilityStatusCodeIneligible() throws {
+        expect(try self.create(.ineligible).status) == IntroEligibilityStatus.ineligible
     }
 
-    func testInitWithEligibilityStatusCodeEligible() {
-        let introElegibility = try! IntroEligibility(eligibilityStatusCode: NSNumber(value: IntroEligibilityStatus.eligible.rawValue))
-        expect(introElegibility.status) == IntroEligibilityStatus.eligible
+    func testInitWithEligibilityStatusCodeEligible() throws {
+        expect(try self.create(.eligible).status) == IntroEligibilityStatus.eligible
     }
     
     func testInitWithEligibilityStatusCodeFailsIfInvalid() {
@@ -34,5 +31,9 @@ class IntroEligibilityTests: XCTestCase {
         expect(try IntroEligibility(eligibilityStatusCode: 3)).to(
             throwError(closure: { expect($0.localizedDescription).to(equal("😿 Invalid status code: 3"))})
         )
+    }
+
+    private func create(_ code: IntroEligibilityStatus) throws -> IntroEligibility {
+        return try IntroEligibility(eligibilityStatusCode: NSNumber(value: code.rawValue))
     }
 }

--- a/PurchasesTests/Purchasing/ReceiptFetcherTests.swift
+++ b/PurchasesTests/Purchasing/ReceiptFetcherTests.swift
@@ -24,13 +24,15 @@ class ReceiptFetcherTests: XCTestCase {
     var mockBundle: MockBundle!
     var mockSystemInfo: MockSystemInfo!
     
-    override func setUp() {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
         mockBundle = MockBundle()
         mockRequestFetcher = MockRequestFetcher()
-        mockSystemInfo = try! MockSystemInfo(platformFlavor: nil,
-                                             platformFlavorVersion: nil,
-                                             finishTransactions: false,
-                                             bundle: mockBundle)
+        mockSystemInfo = try MockSystemInfo(platformFlavor: nil,
+                                            platformFlavorVersion: nil,
+                                            finishTransactions: false,
+                                            bundle: mockBundle)
         receiptFetcher = ReceiptFetcher(requestFetcher: mockRequestFetcher, systemInfo: mockSystemInfo)
     }
     

--- a/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -58,7 +58,9 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
 
     var purchases: Purchases!
 
-    override func setUp() {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
         userDefaults = UserDefaults(suiteName: "TestDefaults")
         self.mockDeviceCache = MockDeviceCache(userDefaults: userDefaults)
 
@@ -73,9 +75,9 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
         self.mockOperationDispatcher = MockOperationDispatcher()
         self.mockIntroEligibilityCalculator = MockIntroEligibilityCalculator()
         self.mockReceiptParser = MockReceiptParser()
-        let systemInfoAttribution = try! MockSystemInfo(platformFlavor: "iOS",
-                                                        platformFlavorVersion: "3.2.1",
-                                                        finishTransactions: true)
+        let systemInfoAttribution = try MockSystemInfo(platformFlavor: "iOS",
+                                                       platformFlavorVersion: "3.2.1",
+                                                       finishTransactions: true)
         self.mockAttributionFetcher = MockAttributionFetcher(attributionFactory: AttributionTypeFactory(),
                                                              systemInfo: systemInfoAttribution)
         self.mockSubscriberAttributesManager = MockSubscriberAttributesManager(

--- a/PurchasesTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -26,14 +26,15 @@ class SubscriberAttributesManagerTests: XCTestCase {
     var subscriberAttributeWeight: SubscriberAttribute!
     var mockAttributes: [String: SubscriberAttribute]!
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
         self.mockDeviceCache = MockDeviceCache()
         self.mockBackend = MockBackend()
         self.mockAttributionFetcher = MockAttributionFetcher(attributionFactory: AttributionTypeFactory(),
-                                                             systemInfo: try! MockSystemInfo(platformFlavor: "iOS",
-                                                                                             platformFlavorVersion: "3.2.1",
-                                                                                             finishTransactions: true))
+                                                             systemInfo: try MockSystemInfo(platformFlavor: "iOS",
+                                                                                            platformFlavorVersion: "3.2.1",
+                                                                                            finishTransactions: true))
         self.mockAttributionDataMigrator = MockAttributionDataMigrator()
         self.subscriberAttributesManager = SubscriberAttributesManager(backend: mockBackend,
                                                                          deviceCache: mockDeviceCache,


### PR DESCRIPTION
Fixes [sc-11146]

### Why?

It converts failures from a fatal error (process crashing):
<img width="699" alt="Screen Shot 2021-11-18 at 11 28 23" src="https://user-images.githubusercontent.com/685609/142486010-88e41be8-017c-4c19-a551-13c556412b88.png">

To a test failure:
<img width="793" alt="Screen Shot 2021-11-18 at 11 29 00" src="https://user-images.githubusercontent.com/685609/142486011-03050497-45c1-4349-a358-ab0f137786a8.png">

