### PR TITLE
ProductFetcherSK1: added retry mechanism to deal with StoreKit error

### DIFF
--- a/APITesters/SwiftAPITester/SwiftAPITester/ErrorCodesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/ErrorCodesAPI.swift
@@ -48,7 +48,8 @@ func checkPurchasesErrorCodeEnums() {
          .productDiscountMissingSubscriptionGroupIdentifierError,
          .customerInfoError,
          .systemInfoError,
-         .beginRefundRequestError:
+         .beginRefundRequestError,
+         .productRequestTimedOut:
         print(errCode!)
     @unknown default:
         fatalError()

--- a/Purchases/Error Handling/ErrorUtils.swift
+++ b/Purchases/Error Handling/ErrorUtils.swift
@@ -377,7 +377,8 @@ private extension ErrorUtils {
                 .invalidAppleSubscriptionKeyError,
                 .ineligibleError,
                 .insufficientPermissionsError,
-                .paymentPendingError:
+                .paymentPendingError,
+                .productRequestTimedOut:
             Logger.appleError(code.description)
 
         @unknown default:

--- a/Purchases/FoundationExtensions/DispatchTimeInterval+Extensions.swift
+++ b/Purchases/FoundationExtensions/DispatchTimeInterval+Extensions.swift
@@ -1,0 +1,32 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  DispatchTimeInterval+Extensions.swift
+//
+//  Created by Nacho Soto on 12/2/21.
+
+// swiftlint:disable identifier_name
+extension DispatchTimeInterval {
+
+    /// `DispatchTimeInterval` can only be used by specifying a unit of time.
+    /// This allows us to easily convert any `DispatchTimeInterval` into seconds.
+    var seconds: Double {
+        switch self {
+        case let .seconds(seconds): return Double(seconds)
+        case let .milliseconds(ms): return Double(ms) / 1000
+        case let .microseconds(ms): return Double(ms) / 1_000_000
+        case let .nanoseconds(ns): return Double(ns) / 1_000_000_000
+        case .never: return 0
+        @unknown default: fatalError("Unknown value: \(self)")
+        }
+    }
+
+}
+
+// swiftlint:enable identifier_name

--- a/Purchases/FoundationExtensions/DispatchTimeInterval+Extensions.swift
+++ b/Purchases/FoundationExtensions/DispatchTimeInterval+Extensions.swift
@@ -27,6 +27,21 @@ extension DispatchTimeInterval {
         }
     }
 
+    fileprivate var milliseconds: Double {
+        switch self {
+        case let .seconds(seconds): return Double(seconds * 1000)
+        case let .milliseconds(ms): return Double(ms)
+        case let .microseconds(ms): return Double(ms) / 1_000
+        case let .nanoseconds(ns): return Double(ns) / 1_000_000
+        case .never: return 0
+        @unknown default: fatalError("Unknown value: \(self)")
+        }
+    }
+
 }
 
 // swiftlint:enable identifier_name
+
+func + (lhs: DispatchTimeInterval, rhs: DispatchTimeInterval) -> DispatchTimeInterval {
+    return .milliseconds(Int(lhs.milliseconds + rhs.milliseconds))
+}

--- a/Purchases/FoundationExtensions/Result+Extensions.swift
+++ b/Purchases/FoundationExtensions/Result+Extensions.swift
@@ -1,0 +1,28 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Result+Extensions.swift
+//
+//  Created by Nacho Soto on 12/1/21.
+
+extension Result {
+    var value: Success? {
+        switch self {
+        case let .success(value): return value
+        case .failure: return nil
+        }
+    }
+
+    var error: Failure? {
+        switch self {
+        case .success: return nil
+        case let .failure(error): return error
+        }
+    }
+}

--- a/Purchases/Public/Errors/ErrorCode.swift
+++ b/Purchases/Public/Errors/ErrorCode.swift
@@ -55,6 +55,8 @@ import Foundation
     case systemInfoError = 30
     @objc(RCBeginRefundRequestError)
     case beginRefundRequestError = 31
+    @objc(RCProductRequestTimedOut)
+    case productRequestTimedOut = 32
 
 }
 
@@ -140,6 +142,8 @@ extension ErrorCode: DescribableError {
             return "There was a problem related to the system info."
         case .beginRefundRequestError:
             return "Error when trying to begin refund request."
+        case .productRequestTimedOut:
+            return "SKProductsRequest took too long to complete."
         @unknown default:
             return "Something went wrong."
         }
@@ -229,6 +233,8 @@ extension ErrorCode {
             return "SYSTEM_INFO_ERROR"
         case .beginRefundRequestError:
             return "BEGIN_REFUND_REQUEST_ERROR"
+        case .productRequestTimedOut:
+            return "PRODUCT_REQUEST_TIMED_OUT_ERROR"
         @unknown default:
             return "UNRECOGNIZED_ERROR"
         }

