### PR TITLE
3rd party integrations proof of concept

### DIFF
--- a/Purchases/Identity/AppUserIdentifiable.swift
+++ b/Purchases/Identity/AppUserIdentifiable.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  AppUserIdentifiable.swift
+//
+//  Created by Joshua Liebowitz on 11/21/21.
+
+import Foundation
+
+/**
+ * Classes that conform to this protocol can provide a `currentAppUserID` property.
+ */
+@objc public protocol AppUserIdentifiable {
+
+    /**
+     * The current appUserID that the implementing class manages.
+     */
+    var currentAppUserID: String { get }
+
+}

--- a/Purchases/Identity/IdentityManager.swift
+++ b/Purchases/Identity/IdentityManager.swift
@@ -13,7 +13,7 @@
 
 import Foundation
 
-class IdentityManager {
+class IdentityManager: AppUserIdentifiable {
 
     static let anonymousRegex = #"\$RCAnonymousID:([a-z0-9]{32})$"#
 

--- a/Purchases/Public/Integrations/AirshipIntegration.swift
+++ b/Purchases/Public/Integrations/AirshipIntegration.swift
@@ -1,0 +1,48 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  AirshipIntegration.swift
+//
+//  Created by Joshua Liebowitz on 11/21/21.
+
+import Foundation
+
+@objc public class AirshipIntegration: NSObject, Integration {
+
+    public static var networkName = "Airship"
+    public var attributeName = "$airshipChannelId"
+
+    private let attributionSetter: SubscriberAttributionSetter
+    private let appUserIdentifier: AppUserIdentifiable
+
+    init(subscriberAttributionSetter: SubscriberAttributionSetter, appUserIdentifier: AppUserIdentifiable) {
+        self.attributionSetter = subscriberAttributionSetter
+        self.appUserIdentifier = appUserIdentifier
+        super.init()
+    }
+
+    /**
+     * Subscriber attribute associated with the Airship Channel ID for the user
+     * Required for the RevenueCat Airship integration
+     *
+     * - Parameter airshipChannelID: nil will delete the subscriber attribute
+     */
+    @objc public func setAirshipChannelID(_ airshipChannelID: String?) {
+        attributionSetter.setAttributionID(airshipChannelID,
+                                           forIntegration: self,
+                                           appUserID: self.appUserIdentifier.currentAppUserID)
+    }
+
+    public static func configure(subscriberAttributionSetter: SubscriberAttributionSetter,
+                                 appUserIdentifier: AppUserIdentifiable) -> Integration {
+        return AirshipIntegration(subscriberAttributionSetter: subscriberAttributionSetter,
+                                  appUserIdentifier: appUserIdentifier)
+    }
+
+}

--- a/Purchases/Public/Integrations/Integration.swift
+++ b/Purchases/Public/Integrations/Integration.swift
@@ -1,0 +1,37 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Integration.swift
+//
+//  Created by Joshua Liebowitz on 11/21/21.
+
+import Foundation
+
+/**
+ * All 3rd party integrations must conform to this protocol.
+ */
+@objc public protocol Integration {
+
+    /**
+     * Human-readable name of the integration, e.g.: Airship
+     */
+    static var networkName: String { get }
+
+    /**
+     * Attribute key that the integration uses, e.g.: $airshipID
+     */
+    var attributeName: String { get }
+
+    /**
+     * Configure is automatically called at the appropriate time during Purchases initialization.
+     */
+    static func configure(subscriberAttributionSetter: SubscriberAttributionSetter,
+                          appUserIdentifier: AppUserIdentifiable) -> Integration
+
+}

--- a/Purchases/Public/Purchases+ConfigureIntegrations.swift
+++ b/Purchases/Public/Purchases+ConfigureIntegrations.swift
@@ -1,0 +1,184 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Purchases+ConfigureIntegrations.swift
+//
+//  Created by Joshua Liebowitz on 11/21/21.
+
+import Foundation
+import SwiftUI
+
+public extension Purchases {
+
+    /**
+     * Configures an instance of the Purchases SDK with a specified API key. The instance will be set as a singleton.
+     * You should access the singleton instance using ``Purchases/shared``
+     *
+     * - Note: Use this initializer if your app does not have an account system.
+     * `Purchases` will generate a unique identifier for the current device and persist it to `NSUserDefaults`.
+     * This also affects the behavior of ``Purchases/restoreTransactions(completion:)``.
+     *
+     * - Parameter apiKey: The API Key generated for your app from https://app.revenuecat.com/
+     * - Parameter integrations: Which ever services you're using that are supported by our integrations.
+     *
+     * - Returns: An instantiated `Purchases` object that has been set as a singleton.
+     */
+    @objc(configureWithAPIKey:integrations:)
+    @discardableResult static func configure(withAPIKey apiKey: String,
+                                             integrations: [Integration.Type]? = nil) -> Purchases {
+        configure(withAPIKey: apiKey, appUserID: nil, integrations: integrations)
+    }
+
+    /**
+     * Configures an instance of the Purchases SDK with a specified API key and app user ID.
+     * The instance will be set as a singleton.
+     * You should access the singleton instance using ``Purchases/shared``
+     *
+     * - Note: Best practice is to use a salted hash of your unique app user ids.
+     *
+     * - Warning: Use this initializer if you have your own user identifiers that you manage.
+     *
+     * - Parameter apiKey: The API Key generated for your app from https://app.revenuecat.com/
+     *
+     * - Parameter appUserID: The unique app user id for this user. This user id will allow users to share their
+     * purchases and subscriptions across devices. Pass nil if you want `Purchases` to generate this for you.
+     *
+     * - Parameter integrations: Which ever services you're using that are supported by our integrations.
+     *
+     * - Returns: An instantiated `Purchases` object that has been set as a singleton.
+     */
+    @objc(configureWithAPIKey:appUserID:integrations:)
+    @discardableResult static func configure(withAPIKey apiKey: String,
+                                             appUserID: String?,
+                                             integrations: [Integration.Type]? = nil) -> Purchases {
+        configure(withAPIKey: apiKey, appUserID: appUserID, observerMode: false)
+    }
+
+    /**
+     * Configures an instance of the Purchases SDK with a custom userDefaults. Use this constructor if you want to
+     * sync status across a shared container, such as between a host app and an extension. The instance of the
+     * Purchases SDK will be set as a singleton.
+     * You should access the singleton instance using ``Purchases.shared``
+     *
+     * - Parameter apiKey: The API Key generated for your app from https://app.revenuecat.com/
+     *
+     * - Parameter appUserID: The unique app user id for this user. This user id will allow users to share their
+     * purchases and subscriptions across devices. Pass nil if you want `Purchases` to generate this for you.
+     *
+     * - Parameter observerMode: Set this to `true` if you have your own IAP implementation and want to use only
+     * RevenueCat's backend. Default is `false`.
+     *
+     * - Parameter integrations: Which ever services you're using that are supported by our integrations.
+     *
+     * - Returns: An instantiated `Purchases` object that has been set as a singleton.
+     */
+    @objc(configureWithAPIKey:appUserID:observerMode:integrations:)
+    @discardableResult static func configure(withAPIKey apiKey: String,
+                                             appUserID: String?,
+                                             observerMode: Bool,
+                                             integrations: [Integration.Type]? = nil) -> Purchases {
+        configure(withAPIKey: apiKey, appUserID: appUserID, observerMode: observerMode, userDefaults: nil)
+    }
+
+    /**
+     * Configures an instance of the Purchases SDK with a custom userDefaults. Use this constructor if you want to
+     * sync status across a shared container, such as between a host app and an extension. The instance of the
+     * Purchases SDK will be set as a singleton.
+     * You should access the singleton instance using ``Purchases.shared``
+     *
+     * - Parameter apiKey: The API Key generated for your app from https://app.revenuecat.com/
+     *
+     * - Parameter appUserID: The unique app user id for this user. This user id will allow users to share their
+     * purchases and subscriptions across devices. Pass nil if you want `Purchases` to generate this for you.
+     *
+     * - Parameter observerMode: Set this to `true` if you have your own IAP implementation and want to use only
+     * RevenueCat's backend. Default is `false`.
+     *
+     * - Parameter userDefaults: Custom userDefaults to use
+     *
+     * - Parameter integrations: Which ever services you're using that are supported by our integrations.
+     *
+     * - Returns: An instantiated `Purchases` object that has been set as a singleton.
+     */
+    @objc(configureWithAPIKey:appUserID:observerMode:userDefaults:integrations:)
+    @discardableResult static func configure(withAPIKey apiKey: String,
+                                             appUserID: String?,
+                                             observerMode: Bool,
+                                             userDefaults: UserDefaults?,
+                                             integrations: [Integration.Type]? = nil) -> Purchases {
+        configure(apiKey: apiKey,
+                  appUserID: appUserID,
+                  observerMode: observerMode,
+                  userDefaults: userDefaults,
+                  platformFlavor: nil,
+                  platformFlavorVersion: nil,
+                  integrations: integrations)
+    }
+
+    /**
+     * Returns a configured integration object if it exists.
+     *
+     * - Parameter integrationType: Integration class that you wish to use
+     *
+     */
+    func getIntegration<T>(for integrationType: T.Type) -> T? where T: Integration {
+        let configuredIntegration = self.configuredIntegrations[integrationType.networkName]
+        if configuredIntegration == nil {
+            Logger.warn(
+                """
+                Attempt to get integration: \(integrationType.networkName), but it wasn't found, please ensure you call
+                 configureWithAPIKey:appUserID:integrations:
+                """
+            )
+        }
+        return configuredIntegration as? T
+    }
+
+    /**
+     * Returns a configured integration object if it exists.
+     * - Note: This is meant for ObjC use.
+     *
+     * - Parameter forIntegrationType: Integration class that you wish to use
+     */
+    @objc func getIntegration(integrationType: Integration.Type) -> Any? {
+        let configuredIntegration = self.configuredIntegrations[integrationType.networkName]
+        if configuredIntegration == nil {
+            Logger.warn(
+                """
+                Attempt to get integration: \(integrationType.networkName), but it wasn't found, please ensure you call
+                 configureWithAPIKey:appUserID:integrations:
+                """
+            )
+        }
+        return configuredIntegration
+    }
+
+    internal func configureIntegrations() {
+        self.configuredIntegrations = [:]
+        guard let integrations = self.integrations else {
+            return
+        }
+
+        integrations.forEach { integrationClass in
+            let integrationKey = integrationClass.networkName
+
+            guard self.configuredIntegrations[integrationKey] == nil else {
+                fatalError("Integration for \(integrationClass.networkName) already exists, cannot add a duplicate.")
+            }
+
+            let initializedIntegration = integrationClass.configure(
+                subscriberAttributionSetter: self.subscriberAttributesManager,
+                appUserIdentifier: self.identityManager
+            )
+
+            self.configuredIntegrations[integrationKey] = initializedIntegration
+        }
+    }
+
+}

--- a/Purchases/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Purchases/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -238,3 +238,13 @@ private extension SubscriberAttributesManager {
     }
 
 }
+
+extension SubscriberAttributesManager: SubscriberAttributionSetter {
+
+    func setAttributionID(_ attributionID: String?, forIntegration integration: Integration, appUserID: String) {
+        collectDeviceIdentifiers(forAppUserID: appUserID)
+        Logger.debug(Strings.attribution.setting_attributes(attributes: [integration.attributeName]))
+        setAttribute(key: integration.attributeName, value: attributionID, appUserID: appUserID)
+    }
+
+}

--- a/Purchases/SubscriberAttributes/SubscriberAttributionSetter.swift
+++ b/Purchases/SubscriberAttributes/SubscriberAttributionSetter.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SubscriberAttributionSetter.swift
+//
+//  Created by Joshua Liebowitz on 11/21/21.
+
+import Foundation
+
+/**
+ * Enables objects to receive attribution data.
+ */
+@objc public protocol SubscriberAttributionSetter {
+
+    /**
+     * Collect attributionID for a given integration.
+     */
+    func setAttributionID(_ attributionID: String?, forIntegration integration: Integration, appUserID: String)
+
+}

--- a/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -356,6 +356,9 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
 
     func testSetAndClearAirshipChannelID() {
         setupPurchases()
+        purchases.integrations = [AirshipIntegration.self]
+        purchases.configureIntegrations()
+
         purchases.setAirshipChannelID("airship")
         purchases.setAirshipChannelID(nil)
         expect(self.mockSubscriberAttributesManager.invokedSetAirshipChannelIDParametersList[0])

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -257,6 +257,11 @@
 		B39E811D268E887500D31189 /* SubscriberAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39E811C268E887500D31189 /* SubscriberAttribute.swift */; };
 		B3A36AAE26BC76340059EDEA /* CustomerInfoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A36AAD26BC76340059EDEA /* CustomerInfoManager.swift */; };
 		B3A55B7D26C452A7007EFC56 /* AttributionPoster.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A55B7C26C452A7007EFC56 /* AttributionPoster.swift */; };
