### PR TITLE
`PurchaseTester`: using new `StoreProduct.introductoryPrice` in SwiftPaywall

### DIFF
--- a/APITesters/SwiftAPITester/SwiftAPITester/PackageAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PackageAPI.swift
@@ -21,9 +21,9 @@ func checkPackageAPI() {
     let pType: PackageType = pack.packageType
     let prod: StoreProduct = pack.storeProduct
     let lps: String = pack.localizedPriceString
-    let lips: String = pack.localizedIntroductoryPriceString
+    let lips: String? = pack.localizedIntroductoryPriceString
 
-    print(pack!, ident, pType, prod, lps, lips)
+    print(pack!, ident, pType, prod, lps, lips!)
 }
 
 var packageType: PackageType!

--- a/IntegrationTests/PurchaseTester/PurchaseTester/SwiftPaywall.swift
+++ b/IntegrationTests/PurchaseTester/PurchaseTester/SwiftPaywall.swift
@@ -543,16 +543,14 @@ extension SwiftPaywall: UICollectionViewDelegate, UICollectionViewDataSource, UI
         
         didChangePackage = true
 
-        if #available(iOS 11.2, *) {
-            // todo: remove this check when sk2 products support introductory price
-            // https://github.com/RevenueCat/purchases-ios/issues/848
-            if let sk1StoreProduct = offering?.availablePackages[indexPath.row].storeProduct as? SK1StoreProduct,
-               let introPrice = sk1StoreProduct.underlyingSK1Product.introductoryPrice, introPrice.price == 0 {
+        if #available(iOS 12.2, *) {
+            if let product = offering?.availablePackages[indexPath.row].storeProduct,
+               let introPrice = product.introductoryPrice, introPrice.price == 0 {
 
                 var trialLength = ""
                 var cancelDate : Date?
                 var cancelString = "end of trial"
-                let numUnits = introPrice.subscriptionPeriod.numberOfUnits
+                let numUnits = introPrice.subscriptionPeriod.value
 
                 switch introPrice.subscriptionPeriod.unit {
                 case .day:
@@ -569,8 +567,10 @@ extension SwiftPaywall: UICollectionViewDelegate, UICollectionViewDataSource, UI
                     trialLength = "\(numUnits)-year"
                     cancelDate = Calendar.current.date(byAdding: .year, value: numUnits, to: Date())
                     cancelDate = Calendar.current.date(byAdding: .day, value: -1, to: cancelDate ?? Date())
+                case .unknown:
+                    fallthrough
                 @unknown default:
-                    fatalError()
+                    fatalError("Unknown unit: \(introPrice.subscriptionPeriod.unit)")
                 }
 
                 let dateFormatter = DateFormatter()

--- a/Purchases/Public/Package.swift
+++ b/Purchases/Public/Package.swift
@@ -82,14 +82,7 @@ private extension PackageType {
     /// The price of the `StoreProduct.introductoryPrice` formatted using ``priceFormatter``.
     /// - Returns: `nil` if there is no `introductoryPrice`.
     @objc public var localizedIntroductoryPriceString: String? {
-        guard #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *),
-              let formatter = storeProduct.priceFormatter,
-              let intro = storeProduct.introductoryPrice
-        else {
-            return nil
-        }
-
-        return formatter.string(from: intro.price as NSDecimalNumber)
+        return self.storeProduct.localizedIntroductoryPriceString
     }
 
     init(identifier: String, packageType: PackageType, storeProduct: StoreProduct, offeringIdentifier: String) {

--- a/Purchases/Public/Package.swift
+++ b/Purchases/Public/Package.swift
@@ -74,18 +74,22 @@ private extension PackageType {
     @objc public let storeProduct: StoreProduct
     @objc public let offeringIdentifier: String
 
+    /// The price of this product using ``priceFormatter``.
     @objc public var localizedPriceString: String {
         return storeProduct.localizedPriceString
     }
 
-    @objc public var localizedIntroductoryPriceString: String {
-        if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *) {
-            // todo: uncomment when product discounts are supported in product details
-            // return storeProduct.localizedIntroductoryPriceString
-            return ""
-        } else {
-            return ""
+    /// The price of the `StoreProduct.introductoryPrice` formatted using ``priceFormatter``.
+    /// - Returns: `nil` if there is no `introductoryPrice`.
+    @objc public var localizedIntroductoryPriceString: String? {
+        guard #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *),
+              let formatter = storeProduct.priceFormatter,
+              let intro = storeProduct.introductoryPrice
+        else {
+            return nil
         }
+
+        return formatter.string(from: intro.price as NSDecimalNumber)
     }
 
     init(identifier: String, packageType: PackageType, storeProduct: StoreProduct, offeringIdentifier: String) {

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -139,6 +139,23 @@ public typealias SK2Product = StoreKit.Product
 
 }
 
+public extension StoreProduct {
+    /// The price of the `introductoryPrice` formatted using ``priceFormatter``.
+    /// - Returns: `nil` if there is no `introductoryPrice`.
+    @objc var localizedIntroductoryPriceString: String? {
+        guard #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *),
+              let formatter = self.priceFormatter,
+              let intro = self.introductoryPrice
+        else {
+            return nil
+        }
+
+        return formatter.string(from: intro.price as NSDecimalNumber)
+    }
+}
+
+// MARK: - Subsclasses
+
 @objc(RCSK1StoreProduct) public class SK1StoreProduct: StoreProduct {
 
     @objc public init(sk1Product: SK1Product) {

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -39,6 +39,7 @@ public typealias SK2Product = StoreKit.Product
     @objc public var localizedDescription: String { fatalError() }
     @objc public var localizedTitle: String { fatalError() }
     @objc public var price: Decimal { fatalError() }
+    /// The price of this product using ``priceFormatter``.
     @objc public var localizedPriceString: String { fatalError() }
     @objc public var productIdentifier: String { fatalError() }
     @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 8.0, *)
@@ -47,6 +48,9 @@ public typealias SK2Product = StoreKit.Product
     @available(iOS 12.0, macCatalyst 13.0, tvOS 12.0, macOS 10.14, watchOS 6.2, *)
     @objc public var subscriptionGroupIdentifier: String? { fatalError() }
 
+    /// Provides a `NumberFormatter`, useful for formatting the price for displaying.
+    /// - Note: This creates a new formatter for every product, which can be slow.
+    /// - Returns: `nil` for StoreKit 2 backed products if the currency code could not be determined.
     @objc public var priceFormatter: NumberFormatter? { fatalError() }
 
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
@@ -91,8 +95,6 @@ public typealias SK2Product = StoreKit.Product
 
     @objc public override var localizedTitle: String { underlyingSK2Product.displayName }
 
-    /// Provides a `NumberFormatter`, useful for formatting the price for displaying.
-    /// - Note: This creates a new formatter for every product, which can be slow.
     @objc public override var priceFormatter: NumberFormatter? {
         // note: if we ever need more information from the jsonRepresentation object, we
         // should use Codable or another decoding method to clean up this code.

--- a/docs/V4_API_Updates.md
+++ b/docs/V4_API_Updates.md
@@ -240,6 +240,10 @@ to your project, and `#import RevenueCat-Swift.h` in your bridging header. You c
 			<td>Package.storeProduct.price: Decimal</td>
 		</tr>
 		<tr>
+			<td>Package.localizedIntroductoryPriceString: String</td>
+			<td>Package.localizedIntroductoryPriceString: String?</td>
+		</tr>
+		<tr>
 			<td>RCDeferredPromotionalPurchaseBlock</td>
 			<td>DeferredPromotionalPurchaseBlock</td>
 		</tr>


### PR DESCRIPTION
#848 and [sc-11623].
Depends on #1038.

Also documented some more methods in `Package` (#1046).

### Questions:
- `Package.localizedIntroductoryPriceString` used to be non-optional and default to an empty string (thank you `SwiftAPITester` for helping me catch this!).
Making it optional would be a breaking change, but I think 4.0 would be a good chance to do that. Version 3.0 doc just said _“A String containing the localized introductory price”_ with no indication that it could return `“”`. Or better yet, if there was no `introductoryPrice`, I guess it would return `$0.00`?