### PR TITLE
Rename `manageSubscriptionModal` -> `manageSubscriptions`

### DIFF
--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -183,12 +183,12 @@ private func checkIdentity(purchases: Purchases) {
 }
 
 private func checkPurchasesSupportAPI(purchases: Purchases) {
-    purchases.showManageSubscriptionModal { _ in }
+    purchases.showManageSubscriptions { _ in }
     #if os(iOS)
     purchases.beginRefundRequest(for: "") { _, _ in }
     if #available(iOS 15.0, macOS 12.0, *) {
         Task.init {
-            try await purchases.showManageSubscriptionModal()
+            try await purchases.showManageSubscriptions()
             let _: RefundRequestStatus = try await purchases.beginRefundRequest(for: "")
         }
     }

--- a/IntegrationTests/PurchaseTester/PurchaseTester/CatsViewController.swift
+++ b/IntegrationTests/PurchaseTester/PurchaseTester/CatsViewController.swift
@@ -70,9 +70,9 @@ class CatsViewController: UIViewController {
     }
 
     @objc func manageSubButtonTapped() {
-        Purchases.shared.showManageSubscriptionModal { maybeError in
+        Purchases.shared.showManageSubscriptions { maybeError in
             if let error = maybeError {
-                print("Error opening Manage Sub Modal: \(error.localizedDescription)")
+                print("Error opening Manage Subs Page: \(error.localizedDescription)")
             }
         }
     }

--- a/Purchases/Public/Purchases+async.swift
+++ b/Purchases/Public/Purchases+async.swift
@@ -245,9 +245,9 @@ extension Purchases {
     @available(iOS 15.0, macOS 12, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
-    func showManageSubscriptionModalAsync() async throws {
+    func showManageSubscriptionsAsync() async throws {
         return try await withCheckedThrowingContinuation { continuation in
-            showManageSubscriptionModal { error in
+            showManageSubscriptions { error in
                 if let error = error {
                     continuation.resume(throwing: error)
                     return

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1261,7 +1261,7 @@ public extension Purchases {
     @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
-    @objc func beginRefundRequest(for productID: String) async throws -> RefundRequestStatus {
+    func beginRefundRequest(for productID: String) async throws -> RefundRequestStatus {
         return try await beginRefundRequestAsync(for: productID)
     }
 

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1220,7 +1220,7 @@ public extension Purchases {
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     @available(iOS 15.0, macOS 12, *)
-    func showManageSubscription() async throws {
+    func showManageSubscriptions() async throws {
         return try await showManageSubscriptionsAsync()
     }
 

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -283,9 +283,9 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
                                                 backend: backend,
                                                 offeringsFactory: offeringsFactory,
                                                 productsManager: productsManager)
-        let manageSubsModalHelper = ManageSubscriptionsModalHelper(systemInfo: systemInfo,
-                                                                   customerInfoManager: customerInfoManager,
-                                                                   identityManager: identityManager)
+        let manageSubsHelper = ManageSubscriptionsHelper(systemInfo: systemInfo,
+                                                         customerInfoManager: customerInfoManager,
+                                                         identityManager: identityManager)
         let beginRefundRequestHelper = BeginRefundRequestHelper(systemInfo: systemInfo)
         let purchasesOrchestrator = PurchasesOrchestrator(productsManager: productsManager,
                                                           storeKitWrapper: storeKitWrapper,
@@ -298,7 +298,7 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
                                                           identityManager: identityManager,
                                                           receiptParser: receiptParser,
                                                           deviceCache: deviceCache,
-                                                          manageSubscriptionsModalHelper: manageSubsModalHelper,
+                                                          manageSubscriptionsHelper: manageSubsHelper,
                                                           beginRefundRequestHelper: beginRefundRequestHelper)
         let trialOrIntroPriceChecker = TrialOrIntroPriceEligibilityChecker(receiptFetcher: receiptFetcher,
                                                                            introEligibilityCalculator: introCalculator,
@@ -1196,8 +1196,8 @@ public extension Purchases {
 #if os(iOS) || os(macOS)
 
     /**
-     * Use this function to open the manage subscriptions modal.
-     * If the manage subscriptions modal can't be opened, the managementURL in the customerInfo will be opened.
+     * Use this function to open the manage subscriptions page.
+     * If the manage subscriptions page can't be opened, the managementURL in the customerInfo will be opened.
      * If managementURL is not available, the App Store's subscription management section will be opened.
      *
      * - Parameter completion: A completion block that is called when the modal is closed.
@@ -1205,8 +1205,8 @@ public extension Purchases {
      */
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
-    @objc func showManageSubscriptionModal(completion: @escaping (Error?) -> Void) {
-        purchasesOrchestrator.showManageSubscriptionModal(completion: completion)
+    @objc func showManageSubscriptions(completion: @escaping (Error?) -> Void) {
+        purchasesOrchestrator.showManageSubscription(completion: completion)
     }
 
     /**
@@ -1220,8 +1220,8 @@ public extension Purchases {
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     @available(iOS 15.0, macOS 12, *)
-    func showManageSubscriptionModal() async throws {
-        return try await showManageSubscriptionModalAsync()
+    func showManageSubscription() async throws {
+        return try await showManageSubscriptionsAsync()
     }
 
 #endif

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -55,7 +55,7 @@ class PurchasesOrchestrator {
     private let identityManager: IdentityManager
     private let receiptParser: ReceiptParser
     private let deviceCache: DeviceCache
-    private let manageSubscriptionsModalHelper: ManageSubscriptionsModalHelper
+    private let manageSubscriptionsHelper: ManageSubscriptionsHelper
     private let beginRefundRequestHelper: BeginRefundRequestHelper
     private let lock = NSRecursiveLock()
 
@@ -73,7 +73,7 @@ class PurchasesOrchestrator {
          identityManager: IdentityManager,
          receiptParser: ReceiptParser,
          deviceCache: DeviceCache,
-         manageSubscriptionsModalHelper: ManageSubscriptionsModalHelper,
+         manageSubscriptionsHelper: ManageSubscriptionsHelper,
          beginRefundRequestHelper: BeginRefundRequestHelper) {
         self.productsManager = productsManager
         self.storeKitWrapper = storeKitWrapper
@@ -86,7 +86,7 @@ class PurchasesOrchestrator {
         self.identityManager = identityManager
         self.receiptParser = receiptParser
         self.deviceCache = deviceCache
-        self.manageSubscriptionsModalHelper = manageSubscriptionsModalHelper
+        self.manageSubscriptionsHelper = manageSubscriptionsHelper
         self.beginRefundRequestHelper = beginRefundRequestHelper
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
             storeKit2Listener.listenForTransactions()
@@ -271,8 +271,8 @@ class PurchasesOrchestrator {
 
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
-    func showManageSubscriptionModal(completion: @escaping (Error?) -> Void) {
-        self.manageSubscriptionsModalHelper.showManageSubscriptionModal { result in
+    func showManageSubscription(completion: @escaping (Error?) -> Void) {
+        self.manageSubscriptionsHelper.showManageSubscriptions { result in
             switch result {
             case .failure(let error):
                 completion(error)

--- a/Purchases/Support/ManageSubscriptionsHelper.swift
+++ b/Purchases/Support/ManageSubscriptionsHelper.swift
@@ -7,13 +7,13 @@
 //
 //      https://opensource.org/licenses/MIT
 //
-//  ManageSubscriptionModalHelper.swift
+//  ManageSubscriptionsHelper.swift
 //
 //  Created by Andrés Boedo on 16/8/21.
 
 import StoreKit
 
-class ManageSubscriptionsModalHelper {
+class ManageSubscriptionsHelper {
 
     private let systemInfo: SystemInfo
     private let customerInfoManager: CustomerInfoManager
@@ -31,17 +31,17 @@ class ManageSubscriptionsModalHelper {
 
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
-    func showManageSubscriptionModal(completion: @escaping (Result<Void, Error>) -> Void) {
+    func showManageSubscriptions(completion: @escaping (Result<Void, Error>) -> Void) {
         let currentAppUserID = identityManager.currentAppUserID
         customerInfoManager.customerInfo(appUserID: currentAppUserID) { maybeCustomerInfo, maybeError in
             if let error = maybeError {
-                let message = "Failed to get managemementURL from CustomerInfo. Details: \(error.localizedDescription)"
+                let message = "Failed to get managementURL from CustomerInfo. Details: \(error.localizedDescription)"
                 completion(.failure(ErrorUtils.customerInfoError(withMessage: message, error: error)))
                 return
             }
 
             guard let customerInfo = maybeCustomerInfo else {
-                let message = "Failed to get managemementURL from CustomerInfo. Details: customerInfo is nil."
+                let message = "Failed to get managementURL from CustomerInfo. Details: customerInfo is nil."
                 completion(.failure(ErrorUtils.customerInfoError(withMessage: message)))
                 return
             }
@@ -72,7 +72,7 @@ class ManageSubscriptionsModalHelper {
 
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
-private extension ManageSubscriptionsModalHelper {
+private extension ManageSubscriptionsHelper {
 
     func showAppleManageSubscriptions(managementURL: URL,
                                       completion: @escaping (Result<Void, Error>) -> Void) {

--- a/PurchasesTests/Mocks/MockManageSubscriptionsHelper.swift
+++ b/PurchasesTests/Mocks/MockManageSubscriptionsHelper.swift
@@ -7,21 +7,21 @@
 //
 //      https://opensource.org/licenses/MIT
 //
-//  MockManageSubsModalHelper.swift
+//  MockManageSubsHelper.swift
 //
 //  Created by César de la Vega on 10/8/21.
 
 import Foundation
 @testable import RevenueCat
 
-class MockManageSubscriptionsModalHelper: ManageSubscriptionsModalHelper {
+class MockManageSubscriptionsHelper: ManageSubscriptionsHelper {
 
     var mockError: Error?
 
 #if os(iOS) || os(macOS)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
-    override func showManageSubscriptionModal(completion: @escaping (Result<Void, Error>) -> Void) {
+    override func showManageSubscriptions(completion: @escaping (Result<Void, Error>) -> Void) {
         if let error = mockError {
             completion(.failure(error))
         } else {

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -69,9 +69,9 @@ class PurchasesTests: XCTestCase {
                                                     backend: backend,
                                                     offeringsFactory: offeringsFactory,
                                                     productsManager: mockProductsManager)
-        mockManageSubsModalHelper = MockManageSubscriptionsModalHelper(systemInfo: systemInfo,
-                                                                       customerInfoManager: customerInfoManager,
-                                                                       identityManager: identityManager)
+        mockManageSubsHelper = MockManageSubscriptionsHelper(systemInfo: systemInfo,
+                                                             customerInfoManager: customerInfoManager,
+                                                             identityManager: identityManager)
         mockBeginRefundRequestHelper = MockBeginRefundRequestHelper(systemInfo: systemInfo)
     }
 
@@ -279,7 +279,7 @@ class PurchasesTests: XCTestCase {
     var mockOfferingsManager: MockOfferingsManager!
     var purchasesOrchestrator: PurchasesOrchestrator!
     var trialOrIntroPriceEligibilityChecker: MockTrialOrIntroPriceEligibilityChecker!
-    var mockManageSubsModalHelper: MockManageSubscriptionsModalHelper!
+    var mockManageSubsHelper: MockManageSubscriptionsHelper!
     var mockBeginRefundRequestHelper: MockBeginRefundRequestHelper!
 
     let purchasesDelegate = MockPurchasesDelegate()
@@ -316,7 +316,7 @@ class PurchasesTests: XCTestCase {
                                                       identityManager: identityManager,
                                                       receiptParser: mockReceiptParser,
                                                       deviceCache: deviceCache,
-                                                      manageSubscriptionsModalHelper: mockManageSubsModalHelper,
+                                                      manageSubscriptionsHelper: mockManageSubsHelper,
                                                       beginRefundRequestHelper: mockBeginRefundRequestHelper)
         trialOrIntroPriceEligibilityChecker = MockTrialOrIntroPriceEligibilityChecker(receiptFetcher: receiptFetcher,
                                                                                       introEligibilityCalculator: mockIntroEligibilityCalculator,

--- a/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -51,9 +51,9 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
         "other_purchases": [:],
         "original_application_version": NSNull()
     ]]
-    
+
     var mockOfferingsManager: MockOfferingsManager!
-    var mockManageSubsModalHelper: MockManageSubscriptionsModalHelper!
+    var mockManageSubsHelper: MockManageSubscriptionsHelper!
     var mockBeginRefundRequestHelper: MockBeginRefundRequestHelper!
 
     var purchases: Purchases!
@@ -104,7 +104,7 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
                                                     offeringsFactory: MockOfferingsFactory(),
                                                     productsManager: mockProductsManager)
         self.mockReceiptFetcher = MockReceiptFetcher(requestFetcher: mockRequestFetcher, systemInfo: systemInfoAttribution)
-        self.mockManageSubsModalHelper = MockManageSubscriptionsModalHelper(systemInfo: systemInfo,
+        self.mockManageSubsHelper = MockManageSubscriptionsHelper(systemInfo: systemInfo,
                                                                             customerInfoManager: customerInfoManager,
                                                                             identityManager: mockIdentityManager)
         self.mockBeginRefundRequestHelper = MockBeginRefundRequestHelper(systemInfo: systemInfo)
@@ -130,7 +130,7 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
                                                           identityManager: mockIdentityManager,
                                                           receiptParser: mockReceiptParser,
                                                           deviceCache: mockDeviceCache,
-                                                          manageSubscriptionsModalHelper: mockManageSubsModalHelper,
+                                                          manageSubscriptionsHelper: mockManageSubsHelper,
                                                           beginRefundRequestHelper: mockBeginRefundRequestHelper)
         let trialOrIntroductoryPriceEligibilityChecker =
         TrialOrIntroPriceEligibilityChecker(receiptFetcher: mockReceiptFetcher,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -181,7 +181,7 @@
 		35549323269E298B005F9AE9 /* OfferingsFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35549322269E298B005F9AE9 /* OfferingsFactory.swift */; };
 		359E3ABF26FBE8CD0094617C /* PartialMockProductsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359E3ABE26FBE8CD0094617C /* PartialMockProductsManager.swift */; };
 		359E8E3F26DEBEEB00B869F9 /* TrialOrIntroPriceEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 359E8E3E26DEBEEB00B869F9 /* TrialOrIntroPriceEligibilityChecker.swift */; };
-		35B745A82711001A00458D46 /* MockManageSubscriptionsModalHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E840CD2710E2EB00899AE2 /* MockManageSubscriptionsModalHelper.swift */; };
+		35B745A82711001A00458D46 /* MockManageSubscriptionsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E840CD2710E2EB00899AE2 /* MockManageSubscriptionsHelper.swift */; };
 		35D0E5D026A5886C0099EAD8 /* ErrorUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D0E5CF26A5886C0099EAD8 /* ErrorUtils.swift */; };
 		35D832CD262A5B7500E60AC5 /* ETagManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D832CC262A5B7500E60AC5 /* ETagManager.swift */; };
 		35D832D2262E56DB00E60AC5 /* HTTPStatusCodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D832D1262E56DB00E60AC5 /* HTTPStatusCodes.swift */; };
@@ -189,8 +189,8 @@
 		35D83300262FAD8000E60AC5 /* ETagManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D832FF262FAD8000E60AC5 /* ETagManagerTests.swift */; };
 		35D8330A262FBA9A00E60AC5 /* MockUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E357D16038F07915D7825D /* MockUserDefaults.swift */; };
 		35D83312262FBD4200E60AC5 /* MockETagManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D83311262FBD4200E60AC5 /* MockETagManager.swift */; };
-		35E840CC270FB70D00899AE2 /* ManageSubscriptionsModalHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E840C5270FB47C00899AE2 /* ManageSubscriptionsModalHelper.swift */; };
-		35E840CE2710E2EB00899AE2 /* MockManageSubscriptionsModalHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E840CD2710E2EB00899AE2 /* MockManageSubscriptionsModalHelper.swift */; };
+		35E840CC270FB70D00899AE2 /* ManageSubscriptionsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E840C5270FB47C00899AE2 /* ManageSubscriptionsHelper.swift */; };
+		35E840CE2710E2EB00899AE2 /* MockManageSubscriptionsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E840CD2710E2EB00899AE2 /* MockManageSubscriptionsHelper.swift */; };
 		35F6FD62267426D600ABCB53 /* ETagAndResponseWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F6FD61267426D600ABCB53 /* ETagAndResponseWrapper.swift */; };
 		35F82BAB26A84E130051DF03 /* Dictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F82BAA26A84E130051DF03 /* Dictionary+Extensions.swift */; };
 		35F82BB226A98EC50051DF03 /* AttributionDataMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35F82BB126A98EC50051DF03 /* AttributionDataMigratorTests.swift */; };
