### PR TITLE
ProductInfo / ProductInfoExtractorTests refactor

### DIFF
--- a/Purchases/Misc/ISOPeriodFormatter.swift
+++ b/Purchases/Misc/ISOPeriodFormatter.swift
@@ -16,7 +16,7 @@ import Foundation
 import StoreKit
 
 @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *)
-class ISOPeriodFormatter {
+enum ISOPeriodFormatter {
 
     static func string(fromProductSubscriptionPeriod period: SKProductSubscriptionPeriod) -> String {
         let unitString = Self.period(fromUnit: period.unit)

--- a/Purchases/Misc/ISOPeriodFormatter.swift
+++ b/Purchases/Misc/ISOPeriodFormatter.swift
@@ -16,16 +16,15 @@ import Foundation
 import StoreKit
 
 @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *)
-
 class ISOPeriodFormatter {
 
-    func string(fromProductSubscriptionPeriod period: SKProductSubscriptionPeriod) -> String {
-        let unitString = self.period(fromUnit: period.unit)
+    static func string(fromProductSubscriptionPeriod period: SKProductSubscriptionPeriod) -> String {
+        let unitString = Self.period(fromUnit: period.unit)
         let stringResult = "P\(period.numberOfUnits)\(unitString)"
         return stringResult
     }
 
-    private func period(fromUnit unit: SK1Product.PeriodUnit) -> String {
+    private static func period(fromUnit unit: SK1Product.PeriodUnit) -> String {
         switch unit {
         case .day:
             return "D"

--- a/Purchases/Purchasing/ProductInfoExtractor.swift
+++ b/Purchases/Purchasing/ProductInfoExtractor.swift
@@ -17,10 +17,7 @@ import StoreKit
 
 class ProductInfoExtractor {
 
-    @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *)
-    private lazy var isoPeriodFormatter = ISOPeriodFormatter()
-
-    func extractInfo(from product: SK1Product) -> ProductInfo {
+    static func extractInfo(from product: SK1Product) -> ProductInfo {
         let paymentMode = extractPaymentMode(for: product)
         let introPrice = extractIntroPrice(for: product)
 
@@ -51,7 +48,7 @@ class ProductInfoExtractor {
 
 private extension ProductInfoExtractor {
 
-    func extractIntroDurationType(for product: SK1Product) -> IntroDurationType {
+    static func extractIntroDurationType(for product: SK1Product) -> IntroDurationType {
         if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *),
            let paymentMode = product.introductoryPrice?.paymentMode {
             return paymentMode == .freeTrial ? .freeTrial : .introPrice
@@ -60,7 +57,7 @@ private extension ProductInfoExtractor {
         }
     }
 
-    func extractSubscriptionGroup(for product: SK1Product) -> String? {
+    static func extractSubscriptionGroup(for product: SK1Product) -> String? {
         if #available(iOS 12.0, macOS 10.14.0, tvOS 12.0, *) {
             return product.subscriptionGroupIdentifier
         } else {
@@ -68,7 +65,7 @@ private extension ProductInfoExtractor {
         }
     }
 
-    func extractDiscounts(for product: SK1Product) -> [PromotionalOffer]? {
+    static func extractDiscounts(for product: SK1Product) -> [PromotionalOffer]? {
         if #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *) {
             return product.discounts.map(PromotionalOffer.init(withProductDiscount:))
         } else {
@@ -76,7 +73,7 @@ private extension ProductInfoExtractor {
         }
     }
 
-    func extractPaymentMode(for product: SK1Product) -> ProductInfo.PaymentMode {
+    static func extractPaymentMode(for product: SK1Product) -> ProductInfo.PaymentMode {
         if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *),
            let paymentMode = product.introductoryPrice?.paymentMode {
             return ProductInfo.paymentMode(fromSKProductDiscountPaymentMode: paymentMode)
@@ -85,7 +82,7 @@ private extension ProductInfoExtractor {
         }
     }
 
-    func extractIntroPrice(for product: SK1Product) -> NSDecimalNumber? {
+    static func extractIntroPrice(for product: SK1Product) -> NSDecimalNumber? {
         if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *),
            let introductoryPrice = product.introductoryPrice {
             return introductoryPrice.price
@@ -94,20 +91,20 @@ private extension ProductInfoExtractor {
         }
     }
 
-    func extractNormalDuration(for product: SK1Product) -> String? {
+    static func extractNormalDuration(for product: SK1Product) -> String? {
         if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *),
            let subscriptionPeriod = product.subscriptionPeriod,
            subscriptionPeriod.numberOfUnits != 0 {
-            return isoPeriodFormatter.string(fromProductSubscriptionPeriod: subscriptionPeriod)
+            return ISOPeriodFormatter.string(fromProductSubscriptionPeriod: subscriptionPeriod)
         } else {
             return nil
         }
     }
 
-    func extractIntroDuration(for product: SK1Product) -> String? {
+    static func extractIntroDuration(for product: SK1Product) -> String? {
         if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *),
            let subscriptionPeriod = product.introductoryPrice?.subscriptionPeriod {
-            return isoPeriodFormatter.string(fromProductSubscriptionPeriod: subscriptionPeriod)
+            return ISOPeriodFormatter.string(fromProductSubscriptionPeriod: subscriptionPeriod)
         } else {
             return nil
         }

--- a/Purchases/Purchasing/ProductInfoExtractor.swift
+++ b/Purchases/Purchasing/ProductInfoExtractor.swift
@@ -15,7 +15,7 @@
 import Foundation
 import StoreKit
 
-class ProductInfoExtractor {
+enum ProductInfoExtractor {
 
     static func extractInfo(from product: SK1Product) -> ProductInfo {
         let paymentMode = extractPaymentMode(for: product)

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -452,7 +452,7 @@ private extension PurchasesOrchestrator {
         var maybeProductInfo: ProductInfo?
         var maybePresentedOfferingID: String?
         if let product = products.first {
-            let productInfo = ProductInfoExtractor().extractInfo(from: product)
+            let productInfo = ProductInfoExtractor.extractInfo(from: product)
             maybeProductInfo = productInfo
 
             let productID = productInfo.productIdentifier

--- a/PurchasesTests/Misc/ISOPeriodFormatterTests.swift
+++ b/PurchasesTests/Misc/ISOPeriodFormatterTests.swift
@@ -20,19 +20,17 @@ class ISOPeriodFormatterTests: XCTestCase {
             throw XCTSkip()
         }
 
-        let formatter = ISOPeriodFormatter()
-
         var period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .day)
-        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P1D"
+        expect(ISOPeriodFormatter.string(fromProductSubscriptionPeriod: period)) == "P1D"
 
         period = SKProductSubscriptionPeriod(numberOfUnits: 10, unit: .day)
-        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P10D"
+        expect(ISOPeriodFormatter.string(fromProductSubscriptionPeriod: period)) == "P10D"
 
         period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .day)
-        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P3D"
+        expect(ISOPeriodFormatter.string(fromProductSubscriptionPeriod: period)) == "P3D"
 
         period = SKProductSubscriptionPeriod(numberOfUnits: 8, unit: .day)
-        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P8D"
+        expect(ISOPeriodFormatter.string(fromProductSubscriptionPeriod: period)) == "P8D"
     }
     
     func testStringFromProductSubscriptionPeriodMonth() throws {
@@ -40,19 +38,17 @@ class ISOPeriodFormatterTests: XCTestCase {
             throw XCTSkip()
         }
 
-        let formatter = ISOPeriodFormatter()
-
         var period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .month)
-        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P1M"
+        expect(ISOPeriodFormatter.string(fromProductSubscriptionPeriod: period)) == "P1M"
 
         period = SKProductSubscriptionPeriod(numberOfUnits: 10, unit: .month)
-        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P10M"
+        expect(ISOPeriodFormatter.string(fromProductSubscriptionPeriod: period)) == "P10M"
 
         period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .month)
-        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P3M"
+        expect(ISOPeriodFormatter.string(fromProductSubscriptionPeriod: period)) == "P3M"
 
         period = SKProductSubscriptionPeriod(numberOfUnits: 8, unit: .month)
-        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P8M"
+        expect(ISOPeriodFormatter.string(fromProductSubscriptionPeriod: period)) == "P8M"
     }
 
     func testStringFromProductSubscriptionPeriodWeek() throws {
@@ -60,19 +56,17 @@ class ISOPeriodFormatterTests: XCTestCase {
             throw XCTSkip()
         }
 
-        let formatter = ISOPeriodFormatter()
-
         var period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .week)
-        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P1W"
+        expect(ISOPeriodFormatter.string(fromProductSubscriptionPeriod: period)) == "P1W"
 
         period = SKProductSubscriptionPeriod(numberOfUnits: 10, unit: .week)
-        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P10W"
+        expect(ISOPeriodFormatter.string(fromProductSubscriptionPeriod: period)) == "P10W"
 
         period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .week)
-        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P3W"
+        expect(ISOPeriodFormatter.string(fromProductSubscriptionPeriod: period)) == "P3W"
 
         period = SKProductSubscriptionPeriod(numberOfUnits: 8, unit: .week)
-        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P8W"
+        expect(ISOPeriodFormatter.string(fromProductSubscriptionPeriod: period)) == "P8W"
     }
     
     func testStringFromProductSubscriptionPeriodYear() throws {
@@ -80,18 +74,16 @@ class ISOPeriodFormatterTests: XCTestCase {
             throw XCTSkip()
         }
 
-        let formatter = ISOPeriodFormatter()
-
         var period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .year)
-        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P1Y"
+        expect(ISOPeriodFormatter.string(fromProductSubscriptionPeriod: period)) == "P1Y"
 
         period = SKProductSubscriptionPeriod(numberOfUnits: 10, unit: .year)
-        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P10Y"
+        expect(ISOPeriodFormatter.string(fromProductSubscriptionPeriod: period)) == "P10Y"
 
         period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .year)
-        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P3Y"
+        expect(ISOPeriodFormatter.string(fromProductSubscriptionPeriod: period)) == "P3Y"
 
         period = SKProductSubscriptionPeriod(numberOfUnits: 8, unit: .year)
-        expect(formatter.string(fromProductSubscriptionPeriod: period)) == "P8Y"
+        expect(ISOPeriodFormatter.string(fromProductSubscriptionPeriod: period)) == "P8Y"
     }
 }

--- a/PurchasesTests/Purchasing/ProductInfoExtractorTests.swift
+++ b/PurchasesTests/Purchasing/ProductInfoExtractorTests.swift
@@ -5,189 +5,155 @@ import StoreKit
 
 class ProductInfoExtractorTests: XCTestCase {
 
+    private var product: MockSK1Product!
+
+    private static let productID = "cool_product"
+
+    override func setUp() {
+        self.product = MockSK1Product(mockProductIdentifier: Self.productID)
+    }
+
+    private func extract() -> ProductInfo {
+        return ProductInfoExtractor.extractInfo(from: self.product)
+    }
+
     func testExtractInfoFromProductExtractsProductIdentifier() {
-        let productID = "cool_product"
-        let product = MockSK1Product(mockProductIdentifier: productID)
-        let productInfoExtractor = ProductInfoExtractor()
+        let receivedProductInfo = self.extract()
 
-        let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
-
-        expect(receivedProductInfo.productIdentifier) == productID
+        expect(receivedProductInfo.productIdentifier) == Self.productID
     }
 
     func testExtractInfoFromProductExtractsPrice() {
-        let product = MockSK1Product(mockProductIdentifier: "cool_product")
         let price: NSDecimalNumber = 10.99
         product.mockPrice = price
-        let productInfoExtractor = ProductInfoExtractor()
 
-        let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
+        let receivedProductInfo = self.extract()
 
         expect(receivedProductInfo.price) == price
     }
 
     func testExtractInfoFromProductExtractsCurrencyCode() {
-        let product = MockSK1Product(mockProductIdentifier: "cool_product")
         product.mockPriceLocale = Locale(identifier: "es_UY")
-        let productInfoExtractor = ProductInfoExtractor()
 
-        var receivedProductInfo = productInfoExtractor.extractInfo(from: product)
+        var receivedProductInfo = self.extract()
 
         expect(receivedProductInfo.currencyCode) == "UYU"
 
         product.mockPriceLocale = Locale(identifier: "en_US")
-        receivedProductInfo = productInfoExtractor.extractInfo(from: product)
+        receivedProductInfo = self.extract()
         expect(receivedProductInfo.currencyCode) == "USD"
     }
 
     func testExtractInfoFromProductExtractsPaymentMode() {
-        let product = MockSK1Product(mockProductIdentifier: "cool_product")
-
         if #available(iOS 11.2, tvOS 11.2, macOS 10.13.2, *) {
             let mockDiscount = MockDiscount()
             mockDiscount.mockPaymentMode = .freeTrial
 
             product.mockDiscount = mockDiscount
-            let productInfoExtractor = ProductInfoExtractor()
 
-            let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
+            let receivedProductInfo = self.extract()
 
             expect(receivedProductInfo.paymentMode.rawValue) == ProductInfo.PaymentMode.freeTrial.rawValue
         } else {
-            let productInfoExtractor = ProductInfoExtractor()
-
-            let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
+            let receivedProductInfo = self.extract()
 
             expect(receivedProductInfo.paymentMode) == ProductInfo.PaymentMode.none
         }
     }
 
     func testExtractInfoFromProductExtractsIntroPrice() {
-        let product = MockSK1Product(mockProductIdentifier: "cool_product")
-
         if #available(iOS 11.2, tvOS 11.2, macOS 10.13.2, *) {
             let mockDiscount = MockDiscount()
             mockDiscount.mockPrice = 10.99
 
             product.mockDiscount = mockDiscount
-            let productInfoExtractor = ProductInfoExtractor()
 
-            let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
+            let receivedProductInfo = self.extract()
 
             expect(receivedProductInfo.introPrice) == 10.99
         } else {
-            let productInfoExtractor = ProductInfoExtractor()
-
-            let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
+            let receivedProductInfo = self.extract()
 
             expect(receivedProductInfo.introPrice).to(beNil())
         }
     }
 
     func testExtractInfoFromProductExtractsNormalDuration() {
-        let product = MockSK1Product(mockProductIdentifier: "cool_product")
-
         if #available(iOS 11.2, tvOS 11.2, macOS 10.13.2, *) {
             product.mockSubscriptionPeriod = SKProductSubscriptionPeriod(numberOfUnits: 2, unit: .month)
-            let productInfoExtractor = ProductInfoExtractor()
 
-            let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
+            let receivedProductInfo = self.extract()
 
             expect(receivedProductInfo.normalDuration) == "P2M"
         } else {
-            let productInfoExtractor = ProductInfoExtractor()
-
-            let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
+            let receivedProductInfo = self.extract()
 
             expect(receivedProductInfo.normalDuration).to(beNil())
         }
     }
 
     func testExtractInfoFromProductDoesNotExtractNormalDurationIfSubscriptionPeriodIsZero() {
-        let product = MockSK1Product(mockProductIdentifier: "cool_product")
-
         if #available(iOS 11.2, tvOS 11.2, macOS 10.13.2, *) {
             product.mockSubscriptionPeriod = SKProductSubscriptionPeriod(numberOfUnits: 0, unit: .month)
-            let productInfoExtractor = ProductInfoExtractor()
-
-            let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
+            let receivedProductInfo = self.extract()
 
             expect(receivedProductInfo.normalDuration).to(beNil())
         } else {
-            let productInfoExtractor = ProductInfoExtractor()
-
-            let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
+            let receivedProductInfo = self.extract()
 
             expect(receivedProductInfo.normalDuration).to(beNil())
         }
     }
 
     func testExtractInfoFromProductExtractsIntroDuration() {
-        let product = MockSK1Product(mockProductIdentifier: "cool_product")
-
         if #available(iOS 11.2, tvOS 11.2, macOS 10.13.2, *) {
             let mockDiscount = MockDiscount()
             mockDiscount.mockSubscriptionPeriod = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .year)
 
             product.mockDiscount = mockDiscount
-            let productInfoExtractor = ProductInfoExtractor()
 
-            let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
+            let receivedProductInfo = self.extract()
 
             expect(receivedProductInfo.introDuration) == "P3Y"
         } else {
-            let productInfoExtractor = ProductInfoExtractor()
-
-            let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
+            let receivedProductInfo = self.extract()
 
             expect(receivedProductInfo.introDuration).to(beNil())
         }
     }
 
     func testExtractInfoFromProductExtractsIntroDurationType() {
-        let product = MockSK1Product(mockProductIdentifier: "cool_product")
-
         if #available(iOS 11.2, macOS 10.14.4, tvOS 11.2, *) {
             let mockDiscount = MockDiscount()
             mockDiscount.mockPaymentMode = .freeTrial
 
             product.mockDiscount = mockDiscount
-            let productInfoExtractor = ProductInfoExtractor()
-
-            let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
+            let receivedProductInfo = self.extract()
 
             expect(receivedProductInfo.introDurationType) == .freeTrial
         } else {
-            let productInfoExtractor = ProductInfoExtractor()
-
-            let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
+            let receivedProductInfo = self.extract()
 
             expect(receivedProductInfo.introDurationType) == IntroDurationType.none
         }
     }
 
     func testExtractInfoFromProductExtractsSubscriptionGroup() {
-        let product = MockSK1Product(mockProductIdentifier: "cool_product")
         if #available(iOS 12.0, macCatalyst 13.0, macOS 10.14, tvOS 12.0, watchOS 6.2, *) {
             let group = "mock_group"
             product.mockSubscriptionGroupIdentifier = group
-            let productInfoExtractor = ProductInfoExtractor()
 
-            let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
+            let receivedProductInfo = self.extract()
 
             expect(receivedProductInfo.subscriptionGroup) == group
         } else {
-            let productInfoExtractor = ProductInfoExtractor()
-
-            let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
+            let receivedProductInfo = self.extract()
 
             expect(receivedProductInfo.subscriptionGroup).to(beNil())
         }
     }
 
     func testExtractInfoFromProductExtractsDiscounts() {
-        let product = MockSK1Product(mockProductIdentifier: "cool_product")
-
         if #available(iOS 12.2, tvOS 12.2, macOS 10.13.2, *) {
             let mockDiscount = MockDiscount()
             let paymentMode: SKProductDiscount.PaymentMode = .freeTrial
@@ -198,9 +164,7 @@ class ProductInfoExtractorTests: XCTestCase {
             mockDiscount.mockIdentifier = discountID
 
             product.mockDiscount = mockDiscount
-            let productInfoExtractor = ProductInfoExtractor()
-
-            let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
+            let receivedProductInfo = self.extract()
 
             expect(receivedProductInfo.discounts?.count) == 1
             let receivedPromotionalOffer = receivedProductInfo.discounts?[0]
@@ -208,9 +172,7 @@ class ProductInfoExtractorTests: XCTestCase {
             expect(receivedPromotionalOffer?.price) == price
             expect(receivedPromotionalOffer?.paymentMode.rawValue) == Int(paymentMode.rawValue)
         } else {
-            let productInfoExtractor = ProductInfoExtractor()
-
-            let receivedProductInfo = productInfoExtractor.extractInfo(from: product)
+            let receivedProductInfo = self.extract()
 
             expect(receivedProductInfo.discounts).to(beNil())
         }


### PR DESCRIPTION
NFC (not functional change)
Just a small refactor while working on #1038, separating here for easier review. Simplifying these will help when adding some new types to `ProductInfo`.

I'm guessing some of these things are leftovers from the Swift migration.

## Changes:

- Refactored `ProductInfoExtractorTests`, moved duplicated code into `setUp`
- `ProductInfoExtractor` and `ISOPeriodFormatter`: replaced method with static function: these types contain no data, and there is only one possible implementation that we can have. For that reason, we're not mocking them or injecting them anywhere, so they're simpler as static functions. As an example, we had `lazy var isoPeriodFormatter = ISOPeriodFormatter()`, but again `ISOPeriodFormatter` contains no data, only logic, so there's no point having a `lazy` variable for it.