### PR TITLE
StoreKit 2 support for `simulatesAskToBuyInSandbox`

### DIFF
--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -126,7 +126,8 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
 
     /**
      * Set this property to true *only* when testing the ask-to-buy / SCA purchases flow. More information:
-     * http://errors.rev.cat/ask-to-buy
+     * http://rev.cat/ask-to-buy
+     * - Seealso: https://support.apple.com/en-us/HT201089
      */
     @available(iOS 8.0, macOS 10.14, watchOS 6.2, macCatalyst 13.0, *)
     @objc public static var simulatesAskToBuyInSandbox: Bool {

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -628,8 +628,10 @@ private extension PurchasesOrchestrator {
         let sk2Product = sk2StoreProduct.underlyingSK2Product
 
         do {
-            var options = Set<Product.PurchaseOption>()
-            options.insert(Product.PurchaseOption.simulatesAskToBuyInSandbox(Purchases.simulatesAskToBuyInSandbox))
+            let options: Set<Product.PurchaseOption> = [
+                .simulatesAskToBuyInSandbox(Purchases.simulatesAskToBuyInSandbox)
+            ]
+
             let result = try await sk2Product.purchase(options: options)
             let userCancelled = await storeKit2Listener.handle(purchaseResult: result)
 

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -628,7 +628,9 @@ private extension PurchasesOrchestrator {
         let sk2Product = sk2StoreProduct.underlyingSK2Product
 
         do {
-            let result = try await sk2Product.purchase()
+            var options = Set<Product.PurchaseOption>()
+            options.insert(Product.PurchaseOption.simulatesAskToBuyInSandbox(Purchases.simulatesAskToBuyInSandbox))
+            let result = try await sk2Product.purchase(options: options)
             let userCancelled = await storeKit2Listener.handle(purchaseResult: result)
 
             return await withCheckedContinuation { continuation in

--- a/Purchases/Purchasing/StoreKit1/StoreKitWrapper.swift
+++ b/Purchases/Purchasing/StoreKit1/StoreKitWrapper.swift
@@ -31,7 +31,7 @@ protocol StoreKitWrapperDelegate: AnyObject {
 
 class StoreKitWrapper: NSObject, SKPaymentTransactionObserver {
 
-    @available(macOS 10.14, macCatalyst 13.0, *)
+    @available(iOS 8.0, macOS 10.14, watchOS 6.2, macCatalyst 13.0, *)
     static var simulatesAskToBuyInSandbox = false
 
     weak var delegate: StoreKitWrapperDelegate? {
@@ -79,7 +79,7 @@ class StoreKitWrapper: NSObject, SKPaymentTransactionObserver {
     func payment(withProduct product: SK1Product) -> SKMutablePayment {
         let payment = SKMutablePayment(product: product)
 
-        if #available(macOS 10.14, watchOS 6.2, macCatalyst 13.0, *) {
+        if #available(iOS 8.0, macOS 10.14, watchOS 6.2, macCatalyst 13.0, *) {
             payment.simulatesAskToBuyInSandbox = Self.simulatesAskToBuyInSandbox
         }
         return payment


### PR DESCRIPTION
Finished #864.
Fixes [sc-7664].

I also updated the [docs on Notion](https://www.notion.so/Ask-to-buy-iOS-68e5cef128b74fedb497f684d360e706).

Note that I haven't been able to get this working though. I tested on Catalyst and on device (Sandbox environment), and I don't see a different dialog as documented. I haven't been able to figure out why.