### PR TITLE
Created MacDevice to get the identifier for vendor for macs

### DIFF
--- a/Purchases/Misc/MacDevice.swift
+++ b/Purchases/Misc/MacDevice.swift
@@ -1,0 +1,84 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MacDevice.swift
+//
+//  Created by Juanpe Catalán on 30/11/21.
+
+#if os(macOS) || targetEnvironment(macCatalyst)
+
+import Foundation
+import IOKit
+
+enum MacDevice {
+
+    // Based on Apple's documentation, the mac address must
+    // be used to validate receipts.
+    // https://developer.apple.com/documentation/appstorereceipts/validating_receipts_on_the_device
+    static var identifierForVendor: String? {
+        networkInterfaceMacAddress?.base64EncodedString()
+    }
+
+    static var networkInterfaceMacAddress: Data? {
+        guard let service = getIOService(named: "en0", wantBuiltIn: true)
+                ?? getIOService(named: "en1", wantBuiltIn: true)
+                ?? getIOService(named: "en0", wantBuiltIn: false)
+            else { return nil }
+        
+        defer { IOObjectRelease(service) }
+        
+        return IORegistryEntrySearchCFProperty(
+            service,
+            kIOServicePlane,
+            "IOMACAddress" as CFString,
+            kCFAllocatorDefault,
+            IOOptionBits(kIORegistryIterateRecursively | kIORegistryIterateParents)
+        ) as? Data
+    }
+
+    static private func getIOService(named name: String, wantBuiltIn: Bool) -> io_service_t? {
+        let default_port = kIOMasterPortDefault
+        var iterator = io_iterator_t()
+        defer {
+            if iterator != IO_OBJECT_NULL {
+                IOObjectRelease(iterator)
+            }
+        }
+        
+        guard let matchingDict = IOBSDNameMatching(default_port, 0, name),
+              IOServiceGetMatchingServices(default_port,
+                                           matchingDict as CFDictionary,
+                                           &iterator) == KERN_SUCCESS,
+              iterator != IO_OBJECT_NULL
+        else {
+            return nil
+        }
+
+        var candidate = IOIteratorNext(iterator)
+        while candidate != IO_OBJECT_NULL {
+            if let cftype = IORegistryEntryCreateCFProperty(candidate,
+                                                            "IOBuiltin" as CFString,
+                                                            kCFAllocatorDefault,
+                                                            0) {
+                let isBuiltIn = cftype.takeRetainedValue() as! CFBoolean
+                if wantBuiltIn == CFBooleanGetValue(isBuiltIn) {
+                    return candidate
+                }
+            }
+
+            IOObjectRelease(candidate)
+            candidate = IOIteratorNext(iterator)
+        }
+
+        return nil
+    }
+    
+}
+
+#endif

