### PR TITLE
Put CustomerInfo Logging into LoginHandler function

### DIFF
--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -495,14 +495,17 @@ private extension Backend {
         }
 
         do {
-            let customerInfo = try CustomerInfo(data: response)
+            let customerInfo = try parseCustomerInfo(fromMaybeResponse: maybeResponse)
             let created = statusCode == HTTPStatusCodes.createdSuccess.rawValue
             Logger.user(Strings.identity.login_success)
             completion(customerInfo, created, nil)
-        } catch {
+        } catch let customerInfoError {
             Logger.error(Strings.backendError.customer_info_instantiation_error(maybeResponse: response))
+            let extraContext = "statusCode: \(statusCode), json:\(maybeResponse.debugDescription)"
             let subErrorCode = UnexpectedBackendResponseSubErrorCode.loginResponseDecoding
-            let responseError = ErrorUtils.unexpectedBackendResponse(withSubError: subErrorCode)
+            let responseError = ErrorUtils.unexpectedBackendResponse(withSubError: customerInfoError,
+                                                                 generatedBy: "\(file) \(function)",
+                                                                 extraContext: extraContext)
             completion(nil, false, responseError)
         }
     }

--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -501,9 +501,11 @@ private extension Backend {
             completion(customerInfo, created, nil)
         } catch let customerInfoError {
             Logger.error(Strings.backendError.customer_info_instantiation_error(maybeResponse: response))
-            let extraContext = "statusCode: \(statusCode), json:\(maybeResponse.debugDescription)"
-            let subErrorCode = UnexpectedBackendResponseSubErrorCode.loginResponseDecoding
-            let responseError = ErrorUtils.unexpectedBackendResponse(withSubError: customerInfoError,
+            let extraContext = "statusCode: \(statusCode)"
+            let subErrorCode = UnexpectedBackendResponseSubErrorCode
+                .loginResponseDecoding
+                .addingUnderlyingError(customerInfoError)
+            let responseError = ErrorUtils.unexpectedBackendResponse(withSubError: subErrorCode,
                                                                      extraContext: extraContext)
             completion(nil, false, responseError)
         }

--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -504,8 +504,7 @@ private extension Backend {
             let extraContext = "statusCode: \(statusCode), json:\(maybeResponse.debugDescription)"
             let subErrorCode = UnexpectedBackendResponseSubErrorCode.loginResponseDecoding
             let responseError = ErrorUtils.unexpectedBackendResponse(withSubError: customerInfoError,
-                                                                 generatedBy: "\(file) \(function)",
-                                                                 extraContext: extraContext)
+                                                                     extraContext: extraContext)
             completion(nil, false, responseError)
         }
     }


### PR DESCRIPTION
The loginHandler function should also be reporting the customer error instantiation failures.

Thank you for contributing to Purchases. Before pressing the "Create Pull Request" button, please provide the following:

  - [x] A description about what and why you are contributing, even if it's trivial.

  - [x] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [x] If applicable, unit tests.
  
  - [x] If applicable, create follow-up tickets for `purchases-android` and hybrids.

Description: 
It was unclear why previous code for logging the customerinfo instantiation failures was not being applied to the `handleLogin` function. This change adds that context.  

Issue to contribute in response:
https://community.revenuecat.com/sdks-51/randomly-and-false-zero-entitlements-returned-from-purchaseproduct-withcompletion-657/index2.html?postid=2884#post2884