### PR TITLE
Using XCTSkip instead of silently passing tests

### DIFF
--- a/PurchasesTests/Attribution/AttributionPosterTests.swift
+++ b/PurchasesTests/Attribution/AttributionPosterTests.swift
@@ -173,6 +173,18 @@ class AttributionPosterTests: XCTestCase {
         expect(self.subscriberAttributesManager.invokedConvertAttributionDataAndSetCount) == 0
     }
 
+    func testPostAppleSearchAdsAttributionIfNeededSkipsIfIAdFrameworkNotIncluded() {
+        MockAttributionTypeFactory.shouldReturnAdClientProxy = false
+        MockAttributionTypeFactory.shouldReturnTrackingManagerProxy = true
+
+        self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
+
+        expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 0
+    }
+
+    // `MockTrackingManagerProxy.mockAuthorizationStatus isn't available on tvOS
+    #if os(iOS)
+    
     func testPostAppleSearchAdsAttributionIfNeededPostsIfATTFrameworkNotIncludedOnOldOS() throws {
         guard #available(iOS 14, *) else { throw XCTSkip() }
 
@@ -183,15 +195,6 @@ class AttributionPosterTests: XCTestCase {
         self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
 
         expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 1
-    }
-
-    func testPostAppleSearchAdsAttributionIfNeededSkipsIfIAdFrameworkNotIncluded() {
-        MockAttributionTypeFactory.shouldReturnAdClientProxy = false
-        MockAttributionTypeFactory.shouldReturnTrackingManagerProxy = true
-
-        self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
-
-        expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 0
     }
 
     func testPostAppleSearchAdsAttributionIfNeededPostsIfAuthorizedOnNewOS() throws {
@@ -291,4 +294,5 @@ class AttributionPosterTests: XCTestCase {
         expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 1
     }
 
+    #endif
 }

--- a/PurchasesTests/Attribution/AttributionPosterTests.swift
+++ b/PurchasesTests/Attribution/AttributionPosterTests.swift
@@ -160,33 +160,29 @@ class AttributionPosterTests: XCTestCase {
         expect(self.subscriberAttributesManager.invokedConvertAttributionDataAndSetCount) == 0
     }
 
-    func testPostAppleSearchAdsAttributionIfNeededSkipsIfATTFrameworkNotIncludedOnNewOS() {
-        #if os(iOS)
-        if #available(iOS 14, *) {
-            systemInfo.stubbedIsOperatingSystemAtLeastVersion = true
-            MockAttributionTypeFactory.shouldReturnAdClientProxy = true
-            MockAttributionTypeFactory.shouldReturnTrackingManagerProxy = false
+    func testPostAppleSearchAdsAttributionIfNeededSkipsIfATTFrameworkNotIncludedOnNewOS() throws {
+        guard #available(iOS 14, *) else { throw XCTSkip() }
+        
+        systemInfo.stubbedIsOperatingSystemAtLeastVersion = true
+        MockAttributionTypeFactory.shouldReturnAdClientProxy = true
+        MockAttributionTypeFactory.shouldReturnTrackingManagerProxy = false
 
-            self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
+        self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
 
-            expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 0
-            expect(self.subscriberAttributesManager.invokedConvertAttributionDataAndSetCount) == 0
-        }
-        #endif
+        expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 0
+        expect(self.subscriberAttributesManager.invokedConvertAttributionDataAndSetCount) == 0
     }
 
-    func testPostAppleSearchAdsAttributionIfNeededPostsIfATTFrameworkNotIncludedOnOldOS() {
-        #if os(iOS)
-        if #available(iOS 14, *) {
-            systemInfo.stubbedIsOperatingSystemAtLeastVersion = false
-            MockAttributionTypeFactory.shouldReturnAdClientProxy = true
-            MockAttributionTypeFactory.shouldReturnTrackingManagerProxy = false
+    func testPostAppleSearchAdsAttributionIfNeededPostsIfATTFrameworkNotIncludedOnOldOS() throws {
+        guard #available(iOS 14, *) else { throw XCTSkip() }
 
-            self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
+        systemInfo.stubbedIsOperatingSystemAtLeastVersion = false
+        MockAttributionTypeFactory.shouldReturnAdClientProxy = true
+        MockAttributionTypeFactory.shouldReturnTrackingManagerProxy = false
 
-            expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 1
-        }
-        #endif
+        self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
+
+        expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 1
     }
 
     func testPostAppleSearchAdsAttributionIfNeededSkipsIfIAdFrameworkNotIncluded() {
@@ -198,115 +194,101 @@ class AttributionPosterTests: XCTestCase {
         expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 0
     }
 
-    func testPostAppleSearchAdsAttributionIfNeededPostsIfAuthorizedOnNewOS() {
-        #if os(iOS)
-        if #available(iOS 14, *) {
-            systemInfo.stubbedIsOperatingSystemAtLeastVersion = true
-            
-            MockTrackingManagerProxy.mockAuthorizationStatus = .authorized
-            MockAttributionTypeFactory.shouldReturnAdClientProxy = true
-            MockAttributionTypeFactory.shouldReturnTrackingManagerProxy = true
+    func testPostAppleSearchAdsAttributionIfNeededPostsIfAuthorizedOnNewOS() throws {
+        guard #available(iOS 14, *) else { throw XCTSkip() }
 
-            self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
+        systemInfo.stubbedIsOperatingSystemAtLeastVersion = true
 
-            expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 1
-        }
-        #endif
+        MockTrackingManagerProxy.mockAuthorizationStatus = .authorized
+        MockAttributionTypeFactory.shouldReturnAdClientProxy = true
+        MockAttributionTypeFactory.shouldReturnTrackingManagerProxy = true
+
+        self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
+
+        expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 1
     }
 
-    func testPostAppleSearchAdsAttributionIfNeededPostsIfAuthorizedOnOldOS() {
-        #if os(iOS)
-        if #available(iOS 14, *) {
-            systemInfo.stubbedIsOperatingSystemAtLeastVersion = false
-            MockTrackingManagerProxy.mockAuthorizationStatus = .authorized
-            MockAttributionTypeFactory.shouldReturnAdClientProxy = true
-            MockAttributionTypeFactory.shouldReturnTrackingManagerProxy = true
+    func testPostAppleSearchAdsAttributionIfNeededPostsIfAuthorizedOnOldOS() throws {
+        guard #available(iOS 14, *) else { throw XCTSkip() }
 
-            self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
+        systemInfo.stubbedIsOperatingSystemAtLeastVersion = false
+        MockTrackingManagerProxy.mockAuthorizationStatus = .authorized
+        MockAttributionTypeFactory.shouldReturnAdClientProxy = true
+        MockAttributionTypeFactory.shouldReturnTrackingManagerProxy = true
 
-            expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 1
-        }
-        #endif
+        self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
+
+        expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 1
     }
 
-    func testPostAppleSearchAdsAttributionIfNeededPostsIfAuthNotDeterminedOnOldOS() {
-        #if os(iOS)
-        if #available(iOS 14, *) {
-            systemInfo.stubbedIsOperatingSystemAtLeastVersion = false
-            MockTrackingManagerProxy.mockAuthorizationStatus = .notDetermined
-            MockAttributionTypeFactory.shouldReturnAdClientProxy = true
-            MockAttributionTypeFactory.shouldReturnTrackingManagerProxy = true
+    func testPostAppleSearchAdsAttributionIfNeededPostsIfAuthNotDeterminedOnOldOS() throws {
+        guard #available(iOS 14, *) else { throw XCTSkip() }
 
-            self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
+        systemInfo.stubbedIsOperatingSystemAtLeastVersion = false
+        MockTrackingManagerProxy.mockAuthorizationStatus = .notDetermined
+        MockAttributionTypeFactory.shouldReturnAdClientProxy = true
+        MockAttributionTypeFactory.shouldReturnTrackingManagerProxy = true
 
-            expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 1
-        }
-        #endif
+        self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
+
+        expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 1
     }
 
-    func testPostAppleSearchAdsAttributionIfNeededSkipsIfAuthNotDeterminedOnNewOS() {
-        #if os(iOS)
-        if #available(iOS 14, *) {
-            systemInfo.stubbedIsOperatingSystemAtLeastVersion = true
+    func testPostAppleSearchAdsAttributionIfNeededSkipsIfAuthNotDeterminedOnNewOS() throws {
+        guard #available(iOS 14, *) else { throw XCTSkip() }
 
-            MockTrackingManagerProxy.mockAuthorizationStatus = .notDetermined
-            MockAttributionTypeFactory.shouldReturnAdClientProxy = true
-            MockAttributionTypeFactory.shouldReturnTrackingManagerProxy = true
+        systemInfo.stubbedIsOperatingSystemAtLeastVersion = true
 
-            self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
+        MockTrackingManagerProxy.mockAuthorizationStatus = .notDetermined
+        MockAttributionTypeFactory.shouldReturnAdClientProxy = true
+        MockAttributionTypeFactory.shouldReturnTrackingManagerProxy = true
 
-            expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 0
-        }
-        #endif
+        self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
+
+        expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 0
     }
 
 
-    func testPostAppleSearchAdsAttributionIfNeededSkipsIfNotAuthorizedOnOldOS() {
-        #if os(iOS)
-        if #available(iOS 14, *) {
-            systemInfo.stubbedIsOperatingSystemAtLeastVersion = false
-            MockTrackingManagerProxy.mockAuthorizationStatus = .denied
-            MockAttributionTypeFactory.shouldReturnAdClientProxy = true
-            MockAttributionTypeFactory.shouldReturnTrackingManagerProxy = true
+    func testPostAppleSearchAdsAttributionIfNeededSkipsIfNotAuthorizedOnOldOS() throws {
+        guard #available(iOS 14, *) else { throw XCTSkip() }
 
-            self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
+        systemInfo.stubbedIsOperatingSystemAtLeastVersion = false
+        MockTrackingManagerProxy.mockAuthorizationStatus = .denied
+        MockAttributionTypeFactory.shouldReturnAdClientProxy = true
+        MockAttributionTypeFactory.shouldReturnTrackingManagerProxy = true
 
-            expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 0
-        }
-        #endif
+        self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
+
+        expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 0
     }
 
-    func testPostAppleSearchAdsAttributionIfNeededSkipsIfNotAuthorizedOnNewOS() {
-        #if os(iOS)
-        if #available(iOS 14, *) {
-            systemInfo.stubbedIsOperatingSystemAtLeastVersion = true
-            MockTrackingManagerProxy.mockAuthorizationStatus = .denied
-            MockAttributionTypeFactory.shouldReturnAdClientProxy = true
-            MockAttributionTypeFactory.shouldReturnTrackingManagerProxy = true
+    func testPostAppleSearchAdsAttributionIfNeededSkipsIfNotAuthorizedOnNewOS() throws {
+        guard #available(iOS 14, *) else { throw XCTSkip() }
 
-            self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
+        systemInfo.stubbedIsOperatingSystemAtLeastVersion = true
+        MockTrackingManagerProxy.mockAuthorizationStatus = .denied
+        MockAttributionTypeFactory.shouldReturnAdClientProxy = true
+        MockAttributionTypeFactory.shouldReturnTrackingManagerProxy = true
 
-            expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 0
-        }
-        #endif
+        self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
+
+        expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 0
     }
 
-    func testPostAppleSearchAdsAttributionIfNeededSkipsIfAlreadySent() {
-        #if os(iOS)
-        if #available(iOS 14, *) {
-            MockTrackingManagerProxy.mockAuthorizationStatus = .authorized
-            MockAttributionTypeFactory.shouldReturnAdClientProxy = true
-            MockAttributionTypeFactory.shouldReturnTrackingManagerProxy = true
+    func testPostAppleSearchAdsAttributionIfNeededSkipsIfAlreadySent() throws {
+        guard #available(iOS 14, *) else { throw XCTSkip() }
 
-            self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
+        MockTrackingManagerProxy.mockAuthorizationStatus = .authorized
+        MockAttributionTypeFactory.shouldReturnAdClientProxy = true
+        MockAttributionTypeFactory.shouldReturnTrackingManagerProxy = true
 
-            expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 1
+        self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
 
-            self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
+        expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 1
 
-            expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 1
-        }
-        #endif
+        self.attributionPoster.postAppleSearchAdsAttributionIfNeeded()
+
+        expect(MockAdClientProxy.requestAttributionDetailsCallCount) == 1
     }
 
 }

--- a/PurchasesTests/Misc/ISOPeriodFormatterTests.swift
+++ b/PurchasesTests/Misc/ISOPeriodFormatterTests.swift
@@ -15,75 +15,83 @@ import XCTest
 
 class ISOPeriodFormatterTests: XCTestCase {
     
-    func testStringFromProductSubscriptionPeriodDay() {
-        if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *) {
-            let formatter = ISOPeriodFormatter()
-            
-            var period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .day)
-            expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P1D"
-            
-            period = SKProductSubscriptionPeriod(numberOfUnits: 10, unit: .day)
-            expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P10D"
-            
-            period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .day)
-            expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P3D"
-            
-            period = SKProductSubscriptionPeriod(numberOfUnits: 8, unit: .day)
-            expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P8D"
+    func testStringFromProductSubscriptionPeriodDay() throws {
+        guard #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *) else {
+            throw XCTSkip()
         }
-    }
-    
-    func testStringFromProductSubscriptionPeriodMonth() {
-        if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *) {
-            let formatter = ISOPeriodFormatter()
 
-            var period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .month)
-            expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P1M"
-            
-            period = SKProductSubscriptionPeriod(numberOfUnits: 10, unit: .month)
-            expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P10M"
-            
-            period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .month)
-            expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P3M"
-            
-            period = SKProductSubscriptionPeriod(numberOfUnits: 8, unit: .month)
-            expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P8M"
-        }
+        let formatter = ISOPeriodFormatter()
+
+        var period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .day)
+        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P1D"
+
+        period = SKProductSubscriptionPeriod(numberOfUnits: 10, unit: .day)
+        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P10D"
+
+        period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .day)
+        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P3D"
+
+        period = SKProductSubscriptionPeriod(numberOfUnits: 8, unit: .day)
+        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P8D"
     }
     
