### PR TITLE
APITester: combined targets into one cross-platform target

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj/project.pbxproj
+++ b/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj/project.pbxproj
@@ -24,38 +24,12 @@
 		2DD77914270E23870079CBD4 /* RCOfferingAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614DF26EBE84F007DDB75 /* RCOfferingAPI.m */; };
 		2DD77915270E23870079CBD4 /* RCPackageAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614DE26EBE84F007DDB75 /* RCPackageAPI.m */; };
 		2DD77916270E23870079CBD4 /* RCTransactionAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614F426EBE84F007DDB75 /* RCTransactionAPI.m */; };
-		575885A02748274600CA2169 /* RevenueCat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5758859F2748274600CA2169 /* RevenueCat.framework */; };
-		575885A12748274600CA2169 /* RevenueCat.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5758859F2748274600CA2169 /* RevenueCat.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		575885A42748274E00CA2169 /* RevenueCat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 575885A32748274E00CA2169 /* RevenueCat.framework */; };
 		575885A52748274E00CA2169 /* RevenueCat.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 575885A32748274E00CA2169 /* RevenueCat.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		A513AD31272B327A00E0C1BA /* RCRefundRequestStatusAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A513AD30272B327A00E0C1BA /* RCRefundRequestStatusAPI.m */; };
 		A513AD32272B328800E0C1BA /* RCRefundRequestStatusAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A513AD30272B327A00E0C1BA /* RCRefundRequestStatusAPI.m */; };
-		A519264D26EBCEF6007D0BD1 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = A519264C26EBCEF6007D0BD1 /* main.m */; };
-		A5D614F926EBE84F007DDB75 /* RCOfferingsAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614DD26EBE84E007DDB75 /* RCOfferingsAPI.m */; };
-		A5D614FA26EBE84F007DDB75 /* RCPackageAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614DE26EBE84F007DDB75 /* RCPackageAPI.m */; };
-		A5D614FB26EBE84F007DDB75 /* RCOfferingAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614DF26EBE84F007DDB75 /* RCOfferingAPI.m */; };
-		A5D614FE26EBE84F007DDB75 /* RCEntitlementInfosAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614E926EBE84F007DDB75 /* RCEntitlementInfosAPI.m */; };
-		A5D614FF26EBE84F007DDB75 /* RCAttributionNetworkAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614EC26EBE84F007DDB75 /* RCAttributionNetworkAPI.m */; };
-		A5D6150026EBE84F007DDB75 /* RCPurchasesAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614ED26EBE84F007DDB75 /* RCPurchasesAPI.m */; };
-		A5D6150126EBE84F007DDB75 /* RCPurchasesErrorCodeAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614EE26EBE84F007DDB75 /* RCPurchasesErrorCodeAPI.m */; };
-		A5D6150226EBE84F007DDB75 /* RCCustomerInfoAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614F026EBE84F007DDB75 /* RCCustomerInfoAPI.m */; };
-		A5D6150326EBE84F007DDB75 /* RCIntroEligibilityAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614F226EBE84F007DDB75 /* RCIntroEligibilityAPI.m */; };
-		A5D6150426EBE84F007DDB75 /* RCTransactionAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614F426EBE84F007DDB75 /* RCTransactionAPI.m */; };
-		A5D6150626EBE84F007DDB75 /* RCEntitlementInfoAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614F826EBE84F007DDB75 /* RCEntitlementInfoAPI.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		575885A22748274600CA2169 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				575885A12748274600CA2169 /* RevenueCat.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		575885A62748274E00CA2169 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -67,19 +41,10 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A519264726EBCEF6007D0BD1 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = /usr/share/man/man1/;
-			dstSubfolderSpec = 0;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 1;
-		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		2DD778F5270E235B0079CBD4 /* ObjCAPITesterIOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ObjCAPITesterIOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		2DD778F5270E235B0079CBD4 /* ObjCAPITester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ObjCAPITester.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2DD778F7270E235B0079CBD4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		2DD778F9270E235B0079CBD4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		2DD778FB270E235B0079CBD4 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -93,7 +58,6 @@
 		575885A32748274E00CA2169 /* RevenueCat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RevenueCat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A513AD2F272B327A00E0C1BA /* RCRefundRequestStatusAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCRefundRequestStatusAPI.h; sourceTree = "<group>"; };
 		A513AD30272B327A00E0C1BA /* RCRefundRequestStatusAPI.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCRefundRequestStatusAPI.m; sourceTree = "<group>"; };
-		A519264926EBCEF6007D0BD1 /* ObjCAPITester */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = ObjCAPITester; sourceTree = BUILT_PRODUCTS_DIR; };
 		A519264C26EBCEF6007D0BD1 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		A5D614DD26EBE84E007DDB75 /* RCOfferingsAPI.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCOfferingsAPI.m; sourceTree = "<group>"; };
 		A5D614DE26EBE84F007DDB75 /* RCPackageAPI.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCPackageAPI.m; sourceTree = "<group>"; };
@@ -128,14 +92,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A519264626EBCEF6007D0BD1 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				575885A02748274600CA2169 /* RevenueCat.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -166,8 +122,7 @@
 		A519264A26EBCEF6007D0BD1 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				A519264926EBCEF6007D0BD1 /* ObjCAPITester */,