@@ -204,11 +204,10 @@
 		37E35C8515C5E2D01B0AF5C1 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3507939634ED5A9280544 /* Strings.swift */; };
 		42F1DF385E3C1F9903A07FBF /* ProductsFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */; };
 		5791CE80273F26A000E50C4B /* base64encoded_sandboxReceipt.txt in Resources */ = {isa = PBXBuildFile; fileRef = 5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */; };
-		57E2230727500BB1002DB06E /* AtomicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E2230627500BB1002DB06E /* AtomicTests.swift */; };
-		57EAE527274324C60060EB74 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE526274324C60060EB74 /* Lock.swift */; };
-		57EAE52D274468900060EB74 /* RawDataContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE52C274468900060EB74 /* RawDataContainer.swift */; };
 		57A0FBF02749C0C2009E2FC3 /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */; };
 		57A0FBF22749CF66009E2FC3 /* SynchronizedUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */; };
+		57E2230727500BB1002DB06E /* AtomicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E2230627500BB1002DB06E /* AtomicTests.swift */; };
+		57EAE527274324C60060EB74 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE526274324C60060EB74 /* Lock.swift */; };
 		57EAE52B274332830060EB74 /* Obsoletions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE52A274332830060EB74 /* Obsoletions.swift */; };
 		57EAE52D274468900060EB74 /* RawDataContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE52C274468900060EB74 /* RawDataContainer.swift */; };
 		6E38843A0CAFD551013D0A3F /* ProductDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECF627761D375C8431EB866 /* ProductDetails.swift */; };
