### PR TITLE
`fastlane backend_integration_tests`: added `trainer` to parse test results in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,8 +160,8 @@ jobs:
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:
-          path: fastlane/test_output/report.html
-          destination: test_report.html
+          path: fastlane/test_output/xctest
+          destination: scan-test-output
 
 
   release-checks: 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -363,7 +363,14 @@ platform :ios do
   desc "Run BackendIntegrationTests"
   lane :backend_integration_tests do |options|
     replace_api_key_integration_tests
-    scan(scheme: "BackendIntegrationTests", derived_data_path: "scan_derived_data")
+    scan(
+      scheme: "BackendIntegrationTests", 
+      derived_data_path: "scan_derived_data",
+      output_types: '',
+      fail_build: false,
+      result_bundle: true
+    )
+    trainer(path: "fastlane/test_output", output_directory: "fastlane/test_output/xctest/ios")
   end
 
   desc "Update swift package commit"


### PR DESCRIPTION
I noticed we were getting no info here: https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/4466/workflows/4e2c5f84-834b-411f-b313-a76babc16a24/jobs/13593/tests