### PR TITLE
`PurchasesOrchestrator`: wrapping `StoreKitError` in our own error

### DIFF
--- a/Purchases/Error Handling/ErrorUtils.swift
+++ b/Purchases/Error Handling/ErrorUtils.swift
@@ -210,20 +210,11 @@ enum ErrorUtils {
      * Constructs an Error with the ``ErrorCode/unknownError`` code and optional message.
      */
     static func unknownError(
-        message: String? = nil,
-        fileName: String = #fileID, functionName: String = #function, line: UInt = #line) -> Error {
-        return error(with: ErrorCode.unknownError, message: message,
-                     fileName: fileName, functionName: functionName, line: line)
-    }
-
-    /**
-     * Constructs an Error with the ``ErrorCode/unknownError`` code.
-     */
-    static func unknownError(
+        message: String? = nil, error: Error? = nil,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
     ) -> Error {
-        return error(with: ErrorCode.unknownError, message: nil,
-                     fileName: fileName, functionName: functionName, line: line)
+        return ErrorUtils.error(with: ErrorCode.unknownError, message: message, underlyingError: error,
+                                fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
@@ -268,6 +259,17 @@ enum ErrorUtils {
     }
 
     /**
+     * Maps a `StoreKitError` to an `Error` with a ``ErrorCode``.
+     * Adds a underlying error in the `NSError.userInfo` dictionary.
+     *
+     * - Parameter skError: The originating `StoreKitError`.
+     */
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    static func purchasesError(withStoreKitError storeKitError: Error) -> Error {
+        return (storeKitError as? StoreKitError)?.toPurchasesError() ?? self.unknownError()
+    }
+
+    /**
      * Constructs an Error with the ``ErrorCode/purchaseCancelledError`` code.
      *
      * - Note: This error is used when  a purchase is cancelled by the user.
@@ -283,12 +285,25 @@ enum ErrorUtils {
     }
 
     /**
+     * Constructs an Error with the ``ErrorCode/productNotAvailableForPurchaseError`` code.
+     *
+     * - Seealso: ``StoreKitError.notAvailableInStorefront``
+     */
+    static func productNotAvailableForPurchaseError(
+        error: Error? = nil,
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
+        return ErrorUtils.error(with: .productNotAvailableForPurchaseError,
+                                underlyingError: error)
+    }
+
+    /**
      * Constructs an Error with the ``ErrorCode/storeProblemError`` code.
      *
      * - Note: This error is used when there is a problem with the App Store.
      */
     static func storeProblemError(
-        withMessage message: String, error: Error? = nil,
+        withMessage message: String? = nil, error: Error? = nil,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
     ) -> Error {
         let errorCode = ErrorCode.storeProblemError

--- a/Purchases/Error Handling/StoreKitError+Extensions.swift
+++ b/Purchases/Error Handling/StoreKitError+Extensions.swift
@@ -1,0 +1,45 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  StoreKitError+Extensions.swift
+//
+//  Created by Nacho Soto on 12/14/21.
+
+import StoreKit
+
+/// - Seealso: SKError+Extensions
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+extension StoreKitError {
+
+    func toPurchasesError() -> Error {
+        switch self {
+        case .userCancelled:
+            return ErrorUtils.purchaseCancelledError()
+
+        case let .networkError(error):
+            return ErrorUtils.networkError(withUnderlyingError: error)
+
+        case let .systemError(error):
+            return ErrorUtils.storeProblemError(error: error)
+
+        case .notAvailableInStorefront:
+            return ErrorUtils.productNotAvailableForPurchaseError(error: self)
+
+        case .unknown:
+            /// See also https://github.com/RevenueCat/purchases-ios/issues/392
+            /// `StoreKitError` doesn't conform to `CustomNSError` as of `iOS 15.2`
+            /// so we can't extract any additional information like we do on ``SKError.toPurchasesErrorCode``
+            return ErrorUtils.storeProblemError(error: self)
+
+        @unknown default:
+            return ErrorUtils.unknownError(error: self)
+        }
+    }
+
+}

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -200,7 +200,7 @@ class PurchasesOrchestrator {
                 DispatchQueue.main.async {
                     switch result {
                     case .failure(let error):
-                        completion(nil, nil, error, false)
+                        completion(nil, nil, ErrorUtils.purchasesError(withStoreKitError: error), false)
                     case .success(let (customerInfo, userCancelled)):
                         // todo: change API and send transaction
                         if userCancelled {

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		5791CE80273F26A000E50C4B /* base64encoded_sandboxReceipt.txt in Resources */ = {isa = PBXBuildFile; fileRef = 5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */; };
 		57A0FBF02749C0C2009E2FC3 /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */; };
 		57A0FBF22749CF66009E2FC3 /* SynchronizedUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */; };
+		57BD50AA27692B7500211D6D /* StoreKitError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */; };
 		57E2230727500BB1002DB06E /* AtomicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E2230627500BB1002DB06E /* AtomicTests.swift */; };
 		57EAE527274324C60060EB74 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE526274324C60060EB74 /* Lock.swift */; };
 		57EAE52B274332830060EB74 /* Obsoletions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE52A274332830060EB74 /* Obsoletions.swift */; };
@@ -561,6 +562,7 @@
 		5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = base64encoded_sandboxReceipt.txt; sourceTree = "<group>"; };
 		57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 		57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedUserDefaults.swift; sourceTree = "<group>"; };
+		57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoreKitError+Extensions.swift"; sourceTree = "<group>"; };
 		57E2230627500BB1002DB06E /* AtomicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicTests.swift; sourceTree = "<group>"; };
 		57EAE526274324C60060EB74 /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		57EAE52A274332830060EB74 /* Obsoletions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Obsoletions.swift; sourceTree = "<group>"; };
@@ -1316,6 +1318,7 @@
 				B3B5FBB5269CED6400104A0C /* ErrorDetails.swift */,
 				35D0E5CF26A5886C0099EAD8 /* ErrorUtils.swift */,
 				2D971CC02744364C0093F35F /* SKError+Extensions.swift */,
+				57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */,
 				B302206B2727436F008F1A0D /* UnexpectedBackendResponseSubErrorCode.swift */,
 			);
 			path = "Error Handling";
@@ -1808,6 +1811,7 @@
 				5791A1AA2767E42B00C972AA /* SKProduct+Extensions.swift in Sources */,
 				F5E4383826B8530700841CC8 /* SKPaymentTransaction+Extensions.swift in Sources */,
 				B3022072272B3DDC008F1A0D /* DescribableError.swift in Sources */,
+				57BD50AA27692B7500211D6D /* StoreKitError+Extensions.swift in Sources */,
 				F5C0196926E880800005D61E /* StoreKitStrings.swift in Sources */,
 				B302206C2727436F008F1A0D /* UnexpectedBackendResponseSubErrorCode.swift in Sources */,
 				2D4E926526990AB1000E10B0 /* StoreKitWrapper.swift in Sources */,


### PR DESCRIPTION
This allows us to handle unknown errors, like reported we did in #943, and provide a better user experience.
I filed FB9808927 for this issue in StoreKit 2. Unfortunately we can't do the same we did in #965 because the `StoreKitError` has no underlying information.

### Before:
<img width="372" alt="Screen Shot 2021-12-14 at 12 25 14" src="https://user-images.githubusercontent.com/685609/146079013-9073a170-d189-4cfc-b05a-d6c7e344b7cd.png">

### After:
<img width="372" alt="Screen Shot 2021-12-14 at 12 21 37" src="https://user-images.githubusercontent.com/685609/146078999-ce9387a8-f26f-43d2-b41c-f477de42a568.png">

