### PR TITLE
ProductsFetcherSK2: improved Error information

### DIFF
--- a/Purchases/Purchasing/StoreKit2/ProductsFetcherSK2.swift
+++ b/Purchases/Purchasing/StoreKit2/ProductsFetcherSK2.swift
@@ -14,14 +14,14 @@
 import Foundation
 import StoreKit
 
-enum ProductsManagerSK2Error: Error {
-
-    case productsRequestError(innerError: Error)
-
-}
-
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 actor ProductsFetcherSK2 {
+
+    enum Error: Swift.Error {
+
+        case productsRequestError(innerError: Swift.Error)
+
+    }
 
     private var cachedProductsByIdentifier: [String: SK2StoreProduct] = [:]
 
@@ -40,7 +40,21 @@ actor ProductsFetcherSK2 {
             let sk2StoreProduct = storeKitProducts.map { SK2StoreProduct(sk2Product: $0) }
             return Set(sk2StoreProduct)
         } catch {
-            throw ProductsManagerSK2Error.productsRequestError(innerError: error)
+            throw Error.productsRequestError(innerError: error)
+        }
+    }
+
+}
+
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+extension ProductsFetcherSK2.Error: CustomNSError {
+
+    var errorUserInfo: [String: Any] {
+        switch self {
+        case let .productsRequestError(inner):
+            return [
+                NSUnderlyingErrorKey: inner
+            ]
         }
     }
 

--- a/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -20,10 +20,6 @@ import XCTest
 @available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 6.2, *)
 class StoreKitConfigTestCase: XCTestCase {
 
-    private static var hasWaited = false
-    private static let waitLock = Lock()
-    private static let waitTimeInSeconds: Double = 20
-
     var testSession: SKTestSession!
     var userDefaults: UserDefaults!
 

--- a/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -20,6 +20,13 @@ import XCTest
 @available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 6.2, *)
 class StoreKitConfigTestCase: XCTestCase {
 
+    private static var hasWaited = false
+    private static let waitLock = Lock()
+    private static let waitTimeInSeconds: Double? = {
+        ProcessInfo.processInfo.environment["CIRCLECI_STOREKIT_TESTS_DELAY_SECONDS"]
+            .flatMap(Double.init)
+    }()
+
     var testSession: SKTestSession!
     var userDefaults: UserDefaults!
 
@@ -29,9 +36,32 @@ class StoreKitConfigTestCase: XCTestCase {
         testSession.disableDialogs = true
         testSession.clearTransactions()
 
+        self.waitForStoreKitTestIfNeeded()
+
         let suiteName = "StoreKitConfigTests"
         userDefaults = UserDefaults(suiteName: suiteName)
         userDefaults.removePersistentDomain(forName: suiteName)
+    }
+
+}
+
+private extension StoreKitConfigTestCase {
+
+    func waitForStoreKitTestIfNeeded() {
+        // StoreKitTest seems to take a few seconds to initialize, and running tests before that
+        // might result in failure. So we give it a few seconds to load before testing.
+
+        guard let waitTime = Self.waitTimeInSeconds else { return }
+
+        Self.waitLock.perform {
+            if !Self.hasWaited {
+                Logger.warn("Delaying tests for \(waitTime) seconds for StoreKit initialization...")
+
+                Thread.sleep(forTimeInterval: waitTime)
+
+                Self.hasWaited = true
+            }
+        }
     }
 
 }

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -18,6 +18,8 @@ import XCTest
 
 class StoreProductTests: StoreKitConfigTestCase {
 
+    private static let requestTimeout: DispatchTimeInterval = .seconds(20)
+
     // - Note: Xcode throws a warning about @available and #available being redundant, but they're actually necessary:
     // Although the method isn't supposed to be called because of our @available marks,
     // everything in this class will still be called by XCTest, and it will cause errors.
@@ -66,7 +68,8 @@ class StoreProductTests: StoreKitConfigTestCase {
 
     func testSk1DetailsWrapsCorrectly() throws {
         let productIdentifier = "com.revenuecat.monthly_4.99.1_week_intro"
-        let sk1Fetcher = ProductsFetcherSK1(productsRequestFactory: ProductsRequestFactory())
+        let sk1Fetcher = ProductsFetcherSK1(productsRequestFactory: ProductsRequestFactory(),
+                                            requestTimeout: Self.requestTimeout)
         var callbackCalled = false
 
         sk1Fetcher.products(withIdentifiers: Set([productIdentifier])) { storeProductSet in
@@ -84,7 +87,7 @@ class StoreProductTests: StoreKitConfigTestCase {
             expect(storeProduct.subscriptionGroupIdentifier) == "7096FF06"
         }
 
-        expect(callbackCalled).toEventually(beTrue(), timeout: .seconds(5))
+        expect(callbackCalled).toEventually(beTrue(), timeout: Self.requestTimeout)
     }
 
     // - Note: Xcode throws a warning about @available and #available being redundant, but they're actually necessary:


### PR DESCRIPTION
Adding this on top of #1017 

Trying to figure out this error:
```xml
<testcase classname="StoreProductTests" name="testSk2DetailsWrapsCorrectly()" time="6.029647946357727">
<failure message="failed: caught error: "The operation couldn’t be completed. (RevenueCat.ProductsManagerSK2Error error 0.)" (#CharacterRangeLen=0)"></failure>
</testcase>
```