### PR TITLE
Create checkForiOS15APIAvailableOrSkipTest()

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -268,6 +268,7 @@
 		B3B5FBBC269D121B00104A0C /* Offerings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B5FBBB269D121B00104A0C /* Offerings.swift */; };
 		B3B5FBBF269E081E00104A0C /* InMemoryCachedObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B5FBBE269E081E00104A0C /* InMemoryCachedObject.swift */; };
 		B3B5FBC1269E17CE00104A0C /* DeviceCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B5FBC0269E17CE00104A0C /* DeviceCache.swift */; };
+		B3BE0264275942D500915B4C /* AvailabilityChecks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE0263275942D500915B4C /* AvailabilityChecks.swift */; };
 		B3C1AEFA268FF4DB0013D50D /* ProductInfoEnums.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C1AEF9268FF4DB0013D50D /* ProductInfoEnums.swift */; };
 		B3C4AAD526B8911300E1B3C8 /* Backend.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C4AAD426B8911300E1B3C8 /* Backend.swift */; };
 		B3DDB55926854865008CCF23 /* PurchaseOwnershipType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3DDB55826854865008CCF23 /* PurchaseOwnershipType.swift */; };
@@ -576,6 +577,7 @@
 		B3B5FBBB269D121B00104A0C /* Offerings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Offerings.swift; sourceTree = "<group>"; };
 		B3B5FBBE269E081E00104A0C /* InMemoryCachedObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemoryCachedObject.swift; sourceTree = "<group>"; };
 		B3B5FBC0269E17CE00104A0C /* DeviceCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceCache.swift; sourceTree = "<group>"; };
+		B3BE0263275942D500915B4C /* AvailabilityChecks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityChecks.swift; sourceTree = "<group>"; };
 		B3C1AEF9268FF4DB0013D50D /* ProductInfoEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInfoEnums.swift; sourceTree = "<group>"; };
 		B3C4AAD426B8911300E1B3C8 /* Backend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backend.swift; sourceTree = "<group>"; };
 		B3D3C4712685784800CB3C21 /* Package.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
@@ -752,6 +754,7 @@
 				2D9C5EC926F2805C0057FC45 /* ProductsManagerTests.swift */,
 				2D43017726EBFD7100BAB891 /* UnitTestsConfiguration.storekit */,
 				2D90F8CB26FD2BA1009B9142 /* StoreKitConfigTestCase.swift */,
+				B3BE0263275942D500915B4C /* AvailabilityChecks.swift */,
 			);
 			path = StoreKitUnitTests;
 			sourceTree = "<group>";
@@ -1647,6 +1650,7 @@
 				2D90F8B626FD2099009B9142 /* MockSubscriberAttributesManager.swift in Sources */,
 				2D90F8BF26FD20D6009B9142 /* MockAttributionFetcher.swift in Sources */,
 				2D90F8C526FD216A009B9142 /* MockSKDiscount.swift in Sources */,
+				B3BE0264275942D500915B4C /* AvailabilityChecks.swift in Sources */,
 				2D90F8B326FD2082009B9142 /* MockProductsManager.swift in Sources */,
 				2D90F8CA26FD257A009B9142 /* MockStoreKit2TransactionListener.swift in Sources */,
 				35B745A82711001A00458D46 /* MockManageSubscriptionsHelper.swift in Sources */,

--- a/StoreKitUnitTests/AvailabilityChecks.swift
+++ b/StoreKitUnitTests/AvailabilityChecks.swift
@@ -1,0 +1,34 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  AvailabilityChecks.swift
+//
+//  Created by Joshua Liebowitz on 12/2/21.
+
+import Foundation
+import XCTest
+
+// Xcode throws a warning about @available and #available being redundant, but they're actually necessary:
+// Although the method isn't supposed to be called because of our @available marks in our subclasses,
+// everything in those classes will still be called by XCTest, and it will cause errors.
+class AvailabilityChecks {
+
+    static func iOS15APIAvailableOrSkipTest() throws {
+        guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {
+            throw XCTSkip("Required API is not available for this test.")
+        }
+    }
+
+    static func iOS14APIAvailableOrSkipTest() throws {
+        guard #available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 6.2, *) else {
+            throw XCTSkip("Required API is not available for this test.")
+        }
+    }
+
+}

