### PR TITLE
Compile APITesters when building `RevenueCat` for testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,32 +141,6 @@ jobs:
           name: Build tvOS, watchOS and macOS
           command: bundle exec fastlane build_tv_watch_mac
 
-  swift_apitest:
-    macos:
-      xcode: "13.1.0"
-    working_directory: ~/purchases-ios
-    shell: /bin/bash --login -o pipefail
-    steps:
-      - checkout
-      - update-spm-integration-commit
-      - run:
-          name: Build SwiftAPITester
-          command: |
-              bundle exec fastlane build_swift_api_tester
-
-  objc_apitest:
-    macos:
-      xcode: "13.1.0"
-    working_directory: ~/purchases-ios
-    shell: /bin/bash --login -o pipefail
-    steps:
-      - checkout
-      - update-spm-integration-commit
-      - run:
-          name: Build ObjCAPITester
-          command: |
-              bundle exec fastlane build_objc_api_tester
-
   backend_integration_tests:
     macos:
       xcode: "13.1.0"
@@ -370,8 +344,6 @@ workflows:
     jobs:
       - lint
       - runtest
-      - swift_apitest
-      - objc_apitest
       - buildTvWatchAndMacOS
       - release-checks: *release-branches
       - backend_integration_tests

--- a/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj/project.pbxproj
+++ b/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj/project.pbxproj
@@ -3,16 +3,16 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		2DD778F8270E235B0079CBD4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD778F7270E235B0079CBD4 /* AppDelegate.swift */; };
 		2DD778FA270E235B0079CBD4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD778F9270E235B0079CBD4 /* SceneDelegate.swift */; };
 		2DD778FC270E235B0079CBD4 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD778FB270E235B0079CBD4 /* ViewController.swift */; };
-		2DD778FF270E235B0079CBD4 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2DD778FD270E235B0079CBD4 /* Main.storyboard */; };
+		2DD778FF270E235B0079CBD4 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2DD778FD270E235B0079CBD4 /* Main.storyboard */; platformFilters = (ios, maccatalyst, macos, watchos, ); };
 		2DD77901270E235C0079CBD4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2DD77900270E235C0079CBD4 /* Assets.xcassets */; };
-		2DD77904270E235C0079CBD4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2DD77902270E235C0079CBD4 /* LaunchScreen.storyboard */; };
+		2DD77904270E235C0079CBD4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2DD77902270E235C0079CBD4 /* LaunchScreen.storyboard */; platformFilters = (ios, maccatalyst, macos, watchos, ); };
 		2DD77909270E23870079CBD4 /* RCAttributionNetworkAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614EC26EBE84F007DDB75 /* RCAttributionNetworkAPI.m */; };
 		2DD7790B270E23870079CBD4 /* RCCustomerInfoAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614F026EBE84F007DDB75 /* RCCustomerInfoAPI.m */; };
 		2DD7790C270E23870079CBD4 /* RCPurchasesErrorCodeAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614EE26EBE84F007DDB75 /* RCPurchasesErrorCodeAPI.m */; };
@@ -319,7 +319,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
 			};
 			name = Debug;
 		};
@@ -356,7 +356,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -137,11 +137,11 @@ shouldPurchasePromoProduct:skp
                                                          NSError * _Nullable error,
                                                          BOOL cancelled)) {}];
 
-#if TARGET_OS_IPHONE || TARGET_OS_MACCATALYST
+#if (TARGET_OS_IPHONE || TARGET_OS_MACCATALYST) && !TARGET_OS_TV
     [p beginRefundRequestFor:@"1234" completion:^(RCRefundRequestStatus s, NSError * _Nullable e) { }];
 #endif
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE && !TARGET_OS_TV
     [p presentCodeRedemptionSheet];
 #endif
 }

