### PR TITLE
Don't allow empty string for `appUserID` during initialization

### DIFF
--- a/Purchases/FoundationExtensions/String+Extensions.swift
+++ b/Purchases/FoundationExtensions/String+Extensions.swift
@@ -20,6 +20,30 @@ extension String {
         ROT13.string(self)
     }
 
+    /// Returns `nil` if `self` is an empty string.
+    var notEmpty: String? {
+        return self.isEmpty
+        ? nil
+        : self
+    }
+
+    /// Returns `nil` if `self` is an empty string or it only contains whitespaces.
+    var notEmptyOrWhitespaces: String? {
+        return self.trimmingWhitespacesAndNewLines.isEmpty
+        ? nil
+        : self
+    }
+
+    var trimmingWhitespacesAndNewLines: String {
+        return self.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+internal extension Optional where Wrapped == String {
+    /// Returns `nil` if `self` is an empty string.
+    var notEmpty: String? {
+        return self.flatMap { $0.notEmpty }
+    }
 }
 
 private struct ROT13 {

--- a/Purchases/Identity/IdentityManager.swift
+++ b/Purchases/Identity/IdentityManager.swift
@@ -49,7 +49,11 @@ class IdentityManager {
         self.backend = backend
         self.customerInfoManager = customerInfoManager
 
-        let appUserID = appUserID
+        if appUserID?.isEmpty == true {
+            Logger.warn(Strings.identity.logging_in_with_empty_appuserid)
+        }
+
+        let appUserID = appUserID?.notEmptyOrWhitespaces
             ?? deviceCache.cachedAppUserID
             ?? deviceCache.cachedLegacyAppUserID
             ?? Self.generateRandomID()
@@ -61,9 +65,9 @@ class IdentityManager {
     }
 
     func logIn(appUserID: String, completion: @escaping (CustomerInfo?, Bool, Error?) -> Void) {
-        let newAppUserID = appUserID.trimmingCharacters(in: .whitespacesAndNewlines)
+        let newAppUserID = appUserID.trimmingWhitespacesAndNewLines
         guard !newAppUserID.isEmpty else {
-            Logger.error(Strings.identity.logging_in_with_nil_appuserid)
+            Logger.error(Strings.identity.logging_in_with_empty_appuserid)
             completion(nil, false, ErrorUtils.missingAppUserIDError())
             return
         }

--- a/Purchases/Logging/Strings/IdentityStrings.swift
+++ b/Purchases/Logging/Strings/IdentityStrings.swift
@@ -18,7 +18,7 @@ enum IdentityStrings {
 
     case changing_app_user_id(from: String, to: String)
 
-    case logging_in_with_nil_appuserid
+    case logging_in_with_empty_appuserid
 
     case logging_in_with_same_appuserid
 
@@ -46,9 +46,9 @@ extension IdentityStrings: CustomStringConvertible {
         switch self {
         case .changing_app_user_id(let from, let to):
             return "Changing App User ID: \(from) -> \(to)"
-        case .logging_in_with_nil_appuserid:
-            return "The appUserID passed to logIn is nil or empty. " +
-                "Can't log in. This method should only be called with non-nil and non-empty values."
+        case .logging_in_with_empty_appuserid:
+            return "The appUserID is empty. " +
+                "This method should only be called with non-empty values."
         case .logging_in_with_same_appuserid:
             return "The appUserID passed to logIn is the same as the one " +
                 "already cached. No action will be taken."

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1299,7 +1299,8 @@ public extension Purchases {
      * - Parameter apiKey: The API Key generated for your app from https://app.revenuecat.com/
      *
      * - Parameter appUserID: The unique app user id for this user. This user id will allow users to share their
-     * purchases and subscriptions across devices. Pass nil if you want `Purchases` to generate this for you.
+     * purchases and subscriptions across devices. Pass `nil` if you want `Purchases` to generate this for you.
+     * An empty `appUserID` is equivalent to `nil`.
      *
      * - Returns: An instantiated `Purchases` object that has been set as a singleton.
      */
@@ -1317,7 +1318,8 @@ public extension Purchases {
      * - Parameter apiKey: The API Key generated for your app from https://app.revenuecat.com/
      *
      * - Parameter appUserID: The unique app user id for this user. This user id will allow users to share their
-     * purchases and subscriptions across devices. Pass nil if you want `Purchases` to generate this for you.
+     * purchases and subscriptions across devices. Pass `nil` if you want `Purchases` to generate this for you.
+     * An empty `appUserID` is equivalent to `nil`.
      *
      * - Parameter observerMode: Set this to `true` if you have your own IAP implementation and want to use only
      * RevenueCat's backend. Default is `false`.
@@ -1340,7 +1342,8 @@ public extension Purchases {
      * - Parameter apiKey: The API Key generated for your app from https://app.revenuecat.com/
      *
      * - Parameter appUserID: The unique app user id for this user. This user id will allow users to share their
-     * purchases and subscriptions across devices. Pass nil if you want `Purchases` to generate this for you.
+     * purchases and subscriptions across devices. Pass `nil` if you want `Purchases` to generate this for you.
+     * An empty `appUserID` is equivalent to `nil`.
      *
      * - Parameter observerMode: Set this to `true` if you have your own IAP implementation and want to use only
      * RevenueCat's backend. Default is `false`.

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1299,8 +1299,8 @@ public extension Purchases {
      * - Parameter apiKey: The API Key generated for your app from https://app.revenuecat.com/
      *
      * - Parameter appUserID: The unique app user id for this user. This user id will allow users to share their
-     * purchases and subscriptions across devices. Pass `nil` if you want `Purchases` to generate this for you.
-     * An empty `appUserID` is equivalent to `nil`.
+     * purchases and subscriptions across devices. Pass `nil` or an empty string if you want `Purchases`
+     * to generate this for you.
      *
      * - Returns: An instantiated `Purchases` object that has been set as a singleton.
      */
@@ -1318,8 +1318,8 @@ public extension Purchases {
      * - Parameter apiKey: The API Key generated for your app from https://app.revenuecat.com/
      *
      * - Parameter appUserID: The unique app user id for this user. This user id will allow users to share their
-     * purchases and subscriptions across devices. Pass `nil` if you want `Purchases` to generate this for you.
-     * An empty `appUserID` is equivalent to `nil`.
+     * purchases and subscriptions across devices. Pass `nil` or an empty string if you want `Purchases`
+     * to generate this for you.
      *
      * - Parameter observerMode: Set this to `true` if you have your own IAP implementation and want to use only
      * RevenueCat's backend. Default is `false`.
@@ -1342,8 +1342,8 @@ public extension Purchases {
      * - Parameter apiKey: The API Key generated for your app from https://app.revenuecat.com/
      *
      * - Parameter appUserID: The unique app user id for this user. This user id will allow users to share their
-     * purchases and subscriptions across devices. Pass `nil` if you want `Purchases` to generate this for you.
-     * An empty `appUserID` is equivalent to `nil`.
+     * purchases and subscriptions across devices. Pass `nil` or an empty string if you want `Purchases`
+     * to generate this for you.
      *
      * - Parameter observerMode: Set this to `true` if you have your own IAP implementation and want to use only
      * RevenueCat's backend. Default is `false`.

--- a/PurchasesTests/Identity/IdentityManagerTests.swift
+++ b/PurchasesTests/Identity/IdentityManagerTests.swift
@@ -53,6 +53,12 @@ class IdentityManagerTests: XCTestCase {
         assertCorrectlyIdentified(manager, expectedAppUserID: "cesar")
     }
 
+    func testAppUserIDDoesNotTrimTrailingOrLeadingSpaces() {
+        let name = "  user with spaces "
+        let manager = create(appUserID: name)
+        assertCorrectlyIdentified(manager, expectedAppUserID: name)
+    }
+
     func testConfigureCleansUpSubscriberAttributes() {
         _ = create(appUserID: "andy")
         expect(self.mockDeviceCache.invokedCleanupSubscriberAttributesCount) == 1

--- a/PurchasesTests/Identity/IdentityManagerTests.swift
+++ b/PurchasesTests/Identity/IdentityManagerTests.swift
@@ -66,6 +66,18 @@ class IdentityManagerTests: XCTestCase {
         assertCorrectlyIdentified(newManager, expectedAppUserID: newAppUserID)
     }
 
+    func testNilAppUserIDBecomesAnonimous() {
+        assertCorrectlyIdentifiedWithAnonymous(create(appUserID: nil))
+    }
+
+    func testEmptyAppUserIDBecomesAnonymous() {
+        assertCorrectlyIdentifiedWithAnonymous(create(appUserID: ""))
+    }
+
+    func testEmptyAppUserWithSpacesIDBecomesAnonymous() {
+        assertCorrectlyIdentifiedWithAnonymous(create(appUserID: "  "))
+    }
+
     func testMigrationFromRandomIDConfiguringAnonymously() {
         self.mockDeviceCache.stubbedLegacyAppUserID = "an_old_random"
 

--- a/PurchasesTests/Mocks/MockDeviceCache.swift
+++ b/PurchasesTests/Mocks/MockDeviceCache.swift
@@ -55,7 +55,7 @@ class MockDeviceCache: DeviceCache {
 
     override func cachedCustomerInfoData(appUserID: String) -> Data? {
         cachedCustomerInfoCount += 1
-        return cachedCustomerInfo[appUserID];
+        return cachedCustomerInfo[appUserID]
     }
 
     override func isCustomerInfoCacheStale(appUserID: String, isAppBackgrounded: Bool) -> Bool {


### PR DESCRIPTION
Fixes [sc-10159].

Based on top of #974 because it contains a significant simplification of `IdentityManager` that makes this a lot easier.

Note that `Purchases.logIn` will still fail with an error when trying to use an empty string. This PR does not change that behavior.