### PR TITLE
`expectFatalError` / `expectNoFatalError`: forward file and line to preserve caller failure

### DIFF
--- a/PurchasesTests/Misc/XCTestCase+Extensions.swift
+++ b/PurchasesTests/Misc/XCTestCase+Extensions.swift
@@ -17,7 +17,11 @@ import XCTest
 
 extension XCTestCase {
 
-    func expectFatalError(expectedMessage: String, testcase: @escaping () -> Void) {
+    func expectFatalError(
+        expectedMessage: String,
+        testcase: @escaping () -> Void,
+        file: StaticString = #filePath, line: UInt = #line
+    ) {
         let expectation = self.expectation(description: "expectingFatalError")
         var fatalErrorReceived = false
         var assertionMessage: String? = nil
@@ -32,14 +36,17 @@ extension XCTestCase {
         DispatchQueue.global(qos: .userInitiated).async(execute: testcase)
 
         waitForExpectations(timeout: 2) { _ in
-            XCTAssert(fatalErrorReceived, "fatalError wasn't received")
-            XCTAssertEqual(assertionMessage, expectedMessage)
+            XCTAssert(fatalErrorReceived, "fatalError wasn't received", file: file, line: line)
+            XCTAssertEqual(assertionMessage, expectedMessage, file: file, line: line)
 
             FatalErrorUtil.restoreFatalError()
         }
     }
 
-    func expectNoFatalError(testcase: @escaping () -> Void) {
+    func expectNoFatalError(
+        testcase: @escaping () -> Void,
+        file: StaticString = #filePath, line: UInt = #line
+    ) {
         let expectation = self.expectation(description: "expectingNoFatalError")
         var fatalErrorReceived = false
 
@@ -54,7 +61,7 @@ extension XCTestCase {
         }
 
         waitForExpectations(timeout: 2) { _ in
-            XCTAssert(!fatalErrorReceived, "fatalError was received")
+            XCTAssert(!fatalErrorReceived, "fatalError was received", file: file, line: line)
             FatalErrorUtil.restoreFatalError()
         }
     }


### PR DESCRIPTION
Without this the test failure originates from `XCTestCase+Extensions.swift` instead of the individual test.