--- a/Purchases/Misc/MacDevice.swift
+++ b/Purchases/Misc/MacDevice.swift
@@ -30,9 +30,9 @@ enum MacDevice {
                 ?? getIOService(named: "en1", wantBuiltIn: true)
                 ?? getIOService(named: "en0", wantBuiltIn: false)
             else { return nil }
-        
+
         defer { IOObjectRelease(service) }
-        
+
         return IORegistryEntrySearchCFProperty(
             service,
             kIOServicePlane,
@@ -43,16 +43,16 @@ enum MacDevice {
     }
 
     static private func getIOService(named name: String, wantBuiltIn: Bool) -> io_service_t? {
-        let default_port = kIOMasterPortDefault
+        let defaultPort = kIOMasterPortDefault
         var iterator = io_iterator_t()
         defer {
             if iterator != IO_OBJECT_NULL {
                 IOObjectRelease(iterator)
             }
         }
-        
-        guard let matchingDict = IOBSDNameMatching(default_port, 0, name),
-              IOServiceGetMatchingServices(default_port,
+
+        guard let matchingDict = IOBSDNameMatching(defaultPort, 0, name),
+              IOServiceGetMatchingServices(defaultPort,
                                            matchingDict as CFDictionary,
                                            &iterator) == KERN_SUCCESS,
               iterator != IO_OBJECT_NULL
@@ -66,6 +66,7 @@ enum MacDevice {
                                                             "IOBuiltin" as CFString,
                                                             kCFAllocatorDefault,
                                                             0) {
+                // swiftlint:disable:next force_cast
                 let isBuiltIn = cftype.takeRetainedValue() as! CFBoolean
                 if wantBuiltIn == CFBooleanGetValue(isBuiltIn) {
                     return candidate
@@ -78,7 +79,7 @@ enum MacDevice {
 
         return nil
     }
-    
+
 }
 
 #endif

--- a/Purchases/Misc/SystemInfo.swift
+++ b/Purchases/Misc/SystemInfo.swift
@@ -86,6 +86,8 @@ class SystemInfo {
             return UIDevice.current.identifierForVendor?.uuidString
         #elseif os(watchOS)
             return WKInterfaceDevice.current().identifierForVendor?.uuidString
+        #elseif os(macOS) || targetEnvironment(macCatalyst)
+            return MacDevice.identifierForVendor
         #else
             return nil
         #endif

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -355,7 +355,6 @@ class HTTPClientTests: XCTestCase {
         expect(headerPresent).toEventually(equal(true))
     }
 
-    #if !os(macOS)
     func testAlwaysPassesAppleDeviceIdentifier() {
         let path = "/a_random_path"
         var headerPresent = false
@@ -375,7 +374,6 @@ class HTTPClientTests: XCTestCase {
         
         expect(headerPresent).toEventually(equal(true))
     }
-    #endif
 
     func testDefaultsPlatformFlavorToNative() {
         let path = "/a_random_path"

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -274,6 +274,7 @@
 		B3DDB55926854865008CCF23 /* PurchaseOwnershipType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3DDB55826854865008CCF23 /* PurchaseOwnershipType.swift */; };
 		B3E26A4A26BE0A8E003ACCF3 /* Error+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E26A4926BE0A8E003ACCF3 /* Error+Extensions.swift */; };
 		B3F8418F26F3A93400E560FB /* ErrorCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F8418E26F3A93400E560FB /* ErrorCodeTests.swift */; };
+		F530E4FF275646EF001AF6BD /* MacDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = F530E4FE275646EF001AF6BD /* MacDevice.swift */; };
 		F5714EA526D6C24D00635477 /* JSONDecoder+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5714EA426D6C24D00635477 /* JSONDecoder+Extensions.swift */; };
 		F5714EA826D7A83A00635477 /* Store+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5714EA726D7A83A00635477 /* Store+Extensions.swift */; };
 		F5714EAA26D7A85D00635477 /* PeriodType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5714EA926D7A85D00635477 /* PeriodType+Extensions.swift */; };
@@ -585,6 +586,7 @@
 		B3E26A4926BE0A8E003ACCF3 /* Error+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+Extensions.swift"; sourceTree = "<group>"; };
 		B3F8418E26F3A93400E560FB /* ErrorCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorCodeTests.swift; sourceTree = "<group>"; };
 		EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsFetcherSK1.swift; sourceTree = "<group>"; };
+		F530E4FE275646EF001AF6BD /* MacDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacDevice.swift; sourceTree = "<group>"; };
 		F5714EA426D6C24D00635477 /* JSONDecoder+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONDecoder+Extensions.swift"; sourceTree = "<group>"; };
 		F5714EA726D7A83A00635477 /* Store+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Store+Extensions.swift"; sourceTree = "<group>"; };
 		F5714EA926D7A85D00635477 /* PeriodType+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PeriodType+Extensions.swift"; sourceTree = "<group>"; };
@@ -814,16 +816,17 @@
 		2DDA3E4524DB0B4500EDFE5B /* Misc */ = {
 			isa = PBXGroup;
 			children = (
+				57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */,
 				37E3567189CF6A746EE3CCC2 /* DateExtensions.swift */,
 				0313FD40268A506400168386 /* DateProvider.swift */,
-				B33CEA9F268CDCC9008A3144 /* ISOPeriodFormatter.swift */,
-				2DDA3E4624DB0B5400EDFE5B /* OperationDispatcher.swift */,
-				B3AA6237268B926F00894871 /* SystemInfo.swift */,
 				2D22BF6426F3CB31001AE2F9 /* FatalErrorUtil.swift */,
+				B33CEA9F268CDCC9008A3144 /* ISOPeriodFormatter.swift */,
 				57EAE526274324C60060EB74 /* Lock.swift */,
+				F530E4FE275646EF001AF6BD /* MacDevice.swift */,
 				57EAE52A274332830060EB74 /* Obsoletions.swift */,
-				57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */,
+				2DDA3E4624DB0B5400EDFE5B /* OperationDispatcher.swift */,
 				57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */,
+				B3AA6237268B926F00894871 /* SystemInfo.swift */,
 			);
 			path = Misc;
 			sourceTree = "<group>";
@@ -1744,6 +1747,7 @@
 				B35F9E0926B4BEED00095C3F /* String+Extensions.swift in Sources */,
 				2DDF41AC24F6F37C005BC22D /* ASN1Container.swift in Sources */,
 				9A65E07B2591977500DE00B0 /* NetworkStrings.swift in Sources */,
+				F530E4FF275646EF001AF6BD /* MacDevice.swift in Sources */,
 				F5714EAC26D7A87B00635477 /* PurchaseOwnershipType+Extensions.swift in Sources */,
 				F5BE424026962ACF00254A30 /* ReceiptRefreshPolicy.swift in Sources */,
 				9A65E0762591977200DE00B0 /* IdentityStrings.swift in Sources */,


### PR DESCRIPTION
Fixes #991 

Based on [Apple's documentation](https://developer.apple.com/documentation/appstorereceipts/validating_receipts_on_the_device), the mac address must be used to validate receipts.

I followed the provided code as a reference to create the methods to obtain the network interfaces and their mac addresses. I created a new namespace called `MacDevice` to group these methods.

I have some doubts:
- Our `HTTPClient` is waiting for the identifier for vendor as `String`, but the type of the obtained mac address is`Data`. Now, I've encoded this address to base64, so our backend has to decode it to obtain the bytes. WDYT?
- The new methods need the IOKit framework and I'm not really sure if we should include it in our framework or if it's not necessary 😕