-				2DD778F5270E235B0079CBD4 /* ObjCAPITesterIOS.app */,
+				2DD778F5270E235B0079CBD4 /* ObjCAPITester.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -218,9 +173,9 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		2DD778F4270E235B0079CBD4 /* ObjCAPITesterIOS */ = {
+		2DD778F4270E235B0079CBD4 /* ObjCAPITester */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 2DD77908270E235C0079CBD4 /* Build configuration list for PBXNativeTarget "ObjCAPITesterIOS" */;
+			buildConfigurationList = 2DD77908270E235C0079CBD4 /* Build configuration list for PBXNativeTarget "ObjCAPITester" */;
 			buildPhases = (
 				2DD778F1270E235B0079CBD4 /* Sources */,
 				2DD778F2270E235B0079CBD4 /* Frameworks */,
@@ -231,32 +186,12 @@
 			);
 			dependencies = (
 			);
-			name = ObjCAPITesterIOS;
-			packageProductDependencies = (
-			);
-			productName = ObjCAPITesterIOS;
-			productReference = 2DD778F5270E235B0079CBD4 /* ObjCAPITesterIOS.app */;
-			productType = "com.apple.product-type.application";
-		};
-		A519264826EBCEF6007D0BD1 /* ObjCAPITester */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = A519265026EBCEF6007D0BD1 /* Build configuration list for PBXNativeTarget "ObjCAPITester" */;
-			buildPhases = (
-				A519264526EBCEF6007D0BD1 /* Sources */,
-				A519264626EBCEF6007D0BD1 /* Frameworks */,
-				A519264726EBCEF6007D0BD1 /* CopyFiles */,
-				575885A22748274600CA2169 /* Embed Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
 			name = ObjCAPITester;
 			packageProductDependencies = (
 			);
-			productName = ObjCAPITester;
-			productReference = A519264926EBCEF6007D0BD1 /* ObjCAPITester */;
-			productType = "com.apple.product-type.tool";
+			productName = ObjCAPITesterIOS;
+			productReference = 2DD778F5270E235B0079CBD4 /* ObjCAPITester.app */;
+			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
 
@@ -270,10 +205,6 @@
 				TargetAttributes = {
 					2DD778F4270E235B0079CBD4 = {
 						CreatedOnToolsVersion = 13.0;
-					};
-					A519264826EBCEF6007D0BD1 = {
-						CreatedOnToolsVersion = 13.0;
-						LastSwiftMigration = 1300;
 					};
 				};
 			};
@@ -292,8 +223,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				A519264826EBCEF6007D0BD1 /* ObjCAPITester */,
-				2DD778F4270E235B0079CBD4 /* ObjCAPITesterIOS */,
+				2DD778F4270E235B0079CBD4 /* ObjCAPITester */,
 			);
 		};
 /* End PBXProject section */
