### PR TITLE
Add `priceFormatter` to `StoreProduct`

### DIFF
--- a/BackendIntegrationTests/BackendIntegrationTests.swift
+++ b/BackendIntegrationTests/BackendIntegrationTests.swift
@@ -48,17 +48,17 @@ class BackendIntegrationTests: XCTestCase {
         configurePurchases()
         var completionCalled = false
         var receivedError: Error? = nil
-        var receivedOfferings: Offerings? = nil
+        var maybeReceivedOfferings: Offerings? = nil
         Purchases.shared.getOfferings { offerings, error in
             completionCalled = true
             receivedError = error
-            receivedOfferings = offerings
+            maybeReceivedOfferings = offerings
         }
         expect(completionCalled).toEventually(beTrue(), timeout: .seconds(10))
 
         expect(receivedError).to(beNil())
-        expect(receivedOfferings).toNot(beNil())
-        expect(receivedOfferings!.all).toNot(beEmpty())
+        let receivedOfferings = try XCTUnwrap(maybeReceivedOfferings)
+        expect(receivedOfferings.all).toNot(beEmpty())
     }
 
     func testCanMakePurchase() throws {
@@ -233,7 +233,7 @@ class BackendIntegrationTests: XCTestCase {
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testEligibleForIntroBeforePurchaseAndIneligibleAfter() throws {
-        AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
         configurePurchases()
         
         var maybeProductID: String?

--- a/BackendIntegrationTests/BackendIntegrationTests.swift
+++ b/BackendIntegrationTests/BackendIntegrationTests.swift
@@ -231,14 +231,9 @@ class BackendIntegrationTests: XCTestCase {
         expect(completionCalled).toEventually(beTrue(), timeout: .seconds(10))
     }
 
-    // - Note: Xcode throws a warning about @available and #available being redundant, but they're actually necessary:
-    // Although the method isn't supposed to be called because of our @available marks,
-    // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testEligibleForIntroBeforePurchaseAndIneligibleAfter() throws {
-        guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {
-            throw XCTSkip("Required API is not available for this test.")
-        }
+        AvailabilityChecks.iOS15APIAvailableOrSkipTest()
         configurePurchases()
         
         var maybeProductID: String?

--- a/IntegrationTests/PurchaseTester/Configuration.storekit
+++ b/IntegrationTests/PurchaseTester/Configuration.storekit
@@ -49,6 +49,11 @@
               "description" : "Monthly subscription with a 1-week free trial",
               "displayName" : "Monthly Free Trial",
               "locale" : "en_US"
+            },
+            {
+              "description" : "Subscripción mensual con 1 semana gratis",
+              "displayName" : "Mensual con prueba gratis",
+              "locale" : "es_ES"
             }
           ],
           "productID" : "com.revenuecat.monthly_4.99.1_week_intro",

--- a/Purchases/Purchasing/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreProduct.swift
@@ -124,6 +124,7 @@ public typealias SK2Product = StoreKit.Product
         let formatter = NumberFormatter()
         formatter.numberStyle = .currency
         formatter.currencyCode = currencyCode
+        formatter.locale = .autoupdatingCurrent
         return formatter
     }
 

--- a/Purchases/Purchasing/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreProduct.swift
@@ -108,7 +108,13 @@ public typealias SK2Product = StoreKit.Product
 
     @objc public override var localizedTitle: String { underlyingSK2Product.displayName }
 
+    // TODO: optimize
+    // This creates a new formatter for every product, which can be slow.
+    // Ideally, we'd have a single, shared formatter, and listen for storefront changes in
+    // order to create a new one.
     @objc public override var priceFormatter: NumberFormatter? {
+        // note: if we ever need more information from the jsonRepresentation object, we
+        // should use Codable or another decoding method to clean up this code.
         guard let attributes = jsonDict["attributes"] as? [String: Any],
               let offers = attributes["offers"] as? [[String: Any]],
               let currencyCode: String = offers.first?["currencyCode"] as? String else {

--- a/Purchases/Purchasing/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreProduct.swift
@@ -108,10 +108,8 @@ public typealias SK2Product = StoreKit.Product
 
     @objc public override var localizedTitle: String { underlyingSK2Product.displayName }
 
-    // TODO: optimize
-    // This creates a new formatter for every product, which can be slow.
-    // Ideally, we'd have a single, shared formatter, and listen for storefront changes in
-    // order to create a new one.
+    /// Provides a `NumerFormatter`, useful for formatting the price for displaying.
+    /// - Note: This creates a new formatter for every product, which can be slow.
     @objc public override var priceFormatter: NumberFormatter? {
         // note: if we ever need more information from the jsonRepresentation object, we
         // should use Codable or another decoding method to clean up this code.

--- a/Purchases/Purchasing/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreProduct.swift
@@ -108,7 +108,7 @@ public typealias SK2Product = StoreKit.Product
 
     @objc public override var localizedTitle: String { underlyingSK2Product.displayName }
 
-    /// Provides a `NumerFormatter`, useful for formatting the price for displaying.
+    /// Provides a `NumberFormatter`, useful for formatting the price for displaying.
     /// - Note: This creates a new formatter for every product, which can be slow.
     @objc public override var priceFormatter: NumberFormatter? {
         // note: if we ever need more information from the jsonRepresentation object, we

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		2CD72942268A823900BFC976 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD72941268A823900BFC976 /* Data+Extensions.swift */; };
 		2CD72944268A826F00BFC976 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD72943268A826F00BFC976 /* Date+Extensions.swift */; };
 		2CD72948268A828400BFC976 /* Locale+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD72947268A828400BFC976 /* Locale+Extensions.swift */; };
+		2D1015DB275A4EAE0086173F /* AvailabilityChecks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE0263275942D500915B4C /* AvailabilityChecks.swift */; };
 		2D11F5E1250FF886005A70E8 /* AttributionStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D11F5E0250FF886005A70E8 /* AttributionStrings.swift */; };
 		2D1C3F3926B9D8B800112626 /* MockBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1C3F3826B9D8B800112626 /* MockBundle.swift */; };
 		2D1E789926FE216800760949 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1E788926FE215500760949 /* SceneDelegate.swift */; };
