### PR TITLE
Add async alternative APIs

### DIFF
--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -143,6 +143,8 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
             let (_, _, _): (SKPaymentTransaction, CustomerInfo, Bool) =
             try await purchases.purchase(package: pack, discount: paymentDiscount)
             let _: [String: IntroEligibility] = await purchases.checkTrialOrIntroductoryPriceEligibility([String]())
+
+            let _: SKPaymentDiscount = try await purchases.paymentDiscount(forProductDiscount: productDiscount, product: skp)
         }
     }
 

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -40,6 +40,7 @@ func checkPurchasesAPI() {
     checkIdentity(purchases: purch)
     checkPurchasesSubscriberAttributesAPI(purchases: purch)
     checkPurchasesPurchasingAPI(purchases: purch)
+    checkPurchasesSupportAPI(purchases: purch)
 }
 
 var periodType: PeriodType!
@@ -143,8 +144,8 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
             let (_, _, _): (SKPaymentTransaction, CustomerInfo, Bool) =
             try await purchases.purchase(package: pack, discount: paymentDiscount)
             let _: [String: IntroEligibility] = await purchases.checkTrialOrIntroductoryPriceEligibility([String]())
-
-            let _: SKPaymentDiscount = try await purchases.paymentDiscount(forProductDiscount: productDiscount, product: skp)
+            let _: SKPaymentDiscount = try await purchases.paymentDiscount(forProductDiscount: productDiscount,
+                                                                           product: skp)
         }
     }
 
@@ -186,6 +187,15 @@ private func checkIdentity(purchases: Purchases) {
         Task.init {
             let (_, _): (CustomerInfo, Bool) = try await purchases.logIn("")
             let _: CustomerInfo = try await purchases.logOut()
+        }
+    }
+}
+
+private func checkPurchasesSupportAPI(purchases: Purchases) {
+    purchases.showManageSubscriptionModal { _ in }
+    if #available(iOS 15.0, macOS 12.0, *) {
+        Task.init {
+            try await purchases.showManageSubscriptionModal()
         }
     }
 }

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -193,6 +193,7 @@ private func checkIdentity(purchases: Purchases) {
 
 private func checkPurchasesSupportAPI(purchases: Purchases) {
     purchases.showManageSubscriptionModal { _ in }
+    #if os(iOS)
     purchases.beginRefundRequest(for: "") { _, _ in }
     if #available(iOS 15.0, macOS 12.0, *) {
         Task.init {
@@ -200,6 +201,7 @@ private func checkPurchasesSupportAPI(purchases: Purchases) {
             let _: RefundRequestStatus = try await purchases.beginRefundRequest(for: "")
         }
     }
+    #endif
 }
 
 private func checkPurchasesSubscriberAttributesAPI(purchases: Purchases) {

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -119,6 +119,7 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
         Task.init {
             let (_, _, _): (SKPaymentTransaction, CustomerInfo, Bool) = try await purchases.purchase(product: skp)
+            let (_, _, _): (SKPaymentTransaction, CustomerInfo, Bool) = try await purchases.purchase(package: pack)
         }
     }
 

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -152,8 +152,10 @@ private func checkIdentity(purchases: Purchases) {
     let loginComplete: (CustomerInfo?, Bool, Error?) -> Void = { _, _, _ in }
     purchases.logIn("", completion: loginComplete)
     purchases.logIn("") { _, _, _ in }
-    Task.init {
-        let (_, _): (CustomerInfo, Bool) = try await purchases.logIn("")
+    if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+        Task.init {
+            let (_, _): (CustomerInfo, Bool) = try await purchases.logIn("")
+        }
     }
 }
 

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -101,9 +101,9 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
 
     if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
         Task.init {
-            let _: CustomerInfo = try await purchases.getCustomerInfo()
-            let _: [SKProduct] = await purchases.getProducts([String]())
-            let _: Offerings = try await purchases.getOfferings()
+            let _: CustomerInfo = try await purchases.customerInfo()
+            let _: [SKProduct] = await purchases.products([String]())
+            let _: Offerings = try await purchases.offerings()
         }
     }
 

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -94,6 +94,7 @@ private func checkStaticMethods() {
           forceUniversalAppStore, simulatesAskToBuyInSandbox, sharedPurchases, isPurchasesConfigured)
 }
 
+// swiftlint:disable:next function_body_length
 private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.getCustomerInfo { _, _ in }
     purchases.getOfferings { _, _ in }

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -155,6 +155,7 @@ private func checkIdentity(purchases: Purchases) {
     if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
         Task.init {
             let (_, _): (CustomerInfo, Bool) = try await purchases.logIn("")
+            let _: CustomerInfo = try await purchases.logOut()
         }
     }
 }

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -120,6 +120,7 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
         Task.init {
             let (_, _, _): (SKPaymentTransaction, CustomerInfo, Bool) = try await purchases.purchase(product: skp)
             let (_, _, _): (SKPaymentTransaction, CustomerInfo, Bool) = try await purchases.purchase(package: pack)
+            let _: CustomerInfo = try await purchases.syncPurchases()
         }
     }
 

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -137,6 +137,8 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
         Task.init {
             let (_, _, _): (SKPaymentTransaction, CustomerInfo, Bool) =
             try await purchases.purchase(product: skp, discount: paymentDiscount)
+            let (_, _, _): (SKPaymentTransaction, CustomerInfo, Bool) =
+            try await purchases.purchase(package: pack, discount: paymentDiscount)
         }
     }
 

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -121,6 +121,7 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
             let (_, _, _): (SKPaymentTransaction, CustomerInfo, Bool) = try await purchases.purchase(product: skp)
             let (_, _, _): (SKPaymentTransaction, CustomerInfo, Bool) = try await purchases.purchase(package: pack)
             let _: CustomerInfo = try await purchases.syncPurchases()
+            let _: CustomerInfo = try await purchases.restoreTransactions()
         }
     }
 

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -193,9 +193,11 @@ private func checkIdentity(purchases: Purchases) {
 
 private func checkPurchasesSupportAPI(purchases: Purchases) {
     purchases.showManageSubscriptionModal { _ in }
+    purchases.beginRefundRequest(for: "") { _, _ in }
     if #available(iOS 15.0, macOS 12.0, *) {
         Task.init {
             try await purchases.showManageSubscriptionModal()
+            let _: RefundRequestStatus = try await purchases.beginRefundRequest(for: "")
         }
     }
 }

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -116,6 +116,12 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.purchase(package: pack) { _, _, _, _  in }
     purchases.syncPurchases { _, _ in }
 
+    if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+        Task.init {
+            let (_, _, _): (SKPaymentTransaction, CustomerInfo, Bool) = try await purchases.purchase(product: skp)
+        }
+    }
+
     let checkEligComplete: ([String: IntroEligibility]) -> Void = { _ in }
     purchases.checkTrialOrIntroductoryPriceEligibility([String](), completion: checkEligComplete)
     purchases.checkTrialOrIntroductoryPriceEligibility([String]()) { _ in }

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -103,6 +103,7 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
         Task.init {
             let _: CustomerInfo = try await purchases.getCustomerInfo()
             let _: [SKProduct] = await purchases.getProducts([String]())
+            let _: Offerings = try await purchases.getOfferings()
         }
     }
 

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -108,8 +108,8 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     }
 
     let skp: SKProduct = SKProduct()
-    let skpd: SKProductDiscount = SKProductDiscount()
-    let skmd: SKPaymentDiscount = SKPaymentDiscount()
+    let productDiscount: SKProductDiscount = SKProductDiscount()
+    let paymentDiscount: SKPaymentDiscount = SKPaymentDiscount()
     let pack: Package! = nil
 
     purchases.purchase(product: skp) { _, _, _, _  in }
@@ -127,11 +127,18 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.checkTrialOrIntroductoryPriceEligibility([String](), completion: checkEligComplete)
     purchases.checkTrialOrIntroductoryPriceEligibility([String]()) { _ in }
 
-    purchases.paymentDiscount(forProductDiscount: skpd, product: skp) { _, _ in }
+    purchases.paymentDiscount(forProductDiscount: productDiscount, product: skp) { _, _ in }
 
-    purchases.purchase(product: skp, discount: skmd) { _, _, _, _  in }
-    purchases.purchase(package: pack, discount: skmd) { _, _, _, _  in }
+    purchases.purchase(product: skp, discount: paymentDiscount) { _, _, _, _  in }
+    purchases.purchase(package: pack, discount: paymentDiscount) { _, _, _, _  in }
     purchases.invalidateCustomerInfoCache()