@@ -226,7 +225,7 @@
 		A525BF4B26C320D100C354C4 /* SubscriberAttributesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A525BF4A26C320D100C354C4 /* SubscriberAttributesManager.swift */; };
 		A55D08302722368600D919E0 /* SK2BeginRefundRequestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55D082F2722368600D919E0 /* SK2BeginRefundRequestHelper.swift */; };
 		A55D083427235DED00D919E0 /* BeginRefundRequestHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A563F587271E076800246E0C /* BeginRefundRequestHelperTests.swift */; };
-		A55D083527235E2800D919E0 /* ManageSubscriptionsModalHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E840C9270FB52800899AE2 /* ManageSubscriptionsModalHelperTests.swift */; };
+		A55D083527235E2800D919E0 /* ManageSubscriptionsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E840C9270FB52800899AE2 /* ManageSubscriptionsHelperTests.swift */; };
 		A55D083627236F0200D919E0 /* MockSK2BeginRefundRequestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55D08312722471200D919E0 /* MockSK2BeginRefundRequestHelper.swift */; };
 		A563F586271E072B00246E0C /* MockBeginRefundRequestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A563F585271E072B00246E0C /* MockBeginRefundRequestHelper.swift */; };
 		A563F589271E1DAD00246E0C /* MockBeginRefundRequestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A563F585271E072B00246E0C /* MockBeginRefundRequestHelper.swift */; };
