### PR TITLE
[DO NOT MERGE]Expose parseCustomerInfo for debugging

### DIFF
--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -429,6 +429,21 @@ class Backend {
         }
     }
 
+    func parseCustomerInfo(fromMaybeResponse maybeResponse: [String: Any]?) throws -> CustomerInfo {
+        guard let customerJson = maybeResponse else {
+            throw UnexpectedBackendResponseSubErrorCode.customerInfoResponseMalformed
+        }
+
+        do {
+            return try CustomerInfo(data: customerJson)
+        } catch {
+            let parsingError = UnexpectedBackendResponseSubErrorCode.customerInfoResponseParsing
+            let subError = parsingError.addingUnderlyingError(error,
+                                                              extraContext: customerJson.stringRepresentation)
+            throw subError
+        }
+    }
+
 }
 
 private extension Backend {
@@ -579,21 +594,6 @@ private extension Backend {
         }
 
         completion?(nil)
-    }
-
-    func parseCustomerInfo(fromMaybeResponse maybeResponse: [String: Any]?) throws -> CustomerInfo {
-        guard let customerJson = maybeResponse else {
-            throw UnexpectedBackendResponseSubErrorCode.customerInfoResponseMalformed
-        }
-
-        do {
-            return try CustomerInfo(data: customerJson)
-        } catch {
-            let parsingError = UnexpectedBackendResponseSubErrorCode.customerInfoResponseParsing
-            let subError = parsingError.addingUnderlyingError(error,
-                                                              extraContext: customerJson.stringRepresentation)
-            throw subError
-        }
     }
 
     // swiftlint:disable:next function_body_length

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -58,6 +58,16 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
 
         return purchases
     }
+
+    @objc public func parseCustomerInfo(fromJSONString json: String) -> CustomerInfo {
+        // swiftlint:disable force_try
+        let jsonObject = try! JSONSerialization.jsonObject(with: json.data(using: .utf8)!,
+                                                           options: .mutableContainers) as? [String: Any]
+        let customerInfo = try! self.backend.parseCustomerInfo(fromMaybeResponse: jsonObject)
+        // swiftlint:enable force_try
+        return customerInfo
+    }
+
     private static var purchases: Purchases?
 
     /// Returns `true` if RevenueCat has already been intialized through `configure()`.

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -83,6 +83,36 @@ class PurchasesTests: XCTestCase {
         UserDefaults().removePersistentDomain(forName: "TestDefaults")
     }
 
+    func testCustomerParsingWithRealData() {
+        setupPurchases()
+        let jsonGoesHere = """
+{
+   \"request_date\":\"2021-12-11T19:28:10Z\",
+   \"request_date_ms\":1639250890283,
+   \"subscriber\":{
+      \"entitlements\":{
+      },
+      \"first_seen\":\"2021-12-11T20:28:11Z\",
+      \"last_seen\":\"2021-12-11T20:28:11Z\",
+      \"management_url\":null,
+      \"non_subscriptions\":{
+      },
+      \"original_app_user_id\":\"U12345678\",
+      \"original_application_version\":null,
+      \"original_purchase_date\":null,
+      \"other_purchases\":{
+
+      },
+      \"subscriptions\":{
+      }
+   }
+}
+"""
+
+        let customerInfo = self.purchases.parseCustomerInfo(fromJSONString: jsonGoesHere)
+        print("Start ***\n\(customerInfo)\n\n ***End")
+    }
+
     class MockBackend: Backend {
         var userID: String?
         var originalApplicationVersion: String?


### PR DESCRIPTION
Exposed the ability to use a string of JSON to instantiate a `CustomerInfo` object in `Purchases`
This is to help with https://github.com/RevenueCat/purchases-ios/issues/1096

