### PR TITLE
Fixes for `showManageSubscriptions`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ jobs:
           name: Run backend_integration Tests
           command: bundle exec fastlane backend_integration_tests
           environment:
-            SCAN_DEVICE: iPhone 11 Pro (15.0)
+            SCAN_DEVICE: iPhone 11 Pro (15.2)
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:

--- a/Purchases/Logging/Strings/ManageSubscriptionsStrings.swift
+++ b/Purchases/Logging/Strings/ManageSubscriptionsStrings.swift
@@ -14,19 +14,24 @@
 import Foundation
 
 // swiftlint:disable identifier_name
-enum ManageSubscriptionStrings {
 
-    case cant_form_apple_subscriptions_url
-    case error_from_appstore_show_manage_subscription(error: Error)
-    case failed_to_get_management_url_error_unknown(error: Error)
-    case failed_to_get_management_url_nil_customer_info
-    case failed_to_get_window_scene
-    case show_manage_subscriptions_called_in_unsupported_platform
-    case susbscription_management_sheet_dismissed
+extension ManageSubscriptionsHelper {
+
+    enum ManageSubscriptionsStrings {
+
+        case cant_form_apple_subscriptions_url
+        case error_from_appstore_show_manage_subscription(error: Error)
+        case failed_to_get_management_url_error_unknown(error: Error)
+        case failed_to_get_management_url_nil_customer_info
+        case failed_to_get_window_scene
+        case show_manage_subscriptions_called_in_unsupported_platform
+        case susbscription_management_sheet_dismissed
+
+    }
 
 }
 
-extension ManageSubscriptionStrings: CustomStringConvertible {
+extension ManageSubscriptionsHelper.ManageSubscriptionsStrings: CustomStringConvertible {
 
     var description: String {
         switch self {

--- a/Purchases/Logging/Strings/ManageSubscriptionsStrings.swift
+++ b/Purchases/Logging/Strings/ManageSubscriptionsStrings.swift
@@ -17,13 +17,14 @@ import Foundation
 
 extension ManageSubscriptionsHelper {
 
-    enum ManageSubscriptionsStrings {
+    enum Strings {
 
         case cant_form_apple_subscriptions_url
         case error_from_appstore_show_manage_subscription(error: Error)
         case failed_to_get_management_url_error_unknown(error: Error)
         case failed_to_get_management_url_nil_customer_info
         case failed_to_get_window_scene
+        case management_url_nil_opening_default
         case show_manage_subscriptions_called_in_unsupported_platform
         case susbscription_management_sheet_dismissed
 
@@ -31,7 +32,7 @@ extension ManageSubscriptionsHelper {
 
 }
 
-extension ManageSubscriptionsHelper.ManageSubscriptionsStrings: CustomStringConvertible {
+extension ManageSubscriptionsHelper.Strings: CustomStringConvertible {
 
     var description: String {
         switch self {
@@ -45,6 +46,8 @@ extension ManageSubscriptionsHelper.ManageSubscriptionsStrings: CustomStringConv
             return "Failed to get managementURL from CustomerInfo. Details: customerInfo is nil."
         case .failed_to_get_window_scene:
             return "Failed to get UIWindowScene"
+        case .management_url_nil_opening_default:
+            return "managementURL is nil, opening Apple's subscription management page"
         case .susbscription_management_sheet_dismissed:
             return "Subscription management sheet dismissed."
         case .show_manage_subscriptions_called_in_unsupported_platform:

--- a/Purchases/Logging/Strings/ManageSubscriptionsStrings.swift
+++ b/Purchases/Logging/Strings/ManageSubscriptionsStrings.swift
@@ -1,0 +1,50 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ManageSubscriptionsStrings.swift
+//
+//  Created by Andrés Boedo on 13/12/21.
+
+import Foundation
+
+// swiftlint:disable identifier_name
+enum ManageSubscriptionStrings {
+
+    case cant_form_apple_subscriptions_url
+    case error_from_appstore_show_manage_subscription(error: Error)
+    case failed_to_get_management_url_error_unknown(error: Error)
+    case failed_to_get_management_url_nil_customer_info
+    case failed_to_get_window_scene
+    case show_manage_subscriptions_called_in_unsupported_platform
+    case susbscription_management_sheet_dismissed
+
+}
+
+extension ManageSubscriptionStrings: CustomStringConvertible {
+
+    var description: String {
+        switch self {
+        case .cant_form_apple_subscriptions_url:
+            return "Error when trying to form the Apple Subscriptions URL."
+        case .error_from_appstore_show_manage_subscription(let error):
+            return "Error when trying to show manage subscription: \(error.localizedDescription)"
+        case .failed_to_get_management_url_error_unknown(let error):
+            return "Failed to get managementURL from CustomerInfo. Details: \(error.localizedDescription)"
+        case .failed_to_get_management_url_nil_customer_info:
+            return "Failed to get managementURL from CustomerInfo. Details: customerInfo is nil."
+        case .failed_to_get_window_scene:
+            return "Failed to get UIWindowScene"
+        case .susbscription_management_sheet_dismissed:
+            return "Subscription management sheet dismissed."
+        case .show_manage_subscriptions_called_in_unsupported_platform:
+            return "tried to call AppStore.showManageSubscriptions in a platform that doesn't support it!"
+        }
+    }
+
+}

--- a/Purchases/Logging/Strings/PurchaseStrings.swift
+++ b/Purchases/Logging/Strings/PurchaseStrings.swift
@@ -37,7 +37,6 @@ enum PurchaseStrings {
     case purchases_nil
     case purchases_delegate_set_multiple_times
     case purchases_delegate_set_to_nil
-    case management_url_nil_opening_default
     case requested_products_not_found(request: SKRequest)
     case callback_not_found_for_request(request: SKRequest)
     case unable_to_get_intro_eligibility_for_user(error: Error)
@@ -137,9 +136,6 @@ extension PurchaseStrings: CustomStringConvertible {
         case .purchases_delegate_set_to_nil:
             return "Purchases delegate is being set to nil, " +
             "you probably don't want to do this."
-
-        case .management_url_nil_opening_default:
-            return "managementURL is nil, opening Apple's subscription management page"
 
         case .requested_products_not_found(let request):
             return "requested products not found for request: \(request)"

--- a/Purchases/Logging/Strings/Strings.swift
+++ b/Purchases/Logging/Strings/Strings.swift
@@ -20,7 +20,6 @@ enum Strings {
     static let backendError = BackendErrorStrings.self
     static let customerInfo = CustomerInfoStrings.self
     static let identity = IdentityStrings.self
-    static let manageSubscription = ManageSubscriptionStrings.self
     static let network = NetworkStrings.self
     static let offering = OfferingStrings.self
     static let purchase = PurchaseStrings.self

--- a/Purchases/Logging/Strings/Strings.swift
+++ b/Purchases/Logging/Strings/Strings.swift
@@ -20,6 +20,7 @@ enum Strings {
     static let backendError = BackendErrorStrings.self
     static let customerInfo = CustomerInfoStrings.self
     static let identity = IdentityStrings.self
+    static let manageSubscription = ManageSubscriptionStrings.self
     static let network = NetworkStrings.self
     static let offering = OfferingStrings.self
     static let purchase = PurchaseStrings.self

--- a/Purchases/Support/ManageSubscriptionsHelper.swift
+++ b/Purchases/Support/ManageSubscriptionsHelper.swift
@@ -123,18 +123,20 @@ private extension ManageSubscriptionsHelper {
                   return .failure(ErrorUtils.storeProblemError(withMessage: "Failed to get UIWindowScene"))
         }
 
-        do {
-
 #if os(iOS)
-            try await AppStore.showManageSubscriptions(in: windowScene)
+            _ = Task.init {
+                do {
+                    try await AppStore.showManageSubscriptions(in: windowScene)
+                } catch {
+                    let message = "Error when trying to show manage subscription: \(error.localizedDescription)"
+                    Logger.appleError(message)
+                }
+            }
+
             return .success(())
 #else
             fatalError("tried to call AppStore.showManageSubscriptions in a platform that doesn't support it!")
 #endif
-        } catch {
-            let message = "Error when trying to show manage subscription: \(error.localizedDescription)"
-            return .failure(ErrorUtils.storeProblemError(withMessage: message, error: error))
-        }
     }
 #endif
 

--- a/Purchases/Support/ManageSubscriptionsHelper.swift
+++ b/Purchases/Support/ManageSubscriptionsHelper.swift
@@ -35,21 +35,21 @@ class ManageSubscriptionsHelper {
         let currentAppUserID = identityManager.currentAppUserID
         customerInfoManager.customerInfo(appUserID: currentAppUserID) { maybeCustomerInfo, maybeError in
             if let error = maybeError {
-                let message = ManageSubscriptionsStrings.failed_to_get_management_url_error_unknown(error: error)
+                let message = Strings.failed_to_get_management_url_error_unknown(error: error)
                 completion(.failure(ErrorUtils.customerInfoError(withMessage: message.description, error: error)))
                 return
             }
 
             guard let customerInfo = maybeCustomerInfo else {
-                let message = ManageSubscriptionsStrings.failed_to_get_management_url_nil_customer_info
+                let message = Strings.failed_to_get_management_url_nil_customer_info
                 completion(.failure(ErrorUtils.customerInfoError(withMessage: message.description)))
                 return
             }
 
             guard let managementURL = customerInfo.managementURL else {
-                Logger.debug(Strings.purchase.management_url_nil_opening_default)
+                Logger.debug(Strings.management_url_nil_opening_default)
                 guard let appleSubscriptionsURL = self.systemInfo.appleSubscriptionsURL else {
-                    let message = ManageSubscriptionsStrings.cant_form_apple_subscriptions_url
+                    let message = Strings.cant_form_apple_subscriptions_url
                     completion(.failure(ErrorUtils.systemInfoError(withMessage: message.description)))
                     return
                 }
@@ -123,7 +123,7 @@ private extension ManageSubscriptionsHelper {
     func showSK2ManageSubscriptions() async -> Result<Void, Error> {
         guard let application = systemInfo.sharedUIApplication,
               let windowScene = application.currentWindowScene else {
-                  let message = ManageSubscriptionsStrings.failed_to_get_window_scene
+                  let message = Strings.failed_to_get_window_scene
                   return .failure(ErrorUtils.storeProblemError(withMessage: message.description))
         }
 
@@ -133,16 +133,16 @@ private extension ManageSubscriptionsHelper {
         _ = Task.init {
             do {
                 try await AppStore.showManageSubscriptions(in: windowScene)
-                Logger.info(ManageSubscriptionsStrings.susbscription_management_sheet_dismissed)
+                Logger.info(Strings.susbscription_management_sheet_dismissed)
             } catch {
-                let message = ManageSubscriptionsStrings.error_from_appstore_show_manage_subscription(error: error)
+                let message = Strings.error_from_appstore_show_manage_subscription(error: error)
                 Logger.appleError(message)
             }
         }
 
         return .success(())
 #else
-        fatalError(ManageSubscriptionsStrings.manageSubscription.show_manage_subscriptions_called_in_unsupported_platform.description)
+        fatalError(Strings.manageSubscription.show_manage_subscriptions_called_in_unsupported_platform.description)
 #endif
     }
 #endif

--- a/Purchases/Support/ManageSubscriptionsHelper.swift
+++ b/Purchases/Support/ManageSubscriptionsHelper.swift
@@ -79,6 +79,7 @@ private extension ManageSubscriptionsHelper {
 #if os(iOS) && !targetEnvironment(macCatalyst)
         if #available(iOS 15.0, *),
            // showManageSubscriptions doesn't work on iOS apps running on Apple Silicon
+           // https://developer.apple.com/documentation/storekit/appstore/3803198-showmanagesubscriptions#
            !ProcessInfo().isiOSAppOnMac {
             _ = Task<Void, Never> {
                 let result = await self.showSK2ManageSubscriptions()

--- a/Purchases/Support/ManageSubscriptionsHelper.swift
+++ b/Purchases/Support/ManageSubscriptionsHelper.swift
@@ -76,8 +76,10 @@ private extension ManageSubscriptionsHelper {
 
     func showAppleManageSubscriptions(managementURL: URL,
                                       completion: @escaping (Result<Void, Error>) -> Void) {
-#if os(iOS)
-        if #available(iOS 15.0, *) {
+#if os(iOS) && !targetEnvironment(macCatalyst)
+        if #available(iOS 15.0, *),
+           // showManageSubscriptions doesn't work on iOS apps running on Apple Silicon
+           !ProcessInfo().isiOSAppOnMac {
             _ = Task<Void, Never> {
                 let result = await self.showSK2ManageSubscriptions()
                 completion(result)

--- a/Purchases/Support/ManageSubscriptionsHelper.swift
+++ b/Purchases/Support/ManageSubscriptionsHelper.swift
@@ -35,13 +35,13 @@ class ManageSubscriptionsHelper {
         let currentAppUserID = identityManager.currentAppUserID
         customerInfoManager.customerInfo(appUserID: currentAppUserID) { maybeCustomerInfo, maybeError in
             if let error = maybeError {
-                let message = Strings.manageSubscription.failed_to_get_management_url_error_unknown(error: error)
+                let message = ManageSubscriptionsStrings.failed_to_get_management_url_error_unknown(error: error)
                 completion(.failure(ErrorUtils.customerInfoError(withMessage: message.description, error: error)))
                 return
             }
 
             guard let customerInfo = maybeCustomerInfo else {
-                let message = Strings.manageSubscription.failed_to_get_management_url_nil_customer_info
+                let message = ManageSubscriptionsStrings.failed_to_get_management_url_nil_customer_info
                 completion(.failure(ErrorUtils.customerInfoError(withMessage: message.description)))
                 return
             }
@@ -49,7 +49,7 @@ class ManageSubscriptionsHelper {
             guard let managementURL = customerInfo.managementURL else {
                 Logger.debug(Strings.purchase.management_url_nil_opening_default)
                 guard let appleSubscriptionsURL = self.systemInfo.appleSubscriptionsURL else {
-                    let message = Strings.manageSubscription.cant_form_apple_subscriptions_url
+                    let message = ManageSubscriptionsStrings.cant_form_apple_subscriptions_url
                     completion(.failure(ErrorUtils.systemInfoError(withMessage: message.description)))
                     return
                 }
@@ -123,7 +123,7 @@ private extension ManageSubscriptionsHelper {
     func showSK2ManageSubscriptions() async -> Result<Void, Error> {
         guard let application = systemInfo.sharedUIApplication,
               let windowScene = application.currentWindowScene else {
-                  let message = Strings.manageSubscription.failed_to_get_window_scene
+                  let message = ManageSubscriptionsStrings.failed_to_get_window_scene
                   return .failure(ErrorUtils.storeProblemError(withMessage: message.description))
         }
 
@@ -133,16 +133,16 @@ private extension ManageSubscriptionsHelper {
         _ = Task.init {
             do {
                 try await AppStore.showManageSubscriptions(in: windowScene)
-                Logger.info(Strings.manageSubscription.susbscription_management_sheet_dismissed)
+                Logger.info(ManageSubscriptionsStrings.susbscription_management_sheet_dismissed)
             } catch {
-                let message = Strings.manageSubscription.error_from_appstore_show_manage_subscription(error: error)
+                let message = ManageSubscriptionsStrings.error_from_appstore_show_manage_subscription(error: error)
                 Logger.appleError(message)
             }
         }
 
         return .success(())
 #else
-        fatalError(Strings.manageSubscription.show_manage_subscriptions_called_in_unsupported_platform.description)
+        fatalError(ManageSubscriptionsStrings.manageSubscription.show_manage_subscriptions_called_in_unsupported_platform.description)
 #endif
     }
 #endif

--- a/PurchasesTests/Support/ManageSubscriptionsHelperTests.swift
+++ b/PurchasesTests/Support/ManageSubscriptionsHelperTests.swift
@@ -88,15 +88,7 @@ class ManageSubscriptionsHelperTests: XCTestCase {
         // then
         expect(callbackCalled).toEventually(beTrue())
         let nonNilReceivedResult: Result<Void, Error> = try XCTUnwrap(receivedResult)
-        if #available(iOS 15.0, *) {
-            // in tests in iOS 15, this method always fails, since the currentWindow scene can't be obtained.
-            expect(nonNilReceivedResult).to(beFailure { error in
-                expect(error).to(matchError(ErrorCode.storeProblemError))
-            })
-        } else {
-            expect(nonNilReceivedResult).to(beSuccess())
-        }
-
+        expect(nonNilReceivedResult).to(beSuccess())
 #endif
     }
 

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		2CD72942268A823900BFC976 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD72941268A823900BFC976 /* Data+Extensions.swift */; };
 		2CD72944268A826F00BFC976 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD72943268A826F00BFC976 /* Date+Extensions.swift */; };
 		2CD72948268A828400BFC976 /* Locale+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD72947268A828400BFC976 /* Locale+Extensions.swift */; };
+		2D00A41D2767C08300FC3DD8 /* ManageSubscriptionsStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D00A41C2767C08300FC3DD8 /* ManageSubscriptionsStrings.swift */; };
 		2D1015DB275A4EAE0086173F /* AvailabilityChecks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE0263275942D500915B4C /* AvailabilityChecks.swift */; };
 		2D1015DE275A57FC0086173F /* SubscriptionPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1015DD275A57FC0086173F /* SubscriptionPeriod.swift */; };
 		2D1015E2275A67E40086173F /* SubscriptionPeriodTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1015E0275A676F0086173F /* SubscriptionPeriodTests.swift */; };
@@ -370,6 +371,7 @@
 		2CD72941268A823900BFC976 /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
 		2CD72943268A826F00BFC976 /* Date+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; };
 		2CD72947268A828400BFC976 /* Locale+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Locale+Extensions.swift"; sourceTree = "<group>"; };
+		2D00A41C2767C08300FC3DD8 /* ManageSubscriptionsStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionsStrings.swift; sourceTree = "<group>"; };
 		2D1015DD275A57FC0086173F /* SubscriptionPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPeriod.swift; sourceTree = "<group>"; };
 		2D1015E0275A676F0086173F /* SubscriptionPeriodTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPeriodTests.swift; sourceTree = "<group>"; };
 		2D11F5E0250FF886005A70E8 /* AttributionStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributionStrings.swift; sourceTree = "<group>"; };
@@ -761,6 +763,7 @@
 				F5714EE426DC2F1D00635477 /* CodableStrings.swift */,
 				9A65E03525918B0500DE00B0 /* ConfigureStrings.swift */,
 				9A65E0752591977200DE00B0 /* IdentityStrings.swift */,
+				2D00A41C2767C08300FC3DD8 /* ManageSubscriptionsStrings.swift */,
 				9A65E07A2591977500DE00B0 /* NetworkStrings.swift */,
 				9A65E09F2591A23200DE00B0 /* OfferingStrings.swift */,
 				9A65E03A25918B0900DE00B0 /* CustomerInfoStrings.swift */,
@@ -1822,6 +1825,7 @@
 				5746508E275949F20053AB09 /* DispatchTimeInterval+Extensions.swift in Sources */,
 				2D294E5C26DECFD500B8FE4F /* StoreKit2TransactionListener.swift in Sources */,
 				2DDF41B524F6F387005BC22D /* AppleReceiptBuilder.swift in Sources */,
+				2D00A41D2767C08300FC3DD8 /* ManageSubscriptionsStrings.swift in Sources */,
 				2DD9F4BE274EADC20031AE2C /* Purchases+async.swift in Sources */,
 				B3C4AAD526B8911300E1B3C8 /* Backend.swift in Sources */,
 				B34D2AA626976FC700D88C3A /* ErrorCode.swift in Sources */,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -44,7 +44,7 @@ platform :ios do
     # Need to run scan multiple times
     scan(
       step_name: "scan - iPhone", 
-      devices: ["iPhone 8 (14.5)", "iPhone 12 (15.0)"],
+      devices: ["iPhone 8 (14.5)", "iPhone 12 (15.2)"],
       scheme: "RevenueCat",
       testplan: "Coverage",
       prelaunch_simulator: true,
@@ -56,7 +56,7 @@ platform :ios do
 
     scan(
       step_name: "scan - Apple TV",
-      devices: ["Apple TV (15.0)"],
+      devices: ["Apple TV (15.2)"],
       scheme: "RevenueCat",
       testplan: "RevenueCat",
       prelaunch_simulator: true,


### PR DESCRIPTION
Fixes for a couple of issues with `showManageSubscriptions`: 
- From [the docs](https://developer.apple.com/documentation/storekit/appstore/3803198-showmanagesubscriptions#), this method shouldn't be called on iOS apps running on Apple Silicon, or on mac Catalyst apps. This updates so that for both of those cases, we just open up the subscription management URL. 
- As of Xcode 13.2 / iOS 15.2, it looks like `showManageSubscriptions` only returns after the manage subscriptions sheet has been closed. This meant that our method wouldn't return right away, but rather once Apple's sheet was dismissed. 
I updated it so that it always returns right away. 
I'm not 100% convinced, though, since this means that if Apple's modal fails to show for whatever reason, we'll no longer be returning an error, since we have no way of knowing whether an error happened. Instead, we're returning success + logging out to console in the case of an error. 

Would love feedback on this. 