### PR TITLE
Pass underlying NSError localizedDescription

### DIFF
--- a/Purchases/FoundationExtensions/Error+Extensions.swift
+++ b/Purchases/FoundationExtensions/Error+Extensions.swift
@@ -27,9 +27,10 @@ extension Error {
         }
 
         let asNSError = self as NSError
+        let underlyingNSError = attachedError as NSError
         var userInfo = asNSError.userInfo as [NSError.UserInfoKey: Any]
-        userInfo[NSUnderlyingErrorKey as NSString] = attachedError
-        userInfo[ErrorDetails.extraContextKey] = extraContext
+        userInfo[NSUnderlyingErrorKey as NSString] = underlyingNSError
+        userInfo[ErrorDetails.extraContextKey] = extraContext ?? underlyingNSError.localizedDescription
         let nsErrorWithUserInfo = NSError(domain: asNSError.domain,
                                           code: asNSError.code,
                                           userInfo: userInfo as [String: Any])

--- a/Purchases/FoundationExtensions/Error+Extensions.swift
+++ b/Purchases/FoundationExtensions/Error+Extensions.swift
@@ -22,12 +22,11 @@ extension Error {
      * - Returns: a new error matching `self` but with the `extraContext` and `error` added.
      */
     func addingUnderlyingError(_ maybeError: Error?, extraContext: String? = nil) -> Error {
-        guard let attachedError = maybeError else {
+        guard let underlyingNSError = maybeError as NSError? else {
             return self
         }
 
         let asNSError = self as NSError
-        let underlyingNSError = attachedError as NSError
         var userInfo = asNSError.userInfo as [NSError.UserInfoKey: Any]
         userInfo[NSUnderlyingErrorKey as NSString] = underlyingNSError
         userInfo[ErrorDetails.extraContextKey] = extraContext ?? underlyingNSError.localizedDescription


### PR DESCRIPTION
If extra context is nil, use the underlying NSError's localizationDescription
