### PR TITLE
`SubscriptionPeriod` abstraction

### DIFF
--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -62,7 +62,7 @@ public typealias SK2Product = StoreKit.Product
     //
 
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
-    var subscriptionPeriod: SubscriptionPeriod? { fatalError() }
+    @objc public var subscriptionPeriod: SubscriptionPeriod? { fatalError() }
 
     // todo: add product discounts
     // https://github.com/RevenueCat/purchases-ios/issues/848
@@ -132,7 +132,7 @@ public typealias SK2Product = StoreKit.Product
         return decoded as? [String: Any] ?? [:]
     }
 
-    public override var subscriptionPeriod: SubscriptionPeriod? {
+    @objc public override var subscriptionPeriod: SubscriptionPeriod? {
         guard let skSubscriptionPeriod = underlyingSK2Product.subscription?.subscriptionPeriod else {
             return nil
         }
@@ -177,7 +177,7 @@ public typealias SK2Product = StoreKit.Product
     }
 
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
-    public override var subscriptionPeriod: SubscriptionPeriod? {
+    @objc public override var subscriptionPeriod: SubscriptionPeriod? {
         guard let skSubscriptionPeriod = underlyingSK1Product.subscriptionPeriod else {
             return nil
         }

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -61,11 +61,8 @@ public typealias SK2Product = StoreKit.Product
     //    var downloadContentVersion: String { get }
     //
 
-    // todo: add subscription period
-    // https://github.com/RevenueCat/purchases-ios/issues/849
-    //    @available(iOS 11.2, *)
-    //    var subscriptionPeriod: SKProductSubscriptionPeriod? { get }
-    //
+    @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
+    var subscriptionPeriod: SubscriptionPeriod? { fatalError() }
 
     // todo: add product discounts
     // https://github.com/RevenueCat/purchases-ios/issues/848
@@ -135,6 +132,13 @@ public typealias SK2Product = StoreKit.Product
         return decoded as? [String: Any] ?? [:]
     }
 
+    public override var subscriptionPeriod: SubscriptionPeriod? {
+        guard let skSubscriptionPeriod = underlyingSK2Product.subscription?.subscriptionPeriod else {
+            return nil
+        }
+        return SubscriptionPeriod.from(sk2SubscriptionPeriod: skSubscriptionPeriod)
+    }
+
 }
 
 @objc(RCSK1StoreProduct) public class SK1StoreProduct: StoreProduct {
@@ -170,6 +174,14 @@ public typealias SK2Product = StoreKit.Product
         formatter.numberStyle = .currency
         formatter.locale = underlyingSK1Product.priceLocale
         return formatter
+    }
+
+    @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
+    public override var subscriptionPeriod: SubscriptionPeriod? {
+        guard let skSubscriptionPeriod = underlyingSK1Product.subscriptionPeriod else {
+            return nil
+        }
+        return SubscriptionPeriod.from(sk1SubscriptionPeriod: skSubscriptionPeriod)
     }
 
 }

--- a/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
@@ -32,27 +32,6 @@ import StoreKit
         case month = 2
         case year = 3
 
-        @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
-        fileprivate static func from(sk1PeriodUnit: SK1Product.PeriodUnit) -> Self {
-            switch sk1PeriodUnit {
-            case .day: return .day
-            case .week: return .week
-            case .month: return .month
-            case .year: return .year
-            @unknown default: return .unknown
-            }
-        }
-
-        @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8, *)
-        fileprivate static func from(sk2PeriodUnit: StoreKit.Product.SubscriptionPeriod.Unit) -> Self {
-            switch sk2PeriodUnit {
-            case .day: return .day
-            case .week: return .week
-            case .month: return .month
-            case .year: return .year
-            @unknown default: return .unknown
-            }
-        }
     }
 
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
@@ -65,6 +44,32 @@ import StoreKit
     static func from(sk2SubscriptionPeriod: StoreKit.Product.SubscriptionPeriod) -> SubscriptionPeriod {
         return .init(value: sk2SubscriptionPeriod.value,
                      unit: SubscriptionPeriod.PeriodUnit.from(sk2PeriodUnit: sk2SubscriptionPeriod.unit))
+    }
+
+}
+
+fileprivate extension SubscriptionPeriod.PeriodUnit {
+
+    @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
+    static func from(sk1PeriodUnit: SK1Product.PeriodUnit) -> Self {
+        switch sk1PeriodUnit {
+        case .day: return .day
+        case .week: return .week
+        case .month: return .month
+        case .year: return .year
+        @unknown default: return .unknown
+        }
+    }
+
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8, *)
+    static func from(sk2PeriodUnit: StoreKit.Product.SubscriptionPeriod.Unit) -> Self {
+        switch sk2PeriodUnit {
+        case .day: return .day
+        case .week: return .week
+        case .month: return .month
+        case .year: return .year
+        @unknown default: return .unknown
+        }
     }
 
 }

