### PR TITLE
`ErrorUtils`: added file/function/line information to errors

### DIFF
--- a/Purchases/Error Handling/ErrorDetails.swift
+++ b/Purchases/Error Handling/ErrorDetails.swift
@@ -20,5 +20,7 @@ class ErrorDetails: NSObject {
     static let readableErrorCodeKey: NSError.UserInfoKey = "readable_error_code"
     static let generatedByKey: NSError.UserInfoKey = "generated_by"
     static let extraContextKey: NSError.UserInfoKey = "extra_context"
+    static let fileKey: NSError.UserInfoKey = "source_file"
+    static let functionKey: NSError.UserInfoKey = "source_function"
 
 }

--- a/Purchases/Error Handling/ErrorUtils.swift
+++ b/Purchases/Error Handling/ErrorUtils.swift
@@ -15,7 +15,9 @@
 import Foundation
 import StoreKit
 
-class ErrorUtils: NSObject {
+// swiftlint:disable file_length multiline_parameters
+
+enum ErrorUtils {
 
     /**
      * Constructs an NSError with the ``ErrorCode/networkError`` code and a populated `NSUnderlyingErrorKey` in
@@ -26,8 +28,12 @@ class ErrorUtils: NSObject {
      * - Note: This error is used when there is an error performing network request returns an error or when there
      * is an `NSJSONSerialization` error.
      */
-    static func networkError(withUnderlyingError underlyingError: Error, generatedBy: String? = nil) -> Error {
-        return error(with: .networkError, underlyingError: underlyingError, generatedBy: generatedBy)
+    static func networkError(
+        withUnderlyingError underlyingError: Error, generatedBy: String? = nil,
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
+        return error(with: .networkError, underlyingError: underlyingError, generatedBy: generatedBy,
+                     fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
@@ -41,8 +47,12 @@ class ErrorUtils: NSObject {
      * - Note: This error is used when an network request returns an error. The backend error returned is wrapped in
      * this internal error code.
      */
-    static func backendError(withBackendCode backendCode: BackendErrorCode, backendMessage: String?) -> Error {
-        return backendError(withBackendCode: backendCode, backendMessage: backendMessage, extraUserInfo: nil)
+    static func backendError(
+        withBackendCode backendCode: BackendErrorCode, backendMessage: String?,
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
+        return backendError(withBackendCode: backendCode, backendMessage: backendMessage, extraUserInfo: nil,
+                            fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
@@ -59,14 +69,18 @@ class ErrorUtils: NSObject {
      * - Note: This error is used when an network request returns an error. The backend error returned is wrapped in
      * this internal error code.
      */
-    static func backendError(withBackendCode backendCode: BackendErrorCode,
-                             backendMessage: String?,
-                             finishable: Bool) -> Error {
+    static func backendError(
+        withBackendCode backendCode: BackendErrorCode,
+        backendMessage: String?,
+        finishable: Bool,
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
         let extraUserInfo: [NSError.UserInfoKey: Any] = [
             ErrorDetails.finishableKey: finishable
         ]
 
-        return backendError(withBackendCode: backendCode, backendMessage: backendMessage, extraUserInfo: extraUserInfo)
+        return backendError(withBackendCode: backendCode, backendMessage: backendMessage, extraUserInfo: extraUserInfo,
+                            fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
@@ -74,8 +88,12 @@ class ErrorUtils: NSObject {
      *
      * - Note: This error is used when a network request returns an unexpected response.
      */
-    static func unexpectedBackendResponseError(extraUserInfo: [NSError.UserInfoKey: Any]? = nil) -> Error {
-        return error(with: ErrorCode.unexpectedBackendResponseError, extraUserInfo: extraUserInfo)
+    static func unexpectedBackendResponseError(
+        extraUserInfo: [NSError.UserInfoKey: Any]? = nil,
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
+        return error(with: ErrorCode.unexpectedBackendResponseError, extraUserInfo: extraUserInfo,
+                     fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
@@ -85,12 +103,16 @@ class ErrorUtils: NSObject {
      * - Note: This error is used when a network request returns an unexpected response and we can determine some
      * of what went wrong with the response.
      */
-    static func unexpectedBackendResponse(withSubError maybeSubError: Error?,
-                                          generatedBy maybeGeneratedBy: String? = nil,
-                                          extraContext maybeExtraContext: String? = nil) -> Error {
+    static func unexpectedBackendResponse(
+        withSubError maybeSubError: Error?,
+        generatedBy maybeGeneratedBy: String? = nil,
+        extraContext maybeExtraContext: String? = nil,
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
         return backendResponseError(withSubError: maybeSubError,
                                     generatedBy: maybeGeneratedBy,
-                                    extraContext: maybeExtraContext)
+                                    extraContext: maybeExtraContext,
+                                    fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
@@ -99,8 +121,11 @@ class ErrorUtils: NSObject {
      * - Note: This error is used when the receipt is missing in the device. This can happen if the user is in
      * sandbox or if there are no previous purchases.
      */
-    static func missingReceiptFileError() -> Error {
-        return error(with: ErrorCode.missingReceiptFileError)
+    static func missingReceiptFileError(
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
+        return error(with: ErrorCode.missingReceiptFileError,
+                     fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
@@ -109,8 +134,11 @@ class ErrorUtils: NSObject {
      * - Note: This error is used when the appUserID can't be found in user defaults. This can happen if user defaults
      * are removed manually or if the OS deletes entries when running out of space.
      */
-    static func missingAppUserIDError() -> Error {
-        return error(with: ErrorCode.invalidAppUserIdError)
+    static func missingAppUserIDError(
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
+        return error(with: ErrorCode.invalidAppUserIdError,
+                     fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
@@ -119,8 +147,11 @@ class ErrorUtils: NSObject {
      * - Note: This error code is used when attemping to post data about product discounts but the discount is
      * missing an indentifier.
      */
-    static func productDiscountMissingIdentifierError() -> Error {
-        return error(with: ErrorCode.productDiscountMissingIdentifierError)
+    static func productDiscountMissingIdentifierError(
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
+        return error(with: ErrorCode.productDiscountMissingIdentifierError,
+                     fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
@@ -129,8 +160,11 @@ class ErrorUtils: NSObject {
      * - Note: This error code is used when attemping to post data about product discounts but the discount is
      * missing a subscriptionGroupIndentifier.
      */
-    static func productDiscountMissingSubscriptionGroupIdentifierError() -> Error {
-        return error(with: ErrorCode.productDiscountMissingSubscriptionGroupIdentifierError)
+    static func productDiscountMissingSubscriptionGroupIdentifierError(
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
+        return error(with: ErrorCode.productDiscountMissingSubscriptionGroupIdentifierError,
+                     fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
@@ -139,8 +173,11 @@ class ErrorUtils: NSObject {
      * - Note: This error is used when the appUserID can't be found in user defaults. This can happen if user defaults
      * are removed manually or if the OS deletes entries when running out of space.
      */
-    static func missingAppUserIDForAliasCreationError() -> Error {
-        return error(with: ErrorCode.missingAppUserIDForAliasCreationError)
+    static func missingAppUserIDForAliasCreationError(
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
+        return error(with: ErrorCode.missingAppUserIDForAliasCreationError,
+                     fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
@@ -149,8 +186,11 @@ class ErrorUtils: NSObject {
      * - Note: This error is used when logOut is called but the current user is anonymous,
      * as noted by ``Purchases/isAnonymous`` property.
      */
-    static func logOutAnonymousUserError() -> Error {
-        return error(with: ErrorCode.logOutAnonymousUserError)
+    static func logOutAnonymousUserError(
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
+        return error(with: ErrorCode.logOutAnonymousUserError,
+                     fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
@@ -159,22 +199,31 @@ class ErrorUtils: NSObject {
      * - Note: This error is used during an “ask to buy” flow for a payment. The completion block of the purchasing
      * function will get this error to indicate the guardian has to complete the purchase.
      */
-    static func paymentDeferredError() -> Error {
-        return error(with: ErrorCode.paymentPendingError, message: "The payment is deferred.")
+    static func paymentDeferredError(
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
+        return error(with: ErrorCode.paymentPendingError, message: "The payment is deferred.",
+                     fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
      * Constructs an Error with the ``ErrorCode/unknownError`` code and optional message.
      */
-    static func unknownError(message: String? = nil) -> Error {
-        return error(with: ErrorCode.unknownError, message: message)
+    static func unknownError(
+        message: String? = nil,
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line) -> Error {
+        return error(with: ErrorCode.unknownError, message: message,
+                     fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
      * Constructs an Error with the ``ErrorCode/unknownError`` code.
      */
-    static func unknownError() -> Error {
-        return error(with: ErrorCode.unknownError, message: nil)
+    static func unknownError(
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
+        return error(with: ErrorCode.unknownError, message: nil,
+                     fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
@@ -183,8 +232,11 @@ class ErrorUtils: NSObject {
      * - Note: This error is used when a purchase is initiated for a product, but there's already a purchase for the
      * same product in progress.
      */
-    static func operationAlreadyInProgressError() -> Error {
-        return error(with: ErrorCode.operationAlreadyInProgressForProductError)
+    static func operationAlreadyInProgressError(
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
+        return error(with: ErrorCode.operationAlreadyInProgressForProductError,
+                     fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
@@ -193,8 +245,12 @@ class ErrorUtils: NSObject {
      * - Note: This error is used when the configuration in App Store Connect doesn't match the configuration
      * in the RevenueCat dashboard.
      */
-    static func configurationError(message: String? = nil) -> Error {
-        return error(with: ErrorCode.configurationError, message: message)
+    static func configurationError(
+        message: String? = nil,
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
+        return error(with: ErrorCode.configurationError, message: message,
+                     fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
@@ -202,9 +258,13 @@ class ErrorUtils: NSObject {
      *
      * - Parameter skError: The originating `SKError`.
      */
-    static func purchasesError(withSKError skError: Error) -> Error {
+    static func purchasesError(
+        withSKError skError: Error,
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
         let errorCode = (skError as? SKError)?.toPurchasesErrorCode() ?? .unknownError
-        return error(with: errorCode, message: errorCode.description, underlyingError: skError)
+        return error(with: errorCode, message: errorCode.description, underlyingError: skError,
+                     fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
@@ -212,11 +272,14 @@ class ErrorUtils: NSObject {
      *
      * - Note: This error is used when  a purchase is cancelled by the user.
      */
-    @objc static func purchaseCancelledError() -> Error {
+    static func purchaseCancelledError(
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
         let errorCode = ErrorCode.purchaseCancelledError
         return ErrorUtils.error(with: errorCode,
                                 message: errorCode.description,
-                                underlyingError: nil)
+                                underlyingError: nil,
+                                fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
@@ -224,11 +287,15 @@ class ErrorUtils: NSObject {
      *
      * - Note: This error is used when there is a problem with the App Store.
      */
-    @objc static func storeProblemError(withMessage message: String, error: Error? = nil) -> Error {
+    static func storeProblemError(
+        withMessage message: String, error: Error? = nil,
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
         let errorCode = ErrorCode.storeProblemError
         return ErrorUtils.error(with: errorCode,
                                 message: message,
-                                underlyingError: error)
+                                underlyingError: error,
+                                fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
@@ -236,11 +303,15 @@ class ErrorUtils: NSObject {
      *
      * - Note: This error is used when there is a problem related to the customer info.
      */
-    @objc static func customerInfoError(withMessage message: String, error: Error? = nil) -> Error {
+    static func customerInfoError(
+        withMessage message: String, error: Error? = nil,
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
         let errorCode = ErrorCode.customerInfoError
         return ErrorUtils.error(with: errorCode,
                                 message: message,
-                                underlyingError: error)
+                                underlyingError: error,
+                                fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
@@ -248,11 +319,15 @@ class ErrorUtils: NSObject {
      *
      * - Note: This error is used when there is a problem related to the system info.
      */
-    @objc static func systemInfoError(withMessage message: String, error: Error? = nil) -> Error {
+    static func systemInfoError(
+        withMessage message: String, error: Error? = nil,
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
         let errorCode = ErrorCode.systemInfoError
         return ErrorUtils.error(with: errorCode,
                                 message: message,
-                                underlyingError: error)
+                                underlyingError: error,
+                                fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
@@ -260,11 +335,15 @@ class ErrorUtils: NSObject {
      *
      * - Note: This error is used when there is a problem beginning a refund request.
      */
-    @objc static func beginRefundRequestError(withMessage message: String, error: Error? = nil) -> Error {
+    static func beginRefundRequestError(
+        withMessage message: String, error: Error? = nil,
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
         let errorCode = ErrorCode.beginRefundRequestError
         return ErrorUtils.error(with: errorCode,
                                 message: message,
-                                underlyingError: error)
+                                underlyingError: error,
+                                fileName: fileName, functionName: functionName, line: line)
     }
 
 }
@@ -273,14 +352,17 @@ extension ErrorUtils {
 
     static func backendError(withBackendCode backendCode: BackendErrorCode,
                              backendMessage maybeBackendMessage: String?,
-                             extraUserInfo: [NSError.UserInfoKey: Any]? = nil) -> Error {
+                             extraUserInfo: [NSError.UserInfoKey: Any]? = nil,
+                             fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
         let errorCode = backendCode.toPurchasesErrorCode()
         let underlyingError = backendUnderlyingError(backendCode: backendCode, backendMessage: maybeBackendMessage)
 
         return error(with: errorCode,
                      message: errorCode.description,
                      underlyingError: underlyingError,
-                     extraUserInfo: extraUserInfo)
+                     extraUserInfo: extraUserInfo,
+                     fileName: fileName, functionName: functionName, line: line)
     }
 
 }
@@ -297,7 +379,10 @@ private extension ErrorUtils {
                       message: String? = nil,
                       underlyingError: Error? = nil,
                       generatedBy: String? = nil,
-                      extraUserInfo: [NSError.UserInfoKey: Any]? = nil) -> Error {
+                      extraUserInfo: [NSError.UserInfoKey: Any]? = nil,
+                      fileName: String = #fileID,
+                      functionName: String = #function,
+                      line: UInt = #line) -> Error {
         var userInfo = extraUserInfo ?? [:]
         userInfo[NSLocalizedDescriptionKey as NSError.UserInfoKey] = message ?? code.description
         if let maybeUnderlyingError = underlyingError {
@@ -305,8 +390,11 @@ private extension ErrorUtils {
         }
         userInfo[ErrorDetails.generatedByKey] = generatedBy
         userInfo[ErrorDetails.readableErrorCodeKey] = code.codeName
+        userInfo[ErrorDetails.fileKey] = "\(fileName):\(line)"
+        userInfo[ErrorDetails.functionKey] = functionName
 
-        Self.logErrorIfNeeded(code)
+        Self.logErrorIfNeeded(code,
+                              fileName: fileName, functionName: functionName, line: line)
 
         let nsError = code as NSError
         let nsErrorWithUserInfo = NSError(domain: nsError.domain,
@@ -315,9 +403,12 @@ private extension ErrorUtils {
         return nsErrorWithUserInfo as Error
     }
 
-    static func backendResponseError(withSubError maybeSubError: Error?,
-                                     generatedBy maybeGeneratedBy: String?,
-                                     extraContext maybeExtraContext: String?) -> Error {
+    static func backendResponseError(
+        withSubError maybeSubError: Error?,
+        generatedBy maybeGeneratedBy: String?,
+        extraContext maybeExtraContext: String?,
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
         var userInfo: [NSError.UserInfoKey: Any] = [:]
         let describableSubError = maybeSubError as? DescribableError
         let errorDescription = describableSubError?.description ?? ErrorCode.unexpectedBackendResponseError.description
@@ -326,6 +417,8 @@ private extension ErrorUtils {
         userInfo[ErrorDetails.readableErrorCodeKey] = ErrorCode.unexpectedBackendResponseError.codeName
         userInfo[ErrorDetails.generatedByKey] = maybeGeneratedBy
         userInfo[ErrorDetails.extraContextKey] = maybeExtraContext
+        userInfo[ErrorDetails.fileKey] = "\(fileName):\(line)"
+        userInfo[ErrorDetails.functionKey] = functionName
 
         let nsError = ErrorCode.unexpectedBackendResponseError as NSError
         let nsErrorWithUserInfo = NSError(domain: nsError.domain,
@@ -342,7 +435,10 @@ private extension ErrorUtils {
         return errorWithUserInfo
     }
 
-    private static func logErrorIfNeeded(_ code: ErrorCode) {
+    private static func logErrorIfNeeded(_ code: ErrorCode,
+                                         fileName: String = #fileID,
+                                         functionName: String = #function,
+                                         line: UInt = #line) {
         switch code {
         case .networkError,
                 .unknownError,


### PR DESCRIPTION
### Other changes:
- `ErrorUtils` doesn't need to be `@objc`
- Changed to `enum` as per the new SwiftLint rule (`convenience_type`)