### PR TITLE
Disable asserts in release builds when using Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,9 @@ func resolveTargets() -> [Target] {
                 exclude: [infoPlist],
                 sources: ["Purchases"],
                 publicHeadersPath: "Purchases/Public",
-                cSettings: objcSources.map { CSetting.headerSearchPath($0) }
+                cSettings: objcSources.map { CSetting.headerSearchPath($0) } + [
+                    .define("NS_BLOCK_ASSERTIONS", to: "1", .when(configuration: .release))
+                ]
         ),
         .target(name: "PurchasesCoreSwift",
                 dependencies: [],


### PR DESCRIPTION
When using Swift Package Manager to integrate `Purchases` into an app, Xcode does not automatically set `NS_BLOCK_ASSERTIONS` to `1` when building the package in release. This means that any `NSAsserts` that are hit in release cause crashes. This appears to only be an issue with [ObjC packages](https://forums.swift.org/t/assertions-in-swift-packages/42692). 

The change I've made is to `Package.swift` to set `NS_BLOCK_ASSERTIONS` to `1` when building in release.

(Note: I didn't actually hit an assert in this Purchases, but the possibility is there)

I haven't added unit tests as I can't think of a way to do that using SPM. I did, however, point to your branch of 3.13.1 and change a configure method to look like: 
```
+ (instancetype)configureWithAPIKey:(NSString *)APIKey appUserID:(nullable NSString *)appUserID {
    NSAssert(0, @"");
    return [self configureWithAPIKey:APIKey appUserID:appUserID observerMode:false];
}
```
When building in release and pointing to your 3.13.1 branch, this causes a crash. I think change SPM to point to my fork with the change in `Package.swift` and the assert no longer caused a crash.