-    func testStringFromProductSubscriptionPeriodWeek() {
-        if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *) {
-            let formatter = ISOPeriodFormatter()
-            
-            var period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .week)
-            expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P1W"
-            
-            period = SKProductSubscriptionPeriod(numberOfUnits: 10, unit: .week)
-            expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P10W"
-            
-            period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .week)
-            expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P3W"
-            
-            period = SKProductSubscriptionPeriod(numberOfUnits: 8, unit: .week)
-            expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P8W"
+    func testStringFromProductSubscriptionPeriodMonth() throws {
+        guard #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *) else {
+            throw XCTSkip()
         }
+
+        let formatter = ISOPeriodFormatter()
+
+        var period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .month)
+        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P1M"
+
+        period = SKProductSubscriptionPeriod(numberOfUnits: 10, unit: .month)
+        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P10M"
+
+        period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .month)
+        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P3M"
+
+        period = SKProductSubscriptionPeriod(numberOfUnits: 8, unit: .month)
+        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P8M"
+    }
+
+    func testStringFromProductSubscriptionPeriodWeek() throws {
+        guard #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *) else {
+            throw XCTSkip()
+        }
+
+        let formatter = ISOPeriodFormatter()
+
+        var period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .week)
+        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P1W"
+
+        period = SKProductSubscriptionPeriod(numberOfUnits: 10, unit: .week)
+        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P10W"
+
+        period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .week)
+        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P3W"
+
+        period = SKProductSubscriptionPeriod(numberOfUnits: 8, unit: .week)
+        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P8W"
     }
     