@@ -334,26 +264,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A519264526EBCEF6007D0BD1 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				A5D6150326EBE84F007DDB75 /* RCIntroEligibilityAPI.m in Sources */,
-				A5D6150226EBE84F007DDB75 /* RCCustomerInfoAPI.m in Sources */,
-				A519264D26EBCEF6007D0BD1 /* main.m in Sources */,
-				A5D614FB26EBE84F007DDB75 /* RCOfferingAPI.m in Sources */,
-				A5D614FF26EBE84F007DDB75 /* RCAttributionNetworkAPI.m in Sources */,
-				A5D6150626EBE84F007DDB75 /* RCEntitlementInfoAPI.m in Sources */,
-				A513AD31272B327A00E0C1BA /* RCRefundRequestStatusAPI.m in Sources */,
-				A5D614FA26EBE84F007DDB75 /* RCPackageAPI.m in Sources */,
-				A5D6150126EBE84F007DDB75 /* RCPurchasesErrorCodeAPI.m in Sources */,
-				A5D614F926EBE84F007DDB75 /* RCOfferingsAPI.m in Sources */,
-				A5D6150426EBE84F007DDB75 /* RCTransactionAPI.m in Sources */,
-				A5D6150026EBE84F007DDB75 /* RCPurchasesAPI.m in Sources */,
-				A5D614FE26EBE84F007DDB75 /* RCEntitlementInfosAPI.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXVariantGroup section */
@@ -379,6 +289,7 @@
 		2DD77906270E235C0079CBD4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -401,7 +312,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.ObjCAPITesterIOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development com.revenuecat.ObjCAPITesterIOS";
-				SDKROOT = iphoneos;
+				SDKROOT = "";
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -413,6 +326,7 @@
 		2DD77907270E235C0079CBD4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -432,10 +346,12 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.sampleapp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.ObjCAPITesterIOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development com.revenuecat.sampleapp";
-				SDKROOT = iphoneos;
+				SDKROOT = "";
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -556,47 +472,10 @@
 			};
 			name = Release;
 		};
-		A519265126EBCEF6007D0BD1 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
-				ENABLE_HARDENED_RUNTIME = YES;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-					"@loader_path/../Frameworks",
-				);
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		A519265226EBCEF6007D0BD1 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
-				ENABLE_HARDENED_RUNTIME = YES;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-					"@loader_path/../Frameworks",
-				);
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "";
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		2DD77908270E235C0079CBD4 /* Build configuration list for PBXNativeTarget "ObjCAPITesterIOS" */ = {
+		2DD77908270E235C0079CBD4 /* Build configuration list for PBXNativeTarget "ObjCAPITester" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2DD77906270E235C0079CBD4 /* Debug */,
@@ -610,15 +489,6 @@
 			buildConfigurations = (
 				A519264E26EBCEF6007D0BD1 /* Debug */,
 				A519264F26EBCEF6007D0BD1 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		A519265026EBCEF6007D0BD1 /* Build configuration list for PBXNativeTarget "ObjCAPITester" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				A519265126EBCEF6007D0BD1 /* Debug */,
-				A519265226EBCEF6007D0BD1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj/xcshareddata/xcschemes/ObjCAPITester.xcscheme
+++ b/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj/xcshareddata/xcschemes/ObjCAPITester.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1310"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2DD778F4270E235B0079CBD4"
+               BuildableName = "ObjCAPITester.app"
+               BlueprintName = "ObjCAPITester"
+               ReferencedContainer = "container:ObjCAPITester.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DD778F4270E235B0079CBD4"
+            BuildableName = "ObjCAPITester.app"
+            BlueprintName = "ObjCAPITester"
+            ReferencedContainer = "container:ObjCAPITester.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj/project.pbxproj
+++ b/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2D6F3874270E593F002C9987 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C626EBE7EA007DDB75 /* main.swift */; };
 		2DD778D3270E233F0079CBD4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD778D2270E233F0079CBD4 /* AppDelegate.swift */; };
 		2DD778D5270E233F0079CBD4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD778D4270E233F0079CBD4 /* SceneDelegate.swift */; };
 		2DD778D7270E233F0079CBD4 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD778D6270E233F0079CBD4 /* ViewController.swift */; };
@@ -25,37 +24,12 @@
 		2DD778ED270E23460079CBD4 /* OfferingAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C726EBE7EA007DDB75 /* OfferingAPI.swift */; };
 		2DD778EE270E23460079CBD4 /* EntitlementInfosAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C526EBE7EA007DDB75 /* EntitlementInfosAPI.swift */; };
 		2DD778EF270E23460079CBD4 /* EntitlementInfoAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C826EBE7EA007DDB75 /* EntitlementInfoAPI.swift */; };
