### PR TITLE
Check for productsWithIntroOffers first, before backend

### DIFF
--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -372,10 +372,10 @@ class Backend {
         }
     }
 
-    func getIntroEligibility(appUserID: String,
-                             receiptData: Data,
-                             productIdentifiers: [String],
-                             completion: @escaping IntroEligibilityResponseHandler) {
+    func fetchIntroEligibility(appUserID: String,
+                               receiptData: Data,
+                               productIdentifiers: [String],
+                               completion: @escaping IntroEligibilityResponseHandler) {
         guard productIdentifiers.count > 0 else {
             completion([:], nil)
             return

--- a/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -93,23 +93,6 @@ class TrialOrIntroPriceEligibilityChecker {
         return introDict
     }
 
-    @available(iOS 11.2, macOS 10.13.2, macCatalyst 13.0, tvOS 11.2, watchOS 6.2, *)
-    func productsWithIntroOffers(productIdentifiers: [String], completion: @escaping ReceiveIntroEligibilityBlock) {
-        self.productsManager.products(withIdentifiers: Set(productIdentifiers)) { products in
-            let eligibility: [(String, IntroEligibility)] = Array(products).compactMap {
-                guard $0.introductoryPrice != nil else {
-                    return nil
-                }
-                return ($0.productIdentifier, IntroEligibility(eligibilityStatus: .eligible))
-            }
-            var productIdsToIntroEligibleStatus: [String: IntroEligibility] = [:]
-            eligibility.forEach { (productId, eligibility) in
-                productIdsToIntroEligibleStatus[productId] = eligibility
-            }
-            completion(productIdsToIntroEligibleStatus)
-        }
-    }
-
 }
 
 fileprivate extension TrialOrIntroPriceEligibilityChecker {
@@ -160,6 +143,18 @@ fileprivate extension TrialOrIntroPriceEligibilityChecker {
 }
 
 private extension TrialOrIntroPriceEligibilityChecker {
+
+    @available(iOS 11.2, macOS 10.13.2, macCatalyst 13.0, tvOS 11.2, watchOS 6.2, *)
+    func productsWithIntroOffers(productIdentifiers: [String], completion: @escaping ReceiveIntroEligibilityBlock) {
+        self.productsManager.products(withIdentifiers: Set(productIdentifiers)) { products in
+            let eligibility: [(String, IntroEligibility)] = Array(products)
+                .filter { $0.introductoryPrice != nil }
+                .map { ($0.productIdentifier, IntroEligibility(eligibilityStatus: .eligible)) }
+
+            let productIdsToIntroEligibleStatus = Dictionary(uniqueKeysWithValues: eligibility)
+            completion(productIdsToIntroEligibleStatus)
+        }
+    }
 
     func getIntroEligibility(with receiptData: Data,
                              productIdentifiers: [String],

--- a/PurchasesTests/Mocks/MockBackend.swift
+++ b/PurchasesTests/Mocks/MockBackend.swift
@@ -91,10 +91,10 @@ class MockBackend: Backend {
         completion: IntroEligibilityResponseHandler?)]()
     var stubbedGetIntroEligibilityCompletionResult: (eligibilities: [String: IntroEligibility], error: Error?)?
 
-    override func getIntroEligibility(appUserID: String,
-                                      receiptData: Data,
-                                      productIdentifiers: [String],
-                                      completion: @escaping IntroEligibilityResponseHandler) {
+    override func fetchIntroEligibility(appUserID: String,
+                                        receiptData: Data,
+                                        productIdentifiers: [String],
+                                        completion: @escaping IntroEligibilityResponseHandler) {
         invokedGetIntroEligibility = true
         invokedGetIntroEligibilityCount += 1
         invokedGetIntroEligibilityParameters = (appUserID, receiptData, productIdentifiers, completion)

--- a/PurchasesTests/Mocks/MockIntroEligibilityCalculator.swift
+++ b/PurchasesTests/Mocks/MockIntroEligibilityCalculator.swift
@@ -31,4 +31,5 @@ class MockIntroEligibilityCalculator: IntroEligibilityCalculator {
             completion(result.0, result.1)
         }
     }
+
 }

--- a/PurchasesTests/Mocks/MockTrialOrIntroPriceEligibilityChecker.swift
+++ b/PurchasesTests/Mocks/MockTrialOrIntroPriceEligibilityChecker.swift
@@ -72,4 +72,5 @@ class MockTrialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityCheck
 
         return stubbedSk2checkTrialOrIntroPriceEligibilityReceiveEligibilityResult
     }
+
 }

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -664,10 +664,10 @@ class BackendTests: XCTestCase {
     }
 
     func testEmptyEligibilityCheckDoesNothing() {
-        backend?.getIntroEligibility(appUserID: userID,
-                                     receiptData: Data(),
-                                     productIdentifiers: [],
-                                     completion: { (eligibilities, error) in
+        backend?.fetchIntroEligibility(appUserID: userID,
+                                       receiptData: Data(),
+                                       productIdentifiers: [],
+                                       completion: { (eligibilities, error) in
             expect(error).to(beNil())
         })
         expect(self.httpClient.calls.count).to(equal(0))
@@ -684,10 +684,10 @@ class BackendTests: XCTestCase {
         var eligibility: [String: IntroEligibility]?
 
         let products = ["producta", "productb", "productc", "productd"]
-        backend?.getIntroEligibility(appUserID: userID,
-                                     receiptData: Data(1...3),
-                                     productIdentifiers: products,
-                                     completion: {(productEligibility, error) in
+        backend?.fetchIntroEligibility(appUserID: userID,
+                                       receiptData: Data(1...3),
+                                       productIdentifiers: products,
+                                       completion: {(productEligibility, error) in
             expect(error).to(beNil())
             eligibility = productEligibility
         })
@@ -722,10 +722,10 @@ class BackendTests: XCTestCase {
         var eligibility: [String: IntroEligibility]?
 
         let products = ["producta", "productb", "productc"]
-        backend?.getIntroEligibility(appUserID: userID,
-                                     receiptData: Data.init(1...2),
-                                     productIdentifiers: products,
-                                     completion: {(productEligibility, error) in
+        backend?.fetchIntroEligibility(appUserID: userID,
+                                       receiptData: Data.init(1...2),
+                                       productIdentifiers: products,
+                                       completion: {(productEligibility, error) in
             expect(error).to(beNil())
             eligibility = productEligibility
         })
@@ -744,10 +744,10 @@ class BackendTests: XCTestCase {
         var eligibility: [String: IntroEligibility]?
         let products = ["producta"]
         var eventualError: NSError?
-        backend?.getIntroEligibility(appUserID: "",
-                                     receiptData: Data.init(1...2),
-                                     productIdentifiers: products,
-                                     completion: {(productEligibility, error) in
+        backend?.fetchIntroEligibility(appUserID: "",
+                                       receiptData: Data.init(1...2),
+                                       productIdentifiers: products,
+                                       completion: {(productEligibility, error) in
             eventualError = error as NSError?
             eligibility = productEligibility
         })
@@ -761,10 +761,10 @@ class BackendTests: XCTestCase {
         var wasRequestSent = errorComingFromBackend != nil
         expect(wasRequestSent) == false
 
-        backend?.getIntroEligibility(appUserID: "   ",
-                                     receiptData: Data.init(1...2),
-                                     productIdentifiers: products,
-                                     completion: {(productEligibility, error) in
+        backend?.fetchIntroEligibility(appUserID: "   ",
+                                       receiptData: Data.init(1...2),
+                                       productIdentifiers: products,
+                                       completion: {(productEligibility, error) in
             eventualError = error as NSError?
             eligibility = productEligibility
         })
@@ -798,10 +798,10 @@ class BackendTests: XCTestCase {
         var eligibility: [String: IntroEligibility]?
 
         let products = ["producta", "productb", "productc"]
-        backend?.getIntroEligibility(appUserID: userID,
-                                     receiptData: Data.init(1...2),
-                                     productIdentifiers: products,
-                                     completion: {(productEligbility, error) in
+        backend?.fetchIntroEligibility(appUserID: userID,
+                                       receiptData: Data.init(1...2),
+                                       productIdentifiers: products,
+                                       completion: {(productEligbility, error) in
             expect(error).to(beNil())
             eligibility = productEligbility
         })
@@ -1113,9 +1113,9 @@ class BackendTests: XCTestCase {
         var eligibility: [String: IntroEligibility]?
 
         let products = ["producta", "productb", "productc"]
-        backend?.getIntroEligibility(appUserID: userID,
-                                     receiptData: Data(),
-                                     productIdentifiers: products, completion: {(productEligibility, error) in
+        backend?.fetchIntroEligibility(appUserID: userID,
+                                       receiptData: Data(),
+                                       productIdentifiers: products, completion: {(productEligibility, error) in
             expect(error).to(beNil())
             eligibility = productEligibility
         })

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -159,10 +159,10 @@ class PurchasesTests: XCTestCase {
 
         var postedProductIdentifiers: [String]?
 
-        override func getIntroEligibility(appUserID: String,
-                                          receiptData: Data,
-                                          productIdentifiers: [String],
-                                          completion: @escaping IntroEligibilityResponseHandler) {
+        override func fetchIntroEligibility(appUserID: String,
+                                            receiptData: Data,
+                                            productIdentifiers: [String],
+                                            completion: @escaping IntroEligibilityResponseHandler) {
             postedProductIdentifiers = productIdentifiers
 
             var eligibilities = [String: IntroEligibility]()


### PR DESCRIPTION
If we can return productsWithIntroOffers for all productIds without asking the backend, we should. Otherwise, we should filter out the ids that we know about and only ask the backend for ones we don't.
Fixes #982