--- a/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
@@ -1,0 +1,70 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SubscriptionPeriod.swift
+//
+//  Created by Andrés Boedo on 3/12/21.
+
+import Foundation
+import StoreKit
+
+@objc public class SubscriptionPeriod: NSObject {
+
+    public let numberOfUnits: Int
+    public let unit: PeriodUnit
+
+    init(numberOfUnits: Int, unit: PeriodUnit) {
+        self.numberOfUnits = numberOfUnits
+        self.unit = unit
+    }
+
+    @objc public enum PeriodUnit: Int {
+
+        case unknown = -1
+        case day = 0
+        case week = 1
+        case month = 2
+        case year = 3
+
+        @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
+        fileprivate static func from(sk1PeriodUnit: SK1Product.PeriodUnit) -> Self {
+            switch sk1PeriodUnit {
+            case .day: return .day
+            case .week: return .week
+            case .month: return .month
+            case .year: return .year
+            @unknown default: return .unknown
+            }
+        }
+
+        @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8, *)
+        fileprivate static func from(sk2PeriodUnit: StoreKit.Product.SubscriptionPeriod.Unit) -> Self {
+            switch sk2PeriodUnit {
+            case .day: return .day
+            case .week: return .week
+            case .month: return .month
+            case .year: return .year
+            @unknown default: return .unknown
+            }
+        }
+    }
+
+    @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
+    static func from(sk1SubscriptionPeriod: SKProductSubscriptionPeriod) -> SubscriptionPeriod {
+        return .init(numberOfUnits: sk1SubscriptionPeriod.numberOfUnits,
+                     unit: SubscriptionPeriod.PeriodUnit.from(sk1PeriodUnit: sk1SubscriptionPeriod.unit))
+    }
+
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8, *)
+    static func from(sk2SubscriptionPeriod: StoreKit.Product.SubscriptionPeriod) -> SubscriptionPeriod {
+        return .init(numberOfUnits: sk2SubscriptionPeriod.value,
+                     unit: SubscriptionPeriod.PeriodUnit.from(sk2PeriodUnit: sk2SubscriptionPeriod.unit))
+    }
+
+}

--- a/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
@@ -16,11 +16,11 @@ import StoreKit
 
 @objc public class SubscriptionPeriod: NSObject {
 
-    public let numberOfUnits: Int
+    public let value: Int
     public let unit: PeriodUnit
 
-    init(numberOfUnits: Int, unit: PeriodUnit) {
-        self.numberOfUnits = numberOfUnits
+    init(value: Int, unit: PeriodUnit) {
+        self.value = value
         self.unit = unit
     }
 
@@ -57,13 +57,13 @@ import StoreKit
 
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
     static func from(sk1SubscriptionPeriod: SKProductSubscriptionPeriod) -> SubscriptionPeriod {
-        return .init(numberOfUnits: sk1SubscriptionPeriod.numberOfUnits,
+        return .init(value: sk1SubscriptionPeriod.numberOfUnits,
                      unit: SubscriptionPeriod.PeriodUnit.from(sk1PeriodUnit: sk1SubscriptionPeriod.unit))
     }
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8, *)
     static func from(sk2SubscriptionPeriod: StoreKit.Product.SubscriptionPeriod) -> SubscriptionPeriod {
-        return .init(numberOfUnits: sk2SubscriptionPeriod.value,
+        return .init(value: sk2SubscriptionPeriod.value,
                      unit: SubscriptionPeriod.PeriodUnit.from(sk2PeriodUnit: sk2SubscriptionPeriod.unit))
     }
 

--- a/PurchasesTests/Purchasing/StoreKitAbstractions/SubscriptionPeriodTests.swift
+++ b/PurchasesTests/Purchasing/StoreKitAbstractions/SubscriptionPeriodTests.swift
@@ -1,0 +1,46 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SubscriptionPeriodTests.swift
+//
+//  Created by Andrés Boedo on 3/12/21.
+
+import Foundation
+import Nimble
+@testable import RevenueCat
+import StoreKit
+import XCTest
+
+class SubscriptionPeriodTests: XCTestCase {
+
+    func testFromSK1WorksCorrectly() throws {
+        guard #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *) else {
+            throw XCTSkip("Required API is unavailable for this test")
+        }
+
+        var sk1Period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .month)
+        var subscriptionPeriod = SubscriptionPeriod.from(sk1SubscriptionPeriod: sk1Period)
+
+        expect(subscriptionPeriod.value) == 1
+        expect(subscriptionPeriod.unit) == .month
+
+        sk1Period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .year)
+        subscriptionPeriod = SubscriptionPeriod.from(sk1SubscriptionPeriod: sk1Period)
+
+        expect(subscriptionPeriod.value) == 3
+        expect(subscriptionPeriod.unit) == .year
+
+        sk1Period = SKProductSubscriptionPeriod(numberOfUnits: 5, unit: .week)
+        subscriptionPeriod = SubscriptionPeriod.from(sk1SubscriptionPeriod: sk1Period)
+
+        expect(subscriptionPeriod.value) == 5
+        expect(subscriptionPeriod.unit) == .week
+    }
+
+}

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		2CD72948268A828400BFC976 /* Locale+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD72947268A828400BFC976 /* Locale+Extensions.swift */; };
 		2D1015DB275A4EAE0086173F /* AvailabilityChecks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE0263275942D500915B4C /* AvailabilityChecks.swift */; };
 		2D1015DE275A57FC0086173F /* SubscriptionPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1015DD275A57FC0086173F /* SubscriptionPeriod.swift */; };
