### PR TITLE
Remove outdated comment

### DIFF
--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -49,18 +49,6 @@ public typealias SK2Product = StoreKit.Product
 
     @objc public var priceFormatter: NumberFormatter? { fatalError() }
 
-    // todo: it looks like StoreKit 2 doesn't have support for these?
-    //    YES if this product has content downloadable using SKDownload
-    //    var isDownloadable: Bool { get }
-    //
-    //    var downloadContentLengths: [NSNumber] { get }
-    //
-    //    // Version of the downloadable content
-    //    var contentVersion: String { get }
-    //
-    //    var downloadContentVersion: String { get }
-    //
-
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
     @objc public var subscriptionPeriod: SubscriptionPeriod? { fatalError() }
 


### PR DESCRIPTION
We're not going to directly wrap the `downloads` property in `SKProduct`. 

This property is used in non-consumables for [Content Hosting](https://developer.apple.com/documentation/storekit/original_api_for_in-app_purchase/unlocking_purchased_content). 

We were not able to find any reference to it in StoreKit 2, it looks like it might not be compatible with it. So we're not going to attempt to wrap the methods for now. 

Note that they're still available if needed, albeit not trivial to access. 
They're still accessible through: 
```swift
guard let sk1StoreProduct = storeProduct as? SK1StoreProduct else {
    return
}
let skProduct = sk1StoreProduct.underlyingSK1Product
let downloads = skProduct.downloads
```