--- a/StoreKitUnitTests/AvailabilityChecks.swift
+++ b/StoreKitUnitTests/AvailabilityChecks.swift
@@ -17,7 +17,7 @@ import XCTest
 // Xcode throws a warning about @available and #available being redundant, but they're actually necessary:
 // Although the method isn't supposed to be called because of our @available marks in our subclasses,
 // everything in those classes will still be called by XCTest, and it will cause errors.
-class AvailabilityChecks {
+enum AvailabilityChecks {
 
     static func iOS15APIAvailableOrSkipTest() throws {
         guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {

--- a/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/StoreKitUnitTests/ProductsManagerTests.swift
@@ -32,9 +32,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
     }
 
     func testFetchProductsFromOptimalStoreKitVersion() throws {
-        guard #available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 6.2, *) else {
-            throw XCTSkip("Required API is not available for this test.")
-        }
+        try AvailabilityChecks.iOS14APIAvailableOrSkipTest()
 
         let identifier = "com.revenuecat.monthly_4.99.1_week_intro"
         var completionCalled = false

--- a/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -94,10 +94,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testPurchaseSK2PackageReturnsCorrectValues() async throws {
-
-        guard #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) else {
-            throw XCTSkip("Required API is not available for this test.")
-        }
+        try checkForiOS15APIAvailableOrSkipTest()
 
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
         backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
@@ -134,9 +131,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testPurchaseSK2PackageHandlesPurchaseResult() async throws {
-        guard #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) else {
-            throw XCTSkip("Required API is not available for this test.")
-        }
+        try checkForiOS15APIAvailableOrSkipTest()
 
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
         backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
@@ -162,9 +157,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testPurchaseSK2PackageSendsReceiptToBackendIfSuccessful() async throws {
-        guard #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) else {
-            throw XCTSkip("Required API is not available for this test.")
-        }
+        try checkForiOS15APIAvailableOrSkipTest()
 
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
         backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
@@ -189,9 +182,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testPurchaseSK2PackageSkipsIfPurchaseFailed() async throws {
-        guard #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) else {
-            throw XCTSkip("Required API is not available for this test.")
-        }
+        try checkForiOS15APIAvailableOrSkipTest()
 
         guard self.systemInfo.useStoreKit2IfAvailable else {
             throw XCTSkip("StoreKit 2 tests are disabled.")

--- a/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -94,7 +94,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testPurchaseSK2PackageReturnsCorrectValues() async throws {
-        try checkForiOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
         backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
@@ -131,7 +131,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testPurchaseSK2PackageHandlesPurchaseResult() async throws {
-        try checkForiOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
         backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
@@ -157,7 +157,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testPurchaseSK2PackageSendsReceiptToBackendIfSuccessful() async throws {
-        try checkForiOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
         backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
@@ -182,7 +182,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testPurchaseSK2PackageSkipsIfPurchaseFailed() async throws {
-        try checkForiOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         guard self.systemInfo.useStoreKit2IfAvailable else {
             throw XCTSkip("StoreKit 2 tests are disabled.")

--- a/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -40,6 +40,16 @@ class StoreKitConfigTestCase: XCTestCase {
         userDefaults.removePersistentDomain(forName: suiteName)
     }
 
+    // - Note: Xcode throws a warning about @available and #available being redundant, but they're actually necessary:
+    // Although the method isn't supposed to be called because of our @available marks in our subclasses,
+    // everything in this class will still be called by XCTest, and it will cause errors.
+    @discardableResult func checkForiOS15APIAvailableOrSkipTest() throws -> Bool {
+        guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {
+            throw XCTSkip("Required API is not available for this test.")
+        }
+        return true
+    }
+
 }
 
 private extension StoreKitConfigTestCase {

--- a/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -40,15 +40,6 @@ class StoreKitConfigTestCase: XCTestCase {
         userDefaults.removePersistentDomain(forName: suiteName)
     }
 
-    // - Note: Xcode throws a warning about @available and #available being redundant, but they're actually necessary:
-    // Although the method isn't supposed to be called because of our @available marks in our subclasses,
-    // everything in this class will still be called by XCTest, and it will cause errors.
-    func checkForiOS15APIAvailableOrSkipTest() throws {
-        guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {
-            throw XCTSkip("Required API is not available for this test.")
-        }
-    }
-
 }
 
 private extension StoreKitConfigTestCase {

--- a/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -43,11 +43,10 @@ class StoreKitConfigTestCase: XCTestCase {
     // - Note: Xcode throws a warning about @available and #available being redundant, but they're actually necessary:
     // Although the method isn't supposed to be called because of our @available marks in our subclasses,
     // everything in this class will still be called by XCTest, and it will cause errors.
-    @discardableResult func checkForiOS15APIAvailableOrSkipTest() throws -> Bool {
+    func checkForiOS15APIAvailableOrSkipTest() throws {
         guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {
             throw XCTSkip("Required API is not available for this test.")
         }
-        return true
     }
 
 }

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -23,9 +23,7 @@ class StoreProductTests: StoreKitConfigTestCase {
     // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testSK1AndSK2DetailsAreEquivalent() async throws {
-        guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {
-            throw XCTSkip("Required API is not available for this test.")
-        }
+        try checkForiOS15APIAvailableOrSkipTest()
 
         let productIdentifiers = Set([
             "com.revenuecat.monthly_4.99.1_week_intro",
@@ -94,9 +92,7 @@ class StoreProductTests: StoreKitConfigTestCase {
     // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testSk2DetailsWrapsCorrectly() async throws {
-        guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {
-            throw XCTSkip("Required API is not available for this test.")
-        }
+        try checkForiOS15APIAvailableOrSkipTest()
 
         let productIdentifier = "com.revenuecat.monthly_4.99.1_week_intro"
         let sk2Fetcher = ProductsFetcherSK2()

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -23,7 +23,7 @@ class StoreProductTests: StoreKitConfigTestCase {
     // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testSK1AndSK2DetailsAreEquivalent() async throws {
-        try checkForiOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         let productIdentifiers = Set([
             "com.revenuecat.monthly_4.99.1_week_intro",
@@ -92,7 +92,7 @@ class StoreProductTests: StoreKitConfigTestCase {
     // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testSk2DetailsWrapsCorrectly() async throws {
-        try checkForiOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         let productIdentifier = "com.revenuecat.monthly_4.99.1_week_intro"
         let sk2Fetcher = ProductsFetcherSK2()

--- a/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
+++ b/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
@@ -53,7 +53,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
     // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testSK2CheckEligibilityAsync() async throws {
-        try checkForiOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         let products = ["product_id",
                         "com.revenuecat.monthly_4.99.1_week_intro",
@@ -78,7 +78,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
     // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testCheckEligibilityNoAsync() throws {
-        try checkForiOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         let products = ["product_id",
                         "com.revenuecat.monthly_4.99.1_week_intro",

--- a/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
+++ b/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
@@ -53,9 +53,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
     // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testSK2CheckEligibilityAsync() async throws {
-        guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {
-            throw XCTSkip("Required API is not available for this test.")
-        }
+        try checkForiOS15APIAvailableOrSkipTest()
 
         let products = ["product_id",
                         "com.revenuecat.monthly_4.99.1_week_intro",
@@ -80,9 +78,8 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
     // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testCheckEligibilityNoAsync() throws {
-        guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {
-            throw XCTSkip("Required API is not available for this test.")
-        }
+        try checkForiOS15APIAvailableOrSkipTest()
+
         let products = ["product_id",
                         "com.revenuecat.monthly_4.99.1_week_intro",
                         "com.revenuecat.annual_39.99.2_week_intro",


### PR DESCRIPTION
Solves extra warnings for:
Xcode throws a warning about @available and #available being redundant, but they're actually necessary
From
![Screen Shot 2021-12-01 at 6 07 07 PM](https://user-images.githubusercontent.com/1304821/144344287-86d51d5f-136c-4293-b3f4-b74947014631.png)

to 
![Screen Shot 2021-12-01 at 6 07 20 PM](https://user-images.githubusercontent.com/1304821/144344306-b4d14d6e-2bc9-47da-9015-a1fc7bcca520.png)


There are some guards that happen for iOS14, in one place instead of 15. We could do the same thing to take care of them.
 