+		2D1015E2275A67E40086173F /* SubscriptionPeriodTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1015E0275A676F0086173F /* SubscriptionPeriodTests.swift */; };
 		2D11F5E1250FF886005A70E8 /* AttributionStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D11F5E0250FF886005A70E8 /* AttributionStrings.swift */; };
 		2D1C3F3926B9D8B800112626 /* MockBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1C3F3826B9D8B800112626 /* MockBundle.swift */; };
 		2D1E789926FE216800760949 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1E788926FE215500760949 /* SceneDelegate.swift */; };
@@ -350,6 +351,7 @@
 		2CD72943268A826F00BFC976 /* Date+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; };
 		2CD72947268A828400BFC976 /* Locale+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Locale+Extensions.swift"; sourceTree = "<group>"; };
 		2D1015DD275A57FC0086173F /* SubscriptionPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPeriod.swift; sourceTree = "<group>"; };
+		2D1015E0275A676F0086173F /* SubscriptionPeriodTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPeriodTests.swift; sourceTree = "<group>"; };
 		2D11F5E0250FF886005A70E8 /* AttributionStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributionStrings.swift; sourceTree = "<group>"; };
 		2D1C3F3826B9D8B800112626 /* MockBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBundle.swift; sourceTree = "<group>"; };
 		2D1E788926FE215500760949 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -700,6 +702,14 @@
 			children = (
 				FECF627761D375C8431EB866 /* StoreProduct.swift */,
 				2D1015DD275A57FC0086173F /* SubscriptionPeriod.swift */,
+			);
+			path = StoreKitAbstractions;
+			sourceTree = "<group>";
+		};
+		2D1015DF275A67560086173F /* StoreKitAbstractions */ = {
+			isa = PBXGroup;
+			children = (
+				2D1015E0275A676F0086173F /* SubscriptionPeriodTests.swift */,
 			);
 			path = StoreKitAbstractions;
 			sourceTree = "<group>";
@@ -1070,6 +1080,7 @@
 		354235D624C11160008C84EE /* Purchasing */ = {
 			isa = PBXGroup;
 			children = (
+				2D1015DF275A67560086173F /* StoreKitAbstractions */,
 				37E3582920E16E065502E5FC /* EntitlementInfosTests.swift */,
 				B3F8418E26F3A93400E560FB /* ErrorCodeTests.swift */,
 				37E354B18710B488B8B0D443 /* IntroEligibilityCalculatorTests.swift */,
@@ -1871,6 +1882,7 @@
 				2DDF41DE24F6F527005BC22D /* MockAppleReceiptBuilder.swift in Sources */,
 				2DDF41E324F6F527005BC22D /* MockASN1ContainerBuilder.swift in Sources */,
 				2DDF41DA24F6F4DB005BC22D /* ReceiptParserTests.swift in Sources */,
+				2D1015E2275A67E40086173F /* SubscriptionPeriodTests.swift in Sources */,
 				351B519F26D4508A00BD2BD7 /* DeviceCacheTests.swift in Sources */,
 				2D22BF6826F3CC6D001AE2F9 /* XCTestCase+Extensions.swift in Sources */,
 				351B51B626D450E800BD2BD7 /* ReceiptFetcherTests.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		2CD72944268A826F00BFC976 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD72943268A826F00BFC976 /* Date+Extensions.swift */; };
 		2CD72948268A828400BFC976 /* Locale+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD72947268A828400BFC976 /* Locale+Extensions.swift */; };
 		2D1015DB275A4EAE0086173F /* AvailabilityChecks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE0263275942D500915B4C /* AvailabilityChecks.swift */; };
