### PR TITLE
Fix: update min xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ commands:
 jobs:
   runtest:
     macos:
-      xcode: "13.1.0"
+      xcode: "13.2.0"
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
     steps:
@@ -130,7 +130,7 @@ jobs:
           destination: scan-test-output
   buildTvWatchAndMacOS:
     macos:
-      xcode: "13.1.0"
+      xcode: "13.2.0"
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
     steps:
@@ -145,7 +145,7 @@ jobs:
 
   backend_integration_tests:
     macos:
-      xcode: "13.1.0"
+      xcode: "13.2.0"
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
     steps:
@@ -166,7 +166,7 @@ jobs:
 
   release-checks: 
     macos:
-      xcode: "13.1.0"
+      xcode: "13.2.0"
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
     steps:
@@ -198,7 +198,7 @@ jobs:
           
   docs-deploy:
     macos:
-      xcode: "13.1.0"
+      xcode: "13.2.0"
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
     steps:
@@ -222,7 +222,7 @@ jobs:
   
   make-release:
     macos:
-      xcode: "13.1.0"
+      xcode: "13.2.0"
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -235,7 +235,7 @@ jobs:
 
   prepare-next-version:
     macos:
-      xcode: "13.1.0"
+      xcode: "13.2.0"
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -248,7 +248,7 @@ jobs:
 
   integration-tests-cocoapods:
     macos:
-      xcode: "13.1.0"
+      xcode: "13.2.0"
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -269,7 +269,7 @@ jobs:
       
   integration-tests-swift-package-manager:
     macos:
-      xcode: "13.1.0"
+      xcode: "13.2.0"
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -281,7 +281,7 @@ jobs:
 
   integration-tests-carthage:
     macos:
-      xcode: "13.1.0"
+      xcode: "13.2.0"
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -311,7 +311,7 @@ jobs:
 
   integration-tests-xcode-direct-integration:
     macos:
-      xcode: "13.1.0"
+      xcode: "13.2.0"
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -322,7 +322,7 @@ jobs:
 
   lint:
     macos:
-      xcode: "13.1.0"
+      xcode: "13.2.0"
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:

--- a/docs/V4_API_Updates.md
+++ b/docs/V4_API_Updates.md
@@ -7,7 +7,7 @@ To start us off, Our framework name changed from `Purchases` to `RevenueCat` ðŸ˜
 If you're using `Carthage`, make sure to use the new `RevenueCat.framework` or `RevenueCat.xcframework` instead of the old `Purchases`.
 
 ### Xcode version requirements and updated deployment targets
-`purchases-ios` v4 requires using Xcode 13.0 or newer. 
+`purchases-ios` v4 requires using Xcode 13.2 or newer. 
 It also updates the minimum deployment targets for iOS, macOS and tvOS. 
 
 ##### Minimum deployment targets


### PR DESCRIPTION
I forgot that #1062 requires Xcode 13.2, currently in RC. 

Updated the Xcode version to use for CircleCI as well as our migration guide to reflect the new required Xcode version. 