@@ -465,9 +464,9 @@
 		35D832FF262FAD8000E60AC5 /* ETagManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ETagManagerTests.swift; sourceTree = "<group>"; };
 		35D83311262FBD4200E60AC5 /* MockETagManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockETagManager.swift; sourceTree = "<group>"; };
 		35E1CE1F26E022C20008560A /* TrialOrIntroPriceEligibilityCheckerSK1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrialOrIntroPriceEligibilityCheckerSK1Tests.swift; sourceTree = "<group>"; };
-		35E840C5270FB47C00899AE2 /* ManageSubscriptionsModalHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionsModalHelper.swift; sourceTree = "<group>"; };
-		35E840C9270FB52800899AE2 /* ManageSubscriptionsModalHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionsModalHelperTests.swift; sourceTree = "<group>"; };
-		35E840CD2710E2EB00899AE2 /* MockManageSubscriptionsModalHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockManageSubscriptionsModalHelper.swift; sourceTree = "<group>"; };
+		35E840C5270FB47C00899AE2 /* ManageSubscriptionsHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionsHelper.swift; sourceTree = "<group>"; };
+		35E840C9270FB52800899AE2 /* ManageSubscriptionsHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionsHelperTests.swift; sourceTree = "<group>"; };
+		35E840CD2710E2EB00899AE2 /* MockManageSubscriptionsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockManageSubscriptionsHelper.swift; sourceTree = "<group>"; };
 		35F6FD61267426D600ABCB53 /* ETagAndResponseWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ETagAndResponseWrapper.swift; sourceTree = "<group>"; };
 		35F82BAA26A84E130051DF03 /* Dictionary+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extensions.swift"; sourceTree = "<group>"; };
 		35F82BB126A98EC50051DF03 /* AttributionDataMigratorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributionDataMigratorTests.swift; sourceTree = "<group>"; };
@@ -523,11 +522,10 @@
 		37E35F783903362B65FB7AF3 /* MockProductsRequestFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockProductsRequestFactory.swift; sourceTree = "<group>"; };
 		37E35FDA0A44EA03EA12DAA2 /* DateFormatter+ExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DateFormatter+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = base64encoded_sandboxReceipt.txt; sourceTree = "<group>"; };
-		57E2230627500BB1002DB06E /* AtomicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicTests.swift; sourceTree = "<group>"; };
-		57EAE526274324C60060EB74 /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
-		57EAE52C274468900060EB74 /* RawDataContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawDataContainer.swift; sourceTree = "<group>"; };
 		57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 		57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedUserDefaults.swift; sourceTree = "<group>"; };
+		57E2230627500BB1002DB06E /* AtomicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicTests.swift; sourceTree = "<group>"; };
+		57EAE526274324C60060EB74 /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		57EAE52A274332830060EB74 /* Obsoletions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Obsoletions.swift; sourceTree = "<group>"; };
 		57EAE52C274468900060EB74 /* RawDataContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawDataContainer.swift; sourceTree = "<group>"; };
 		80E80EF026970DC3008F245A /* ReceiptFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptFetcher.swift; sourceTree = "<group>"; };
@@ -920,7 +918,7 @@
 				37E357D16038F07915D7825D /* MockUserDefaults.swift */,
 				2DDF41E924F6F844005BC22D /* SKProductSubscriptionDurationExtensions.swift */,
 				2D90F8C926FD257A009B9142 /* MockStoreKit2TransactionListener.swift */,