+		2D1015DE275A57FC0086173F /* SubscriptionPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1015DD275A57FC0086173F /* SubscriptionPeriod.swift */; };
 		2D11F5E1250FF886005A70E8 /* AttributionStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D11F5E0250FF886005A70E8 /* AttributionStrings.swift */; };
 		2D1C3F3926B9D8B800112626 /* MockBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1C3F3826B9D8B800112626 /* MockBundle.swift */; };
 		2D1E789926FE216800760949 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1E788926FE215500760949 /* SceneDelegate.swift */; };
@@ -348,6 +349,7 @@
 		2CD72941268A823900BFC976 /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
 		2CD72943268A826F00BFC976 /* Date+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; };
 		2CD72947268A828400BFC976 /* Locale+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Locale+Extensions.swift"; sourceTree = "<group>"; };
+		2D1015DD275A57FC0086173F /* SubscriptionPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPeriod.swift; sourceTree = "<group>"; };
 		2D11F5E0250FF886005A70E8 /* AttributionStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributionStrings.swift; sourceTree = "<group>"; };
 		2D1C3F3826B9D8B800112626 /* MockBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBundle.swift; sourceTree = "<group>"; };
 		2D1E788926FE215500760949 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -693,6 +695,15 @@
 			path = FoundationExtensions;
 			sourceTree = "<group>";
 		};
+		2D1015DC275A57DB0086173F /* StoreKitAbstractions */ = {
+			isa = PBXGroup;
+			children = (
+				FECF627761D375C8431EB866 /* StoreProduct.swift */,
+				2D1015DD275A57FC0086173F /* SubscriptionPeriod.swift */,
+			);
+			path = StoreKitAbstractions;
+			sourceTree = "<group>";
+		};
 		2D11F5DE250FF63E005A70E8 /* Logging */ = {
 			isa = PBXGroup;
 			children = (
@@ -1035,6 +1046,7 @@
 		354235D524C11138008C84EE /* Purchasing */ = {
 			isa = PBXGroup;
 			children = (
+				2D1015DC275A57DB0086173F /* StoreKitAbstractions */,
 				2D1DB44A26EA61AB00DDE736 /* StoreKit1 */,
 				006E105DDA8D0D0FA32D690C /* StoreKit2 */,
 				2D97458E24BDFCEF006245E9 /* IntroEligibilityCalculator.swift */,
@@ -1050,7 +1062,6 @@
 				80E80EF026970DC3008F245A /* ReceiptFetcher.swift */,
 				F5BE423F26962ACF00254A30 /* ReceiptRefreshPolicy.swift */,
 				3597020F24BF6A710010506E /* TransactionsFactory.swift */,
-				FECF627761D375C8431EB866 /* StoreProduct.swift */,
 				359E8E3E26DEBEEB00B869F9 /* TrialOrIntroPriceEligibilityChecker.swift */,
 			);
 			path = Purchasing;
@@ -1734,6 +1745,7 @@
 				57EAE52D274468900060EB74 /* RawDataContainer.swift in Sources */,
 				B35042C426CDB79A00905B95 /* Purchases.swift in Sources */,
 				2D22BF6526F3CB31001AE2F9 /* FatalErrorUtil.swift in Sources */,
+				2D1015DE275A57FC0086173F /* SubscriptionPeriod.swift in Sources */,
 				B3B5FBBF269E081E00104A0C /* InMemoryCachedObject.swift in Sources */,
 				9A65E0802591977900DE00B0 /* ReceiptStrings.swift in Sources */,
 				B3DDB55926854865008CCF23 /* PurchaseOwnershipType.swift in Sources */,

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -79,6 +79,9 @@ class StoreProductTests: StoreKitConfigTestCase {
             expect(storeProduct.localizedTitle) == "Monthly Free Trial"
             // open the StoreKit Config file as source code to see the expected value
             expect(storeProduct.subscriptionGroupIdentifier) == "7096FF06"
+
+            expect(storeProduct.subscriptionPeriod?.unit) == .month
+            expect(storeProduct.subscriptionPeriod?.value) == 1
         }
 
         expect(callbackCalled).toEventually(beTrue(), timeout: .seconds(5))
@@ -104,6 +107,9 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(storeProduct.localizedTitle) == "Monthly Free Trial"
         // open the StoreKit Config file as source code to see the expected value
         expect(storeProduct.subscriptionGroupIdentifier) == "7096FF06"
+
+        expect(storeProduct.subscriptionPeriod?.unit) == .month
+        expect(storeProduct.subscriptionPeriod?.value) == 1
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)


### PR DESCRIPTION
Added an abstraction for `SubscriptionPeriod` so that we can re-enable it in StoreProduct. 
This wraps the native types for both SK1 and SK2. 