### PR TITLE
`PurchasesOrchestratorTests.testPurchaseSK2PackageSkipsIfPurchaseFailed`: don't skip if SK2 isn't enabled

### DIFF
--- a/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -172,10 +172,6 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     func testPurchaseSK2PackageSkipsIfPurchaseFailed() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        guard self.systemInfo.useStoreKit2IfAvailable else {
-            throw XCTSkip("StoreKit 2 tests are disabled.")
-        }
-
         testSession.failTransactionsEnabled = true
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
         backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo


### PR DESCRIPTION
We always want to run the test. This test was currently skipped.