-				35E840CD2710E2EB00899AE2 /* MockManageSubscriptionsModalHelper.swift */,
+				35E840CD2710E2EB00899AE2 /* MockManageSubscriptionsHelper.swift */,
 				A563F585271E072B00246E0C /* MockBeginRefundRequestHelper.swift */,
 				A55D08312722471200D919E0 /* MockSK2BeginRefundRequestHelper.swift */,
 			);
@@ -1124,7 +1122,7 @@
 		35E840C1270FB45600899AE2 /* Support */ = {
 			isa = PBXGroup;
 			children = (
-				35E840C5270FB47C00899AE2 /* ManageSubscriptionsModalHelper.swift */,
+				35E840C5270FB47C00899AE2 /* ManageSubscriptionsHelper.swift */,
 				A5F0104D2717B3150090732D /* BeginRefundRequestHelper.swift */,
 			);
 			path = Support;
@@ -1133,7 +1131,7 @@
 		35E840C8270FB51C00899AE2 /* Support */ = {
 			isa = PBXGroup;
 			children = (
-				35E840C9270FB52800899AE2 /* ManageSubscriptionsModalHelperTests.swift */,
+				35E840C9270FB52800899AE2 /* ManageSubscriptionsHelperTests.swift */,
 				A563F587271E076800246E0C /* BeginRefundRequestHelperTests.swift */,
 			);
 			path = Support;
@@ -1522,7 +1520,7 @@
 			mainGroup = 352629F41F7C4B9100C04F2C;
 			packageReferences = (
 				2D803F6126F144830069D717 /* XCRemoteSwiftPackageReference "nimble" */,
-				2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */,
+				2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs.git" */,
 			);
 			productRefGroup = 352629FF1F7C4B9100C04F2C /* Products */;
 			projectDirPath = "";
@@ -1641,7 +1639,7 @@
 				2D90F8C226FD20F7009B9142 /* MockETagManager.swift in Sources */,
 				2D90F8B526FD2093009B9142 /* MockSystemInfo.swift in Sources */,
 				2D90F8C126FD20F2009B9142 /* MockHTTPClient.swift in Sources */,
-				A55D083527235E2800D919E0 /* ManageSubscriptionsModalHelperTests.swift in Sources */,
+				A55D083527235E2800D919E0 /* ManageSubscriptionsHelperTests.swift in Sources */,
 				2DFF6C56270CA28800ECAFAB /* MockRequestFetcher.swift in Sources */,
 				2D90F8C826FD2225009B9142 /* MockAppleReceiptBuilder.swift in Sources */,
 				2D90F8C026FD20DF009B9142 /* MockAttributionDataMigrator.swift in Sources */,
@@ -1651,7 +1649,7 @@
 				2D90F8C526FD216A009B9142 /* MockSKDiscount.swift in Sources */,
 				2D90F8B326FD2082009B9142 /* MockProductsManager.swift in Sources */,
 				2D90F8CA26FD257A009B9142 /* MockStoreKit2TransactionListener.swift in Sources */,
-				35B745A82711001A00458D46 /* MockManageSubscriptionsModalHelper.swift in Sources */,
+				35B745A82711001A00458D46 /* MockManageSubscriptionsHelper.swift in Sources */,
 				2D90F8B126FD1E52009B9142 /* PurchasesOrchestratorTests.swift in Sources */,
 				A563F589271E1DAD00246E0C /* MockBeginRefundRequestHelper.swift in Sources */,
 				2D90F8B426FD208B009B9142 /* MockStoreKitWrapper.swift in Sources */,
@@ -1783,7 +1781,7 @@
 				B302206A27271BCB008F1A0D /* Decoder+Extensions.swift in Sources */,
 				B3766F1E26BDA95100141450 /* IntroEligibilityResponse.swift in Sources */,
 				6E38843A0CAFD551013D0A3F /* ProductDetails.swift in Sources */,
-				35E840CC270FB70D00899AE2 /* ManageSubscriptionsModalHelper.swift in Sources */,
+				35E840CC270FB70D00899AE2 /* ManageSubscriptionsHelper.swift in Sources */,
 				42F1DF385E3C1F9903A07FBF /* ProductsFetcherSK1.swift in Sources */,
 				805B60C97993B311CEC93EAF /* ProductsFetcherSK2.swift in Sources */,
 			);
@@ -1837,7 +1835,7 @@
 				351B51B826D450E800BD2BD7 /* StoreKitWrapperTests.swift in Sources */,
 				2DDF41E624F6F5DC005BC22D /* MockSK1Product.swift in Sources */,
 				351B51BA26D450E800BD2BD7 /* ProductInfoExtensions.swift in Sources */,
-				35E840CE2710E2EB00899AE2 /* MockManageSubscriptionsModalHelper.swift in Sources */,
+				35E840CE2710E2EB00899AE2 /* MockManageSubscriptionsHelper.swift in Sources */,
 				F591492826B9956C00D32E58 /* MockTransaction.swift in Sources */,
 				351B517626D44F7200BD2BD7 /* MockProductDiscount.swift in Sources */,
 				351B516A26D44CB300BD2BD7 /* ISOPeriodFormatterTests.swift in Sources */,
@@ -2537,7 +2535,7 @@
 				kind = branch;
 			};
 		};
