### PR TITLE
Storekit 2: update deployment targets

### DIFF
--- a/Examples/MagicWeatherSwiftUI/Magic Weather SwiftUI.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/MagicWeatherSwiftUI/Magic Weather SwiftUI.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -21,10 +21,10 @@
       },
       {
         "package": "Nimble",
-        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "repositoryURL": "https://github.com/quick/nimble",
         "state": {
-          "branch": null,
-          "revision": "0fd4ba405699eb8ca939aefa34babf988f4ff9ff",
+          "branch": "main",
+          "revision": "ea662491f7f4b6ec72656674488bf830003eaaf5",
           "version": null
         }
       },

--- a/IntegrationTests/CocoapodsIntegration/CocoapodsIntegration.xcodeproj/project.pbxproj
+++ b/IntegrationTests/CocoapodsIntegration/CocoapodsIntegration.xcodeproj/project.pbxproj
@@ -513,7 +513,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 8SXR2327BM;
 				INFOPLIST_FILE = "$(SRCROOT)/../CommonFiles/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -541,7 +541,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 8SXR2327BM;
 				INFOPLIST_FILE = "$(SRCROOT)/../CommonFiles/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/IntegrationTests/CocoapodsIntegration/Podfile
+++ b/IntegrationTests/CocoapodsIntegration/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-platform :ios, '9.0'
+platform :ios, '11.0'
 
 target 'CocoapodsIntegration' do
   # Comment the next line if you don't want to use dynamic frameworks

--- a/IntegrationTests/CocoapodsIntegration/Podfile.lock
+++ b/IntegrationTests/CocoapodsIntegration/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - RevenueCat (4.0.0-beta.1)
+  - RevenueCat (4.0.0-beta.6)
 
 DEPENDENCIES:
   - RevenueCat (from `../../`)
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  RevenueCat: d40fad138e5d1506f8f4038dc9660be1c36f481f
+  RevenueCat: ab83627a82043e58f91cdca72301538dd4f49ddb
 
-PODFILE CHECKSUM: cf043c6421991b93dcc0bf3bb2a4bc20d46d0655
+PODFILE CHECKSUM: 6710b07378ac75160af9fb583eb931b3c73b3726
 
-COCOAPODS: 1.11.0
+COCOAPODS: 1.11.2