-		575885982748271100CA2169 /* RevenueCat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 575885972748271100CA2169 /* RevenueCat.framework */; };
-		575885992748271100CA2169 /* RevenueCat.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 575885972748271100CA2169 /* RevenueCat.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5758859C2748272A00CA2169 /* RevenueCat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5758859B2748272A00CA2169 /* RevenueCat.framework */; };
 		5758859D2748272A00CA2169 /* RevenueCat.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5758859B2748272A00CA2169 /* RevenueCat.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		A513AD34272B4C0100E0C1BA /* RefundRequestStatusAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A513AD33272B4C0100E0C1BA /* RefundRequestStatusAPI.swift */; };
 		A513AD35272B4C0100E0C1BA /* RefundRequestStatusAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A513AD33272B4C0100E0C1BA /* RefundRequestStatusAPI.swift */; };
-		A5D614CF26EBE7EA007DDB75 /* ErrorCodesAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C226EBE7EA007DDB75 /* ErrorCodesAPI.swift */; };
-		A5D614D026EBE7EA007DDB75 /* OfferingsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C326EBE7EA007DDB75 /* OfferingsAPI.swift */; };
-		A5D614D126EBE7EA007DDB75 /* CustomerInfoAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C426EBE7EA007DDB75 /* CustomerInfoAPI.swift */; };
-		A5D614D226EBE7EA007DDB75 /* EntitlementInfosAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C526EBE7EA007DDB75 /* EntitlementInfosAPI.swift */; };
-		A5D614D426EBE7EA007DDB75 /* OfferingAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C726EBE7EA007DDB75 /* OfferingAPI.swift */; };
-		A5D614D526EBE7EA007DDB75 /* EntitlementInfoAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C826EBE7EA007DDB75 /* EntitlementInfoAPI.swift */; };
-		A5D614D626EBE7EA007DDB75 /* PackageAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C926EBE7EA007DDB75 /* PackageAPI.swift */; };
-		A5D614D726EBE7EA007DDB75 /* AttributionNetworkAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614CA26EBE7EA007DDB75 /* AttributionNetworkAPI.swift */; };
-		A5D614D826EBE7EA007DDB75 /* TransactionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614CB26EBE7EA007DDB75 /* TransactionAPI.swift */; };
-		A5D614DA26EBE7EA007DDB75 /* IntroEligibilityAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614CD26EBE7EA007DDB75 /* IntroEligibilityAPI.swift */; };
-		A5D614DB26EBE7EA007DDB75 /* PurchasesAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614CE26EBE7EA007DDB75 /* PurchasesAPI.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		5758859A2748271100CA2169 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				575885992748271100CA2169 /* RevenueCat.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		5758859E2748272A00CA2169 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -67,19 +41,10 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A55F62B326EAFFD200A1B466 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = /usr/share/man/man1/;
-			dstSubfolderSpec = 0;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 1;
-		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		2DD778D0270E233F0079CBD4 /* SwiftAPITesterIOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftAPITesterIOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		2DD778D0270E233F0079CBD4 /* SwiftAPITester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftAPITester.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2DD778D2270E233F0079CBD4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		2DD778D4270E233F0079CBD4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		2DD778D6270E233F0079CBD4 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -90,7 +55,6 @@
 		575885972748271100CA2169 /* RevenueCat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RevenueCat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5758859B2748272A00CA2169 /* RevenueCat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RevenueCat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A513AD33272B4C0100E0C1BA /* RefundRequestStatusAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundRequestStatusAPI.swift; sourceTree = "<group>"; };
-		A55F62B526EAFFD200A1B466 /* SwiftAPITester */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = SwiftAPITester; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5D614C226EBE7EA007DDB75 /* ErrorCodesAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorCodesAPI.swift; sourceTree = "<group>"; };
 		A5D614C326EBE7EA007DDB75 /* OfferingsAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OfferingsAPI.swift; sourceTree = "<group>"; };
 		A5D614C426EBE7EA007DDB75 /* CustomerInfoAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerInfoAPI.swift; sourceTree = "<group>"; };
@@ -111,14 +75,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				5758859C2748272A00CA2169 /* RevenueCat.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		A55F62B226EAFFD200A1B466 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				575885982748271100CA2169 /* RevenueCat.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -161,8 +117,7 @@
 		A55F62B626EAFFD200A1B466 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				A55F62B526EAFFD200A1B466 /* SwiftAPITester */,