-		2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */ = {
+		2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs.git" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/AliSoftware/OHHTTPStubs.git";
 			requirement = {
@@ -2565,22 +2563,22 @@
 		};
 		2D9C5ED026F2816F0057FC45 /* OHHTTPStubs */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */;
+			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs.git" */;
 			productName = OHHTTPStubs;
 		};
 		2D9C5ED226F2816F0057FC45 /* OHHTTPStubsSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */;
+			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs.git" */;
 			productName = OHHTTPStubsSwift;
 		};
 		2D9C5ED426F281750057FC45 /* OHHTTPStubs */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */;
+			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs.git" */;
 			productName = OHHTTPStubs;
 		};
 		2D9C5ED626F281750057FC45 /* OHHTTPStubsSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */;
+			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs.git" */;
 			productName = OHHTTPStubsSwift;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1520,7 +1520,7 @@
 			mainGroup = 352629F41F7C4B9100C04F2C;
 			packageReferences = (
 				2D803F6126F144830069D717 /* XCRemoteSwiftPackageReference "nimble" */,
-				2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs.git" */,
+				2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */,
 			);
 			productRefGroup = 352629FF1F7C4B9100C04F2C /* Products */;
 			projectDirPath = "";
@@ -2535,7 +2535,7 @@
 				kind = branch;
 			};
 		};
