### PR TITLE
Removed build phase

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1378,7 +1378,6 @@
 				2DC5621224EC63420031F69B /* Sources */,
 				2DC5621324EC63420031F69B /* Frameworks */,
 				2DC5621424EC63420031F69B /* Resources */,
-				F578415E26A0407A00EA3D8A /* Check TARGET_OS macro */,
 				B3C302D926D8066F002B72D1 /* SwiftLint */,
 			);
 			buildRules = (
@@ -1611,24 +1610,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "scripts/swiftlint.sh\n";
-		};
-		F578415E26A0407A00EA3D8A /* Check TARGET_OS macro */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Check TARGET_OS macro";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if grep -rl 2>/dev/null --include=\"*.swift\" \"TARGET_OS\" \"${SRCROOT}\"; then\n  echo \"error: TARGET_OS macro has been found in some Swift files\"\n  exit 1\nfi\n\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Closes #1011 

Tiny PR that removes the build phase that validated that the `TARGET_OS_` macro was not included in any Swift file.