### PR TITLE
`StoreProductTests`: skip `testSk2PriceFormatterReactsToStorefrontChanges` on iOS 14

### DIFF
--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -206,7 +206,9 @@ private func checkAsyncMethods(purchases: Purchases) async {
         let _: CustomerInfo = try await purchases.restoreTransactions()
         let _: CustomerInfo = try await purchases.syncPurchases()
 
+        #if os(iOS)
         try await purchases.showManageSubscriptions()
         let _: RefundRequestStatus = try await purchases.beginRefundRequest(for: "")
+        #endif
     } catch {}
 }

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -229,6 +229,8 @@ class StoreProductTests: StoreKitConfigTestCase {
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testSk2PriceFormatterReactsToStorefrontChanges() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
         testSession.locale = Locale(identifier: "es_ES")
         testSession.storefront = "ESP"
 


### PR DESCRIPTION
It's pretty incredible that `XCTest` isn't smart enough to not call the test method that isn't available.

Fixes https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/4447/workflows/c4b567b8-b040-4c83-9de6-efd4be43d7eb/jobs/13515

Also fixed `SwiftAPITests` running on `tvOS` (I broke this on #1056 but didn't notice because of the other test failures).