-		2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs.git" */ = {
+		2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/AliSoftware/OHHTTPStubs.git";
 			requirement = {
@@ -2563,22 +2563,22 @@
 		};
 		2D9C5ED026F2816F0057FC45 /* OHHTTPStubs */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs.git" */;
+			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */;
 			productName = OHHTTPStubs;
 		};
 		2D9C5ED226F2816F0057FC45 /* OHHTTPStubsSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs.git" */;
+			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */;
 			productName = OHHTTPStubsSwift;
 		};
 		2D9C5ED426F281750057FC45 /* OHHTTPStubs */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs.git" */;
+			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */;
 			productName = OHHTTPStubs;
 		};
 		2D9C5ED626F281750057FC45 /* OHHTTPStubsSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs.git" */;
+			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */;
 			productName = OHHTTPStubsSwift;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -30,7 +30,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     var identityManager: MockIdentityManager!
     var receiptParser: MockReceiptParser!
     var deviceCache: MockDeviceCache!
-    var mockManageSubsModalHelper: MockManageSubscriptionsModalHelper!
+    var mockManageSubsHelper: MockManageSubscriptionsHelper!
     var mockBeginRefundRequestHelper: MockBeginRefundRequestHelper!
 
     var orchestrator: PurchasesOrchestrator!