-				2DD778D0270E233F0079CBD4 /* SwiftAPITesterIOS.app */,
+				2DD778D0270E233F0079CBD4 /* SwiftAPITester.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -190,9 +145,9 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		2DD778CF270E233F0079CBD4 /* SwiftAPITesterIOS */ = {
+		2DD778CF270E233F0079CBD4 /* SwiftAPITester */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 2DD778E3270E23400079CBD4 /* Build configuration list for PBXNativeTarget "SwiftAPITesterIOS" */;
+			buildConfigurationList = 2DD778E3270E23400079CBD4 /* Build configuration list for PBXNativeTarget "SwiftAPITester" */;
 			buildPhases = (
 				2DD778CC270E233F0079CBD4 /* Sources */,
 				2DD778CD270E233F0079CBD4 /* Frameworks */,
@@ -203,32 +158,12 @@
 			);
 			dependencies = (
 			);
-			name = SwiftAPITesterIOS;
-			packageProductDependencies = (
-			);
-			productName = SwiftAPITesterIOS;
-			productReference = 2DD778D0270E233F0079CBD4 /* SwiftAPITesterIOS.app */;
-			productType = "com.apple.product-type.application";
-		};
-		A55F62B426EAFFD200A1B466 /* SwiftAPITester */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = A55F62BC26EAFFD200A1B466 /* Build configuration list for PBXNativeTarget "SwiftAPITester" */;
-			buildPhases = (
-				A55F62B126EAFFD200A1B466 /* Sources */,
-				A55F62B226EAFFD200A1B466 /* Frameworks */,
-				A55F62B326EAFFD200A1B466 /* CopyFiles */,
-				5758859A2748271100CA2169 /* Embed Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
 			name = SwiftAPITester;
 			packageProductDependencies = (
 			);
-			productName = SwiftAPITester;
-			productReference = A55F62B526EAFFD200A1B466 /* SwiftAPITester */;
-			productType = "com.apple.product-type.tool";
+			productName = SwiftAPITesterIOS;
+			productReference = 2DD778D0270E233F0079CBD4 /* SwiftAPITester.app */;
+			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
 
@@ -241,9 +176,6 @@
 				LastUpgradeCheck = 1300;
 				TargetAttributes = {
 					2DD778CF270E233F0079CBD4 = {
-						CreatedOnToolsVersion = 13.0;
-					};
-					A55F62B426EAFFD200A1B466 = {
 						CreatedOnToolsVersion = 13.0;
 					};
 				};
@@ -263,8 +195,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				A55F62B426EAFFD200A1B466 /* SwiftAPITester */,
-				2DD778CF270E233F0079CBD4 /* SwiftAPITesterIOS */,
+				2DD778CF270E233F0079CBD4 /* SwiftAPITester */,
 			);
 		};
 /* End PBXProject section */
@@ -305,26 +236,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A55F62B126EAFFD200A1B466 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				A513AD34272B4C0100E0C1BA /* RefundRequestStatusAPI.swift in Sources */,
-				A5D614CF26EBE7EA007DDB75 /* ErrorCodesAPI.swift in Sources */,
-				2D6F3874270E593F002C9987 /* main.swift in Sources */,
-				A5D614D126EBE7EA007DDB75 /* CustomerInfoAPI.swift in Sources */,
-				A5D614D026EBE7EA007DDB75 /* OfferingsAPI.swift in Sources */,
-				A5D614D426EBE7EA007DDB75 /* OfferingAPI.swift in Sources */,
-				A5D614D526EBE7EA007DDB75 /* EntitlementInfoAPI.swift in Sources */,
-				A5D614DA26EBE7EA007DDB75 /* IntroEligibilityAPI.swift in Sources */,
-				A5D614D826EBE7EA007DDB75 /* TransactionAPI.swift in Sources */,
-				A5D614DB26EBE7EA007DDB75 /* PurchasesAPI.swift in Sources */,
-				A5D614D626EBE7EA007DDB75 /* PackageAPI.swift in Sources */,
-				A5D614D726EBE7EA007DDB75 /* AttributionNetworkAPI.swift in Sources */,
-				A5D614D226EBE7EA007DDB75 /* EntitlementInfosAPI.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXVariantGroup section */
@@ -350,6 +261,7 @@
 		2DD778E1270E23400079CBD4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -372,7 +284,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.SwiftAPITesterIOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development com.revenuecat.SwiftAPITesterIOS";
-				SDKROOT = iphoneos;
+				SDKROOT = "";
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -382,6 +296,7 @@
 		2DD778E2270E23400079CBD4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -404,7 +319,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.SwiftAPITesterIOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development com.revenuecat.SwiftAPITesterIOS";
