### PR TITLE
SwiftAPITester: fixed several `@unknown default` warnings

### DIFF
--- a/APITesters/SwiftAPITester/SwiftAPITester/EntitlementInfoAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/EntitlementInfoAPI.swift
@@ -44,6 +44,8 @@ func checkEntitlementInfoEnums() {
          .promotional,
          .unknownStore:
         print(store!)
+    @unknown default:
+        fatalError()
     }
 
     switch pType! {
@@ -51,5 +53,7 @@ func checkEntitlementInfoEnums() {
          .trial,
          .normal:
         print(pType!)
+    @unknown default:
+        fatalError()
     }
 }

--- a/APITesters/SwiftAPITester/SwiftAPITester/ErrorCodesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/ErrorCodesAPI.swift
@@ -50,5 +50,7 @@ func checkPurchasesErrorCodeEnums() {
          .systemInfoError,
          .beginRefundRequestError:
         print(errCode!)
+    @unknown default:
+        fatalError()
     }
 }

--- a/APITesters/SwiftAPITester/SwiftAPITester/PackageAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PackageAPI.swift
@@ -39,5 +39,7 @@ func checkPackageEnums() {
          .weekly,
          .unknown:
         print(packageType!)
+    @unknown default:
+        fatalError()
     }
 }

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -52,6 +52,8 @@ func checkPurchasesEnums() {
          .intro,
          .trial:
         print(periodType!)
+    @unknown default:
+        fatalError()
     }
 
     switch oType! {
@@ -59,6 +61,8 @@ func checkPurchasesEnums() {
          .familyShared,
          .unknown:
         print(oType!)
+    @unknown default:
+        fatalError()
     }
 
     switch logLevel! {
@@ -67,6 +71,8 @@ func checkPurchasesEnums() {
          .debug,
          .error:
         print(logLevel!)
+    @unknown default:
+        fatalError()
     }
 }
 


### PR DESCRIPTION
Note that thanks to the use of `@unknown`, these will still fail to compile if we don't add new `case`s, which is what we want.