### PR TITLE
Update availability for async methods

### DIFF
--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -107,7 +107,7 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.getOfferings { _, _ in }
     purchases.getProducts([String]()) { _ in }
 
-    if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+    if #available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *) {
         Task.init {
             let _: CustomerInfo = try await purchases.customerInfo()
             let _: [SKProduct] = await purchases.products([String]())
@@ -124,7 +124,7 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.purchase(package: pack) { _, _, _, _  in }
     purchases.syncPurchases { _, _ in }
 
-    if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+    if #available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *) {
         Task.init {
             let (_, _, _): (SKPaymentTransaction, CustomerInfo, Bool) = try await purchases.purchase(product: skp)
             let (_, _, _): (SKPaymentTransaction, CustomerInfo, Bool) = try await purchases.purchase(package: pack)
@@ -143,7 +143,7 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.purchase(package: pack, discount: paymentDiscount) { _, _, _, _  in }
     purchases.invalidateCustomerInfoCache()
 
-    if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+    if #available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *) {
         Task.init {
             let (_, _, _): (SKPaymentTransaction, CustomerInfo, Bool) =
             try await purchases.purchase(product: skp, discount: paymentDiscount)
@@ -180,7 +180,7 @@ private func checkIdentity(purchases: Purchases) {
     let loginComplete: (CustomerInfo?, Bool, Error?) -> Void = { _, _, _ in }
     purchases.logIn("", completion: loginComplete)
     purchases.logIn("") { _, _, _ in }
-    if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+    if #available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *) {
         Task.init {
             let (_, _): (CustomerInfo, Bool) = try await purchases.logIn("")
             let _: CustomerInfo = try await purchases.logOut()
@@ -192,7 +192,7 @@ private func checkPurchasesSupportAPI(purchases: Purchases) {
     #if os(iOS)
     purchases.showManageSubscriptions { _ in }
     purchases.beginRefundRequest(for: "") { _, _ in }
-    if #available(iOS 15.0, macOS 12.0, *) {
+    if #available(iOS 13.0, macOS 10.15, *) {
         Task.init {
             try await purchases.showManageSubscriptions()
             let _: RefundRequestStatus = try await purchases.beginRefundRequest(for: "")

--- a/Purchases/FoundationExtensions/UIApplication+RCExtensions.swift
+++ b/Purchases/FoundationExtensions/UIApplication+RCExtensions.swift
@@ -17,7 +17,7 @@ import UIKit
 
 extension UIApplication {
 
-    @available(iOS 15.0, *)
+    @available(iOS 13.0, *)
     @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(watchOSApplicationExtension, unavailable)

--- a/Purchases/Public/Purchases+async.swift
+++ b/Purchases/Public/Purchases+async.swift
@@ -17,7 +17,7 @@ import StoreKit
 /// This extension holds the biolerplate logic to convert methods with completion blocks into async / await syntax.
 extension Purchases {
 
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func logInAsync(_ appUserID: String) async throws -> (customerInfo: CustomerInfo, created: Bool) {
         return try await withCheckedThrowingContinuation { continuation in
             logIn(appUserID) { maybeCustomerInfo, created, maybeError in
@@ -33,7 +33,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func logOutAsync() async throws -> CustomerInfo {
         return try await withCheckedThrowingContinuation { continuation in
             logOut { maybeCustomerInfo, maybeError in
@@ -49,7 +49,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func offeringsAsync() async throws -> Offerings {
         return try await withCheckedThrowingContinuation { continuation in
             getOfferings { maybeOfferings, maybeError in
@@ -65,7 +65,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func customerInfoAsync() async throws -> CustomerInfo {
         return try await withCheckedThrowingContinuation { continuation in
             getCustomerInfo { maybeCustomerInfo, maybeError in
@@ -81,7 +81,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func productsAsync(_ productIdentifiers: [String]) async -> [SKProduct] {
         return await withCheckedContinuation { continuation in
             getProducts(productIdentifiers) { result in
@@ -90,7 +90,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func purchaseAsync(product: SKProduct) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
@@ -112,7 +112,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func purchaseAsync(package: Package) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
@@ -134,7 +134,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func purchaseAsync(product: SKProduct, discount: SKPaymentDiscount) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
@@ -158,7 +158,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func purchaseAsync(package: Package, discount: SKPaymentDiscount) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
@@ -181,7 +181,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func syncPurchasesAsync() async throws -> CustomerInfo {
         return try await withCheckedThrowingContinuation { continuation in
             syncPurchases { maybeCustomerInfo, maybeError in
@@ -197,7 +197,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func restoreTransactionsAsync() async throws -> CustomerInfo {
         return try await withCheckedThrowingContinuation { continuation in
             restoreTransactions { maybeCustomerInfo, maybeError in
@@ -213,7 +213,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func checkTrialOrIntroductoryPriceEligibilityAsync(_ productIdentifiers: [String]) async
     -> [String: IntroEligibility] {
         return await withCheckedContinuation { continuation in
@@ -223,7 +223,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func paymentDiscountAsync(forProductDiscount discount: SKProductDiscount,
                               product: SKProduct) async throws -> SKPaymentDiscount {
         return try await withCheckedThrowingContinuation { continuation in
@@ -242,7 +242,7 @@ extension Purchases {
 
 #if os(iOS) || os(macOS)
 
-    @available(iOS 15.0, macOS 12, *)
+    @available(iOS 13.0, macOS 10.15, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     func showManageSubscriptionsAsync() async throws {

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -678,7 +678,7 @@ public extension Purchases {
      * indicating whether the user was created for the first time in the RevenueCat backend.
      * See https://docs.revenuecat.com/docs/user-ids
      */
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func logIn(_ appUserID: String) async throws -> (customerInfo: CustomerInfo, created: Bool) {
         return try await logInAsync(appUserID)
     }
@@ -710,7 +710,7 @@ public extension Purchases {
      * If this method is called and the current user is anonymous, it will return an error.
      * See https://docs.revenuecat.com/docs/user-ids
      */
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func logOut() async throws -> CustomerInfo {
         return try await logOutAsync()
     }
@@ -741,7 +741,7 @@ public extension Purchases {
      * - Parameter completion: A completion block called when offerings are available.
      * Called immediately if offerings are cached. Offerings will be nil if an error occurred.
      */
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func offerings() async throws -> Offerings {
         return try await offeringsAsync()
     }
@@ -767,7 +767,7 @@ public extension Purchases {
      * - Parameter completion: A completion block called when customer info is available and not stale.
      * Called immediately if ``CustomerInfo`` is cached. Customer info can be nil * if an error occurred.
      */
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func customerInfo() async throws -> CustomerInfo {
         return try await customerInfoAsync()
     }
@@ -813,7 +813,7 @@ public extension Purchases {
      * - Parameter completion: An @escaping callback that is called with the loaded products.
      * If the fetch fails for any reason it will return an empty array.
      */
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func products(_ productIdentifiers: [String]) async -> [SKProduct] {
         return await productsAsync(productIdentifiers)
     }
@@ -864,7 +864,7 @@ public extension Purchases {
      *
      * If the user cancelled, `userCancelled` will be `YES`.
      */
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func purchase(product: SKProduct) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
@@ -910,7 +910,7 @@ public extension Purchases {
      *
      * If the user cancelled, `userCancelled` will be `true`.
      */
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func purchase(package: Package) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
@@ -966,7 +966,7 @@ public extension Purchases {
      * If the purchase was not successful, there will be an `Error`.
      * If the user cancelled, `userCancelled` will be `true`.
      */
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func purchase(product: SKProduct, discount: SKPaymentDiscount) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
@@ -1024,7 +1024,7 @@ public extension Purchases {
      * If the purchase was not successful, there will be an `Error`.
      * If the user cancelled, `userCancelled` will be `true`.
      */
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func purchase(package: Package, discount: SKPaymentDiscount) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
@@ -1063,7 +1063,7 @@ public extension Purchases {
      * on the device does not contain subscriptions, but the user has made subscription purchases, this method
      * won't be able to restore them. Use `restoreTransactions(completion:)` to cover those cases.
      */
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func syncPurchases() async throws -> CustomerInfo {
         return try await syncPurchasesAsync()
     }
@@ -1098,7 +1098,7 @@ public extension Purchases {
      * the user. Typically with a button in settings or near your purchase UI. Use
      * ``Purchases/syncPurchases(completion:)`` if you need to restore transactions programmatically.
      */
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func restoreTransactions() async throws -> CustomerInfo {
         return try await restoreTransactionsAsync()
     }
@@ -1138,7 +1138,7 @@ public extension Purchases {
      * - Parameter productIdentifiers: Array of product identifiers for which you want to compute eligibility
      * - Parameter completion: A block that receives a dictionary of product_id -> ``IntroEligibility``.
      */
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
     func checkTrialOrIntroductoryPriceEligibility(_ productIdentifiers: [String]) async -> [String: IntroEligibility] {
         return await checkTrialOrIntroductoryPriceEligibilityAsync(productIdentifiers)
     }
@@ -1194,7 +1194,7 @@ public extension Purchases {
      * - Parameter completion: A completion block that is called when the `SKPaymentDiscount` is returned.
      * If it was not successful, there will be an `Error`.
      */
-    @available(iOS 15.0, macOS 12, tvOS 15.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func paymentDiscount(forProductDiscount discount: SKProductDiscount,
                          product: SKProduct) async throws -> SKPaymentDiscount {
         return try await paymentDiscountAsync(forProductDiscount: discount, product: product)
@@ -1226,7 +1226,7 @@ public extension Purchases {
      */
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
-    @available(iOS 15.0, macOS 12, *)
+    @available(iOS 13.0, macOS 10.15, *)
     func showManageSubscriptions() async throws {
         return try await showManageSubscriptionsAsync()
     }

--- a/Purchases/Purchasing/ProductsManager.swift
+++ b/Purchases/Purchasing/ProductsManager.swift
@@ -52,7 +52,7 @@ class ProductsManager: NSObject {
         }
     }
 
-    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
     func productsFromOptimalStoreKitVersion(
         withIdentifiers identifiers: Set<String>
     ) async throws -> Set<StoreProduct> {

--- a/Purchases/Purchasing/StoreKit1/ProductsFetcherSK1.swift
+++ b/Purchases/Purchasing/StoreKit1/ProductsFetcherSK1.swift
@@ -90,7 +90,7 @@ class ProductsFetcherSK1: NSObject {
         }
     }
 
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     func products(withIdentifiers identifiers: Set<String>) async throws -> Set<StoreProduct> {
         return try await withCheckedThrowingContinuation { continuation in
             products(withIdentifiers: identifiers) { result in

--- a/PurchasesTests/Mocks/MockProductsManager.swift
+++ b/PurchasesTests/Mocks/MockProductsManager.swift
@@ -45,7 +45,7 @@ class MockProductsManager: ProductsManager {
     var invokedProductsFromOptimalStoreKitVersionParameters: (identifiers: Set<String>, Void)?
     var invokedProductsFromOptimalStoreKitVersionParametersList = [(identifiers: Set<String>, Void)]()
 
-    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
     override func productsFromOptimalStoreKitVersion(withIdentifiers identifiers: Set<String>) async -> Set<StoreProduct> {
         invokedProductsFromOptimalStoreKitVersion = true
         invokedProductsFromOptimalStoreKitVersionCount += 1

--- a/StoreKitUnitTests/AvailabilityChecks.swift
+++ b/StoreKitUnitTests/AvailabilityChecks.swift
@@ -19,6 +19,12 @@ import XCTest
 // everything in those classes will still be called by XCTest, and it will cause errors.
 enum AvailabilityChecks {
 
+    static func iOS13APIAvailableOrSkipTest() throws {
+        guard #available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *) else {
+            throw XCTSkip("Required API is not available for this test.")
+        }
+    }
+
     static func iOS15APIAvailableOrSkipTest() throws {
         guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {
             throw XCTSkip("Required API is not available for this test.")

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -130,8 +130,10 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(priceFormatter.string(from: productPrice)) == "$4.99"
     }
 
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
     func testSk1PriceFormatterFormatsCorrectly() async throws {
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
         let productIdentifier = "com.revenuecat.monthly_4.99.1_week_intro"
         let sk1Fetcher = ProductsFetcherSK1()
 
@@ -144,8 +146,10 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(priceFormatter.string(from: productPrice)) == "$4.99"
     }
 
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
     func testSk1PriceFormatterReactsToStorefrontChanges() async throws {
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
         testSession.locale = Locale(identifier: "es_ES")
         testSession.storefront = "ESP"
 


### PR DESCRIPTION
Resolves #1052 

Swift Concurrency support was modified, so I've updated the availability of all the async methods in the codebase. Some of them couldn't be updated because depend on StoreKit 2.