### PR TITLE
Disallow abstract `StoreProduct` initialization

### DIFF
--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -24,8 +24,10 @@ public typealias SK2Product = StoreKit.Product
 
 /// Abstract class that provides access to all of StoreKit's product type's properties.
 @objc(RCStoreProduct) public class StoreProduct: NSObject {
-    public override init() {
+    fileprivate override init() {
         super.init()
+
+        precondition(type(of: self) != StoreProduct.self, "StoreProduct is an abstract class")
 
         if self.localizedTitle.isEmpty {
             Logger.warn(Strings.offering.product_details_empty_title(productIdentifier: self.productIdentifier))


### PR DESCRIPTION
This now produces an error at compile time:
```
'StoreProduct' initializer is inaccessible due to 'fileprivate' protection level
```

Since this is an Objective-C class, `[[RCStoreProduct alloc] init]` also produces a better error rather than crashing in the different `fatalErrors` of the abstract methods.