--- a/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj/project.pbxproj
+++ b/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj/project.pbxproj
@@ -3,16 +3,16 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		2DD778D3270E233F0079CBD4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD778D2270E233F0079CBD4 /* AppDelegate.swift */; };
 		2DD778D5270E233F0079CBD4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD778D4270E233F0079CBD4 /* SceneDelegate.swift */; };
 		2DD778D7270E233F0079CBD4 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD778D6270E233F0079CBD4 /* ViewController.swift */; };
-		2DD778DA270E233F0079CBD4 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2DD778D8270E233F0079CBD4 /* Main.storyboard */; };
+		2DD778DA270E233F0079CBD4 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2DD778D8270E233F0079CBD4 /* Main.storyboard */; platformFilters = (ios, maccatalyst, macos, watchos, ); };
 		2DD778DC270E23400079CBD4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2DD778DB270E23400079CBD4 /* Assets.xcassets */; };
-		2DD778DF270E23400079CBD4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2DD778DD270E23400079CBD4 /* LaunchScreen.storyboard */; };
+		2DD778DF270E23400079CBD4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2DD778DD270E23400079CBD4 /* LaunchScreen.storyboard */; platformFilters = (ios, maccatalyst, macos, watchos, ); };
 		2DD778E4270E23460079CBD4 /* AttributionNetworkAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614CA26EBE7EA007DDB75 /* AttributionNetworkAPI.swift */; };
 		2DD778E5270E23460079CBD4 /* IntroEligibilityAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614CD26EBE7EA007DDB75 /* IntroEligibilityAPI.swift */; };
 		2DD778E6270E23460079CBD4 /* PurchasesAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614CE26EBE7EA007DDB75 /* PurchasesAPI.swift */; };
@@ -289,7 +289,7 @@
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
 			};
 			name = Debug;
 		};
@@ -324,7 +324,7 @@
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -189,8 +189,8 @@ private func checkIdentity(purchases: Purchases) {
 }
 
 private func checkPurchasesSupportAPI(purchases: Purchases) {
-    purchases.showManageSubscriptions { _ in }
     #if os(iOS)
+    purchases.showManageSubscriptions { _ in }
     purchases.beginRefundRequest(for: "") { _, _ in }
     if #available(iOS 15.0, macOS 12.0, *) {
         Task.init {

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -340,6 +340,20 @@
 			remoteGlobalIDString = 2DEAC2D926EFE46E006914ED;
 			remoteInfo = UnitTestsHostApp;
 		};
+		570896BB27596E8800296F1C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 570896B727596E8800296F1C /* SwiftAPITester.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 2DD778D0270E233F0079CBD4;
+			remoteInfo = SwiftAPITester;
+		};
+		570896C127596E8800296F1C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 570896BD27596E8800296F1C /* ObjCAPITester.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 2DD778F5270E235B0079CBD4;
+			remoteInfo = ObjCAPITester;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -525,6 +539,8 @@
 		570896B327595C8100296F1C /* RevenueCat.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = RevenueCat.xctestplan; path = TestPlans/RevenueCat.xctestplan; sourceTree = "<group>"; };
 		570896B427595C8100296F1C /* Coverage.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = Coverage.xctestplan; path = TestPlans/Coverage.xctestplan; sourceTree = "<group>"; };
 		570896B527595C8100296F1C /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = UnitTests.xctestplan; path = TestPlans/UnitTests.xctestplan; sourceTree = "<group>"; };
+		570896B727596E8800296F1C /* SwiftAPITester.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SwiftAPITester.xcodeproj; path = APITesters/SwiftAPITester/SwiftAPITester.xcodeproj; sourceTree = "<group>"; };
+		570896BD27596E8800296F1C /* ObjCAPITester.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ObjCAPITester.xcodeproj; path = APITesters/ObjCAPITester/ObjCAPITester.xcodeproj; sourceTree = "<group>"; };
 		5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = base64encoded_sandboxReceipt.txt; sourceTree = "<group>"; };
 		57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 		57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedUserDefaults.swift; sourceTree = "<group>"; };
@@ -987,6 +1003,7 @@
 				352629FF1F7C4B9100C04F2C /* Products */,
 				3530C18722653E8F00D6DF52 /* Frameworks */,
 				57B425A3275800B60075BDC4 /* Test Plans */,
+				570896B627596E6E00296F1C /* APITesters */,
 				2DBB3E10269C9B8700BBF431 /* SwiftStyleGuide.swift */,
 				2DEC0CFB24A2A1B100B0E5BB /* Package.swift */,
 			);
