### PR TITLE
SwiftLint / SwiftStyleGuide: added rules for parameter locations

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,6 +13,7 @@ opt_in_rules:
   - sorted_imports
   - missing_docs
   - convenience_type
+  - multiline_parameters
 
 identifier_name:
   max_length: 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -14,6 +14,7 @@ opt_in_rules:
   - missing_docs
   - convenience_type
   - multiline_parameters
+  - vertical_parameter_alignment_on_call
 
 identifier_name:
   max_length: 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -14,6 +14,7 @@ opt_in_rules:
   - missing_docs
   - convenience_type
   - multiline_parameters
+  - vertical_parameter_alignment
   - vertical_parameter_alignment_on_call
 
 identifier_name:

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -255,9 +255,9 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
         let receiptParser = ReceiptParser()
         let transactionsManager = TransactionsManager(receiptParser: receiptParser)
         let customerInfoManager = CustomerInfoManager(operationDispatcher: operationDispatcher,
-                                                        deviceCache: deviceCache,
-                                                        backend: backend,
-                                                        systemInfo: systemInfo)
+                                                      deviceCache: deviceCache,
+                                                      backend: backend,
+                                                      systemInfo: systemInfo)
         let identityManager = IdentityManager(deviceCache: deviceCache,
                                               backend: backend,
                                               customerInfoManager: customerInfoManager,

--- a/Purchases/Purchasing/OfferingsFactory.swift
+++ b/Purchases/Purchasing/OfferingsFactory.swift
@@ -60,7 +60,7 @@ class OfferingsFactory {
         }
 
         return Offering(identifier: offeringIdentifier, serverDescription: serverDescription,
-                availablePackages: availablePackages)
+                        availablePackages: availablePackages)
     }
 
     func createPackage(with data: [String: Any],

--- a/Purchases/SubscriberAttributes/AttributionDataMigrator.swift
+++ b/Purchases/SubscriberAttributes/AttributionDataMigrator.swift
@@ -33,8 +33,10 @@ class AttributionDataMigrator {
             convertedAttribution[ReservedSubscriberAttribute.gpsAdId.key] = value
         }
 
-        let networkSpecificSubscriberAttributes = convertNetworkSpecificSubscriberAttributes(for: network,
-                attributionData: attributionData)
+        let networkSpecificSubscriberAttributes = convertNetworkSpecificSubscriberAttributes(
+            for: network,
+            attributionData: attributionData
+        )
 
         return convertedAttribution.merging(networkSpecificSubscriberAttributes)
     }

--- a/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
+++ b/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
@@ -46,8 +46,8 @@ class ManageSubscriptionsHelperTests: XCTestCase {
                                                       systemInfo: systemInfo)
         identityManager = MockIdentityManager(mockAppUserID: "appUserID")
         helper = ManageSubscriptionsHelper(systemInfo: systemInfo,
-                                                customerInfoManager: customerInfoManager,
-                                                identityManager: identityManager)
+                                           customerInfoManager: customerInfoManager,
+                                           identityManager: identityManager)
     }
 
     func testShowManageSubscriptionsMakesRightCalls() throws {

--- a/SwiftStyleGuide.swift
+++ b/SwiftStyleGuide.swift
@@ -80,6 +80,23 @@ struct MyStruct {
         print(self.mercury)
     }
 
+    func whenMethodIsTooLongToFitInOneLine(becauseOfTooMany: Int,
+                                           parameters: String,
+                                           eachOne: Float,
+                                           shouldBeInItsOwnLine: Double) {}
+
+    // swiftlint:disable:next multiline_parameters
+    func whenMethodIsTooLongToFitInOneLine(
+        becauseOfTooMany: Int,
+        parameters: String,
+        eachOne: Float,
+        shouldBeInItsOwnLine: Double,
+        // special file / function / line parameters may be grouped together in their own line
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) {
+
+    }
+
 }
 
 // separate protocol conformance into extension


### PR DESCRIPTION
## Rules:
- [multiline_parameters](https://realm.github.io/SwiftLint/multiline_parameters.html)
- [vertical_parameter_alignment](https://realm.github.io/SwiftLint/vertical_parameter_alignment.html)
- [vertical_parameter_alignment_on_call](https://realm.github.io/SwiftLint/vertical_parameter_alignment_on_call.html)

Brought up in #1078.