+
+    if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+        Task.init {
+            let (_, _, _): (SKPaymentTransaction, CustomerInfo, Bool) =
+            try await purchases.purchase(product: skp, discount: paymentDiscount)
+        }
+    }
 
 #if os(iOS) || targetEnvironment(macCatalyst)
     let beginRefundRequestCompletion: (RefundRequestStatus, Error?) -> Void = { _, _ in }

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -152,6 +152,9 @@ private func checkIdentity(purchases: Purchases) {
     let loginComplete: (CustomerInfo?, Bool, Error?) -> Void = { _, _, _ in }
     purchases.logIn("", completion: loginComplete)
     purchases.logIn("") { _, _, _ in }
+    Task.init {
+        let (_, _): (CustomerInfo, Bool) = try await purchases.logIn("")
+    }
 }
 
 private func checkPurchasesSubscriberAttributesAPI(purchases: Purchases) {

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -99,6 +99,12 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.getOfferings { _, _ in }
     purchases.getProducts([String]()) { _ in }
 
+    if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+        Task.init {
+            let _: CustomerInfo = try await purchases.getCustomerInfo()
+        }
+    }
+
     let skp: SKProduct = SKProduct()
     let skpd: SKProductDiscount = SKProductDiscount()
     let skmd: SKPaymentDiscount = SKPaymentDiscount()

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -141,6 +141,7 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
             try await purchases.purchase(product: skp, discount: paymentDiscount)
             let (_, _, _): (SKPaymentTransaction, CustomerInfo, Bool) =
             try await purchases.purchase(package: pack, discount: paymentDiscount)
+            let _: [String: IntroEligibility] = await purchases.checkTrialOrIntroductoryPriceEligibility([String]())
         }
     }
 

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -102,6 +102,7 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
         Task.init {
             let _: CustomerInfo = try await purchases.getCustomerInfo()
+            let _: [SKProduct] = await purchases.getProducts([String]())
         }
     }
 