--- a/Purchases/Purchasing/IntroEligibilityCalculator.swift
+++ b/Purchases/Purchasing/IntroEligibilityCalculator.swift
@@ -47,7 +47,9 @@ class IntroEligibilityCalculator {
             let allProductIdentifiers =
                 candidateProductIdentifiers.union(purchasedProductIdsWithIntroOffersOrFreeTrials)
 
-            productsManager.products(withIdentifiers: allProductIdentifiers) { allProducts in
+            productsManager.products(withIdentifiers: allProductIdentifiers) {
+                let allProducts = $0.value ?? []
+
                 let purchasedProductsWithIntroOffersOrFreeTrials = allProducts.filter {
                     purchasedProductIdsWithIntroOffersOrFreeTrials.contains($0.productIdentifier)
                 }

--- a/Purchases/Purchasing/OfferingsManager.swift
+++ b/Purchases/Purchasing/OfferingsManager.swift
@@ -105,8 +105,10 @@ private extension OfferingsManager {
             return
         }
 
-        productsManager.productsFromOptimalStoreKitVersion(withIdentifiers: productIdentifiers) { products in
-            guard !products.isEmpty else {
+        productsManager.productsFromOptimalStoreKitVersion(withIdentifiers: productIdentifiers) { result in
+            let products = result.value ?? []
+
+            guard products.isEmpty == false else {
                 let errorMessage = Strings.offering.configuration_error_skproducts_not_found.description
                 self.handleOfferingsUpdateError(ErrorUtils.configurationError(message: errorMessage),
                                                 completion: completion)

--- a/Purchases/Purchasing/ProductsManager.swift
+++ b/Purchases/Purchasing/ProductsManager.swift
@@ -35,13 +35,17 @@ class ProductsManager: NSObject {
     }
 
     func productsFromOptimalStoreKitVersion(withIdentifiers identifiers: Set<String>,
-                                            completion: @escaping (Set<StoreProduct>) -> Void) {
+                                            completion: @escaping (Result<Set<StoreProduct>, Error>) -> Void) {
 
         if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *),
            self.systemInfo.useStoreKit2IfAvailable {
             _ = Task<Void, Never> {
-                let storeProduct = await self.sk2StoreProduct(withIdentifiers: identifiers)
-                completion(storeProduct)
+                do {
+                    let storeProduct = try await self.sk2StoreProduct(withIdentifiers: identifiers)
+                    completion(.success(storeProduct))
+                } catch {
+                    completion(.failure(error))
+                }
             }
         } else {
             productsFetcherSK1.products(withIdentifiers: identifiers, completion: completion)
@@ -49,27 +53,25 @@ class ProductsManager: NSObject {
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    func productsFromOptimalStoreKitVersion(withIdentifiers identifiers: Set<String>) async -> Set<StoreProduct> {
-        return await withCheckedContinuation { continuation in
+    func productsFromOptimalStoreKitVersion(
+        withIdentifiers identifiers: Set<String>
+    ) async throws -> Set<StoreProduct> {
+        return try await withCheckedThrowingContinuation { continuation in
             productsFromOptimalStoreKitVersion(withIdentifiers: identifiers) { result in
-                continuation.resume(returning: result)
+                continuation.resume(with: result)
             }
         }
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    func sk2StoreProduct(withIdentifiers identifiers: Set<String>) async -> Set<SK2StoreProduct> {
-        do {
-            let storeProduct = try await productsFetcherSK2.products(identifiers: identifiers)
-            return Set(storeProduct)
-        } catch {
-            Logger.error("Error when fetching SK2 products: \(error.localizedDescription)")
-            return Set()
-        }
+    func sk2StoreProduct(withIdentifiers identifiers: Set<String>) async throws -> Set<SK2StoreProduct> {
+        let storeProduct = try await productsFetcherSK2.products(identifiers: identifiers)
+
+        return Set(storeProduct)
     }
 
     func products(withIdentifiers identifiers: Set<String>,
-                  completion: @escaping (Set<SK1Product>) -> Void) {
+                  completion: @escaping (Result<Set<SK1Product>, Error>) -> Void) {
         return productsFetcherSK1.sk1Products(withIdentifiers: identifiers, completion: completion)
     }
 

--- a/Purchases/Purchasing/ProductsManager.swift
+++ b/Purchases/Purchasing/ProductsManager.swift
@@ -24,8 +24,13 @@ class ProductsManager: NSObject {
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     private(set) lazy var productsFetcherSK2 = ProductsFetcherSK2()
 
-    init(productsRequestFactory: ProductsRequestFactory = ProductsRequestFactory(), systemInfo: SystemInfo) {
-        self.productsFetcherSK1 = ProductsFetcherSK1(productsRequestFactory: productsRequestFactory)
+    init(
+        productsRequestFactory: ProductsRequestFactory = ProductsRequestFactory(),
+        systemInfo: SystemInfo,
+        requestTimeout: DispatchTimeInterval = .seconds(30)
+    ) {
+        self.productsFetcherSK1 = ProductsFetcherSK1(productsRequestFactory: productsRequestFactory,
+                                                     requestTimeout: requestTimeout)
         self.systemInfo = systemInfo
     }
 

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -112,7 +112,7 @@ class PurchasesOrchestrator {
 
         productsManager.products(withIdentifiers: productIdentifiersSet) { products in
             self.operationDispatcher.dispatchOnMainThread {
-                completion(Array(products))
+                completion(Array(products.value ?? []))
             }
         }
     }
@@ -127,7 +127,7 @@ class PurchasesOrchestrator {
 
         productsManager.productsFromOptimalStoreKitVersion(withIdentifiers: productIdentifiersSet) { products in
             self.operationDispatcher.dispatchOnMainThread {
-                completion(Array(products))
+                completion(Array(products.value ?? []))
             }
         }
     }

--- a/Purchases/Purchasing/StoreKit1/ProductsFetcherSK1.swift
+++ b/Purchases/Purchasing/StoreKit1/ProductsFetcherSK1.swift
@@ -26,7 +26,7 @@ class ProductsFetcherSK1: NSObject {
     private var completionHandlers: [Set<String>: [Callback]] = [:]
     private let requestTimeout: DispatchTimeInterval
 
-    private static let numberOfRetries: Int = 2
+    private static let numberOfRetries: Int = 5
 
     init(productsRequestFactory: ProductsRequestFactory = ProductsRequestFactory(),
          requestTimeout: DispatchTimeInterval = .seconds(30)) {
@@ -167,8 +167,12 @@ extension ProductsFetcherSK1: SKProductsRequestDelegate {
                     completion(.failure(error))
                 }
             } else {
-                self.startRequest(forIdentifiers: productRequest.identifiers,
-                                  retriesLeft: productRequest.retriesLeft - 1)
+                let delayInSeconds = Int((self.requestTimeout.seconds / 10).rounded())
+
+                queue.asyncAfter(deadline: .now() + .seconds(delayInSeconds)) { [self] in
+                    self.startRequest(forIdentifiers: productRequest.identifiers,
+                                      retriesLeft: productRequest.retriesLeft - 1)
+                }
             }
         }
     }

--- a/Purchases/Purchasing/StoreKit1/ProductsFetcherSK1.swift
+++ b/Purchases/Purchasing/StoreKit1/ProductsFetcherSK1.swift
@@ -26,8 +26,12 @@ class ProductsFetcherSK1: NSObject {
     private var completionHandlers: [Set<String>: [Callback]] = [:]
     private let requestTimeout: DispatchTimeInterval
 
-    private static let numberOfRetries: Int = 5
+    private static let numberOfRetries: Int = 10
 
+    /// - Parameter requestTimeout: requests made by this class will return after whichever condition comes first:
+    ///     - A success
+    ///     - Retries up to ``Self.numberOfRetries``
+    ///     - Timeout specified by this parameter
     init(productsRequestFactory: ProductsRequestFactory = ProductsRequestFactory(),
          requestTimeout: DispatchTimeInterval = .seconds(30)) {
         self.productsRequestFactory = productsRequestFactory

--- a/Purchases/Purchasing/StoreKit1/ProductsFetcherSK1.swift
+++ b/Purchases/Purchasing/StoreKit1/ProductsFetcherSK1.swift
@@ -230,21 +230,3 @@ private extension ProductsFetcherSK1 {
     }
 
 }
-
-// swiftlint:disable identifier_name
-private extension DispatchTimeInterval {
-
-    var seconds: Double {
-        switch self {
-        case let .seconds(seconds): return Double(seconds)
-        case let .milliseconds(ms): return Double(ms) / 1000
-        case let .microseconds(ms): return Double(ms) / 1_000_000
-        case let .nanoseconds(ns): return Double(ns) / 1_000_000_000
-        case .never: return 0
-        @unknown default: fatalError("Unknown value: \(self)")
-        }
-    }
-
-}
-
-// swiftlint:enable identifier_name

--- a/Purchases/Purchasing/StoreKit1/ProductsFetcherSK1.swift
+++ b/Purchases/Purchasing/StoreKit1/ProductsFetcherSK1.swift
@@ -20,14 +20,16 @@ class ProductsFetcherSK1: NSObject {
 
     private var cachedProductsByIdentifier: [String: SK1Product] = [:]
     private let queue = DispatchQueue(label: "ProductsFetcherSK1")
-    private var productsByRequests: [SKRequest: Set<String>] = [:]
+    private var productsByRequests: [SKRequest: ProductRequest] = [:]
     private var completionHandlers: [Set<String>: [(Set<SK1Product>) -> Void]] = [:]
-    private let requestTimeoutInSeconds: Int
+    private let requestTimeout: DispatchTimeInterval
+
+    private static let numberOfRetries: Int = 2
 
     init(productsRequestFactory: ProductsRequestFactory = ProductsRequestFactory(),
-         requestTimeoutInSeconds: Int = 30) {
+         requestTimeout: DispatchTimeInterval = .seconds(30)) {
         self.productsRequestFactory = productsRequestFactory
-        self.requestTimeoutInSeconds = requestTimeoutInSeconds
+        self.requestTimeout = requestTimeout
     }
 
     func sk1Products(withIdentifiers identifiers: Set<String>,
@@ -54,13 +56,25 @@ class ProductsFetcherSK1: NSObject {
             Logger.debug(
                 Strings.offering.no_cached_requests_and_products_starting_skproduct_request(identifiers: identifiers)
             )
-            let request = self.productsRequestFactory.request(productIdentifiers: identifiers)
-            request.delegate = self
+
             self.completionHandlers[identifiers] = [completion]
-            self.productsByRequests[request] = identifiers
-            request.start()
-            scheduleCancellationInCaseOfTimeout(for: request)
+
+            let request = self.startRequest(forIdentifiers: identifiers, retriesLeft: Self.numberOfRetries)
+            self.scheduleCancellationInCaseOfTimeout(for: request)
         }
+    }
+
+    @discardableResult
+    private func startRequest(
+        forIdentifiers identifiers: Set<String>,
+        retriesLeft: Int
+    ) -> SKProductsRequest {
+        let request = self.productsRequestFactory.request(productIdentifiers: identifiers)
+        request.delegate = self
+        self.productsByRequests[request] = .init(identifiers, retriesLeft: retriesLeft)
+        request.start()
+
+        return request
     }
 
     func products(withIdentifiers identifiers: Set<String>,
@@ -82,22 +96,36 @@ class ProductsFetcherSK1: NSObject {
 
 }
 
+private extension ProductsFetcherSK1 {
+
+    struct ProductRequest {
+        let identifiers: Set<String>
+        var retriesLeft: Int
+
+        init(_ identifiers: Set<String>, retriesLeft: Int) {
+            self.identifiers = identifiers
+            self.retriesLeft = retriesLeft
+        }
+    }
+
+}
+
 extension ProductsFetcherSK1: SKProductsRequestDelegate {
 
     func productsRequest(_ request: SKProductsRequest, didReceive response: SKProductsResponse) {
         queue.async { [self] in
             Logger.rcSuccess(Strings.storeKit.skproductsrequest_received_response)
-            guard let requestProducts = self.productsByRequests[request] else {
+            guard let productRequest = self.productsByRequests[request] else {
                 Logger.error("requested products not found for request: \(request)")
                 return
             }
-            guard let completionBlocks = self.completionHandlers[requestProducts] else {
+            guard let completionBlocks = self.completionHandlers[productRequest.identifiers] else {
                 Logger.error("callback not found for failing request: \(request)")
                 self.productsByRequests.removeValue(forKey: request)
                 return
             }
 
-            self.completionHandlers.removeValue(forKey: requestProducts)
+            self.completionHandlers.removeValue(forKey: productRequest.identifiers)
             self.productsByRequests.removeValue(forKey: request)
 
             self.cacheProducts(response.products)
@@ -113,25 +141,35 @@ extension ProductsFetcherSK1: SKProductsRequestDelegate {
     }
 
     func request(_ request: SKRequest, didFailWithError error: Error) {
+        defer {
+            self.cancelRequestToPreventTimeoutWarnings(request)
+        }
+
         queue.async { [self] in
             Logger.appleError(Strings.storeKit.skproductsrequest_failed(error: error))
-            guard let products = self.productsByRequests[request] else {
+
+            guard let productRequest = self.productsByRequests[request] else {
                 Logger.error(Strings.purchase.requested_products_not_found(request: request))
                 return
             }
-            guard let completionBlocks = self.completionHandlers[products] else {
-                Logger.error(Strings.purchase.callback_not_found_for_request(request: request))
-                self.productsByRequests.removeValue(forKey: request)
-                return
-            }
 
-            self.completionHandlers.removeValue(forKey: products)
-            self.productsByRequests.removeValue(forKey: request)
-            for completion in completionBlocks {
-                completion(Set())
+            if productRequest.retriesLeft <= 0 {
+                guard let completionBlocks = self.completionHandlers[productRequest.identifiers] else {
+                    Logger.error(Strings.purchase.callback_not_found_for_request(request: request))
+                    self.productsByRequests.removeValue(forKey: request)
+                    return
+                }
+
+                self.completionHandlers.removeValue(forKey: productRequest.identifiers)
+                self.productsByRequests.removeValue(forKey: request)
+                for completion in completionBlocks {
+                    completion(Set())
+                }
+            } else {
+                self.startRequest(forIdentifiers: productRequest.identifiers,
+                                  retriesLeft: productRequest.retriesLeft - 1)
             }
         }
-        self.cancelRequestToPreventTimeoutWarnings(request)
     }
 
     func cacheProduct(_ product: SK1Product) {
@@ -139,6 +177,7 @@ extension ProductsFetcherSK1: SKProductsRequestDelegate {
             self.cachedProductsByIdentifier[product.productIdentifier] = product
         }
     }
+
 }
 
 private extension ProductsFetcherSK1 {
@@ -167,19 +206,21 @@ private extension ProductsFetcherSK1 {
     // So we schedule a cancellation just in case, and skip it if all goes as expected.
     // More information: https://rev.cat/skproductsrequest-hangs
     func scheduleCancellationInCaseOfTimeout(for request: SKProductsRequest) {
-        queue.asyncAfter(deadline: .now() + .seconds(requestTimeoutInSeconds)) { [weak self] in
+        queue.asyncAfter(deadline: .now() + self.requestTimeout) { [weak self] in
             guard let self = self,
-                  let products = self.productsByRequests[request] else { return }
+                  let productRequest = self.productsByRequests[request] else { return }
 
             request.cancel()
 
-            Logger.appleError(Strings.storeKit.skproductsrequest_timed_out(after: self.requestTimeoutInSeconds))
-            guard let completionBlocks = self.completionHandlers[products] else {
+            Logger.appleError(Strings.storeKit.skproductsrequest_timed_out(
+                after: Int(self.requestTimeout.seconds.rounded())
+            ))
+            guard let completionBlocks = self.completionHandlers[productRequest.identifiers] else {
                 Logger.error("callback not found for failing request: \(request)")
                 return
             }
 
-            self.completionHandlers.removeValue(forKey: products)
+            self.completionHandlers.removeValue(forKey: productRequest.identifiers)
             self.productsByRequests.removeValue(forKey: request)
             for completion in completionBlocks {
                 completion(Set())
@@ -188,3 +229,21 @@ private extension ProductsFetcherSK1 {
     }
 
 }
+
+// swiftlint:disable identifier_name
+private extension DispatchTimeInterval {
+
+    var seconds: Double {
+        switch self {
+        case let .seconds(seconds): return Double(seconds)
+        case let .milliseconds(ms): return Double(ms) / 1000
+        case let .microseconds(ms): return Double(ms) / 1_000_000
+        case let .nanoseconds(ns): return Double(ns) / 1_000_000_000
+        case .never: return 0
+        @unknown default: fatalError("Unknown value: \(self)")
+        }
+    }
+
+}
+
+// swiftlint:enable identifier_name

--- a/Purchases/Purchasing/StoreKit2/ProductsFetcherSK2.swift
+++ b/Purchases/Purchasing/StoreKit2/ProductsFetcherSK2.swift
@@ -14,14 +14,14 @@
 import Foundation
 import StoreKit
 
-enum ProductsManagerSK2Error: Error {
-
-    case productsRequestError(innerError: Error)
-
-}
-
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 actor ProductsFetcherSK2 {
+
+    enum Error: Swift.Error {
+
+        case productsRequestError(innerError: Swift.Error)
+
+    }
 
     private var cachedProductsByIdentifier: [String: SK2StoreProduct] = [:]
 
@@ -40,7 +40,21 @@ actor ProductsFetcherSK2 {
             let sk2StoreProduct = storeKitProducts.map { SK2StoreProduct(sk2Product: $0) }
             return Set(sk2StoreProduct)
         } catch {
-            throw ProductsManagerSK2Error.productsRequestError(innerError: error)
+            throw Error.productsRequestError(innerError: error)
+        }
+    }
+
+}
+
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+extension ProductsFetcherSK2.Error: CustomNSError {
+
+    var errorUserInfo: [String: Any] {
+        switch self {
+        case let .productsRequestError(inner):
+            return [
+                NSUnderlyingErrorKey: inner
+            ]
         }
     }
 

--- a/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -74,7 +74,9 @@ class TrialOrIntroPriceEligibilityChecker {
         var introDict = productIdentifiers.reduce(into: [:]) { resultDict, productId in
             resultDict[productId] = IntroEligibility(eligibilityStatus: IntroEligibilityStatus.unknown)
         }
-        let products = await productsManager.sk2StoreProduct(withIdentifiers: identifiers)
+
+        // fixme: handle errors
+        let products = (try? await productsManager.sk2StoreProduct(withIdentifiers: identifiers)) ?? []
         for sk2StoreProduct in products {
             let sk2Product = sk2StoreProduct.underlyingSK2Product
             let maybeIsEligible = await sk2Product.subscription?.isEligibleForIntroOffer

--- a/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -149,7 +149,7 @@ private extension TrialOrIntroPriceEligibilityChecker {
     @available(iOS 11.2, macOS 10.13.2, macCatalyst 13.0, tvOS 11.2, watchOS 6.2, *)
     func productsWithIntroOffers(productIdentifiers: [String], completion: @escaping ReceiveIntroEligibilityBlock) {
         self.productsManager.products(withIdentifiers: Set(productIdentifiers)) { products in
-            let eligibility: [(String, IntroEligibility)] = Array(products)
+            let eligibility: [(String, IntroEligibility)] = Array(products.value ?? [])
                 .filter { $0.introductoryPrice != nil }
                 .map { ($0.productIdentifier, IntroEligibility(eligibilityStatus: .eligible)) }
 

--- a/PurchasesTests/Mocks/MockProductsManager.swift
+++ b/PurchasesTests/Mocks/MockProductsManager.swift
@@ -16,13 +16,13 @@ class MockProductsManager: ProductsManager {
     var stubbedProductsFromOptimalStoreKitVersionWithIdentifiersCompletionResult: (Set<StoreProduct>, Void)?
 
     override func productsFromOptimalStoreKitVersion(withIdentifiers identifiers: Set<String>,
-                                                     completion: @escaping (Set<StoreProduct>) -> Void) {
+                                                     completion: @escaping (Result<Set<StoreProduct>, Error>) -> Void) {
         invokedProductsFromOptimalStoreKitVersionWithIdentifiers = true
         invokedProductsFromOptimalStoreKitVersionWithIdentifiersCount += 1
         invokedProductsFromOptimalStoreKitVersionWithIdentifiersParameters = (identifiers, ())
         invokedProductsFromOptimalStoreKitVersionWithIdentifiersParametersList.append((identifiers, ()))
         if let result = stubbedProductsFromOptimalStoreKitVersionWithIdentifiersCompletionResult {
-            completion(result.0)
+            completion(.success(result.0))
         } else {
             let products: [SK1Product] = identifiers.map { (identifier) -> MockSK1Product in
                 let p = MockSK1Product(mockProductIdentifier: identifier)
@@ -36,7 +36,7 @@ class MockProductsManager: ProductsManager {
             }
             let result = Set(products).map { SK1StoreProduct(sk1Product: $0) }
 
-            completion(Set(result))
+            completion(.success(Set(result)))
         }
     }
 
@@ -75,13 +75,16 @@ class MockProductsManager: ProductsManager {
     var invokedProductsParametersList = [Set<String>]()
     var stubbedProductsCompletionResult: Set<SK1Product>?
 
-    override func products(withIdentifiers identifiers: Set<String>, completion: @escaping (Set<SK1Product>) -> Void) {
+    override func products(
+        withIdentifiers identifiers: Set<String>,
+        completion: @escaping (Result<Set<SK1Product>, Error>) -> Void
+    ) {
         invokedProducts = true
         invokedProductsCount += 1
         invokedProductsParameters = identifiers
         invokedProductsParametersList.append(identifiers)
         if let result = stubbedProductsCompletionResult {
-            completion(result)
+            completion(.success(result))
         } else {
             let products: [SK1Product] = identifiers.map { (identifier) -> MockSK1Product in
                 let p = MockSK1Product(mockProductIdentifier: identifier)
@@ -93,7 +96,7 @@ class MockProductsManager: ProductsManager {
                 }
                 return p
             }
-            completion(Set(products))
+            completion(.success(Set(products)))
         }
     }
 

--- a/PurchasesTests/Mocks/MockProductsRequest.swift
+++ b/PurchasesTests/Mocks/MockProductsRequest.swift
@@ -32,17 +32,17 @@ class MockProductsRequest: SKProductsRequest {
     var cancelCalled = false
     var requestedIdentifiers: Set<String>
     var fails = false
-    var responseTimeInSeconds: Int
+    var responseTime: DispatchTimeInterval
 
-    init(productIdentifiers: Set<String>, responseTimeInSeconds: Int = 0) {
+    init(productIdentifiers: Set<String>, responseTime: DispatchTimeInterval = .seconds(0)) {
         self.requestedIdentifiers = productIdentifiers
-        self.responseTimeInSeconds = responseTimeInSeconds
+        self.responseTime = responseTime
         super.init()
     }
 
     override func start() {
         startCalled = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(responseTimeInSeconds)) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.responseTime) {
             if (self.fails) {
                 self.delegate?.request!(self, didFailWithError: Error.unknown)
             } else {

--- a/PurchasesTests/Mocks/MockProductsRequestFactory.swift
+++ b/PurchasesTests/Mocks/MockProductsRequestFactory.swift
@@ -14,7 +14,7 @@ class MockProductsRequestFactory: ProductsRequestFactory {
     var invokedRequestParameters: Set<String>?
     var invokedRequestParametersList = [Set<String>]()
     var stubbedRequestResult: MockProductsRequest!
-    var requestResponseTimeInSeconds: Int = 0
+    var requestResponseTime: DispatchTimeInterval = .seconds(0)
 
     override func request(productIdentifiers: Set<String>) -> SKProductsRequest {
         invokedRequest = true
@@ -22,6 +22,6 @@ class MockProductsRequestFactory: ProductsRequestFactory {
         invokedRequestParameters = productIdentifiers
         invokedRequestParametersList.append(productIdentifiers)
         return stubbedRequestResult ?? MockProductsRequest(productIdentifiers: productIdentifiers,
-                                                           responseTimeInSeconds: requestResponseTimeInSeconds)
+                                                           responseTime: requestResponseTime)
     }
 }

--- a/PurchasesTests/Purchasing/ErrorCodeTests.swift
+++ b/PurchasesTests/Purchasing/ErrorCodeTests.swift
@@ -153,8 +153,13 @@ class ErrorCodeTests: XCTestCase {
                                               expectedRawValue: 31)
     }
 
+    func testProductRequestTimedOut() {
+        ensureEnumCaseMatchesExpectedRawValue(errorCode: .productRequestTimedOut,
+                                              expectedRawValue: 32)
+    }
+
     func testErrorCodeEnumCasesAreCoveredInTests() {
-        expect(ErrorCode.allCases.count).to(equal(32))
+        expect(ErrorCode.allCases.count).to(equal(33))
     }
 
     func ensureEnumCaseMatchesExpectedRawValue(errorCode: ErrorCode, expectedRawValue: Int) {

--- a/PurchasesTests/Purchasing/ProductsFetcherSK1Tests.swift
+++ b/PurchasesTests/Purchasing/ProductsFetcherSK1Tests.swift
@@ -8,7 +8,7 @@ class ProductsFetcherSK1Tests: XCTestCase {
     var productsRequestFactory: MockProductsRequestFactory!
     var productsFetcherSK1: ProductsFetcherSK1!
 
-    private static let defaultTimeout: DispatchTimeInterval = .seconds(30)
+    private static let defaultTimeout: DispatchTimeInterval = .seconds(5)
 
     override func setUp() {
         super.setUp()
@@ -97,7 +97,7 @@ class ProductsFetcherSK1Tests: XCTestCase {
             completionCalled = true
             receivedProducts = products
         }
-        expect(completionCalled).toEventually(beTrue(), timeout: Self.defaultTimeout)
+        expect(completionCalled).toEventually(beTrue(), timeout: Self.defaultTimeout + .seconds(1))
         expect(receivedProducts?.error).toNot(beNil())
     }
     
@@ -125,7 +125,7 @@ class ProductsFetcherSK1Tests: XCTestCase {
     func testProductsWithIdentifiersTimesOutIfMaxToleranceExceeded() throws {
         let productIdentifiers = Set(["1", "2", "3"])
         let tolerance: DispatchTimeInterval = .seconds(1)
-        let productsRequestResponseTime: DispatchTimeInterval = .seconds(2)
+        let productsRequestResponseTime: DispatchTimeInterval = tolerance + .seconds(1)
         let request = MockProductsRequest(productIdentifiers: productIdentifiers,
                                           responseTime: productsRequestResponseTime)
         productsRequestFactory.stubbedRequestResult = request
@@ -142,7 +142,8 @@ class ProductsFetcherSK1Tests: XCTestCase {
             maybeReceivedProducts = products
         }
 
-        expect(completionCallCount).toEventually(equal(1), timeout: .seconds(3))
+        expect(completionCallCount).toEventually(equal(1),
+                                                 timeout: productsRequestResponseTime + .seconds(1))
         expect(self.productsRequestFactory.invokedRequestCount) == 1
         let error = try XCTUnwrap(maybeReceivedProducts?.error as? ErrorCode)
         expect(error) == ErrorCode.productRequestTimedOut

--- a/PurchasesTests/Purchasing/ProductsFetcherSK1Tests.swift
+++ b/PurchasesTests/Purchasing/ProductsFetcherSK1Tests.swift
@@ -144,8 +144,8 @@ class ProductsFetcherSK1Tests: XCTestCase {
 
         expect(completionCallCount).toEventually(equal(1), timeout: .seconds(3))
         expect(self.productsRequestFactory.invokedRequestCount) == 1
-        let receivedProducts = try XCTUnwrap(maybeReceivedProducts?.get())
-        expect(receivedProducts).to(beEmpty())
+        let error = try XCTUnwrap(maybeReceivedProducts?.error as? ErrorCode)
+        expect(error) == ErrorCode.productRequestTimedOut
         expect(request.cancelCalled) == true
     }
 

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 		37E35C8515C5E2D01B0AF5C1 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3507939634ED5A9280544 /* Strings.swift */; };
 		42F1DF385E3C1F9903A07FBF /* ProductsFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */; };
 		5746508C27586B2E0053AB09 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5746508B27586B2E0053AB09 /* Result+Extensions.swift */; };
+		5746508E275949F20053AB09 /* DispatchTimeInterval+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5746508D275949F20053AB09 /* DispatchTimeInterval+Extensions.swift */; };
 		5791CE80273F26A000E50C4B /* base64encoded_sandboxReceipt.txt in Resources */ = {isa = PBXBuildFile; fileRef = 5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */; };
 		57A0FBF02749C0C2009E2FC3 /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */; };
 		57A0FBF22749CF66009E2FC3 /* SynchronizedUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */; };
@@ -548,6 +549,7 @@
 		570896B727596E8800296F1C /* SwiftAPITester.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SwiftAPITester.xcodeproj; path = APITesters/SwiftAPITester/SwiftAPITester.xcodeproj; sourceTree = "<group>"; };
 		570896BD27596E8800296F1C /* ObjCAPITester.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ObjCAPITester.xcodeproj; path = APITesters/ObjCAPITester/ObjCAPITester.xcodeproj; sourceTree = "<group>"; };
 		5746508B27586B2E0053AB09 /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
+		5746508D275949F20053AB09 /* DispatchTimeInterval+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchTimeInterval+Extensions.swift"; sourceTree = "<group>"; };
 		5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = base64encoded_sandboxReceipt.txt; sourceTree = "<group>"; };
 		57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 		57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedUserDefaults.swift; sourceTree = "<group>"; };
@@ -712,6 +714,7 @@
 				B35F9E0826B4BEED00095C3F /* String+Extensions.swift */,
 				2D9C7BB226D838FC006838BE /* UIApplication+RCExtensions.swift */,
 				5746508B27586B2E0053AB09 /* Result+Extensions.swift */,
+				5746508D275949F20053AB09 /* DispatchTimeInterval+Extensions.swift */,
 			);
 			path = FoundationExtensions;
 			sourceTree = "<group>";
@@ -1804,6 +1807,7 @@
 				2D11F5E1250FF886005A70E8 /* AttributionStrings.swift in Sources */,
 				2CD72944268A826F00BFC976 /* Date+Extensions.swift in Sources */,
 				B3AA6238268B926F00894871 /* SystemInfo.swift in Sources */,
+				5746508E275949F20053AB09 /* DispatchTimeInterval+Extensions.swift in Sources */,
 				2D294E5C26DECFD500B8FE4F /* StoreKit2TransactionListener.swift in Sources */,
 				2DDF41B524F6F387005BC22D /* AppleReceiptBuilder.swift in Sources */,
 				2DD9F4BE274EADC20031AE2C /* Purchases+async.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -206,6 +206,7 @@
 		37E3578711F5FDD5DC6458A8 /* AttributionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3521731D8DC16873F55F3 /* AttributionFetcher.swift */; };
 		37E35C8515C5E2D01B0AF5C1 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3507939634ED5A9280544 /* Strings.swift */; };
 		42F1DF385E3C1F9903A07FBF /* ProductsFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */; };
+		5746508C27586B2E0053AB09 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5746508B27586B2E0053AB09 /* Result+Extensions.swift */; };
 		5791CE80273F26A000E50C4B /* base64encoded_sandboxReceipt.txt in Resources */ = {isa = PBXBuildFile; fileRef = 5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */; };
 		57A0FBF02749C0C2009E2FC3 /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */; };
 		57A0FBF22749CF66009E2FC3 /* SynchronizedUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */; };
@@ -546,6 +547,7 @@
 		570896B527595C8100296F1C /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = UnitTests.xctestplan; path = TestPlans/UnitTests.xctestplan; sourceTree = "<group>"; };
 		570896B727596E8800296F1C /* SwiftAPITester.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SwiftAPITester.xcodeproj; path = APITesters/SwiftAPITester/SwiftAPITester.xcodeproj; sourceTree = "<group>"; };
 		570896BD27596E8800296F1C /* ObjCAPITester.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ObjCAPITester.xcodeproj; path = APITesters/ObjCAPITester/ObjCAPITester.xcodeproj; sourceTree = "<group>"; };
+		5746508B27586B2E0053AB09 /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
 		5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = base64encoded_sandboxReceipt.txt; sourceTree = "<group>"; };
 		57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 		57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedUserDefaults.swift; sourceTree = "<group>"; };
@@ -709,6 +711,7 @@
 				2CD72947268A828400BFC976 /* Locale+Extensions.swift */,
 				B35F9E0826B4BEED00095C3F /* String+Extensions.swift */,
 				2D9C7BB226D838FC006838BE /* UIApplication+RCExtensions.swift */,
+				5746508B27586B2E0053AB09 /* Result+Extensions.swift */,
 			);
 			path = FoundationExtensions;
 			sourceTree = "<group>";
@@ -1873,6 +1876,7 @@
 				B32B74FF26868AEB005647BF /* Package.swift in Sources */,
 				2DDF41B324F6F387005BC22D /* InAppPurchaseBuilder.swift in Sources */,
 				F5BE447B269E4A7500254A30 /* TrackingManagerProxy.swift in Sources */,
+				5746508C27586B2E0053AB09 /* Result+Extensions.swift in Sources */,
 				B34D2AA0269606E400D88C3A /* IntroEligibility.swift in Sources */,
 				B302206E2728B798008F1A0D /* BackendErrorStrings.swift in Sources */,
 				35D0E5D026A5886C0099EAD8 /* ErrorUtils.swift in Sources */,

--- a/StoreKitUnitTests/Mocks/PartialMockProductsManager.swift
+++ b/StoreKitUnitTests/Mocks/PartialMockProductsManager.swift
@@ -24,13 +24,13 @@ class PartialMockProductsManager: ProductsManager {
     var stubbedProductsFromOptimalStoreKitVersionCompletionResult: (Set<StoreProduct>, Void)?
 
     override func productsFromOptimalStoreKitVersion(withIdentifiers identifiers: Set<String>,
-                                                     completion: @escaping (Set<StoreProduct>) -> Void) {
+                                                     completion: @escaping (Result<Set<StoreProduct>, Error>) -> Void) {
         invokedProductsFromOptimalStoreKitVersionWithIdentifiers = true
         invokedProductsFromOptimalStoreKitVersionCount += 1
         invokedProductsFromOptimalStoreKitVersionParameters = (identifiers, ())
         invokedProductsFromOptimalStoreKitVersionParametersList.append((identifiers, ()))
         if let result = stubbedProductsFromOptimalStoreKitVersionCompletionResult {
-            completion(result.0)
+            completion(.success(result.0))
         } else {
             let products: [SK1Product] = identifiers.map { (identifier) -> MockSK1Product in
                 let sk1Product = MockSK1Product(mockProductIdentifier: identifier)
@@ -44,7 +44,7 @@ class PartialMockProductsManager: ProductsManager {
             }
             let result = Set(products).map { SK1StoreProduct(sk1Product: $0) }
 
-            completion(Set(result))
+            completion(.success(Set(result)))
         }
     }
 
@@ -54,13 +54,16 @@ class PartialMockProductsManager: ProductsManager {
     var invokedProductsParametersList = [Set<String>]()
     var stubbedProductsCompletionResult: Set<SK1Product>?
 
-    override func products(withIdentifiers identifiers: Set<String>, completion: @escaping (Set<SK1Product>) -> Void) {
+    override func products(
+        withIdentifiers identifiers: Set<String>,
+        completion: @escaping (Result<Set<SK1Product>, Error>) -> Void
+    ) {
         invokedProducts = true
         invokedProductsCount += 1
         invokedProductsParameters = identifiers
         invokedProductsParametersList.append(identifiers)
         if let result = stubbedProductsCompletionResult {
-            completion(result)
+            completion(.success(result))
         } else {
             let products: [SK1Product] = identifiers.map { (identifier) -> MockSK1Product in
                 let sk1Product = MockSK1Product(mockProductIdentifier: identifier)
@@ -72,7 +75,7 @@ class PartialMockProductsManager: ProductsManager {
                 }
                 return sk1Product
             }
-            completion(Set(products))
+            completion(.success(Set(products)))
         }
     }
 

--- a/StoreKitUnitTests/Mocks/PartialMockProductsManager.swift
+++ b/StoreKitUnitTests/Mocks/PartialMockProductsManager.swift
@@ -23,8 +23,10 @@ class PartialMockProductsManager: ProductsManager {
     var invokedProductsFromOptimalStoreKitVersionParametersList = [(identifiers: Set<String>, Void)]()
     var stubbedProductsFromOptimalStoreKitVersionCompletionResult: (Set<StoreProduct>, Void)?
 
-    override func productsFromOptimalStoreKitVersion(withIdentifiers identifiers: Set<String>,
-                                                     completion: @escaping (Result<Set<StoreProduct>, Error>) -> Void) {
+    override func productsFromOptimalStoreKitVersion(
+        withIdentifiers identifiers: Set<String>,
+        completion: @escaping (Result<Set<StoreProduct>, Error>) -> Void
+    ) {
         invokedProductsFromOptimalStoreKitVersionWithIdentifiers = true
         invokedProductsFromOptimalStoreKitVersionCount += 1
         invokedProductsFromOptimalStoreKitVersionParameters = (identifiers, ())

--- a/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/StoreKitUnitTests/ProductsManagerTests.swift
@@ -22,10 +22,12 @@ class ProductsManagerTests: StoreKitConfigTestCase {
     var productsManager: ProductsManager!
     var systemInfo: MockSystemInfo!
 
+    private static let defaultTimeout: DispatchTimeInterval = .seconds(30)
+
     override func setUpWithError() throws {
         try super.setUpWithError()
         systemInfo = try MockSystemInfo(platformFlavor: "xyz", platformFlavorVersion: "123", finishTransactions: true)
-        productsManager = ProductsManager(systemInfo: systemInfo)
+        productsManager = ProductsManager(systemInfo: systemInfo, requestTimeout: Self.defaultTimeout)
     }
 
     func testFetchProductsFromOptimalStoreKitVersion() throws {
@@ -40,7 +42,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
             maybeReceivedProducts = products
         })
 
-        expect(completionCalled).toEventually(beTrue())
+        expect(completionCalled).toEventually(beTrue(), timeout: Self.defaultTimeout)
         let receivedProducts = try XCTUnwrap(maybeReceivedProducts)
         expect(receivedProducts.count) == 1
 
@@ -61,7 +63,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
                                         platformFlavorVersion: "123",
                                         finishTransactions: true,
                                         useStoreKit2IfAvailable: true)
-        productsManager = ProductsManager(systemInfo: systemInfo)
+        productsManager = ProductsManager(systemInfo: systemInfo, requestTimeout: Self.defaultTimeout)
 
         guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 7.0, *) else {
             throw XCTSkip("Required API is not available for this test.")
@@ -76,7 +78,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
             maybeReceivedProducts = products
         })
 
-        expect(completionCalled).toEventually(beTrue())
+        expect(completionCalled).toEventually(beTrue(), timeout: Self.defaultTimeout)
         let receivedProducts = try XCTUnwrap(maybeReceivedProducts)
         expect(receivedProducts.count) == 1
 
@@ -90,7 +92,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         systemInfo = try MockSystemInfo(platformFlavor: "xyz",
                                         platformFlavorVersion: "123",
                                         finishTransactions: true)
-        productsManager = ProductsManager(systemInfo: systemInfo)
+        productsManager = ProductsManager(systemInfo: systemInfo, requestTimeout: Self.defaultTimeout)
 
         guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 7.0, *) else {
             throw XCTSkip("Required API is not available for this test.")
@@ -105,7 +107,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
             maybeReceivedProducts = products
         })
 
-        expect(completionCalled).toEventually(beTrue())
+        expect(completionCalled).toEventually(beTrue(), timeout: Self.defaultTimeout)
         let receivedProducts = try XCTUnwrap(maybeReceivedProducts)
         expect(receivedProducts.count) == 1
 

--- a/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/StoreKitUnitTests/ProductsManagerTests.swift
@@ -22,12 +22,10 @@ class ProductsManagerTests: StoreKitConfigTestCase {
     var productsManager: ProductsManager!
     var systemInfo: MockSystemInfo!
 
-    private static let defaultTimeout: DispatchTimeInterval = .seconds(30)
-
     override func setUpWithError() throws {
         try super.setUpWithError()
         systemInfo = try MockSystemInfo(platformFlavor: "xyz", platformFlavorVersion: "123", finishTransactions: true)
-        productsManager = ProductsManager(systemInfo: systemInfo, requestTimeout: Self.defaultTimeout)
+        productsManager = ProductsManager(systemInfo: systemInfo, requestTimeout: Self.requestTimeout)
     }
 
     func testFetchProductsFromOptimalStoreKitVersion() throws {
@@ -42,7 +40,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
             maybeReceivedProducts = products
         })
 
-        expect(completionCalled).toEventually(beTrue(), timeout: Self.defaultTimeout)
+        expect(completionCalled).toEventually(beTrue(), timeout: Self.requestTimeout)
         let receivedProducts = try XCTUnwrap(maybeReceivedProducts?.get())
         expect(receivedProducts.count) == 1
 
@@ -63,7 +61,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
                                         platformFlavorVersion: "123",
                                         finishTransactions: true,
                                         useStoreKit2IfAvailable: true)
-        productsManager = ProductsManager(systemInfo: systemInfo, requestTimeout: Self.defaultTimeout)
+        productsManager = ProductsManager(systemInfo: systemInfo, requestTimeout: Self.requestTimeout)
 
         guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 7.0, *) else {
             throw XCTSkip("Required API is not available for this test.")
@@ -78,7 +76,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
             maybeReceivedProducts = products
         })
 
-        expect(completionCalled).toEventually(beTrue(), timeout: Self.defaultTimeout)
+        expect(completionCalled).toEventually(beTrue(), timeout: Self.requestTimeout)
         let receivedProducts = try XCTUnwrap(maybeReceivedProducts?.get())
         expect(receivedProducts.count) == 1
 
@@ -92,7 +90,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         systemInfo = try MockSystemInfo(platformFlavor: "xyz",
                                         platformFlavorVersion: "123",
                                         finishTransactions: true)
-        productsManager = ProductsManager(systemInfo: systemInfo, requestTimeout: Self.defaultTimeout)
+        productsManager = ProductsManager(systemInfo: systemInfo, requestTimeout: Self.requestTimeout)
 
         guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 7.0, *) else {
             throw XCTSkip("Required API is not available for this test.")
@@ -107,7 +105,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
             maybeReceivedProducts = products
         })
 
-        expect(completionCalled).toEventually(beTrue(), timeout: Self.defaultTimeout)
+        expect(completionCalled).toEventually(beTrue(), timeout: Self.requestTimeout)
         let receivedProducts = try XCTUnwrap(maybeReceivedProducts?.get())
         expect(receivedProducts.count) == 1
 

--- a/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/StoreKitUnitTests/ProductsManagerTests.swift
@@ -35,7 +35,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
 
         let identifier = "com.revenuecat.monthly_4.99.1_week_intro"
         var completionCalled = false
-        var maybeReceivedProducts: Set<StoreProduct>?
+        var maybeReceivedProducts: Result<Set<StoreProduct>, Error>?
 
         productsManager.productsFromOptimalStoreKitVersion(withIdentifiers: Set([identifier]), completion: { products in
             completionCalled = true
@@ -43,7 +43,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         })
 
         expect(completionCalled).toEventually(beTrue(), timeout: Self.defaultTimeout)
-        let receivedProducts = try XCTUnwrap(maybeReceivedProducts)
+        let receivedProducts = try XCTUnwrap(maybeReceivedProducts?.get())
         expect(receivedProducts.count) == 1
 
         let firstProduct = try XCTUnwrap(receivedProducts.first)
@@ -71,7 +71,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
 
         let identifier = "com.revenuecat.monthly_4.99.1_week_intro"
         var completionCalled = false
-        var maybeReceivedProducts: Set<StoreProduct>?
+        var maybeReceivedProducts: Result<Set<StoreProduct>, Error>?
 
         productsManager.productsFromOptimalStoreKitVersion(withIdentifiers: Set([identifier]), completion: { products in
             completionCalled = true
@@ -79,7 +79,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         })
 
         expect(completionCalled).toEventually(beTrue(), timeout: Self.defaultTimeout)
-        let receivedProducts = try XCTUnwrap(maybeReceivedProducts)
+        let receivedProducts = try XCTUnwrap(maybeReceivedProducts?.get())
         expect(receivedProducts.count) == 1
 
         let firstProduct = try XCTUnwrap(receivedProducts.first)
@@ -100,7 +100,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
 
         let identifier = "com.revenuecat.monthly_4.99.1_week_intro"
         var completionCalled = false
-        var maybeReceivedProducts: Set<StoreProduct>?
+        var maybeReceivedProducts: Result<Set<StoreProduct>, Error>?
 
         productsManager.productsFromOptimalStoreKitVersion(withIdentifiers: Set([identifier]), completion: { products in
             completionCalled = true
@@ -108,7 +108,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         })
 
         expect(completionCalled).toEventually(beTrue(), timeout: Self.defaultTimeout)
-        let receivedProducts = try XCTUnwrap(maybeReceivedProducts)
+        let receivedProducts = try XCTUnwrap(maybeReceivedProducts?.get())
         expect(receivedProducts.count) == 1
 
         let firstProduct = try XCTUnwrap(receivedProducts.first)

--- a/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -38,7 +38,7 @@ class StoreKitConfigTestCase: XCTestCase {
         testSession.disableDialogs = true
         testSession.clearTransactions()
 
-//        self.waitForStoreKitTestIfNeeded()
+        self.waitForStoreKitTestIfNeeded()
 
         let suiteName = "StoreKitConfigTests"
         userDefaults = UserDefaults(suiteName: suiteName)

--- a/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -33,26 +33,9 @@ class StoreKitConfigTestCase: XCTestCase {
         testSession.disableDialogs = true
         testSession.clearTransactions()
 
-        self.waitForStoreKitTestIfNeeded()
-
         let suiteName = "StoreKitConfigTests"
         userDefaults = UserDefaults(suiteName: suiteName)
         userDefaults.removePersistentDomain(forName: suiteName)
-    }
-
-}
-
-private extension StoreKitConfigTestCase {
-
-    func waitForStoreKitTestIfNeeded() {
-        // StoreKitTest seems to take a few seconds to initialize, and running tests before that
-        // might result in failure. So we give it a few seconds to load before testing.
-        Self.waitLock.perform {
-            if !Self.hasWaited {
-                Self.hasWaited = true
-                Thread.sleep(forTimeInterval: Self.waitTimeInSeconds)
-            }
-        }
     }
 
 }

--- a/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -20,6 +20,8 @@ import XCTest
 @available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 6.2, *)
 class StoreKitConfigTestCase: XCTestCase {
 
+    static var requestTimeout: DispatchTimeInterval = .seconds(60)
+
     private static var hasWaited = false
     private static let waitLock = Lock()
     private static let waitTimeInSeconds: Double? = {
@@ -36,7 +38,7 @@ class StoreKitConfigTestCase: XCTestCase {
         testSession.disableDialogs = true
         testSession.clearTransactions()
 
-        self.waitForStoreKitTestIfNeeded()
+//        self.waitForStoreKitTestIfNeeded()
 
         let suiteName = "StoreKitConfigTests"
         userDefaults = UserDefaults(suiteName: suiteName)

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -18,6 +18,8 @@ import XCTest
 
 class StoreProductTests: StoreKitConfigTestCase {
 
+    private static let requestTimeout: DispatchTimeInterval = .seconds(20)
+
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testSK1AndSK2DetailsAreEquivalent() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
@@ -63,7 +65,8 @@ class StoreProductTests: StoreKitConfigTestCase {
 
     func testSk1DetailsWrapsCorrectly() throws {
         let productIdentifier = "com.revenuecat.monthly_4.99.1_week_intro"
-        let sk1Fetcher = ProductsFetcherSK1(productsRequestFactory: ProductsRequestFactory())
+        let sk1Fetcher = ProductsFetcherSK1(productsRequestFactory: ProductsRequestFactory(),
+                                            requestTimeout: Self.requestTimeout)
         var callbackCalled = false
 
         sk1Fetcher.products(withIdentifiers: Set([productIdentifier])) { storeProductSet in
@@ -84,7 +87,7 @@ class StoreProductTests: StoreKitConfigTestCase {
             expect(storeProduct.subscriptionPeriod?.value) == 1
         }
 
-        expect(callbackCalled).toEventually(beTrue(), timeout: .seconds(5))
+        expect(callbackCalled).toEventually(beTrue(), timeout: Self.requestTimeout)
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -18,8 +18,6 @@ import XCTest
 
 class StoreProductTests: StoreKitConfigTestCase {
 
-    private static let requestTimeout: DispatchTimeInterval = .seconds(20)
-
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testSK1AndSK2DetailsAreEquivalent() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
@@ -137,7 +135,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         let productIdentifier = "com.revenuecat.monthly_4.99.1_week_intro"
         let sk1Fetcher = ProductsFetcherSK1()
 
-        let storeProductSet = await sk1Fetcher.products(withIdentifiers: Set([productIdentifier]))
+        let storeProductSet = try await sk1Fetcher.products(withIdentifiers: Set([productIdentifier]))
 
         let storeProduct = try XCTUnwrap(storeProductSet.first)
         let priceFormatter = try XCTUnwrap(storeProduct.priceFormatter)
@@ -154,7 +152,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         let productIdentifier = "com.revenuecat.monthly_4.99.1_week_intro"
         var sk1Fetcher = ProductsFetcherSK1()
 
-        var storeProductSet = await sk1Fetcher.products(withIdentifiers: Set([productIdentifier]))
+        var storeProductSet = try await sk1Fetcher.products(withIdentifiers: Set([productIdentifier]))
 
         var storeProduct = try XCTUnwrap(storeProductSet.first)
         var priceFormatter = try XCTUnwrap(storeProduct.priceFormatter)
@@ -167,7 +165,7 @@ class StoreProductTests: StoreKitConfigTestCase {
 
         sk1Fetcher = ProductsFetcherSK1()
 
-        storeProductSet = await sk1Fetcher.products(withIdentifiers: Set([productIdentifier]))
+        storeProductSet = try await sk1Fetcher.products(withIdentifiers: Set([productIdentifier]))
 
         storeProduct = try XCTUnwrap(storeProductSet.first)
         priceFormatter = try XCTUnwrap(storeProduct.priceFormatter)

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -28,7 +28,7 @@ class StoreProductTests: StoreKitConfigTestCase {
             "lifetime"
         ])
         let sk1Fetcher = ProductsFetcherSK1(productsRequestFactory: ProductsRequestFactory())
-        let sk1StoreProduct = await sk1Fetcher.products(withIdentifiers: productIdentifiers)
+        let sk1StoreProduct = try await sk1Fetcher.products(withIdentifiers: productIdentifiers)
         let sk1StoreProductsByID = sk1StoreProduct.reduce(into: [:]) { partialResult, wrapper in
             partialResult[wrapper.productIdentifier] = wrapper
         }
@@ -68,7 +68,7 @@ class StoreProductTests: StoreKitConfigTestCase {
 
         sk1Fetcher.products(withIdentifiers: Set([productIdentifier])) { storeProductSet in
             callbackCalled = true
-            guard let storeProduct = storeProductSet.first else { fatalError("couldn't get product!") }
+            guard let storeProduct = storeProductSet.value?.first else { fatalError("couldn't get product!") }
 
             expect(storeProduct.productIdentifier) == "com.revenuecat.monthly_4.99.1_week_intro"
             expect(storeProduct.localizedDescription) == "Monthly subscription with a 1-week free trial"

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -29,7 +29,8 @@ class StoreProductTests: StoreKitConfigTestCase {
             "com.revenuecat.annual_39.99.2_week_intro",
             "lifetime"
         ])
-        let sk1Fetcher = ProductsFetcherSK1(productsRequestFactory: ProductsRequestFactory())
+        let sk1Fetcher = ProductsFetcherSK1(productsRequestFactory: ProductsRequestFactory(),
+                                            requestTimeout: Self.requestTimeout)
         let sk1StoreProduct = try await sk1Fetcher.products(withIdentifiers: productIdentifiers)
         let sk1StoreProductsByID = sk1StoreProduct.reduce(into: [:]) { partialResult, wrapper in
             partialResult[wrapper.productIdentifier] = wrapper


### PR DESCRIPTION
Fixes [sc-10709] and #1018.

After a lot of debugging I found out the source of the problem:
```
Error Domain=NSCocoaErrorDomain Code=4097 "connection to service with pid 4422 named com.apple.storekitservice" UserInfo={NSDebugDescription=connection to service with pid 4422 named com.apple.storekitservice}"
```

To deal with that, `StoreKitConfigTestCase` had an artificial delay to make sure `StoreKit` was ready and didn't lead to these random errors, which also happened in production.
With this new mechanism, we can try again within the timeout window.