### PR TITLE
`ProductFetcherSK1`: changed `ErrorCode.productRequestTimedOut` creation to use `ErrorUtils`

### DIFF
--- a/Purchases/Error Handling/ErrorUtils.swift
+++ b/Purchases/Error Handling/ErrorUtils.swift
@@ -346,6 +346,18 @@ enum ErrorUtils {
                                 fileName: fileName, functionName: functionName, line: line)
     }
 
+    /**
+     * Constructs an Error with the ``ErrorCode/productRequestTimedOut`` code.
+     *
+     * - Note: This error is used  when fetching products times out.
+     */
+    static func productRequestTimedOutError(
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
+        return ErrorUtils.error(with: .productRequestTimedOut,
+                                fileName: fileName, functionName: functionName, line: line)
+    }
+
 }
 
 extension ErrorUtils {

--- a/Purchases/Purchasing/StoreKit1/ProductsFetcherSK1.swift
+++ b/Purchases/Purchasing/StoreKit1/ProductsFetcherSK1.swift
@@ -232,7 +232,7 @@ private extension ProductsFetcherSK1 {
             self.completionHandlers.removeValue(forKey: productRequest.identifiers)
             self.productsByRequests.removeValue(forKey: request)
             for completion in completionBlocks {
-                completion(.failure(ErrorCode.productRequestTimedOut))
+                completion(.failure(ErrorUtils.productRequestTimedOutError()))
             }
         }
     }


### PR DESCRIPTION
Depends on #1078.