### PR TITLE
Introduced `Set.dictionaryWithValues`, `Sequence.uniqueIndex`, and `Sequence.indexAllowingDuplicateKeys`

### DIFF
--- a/Purchases/FoundationExtensions/Dictionary+Extensions.swift
+++ b/Purchases/FoundationExtensions/Dictionary+Extensions.swift
@@ -90,6 +90,7 @@ extension Dictionary {
 }
 
 extension Sequence {
+
     /// Creates a `Dictionary` with the values in the receiver sequence, and the keys provided by `key`.
     /// - Precondition: The sequence must not have duplicate keys.
     func dictionaryWithKeys<Key>(_ key: @escaping (Element) -> Key) -> [Key: Element] {
@@ -103,4 +104,5 @@ extension Sequence {
             uniquingKeysWith: { (_, last) in last }
         )
     }
+
 }

--- a/Purchases/FoundationExtensions/Dictionary+Extensions.swift
+++ b/Purchases/FoundationExtensions/Dictionary+Extensions.swift
@@ -88,3 +88,23 @@ extension Dictionary {
     }
 
 }
+
+extension Sequence {
+    /// Creates a `Dictionary` with the values in the receiver sequence, and the keys provided by `key`.
+    /// - Precondition: The sequence must not have duplicate keys.
+    func uniqueIndex<Key>(
+        _ key: @escaping (Element) -> Key
+    ) -> [Key: Element] {
+        Dictionary(uniqueKeysWithValues: self.lazy.map { (key($0), $0) })
+    }
+
+    /// Creates a `Dictionary` with the values in the receiver sequence, and the keys provided by `key`.
+    func indexAllowingDuplicateKeys<Key>(
+        _ key: @escaping (Element) -> Key
+    ) -> [Key: Element] {
+        return Dictionary(
+            self.lazy.map { (key($0), $0) },
+            uniquingKeysWith: { (_, last) in last }
+        )
+    }
+}

