### PR TITLE
StoreProduct.pricePerMonth

### DIFF
--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -38,9 +38,15 @@ public typealias SK2Product = StoreKit.Product
 
     @objc public var localizedDescription: String { fatalError() }
     @objc public var localizedTitle: String { fatalError() }
+
+    /// The decimal representation of the cost of the product, in local currency.
+    /// For a string representation of the price to display to customers, use ``localizedPriceString``.
+    /// - Seealso: `pricePerMonth`.
     @objc public var price: Decimal { fatalError() }
+
     /// The price of this product using ``priceFormatter``.
     @objc public var localizedPriceString: String { fatalError() }
+
     @objc public var productIdentifier: String { fatalError() }
     @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 8.0, *)
     @objc public var isFamilyShareable: Bool { fatalError() }
@@ -53,6 +59,8 @@ public typealias SK2Product = StoreKit.Product
     /// - Returns: `nil` for StoreKit 2 backed products if the currency code could not be determined.
     @objc public var priceFormatter: NumberFormatter? { fatalError() }
 
+    /// The period details for products that are subscriptions.
+    /// - Returns: `nil` if the product is not a subscription.
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
     @objc public var subscriptionPeriod: SubscriptionPeriod? { fatalError() }
 
@@ -62,6 +70,24 @@ public typealias SK2Product = StoreKit.Product
     @available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *)
     @objc public var discounts: [PromotionalOffer] { fatalError() }
 }
+
+public extension StoreProduct {
+
+    /// Calculates the price of this subscription product per month.
+    /// - Returns: `nil` if the product is not a subscription.
+    @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
+    @objc var pricePerMonth: NSDecimalNumber? {
+        guard let period = self.subscriptionPeriod,
+              period.unit != .unknown else {
+                  return nil
+              }
+
+        return period.pricePerMonth(withTotalPrice: self.price) as NSDecimalNumber?
+    }
+
+}
+
+// MARK: - Subclasses
 
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 @objc(RCSK2StoreProduct) public class SK2StoreProduct: StoreProduct {

--- a/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
@@ -64,6 +64,22 @@ import StoreKit
 
 }
 
+extension SubscriptionPeriod {
+    func pricePerMonth(withTotalPrice price: Decimal) -> Decimal {
+        let periodsPerMonth: Decimal = {
+            switch self.unit {
+            case .day: return 1 / 30
+            case .week: return 1 / 4
+            case .month: return 1
+            case .year: return 12
+            case .unknown: return 1
+            }
+        }() * Decimal(self.value)
+
+        return price / periodsPerMonth
+    }
+}
+
 extension SubscriptionPeriod.Unit: CustomDebugStringConvertible {
     public var debugDescription: String {
         switch self {

--- a/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
@@ -76,8 +76,19 @@ extension SubscriptionPeriod {
             }
         }() * Decimal(self.value)
 
-        return price / periodsPerMonth
+        return (price as NSDecimalNumber)
+            .dividing(by: periodsPerMonth as NSDecimalNumber,
+                      withBehavior: Self.roundingBehavior) as Decimal
     }
+
+    private static let roundingBehavior = NSDecimalNumberHandler(
+        roundingMode: .down,
+        scale: 2,
+        raiseOnExactness: false,
+        raiseOnOverflow: false,
+        raiseOnUnderflow: false,
+        raiseOnDivideByZero: false
+    )
 }
 
 extension SubscriptionPeriod.Unit: CustomDebugStringConvertible {

--- a/PurchasesTests/Purchasing/StoreKitAbstractions/SubscriptionPeriodTests.swift
+++ b/PurchasesTests/Purchasing/StoreKitAbstractions/SubscriptionPeriodTests.swift
@@ -43,4 +43,30 @@ class SubscriptionPeriodTests: XCTestCase {
         expect(subscriptionPeriod.unit) == .week
     }
 
+    // Note: can't test creation from `StoreKit.Product.SubscriptionPeriod` because it has no public constructors.
+
+    func testPricePerMonth() {
+        let expectations: [(period: SubscriptionPeriod, price: Decimal, expected: Decimal)] = [
+            (p(1, .day), 2, 60),
+            (p(15, .day), 5, 10),
+            (p(1, .week), 10, 40),
+            (p(2, .week), 10, 20),
+            (p(1, .month), 14.99, 14.99),
+            (p(2, .month), 30, 15),
+            (p(1, .year), 120, 10),
+            (p(3, .year), 720, 20)
+        ]
+
+        for expectation in expectations {
+            let result = Double(truncating: expectation.period.pricePerMonth(withTotalPrice: expectation.price) as NSDecimalNumber)
+            let expected = Double(truncating: expectation.expected as NSDecimalNumber)
+
+            expect(result).to(beCloseTo(expected),
+                              description: "\(expectation.price) / \(expectation.period.debugDescription)")
+        }
+    }
+
+    private func p(_ value: Int, _ unit: SubscriptionPeriod.Unit) -> SubscriptionPeriod {
+        return .init(value: value, unit: unit)
+    }
 }

--- a/PurchasesTests/Purchasing/StoreKitAbstractions/SubscriptionPeriodTests.swift
+++ b/PurchasesTests/Purchasing/StoreKitAbstractions/SubscriptionPeriodTests.swift
@@ -53,7 +53,10 @@ class SubscriptionPeriodTests: XCTestCase {
             (p(2, .week), 10, 20),
             (p(1, .month), 14.99, 14.99),
             (p(2, .month), 30, 15),
+            (p(3, .month), 40, 13.33),
             (p(1, .year), 120, 10),
+            (p(1, .year), 50, 4.16),
+            (p(1, .year), 29.99, 2.49),
             (p(3, .year), 720, 20)
         ]
 


### PR DESCRIPTION
This will be very useful to users, and will simplify the logic in the `PurchaseTester`.

Related: [sc-11623].
Also documented more methods: #1046.

Depends on #1047.