--- a/IntegrationTests/PurchaseTester/Podfile.lock
+++ b/IntegrationTests/PurchaseTester/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - RevenueCat (4.0.0-beta.6)
+  - RevenueCat (4.0.0-beta.7)
 
 DEPENDENCIES:
   - RevenueCat (from `../../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  RevenueCat: cf8ccc9a15ad770c4c053c480b6c4f946a9c776e
+  RevenueCat: fc617745a64ce00960bf390604d502b95c990e9b
 
 PODFILE CHECKSUM: f0880c6eb8b2a5f9b4e9e9475c5cfb18b532cde0
 

--- a/Purchases/Public/CustomerInfo.swift
+++ b/Purchases/Public/CustomerInfo.swift
@@ -16,7 +16,7 @@ import Foundation
 
 @objc(RCCustomerInfo) public class CustomerInfo: NSObject {
 
-    /// ``EntitlementInfos`` attached to this purchaser info.
+    /// ``EntitlementInfos`` attached to this customer info.
     @objc public let entitlements: EntitlementInfos
 
     /// All *subscription* product identifiers with expiration dates in the future.

--- a/Purchases/Public/Purchases+async.swift
+++ b/Purchases/Public/Purchases+async.swift
@@ -12,6 +12,7 @@
 //  Created by Andrés Boedo on 24/11/21.
 
 import Foundation
+import StoreKit
 
 /// This extension holds the biolerplate logic to convert methods with completion blocks into async / await syntax.
 extension Purchases {
@@ -79,5 +80,15 @@ extension Purchases {
             }
         }
     }
+
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    func productsAsync(_ productIdentifiers: [String]) async -> [SKProduct] {
+        return await withCheckedContinuation { continuation in
+            getProducts(productIdentifiers) { result in
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
 
 }

--- a/Purchases/Public/Purchases+async.swift
+++ b/Purchases/Public/Purchases+async.swift
@@ -238,9 +238,12 @@ extension Purchases {
         }
     }
 
+
+#if os(iOS) || os(macOS)
+
+    @available(iOS 15.0, macOS 12, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
-    @available(iOS 15.0, macOS 12, *)
     func showManageSubscriptionModalAsync() async throws {
         return try await withCheckedThrowingContinuation { continuation in
             showManageSubscriptionModal { error in
@@ -253,7 +256,12 @@ extension Purchases {
         }
     }
 
-    @available(iOS 15.0, macOS 12.0, *)
+#endif
+
+#if os(iOS)
+
+    @available(iOS 15.0, *)
+    @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     @objc func beginRefundRequestAsync(for productID: String) async throws -> RefundRequestStatus {
@@ -267,5 +275,7 @@ extension Purchases {
             }
         }
     }
+
+#endif
 
 }

--- a/Purchases/Public/Purchases+async.swift
+++ b/Purchases/Public/Purchases+async.swift
@@ -90,5 +90,109 @@ extension Purchases {
         }
     }
 
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    // swiftlint:disable:next large_tuple
+    func purchaseAsync(product: SKProduct) async throws -> (SKPaymentTransaction, CustomerInfo, Bool) {
+        return try await withCheckedThrowingContinuation { continuation in
+            purchase(product: product) { maybeTransaction, maybeCustomerInfo, maybeError, userCancelled in
+                if let error = maybeError {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let customerInfo = maybeCustomerInfo else {
+                    fatalError("Expected non-nil result 'customerInfo' for nil error")
+                }
+                guard let transaction = maybeTransaction else {
+                    fatalError("Expected non-nil result 'transaction' for nil error")
+                }
+
+                continuation.resume(returning: (transaction, customerInfo, userCancelled))
+            }
+        }
+    }
+
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    // swiftlint:disable:next large_tuple
+    func purchaseAsync(package: Package) async throws -> (SKPaymentTransaction, CustomerInfo, Bool) {
+        return try await withCheckedThrowingContinuation { continuation in
+            purchase(package: package) { maybeTransaction, maybeCustomerInfo, maybeError, userCancelled in
+                if let error = maybeError {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let customerInfo = maybeCustomerInfo else {
+                    fatalError("Expected non-nil result 'customerInfo' for nil error")
+                }
+                guard let transaction = maybeTransaction else {
+                    fatalError("Expected non-nil result 'transaction' for nil error")
+                }
+
+                continuation.resume(returning: (transaction, customerInfo, userCancelled))
+            }
+        }
+    }
+
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    func purchaseAsync(product: SKProduct, discount: SKPaymentDiscount) async throws ->
+    // swiftlint:disable:next large_tuple
+    (SKPaymentTransaction, CustomerInfo, Bool) {
+
+        return try await withCheckedThrowingContinuation { continuation in
+            purchase(product: product,
+                     discount: discount) { maybeTransaction, maybeCustomerInfo, maybeError, userCancelled in
+                if let error = maybeError {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let customerInfo = maybeCustomerInfo else {
+                    fatalError("Expected non-nil result 'customerInfo' for nil error")
+                }
+                guard let transaction = maybeTransaction else {
+                    fatalError("Expected non-nil result 'transaction' for nil error")
+                }
+
+                continuation.resume(returning: (transaction, customerInfo, userCancelled))
+            }
+        }
+    }
+
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    func purchaseAsync(package: Package, discount: SKPaymentDiscount) async throws ->
+    // swiftlint:disable:next large_tuple
+    (SKPaymentTransaction, CustomerInfo, Bool) {
+        return try await withCheckedThrowingContinuation { continuation in
+            purchase(package: package,
+                     discount: discount) { maybeTransaction, maybeCustomerInfo, maybeError, userCancelled in
+                if let error = maybeError {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let customerInfo = maybeCustomerInfo else {
+                    fatalError("Expected non-nil result 'customerInfo' for nil error")
+                }
+                guard let transaction = maybeTransaction else {
+                    fatalError("Expected non-nil result 'transaction' for nil error")
+                }
+
+                continuation.resume(returning: (transaction, customerInfo, userCancelled))
+            }
+        }
+    }
+
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    func syncPurchasesAsync() async throws -> CustomerInfo {
+        return try await withCheckedThrowingContinuation { continuation in
+            syncPurchases { maybeCustomerInfo, maybeError in
+                if let error = maybeError {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let customerInfo = maybeCustomerInfo else {
+                    fatalError("Expected non-nil result 'customerInfo' for nil error")
+                }
+                continuation.resume(returning: customerInfo)
+            }
+        }
+    }
 
 }

--- a/Purchases/Public/Purchases+async.swift
+++ b/Purchases/Public/Purchases+async.swift
@@ -18,7 +18,7 @@ import StoreKit
 extension Purchases {
 
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
-    func logInAsync(_ appUserID: String) async throws -> (CustomerInfo, Bool) {
+    func logInAsync(_ appUserID: String) async throws -> (customerInfo: CustomerInfo, created: Bool) {
         return try await withCheckedThrowingContinuation { continuation in
             logIn(appUserID) { maybeCustomerInfo, created, maybeError in
                 if let error = maybeError {

--- a/Purchases/Public/Purchases+async.swift
+++ b/Purchases/Public/Purchases+async.swift
@@ -195,4 +195,77 @@ extension Purchases {
         }
     }
 
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    func restoreTransactionsAsync() async throws -> CustomerInfo {
+        return try await withCheckedThrowingContinuation { continuation in
+            restoreTransactions { maybeCustomerInfo, maybeError in
+                if let error = maybeError {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let customerInfo = maybeCustomerInfo else {
+                    fatalError("Expected non-nil result 'customerInfo' for nil error")
+                }
+                continuation.resume(returning: customerInfo)
+            }
+        }
+    }
+
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    func checkTrialOrIntroductoryPriceEligibilityAsync(_ productIdentifiers: [String]) async
+    -> [String: IntroEligibility] {
+        return await withCheckedContinuation { continuation in
+            checkTrialOrIntroductoryPriceEligibility(productIdentifiers) { result in
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    func paymentDiscountAsync(forProductDiscount discount: SKProductDiscount,
+                         product: SKProduct) async throws -> SKPaymentDiscount {
+        return try await withCheckedThrowingContinuation { continuation in
+            paymentDiscount(forProductDiscount: discount, product: product) { maybeDiscount, maybeError in
+                if let error = maybeError {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let discount = maybeDiscount else {
+                    fatalError("Expected non-nil 'discount' for nil error")
+                }
+                continuation.resume(returning: discount)
+            }
+        }
+    }
+
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(iOS 15.0, macOS 12, *)
+    func showManageSubscriptionModalAsync() async throws {
+        return try await withCheckedThrowingContinuation { continuation in
+            showManageSubscriptionModal { error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                continuation.resume(returning: ())
+            }
+        }
+    }
+
+    @available(iOS 15.0, macOS 12.0, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    @objc func beginRefundRequestAsync(for productID: String) async throws -> RefundRequestStatus {
+        return try await withCheckedThrowingContinuation { continuation in
+            beginRefundRequest(for: productID) { result, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
 }

--- a/Purchases/Public/Purchases+async.swift
+++ b/Purchases/Public/Purchases+async.swift
@@ -223,7 +223,7 @@ extension Purchases {
 
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     func paymentDiscountAsync(forProductDiscount discount: SKProductDiscount,
-                         product: SKProduct) async throws -> SKPaymentDiscount {
+                              product: SKProduct) async throws -> SKPaymentDiscount {
         return try await withCheckedThrowingContinuation { continuation in
             paymentDiscount(forProductDiscount: discount, product: product) { maybeDiscount, maybeError in
                 if let error = maybeError {

--- a/Purchases/Public/Purchases+async.swift
+++ b/Purchases/Public/Purchases+async.swift
@@ -238,7 +238,6 @@ extension Purchases {
         }
     }
 
-
 #if os(iOS) || os(macOS)
 
     @available(iOS 15.0, macOS 12, *)

--- a/Purchases/Public/Purchases+async.swift
+++ b/Purchases/Public/Purchases+async.swift
@@ -1,0 +1,83 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Purchases+async.swift
+//
+//  Created by Andrés Boedo on 24/11/21.
+
+import Foundation
+
+/// This extension holds the biolerplate logic to convert methods with completion blocks into async / await syntax.
+extension Purchases {
+
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    func logInAsync(_ appUserID: String) async throws -> (CustomerInfo, Bool) {
+        return try await withCheckedThrowingContinuation { continuation in
+            logIn(appUserID) { maybeCustomerInfo, created, maybeError in
+                if let error = maybeError {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let customerInfo = maybeCustomerInfo else {
+                    fatalError("Expected non-nil result 'customerInfo' for nil error")
+                }
+                continuation.resume(returning: (customerInfo, created))
+            }
+        }
+    }
+
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    func logOutAsync() async throws -> CustomerInfo {
+        return try await withCheckedThrowingContinuation { continuation in
+            logOut { maybeCustomerInfo, maybeError in
+                if let error = maybeError {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let customerInfo = maybeCustomerInfo else {
+                    fatalError("Expected non-nil result 'customerInfo' for nil error")
+                }
+                continuation.resume(returning: customerInfo)
+            }
+        }
+    }
+
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    func offeringsAsync() async throws -> Offerings {
+        return try await withCheckedThrowingContinuation { continuation in
+            getOfferings { maybeOfferings, maybeError in
+                if let error = maybeError {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let offerings = maybeOfferings else {
+                    fatalError("Expected non-nil result 'result' for nil error")
+                }
+                continuation.resume(returning: offerings)
+            }
+        }
+    }
+
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    func customerInfoAsync() async throws -> CustomerInfo {
+        return try await withCheckedThrowingContinuation { continuation in
+            getCustomerInfo { maybeCustomerInfo, maybeError in
+                if let error = maybeError {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let customerInfo = maybeCustomerInfo else {
+                    fatalError("Expected non-nil result 'customerInfo' for nil error")
+                }
+                continuation.resume(returning: customerInfo)
+            }
+        }
+    }
+
+}

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -763,11 +763,7 @@ public extension Purchases {
      */
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     func products(_ productIdentifiers: [String]) async -> [SKProduct] {
-        return await withCheckedContinuation { continuation in
-            getProducts(productIdentifiers) { result in
-                continuation.resume(returning: result)
-            }
-        }
+        return await productsAsync(productIdentifiers)
     }
 
     /**

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1342,11 +1342,38 @@ public extension Purchases {
      * If the request was unsuccessful, there will be an `Error`.
      */
     @available(iOS 15.0, *)
+    @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     @objc func beginRefundRequest(for productID: String,
                                   completion: @escaping (RefundRequestStatus, Error?) -> Void) {
         purchasesOrchestrator.beginRefundRequest(for: productID, completion: completion)
+    }
+
+    /**
+     * Presents a refund request sheet in the current window scene for
+     * the latest transaction associated with the productID
+     *
+     * - Parameter productID: The productID to begin a refund request for.
+     * - Parameter completion: A completion block that is called when the modal is closed.
+     * If the request was successful, there will be a `RefundRequestStatus`.
+     * Keep in mind the status could be `userCancelled`
+     * If the request was unsuccessful, there will be an `Error`.
+     */
+    @available(iOS 15.0, *)
+    @available(macOS, unavailable)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    @objc func beginRefundRequest(for productID: String) async throws -> RefundRequestStatus {
+        return try await withCheckedThrowingContinuation { continuation in
+            beginRefundRequest(for: productID) { result, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                continuation.resume(returning: result)
+            }
+        }
     }
 
 }

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -716,6 +716,28 @@ public extension Purchases {
     }
 
     /**
+     * Get latest available purchaser info.
+     *
+     * - Parameter completion: A completion block called when customer info is available and not stale.
+     * Called immediately if ``CustomerInfo`` is cached. Customer info can be nil * if an error occurred.
+     */
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    func getCustomerInfo() async throws -> CustomerInfo {
+        return try await withCheckedThrowingContinuation { continuation in
+            getCustomerInfo { maybeCustomerInfo, maybeError in
+                if let error = maybeError {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let customerInfo = maybeCustomerInfo else {
+                    fatalError("Expected non-nil result 'customerInfo' for nil error")
+                }
+                continuation.resume(returning: customerInfo)
+            }
+        }
+    }
+
+    /**
      * Fetches the `SKProducts` for your IAPs for given `productIdentifiers`.
      * Use this method if you aren't using `getOfferings(completion:)`.
      * You should use getOfferings though.
@@ -923,6 +945,9 @@ public extension Purchases {
      * Displays a sheet that enables users to redeem subscription offer codes that you generated in App Store Connect.
      */
     @available(iOS 14.0, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(macOS, unavailable)
     @objc func presentCodeRedemptionSheet() {
         storeKitWrapper.presentCodeRedemptionSheet()
     }

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -761,6 +761,33 @@ public extension Purchases {
     }
 
     /**
+     * Fetches the `SKProducts` for your IAPs for given `productIdentifiers`.
+     * Use this method if you aren't using `getOfferings(completion:)`.
+     * You should use getOfferings though.
+     *
+     * - Note: `completion` may be called without `SKProduct`s that you are expecting. This is usually caused by
+     * iTunesConnect configuration errors. Ensure your IAPs have the "Ready to Submit" status in iTunesConnect.
+     * Also ensure that you have an active developer program subscription and you have signed the latest paid
+     * application agreements.
+     * If you're having trouble see: https://www.revenuecat.com/2018/10/11/configuring-in-app-products-is-hard
+     *
+     * - Parameter productIdentifiers: A set of product identifiers for in app purchases setup via AppStoreConnect:
+     * https://appstoreconnect.apple.com/
+     * This should be either hard coded in your application, from a file, or from a custom endpoint if you want
+     * to be able to deploy new IAPs without an app update.
+     * - Parameter completion: An @escaping callback that is called with the loaded products.
+     * If the fetch fails for any reason it will return an empty array.
+     */
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    func getProducts(_ productIdentifiers: [String]) async -> [SKProduct] {
+        return await withCheckedContinuation { continuation in
+            getProducts(productIdentifiers) { result in
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
+    /**
      * Use this function if you are not using the Offerings system to purchase an `SKProduct`.
      * If you are using the Offerings system, use ``Purchases/purchase(package:completion:)`` instead.
      *

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1294,7 +1294,6 @@ public extension Purchases {
      * If the request was unsuccessful, there will be an `Error`.
      */
     @available(iOS 15.0, *)
-    @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     @objc func beginRefundRequest(for productID: String,

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -628,18 +628,7 @@ public extension Purchases {
      */
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     func logIn(_ appUserID: String) async throws -> (CustomerInfo, Bool) {
-        return try await withCheckedThrowingContinuation { continuation in
-            logIn(appUserID) { maybeCustomerInfo, created, maybeError in
-                if let error = maybeError {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let customerInfo = maybeCustomerInfo else {
-                    fatalError("Expected non-nil result 'customerInfo' for nil error")
-                }
-                continuation.resume(returning: (customerInfo, created))
-            }
-        }
+        return try await logInAsync(appUserID)
     }
 
     /**
@@ -671,18 +660,7 @@ public extension Purchases {
      */
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     func logOut() async throws -> CustomerInfo {
-        return try await withCheckedThrowingContinuation { continuation in
-            logOut { maybeCustomerInfo, maybeError in
-                if let error = maybeError {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let customerInfo = maybeCustomerInfo else {
-                    fatalError("Expected non-nil result 'customerInfo' for nil error")
-                }
-                continuation.resume(returning: customerInfo)
-            }
-        }
+        return try await logOutAsync()
     }
 
     /**
@@ -713,18 +691,7 @@ public extension Purchases {
      */
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     func offerings() async throws -> Offerings {
-        return try await withCheckedThrowingContinuation { continuation in
-            getOfferings { maybeOfferings, maybeError in
-                if let error = maybeError {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let offerings = maybeOfferings else {
-                    fatalError("Expected non-nil result 'result' for nil error")
-                }
-                continuation.resume(returning: offerings)
-            }
-        }
+        return try await offeringsAsync()
     }
 
 }
@@ -750,18 +717,7 @@ public extension Purchases {
      */
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     func customerInfo() async throws -> CustomerInfo {
-        return try await withCheckedThrowingContinuation { continuation in
-            getCustomerInfo { maybeCustomerInfo, maybeError in
-                if let error = maybeError {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let customerInfo = maybeCustomerInfo else {
-                    fatalError("Expected non-nil result 'customerInfo' for nil error")
-                }
-                continuation.resume(returning: customerInfo)
-            }
-        }
+        return try await customerInfoAsync()
     }
 
     /**

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1270,6 +1270,31 @@ public extension Purchases {
     }
 
     /**
+     * Use this function to retrieve the `SKPaymentDiscount` for a given `SKProduct`.
+     *
+     * - Parameter discount: The `SKProductDiscount` to apply to the product.
+     * - Parameter product: The `SKProduct` the user intends to purchase.
+     * - Parameter completion: A completion block that is called when the `SKPaymentDiscount` is returned.
+     * If it was not successful, there will be an `Error`.
+     */
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    func paymentDiscount(forProductDiscount discount: SKProductDiscount,
+                         product: SKProduct) async throws -> SKPaymentDiscount {
+        return try await withCheckedThrowingContinuation { continuation in
+            paymentDiscount(forProductDiscount: discount, product: product) { maybeDiscount, maybeError in
+                if let error = maybeError {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let discount = maybeDiscount else {
+                    fatalError("Expected non-nil 'discount' for nil error")
+                }
+                continuation.resume(returning: discount)
+            }
+        }
+    }
+
+    /**
      * Use this function to open the manage subscriptions modal.
      * If the manage subscriptions modal can't be opened, the managementURL in the customerInfo will be opened.
      * If managementURL is not available, the App Store's subscription management section will be opened.

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1162,7 +1162,6 @@ public extension Purchases {
         purchasesOrchestrator.showManageSubscriptionModal(completion: completion)
     }
 
-
     /**
      * Use this function to open the manage subscriptions modal.
      * If the manage subscriptions modal can't be opened, the managementURL in the customerInfo will be opened.

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -627,7 +627,7 @@ public extension Purchases {
      * See https://docs.revenuecat.com/docs/user-ids
      */
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
-    func logIn(_ appUserID: String) async throws -> (CustomerInfo, Bool) {
+    func logIn(_ appUserID: String) async throws -> (customerInfo: CustomerInfo, created: Bool) {
         return try await logInAsync(appUserID)
     }
 

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1049,6 +1049,47 @@ public extension Purchases {
     }
 
     /**
+     * Purchase the passed ``Package``.
+     * Call this method when a user has decided to purchase a product with an applied discount. Only call this in
+     * direct response to user input. From here `Purchases` will handle the purchase with `StoreKit` and call the
+     * `PurchaseCompletedBlock`.
+     *
+     * - Note: You do not need to finish the transaction yourself in the completion callback, Purchases will handle
+     * this for you.
+     *
+     * - Parameter package: The ``Package`` the user intends to purchase
+     * - Parameter discount: The `SKPaymentDiscount` to apply to the purchase
+     * - Parameter completion: A completion block that is called when the purchase completes.
+     *
+     * If the purchase was successful there will be a `SKPaymentTransaction` and a ``CustomerInfo``.
+     * If the purchase was not successful, there will be an `Error`.
+     * If the user cancelled, `userCancelled` will be `true`.
+     */
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+
+    func purchase(package: Package, discount: SKPaymentDiscount) async throws ->
+    // swiftlint:disable:next large_tuple
+    (SKPaymentTransaction, CustomerInfo, Bool) {
+        return try await withCheckedThrowingContinuation { continuation in
+            purchase(package: package,
+                     discount: discount) { maybeTransaction, maybeCustomerInfo, maybeError, userCancelled in
+                if let error = maybeError {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let customerInfo = maybeCustomerInfo else {
+                    fatalError("Expected non-nil result 'customerInfo' for nil error")
+                }
+                guard let transaction = maybeTransaction else {
+                    fatalError("Expected non-nil result 'transaction' for nil error")
+                }
+
+                continuation.resume(returning: (transaction, customerInfo, userCancelled))
+            }
+        }
+    }
+
+    /**
      * This method will post all purchases associated with the current App Store account to RevenueCat and
      * become associated with the current ``appUserID``.
      *

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -700,6 +700,33 @@ public extension Purchases {
         offeringsManager.offerings(appUserID: appUserID, completion: completion)
     }
 
+    /**
+     * Fetch the configured offerings for this users. ``Offerings`` allows you to configure your in-app products
+     * via RevenueCat and greatly simplifies management.
+     * See the guide (https://docs.revenuecat.com/entitlements) for more info.
+     *
+     * ``Offerings`` will be fetched and cached on instantiation so that, by the time they are needed,
+     * your prices are loaded for your purchase flow. Time is money.
+     *
+     * - Parameter completion: A completion block called when offerings are available.
+     * Called immediately if offerings are cached. Offerings will be nil if an error occurred.
+     */
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @objc func getOfferings() async throws -> Offerings {
+        return try await withCheckedThrowingContinuation { continuation in
+            getOfferings { maybeOfferings, maybeError in
+                if let error = maybeError {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let offerings = maybeOfferings else {
+                    fatalError("Expected non-nil result 'result' for nil error")
+                }
+                continuation.resume(returning: offerings)
+            }
+        }
+    }
+
 }
 
 // MARK: Purchasing

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -706,7 +706,7 @@ public extension Purchases {
 public extension Purchases {
 
     /**
-     * Get latest available purchaser info.
+     * Get latest available customer  info.
      *
      * - Parameter completion: A completion block called when customer info is available and not stale.
      * Called immediately if ``CustomerInfo`` is cached. Customer info can be nil * if an error occurred.
@@ -716,7 +716,7 @@ public extension Purchases {
     }
 
     /**
-     * Get latest available purchaser info.
+     * Get latest available customer  info.
      *
      * - Parameter completion: A completion block called when customer info is available and not stale.
      * Called immediately if ``CustomerInfo`` is cached. Customer info can be nil * if an error occurred.

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1309,6 +1309,29 @@ public extension Purchases {
     }
 
     /**
+     * Use this function to open the manage subscriptions modal.
+     * If the manage subscriptions modal can't be opened, the managementURL in the customerInfo will be opened.
+     * If managementURL is not available, the App Store's subscription management section will be opened.
+     *
+     * - Parameter completion: A completion block that is called when the modal is closed.
+     * If it was not successful, there will be an `Error`.
+     */
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(iOS 15.0, macOS 12, *)
+    func showManageSubscriptionModal() async throws {
+        return try await withCheckedThrowingContinuation { continuation in
+            showManageSubscriptionModal { error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                continuation.resume(returning: ())
+            }
+        }
+    }
+
+    /**
      * Presents a refund request sheet in the current window scene for
      * the latest transaction associated with the productID
      *

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -904,6 +904,44 @@ public extension Purchases {
     }
 
     /**
+     * Purchase the passed ``Package``.
+     * Call this method when a user has decided to purchase a product. Only call this in direct response to user input.
+     * From here `Purchases` will handle the purchase with `StoreKit` and call the `PurchaseCompletedBlock`.
+     *
+     * - Note: You do not need to finish the transaction yourself in the completion callback, Purchases will
+     * handle this for you.
+     *
+     * - Parameter package: The ``Package`` the user intends to purchase
+     * - Parameter completion: A completion block that is called when the purchase completes.
+     *
+     * If the purchase was successful there will be a `SKPaymentTransaction` and a ``CustomerInfo``.
+     *
+     * If the purchase was not successful, there will be an `Error`.
+     *
+     * If the user cancelled, `userCancelled` will be `true`.
+     */
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    // swiftlint:disable:next large_tuple
+    func purchase(package: Package) async throws -> (SKPaymentTransaction, CustomerInfo, Bool) {
+        return try await withCheckedThrowingContinuation { continuation in
+            purchase(package: package) { maybeTransaction, maybeCustomerInfo, maybeError, userCancelled in
+                if let error = maybeError {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let customerInfo = maybeCustomerInfo else {
+                    fatalError("Expected non-nil result 'customerInfo' for nil error")
+                }
+                guard let transaction = maybeTransaction else {
+                    fatalError("Expected non-nil result 'transaction' for nil error")
+                }
+
+                continuation.resume(returning: (transaction, customerInfo, userCancelled))
+            }
+        }
+    }
+
+    /**
      * Use this function if you are not using the Offerings system to purchase an `SKProduct` with an
      * applied `SKPaymentDiscount`.
      * If you are using the Offerings system, use ``Purchases/purchase(package:discount:completion:)`` instead.

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -629,12 +629,12 @@ public extension Purchases {
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     func logIn(_ appUserID: String) async throws -> (CustomerInfo, Bool) {
         return try await withCheckedThrowingContinuation { continuation in
-            logIn(appUserID) { customerInfo, created, error in
-                if let error = error {
+            logIn(appUserID) { maybeCustomerInfo, created, maybeError in
+                if let error = maybeError {
                     continuation.resume(throwing: error)
                     return
                 }
-                guard let customerInfo = customerInfo else {
+                guard let customerInfo = maybeCustomerInfo else {
                     fatalError("Expected non-nil result 'customerInfo' for nil error")
                 }
                 continuation.resume(returning: (customerInfo, created))
@@ -660,6 +660,28 @@ public extension Purchases {
             }
 
             self.updateAllCaches(completion: completion)
+        }
+    }
+
+    /**
+     * Logs out the Purchases client clearing the saved appUserID.
+     * This will generate a random user id and save it in the cache.
+     * If this method is called and the current user is anonymous, it will return an error.
+     * See https://docs.revenuecat.com/docs/user-ids
+     */
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    func logOut() async throws -> CustomerInfo {
+        return try await withCheckedThrowingContinuation { continuation in
+            logOut { maybeCustomerInfo, maybeError in
+                if let error = maybeError {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let customerInfo = maybeCustomerInfo else {
+                    fatalError("Expected non-nil result 'customerInfo' for nil error")
+                }
+                continuation.resume(returning: customerInfo)
+            }
         }
     }
 

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1201,7 +1201,30 @@ public extension Purchases {
                                                   completion: @escaping ([String: IntroEligibility]) -> Void) {
             trialOrIntroPriceEligibilityChecker.checkEligibility(productIdentifiers: productIdentifiers,
                                                                  completion: completion)
+    }
+
+    /**
+     * Computes whether or not a user is eligible for the introductory pricing period of a given product.
+     * You should use this method to determine whether or not you show the user the normal product price or
+     * the introductory price. This also applies to trials (trials are considered a type of introductory pricing).
+     *
+     * - Note: Subscription groups are automatically collected for determining eligibility. If RevenueCat can't
+     * definitively compute the eligibilty, most likely because of missing group information, it will return
+     * ``IntroEligibilityStatus/unknown``. The best course of action on unknown status is to display the non-intro
+     * pricing, to not create a misleading situation. To avoid this, make sure you are testing with the latest
+     * version of iOS so that the subscription group can be collected by the SDK.
+     *
+     * - Parameter productIdentifiers: Array of product identifiers for which you want to compute eligibility
+     * - Parameter completion: A block that receives a dictionary of product_id -> ``IntroEligibility``.
+     */
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    func checkTrialOrIntroductoryPriceEligibility(_ productIdentifiers: [String]) async -> [String: IntroEligibility] {
+        return await withCheckedContinuation { continuation in
+            checkTrialOrIntroductoryPriceEligibility(productIdentifiers) { result in
+                continuation.resume(returning: result)
+            }
         }
+    }
 
     /**
      * Invalidates the cache for customer information.

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1046,18 +1046,7 @@ public extension Purchases {
      */
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     func restoreTransactions() async throws -> CustomerInfo {
-        return try await withCheckedThrowingContinuation { continuation in
-            restoreTransactions { maybeCustomerInfo, maybeError in
-                if let error = maybeError {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let customerInfo = maybeCustomerInfo else {
-                    fatalError("Expected non-nil result 'customerInfo' for nil error")
-                }
-                continuation.resume(returning: customerInfo)
-            }
-        }
+        return try await restoreTransactionsAsync()
     }
 
     /**
@@ -1097,11 +1086,7 @@ public extension Purchases {
      */
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     func checkTrialOrIntroductoryPriceEligibility(_ productIdentifiers: [String]) async -> [String: IntroEligibility] {
-        return await withCheckedContinuation { continuation in
-            checkTrialOrIntroductoryPriceEligibility(productIdentifiers) { result in
-                continuation.resume(returning: result)
-            }
-        }
+        return await checkTrialOrIntroductoryPriceEligibilityAsync(productIdentifiers)
     }
 
     /**
@@ -1158,18 +1143,7 @@ public extension Purchases {
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     func paymentDiscount(forProductDiscount discount: SKProductDiscount,
                          product: SKProduct) async throws -> SKPaymentDiscount {
-        return try await withCheckedThrowingContinuation { continuation in
-            paymentDiscount(forProductDiscount: discount, product: product) { maybeDiscount, maybeError in
-                if let error = maybeError {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let discount = maybeDiscount else {
-                    fatalError("Expected non-nil 'discount' for nil error")
-                }
-                continuation.resume(returning: discount)
-            }
-        }
+        return try await paymentDiscountAsync(forProductDiscount: discount, product: product)
     }
 
     /**
@@ -1198,15 +1172,7 @@ public extension Purchases {
     @available(tvOS, unavailable)
     @available(iOS 15.0, macOS 12, *)
     func showManageSubscriptionModal() async throws {
-        return try await withCheckedThrowingContinuation { continuation in
-            showManageSubscriptionModal { error in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                continuation.resume(returning: ())
-            }
-        }
+        return try await showManageSubscriptionModalAsync()
     }
 
     /**
@@ -1241,15 +1207,7 @@ public extension Purchases {
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     @objc func beginRefundRequest(for productID: String) async throws -> RefundRequestStatus {
-        return try await withCheckedThrowingContinuation { continuation in
-            beginRefundRequest(for: productID) { result, error in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                continuation.resume(returning: result)
-            }
-        }
+        return try await beginRefundRequestAsync(for: productID)
     }
 
 }

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -58,7 +58,7 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
 
     /**
      * Delegate for `Purchases` instance. The delegate is responsible for handling promotional product purchases and
-     * changes to purchaser information.
+     * changes to customer information.
      */
     @objc public var delegate: PurchasesDelegate? {
         get { privateDelegate }
@@ -927,13 +927,13 @@ public extension Purchases {
         }
 
     /**
-     * Invalidates the cache for purchaser information.
+     * Invalidates the cache for customer information.
      *
      * Most apps will not need to use this method; invalidating the cache can leave your app in an invalid state.
      * Refer to https://docs.revenuecat.com/docs/purchaserinfo#section-get-user-information for more information on
      * using the cache properly.
      *
-     * This is useful for cases where purchaser information might have been updated outside of the app, like if a
+     * This is useful for cases where customer information might have been updated outside of the app, like if a
      * promotional subscription is granted through the RevenueCat dashboard.
      */
     @objc func invalidateCustomerInfoCache() {

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -618,6 +618,31 @@ public extension Purchases {
     }
 
     /**
+     * This function will logIn the current user with an appUserID.
+     *
+     * - Parameter appUserID: The appUserID that should be linked to the current user.
+     *
+     * The callback will be called with the latest CustomerInfo for the user, as well as a boolean
+     * indicating whether the user was created for the first time in the RevenueCat backend.
+     * See https://docs.revenuecat.com/docs/user-ids
+     */
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0 , *)
+    func logIn(_ appUserID: String) async throws -> (CustomerInfo, Bool) {
+        return try await withCheckedThrowingContinuation { continuation in
+            logIn(appUserID) { customerInfo, created, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let customerInfo = customerInfo else {
+                    fatalError("Expected non-nil result 'customerInfo' for nil error")
+                }
+                continuation.resume(returning: (customerInfo, created))
+            }
+        }
+    }
+
+    /**
      * Logs out the Purchases client clearing the saved appUserID.
      * This will generate a random user id and save it in the cache.
      * If this method is called and the current user is anonymous, it will return an error.

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1103,7 +1103,7 @@ public extension Purchases {
         customerInfoManager.clearCustomerInfoCache(forAppUserID: appUserID)
     }
 
-    #if os(iOS)
+#if os(iOS)
     /**
      * Displays a sheet that enables users to redeem subscription offer codes that you generated in App Store Connect.
      */
@@ -1114,7 +1114,7 @@ public extension Purchases {
     @objc func presentCodeRedemptionSheet() {
         storeKitWrapper.presentCodeRedemptionSheet()
     }
-    #endif
+#endif
 
     /**
      * Use this function to retrieve the `SKPaymentDiscount` for a given `SKProduct`.
@@ -1146,6 +1146,8 @@ public extension Purchases {
         return try await paymentDiscountAsync(forProductDiscount: discount, product: product)
     }
 
+#if os(iOS) || os(macOS)
+
     /**
      * Use this function to open the manage subscriptions modal.
      * If the manage subscriptions modal can't be opened, the managementURL in the customerInfo will be opened.
@@ -1159,6 +1161,7 @@ public extension Purchases {
     @objc func showManageSubscriptionModal(completion: @escaping (Error?) -> Void) {
         purchasesOrchestrator.showManageSubscriptionModal(completion: completion)
     }
+
 
     /**
      * Use this function to open the manage subscriptions modal.
@@ -1175,6 +1178,10 @@ public extension Purchases {
         return try await showManageSubscriptionModalAsync()
     }
 
+#endif
+
+#if os(iOS)
+
     /**
      * Presents a refund request sheet in the current window scene for
      * the latest transaction associated with the productID
@@ -1186,6 +1193,7 @@ public extension Purchases {
      * If the request was unsuccessful, there will be an `Error`.
      */
     @available(iOS 15.0, *)
+    @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     @objc func beginRefundRequest(for productID: String,
@@ -1203,12 +1211,15 @@ public extension Purchases {
      * Keep in mind the status could be `userCancelled`
      * If the request was unsuccessful, there will be an `Error`.
      */
-    @available(iOS 15.0, macOS 12.0, *)
+    @available(iOS 15.0, *)
+    @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     @objc func beginRefundRequest(for productID: String) async throws -> RefundRequestStatus {
         return try await beginRefundRequestAsync(for: productID)
     }
+
+#endif
 
 }
 

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1154,6 +1154,35 @@ public extension Purchases {
     }
 
     /**
+     * This method will post all purchases associated with the current App Store account to RevenueCat and become
+     * associated with the current ``appUserID``. If the receipt is being used by an existing user, the current
+     * ``appUserID`` will be aliased together with the `appUserID` of the existing user.
+     *  Going forward, either `appUserID` will be able to reference the same user.
+     *
+     * You shouldn't use this method if you have your own account system. In that case "restoration" is provided
+     * by your app passing the same `appUserId` used to purchase originally.
+     *
+     * - Note: This may force your users to enter the App Store password so should only be performed on request of
+     * the user. Typically with a button in settings or near your purchase UI. Use
+     * ``Purchases/syncPurchases(completion:)`` if you need to restore transactions programmatically.
+     */
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    func restoreTransactions() async throws -> CustomerInfo {
+        return try await withCheckedThrowingContinuation { continuation in
+            restoreTransactions { maybeCustomerInfo, maybeError in
+                if let error = maybeError {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let customerInfo = maybeCustomerInfo else {
+                    fatalError("Expected non-nil result 'customerInfo' for nil error")
+                }
+                continuation.resume(returning: customerInfo)
+            }
+        }
+    }
+
+    /**
      * Computes whether or not a user is eligible for the introductory pricing period of a given product.
      * You should use this method to determine whether or not you show the user the normal product price or
      * the introductory price. This also applies to trials (trials are considered a type of introductory pricing).

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -626,7 +626,7 @@ public extension Purchases {
      * indicating whether the user was created for the first time in the RevenueCat backend.
      * See https://docs.revenuecat.com/docs/user-ids
      */
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0 , *)
+    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     func logIn(_ appUserID: String) async throws -> (CustomerInfo, Bool) {
         return try await withCheckedThrowingContinuation { continuation in
             logIn(appUserID) { customerInfo, created, error in

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -815,22 +815,7 @@ public extension Purchases {
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     // swiftlint:disable:next large_tuple
     func purchase(product: SKProduct) async throws -> (SKPaymentTransaction, CustomerInfo, Bool) {
-        return try await withCheckedThrowingContinuation { continuation in
-            purchase(product: product) { maybeTransaction, maybeCustomerInfo, maybeError, userCancelled in
-                if let error = maybeError {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let customerInfo = maybeCustomerInfo else {
-                    fatalError("Expected non-nil result 'customerInfo' for nil error")
-                }
-                guard let transaction = maybeTransaction else {
-                    fatalError("Expected non-nil result 'transaction' for nil error")
-                }
-
-                continuation.resume(returning: (transaction, customerInfo, userCancelled))
-            }
-        }
+        return try await purchaseAsync(product: product)
     }
 
     /**
@@ -875,22 +860,7 @@ public extension Purchases {
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     // swiftlint:disable:next large_tuple
     func purchase(package: Package) async throws -> (SKPaymentTransaction, CustomerInfo, Bool) {
-        return try await withCheckedThrowingContinuation { continuation in
-            purchase(package: package) { maybeTransaction, maybeCustomerInfo, maybeError, userCancelled in
-                if let error = maybeError {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let customerInfo = maybeCustomerInfo else {
-                    fatalError("Expected non-nil result 'customerInfo' for nil error")
-                }
-                guard let transaction = maybeTransaction else {
-                    fatalError("Expected non-nil result 'transaction' for nil error")
-                }
-
-                continuation.resume(returning: (transaction, customerInfo, userCancelled))
-            }
-        }
+        return try await purchaseAsync(package: package)
     }
 
     /**
@@ -946,24 +916,7 @@ public extension Purchases {
     func purchase(product: SKProduct, discount: SKPaymentDiscount) async throws ->
     // swiftlint:disable:next large_tuple
     (SKPaymentTransaction, CustomerInfo, Bool) {
-
-        return try await withCheckedThrowingContinuation { continuation in
-            purchase(product: product,
-                     discount: discount) { maybeTransaction, maybeCustomerInfo, maybeError, userCancelled in
-                if let error = maybeError {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let customerInfo = maybeCustomerInfo else {
-                    fatalError("Expected non-nil result 'customerInfo' for nil error")
-                }
-                guard let transaction = maybeTransaction else {
-                    fatalError("Expected non-nil result 'transaction' for nil error")
-                }
-
-                continuation.resume(returning: (transaction, customerInfo, userCancelled))
-            }
-        }
+        return try await purchaseAsync(product: product, discount: discount)
     }
 
     /**
@@ -1021,23 +974,7 @@ public extension Purchases {
     func purchase(package: Package, discount: SKPaymentDiscount) async throws ->
     // swiftlint:disable:next large_tuple
     (SKPaymentTransaction, CustomerInfo, Bool) {
-        return try await withCheckedThrowingContinuation { continuation in
-            purchase(package: package,
-                     discount: discount) { maybeTransaction, maybeCustomerInfo, maybeError, userCancelled in
-                if let error = maybeError {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let customerInfo = maybeCustomerInfo else {
-                    fatalError("Expected non-nil result 'customerInfo' for nil error")
-                }
-                guard let transaction = maybeTransaction else {
-                    fatalError("Expected non-nil result 'transaction' for nil error")
-                }
-
-                continuation.resume(returning: (transaction, customerInfo, userCancelled))
-            }
-        }
+        return try await purchaseAsync(package: package, discount: discount)
     }
 
     /**
@@ -1074,18 +1011,7 @@ public extension Purchases {
      */
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     func syncPurchases() async throws -> CustomerInfo {
-        return try await withCheckedThrowingContinuation { continuation in
-            syncPurchases { maybeCustomerInfo, maybeError in
-                if let error = maybeError {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let customerInfo = maybeCustomerInfo else {
-                    fatalError("Expected non-nil result 'customerInfo' for nil error")
-                }
-                continuation.resume(returning: customerInfo)
-            }
-        }
+        return try await syncPurchasesAsync()
     }
 
     /**

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -712,7 +712,7 @@ public extension Purchases {
      * Called immediately if offerings are cached. Offerings will be nil if an error occurred.
      */
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
-    func getOfferings() async throws -> Offerings {
+    func offerings() async throws -> Offerings {
         return try await withCheckedThrowingContinuation { continuation in
             getOfferings { maybeOfferings, maybeError in
                 if let error = maybeError {
@@ -749,7 +749,7 @@ public extension Purchases {
      * Called immediately if ``CustomerInfo`` is cached. Customer info can be nil * if an error occurred.
      */
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
-    func getCustomerInfo() async throws -> CustomerInfo {
+    func customerInfo() async throws -> CustomerInfo {
         return try await withCheckedThrowingContinuation { continuation in
             getCustomerInfo { maybeCustomerInfo, maybeError in
                 if let error = maybeError {
@@ -806,7 +806,7 @@ public extension Purchases {
      * If the fetch fails for any reason it will return an empty array.
      */
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
-    func getProducts(_ productIdentifiers: [String]) async -> [SKProduct] {
+    func products(_ productIdentifiers: [String]) async -> [SKProduct] {
         return await withCheckedContinuation { continuation in
             getProducts(productIdentifiers) { result in
                 continuation.resume(returning: result)

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1311,8 +1311,7 @@ public extension Purchases {
      * Keep in mind the status could be `userCancelled`
      * If the request was unsuccessful, there will be an `Error`.
      */
-    @available(iOS 15.0, *)
-    @available(macOS, unavailable)
+    @available(iOS 15.0, macOS 12.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     @objc func beginRefundRequest(for productID: String) async throws -> RefundRequestStatus {

--- a/Purchases/Public/PurchasesDelegate.swift
+++ b/Purchases/Public/PurchasesDelegate.swift
@@ -16,7 +16,7 @@ import Foundation
 import StoreKit
 
 /**
- * Delegate for ``Purchases`` responsible for handling updating your app's state in response to updated purchaser info
+ * Delegate for ``Purchases`` responsible for handling updating your app's state in response to updated customer info
  * or promotional product purchases.
  *
  * - Note: Delegate methods can be called at any time after the `delegate` is set, not just in response to
@@ -37,7 +37,7 @@ import StoreKit
     optional func purchases(_ purchases: Purchases, didReceiveUpdated purchaserInfo: CustomerInfo)
 
     /**
-     * Called whenever ``Purchases`` receives updated purchaser info. This may happen periodically
+     * Called whenever ``Purchases`` receives updated customer info. This may happen periodically
      * throughout the life of the app if new information becomes available (e.g. UIApplicationDidBecomeActive).*
      * - Parameter purchases: Related ``Purchases`` object
      * - Parameter customerInfo: Updated ``CustomerInfo``

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -281,6 +281,7 @@ class PurchasesOrchestrator {
     }
 
     @available(iOS 15.0, *)
+    @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     func beginRefundRequest(for productID: String, completion: @escaping (RefundRequestStatus, Error?) -> Void) {

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -286,6 +286,7 @@ class PurchasesOrchestrator {
 #if os(iOS)
 
     @available(iOS 15.0, *)
+    @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     func beginRefundRequest(for productID: String, completion: @escaping (RefundRequestStatus, Error?) -> Void) {

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -281,7 +281,6 @@ class PurchasesOrchestrator {
     }
 
     @available(iOS 15.0, *)
-    @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     func beginRefundRequest(for productID: String, completion: @escaping (RefundRequestStatus, Error?) -> Void) {

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -267,6 +267,8 @@ class PurchasesOrchestrator {
         storeKitWrapper.add(payment)
     }
 
+#if os(iOS) || os(macOS)
+
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     func showManageSubscriptionModal(completion: @escaping (Error?) -> Void) {
@@ -279,6 +281,9 @@ class PurchasesOrchestrator {
             }
         }
     }
+#endif
+
+#if os(iOS)
 
     @available(iOS 15.0, *)
     @available(watchOS, unavailable)
@@ -293,6 +298,8 @@ class PurchasesOrchestrator {
             }
         }
     }
+
+#endif
 
 }
 

--- a/Purchases/Support/BeginRefundRequestHelper.swift
+++ b/Purchases/Support/BeginRefundRequestHelper.swift
@@ -23,7 +23,6 @@ class BeginRefundRequestHelper {
 
 #if os(iOS) || targetEnvironment(macCatalyst)
     @available(iOS 15.0, *)
-    @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     lazy var sk2Helper = SK2BeginRefundRequestHelper()
@@ -38,7 +37,6 @@ class BeginRefundRequestHelper {
      * on the current platform, else passes the request on to `beginRefundRequest(productID:)`.
      */
     @available(iOS 15.0, *)
-    @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     func beginRefundRequest(productID: String, completion: @escaping (Result<RefundRequestStatus, Error>) -> Void) {
@@ -58,7 +56,6 @@ class BeginRefundRequestHelper {
 
 #if os(iOS) || targetEnvironment(macCatalyst)
 @available(iOS 15.0, *)
-@available(macOS, unavailable)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 private extension BeginRefundRequestHelper {
@@ -69,7 +66,6 @@ private extension BeginRefundRequestHelper {
      */
     @MainActor
     @available(iOS 15.0, *)
-    @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     func beginRefundRequest(productID: String) async -> Result<RefundRequestStatus, Error> {

--- a/Purchases/Support/BeginRefundRequestHelper.swift
+++ b/Purchases/Support/BeginRefundRequestHelper.swift
@@ -21,7 +21,7 @@ class BeginRefundRequestHelper {
 
     private let systemInfo: SystemInfo
 
-#if os(iOS) || targetEnvironment(macCatalyst)
+#if os(iOS)
     @available(iOS 15.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
@@ -32,29 +32,27 @@ class BeginRefundRequestHelper {
         self.systemInfo = systemInfo
     }
 
+#if os(iOS)
     /*
      * Entry point for beginning the refund request. fatalErrors if beginning a refund request is not supported
      * on the current platform, else passes the request on to `beginRefundRequest(productID:)`.
      */
     @available(iOS 15.0, *)
+    @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     func beginRefundRequest(productID: String, completion: @escaping (Result<RefundRequestStatus, Error>) -> Void) {
-#if os(iOS) || targetEnvironment(macCatalyst)
         _ = Task<Void, Never> {
             let result = await self.beginRefundRequest(productID: productID)
             completion(result)
         }
 
         return
-#else
-        fatalError(Strings.purchase.begin_refund_request_unsupported.description)
-#endif
     }
-
+#endif
 }
 
-#if os(iOS) || targetEnvironment(macCatalyst)
+#if os(iOS)
 @available(iOS 15.0, *)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
@@ -92,9 +90,9 @@ private extension BeginRefundRequestHelper {
 
     /// User canceled submission of the refund request.
     @objc(RCRefundRequestUserCancelled) case userCancelled = 0
-     /// Apple has received the refund request.
+    /// Apple has received the refund request.
     @objc(RCRefundRequestSuccess) case success
-     /// There was an error with the request. See message for more details.
+    /// There was an error with the request. See message for more details.
     @objc(RCRefundRequestError) case error
 
 }

--- a/Purchases/Support/BeginRefundRequestHelper.swift
+++ b/Purchases/Support/BeginRefundRequestHelper.swift
@@ -23,6 +23,7 @@ class BeginRefundRequestHelper {
 
 #if os(iOS) || targetEnvironment(macCatalyst)
     @available(iOS 15.0, *)
+    @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     lazy var sk2Helper = SK2BeginRefundRequestHelper()
@@ -37,6 +38,7 @@ class BeginRefundRequestHelper {
      * on the current platform, else passes the request on to `beginRefundRequest(productID:)`.
      */
     @available(iOS 15.0, *)
+    @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     func beginRefundRequest(productID: String, completion: @escaping (Result<RefundRequestStatus, Error>) -> Void) {
@@ -56,6 +58,7 @@ class BeginRefundRequestHelper {
 
 #if os(iOS) || targetEnvironment(macCatalyst)
 @available(iOS 15.0, *)
+@available(macOS, unavailable)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 private extension BeginRefundRequestHelper {
@@ -66,6 +69,7 @@ private extension BeginRefundRequestHelper {
      */
     @MainActor
     @available(iOS 15.0, *)
+    @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     func beginRefundRequest(productID: String) async -> Result<RefundRequestStatus, Error> {

--- a/Purchases/Support/BeginRefundRequestHelper.swift
+++ b/Purchases/Support/BeginRefundRequestHelper.swift
@@ -23,6 +23,7 @@ class BeginRefundRequestHelper {
 
 #if os(iOS)
     @available(iOS 15.0, *)
+    @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     lazy var sk2Helper = SK2BeginRefundRequestHelper()
@@ -54,6 +55,7 @@ class BeginRefundRequestHelper {
 
 #if os(iOS)
 @available(iOS 15.0, *)
+@available(macOS, unavailable)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 private extension BeginRefundRequestHelper {
@@ -63,9 +65,6 @@ private extension BeginRefundRequestHelper {
      * transaction before calling into `SK2BeginRefundRequestHelper`'s `initiateRefundRequest`.
      */
     @MainActor
-    @available(iOS 15.0, *)
-    @available(watchOS, unavailable)
-    @available(tvOS, unavailable)
     func beginRefundRequest(productID: String) async -> Result<RefundRequestStatus, Error> {
         guard let windowScene = systemInfo.sharedUIApplication?.currentWindowScene else {
             return .failure(ErrorUtils.storeProblemError(withMessage: "Failed to get UIWindowScene"))

--- a/Purchases/Support/ManageSubscriptionsModalHelper.swift
+++ b/Purchases/Support/ManageSubscriptionsModalHelper.swift
@@ -27,6 +27,8 @@ class ManageSubscriptionsModalHelper {
         self.identityManager = identityManager
     }
 
+#if os(iOS) || os(macOS)
+
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     func showManageSubscriptionModal(completion: @escaping (Result<Void, Error>) -> Void) {
@@ -63,6 +65,8 @@ class ManageSubscriptionsModalHelper {
             self.openURL(managementURL, completion: completion)
         }
     }
+
+#endif
 
 }
 

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		2DC5622E24EC636C0031F69B /* Transaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E355CBB3F3A31A32687B14 /* Transaction.swift */; };
 		2DC5623024EC63730031F69B /* OperationDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DDA3E4624DB0B5400EDFE5B /* OperationDispatcher.swift */; };
 		2DC5623224EC63730031F69B /* TransactionsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3597020F24BF6A710010506E /* TransactionsFactory.swift */; };
+		2DD9F4BE274EADC20031AE2C /* Purchases+async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD9F4BD274EADC20031AE2C /* Purchases+async.swift */; };
 		2DDF419624F6F331005BC22D /* ProductsRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35E8DCF998D9DB63850F8 /* ProductsRequestFactory.swift */; };
 		2DDF419724F6F331005BC22D /* DateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3567189CF6A746EE3CCC2 /* DateExtensions.swift */; };
 		2DDF419D24F6F331005BC22D /* IntroEligibilityCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D97458E24BDFCEF006245E9 /* IntroEligibilityCalculator.swift */; };
@@ -374,6 +375,7 @@
 		2DC5621E24EC63430031F69B /* RevenueCatTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RevenueCatTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2DC5622524EC63430031F69B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2DD269162522A20A006AC4BC /* DictionaryExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryExtensionsTests.swift; sourceTree = "<group>"; };
+		2DD9F4BD274EADC20031AE2C /* Purchases+async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Purchases+async.swift"; sourceTree = "<group>"; };
 		2DDA3E4624DB0B5400EDFE5B /* OperationDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationDispatcher.swift; sourceTree = "<group>"; };
 		2DDE559A24C8B5E300DCB087 /* verifyReceiptSample1.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = verifyReceiptSample1.txt; sourceTree = "<group>"; };
 		2DDE559B24C8B5E300DCB087 /* base64encodedreceiptsample1.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = base64encodedreceiptsample1.txt; sourceTree = "<group>"; };
@@ -1273,6 +1275,7 @@
 				57EAE52C274468900060EB74 /* RawDataContainer.swift */,
 				2DC5621824EC63430031F69B /* RevenueCat.h */,
 				37E355CBB3F3A31A32687B14 /* Transaction.swift */,
+				2DD9F4BD274EADC20031AE2C /* Purchases+async.swift */,
 			);
 			path = Public;
 			sourceTree = "<group>";
@@ -1708,6 +1711,7 @@
 				B3AA6238268B926F00894871 /* SystemInfo.swift in Sources */,
 				2D294E5C26DECFD500B8FE4F /* StoreKit2TransactionListener.swift in Sources */,
 				2DDF41B524F6F387005BC22D /* AppleReceiptBuilder.swift in Sources */,
+				2DD9F4BE274EADC20031AE2C /* Purchases+async.swift in Sources */,
 				B3C4AAD526B8911300E1B3C8 /* Backend.swift in Sources */,
 				B34D2AA626976FC700D88C3A /* ErrorCode.swift in Sources */,
 				B39E811D268E887500D31189 /* SubscriberAttribute.swift in Sources */,


### PR DESCRIPTION
Adds `async` alternatives to all of our public methods that have completion blocks. Let me know if I missed any. 

This is somewhat necessary, because for purchases-ios v3, these async alternatives would be auto-generated, because it's an objective-c project. 
However, for Swift targets, this isn't done automatically. So not having them now means that we're effectively breaking the API. 

Remaning work:
- add more detail to the v4 migration guide, including some of the naming differences for methods that start with a `get` prefix, which Apple recommends against for `async` methods. 

### Notes: 
- I'm setting min deployment target to iOS 15.0 (and equivalent OS versions) for now, but as soon as Xcode 13.2 is stable, we can update that to 13.0 🎉 