+		B3A6DEB7274AFE50002A0790 /* Integration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A6DEB6274AFE50002A0790 /* Integration.swift */; };
+		B3A6DEB9274AFE7A002A0790 /* AirshipIntegration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A6DEB8274AFE7A002A0790 /* AirshipIntegration.swift */; };
+		B3A6DEBD274B00F0002A0790 /* SubscriberAttributionSetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A6DEBC274B00F0002A0790 /* SubscriberAttributionSetter.swift */; };
+		B3A6DEBF274B0550002A0790 /* Purchases+ConfigureIntegrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A6DEBE274B0550002A0790 /* Purchases+ConfigureIntegrations.swift */; };
+		B3A6DEC1274B09A2002A0790 /* AppUserIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A6DEC0274B09A2002A0790 /* AppUserIdentifiable.swift */; };
 		B3AA6236268A81C700894871 /* EntitlementInfos.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AA6235268A81C700894871 /* EntitlementInfos.swift */; };
 		B3AA6238268B926F00894871 /* SystemInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AA6237268B926F00894871 /* SystemInfo.swift */; };
 		B3B5FBB4269CED4B00104A0C /* BackendErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B5FBB3269CED4B00104A0C /* BackendErrorCode.swift */; };
@@ -560,6 +565,11 @@
 		B39E811C268E887500D31189 /* SubscriberAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriberAttribute.swift; sourceTree = "<group>"; };
 		B3A36AAD26BC76340059EDEA /* CustomerInfoManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoManager.swift; sourceTree = "<group>"; };
 		B3A55B7C26C452A7007EFC56 /* AttributionPoster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributionPoster.swift; sourceTree = "<group>"; };
+		B3A6DEB6274AFE50002A0790 /* Integration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Integration.swift; sourceTree = "<group>"; };
+		B3A6DEB8274AFE7A002A0790 /* AirshipIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AirshipIntegration.swift; sourceTree = "<group>"; };
+		B3A6DEBC274B00F0002A0790 /* SubscriberAttributionSetter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriberAttributionSetter.swift; sourceTree = "<group>"; };
+		B3A6DEBE274B0550002A0790 /* Purchases+ConfigureIntegrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Purchases+ConfigureIntegrations.swift"; sourceTree = "<group>"; };
+		B3A6DEC0274B09A2002A0790 /* AppUserIdentifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUserIdentifiable.swift; sourceTree = "<group>"; };
 		B3AA6235268A81C700894871 /* EntitlementInfos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntitlementInfos.swift; sourceTree = "<group>"; };
 		B3AA6237268B926F00894871 /* SystemInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemInfo.swift; sourceTree = "<group>"; };
 		B3B4E76026E036E700C200D3 /* RevenueCat.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = RevenueCat.xctestplan; path = RevenueCat.xcodeproj/RevenueCat.xctestplan; sourceTree = "<group>"; };
@@ -1078,6 +1088,7 @@
 				354895D5267BEDE3001DC5B1 /* ReservedSubscriberAttributes.swift */,
 				B39E811C268E887500D31189 /* SubscriberAttribute.swift */,
 				A525BF4A26C320D100C354C4 /* SubscriberAttributesManager.swift */,