@@ -1913,6 +1914,7 @@
 				2D3BFAD126DEA45C00370B11 /* MockSK1Product.swift in Sources */,
 				2DE61A84264190830021CEA0 /* Constants.swift in Sources */,
 				2D3BFAD226DEA46600370B11 /* MockProductsRequest.swift in Sources */,
+				2D1015DB275A4EAE0086173F /* AvailabilityChecks.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/StoreKitUnitTests/ProductsManagerTests.swift
@@ -16,9 +16,6 @@ import Nimble
 import StoreKitTest
 import XCTest
 
-// - Note: Xcode throws a warning about @available and #available being redundant, but they're actually necessary:
-// Although the method isn't supposed to be called because of our @available marks,
-// everything in this class will still be called by XCTest, and it will cause errors.
 @available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 6.2, *)
 class ProductsManagerTests: StoreKitConfigTestCase {
 

--- a/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -89,9 +89,6 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                                         finishTransactions: true)
     }
 
-    // - Note: Xcode throws a warning about @available and #available being redundant, but they're actually necessary:
-    // Although the method isn't supposed to be called because of our @available marks,
-    // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testPurchaseSK2PackageReturnsCorrectValues() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
@@ -126,9 +123,6 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         expect(customerInfo) == expectedCustomerInfo
     }
 
-    // - Note: Xcode throws a warning about @available and #available being redundant, but they're actually necessary:
-    // Although the method isn't supposed to be called because of our @available marks,
-    // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testPurchaseSK2PackageHandlesPurchaseResult() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
@@ -152,9 +146,6 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         expect(mockListener.invokedHandle) == true
     }
 
-    // - Note: Xcode throws a warning about @available and #available being redundant, but they're actually necessary:
-    // Although the method isn't supposed to be called because of our @available marks,
-    // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testPurchaseSK2PackageSendsReceiptToBackendIfSuccessful() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
@@ -177,9 +168,6 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         expect(self.backend.invokedPostReceiptDataCount) == 1
     }
 
-    // - Note: Xcode throws a warning about @available and #available being redundant, but they're actually necessary:
-    // Although the method isn't supposed to be called because of our @available marks,
-    // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testPurchaseSK2PackageSkipsIfPurchaseFailed() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -136,4 +136,68 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(priceFormatter.string(from: productPrice)) == "$4.99"
     }
 
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func testSk1PriceFormatterReactsToStorefrontChanges() async throws {
+        testSession.locale = Locale(identifier: "es_ES")
+        testSession.storefront = "ESP"
+
+        let productIdentifier = "com.revenuecat.monthly_4.99.1_week_intro"
+        var sk1Fetcher = ProductsFetcherSK1()
+
+        var storeProductSet = await sk1Fetcher.products(withIdentifiers: Set([productIdentifier]))
+
+        var storeProduct = try XCTUnwrap(storeProductSet.first)
+        var priceFormatter = try XCTUnwrap(storeProduct.priceFormatter)
+        var productPrice = storeProduct.price as NSNumber
+
+        expect(priceFormatter.string(from: productPrice)) == "4,99 €"
+
+        testSession.locale = Locale(identifier: "en_EN")
+        testSession.storefront = "USA"
+
+        sk1Fetcher = ProductsFetcherSK1()
+
+        storeProductSet = await sk1Fetcher.products(withIdentifiers: Set([productIdentifier]))
+
+        storeProduct = try XCTUnwrap(storeProductSet.first)
+        priceFormatter = try XCTUnwrap(storeProduct.priceFormatter)
+        productPrice = storeProduct.price as NSNumber
+
+        expect(priceFormatter.string(from: productPrice)) == "$4.99"
+
+        testSession.locale = Locale(identifier: "es_ES")
+    }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func testSk2PriceFormatterReactsToStorefrontChanges() async throws {
+        testSession.locale = Locale(identifier: "es_ES")
+        testSession.storefront = "ESP"
+
+        let productIdentifier = "com.revenuecat.monthly_4.99.1_week_intro"
+        var sk2Fetcher = ProductsFetcherSK2()
+
+        var storeProductSet = try await sk2Fetcher.products(identifiers: Set([productIdentifier]))
+
+        var storeProduct = try XCTUnwrap(storeProductSet.first)
+        var priceFormatter = try XCTUnwrap(storeProduct.priceFormatter)
+        var productPrice = storeProduct.price as NSNumber
+
+        expect(priceFormatter.string(from: productPrice)) == "4,99 €"
+
+        testSession.locale = Locale(identifier: "en_EN")
+        testSession.storefront = "USA"
+
+        sk2Fetcher = ProductsFetcherSK2()
+
+        storeProductSet = try await sk2Fetcher.products(identifiers: Set([productIdentifier]))
+
+        storeProduct = try XCTUnwrap(storeProductSet.first)
+        priceFormatter = try XCTUnwrap(storeProduct.priceFormatter)
+        productPrice = storeProduct.price as NSNumber
+
+        expect(priceFormatter.string(from: productPrice)) == "$4.99"
+
+        testSession.locale = Locale(identifier: "es_ES")
+    }
+
 }

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -182,7 +182,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         var priceFormatter = try XCTUnwrap(storeProduct.priceFormatter)
         var productPrice = storeProduct.price as NSNumber
 
-        expect(priceFormatter.string(from: productPrice)) == "4,99 €"
+        expect(priceFormatter.string(from: productPrice)) == "€4.99"
 
         testSession.locale = Locale(identifier: "en_EN")
         testSession.storefront = "USA"

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -112,4 +112,39 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(storeProduct.subscriptionGroupIdentifier) == "7096FF06"
     }
 
+    // - Note: Xcode throws a warning about @available and #available being redundant, but they're actually necessary:
+    // Although the method isn't supposed to be called because of our @available marks,
+    // everything in this class will still be called by XCTest, and it will cause errors.
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func testSk2PriceFormatterFormatsCorrectly() async throws {
+        guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {
+            throw XCTSkip("Required API is not available for this test.")
+        }
+
+        let productIdentifier = "com.revenuecat.monthly_4.99.1_week_intro"
+        let sk2Fetcher = ProductsFetcherSK2()
+
+        let storeProductSet = try await sk2Fetcher.products(identifiers: Set([productIdentifier]))
+
+        let storeProduct = try XCTUnwrap(storeProductSet.first)
+        let priceFormatter = try XCTUnwrap(storeProduct.priceFormatter)
+        let productPrice = storeProduct.price as NSNumber
+
+        expect(priceFormatter.string(from: productPrice)) == "$4.99"
+    }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func testSk1PriceFormatterFormatsCorrectly() async throws {
+        let productIdentifier = "com.revenuecat.monthly_4.99.1_week_intro"
+        let sk1Fetcher = ProductsFetcherSK1()
+
+        let storeProductSet = await sk1Fetcher.products(withIdentifiers: Set([productIdentifier]))
+
+        let storeProduct = try XCTUnwrap(storeProductSet.first)
+        let priceFormatter = try XCTUnwrap(storeProduct.priceFormatter)
+        let productPrice = storeProduct.price as NSNumber
+
+        expect(priceFormatter.string(from: productPrice)) == "$4.99"
+    }
+
 }

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -18,9 +18,6 @@ import XCTest
 
 class StoreProductTests: StoreKitConfigTestCase {
 
-    // - Note: Xcode throws a warning about @available and #available being redundant, but they're actually necessary:
-    // Although the method isn't supposed to be called because of our @available marks,
-    // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testSK1AndSK2DetailsAreEquivalent() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
@@ -87,9 +84,6 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(callbackCalled).toEventually(beTrue(), timeout: .seconds(5))
     }
 
-    // - Note: Xcode throws a warning about @available and #available being redundant, but they're actually necessary:
-    // Although the method isn't supposed to be called because of our @available marks,
-    // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testSk2DetailsWrapsCorrectly() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
@@ -112,14 +106,9 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(storeProduct.subscriptionGroupIdentifier) == "7096FF06"
     }
 
-    // - Note: Xcode throws a warning about @available and #available being redundant, but they're actually necessary:
-    // Although the method isn't supposed to be called because of our @available marks,
-    // everything in this class will still be called by XCTest, and it will cause errors.
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testSk2PriceFormatterFormatsCorrectly() async throws {
-        guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {
-            throw XCTSkip("Required API is not available for this test.")
-        }
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         let productIdentifier = "com.revenuecat.monthly_4.99.1_week_intro"
         let sk2Fetcher = ProductsFetcherSK2()


### PR DESCRIPTION
Fixes #1013 

Will follow up with another PR for the new methods that already format the price, figured smaller PRs was probably better. 

Also does some small cleanup for outdated comments after the AvailabilityChecks PR