### PR TITLE
Replaced custom `DateFormatter` with new `ISO8601DateFormatter`

### DIFF
--- a/Purchases/FoundationExtensions/DateFormatter+Extensions.swift
+++ b/Purchases/FoundationExtensions/DateFormatter+Extensions.swift
@@ -25,26 +25,16 @@ protocol DateFormatterType {
 extension DateFormatter: DateFormatterType {}
 extension ISO8601DateFormatter: DateFormatterType {}
 
-internal extension ISO8601DateFormatter {
+extension DateFormatterType {
 
-    private static let withMilliseconds: DateFormatterType = {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [
-            .withInternetDateTime,
-            .withFractionalSeconds
-        ]
+    func date(from maybeDateString: String?) -> Date? {
+        guard let dateString = maybeDateString else { return nil }
+        return date(from: dateString)
+    }
 
-        return formatter
-    }()
+}
 
-    private static let noMilliseconds: DateFormatterType = {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [
-            .withInternetDateTime
-        ]
-
-        return formatter
-    }()
+extension ISO8601DateFormatter {
 
     /// This behaves like a traditional `DateFormatter` with format
     /// `yyyy-MM-dd'T'HH:mm:ssZ"`, so milliseconds are optional.
@@ -65,11 +55,25 @@ internal extension ISO8601DateFormatter {
 
 }
 
-internal extension DateFormatterType {
+private extension ISO8601DateFormatter {
 
-    func date(from maybeDateString: String?) -> Date? {
-        guard let dateString = maybeDateString else { return nil }
-        return date(from: dateString)
-    }
+    static let withMilliseconds: DateFormatterType = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [
+            .withInternetDateTime,
+            .withFractionalSeconds
+        ]
+
+        return formatter
+    }()
+
+    static let noMilliseconds: DateFormatterType = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [
+            .withInternetDateTime
+        ]
+
+        return formatter
+    }()
 
 }

--- a/Purchases/FoundationExtensions/DateFormatter+Extensions.swift
+++ b/Purchases/FoundationExtensions/DateFormatter+Extensions.swift
@@ -20,24 +20,10 @@ protocol DateFormatterType {
     func string(from date: Date) -> String
     func date(from string: String) -> Date?
 
-    var dateDecodingStrategy: JSONDecoder.DateDecodingStrategy { get }
 }
 
-extension DateFormatter: DateFormatterType {
-
-    var dateDecodingStrategy: JSONDecoder.DateDecodingStrategy {
-        return .formatted(self)
-    }
-
-}
-
-extension ISO8601DateFormatter: DateFormatterType {
-
-    var dateDecodingStrategy: JSONDecoder.DateDecodingStrategy {
-        return .iso8601
-    }
-
-}
+extension DateFormatter: DateFormatterType {}
+extension ISO8601DateFormatter: DateFormatterType {}
 
 internal extension ISO8601DateFormatter {
 
@@ -71,10 +57,6 @@ internal extension ISO8601DateFormatter {
 
             func string(from date: Date) -> String {
                 return ISO8601DateFormatter.withMilliseconds.string(from: date)
-            }
-
-            var dateDecodingStrategy: JSONDecoder.DateDecodingStrategy {
-                return .iso8601
             }
         }
 

--- a/Purchases/FoundationExtensions/DateFormatter+Extensions.swift
+++ b/Purchases/FoundationExtensions/DateFormatter+Extensions.swift
@@ -15,22 +15,17 @@
 import Foundation
 
 /// A type that can convert from and to `Dates`.
-public protocol DateFormatterType {
+protocol DateFormatterType {
 
-    /// Returns a date representation of a specified string that the system interprets
-    /// using the receiver’s current settings.
     func string(from date: Date) -> String
-    /// Returns a string representation of a specified date that the system formats
-    /// using the receiver’s current settings.
     func date(from string: String) -> Date?
 
-    /// Creates a `JSONDecoder.DateDecodingStrategy` from `self`
     var dateDecodingStrategy: JSONDecoder.DateDecodingStrategy { get }
 }
 
 extension DateFormatter: DateFormatterType {
 
-    public var dateDecodingStrategy: JSONDecoder.DateDecodingStrategy {
+    var dateDecodingStrategy: JSONDecoder.DateDecodingStrategy {
         return .formatted(self)
     }
 
@@ -38,7 +33,7 @@ extension DateFormatter: DateFormatterType {
 
 extension ISO8601DateFormatter: DateFormatterType {
 
-    public var dateDecodingStrategy: JSONDecoder.DateDecodingStrategy {
+    var dateDecodingStrategy: JSONDecoder.DateDecodingStrategy {
         return .iso8601
     }
 

--- a/Purchases/LocalReceiptParsing/DataConverters/ArraySlice_UInt8+Extensions.swift
+++ b/Purchases/LocalReceiptParsing/DataConverters/ArraySlice_UInt8+Extensions.swift
@@ -44,7 +44,8 @@ extension ArraySlice where Element == UInt8 {
 
     func toDate() -> Date? {
         guard let dateString = String(bytes: Array(self), encoding: .ascii) else { return nil }
-        return DateFormatter.date(fromISO8601SecondsOrMillisecondsString: dateString)
+
+        return ISO8601DateFormatter.default.date(from: dateString)
     }
 
     func toData() -> Data {

--- a/Purchases/Public/CustomerInfo.swift
+++ b/Purchases/Public/CustomerInfo.swift
@@ -163,11 +163,11 @@ import Foundation
 
     convenience init(data: [String: Any]) throws {
         try self.init(data: data,
-                      dateFormatter: .iso8601SecondsDateFormatter,
+                      dateFormatter: ISO8601DateFormatter.default,
                       transactionsFactory: TransactionsFactory())
     }
 
-    init(data: [String: Any], dateFormatter: DateFormatter, transactionsFactory: TransactionsFactory) throws {
+    init(data: [String: Any], dateFormatter: DateFormatterType, transactionsFactory: TransactionsFactory) throws {
         guard let subscriberObject = data["subscriber"] as? [String: Any] else {
             Logger.error(Strings.customerInfo.missing_json_object_instantiation_error(maybeJsonData: data))
             throw CustomerInfoError.missingJsonObject
@@ -222,7 +222,7 @@ import Foundation
 
     private let allPurchases: [String: [String: Any]]
     private let subscriptionTransactionsByProductId: [String: [String: Any]]
-    private let dateFormatter: DateFormatter
+    private let dateFormatter: DateFormatterType
 
     private lazy var expirationDatesByProductId: [String: Date?] = {
         return parseExpirationDates(transactionsByProductId: subscriptionTransactionsByProductId)
@@ -266,7 +266,7 @@ import Foundation
         let allPurchases: [String: [String: Any]]
 
         init(subscriberData: [String: Any],
-             dateFormatter: DateFormatter,
+             dateFormatter: DateFormatterType,
              transactionsFactory: TransactionsFactory) throws {
             let maybeSubscriptions = subscriberData["subscriptions"] as? [String: [String: Any]] ?? [:]
             self.subscriptionTransactionsByProductId = maybeSubscriptions
@@ -275,13 +275,13 @@ import Foundation
             self.originalApplicationVersion = subscriberData["original_application_version"] as? String
 
             self.originalPurchaseDate =
-            dateFormatter.date(fromString: subscriberData["original_purchase_date"] as? String ?? "")
+            dateFormatter.date(from: subscriberData["original_purchase_date"] as? String ?? "")
 
             guard let firstSeenDateString = subscriberData["first_seen"] as? String else {
                 throw SubscriberDataError.firstSeenMissing
             }
 
-            guard let firstSeenDate = dateFormatter.date(fromString: firstSeenDateString) else {
+            guard let firstSeenDate = dateFormatter.date(from: firstSeenDateString) else {
                 throw SubscriberDataError.firstSeenFormat
             }
 
@@ -384,7 +384,7 @@ private extension CustomerInfo {
         // mapValues will keep the key-value pair in the dictionary for nil values, as desired
         return transactionsByProductId.mapValues { transaction in
             if let dateString = transaction[dateLabel] as? String {
-                return dateFormatter.date(fromString: dateString)
+                return dateFormatter.date(from: dateString)
             }
             return nil
         }

--- a/Purchases/Public/EntitlementInfo.swift
+++ b/Purchases/Public/EntitlementInfo.swift
@@ -246,7 +246,7 @@ import Foundation
                   entitlementData: entitlementData,
                   productData: productData,
                   requestDate: requestDate,
-                  dateFormatter: .iso8601SecondsDateFormatter,
+                  dateFormatter: ISO8601DateFormatter.default,
                   jsonDecoder: JSONDecoder())
     }
 
@@ -254,13 +254,13 @@ import Foundation
           entitlementData entitlementDataDict: [String: Any],
           productData productDataDict: [String: Any],
           requestDate: Date?,
-          dateFormatter: DateFormatter,
+          dateFormatter: DateFormatterType,
           jsonDecoder: JSONDecoder) {
         // Entitlement data
         guard let entitlementData: EntitlementData = try? jsonDecoder.decode(
             dictionary: entitlementDataDict,
             keyDecodingStrategy: .convertFromSnakeCase,
-            dateDecodingStrategy: .formatted(dateFormatter)
+            dateDecodingStrategy: dateFormatter.dateDecodingStrategy
         ) else {
             return nil
         }
@@ -269,7 +269,7 @@ import Foundation
         guard let productData: ProductData = try? jsonDecoder.decode(
             dictionary: productDataDict,
             keyDecodingStrategy: .convertFromSnakeCase,
-            dateDecodingStrategy: .formatted(dateFormatter)
+            dateDecodingStrategy: dateFormatter.dateDecodingStrategy
         ) else {
             return nil
         }

--- a/Purchases/Public/EntitlementInfo.swift
+++ b/Purchases/Public/EntitlementInfo.swift
@@ -246,7 +246,7 @@ import Foundation
                   entitlementData: entitlementData,
                   productData: productData,
                   requestDate: requestDate,
-                  dateFormatter: ISO8601DateFormatter.default,
+                  dateDecodingStrategy: .iso8601,
                   jsonDecoder: JSONDecoder())
     }
 
@@ -254,13 +254,13 @@ import Foundation
           entitlementData entitlementDataDict: [String: Any],
           productData productDataDict: [String: Any],
           requestDate: Date?,
-          dateFormatter: DateFormatterType,
+          dateDecodingStrategy: JSONDecoder.DateDecodingStrategy,
           jsonDecoder: JSONDecoder) {
         // Entitlement data
         guard let entitlementData: EntitlementData = try? jsonDecoder.decode(
             dictionary: entitlementDataDict,
             keyDecodingStrategy: .convertFromSnakeCase,
-            dateDecodingStrategy: dateFormatter.dateDecodingStrategy
+            dateDecodingStrategy: dateDecodingStrategy
         ) else {
             return nil
         }
@@ -269,7 +269,7 @@ import Foundation
         guard let productData: ProductData = try? jsonDecoder.decode(
             dictionary: productDataDict,
             keyDecodingStrategy: .convertFromSnakeCase,
-            dateDecodingStrategy: dateFormatter.dateDecodingStrategy
+            dateDecodingStrategy: dateDecodingStrategy
         ) else {
             return nil
         }

--- a/Purchases/Public/EntitlementInfos.swift
+++ b/Purchases/Public/EntitlementInfos.swift
@@ -58,13 +58,13 @@ import Foundation
         self.init(entitlementsData: entitlementsData,
                   purchasesData: purchasesData,
                   requestDate: requestDate,
-                  dateFormatter: .iso8601SecondsDateFormatter)
+                  dateFormatter: ISO8601DateFormatter.default)
     }
 
     init(entitlementsData: [String: Any]?,
          purchasesData: [String: Any],
          requestDate: Date?,
-         dateFormatter: DateFormatter) {
+         dateFormatter: DateFormatterType) {
         guard let entitlementsData = entitlementsData else {
             self.all = [:]
             return

--- a/Purchases/Public/Transaction.swift
+++ b/Purchases/Public/Transaction.swift
@@ -26,10 +26,10 @@ import Foundation
         self.purchaseDate = purchaseDate
     }
 
-    @objc public init?(with serverResponse: [String: Any], productId: String, dateFormatter: DateFormatter) {
+    internal init?(with serverResponse: [String: Any], productId: String, dateFormatter: DateFormatterType) {
         guard let revenueCatId = serverResponse["id"] as? String,
               let dateString = serverResponse["purchase_date"] as? String,
-              let purchaseDate = dateFormatter.date(fromString: dateString) else {
+              let purchaseDate = dateFormatter.date(from: dateString) else {
             Logger.error("Couldn't initialize Transaction from dictionary. " +
                          "Reason: unexpected format. Dictionary: \(serverResponse).")
             return nil

--- a/Purchases/Purchasing/TransactionsFactory.swift
+++ b/Purchases/Purchasing/TransactionsFactory.swift
@@ -17,7 +17,7 @@ import Foundation
 class TransactionsFactory {
 
     func nonSubscriptionTransactions(withSubscriptionsData subscriptionsData: [String: [[String: Any]]],
-                                     dateFormatter: DateFormatter) -> [Transaction] {
+                                     dateFormatter: DateFormatterType) -> [Transaction] {
         subscriptionsData.flatMap { (productId: String, transactionData: [[String: Any]]) -> [Transaction] in
             transactionData.map {
                 Transaction(with: $0, productId: productId, dateFormatter: dateFormatter)

--- a/PurchasesTests/Purchasing/CustomerInfoTests.swift
+++ b/PurchasesTests/Purchasing/CustomerInfoTests.swift
@@ -755,7 +755,7 @@ extension CustomerInfo {
     convenience init?(testData: [String: Any]) {
         do {
             try self.init(data: testData,
-                          dateFormatter: .iso8601SecondsDateFormatter,
+                          dateFormatter: ISO8601DateFormatter.default,
                           transactionsFactory: TransactionsFactory())
         } catch {
             let errorDescription = (error as? DescribableError)?.description ?? error.localizedDescription


### PR DESCRIPTION
Fixes #988.

Unfortunately `ISO8601DateFormatter` inherits from `Formatter`, and not `DateFormatter`, so this introduces a new protocol `DateFormatterType` that both types can implement.

Another unfortunate difference with the new type compared to the old implementation is that milliseconds are either optional or mandatory.
For that reason, I added `ISO8601DateFormatter.default` which replicates the same behavior by deferring `date(from: String) -> Date` to one formatter or the other.
I added tests to cover this behavior directly, but it was only thanks to the existing `ArraySlice` tests that I became aware of this requirement.

Additionally, I made `Transaction.init(with:productId:dateFormatter)` not `public` and not `@objc` so it can take a new `DateFormatterType`.
The method didn't need to be `public`, it was just a pre-Swift-migration leftover.

As a bonus I changed some of the tests in `DateFormatter+ExtensionsTests` to use `XCTUnwrap`.