@@ -57,7 +57,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
             deviceCache: deviceCache,
             attributionFetcher: attributionFetcher,
             attributionDataMigrator: MockAttributionDataMigrator())
-        mockManageSubsModalHelper = MockManageSubscriptionsModalHelper(systemInfo: systemInfo,
+        mockManageSubsHelper = MockManageSubscriptionsHelper(systemInfo: systemInfo,
                                                                        customerInfoManager: customerInfoManager,
                                                                        identityManager: identityManager)
         mockBeginRefundRequestHelper = MockBeginRefundRequestHelper(systemInfo: systemInfo)
@@ -72,7 +72,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                                              identityManager: identityManager,
                                              receiptParser: receiptParser,
                                              deviceCache: deviceCache,
-                                             manageSubscriptionsModalHelper: mockManageSubsModalHelper,
+                                             manageSubscriptionsHelper: mockManageSubsHelper,
                                              beginRefundRequestHelper: mockBeginRefundRequestHelper)
         setUpStoreKit2Listener()
     }
@@ -222,12 +222,12 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         expect(mockListener.invokedHandle) == false
     }
 
-    func testShowManageSubscriptionModalCallsCompletionWithErrorIfThereIsAFailure() {
-        let message = "Failed to get managemementURL from CustomerInfo. Details: customerInfo is nil."
-        mockManageSubsModalHelper.mockError = ErrorUtils.customerInfoError(withMessage: message)
+    func testShowManageSubscriptionsCallsCompletionWithErrorIfThereIsAFailure() {
+        let message = "Failed to get managementURL from CustomerInfo. Details: customerInfo is nil."
+        mockManageSubsHelper.mockError = ErrorUtils.customerInfoError(withMessage: message)
         var receivedError: Error?
         var completionCalled = false
-        orchestrator.showManageSubscriptionModal { maybeError in
+        orchestrator.showManageSubscription { maybeError in
             completionCalled = true
             receivedError = maybeError
         }

--- a/docs/V4_API_Updates.md
+++ b/docs/V4_API_Updates.md
@@ -389,6 +389,11 @@ if let error = error as? RevenueCat.ErrorCode {
 }
 ```
 
+### New APIs
+
+- `showManageSuscriptions(completion:)`: Use this method to show the subscription management for the current user. Depending on where they made the purchase and their OS version, this might take them to the `managementURL`, or open the iOS Subscription Management page. 
+- `beginRefundRequest(for:)`: Use this method to begin a refund request for a purchase, specifying the product identifier.
+
 ## Reporting undocumented issues:
 
 Feel free to file an issue! [New RevenueCat Issue](https://github.com/RevenueCat/purchases-ios/issues/new/).


### PR DESCRIPTION
The method isn't guaranteed to open up a modal, since depending on the OS version it might take you to iOS Settings instead. 
So this renames it to remove the word 'modal'. 

Also, this uses the plural "subscriptions", since the page allows you to manage more than one subscription to the current app. 