-				SDKROOT = iphoneos;
+				SDKROOT = "";
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -527,32 +444,10 @@
 			};
 			name = Release;
 		};
-		A55F62BD26EAFFD200A1B466 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
-				ENABLE_HARDENED_RUNTIME = YES;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
-			};
-			name = Debug;
-		};
-		A55F62BE26EAFFD200A1B466 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
-				ENABLE_HARDENED_RUNTIME = YES;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		2DD778E3270E23400079CBD4 /* Build configuration list for PBXNativeTarget "SwiftAPITesterIOS" */ = {
+		2DD778E3270E23400079CBD4 /* Build configuration list for PBXNativeTarget "SwiftAPITester" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2DD778E1270E23400079CBD4 /* Debug */,
@@ -566,15 +461,6 @@
 			buildConfigurations = (
 				A55F62BA26EAFFD200A1B466 /* Debug */,
 				A55F62BB26EAFFD200A1B466 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		A55F62BC26EAFFD200A1B466 /* Build configuration list for PBXNativeTarget "SwiftAPITester" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				A55F62BD26EAFFD200A1B466 /* Debug */,
-				A55F62BE26EAFFD200A1B466 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj/xcshareddata/xcschemes/SwiftAPITester.xcscheme
+++ b/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj/xcshareddata/xcschemes/SwiftAPITester.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1310"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,10 +14,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "2DD778F4270E235B0079CBD4"
-               BuildableName = "ObjCAPITesterIOS.app"
-               BlueprintName = "ObjCAPITesterIOS"
-               ReferencedContainer = "container:ObjCAPITester.xcodeproj">
+               BlueprintIdentifier = "2DD778CF270E233F0079CBD4"
+               BuildableName = "SwiftAPITester.app"
+               BlueprintName = "SwiftAPITester"
+               ReferencedContainer = "container:SwiftAPITester.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -40,16 +40,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "2DD778F4270E235B0079CBD4"
-            BuildableName = "ObjCAPITesterIOS.app"
-            BlueprintName = "ObjCAPITesterIOS"
-            ReferencedContainer = "container:ObjCAPITester.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -57,16 +47,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "2DD778F4270E235B0079CBD4"
-            BuildableName = "ObjCAPITesterIOS.app"
-            BlueprintName = "ObjCAPITesterIOS"
-            ReferencedContainer = "container:ObjCAPITester.xcodeproj">
+            BlueprintIdentifier = "2DD778CF270E233F0079CBD4"
+            BuildableName = "SwiftAPITester.app"
+            BlueprintName = "SwiftAPITester"
+            ReferencedContainer = "container:SwiftAPITester.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -173,28 +173,38 @@ platform :ios do
 
   desc "build Swift API tester"
   lane :build_swift_api_tester do
-      match(
-        type: "development",
-        git_url: ENV["CERTS_REPO_URL"],
-        storage_mode: "git",
-        type: "development",
-        app_identifier: ["com.revenuecat.SwiftAPITesterIOS"],
-        username: ENV["FASTLANE_USER"])
-      sh('xcodebuild', '-workspace', '../APITesters/APITesters.xcworkspace', '-scheme', 'SwiftAPITesterIOS')
-      sh('xcodebuild', '-workspace', '../APITesters/APITesters.xcworkspace', '-scheme', 'SwiftAPITester')
+    match(
+      type: "development",
+      git_url: ENV["CERTS_REPO_URL"],
+      storage_mode: "git",
+      type: "development",
+      app_identifier: ["com.revenuecat.SwiftAPITesterIOS"],
+      username: ENV["FASTLANE_USER"]
+    )
+
+    workspace = '../APITesters/APITesters.xcworkspace'
+    scheme = 'SwiftAPITester'
+
+    sh('xcodebuild', '-workspace', workspace, '-scheme', scheme, '-destination', 'generic/platform=iOS Simulator')
+    sh('xcodebuild', '-workspace', workspace, '-scheme', scheme, '-destination', 'generic/platform=macOS')
   end
   
   desc "build ObjC API tester"
   lane :build_objc_api_tester do
-      match(
-        type: "development",
-        git_url: ENV["CERTS_REPO_URL"],
-        storage_mode: "git",
-        type: "development",
-        app_identifier: ["com.revenuecat.ObjCAPITesterIOS"],
-        username: ENV["FASTLANE_USER"])
-      sh('xcodebuild', '-workspace', '../APITesters/APITesters.xcworkspace', '-scheme', 'ObjCAPITesterIOS')
-      sh('xcodebuild', '-workspace', '../APITesters/APITesters.xcworkspace', '-scheme', 'ObjCAPITester')
+    match(
+      type: "development",
+      git_url: ENV["CERTS_REPO_URL"],
+      storage_mode: "git",
+      type: "development",
+      app_identifier: ["com.revenuecat.ObjCAPITesterIOS"],
+      username: ENV["FASTLANE_USER"]
+    )
+
+    workspace = '../APITesters/APITesters.xcworkspace'
+    scheme = 'ObjCAPITester'
+
+    sh('xcodebuild', '-workspace', workspace, '-scheme', scheme, '-destination', 'generic/platform=iOS Simulator')
+    sh('xcodebuild', '-workspace', workspace, '-scheme', scheme, '-destination', 'generic/platform=macOS')
   end
 
   desc "replace API KEY for integration tests"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -171,15 +171,22 @@ platform :ios do
     gym(export_method: "app-store")
   end
 
-  # TODO: use fastlane instead of xcodebuild
   desc "build Swift API tester"
   lane :build_swift_api_tester do
-    sh('xcodebuild', '-workspace', '../APITesters/APITesters.xcworkspace', '-scheme', 'SwiftAPITester', '-destination', 'generic/platform=iOS Simulator')
+    xcodebuild(
+      workspace: 'APITesters/APITesters.xcworkspace',
+      scheme: 'SwiftAPITester',
+      destination: 'generic/platform=iOS Simulator'
+    )
   end
   
   desc "build ObjC API tester"
   lane :build_objc_api_tester do
-    sh('xcodebuild', '-workspace', '../APITesters/APITesters.xcworkspace', '-scheme', 'ObjCAPITester', '-destination', 'generic/platform=iOS Simulator')
+    xcodebuild(
+      workspace: 'APITesters/APITesters.xcworkspace',
+      scheme: 'ObjCAPITester',
+      destination: 'generic/platform=iOS Simulator'
+    )
   end
 
   desc "replace API KEY for integration tests"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -171,40 +171,15 @@ platform :ios do
     gym(export_method: "app-store")
   end
 
+  # TODO: use fastlane instead of xcodebuild
   desc "build Swift API tester"
   lane :build_swift_api_tester do
-    match(
-      type: "development",
-      git_url: ENV["CERTS_REPO_URL"],
-      storage_mode: "git",
-      type: "development",
-      app_identifier: ["com.revenuecat.SwiftAPITesterIOS"],
-      username: ENV["FASTLANE_USER"]
-    )
-
-    workspace = '../APITesters/APITesters.xcworkspace'
-    scheme = 'SwiftAPITester'
-
-    sh('xcodebuild', '-workspace', workspace, '-scheme', scheme, '-destination', 'generic/platform=iOS Simulator')
-    sh('xcodebuild', '-workspace', workspace, '-scheme', scheme, '-destination', 'generic/platform=macOS')
+    sh('xcodebuild', '-workspace', '../APITesters/APITesters.xcworkspace', '-scheme', 'SwiftAPITester', '-destination', 'generic/platform=iOS Simulator')
   end
   
   desc "build ObjC API tester"
   lane :build_objc_api_tester do
-    match(
-      type: "development",
-      git_url: ENV["CERTS_REPO_URL"],
-      storage_mode: "git",
-      type: "development",
-      app_identifier: ["com.revenuecat.ObjCAPITesterIOS"],
-      username: ENV["FASTLANE_USER"]
-    )
-
-    workspace = '../APITesters/APITesters.xcworkspace'
-    scheme = 'ObjCAPITester'
-
-    sh('xcodebuild', '-workspace', workspace, '-scheme', scheme, '-destination', 'generic/platform=iOS Simulator')
-    sh('xcodebuild', '-workspace', workspace, '-scheme', scheme, '-destination', 'generic/platform=macOS')
+    sh('xcodebuild', '-workspace', '../APITesters/APITesters.xcworkspace', '-scheme', 'ObjCAPITester', '-destination', 'generic/platform=iOS Simulator')
   end
 
   desc "replace API KEY for integration tests"


### PR DESCRIPTION
Follow up to #979.
This simplifies APITesters like so:
- 1 Workspace including ObjC/Swift
- Each project only has 1 cross-platform target

These can be built easily locally from Xcode, and therefore they're easier to maintain.