### PR TITLE
CircleCI: added store_test_results to `runtest` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,8 @@ jobs:
       - run:
           name: Run tests
           command: bundle exec fastlane test
+      - store_test_results:
+          path: fastlane/test_output
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output


### PR DESCRIPTION
Fixes #1025: https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/4339/workflows/f84cb4bd-fdf1-47f0-89a8-26622457ce30/jobs/12887/tests