### PR TITLE
`ErrorCode` conforms to `CustomNSError` to provide description

### DIFF
--- a/Purchases/Public/Errors/ErrorCode.swift
+++ b/Purchases/Public/Errors/ErrorCode.swift
@@ -147,6 +147,17 @@ extension ErrorCode: DescribableError {
 
 }
 
+extension ErrorCode: CustomNSError {
+
+    public var errorUserInfo: [String: Any] {
+        return [
+            NSDebugDescriptionErrorKey: self.description,
+            "rc_code_name": self.codeName
+        ]
+    }
+    
+}
+
 extension ErrorCode {
 
     /**


### PR DESCRIPTION
Without this, the error becomes the default: `The operation couldn’t be completed.`.