### PR TITLE
Backend: changed asserts into force-unwrapped

### DIFF
--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -749,33 +749,25 @@ private extension Backend {
 
     func getOfferingsCallbacksAndClearCache(forKey key: String) -> [OfferingsResponseHandler] {
         return callbackQueue.sync { [self] in
-            let callbacks = offeringsCallbacksCache.removeValue(forKey: key)
-            assert(callbacks != nil)
-            return callbacks ?? []
+            return offeringsCallbacksCache.removeValue(forKey: key)!
         }
     }
 
     func getCustomerInfoCallbacksAndClearCache(forKey key: String) -> [BackendCustomerInfoResponseHandler] {
         return callbackQueue.sync { [self] in
-            let callbacks = customerInfoCallbacksCache.removeValue(forKey: key)
-            assert(callbacks != nil)
-            return callbacks ?? []
+            return customerInfoCallbacksCache.removeValue(forKey: key)!
         }
     }
 
     func getCreateAliasCallbacksAndClearCache(forKey key: String) -> [PostRequestResponseHandler?] {
         return callbackQueue.sync { [self] in
-            let callbacks = createAliasCallbacksCache.removeValue(forKey: key)
-            assert(callbacks != nil)
-            return callbacks ?? []
+            return createAliasCallbacksCache.removeValue(forKey: key)!
         }
     }
 
     func getIdentifyCallbacksAndClearCache(forKey key: String) -> [IdentifyResponseHandler] {
         return callbackQueue.sync { [self] in
-            let callbacks = identifyCallbacksCache.removeValue(forKey: key)
-            assert(callbacks != nil)
-            return callbacks ?? []
+            return identifyCallbacksCache.removeValue(forKey: key)!
         }
     }
 

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -65,7 +65,7 @@ class BackendTests: XCTestCase {
                                     requestBody: [String : Any]?,
                                     headers: [String : String],
                                     completionHandler: ((Int, [String: Any]?, Error?) -> Void)?) {
-            assert(mocks[path] != nil, "Path " + path + " not mocked")
+            XCTAssert(mocks[path] != nil, "Path " + path + " not mocked")
             let response = mocks[path]!
 
             calls.append(HTTPRequest(HTTPMethod: httpMethod,


### PR DESCRIPTION
Fixes #771

The issue recommended changing it to `precondition`, but that's essentially the same as force-unwrapping them so this is simpler.