--- a/IntegrationTests/SPMIntegration/SPMIntegration.xcodeproj/project.pbxproj
+++ b/IntegrationTests/SPMIntegration/SPMIntegration.xcodeproj/project.pbxproj
@@ -425,7 +425,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 8SXR2327BM;
 				INFOPLIST_FILE = ../CommonFiles/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -451,7 +451,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 8SXR2327BM;
 				INFOPLIST_FILE = ../CommonFiles/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/IntegrationTests/XcodeDirectIntegration/XcodeDirectIntegration.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/IntegrationTests/XcodeDirectIntegration/XcodeDirectIntegration.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
         "state": {
           "branch": null,
-          "revision": "682841464136f8c66e04afe5dbd01ab51a3a56f2",
-          "version": "2.1.0"
+          "revision": "35f9e770f54ce62dd8526470f14c6e137cef3eea",
+          "version": "2.1.1"
         }
       },
       {
@@ -15,17 +15,17 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
         "state": {
           "branch": null,
-          "revision": "02b7a39a99c4da27abe03cab2053a9034379639f",
-          "version": "2.0.0"
+          "revision": "fb7a26374e8570ff5c68142e5c83406d6abae0d8",
+          "version": "2.0.2"
         }
       },
       {
         "package": "Nimble",
-        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "repositoryURL": "https://github.com/quick/nimble",
         "state": {
-          "branch": null,
-          "revision": "af1730dde4e6c0d45bf01b99f8a41713ce536790",
-          "version": "9.2.0"
+          "branch": "main",
+          "revision": "ea662491f7f4b6ec72656674488bf830003eaaf5",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -20,15 +20,10 @@ func resolveTargets() -> [Target] {
 let package = Package(
     name: "RevenueCat",
     platforms: [
-        .macOS(.v10_12),
-        .watchOS("6.2"),
-        .tvOS(.v9),
-
-        // todo: deployment_target set to 12.0 instead of 9.0 temporarily for iOS due to a known issue in 
-        // Xcode-beta 5, where swift libraries fail to build for iOS targets that use armv7.
-        // See issue 74120874 in the release notes:
-        // https://developer.apple.com/documentation/xcode-release-notes/xcode-13-beta-release-notes
-        .iOS(.v12)
+        .macOS(.v10_13),
+        .watchOS(.v6_2),
+        .tvOS(.v11),
+        .iOS(.v11)
     ],
     products: [
         .library(name: "RevenueCat",

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     name: "RevenueCat",
     platforms: [
         .macOS(.v10_13),
-        .watchOS(.v6_2),
+        .watchOS("6.2"),
         .tvOS(.v11),
         .iOS(.v11)
     ],

--- a/RevenueCat.podspec
+++ b/RevenueCat.podspec
@@ -16,14 +16,10 @@ Pod::Spec.new do |s|
   s.framework      = 'StoreKit'
   s.swift_version       = '5.5'
 
-  # todo: deployment_target set to 12.0 instead of 9.0 temporarily for iOS due to a known issue in 
-  # Xcode-beta 5, where swift libraries fail to build for iOS targets that use armv7.
-  # See issue 74120874 in the release notes:
-  # https://developer.apple.com/documentation/xcode-release-notes/xcode-13-beta-release-notes
-  s.ios.deployment_target = '12.0'
+  s.ios.deployment_target = '11.0'
   s.watchos.deployment_target = '6.2'
-  s.tvos.deployment_target = '9.0'
-  s.osx.deployment_target = '10.12'
+  s.tvos.deployment_target = '11.0'
+  s.osx.deployment_target = '10.13'
   
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -2059,13 +2059,13 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Purchases/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.Purchases;
@@ -2077,7 +2077,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 				WATCHOS_DEPLOYMENT_TARGET = 6.2;
 			};
 			name = Debug;
@@ -2098,13 +2098,13 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Purchases/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.Purchases;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -2115,7 +2115,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 				WATCHOS_DEPLOYMENT_TARGET = 6.2;
 			};
 			name = Release;
@@ -2131,13 +2131,13 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 8SXR2327BM;
 				INFOPLIST_FILE = PurchasesTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.PurchasesTests;
@@ -2150,7 +2150,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,6";
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 				WATCHOS_DEPLOYMENT_TARGET = 6.2;
 			};
 			name = Debug;
@@ -2166,13 +2166,13 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 8SXR2327BM;
 				INFOPLIST_FILE = PurchasesTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.PurchasesTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2182,7 +2182,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,6";
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 				WATCHOS_DEPLOYMENT_TARGET = 6.2;
 			};
 			name = Release;
@@ -2320,7 +2320,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 				WATCHOS_DEPLOYMENT_TARGET = 6.2;
 			};
 			name = Debug;
@@ -2345,7 +2345,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 11.0;
 				WATCHOS_DEPLOYMENT_TARGET = 6.2;
 			};
 			name = Release;

--- a/docs/V4_API_Updates.md
+++ b/docs/V4_API_Updates.md
@@ -4,6 +4,18 @@ but a number of updates make our Swift API more idomatic. We'll be updating this
 
 To start us off, Our framework name changed from `Purchases` to `RevenueCat` 😻! We also updated all references of `Purchaser` to `Customer` to be more consistent across our platform. 
 
+### Xcode version requirements and updated deployment targets
+`purchases-ios` v4 requires using Xcode 13.0 or newer. 
+It also updates the minimum deployment targets for iOS, macOS and tvOS. 
+
+##### Minimum deployment targets
+|  | v3 | v4 |
+| :-: | :-: | :-: |
+| iOS | 9.0 | 11.0 |
+| tvOS | 9.0 | 11.0 |
+| macOS | 10.12 | 10.13 |
+| watchOS | 6.2 | 6.2 (unchanged) |
+
 ### Known Issues
 
 #### ObjC + SPM


### PR DESCRIPTION
Updated min deployment targets for `purchases-ios`. 

Here's a comparison of what the min deployment targets look like before and after:

|  | v3 | v4 |
| :-: | :-: | :-: |
| iOS | 9.0 | 11.0 |
| tvOS | 9.0 | 11.0 |
| macOS | 10.12 | 10.13 |
| watchOS | 6.2 | 6.2 (unchanged) |

### Motivation

As soon as we include any methods from StoreKit 2, the SDK stops compiling correctly for iOS 9.0 and 10.0. It seems like an incompatibility issue with SK2, and we haven't found a way to keep compatibility with both. 

The errors logs look like this, and happen when archiving (also reproducible by running `pod lib lint`)
```ruby
    - ERROR | [iOS] xcodebuild:  /Users/andresboedo/repos/purchases-ios/Purchases/Support/ManageSubscriptionsModalHelper.swift:136:23: error: cannot find 'AppStore' in scope
    - ERROR | [iOS] xcodebuild:  /Users/andresboedo/repos/purchases-ios/Purchases/Purchasing/ProductDetails.swift:23:40: error: no type named 'Product' in module 'StoreKit'
    - ERROR | [iOS] xcodebuild:  /Users/andresboedo/repos/purchases-ios/Purchases/Purchasing/StoreKit2/ProductsFetcherSK2.swift:39:46: error: module 'StoreKit' has no member named 'Product'
    - ERROR | [iOS] xcodebuild:  /Users/andresboedo/repos/purchases-ios/Purchases/Purchasing/StoreKit2/StoreKit2TransactionListener.swift:39:42: error: no type named 'Product' in module 'StoreKit'
    - ERROR | [iOS] xcodebuild:  /Users/andresboedo/repos/purchases-ios/Purchases/Purchasing/StoreKit2/SK2BeginRefundRequestHelper.swift:62:21: error: no type named 'Transaction' in module 'StoreKit'
    - ERROR | [iOS] xcodebuild:  /Users/andresboedo/repos/purchases-ios/Purchases/Purchasing/StoreKit2/SK2BeginRefundRequestHelper.swift:100:55: error: no type named 'Transaction' in module 'StoreKit'
    - ERROR | [iOS] xcodebuild:  /Users/andresboedo/repos/purchases-ios/Purchases/Purchasing/StoreKit2/SK2BeginRefundRequestHelper.swift:122:62: error: no type named 'Transaction' in module 'StoreKit'
    - ERROR | [iOS] xcodebuild:  /Users/andresboedo/repos/purchases-ios/Purchases/Purchasing/StoreKit2/SK2BeginRefundRequestHelper.swift:37:33: error: module 'StoreKit' has no member named 'Transaction'
    - ERROR | [iOS] xcodebuild:  /Users/andresboedo/repos/purchases-ios/Purchases/Purchasing/StoreKit2/SK2BeginRefundRequestHelper.swift:64:39: error: module 'StoreKit' has no member named 'Transaction'
    - ERROR | [iOS] xcodebuild:  /Users/andresboedo/repos/purchases-ios/Purchases/Purchasing/StoreKit2/SK2BeginRefundRequestHelper.swift:81:53: error: no type named 'Transaction' in module 'StoreKit'
    - ERROR | [iOS] xcodebuild:  /Users/andresboedo/repos/purchases-ios/Purchases/Purchasing/StoreKit2/StoreKit2TransactionListener.swift:64:36: error: cannot find type 'VerificationResult' in scope
    - ERROR | [iOS] xcodebuild:  /Users/andresboedo/repos/purchases-ios/Purchases/Purchasing/StoreKit2/StoreKit2TransactionListener.swift:81:39: error: no type named 'Transaction' in module 'StoreKit'
    - ERROR | [iOS] xcodebuild:  /Users/andresboedo/repos/purchases-ios/Purchases/Purchasing/StoreKit2/StoreKit2TransactionListener.swift:33:33: error: module 'StoreKit' has no member named 'Transaction'
    - ERROR | [iOS] xcodebuild:  /Users/andresboedo/repos/purchases-ios/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift:79:35: error: type of expression is ambiguous without more context
```

While this only seems to apply to iOS, since the usage in older tvOS and macOS versions is low, we're also updating their deployment targets to match API levels with iOS. This will allow us to simplify our code in places where we check for OS-level API availability. 