### PR TITLE
Renamed `StoreKitError` overload to avoid confusion

### DIFF
--- a/PurchasesTests/Mocks/MockProductsRequest.swift
+++ b/PurchasesTests/Mocks/MockProductsRequest.swift
@@ -22,11 +22,12 @@ class MockProductResponse: SKProductsResponse {
     }
 }
 
-enum StoreKitError: Error {
-    case unknown
-}
-
 class MockProductsRequest: SKProductsRequest {
+
+    enum Error: Swift.Error {
+        case unknown
+    }
+
     var startCalled = false
     var cancelCalled = false
     var requestedIdentifiers: Set<String>
@@ -43,7 +44,7 @@ class MockProductsRequest: SKProductsRequest {
         startCalled = true
         DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(responseTimeInSeconds)) {
             if (self.fails) {
-                self.delegate?.request!(self, didFailWithError: StoreKitError.unknown)
+                self.delegate?.request!(self, didFailWithError: Error.unknown)
             } else {
                 let response = MockProductResponse(productIdentifiers: self.requestedIdentifiers)
                 self.delegate?.productsRequest(self, didReceive: response)

--- a/PurchasesTests/Purchasing/StoreKitRequestFetcherTests.swift
+++ b/PurchasesTests/Purchasing/StoreKitRequestFetcherTests.swift
@@ -15,13 +15,17 @@ import StoreKit
 class StoreKitRequestFetcherTests: XCTestCase {
 
     class MockReceiptRequest: SKReceiptRefreshRequest {
+        enum Error: Swift.Error {
+            case unknown
+        }
+
         var startCalled = false
         var fails = false
         override func start() {
             startCalled = true
             DispatchQueue.main.async {
                 if (self.fails) {
-                    self.delegate?.request!(self, didFailWithError: StoreKitError.unknown)
+                    self.delegate?.request!(self, didFailWithError: Error.unknown)
                 } else {
                     self.delegate?.requestDidFinish!(self)
                 }


### PR DESCRIPTION
I was trying to look at this failure:
```xml
<testcase classname="PurchasesOrchestratorTests" name="testPurchaseSK2PackageHandlesPurchaseResult()" time="0.07754290103912354">
<failure message="failed: caught error: "The operation couldn’t be completed. (StoreKit.StoreKitError error 1.)" (#CharacterRangeLen=0)"></failure>
</testcase>
```
When I realized that this was `StoreKit.StoreKitError`, not `RevenueCat.StoreKitError`.
To avoid confusion, this uses a custom namespaced error type.