--- a/Purchases/FoundationExtensions/Dictionary+Extensions.swift
+++ b/Purchases/FoundationExtensions/Dictionary+Extensions.swift
@@ -92,16 +92,12 @@ extension Dictionary {
 extension Sequence {
     /// Creates a `Dictionary` with the values in the receiver sequence, and the keys provided by `key`.
     /// - Precondition: The sequence must not have duplicate keys.
-    func uniqueIndex<Key>(
-        _ key: @escaping (Element) -> Key
-    ) -> [Key: Element] {
+    func dictionaryWithKeys<Key>(_ key: @escaping (Element) -> Key) -> [Key: Element] {
         Dictionary(uniqueKeysWithValues: self.lazy.map { (key($0), $0) })
     }
 
     /// Creates a `Dictionary` with the values in the receiver sequence, and the keys provided by `key`.
-    func indexAllowingDuplicateKeys<Key>(
-        _ key: @escaping (Element) -> Key
-    ) -> [Key: Element] {
+    func dictionaryAllowingDuplicateKeys<Key>(_ key: @escaping (Element) -> Key) -> [Key: Element] {
         return Dictionary(
             self.lazy.map { (key($0), $0) },
             uniquingKeysWith: { (_, last) in last }

--- a/Purchases/FoundationExtensions/Set+Extensions.swift
+++ b/Purchases/FoundationExtensions/Set+Extensions.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Set+Extensions.swift
+//
+//  Created by Nacho Soto on 12/15/21.
+
+import Foundation
+
+extension Set {
+    /// Creates a `Dictionary` with the keys in the receiver `Set`, and the values provided by `value`.
+    func dictionaryWithValues<Value>(_ value: @escaping (Element) -> Value) -> [Element: Value] {
+        return Dictionary(uniqueKeysWithValues: self.lazy.map { ($0, value($0)) })
+    }
+}

--- a/Purchases/Purchasing/OfferingsManager.swift
+++ b/Purchases/Purchasing/OfferingsManager.swift
@@ -115,9 +115,7 @@ private extension OfferingsManager {
                 return
             }
 
-            let productsByID = products.reduce(into: [:]) { result, product in
-                result[product.productIdentifier] = product
-            }
+            let productsByID = products.uniqueIndex { $0.productIdentifier }
 
             if let createdOfferings = self.offeringsFactory.createOfferings(from: productsByID,
                                                                             data: data) {

--- a/Purchases/Purchasing/OfferingsManager.swift
+++ b/Purchases/Purchasing/OfferingsManager.swift
@@ -115,7 +115,7 @@ private extension OfferingsManager {
                 return
             }
 
-            let productsByID = products.uniqueIndex { $0.productIdentifier }
+            let productsByID = products.dictionaryWithKeys { $0.productIdentifier }
 
             if let createdOfferings = self.offeringsFactory.createOfferings(from: productsByID,
                                                                             data: data) {

--- a/Purchases/Purchasing/StoreKit1/ProductsFetcherSK1.swift
+++ b/Purchases/Purchasing/StoreKit1/ProductsFetcherSK1.swift
@@ -193,7 +193,7 @@ private extension ProductsFetcherSK1 {
 
     func cacheProducts(_ products: [SK1Product]) {
         queue.async {
-            let productsByIdentifier = products.indexAllowingDuplicateKeys {
+            let productsByIdentifier = products.dictionaryAllowingDuplicateKeys {
                 $0.productIdentifier
             }
 

--- a/Purchases/Purchasing/StoreKit1/ProductsFetcherSK1.swift
+++ b/Purchases/Purchasing/StoreKit1/ProductsFetcherSK1.swift
@@ -193,8 +193,8 @@ private extension ProductsFetcherSK1 {
 
     func cacheProducts(_ products: [SK1Product]) {
         queue.async {
-            let productsByIdentifier = products.reduce(into: [:]) { resultDict, product in
-                resultDict[product.productIdentifier] = product
+            let productsByIdentifier = products.indexAllowingDuplicateKeys {
+                $0.productIdentifier
             }
 
             self.cachedProductsByIdentifier += productsByIdentifier

--- a/PurchasesTests/FoundationExtensions/DictionaryExtensionsTests.swift
+++ b/PurchasesTests/FoundationExtensions/DictionaryExtensionsTests.swift
@@ -100,13 +100,17 @@ class DictionaryExtensionsTests: XCTestCase {
 
 
     func testCreatingDictionaryWithNoValues() {
-        expect(Array<String>().uniqueIndex { $0 }) == [:]
+        expect(Array<String>().dictionaryWithKeys { $0 }) == [:]
+    }
+
+    func testCreatingDictionaryAllowingDuplicateKeysWithNoValues() {
+        expect(Array<String>().dictionaryAllowingDuplicateKeys { $0 }) == [:]
     }
 
     func testCreatingDictionaryWithOneItem() {
         let values = ["1"]
 
-        expect(values.uniqueIndex { Int($0)! }) == [
+        expect(values.dictionaryWithKeys { Int($0)! }) == [
             1: "1"
         ]
     }
@@ -114,7 +118,7 @@ class DictionaryExtensionsTests: XCTestCase {
     func testCreatingDictionaryWithMultipleValues() {
         let values = ["1", "2", "3"]
 
-        expect(values.uniqueIndex { Int($0)! + 1 }) == [
+        expect(values.dictionaryWithKeys { Int($0)! + 1 }) == [
             2: "1",
             3: "2",
             4: "3"
@@ -124,7 +128,7 @@ class DictionaryExtensionsTests: XCTestCase {
     func testCreatingDictionaryWithDuplicateKeys() {
         let values = ["1", "2", "3", "2"]
 
-        expect(values.indexAllowingDuplicateKeys { Int($0)! }) == [
+        expect(values.dictionaryAllowingDuplicateKeys { Int($0)! }) == [
             1: "1",
             2: "2",
             3: "3"

--- a/PurchasesTests/FoundationExtensions/DictionaryExtensionsTests.swift
+++ b/PurchasesTests/FoundationExtensions/DictionaryExtensionsTests.swift
@@ -98,4 +98,36 @@ class DictionaryExtensionsTests: XCTestCase {
         expect(original).to(equal(expectedDict))
     }
 
+
+    func testCreatingDictionaryWithNoValues() {
+        expect(Array<String>().uniqueIndex { $0 }) == [:]
+    }
+
+    func testCreatingDictionaryWithOneItem() {
+        let values = ["1"]
+
+        expect(values.uniqueIndex { Int($0)! }) == [
+            1: "1"
+        ]
+    }
+
+    func testCreatingDictionaryWithMultipleValues() {
+        let values = ["1", "2", "3"]
+
+        expect(values.uniqueIndex { Int($0)! + 1 }) == [
+            2: "1",
+            3: "2",
+            4: "3"
+        ]
+    }
+
+    func testCreatingDictionaryWithDuplicateKeys() {
+        let values = ["1", "2", "3", "2"]
+
+        expect(values.indexAllowingDuplicateKeys { Int($0)! }) == [
+            1: "1",
+            2: "2",
+            3: "3"
+        ]
+    }
 }

--- a/PurchasesTests/FoundationExtensions/SetExtensionsTests.swift
+++ b/PurchasesTests/FoundationExtensions/SetExtensionsTests.swift
@@ -1,0 +1,43 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SetExtensionsTests.swift
+//
+//  Created by Nacho Soto on 12/15/21.
+
+import XCTest
+import Nimble
+
+@testable import RevenueCat
+
+class SetExtensionsTests: XCTestCase {
+
+    func testCreatingDictionaryWithEmptySet() {
+        expect(Set<String>().dictionaryWithValues { $0 }) == [:]
+    }
+
+    func testCreatingDictionaryWithOneItem() {
+        let keys: Set<String> = ["1"]
+
+        expect(keys.dictionaryWithValues { Int($0)! }) == [
+            "1": 1
+        ]
+    }
+
+    func testCreatingDictionaryWithMultipleValues() {
+        let keys: Set<String> = ["1", "2", "3"]
+
+        expect(keys.dictionaryWithValues { Int($0)! + 1 }) == [
+            "1": 2,
+            "2": 3,
+            "3": 4
+        ]
+    }
+    
+}

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -215,6 +215,8 @@
 		57A0FBF02749C0C2009E2FC3 /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */; };
 		57A0FBF22749CF66009E2FC3 /* SynchronizedUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */; };
 		57BD50AA27692B7500211D6D /* StoreKitError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */; };
+		57A17727276A721D0052D3A8 /* Set+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A17726276A721D0052D3A8 /* Set+Extensions.swift */; };
+		57A1772B276A726C0052D3A8 /* SetExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A1772A276A726C0052D3A8 /* SetExtensionsTests.swift */; };
 		57E2230727500BB1002DB06E /* AtomicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E2230627500BB1002DB06E /* AtomicTests.swift */; };
 		57EAE527274324C60060EB74 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE526274324C60060EB74 /* Lock.swift */; };
 		57EAE52B274332830060EB74 /* Obsoletions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE52A274332830060EB74 /* Obsoletions.swift */; };
@@ -563,6 +565,8 @@
 		57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 		57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedUserDefaults.swift; sourceTree = "<group>"; };
 		57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoreKitError+Extensions.swift"; sourceTree = "<group>"; };
+		57A17726276A721D0052D3A8 /* Set+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Set+Extensions.swift"; sourceTree = "<group>"; };
+		57A1772A276A726C0052D3A8 /* SetExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetExtensionsTests.swift; sourceTree = "<group>"; };
 		57E2230627500BB1002DB06E /* AtomicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicTests.swift; sourceTree = "<group>"; };
 		57EAE526274324C60060EB74 /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		57EAE52A274332830060EB74 /* Obsoletions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Obsoletions.swift; sourceTree = "<group>"; };
@@ -721,6 +725,7 @@
 				37E353FD94A8FD5CD8796530 /* DateFormatter+Extensions.swift */,
 				B302206927271BCB008F1A0D /* Decoder+Extensions.swift */,
 				35F82BAA26A84E130051DF03 /* Dictionary+Extensions.swift */,
+				57A17726276A721D0052D3A8 /* Set+Extensions.swift */,
 				B3E26A4926BE0A8E003ACCF3 /* Error+Extensions.swift */,
 				F5714EA426D6C24D00635477 /* JSONDecoder+Extensions.swift */,
 				2CD72947268A828400BFC976 /* Locale+Extensions.swift */,
@@ -1211,6 +1216,7 @@
 				37E3508EC20EEBAB4EAC4C82 /* NSDate+RCExtensionsTests.swift */,
 				37E35ABEE9FD79CCA64E4F8B /* NSData+RCExtensionsTests.swift */,
 				2DD269162522A20A006AC4BC /* DictionaryExtensionsTests.swift */,
+				57A1772A276A726C0052D3A8 /* SetExtensionsTests.swift */,
 				37E35FDA0A44EA03EA12DAA2 /* DateFormatter+ExtensionsTests.swift */,
 			);
 			path = FoundationExtensions;
@@ -1917,6 +1923,7 @@
 				37E35C8515C5E2D01B0AF5C1 /* Strings.swift in Sources */,
 				2D9F4A5526C30CA800B07B43 /* PurchasesOrchestrator.swift in Sources */,
 				37E3529267833EA8ED9F06BE /* DateFormatter+Extensions.swift in Sources */,
+				57A17727276A721D0052D3A8 /* Set+Extensions.swift in Sources */,
 				37E350C67712B9E054FEF297 /* AttributionData.swift in Sources */,
 				37E3578711F5FDD5DC6458A8 /* AttributionFetcher.swift in Sources */,
 				F5714EA526D6C24D00635477 /* JSONDecoder+Extensions.swift in Sources */,
@@ -2016,6 +2023,7 @@
 				351B517026D44E8D00BD2BD7 /* MockDateProvider.swift in Sources */,
 				2D1C3F3926B9D8B800112626 /* MockBundle.swift in Sources */,
 				351B515E26D44B9900BD2BD7 /* MockPurchasesDelegate.swift in Sources */,
+				57A1772B276A726C0052D3A8 /* SetExtensionsTests.swift in Sources */,
 				351B515A26D44B6200BD2BD7 /* MockAttributionFetcher.swift in Sources */,
 				351B51BD26D450E800BD2BD7 /* EntitlementInfosTests.swift in Sources */,
 				351B514526D449E600BD2BD7 /* MockAttributionTypeFactory.swift in Sources */,

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -30,11 +30,11 @@ class StoreProductTests: StoreKitConfigTestCase {
         let sk1Fetcher = ProductsFetcherSK1(productsRequestFactory: ProductsRequestFactory(),
                                             requestTimeout: Self.requestTimeout)
         let sk1StoreProducts = try await sk1Fetcher.products(withIdentifiers: productIdentifiers)
-        let sk1StoreProductsByID = sk1StoreProducts.uniqueIndex { $0.productIdentifier }
+        let sk1StoreProductsByID = sk1StoreProducts.dictionaryWithKeys { $0.productIdentifier }
 
         let sk2Fetcher = ProductsFetcherSK2()
         let sk2StoreProducts = try await sk2Fetcher.products(identifiers: productIdentifiers)
-        let sk2StoreProductsByID = sk2StoreProducts.uniqueIndex { $0.productIdentifier }
+        let sk2StoreProductsByID = sk2StoreProducts.dictionaryWithKeys { $0.productIdentifier }
 
         expect(sk1StoreProducts.count) == productIdentifiers.count
         expect(sk1StoreProducts.count) == sk2StoreProducts.count

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -29,19 +29,15 @@ class StoreProductTests: StoreKitConfigTestCase {
         ])
         let sk1Fetcher = ProductsFetcherSK1(productsRequestFactory: ProductsRequestFactory(),
                                             requestTimeout: Self.requestTimeout)
-        let sk1StoreProduct = try await sk1Fetcher.products(withIdentifiers: productIdentifiers)
-        let sk1StoreProductsByID = sk1StoreProduct.reduce(into: [:]) { partialResult, wrapper in
-            partialResult[wrapper.productIdentifier] = wrapper
-        }
+        let sk1StoreProducts = try await sk1Fetcher.products(withIdentifiers: productIdentifiers)
+        let sk1StoreProductsByID = sk1StoreProducts.uniqueIndex { $0.productIdentifier }
 
         let sk2Fetcher = ProductsFetcherSK2()
-        let sk2StoreProduct = try await sk2Fetcher.products(identifiers: productIdentifiers)
-        let sk2StoreProductsByID = sk2StoreProduct.reduce(into: [:]) { partialResult, wrapper in
-            partialResult[wrapper.productIdentifier] = wrapper
-        }
+        let sk2StoreProducts = try await sk2Fetcher.products(identifiers: productIdentifiers)
+        let sk2StoreProductsByID = sk2StoreProducts.uniqueIndex { $0.productIdentifier }
 
-        expect(sk1StoreProduct.count) == productIdentifiers.count
-        expect(sk1StoreProduct.count) == sk2StoreProduct.count
+        expect(sk1StoreProducts.count) == productIdentifiers.count
+        expect(sk1StoreProducts.count) == sk2StoreProducts.count
 
         for sk1ProductID in sk1StoreProductsByID.keys {
             let sk1Product = try XCTUnwrap(sk1StoreProductsByID[sk1ProductID])


### PR DESCRIPTION
This makes creating dictionaries simpler than using `reduce(into:)`.
Note that this doesn't change any behaviors. The existing implementations that allowed duplicates still do, and vice-versa.