+				B3A6DEBC274B00F0002A0790 /* SubscriberAttributionSetter.swift */,
 			);
 			path = SubscriberAttributes;
 			sourceTree = "<group>";
@@ -1232,10 +1243,20 @@
 		B3A36AAC26BC76230059EDEA /* Identity */ = {
 			isa = PBXGroup;
 			children = (
-				B3852F9F26C1ED1F005384F8 /* IdentityManager.swift */,
+				B3A6DEC0274B09A2002A0790 /* AppUserIdentifiable.swift */,
 				B3A36AAD26BC76340059EDEA /* CustomerInfoManager.swift */,
+				B3852F9F26C1ED1F005384F8 /* IdentityManager.swift */,
 			);
 			path = Identity;
+			sourceTree = "<group>";
+		};
+		B3A6DEB5274AFE38002A0790 /* Integrations */ = {
+			isa = PBXGroup;
+			children = (
+				B3A6DEB6274AFE50002A0790 /* Integration.swift */,
+				B3A6DEB8274AFE7A002A0790 /* AirshipIntegration.swift */,
+			);
+			path = Integrations;
 			sourceTree = "<group>";
 		};
 		B3B5FBB7269CED6D00104A0C /* Errors */ = {
@@ -1258,6 +1279,7 @@
 		B3DDB55726854850008CCF23 /* Public */ = {
 			isa = PBXGroup;
 			children = (
+				B3A6DEB5274AFE38002A0790 /* Integrations */,
 				B3B5FBB7269CED6D00104A0C /* Errors */,
 				B39E8119268E849900D31189 /* AttributionNetwork.swift */,
 				A56F9AB026990E9200AFC48F /* CustomerInfo.swift */,
@@ -1273,6 +1295,7 @@
 				57EAE52C274468900060EB74 /* RawDataContainer.swift */,
 				2DC5621824EC63430031F69B /* RevenueCat.h */,
 				37E355CBB3F3A31A32687B14 /* Transaction.swift */,
+				B3A6DEBE274B0550002A0790 /* Purchases+ConfigureIntegrations.swift */,
 			);
 			path = Public;
 			sourceTree = "<group>";
@@ -1687,6 +1710,7 @@
 				2DDF41B624F6F387005BC22D /* ASN1ObjectIdentifierBuilder.swift in Sources */,
 				35D832D2262E56DB00E60AC5 /* HTTPStatusCodes.swift in Sources */,
 				F5E4383826B8530700841CC8 /* SKPaymentTransaction+Extensions.swift in Sources */,
+				B3A6DEC1274B09A2002A0790 /* AppUserIdentifiable.swift in Sources */,
 				B3022072272B3DDC008F1A0D /* DescribableError.swift in Sources */,
 				F5C0196926E880800005D61E /* StoreKitStrings.swift in Sources */,
 				B302206C2727436F008F1A0D /* UnexpectedBackendResponseSubErrorCode.swift in Sources */,
@@ -1714,6 +1738,8 @@
 				A5F0104E2717B3150090732D /* BeginRefundRequestHelper.swift in Sources */,
 				F5BE4479269E4A4C00254A30 /* AfficheClientProxy.swift in Sources */,
 				B33CEAA0268CDCC9008A3144 /* ISOPeriodFormatter.swift in Sources */,
+				B3A6DEBF274B0550002A0790 /* Purchases+ConfigureIntegrations.swift in Sources */,
+				B3A6DEBD274B00F0002A0790 /* SubscriberAttributionSetter.swift in Sources */,
 				2DDF41A324F6F331005BC22D /* ReceiptParser.swift in Sources */,
 				35D832F4262E606500E60AC5 /* HTTPResponse.swift in Sources */,
 				A56F9AB126990E9200AFC48F /* CustomerInfo.swift in Sources */,
@@ -1734,6 +1760,7 @@
 				B3DDB55926854865008CCF23 /* PurchaseOwnershipType.swift in Sources */,
 				2DC5623224EC63730031F69B /* TransactionsFactory.swift in Sources */,
 				2DDF41B424F6F387005BC22D /* ASN1ContainerBuilder.swift in Sources */,
+				B3A6DEB7274AFE50002A0790 /* Integration.swift in Sources */,
 				B35F9E0926B4BEED00095C3F /* String+Extensions.swift in Sources */,
 				2DDF41AC24F6F37C005BC22D /* ASN1Container.swift in Sources */,
 				9A65E07B2591977500DE00B0 /* NetworkStrings.swift in Sources */,
@@ -1772,6 +1799,7 @@
 				2D971CC12744364C0093F35F /* SKError+Extensions.swift in Sources */,
 				57EAE527274324C60060EB74 /* Lock.swift in Sources */,
 				B32B74FF26868AEB005647BF /* Package.swift in Sources */,
+				B3A6DEB9274AFE7A002A0790 /* AirshipIntegration.swift in Sources */,
 				2DDF41B324F6F387005BC22D /* InAppPurchaseBuilder.swift in Sources */,
 				F5BE447B269E4A7500254A30 /* TrackingManagerProxy.swift in Sources */,
 				B34D2AA0269606E400D88C3A /* IntroEligibility.swift in Sources */,


### PR DESCRIPTION
Goals:
- Reduce public API in Purchases for specific integrations.
- Make integrations as easy as possible for consumers.
- Encapsulate integrations so they are easy to maintain/test/discover

**New API:**
```swift
 @discardableResult static func configure(withAPIKey apiKey: String, integrations: [Integration.Type]? = nil) -> Purchases {
```

**Example:**
```swift
// Added optional param to configure call
 Purchases.configure(withAPIKey: "myApiKey", integrations: [AirshipIntegration.self])
 
 let airship = purchases.getIntegration(for: AirshipIntegration.self)
 airship?.setAirshipChannelID("myChannel")
```

or:
```swift
purchases.getIntegration(for: AirshipIntegration.self)?.setAirshipChannelID("myChannel")
```

