### PR TITLE
OfferingsManager: fixed erroneous "Could not find SKProduct" log

### DIFF
--- a/Purchases/Purchasing/OfferingsManager.swift
+++ b/Purchases/Purchasing/OfferingsManager.swift
@@ -83,13 +83,13 @@ class OfferingsManager {
         }
     }
 
-    func getMissingProductIDs(productsFromStore: [String: StoreProduct],
+    func getMissingProductIDs(productIDsFromStore: Set<String>,
                               productIDsFromBackend: Set<String>) -> Set<String> {
         guard !productIDsFromBackend.isEmpty else {
             return []
         }
 
-        return productIDsFromBackend.subtracting(productsFromStore.keys)
+        return productIDsFromBackend.subtracting(productIDsFromStore)
     }
 
 }
@@ -117,7 +117,7 @@ private extension OfferingsManager {
 
             let productsByID = products.dictionaryWithKeys { $0.productIdentifier }
 
-            let missingProductIDs = self.getMissingProductIDs(productsFromStore: productsByID,
+            let missingProductIDs = self.getMissingProductIDs(productIDsFromStore: Set(productsByID.keys),
                                                               productIDsFromBackend: productIdentifiers)
             if !missingProductIDs.isEmpty {
                 Logger.appleWarning(

--- a/PurchasesTests/Purchasing/OfferingsManagerTests.swift
+++ b/PurchasesTests/Purchasing/OfferingsManagerTests.swift
@@ -243,14 +243,14 @@ extension OfferingsManagerTests {
 
     func testGetMissingProductIDs() {
         let productIDs: Set<String> = ["a", "b", "c"]
-        let skProducts = ["a" : SKProduct(), "b" : SKProduct()]
+        let productsFromStore: Set<String> = ["a", "b"]
 
-        expect(self.offeringsManager.getMissingProductIDs(productsFromStore: [:],
-                                                          productIDsFromBackend: productIDs)).to(equal(productIDs))
-        expect(self.offeringsManager.getMissingProductIDs(productsFromStore: skProducts,
-                                                          productIDsFromBackend: [])).to(equal([]))
-        expect(self.offeringsManager.getMissingProductIDs(productsFromStore: skProducts,
-                                                          productIDsFromBackend:productIDs)).to(equal(["c"]))
+        expect(self.offeringsManager.getMissingProductIDs(productIDsFromStore: [],
+                                                          productIDsFromBackend: productIDs)) == productIDs
+        expect(self.offeringsManager.getMissingProductIDs(productIDsFromStore: productsFromStore,
+                                                          productIDsFromBackend: [])) == []
+        expect(self.offeringsManager.getMissingProductIDs(productIDsFromStore: productsFromStore,
+                                                          productIDsFromBackend:productIDs)) == ["c"]
     }
 
 }


### PR DESCRIPTION
The current implementation was computing the intersection of products found in the backend and in the App Store.
If everything was set up correctly, this would lead to the intersection of all products being all of them.

Instead what the implementation needed was to find the products not found in the App Store.

This lead to showing the following error even when everything was set up correctly:
```
WARN: 🍎‼️ Could not find SKProduct for ["...."] 
There is a problem with your configuration in App Store Connect. 
More info here: https://errors.rev.cat/configuring-products
```

This was already fixed in #868, but looks like it got reverted in #953.