@@ -1209,6 +1226,31 @@
 				2DDF41AA24F6F37C005BC22D /* InAppPurchase.swift */,
 			);
 			path = BasicTypes;
+			sourceTree = "<group>";
+		};
+		570896B627596E6E00296F1C /* APITesters */ = {
+			isa = PBXGroup;
+			children = (
+				570896BD27596E8800296F1C /* ObjCAPITester.xcodeproj */,
+				570896B727596E8800296F1C /* SwiftAPITester.xcodeproj */,
+			);
+			name = APITesters;
+			sourceTree = "<group>";
+		};
+		570896B827596E8800296F1C /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				570896BC27596E8800296F1C /* SwiftAPITester.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		570896BE27596E8800296F1C /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				570896C227596E8800296F1C /* ObjCAPITester.app */,
+			);
+			name = Products;
 			sourceTree = "<group>";
 		};
 		57B425A3275800B60075BDC4 /* Test Plans */ = {
@@ -1539,6 +1581,16 @@
 			);
 			productRefGroup = 352629FF1F7C4B9100C04F2C /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 570896BE27596E8800296F1C /* Products */;
+					ProjectRef = 570896BD27596E8800296F1C /* ObjCAPITester.xcodeproj */;
+				},
+				{
+					ProductGroup = 570896B827596E8800296F1C /* Products */;
+					ProjectRef = 570896B727596E8800296F1C /* SwiftAPITester.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				2DC5621524EC63420031F69B /* RevenueCat */,
@@ -1550,6 +1602,23 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		570896BC27596E8800296F1C /* SwiftAPITester.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = SwiftAPITester.app;
+			remoteRef = 570896BB27596E8800296F1C /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		570896C227596E8800296F1C /* ObjCAPITester.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = ObjCAPITester.app;
+			remoteRef = 570896C127596E8800296F1C /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		2DAC5F7026F13C9800C5258F /* Resources */ = {

--- a/RevenueCat.xcodeproj/xcshareddata/xcschemes/RevenueCat.xcscheme
+++ b/RevenueCat.xcodeproj/xcshareddata/xcschemes/RevenueCat.xcscheme
@@ -28,6 +28,34 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2DD778CF270E233F0079CBD4"
+               BuildableName = "SwiftAPITester.app"
+               BlueprintName = "SwiftAPITester"
+               ReferencedContainer = "container:APITesters/SwiftAPITester/SwiftAPITester.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2DD778F4270E235B0079CBD4"
+               BuildableName = "ObjCAPITester.app"
+               BlueprintName = "ObjCAPITester"
+               ReferencedContainer = "container:APITesters/ObjCAPITester/ObjCAPITester.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "2DC5621D24EC63430031F69B"
                BuildableName = "RevenueCatTests.xctest"
                BlueprintName = "RevenueCatTests"


### PR DESCRIPTION
They don't compile when _building_ the framework, but they will when running for testing.
This adds an extra step for us locally to ensure that we don't break an API, without having to manually build those projects.

<img width="733" alt="Screen Shot 2021-12-02 at 13 14 42" src="https://user-images.githubusercontent.com/685609/144505641-35a89386-f20a-46f7-8783-303989a0a0f7.png">

Because they're part of tests now, we don't need the extra CircleCI steps. I left the `fastlane` lanes because they might still be useful to run from the command line.

Because the testers are now part of the main project too, they can easily be run by themselves as well:
<img width="211" alt="Screen Shot 2021-12-03 at 09 47 14" src="https://user-images.githubusercontent.com/685609/144648963-57205c32-f31c-4c11-92c6-45f4b20310a1.png">