-    func testStringFromProductSubscriptionPeriodYear() {
-        if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *) {
-            let formatter = ISOPeriodFormatter()
-            
-            var period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .year)
-            expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P1Y"
-            
-            period = SKProductSubscriptionPeriod(numberOfUnits: 10, unit: .year)
-            expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P10Y"
-            
-            period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .year)
-            expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P3Y"
-            
-            period = SKProductSubscriptionPeriod(numberOfUnits: 8, unit: .year)
-            expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P8Y"
+    func testStringFromProductSubscriptionPeriodYear() throws {
+        guard #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *) else {
+            throw XCTSkip()
         }
+
+        let formatter = ISOPeriodFormatter()
+
+        var period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .year)
+        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P1Y"
+
+        period = SKProductSubscriptionPeriod(numberOfUnits: 10, unit: .year)
+        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P10Y"
+
+        period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .year)
+        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P3Y"
+
+        period = SKProductSubscriptionPeriod(numberOfUnits: 8, unit: .year)
+        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P8Y"
     }
 }

--- a/PurchasesTests/Purchasing/StoreKitWrapperTests.swift
+++ b/PurchasesTests/Purchasing/StoreKitWrapperTests.swift
@@ -173,19 +173,17 @@ class StoreKitWrapperTests: XCTestCase, StoreKitWrapperDelegate {
 
     }
 
