### PR TITLE
async/await APIs: name values in tuples

### DIFF
--- a/Purchases/Public/Purchases+async.swift
+++ b/Purchases/Public/Purchases+async.swift
@@ -92,7 +92,8 @@ extension Purchases {
 
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     // swiftlint:disable:next large_tuple
-    func purchaseAsync(product: SKProduct) async throws -> (SKPaymentTransaction, CustomerInfo, Bool) {
+    func purchaseAsync(product: SKProduct) async throws ->
+    (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(product: product) { maybeTransaction, maybeCustomerInfo, maybeError, userCancelled in
                 if let error = maybeError {
@@ -113,7 +114,8 @@ extension Purchases {
 
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     // swiftlint:disable:next large_tuple
-    func purchaseAsync(package: Package) async throws -> (SKPaymentTransaction, CustomerInfo, Bool) {
+    func purchaseAsync(package: Package) async throws ->
+    (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(package: package) { maybeTransaction, maybeCustomerInfo, maybeError, userCancelled in
                 if let error = maybeError {
@@ -135,7 +137,7 @@ extension Purchases {
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     func purchaseAsync(product: SKProduct, discount: SKPaymentDiscount) async throws ->
     // swiftlint:disable:next large_tuple
-    (SKPaymentTransaction, CustomerInfo, Bool) {
+    (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
 
         return try await withCheckedThrowingContinuation { continuation in
             purchase(product: product,
@@ -159,7 +161,7 @@ extension Purchases {
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     func purchaseAsync(package: Package, discount: SKPaymentDiscount) async throws ->
     // swiftlint:disable:next large_tuple
-    (SKPaymentTransaction, CustomerInfo, Bool) {
+    (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(package: package,
                      discount: discount) { maybeTransaction, maybeCustomerInfo, maybeError, userCancelled in

--- a/Purchases/Public/Purchases+async.swift
+++ b/Purchases/Public/Purchases+async.swift
@@ -91,8 +91,8 @@ extension Purchases {
     }
 
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
-    // swiftlint:disable:next large_tuple
     func purchaseAsync(product: SKProduct) async throws ->
+    // swiftlint:disable:next large_tuple
     (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(product: product) { maybeTransaction, maybeCustomerInfo, maybeError, userCancelled in
@@ -113,8 +113,8 @@ extension Purchases {
     }
 
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
-    // swiftlint:disable:next large_tuple
     func purchaseAsync(package: Package) async throws ->
+    // swiftlint:disable:next large_tuple
     (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(package: package) { maybeTransaction, maybeCustomerInfo, maybeError, userCancelled in

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -859,7 +859,8 @@ public extension Purchases {
      */
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     // swiftlint:disable:next large_tuple
-    func purchase(product: SKProduct) async throws -> (SKPaymentTransaction, CustomerInfo, Bool) {
+    func purchase(product: SKProduct) async throws ->
+    (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
         return try await purchaseAsync(product: product)
     }
 
@@ -904,7 +905,8 @@ public extension Purchases {
      */
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     // swiftlint:disable:next large_tuple
-    func purchase(package: Package) async throws -> (SKPaymentTransaction, CustomerInfo, Bool) {
+    func purchase(package: Package) async throws ->
+    (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
         return try await purchaseAsync(package: package)
     }
 
@@ -960,7 +962,7 @@ public extension Purchases {
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     func purchase(product: SKProduct, discount: SKPaymentDiscount) async throws ->
     // swiftlint:disable:next large_tuple
-    (SKPaymentTransaction, CustomerInfo, Bool) {
+    (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
         return try await purchaseAsync(product: product, discount: discount)
     }
 
@@ -1018,7 +1020,7 @@ public extension Purchases {
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
     func purchase(package: Package, discount: SKPaymentDiscount) async throws ->
     // swiftlint:disable:next large_tuple
-    (SKPaymentTransaction, CustomerInfo, Bool) {
+    (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
         return try await purchaseAsync(package: package, discount: discount)
     }
 

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -858,8 +858,8 @@ public extension Purchases {
      * If the user cancelled, `userCancelled` will be `YES`.
      */
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
-    // swiftlint:disable:next large_tuple
     func purchase(product: SKProduct) async throws ->
+    // swiftlint:disable:next large_tuple
     (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
         return try await purchaseAsync(product: product)
     }
@@ -904,8 +904,8 @@ public extension Purchases {
      * If the user cancelled, `userCancelled` will be `true`.
      */
     @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
-    // swiftlint:disable:next large_tuple
     func purchase(package: Package) async throws ->
+    // swiftlint:disable:next large_tuple
     (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
         return try await purchaseAsync(package: package)
     }


### PR DESCRIPTION
Forgot to push this before merging #987 🤦 

This PR adds names to tuple values for transaction results.