-    func testDidRevokeEntitlementsForProductIdentifiersCallsDelegateWithRightArguments() {
-        #if swift(>=5.3)
-        if #available(iOS 14.0, macOS 14.0, tvOS 14.0, watchOS 7.0, *) {
-            expect(self.productIdentifiersWithRevokedEntitlements).to(beNil())
-            let revokedProductIdentifiers = [
-                "mySuperProduct",
-                "theOtherProduct"
-            ]
+    func testDidRevokeEntitlementsForProductIdentifiersCallsDelegateWithRightArguments() throws {
+        guard #available(iOS 14.0, macOS 14.0, tvOS 14.0, watchOS 7.0, *) else { throw XCTSkip() }
 
-            wrapper?.paymentQueue(paymentQueue, didRevokeEntitlementsForProductIdentifiers: revokedProductIdentifiers)
-            expect(self.productIdentifiersWithRevokedEntitlements) == revokedProductIdentifiers
-        }
-        #endif
+        expect(self.productIdentifiersWithRevokedEntitlements).to(beNil())
+        let revokedProductIdentifiers = [
+            "mySuperProduct",
+            "theOtherProduct"
+        ]
+
+        wrapper?.paymentQueue(paymentQueue, didRevokeEntitlementsForProductIdentifiers: revokedProductIdentifiers)
+        expect(self.productIdentifiersWithRevokedEntitlements) == revokedProductIdentifiers
     }
 
     func testPaymentWithProductReturnsCorrectPayment() {
@@ -212,36 +210,38 @@ class StoreKitWrapperTests: XCTestCase, StoreKitWrapperDelegate {
         expect(payment2.simulatesAskToBuyInSandbox) == true
     }
 
-    func testPaymentWithProductAndDiscountReturnsCorrectPaymentWithDiscount() {
-        if #available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvOS 12.2, *) {
-            guard let wrapper = wrapper else { fatalError("wrapper is not initialized!") }
-
-            let productId = "mySuperProduct"
-            let discountId = "mySuperDiscount"
-
-            let mockProduct = MockSK1Product(mockProductIdentifier: productId)
-            let mockDiscount = MockPaymentDiscount(mockIdentifier: discountId)
-            let payment = wrapper.payment(withProduct: mockProduct, discount: mockDiscount)
-            expect(payment.productIdentifier) == productId
-            expect(payment.paymentDiscount) == mockDiscount
+    func testPaymentWithProductAndDiscountReturnsCorrectPaymentWithDiscount() throws {
+        guard #available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvOS 12.2, *) else {
+            throw XCTSkip()
         }
+        guard let wrapper = wrapper else { fatalError("wrapper is not initialized!") }
+
+        let productId = "mySuperProduct"
+        let discountId = "mySuperDiscount"
+
+        let mockProduct = MockSK1Product(mockProductIdentifier: productId)
+        let mockDiscount = MockPaymentDiscount(mockIdentifier: discountId)
+        let payment = wrapper.payment(withProduct: mockProduct, discount: mockDiscount)
+        expect(payment.productIdentifier) == productId
+        expect(payment.paymentDiscount) == mockDiscount
     }
 
-    func testPaymentWithProductAndDiscountSetsSimulatesAskToBuyInSandbox() {
-        if #available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvOS 12.2, *) {
-            guard let wrapper = wrapper else { fatalError("wrapper is not initialized!") }
-
-            let mockProduct = MockSK1Product(mockProductIdentifier: "mySuperProduct")
-            let mockDiscount = MockPaymentDiscount(mockIdentifier: "mySuperDiscount")
-
-            StoreKitWrapper.simulatesAskToBuyInSandbox = false
-            let payment1 = wrapper.payment(withProduct: mockProduct, discount: mockDiscount)
-            expect(payment1.simulatesAskToBuyInSandbox) == false
-
-            StoreKitWrapper.simulatesAskToBuyInSandbox = true
-            let payment2 = wrapper.payment(withProduct: mockProduct)
-            expect(payment2.simulatesAskToBuyInSandbox) == true
+    func testPaymentWithProductAndDiscountSetsSimulatesAskToBuyInSandbox() throws {
+        guard #available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvOS 12.2, *) else {
+            throw XCTSkip()
         }
+        guard let wrapper = wrapper else { fatalError("wrapper is not initialized!") }
+
+        let mockProduct = MockSK1Product(mockProductIdentifier: "mySuperProduct")
+        let mockDiscount = MockPaymentDiscount(mockIdentifier: "mySuperDiscount")
+
+        StoreKitWrapper.simulatesAskToBuyInSandbox = false
+        let payment1 = wrapper.payment(withProduct: mockProduct, discount: mockDiscount)
+        expect(payment1.simulatesAskToBuyInSandbox) == false
+
+        StoreKitWrapper.simulatesAskToBuyInSandbox = true
+        let payment2 = wrapper.payment(withProduct: mockProduct)
+        expect(payment2.simulatesAskToBuyInSandbox) == true
     }
 
 }


### PR DESCRIPTION
Fixes #990 and [sc-5246].