### PR TITLE
Detect when API requests are being blocked

### DIFF
--- a/Purchases/Logging/Strings/NetworkStrings.swift
+++ b/Purchases/Logging/Strings/NetworkStrings.swift
@@ -30,6 +30,7 @@ enum NetworkStrings {
     case retrying_request(httpMethod: String, path: String)
     case could_not_find_cached_response
     case could_not_find_cached_response_in_already_retried(response: String)
+    case blocked_network(newHost: String)
 
 }
 
@@ -81,6 +82,9 @@ extension NetworkStrings: CustomStringConvertible {
             return "We can't find the cached response, but call has already been retried. " +
                 "Returning result from backend \(response)"
 
+        case .blocked_network(let newHost):
+            return "It looks like requests to RevenueCat are being blocked. Context: We're attempting to connect " +
+                "to host: (\(newHost)), see: https://rev.cat/dnsBlocking for more info."
         }
     }
 

--- a/Purchases/Networking/DNSChecker.swift
+++ b/Purchases/Networking/DNSChecker.swift
@@ -1,0 +1,67 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  DNSChecker.swift
+//
+//  Created by Joshua Liebowitz on 12/20/21.
+
+import Foundation
+
+enum DNSChecker {
+
+    static let invalidHosts = Set(["0.0.0.0", "127.0.0.1"])
+
+    static func isBlockedAPIError(_ error: Error?) -> Bool {
+        guard let error = error else {
+            return false
+        }
+
+        let nsError = error as NSError
+
+        guard let failedURL = nsError.userInfo[NSURLErrorFailingURLErrorKey] as? URL else {
+            return false
+        }
+
+        return isBlockedURL(failedURL)
+    }
+
+    static func blockedHostFromError(_ error: Error?) -> String? {
+        guard let failedURL = (error as NSError?)?.userInfo[NSURLErrorFailingURLErrorKey] as? URL else {
+            return nil
+        }
+
+        return resolvedHost(fromURL: failedURL)
+    }
+
+    static func isBlockedURL(_ url: URL) -> Bool {
+        guard let resolvedHostName = resolvedHost(fromURL: url) else {
+            return false
+        }
+
+        return self.invalidHosts.contains(resolvedHostName)
+    }
+
+    static func resolvedHost(fromURL url: URL) -> String? {
+        guard let name = url.host,
+              let host = name.withCString({gethostbyname($0)}),
+              host.pointee.h_length > 0 else {
+                  return nil
+              }
+        var addr = in_addr()
+        memcpy(&addr.s_addr, host.pointee.h_addr_list[0], Int(host.pointee.h_length))
+
+        guard let remoteIPAsC = inet_ntoa(addr) else {
+            return nil
+        }
+
+        let hostIP = String.init(cString: remoteIPAsC)
+        return hostIP
+    }
+
+}

--- a/Purchases/Networking/DNSChecker.swift
+++ b/Purchases/Networking/DNSChecker.swift
@@ -23,6 +23,10 @@ enum DNSChecker {
         }
 
         let nsError = error as NSError
+        guard nsError.domain == NSURLErrorDomain,
+              nsError.code == NSURLErrorCannotConnectToHost else {
+            return false
+        }
 
         guard let failedURL = nsError.userInfo[NSURLErrorFailingURLErrorKey] as? URL else {
             return false
@@ -60,7 +64,7 @@ enum DNSChecker {
             return nil
         }
 
-        let hostIP = String.init(cString: remoteIPAsC)
+        let hostIP = String(cString: remoteIPAsC)
         return hostIP
     }
 

--- a/Purchases/Networking/HTTPClient.swift
+++ b/Purchases/Networking/HTTPClient.swift
@@ -224,6 +224,11 @@ private extension HTTPClient {
             }
         }
 
+        if DNSChecker.isBlockedAPIError(maybeNetworkError),
+            let resolvedHost = DNSChecker.blockedHostFromError(maybeNetworkError) {
+            Logger.error(NetworkStrings.blocked_network(newHost: resolvedHost))
+        }
+
         if let httpResponse = maybeHTTPResponse,
             let completionHandler = maybeCompletionHandler {
             let error = maybeJSONError ?? maybeNetworkError

--- a/PurchasesTests/Networking/DNSCheckerTests.swift
+++ b/PurchasesTests/Networking/DNSCheckerTests.swift
@@ -48,16 +48,48 @@ class DNSCheckerTests: XCTestCase {
 
     func testIsBlockedLocalHostIPAPIError() {
         let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: URL(string: "https://127.0.0.1/subscribers")!]
-        let nsErrorWithUserInfo = NSError(domain: "Testing",
-                                          code: -1,
+        let nsErrorWithUserInfo = NSError(domain: NSURLErrorDomain,
+                                          code: NSURLErrorCannotConnectToHost,
                                           userInfo: userInfo as [String: Any])
         expect(DNSChecker.isBlockedAPIError(nsErrorWithUserInfo as Error)) == true
     }
 
+    func testWrongErrorCode() {
+        let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: URL(string: "https://127.0.0.1/subscribers")!]
+        let nsErrorWithUserInfo = NSError(domain: NSURLErrorDomain,
+                                          code: -1,
+                                          userInfo: userInfo as [String: Any])
+        expect(DNSChecker.isBlockedAPIError(nsErrorWithUserInfo as Error)) == false
+    }
+
+    func testWrongErrorDomain() {
+        let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: URL(string: "https://127.0.0.1/subscribers")!]
+        let nsErrorWithUserInfo = NSError(domain: "FakeDomain",
+                                          code: NSURLErrorCannotConnectToHost,
+                                          userInfo: userInfo as [String: Any])
+        expect(DNSChecker.isBlockedAPIError(nsErrorWithUserInfo as Error)) == false
+    }
+
+    func testWrongErrorDomainAndWrongErrorCode() {
+        let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: URL(string: "https://127.0.0.1/subscribers")!]
+        let nsErrorWithUserInfo = NSError(domain: "FakeDomain",
+                                          code: -1,
+                                          userInfo: userInfo as [String: Any])
+        expect(DNSChecker.isBlockedAPIError(nsErrorWithUserInfo as Error)) == false
+    }
+
+    func testIsOnlyValidForCorrectErrorDomainAnd() {
+        let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: URL(string: "https://127.0.0.1/subscribers")!]
+        let nsErrorWithUserInfo = NSError(domain: "FakeDomain",
+                                          code: NSURLErrorCannotConnectToHost,
+                                          userInfo: userInfo as [String: Any])
+        expect(DNSChecker.isBlockedAPIError(nsErrorWithUserInfo as Error)) == false
+    }
+
     func testIsBlockedZerosIPHostAPIError() {
         let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: URL(string: "https://0.0.0.0/subscribers")!]
-        let nsErrorWithUserInfo = NSError(domain: "Testing",
-                                          code: -1,
+        let nsErrorWithUserInfo = NSError(domain: NSURLErrorDomain,
+                                          code: NSURLErrorCannotConnectToHost,
                                           userInfo: userInfo as [String: Any])
         expect(DNSChecker.isBlockedAPIError(nsErrorWithUserInfo as Error)) == true
     }

--- a/PurchasesTests/Networking/DNSCheckerTests.swift
+++ b/PurchasesTests/Networking/DNSCheckerTests.swift
@@ -19,26 +19,31 @@ import XCTest
 
 class DNSCheckerTests: XCTestCase {
 
-    func testResolvedHost() {
-        let host = DNSChecker.resolvedHost(fromURL: URL(string: "https://api.revenuecat.com")!)
-        let validIpAddressRegex = "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
+    let apiURL = URL(string: "https://api.revenuecat.com")!
+    let fakeSubscribersURL1 = URL(string: "https://0.0.0.0/subscribers")!
+    let fakeSubscribersURL2 = URL(string: "https://127.0.0.1/subscribers")!
+    let fakeOffersURL = URL(string: "https://0.0.0.0/offers")!
 
-        expect(host!.range(of: validIpAddressRegex, options: .regularExpression)).toNot(beNil())
+    func testResolvedHost() {
+        let host = DNSChecker.resolvedHost(fromURL: apiURL)
+        let validIPAddressRegex = "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
+
+        expect(host!.range(of: validIPAddressRegex, options: .regularExpression)).toNot(beNil())
         expect(DNSChecker.invalidHosts.contains(host!)).to(equal(false))
     }
 
-    func testIsBlockedURL() {
+    func testIsBlockedURL() throws {
         let blockedURLs = ["https://127.0.0.1/subscribers", "https://0.0.0.0/offers"];
 
         for urlString in blockedURLs {
-            expect(DNSChecker.isBlockedURL(URL(string: urlString)!)) == true
+            expect(DNSChecker.isBlockedURL(try XCTUnwrap(URL(string: urlString)))) == true
         }
 
-        expect(DNSChecker.isBlockedURL(URL(string: "https://api.revenuecat.com/offers")!)) == false
+        expect(DNSChecker.isBlockedURL(try XCTUnwrap(URL(string: "https://api.revenuecat.com/offers")))) == false
     }
 
     func testIsBlockedHostFromError() {
-        let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: URL(string: "https://127.0.0.1/subscribers")!]
+        let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: fakeSubscribersURL2]
         let nsErrorWithUserInfo = NSError(domain: "Testing",
                                           code: -1,
                                           userInfo: userInfo as [String: Any])
@@ -47,7 +52,7 @@ class DNSCheckerTests: XCTestCase {
     }
 
     func testIsBlockedLocalHostIPAPIError() {
-        let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: URL(string: "https://127.0.0.1/subscribers")!]
+        let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: fakeSubscribersURL1]
         let nsErrorWithUserInfo = NSError(domain: NSURLErrorDomain,
                                           code: NSURLErrorCannotConnectToHost,
                                           userInfo: userInfo as [String: Any])
@@ -55,7 +60,7 @@ class DNSCheckerTests: XCTestCase {
     }
 
     func testWrongErrorCode() {
-        let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: URL(string: "https://127.0.0.1/subscribers")!]
+        let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: fakeSubscribersURL2]
         let nsErrorWithUserInfo = NSError(domain: NSURLErrorDomain,
                                           code: -1,
                                           userInfo: userInfo as [String: Any])
@@ -63,7 +68,7 @@ class DNSCheckerTests: XCTestCase {
     }
 
     func testWrongErrorDomain() {
-        let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: URL(string: "https://127.0.0.1/subscribers")!]
+        let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: fakeSubscribersURL2]
         let nsErrorWithUserInfo = NSError(domain: "FakeDomain",
                                           code: NSURLErrorCannotConnectToHost,
                                           userInfo: userInfo as [String: Any])
@@ -71,7 +76,7 @@ class DNSCheckerTests: XCTestCase {
     }
 
     func testWrongErrorDomainAndWrongErrorCode() {
-        let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: URL(string: "https://127.0.0.1/subscribers")!]
+        let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: fakeSubscribersURL2]
         let nsErrorWithUserInfo = NSError(domain: "FakeDomain",
                                           code: -1,
                                           userInfo: userInfo as [String: Any])
@@ -79,7 +84,7 @@ class DNSCheckerTests: XCTestCase {
     }
 
     func testIsOnlyValidForCorrectErrorDomainAnd() {
-        let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: URL(string: "https://127.0.0.1/subscribers")!]
+        let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: fakeSubscribersURL2]
         let nsErrorWithUserInfo = NSError(domain: "FakeDomain",
                                           code: NSURLErrorCannotConnectToHost,
                                           userInfo: userInfo as [String: Any])
@@ -87,7 +92,7 @@ class DNSCheckerTests: XCTestCase {
     }
 
     func testIsBlockedZerosIPHostAPIError() {
-        let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: URL(string: "https://0.0.0.0/subscribers")!]
+        let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: fakeSubscribersURL1]
         let nsErrorWithUserInfo = NSError(domain: NSURLErrorDomain,
                                           code: NSURLErrorCannotConnectToHost,
                                           userInfo: userInfo as [String: Any])

--- a/PurchasesTests/Networking/DNSCheckerTests.swift
+++ b/PurchasesTests/Networking/DNSCheckerTests.swift
@@ -1,0 +1,65 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  DNSCheckerTests.swift
+//
+//  Created by Joshua Liebowitz on 12/21/21.
+
+import Foundation
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+class DNSCheckerTests: XCTestCase {
+
+    func testResolvedHost() {
+        let host = DNSChecker.resolvedHost(fromURL: URL(string: "https://api.revenuecat.com")!)
+        let validIpAddressRegex = "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
+
+        expect(host!.range(of: validIpAddressRegex, options: .regularExpression)).toNot(beNil())
+        expect(DNSChecker.invalidHosts.contains(host!)).to(equal(false))
+    }
+
+    func testIsBlockedURL() {
+        let blockedURLs = ["https://127.0.0.1/subscribers", "https://0.0.0.0/offers"];
+
+        for urlString in blockedURLs {
+            expect(DNSChecker.isBlockedURL(URL(string: urlString)!)) == true
+        }
+
+        expect(DNSChecker.isBlockedURL(URL(string: "https://api.revenuecat.com/offers")!)) == false
+    }
+
+    func testIsBlockedHostFromError() {
+        let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: URL(string: "https://127.0.0.1/subscribers")!]
+        let nsErrorWithUserInfo = NSError(domain: "Testing",
+                                          code: -1,
+                                          userInfo: userInfo as [String: Any])
+        let blocked = DNSChecker.blockedHostFromError(nsErrorWithUserInfo as Error)
+        expect(blocked) == "127.0.0.1"
+    }
+
+    func testIsBlockedLocalHostIPAPIError() {
+        let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: URL(string: "https://127.0.0.1/subscribers")!]
+        let nsErrorWithUserInfo = NSError(domain: "Testing",
+                                          code: -1,
+                                          userInfo: userInfo as [String: Any])
+        expect(DNSChecker.isBlockedAPIError(nsErrorWithUserInfo as Error)) == true
+    }
+
+    func testIsBlockedZerosIPHostAPIError() {
+        let userInfo: [String: Any] = [NSURLErrorFailingURLErrorKey: URL(string: "https://0.0.0.0/subscribers")!]
+        let nsErrorWithUserInfo = NSError(domain: "Testing",
+                                          code: -1,
+                                          userInfo: userInfo as [String: Any])
+        expect(DNSChecker.isBlockedAPIError(nsErrorWithUserInfo as Error)) == true
+    }
+
+}

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -209,16 +209,16 @@
 		42F1DF385E3C1F9903A07FBF /* ProductsFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */; };
 		5746508C27586B2E0053AB09 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5746508B27586B2E0053AB09 /* Result+Extensions.swift */; };
 		5746508E275949F20053AB09 /* DispatchTimeInterval+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5746508D275949F20053AB09 /* DispatchTimeInterval+Extensions.swift */; };
-		5791A1C82767FC9400C972AA /* ManageSubscriptionsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791A1C72767FC9400C972AA /* ManageSubscriptionsHelperTests.swift */; };
 		5791A1AA2767E42B00C972AA /* SKProduct+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791A1A92767E42A00C972AA /* SKProduct+Extensions.swift */; };
+		5791A1C82767FC9400C972AA /* ManageSubscriptionsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791A1C72767FC9400C972AA /* ManageSubscriptionsHelperTests.swift */; };
 		5791CE80273F26A000E50C4B /* base64encoded_sandboxReceipt.txt in Resources */ = {isa = PBXBuildFile; fileRef = 5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */; };
 		57A0FBF02749C0C2009E2FC3 /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */; };
 		57A0FBF22749CF66009E2FC3 /* SynchronizedUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */; };
-		57BD50AA27692B7500211D6D /* StoreKitError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */; };
 		57A17727276A721D0052D3A8 /* Set+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A17726276A721D0052D3A8 /* Set+Extensions.swift */; };
 		57A1772B276A726C0052D3A8 /* SetExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A1772A276A726C0052D3A8 /* SetExtensionsTests.swift */; };
 		57AC4C182770F55C00DDE30F /* SK2StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AC4C172770F55C00DDE30F /* SK2StoreProduct.swift */; };
 		57AC4C1C2770F56200DDE30F /* SK1StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AC4C1B2770F56200DDE30F /* SK1StoreProduct.swift */; };
+		57BD50AA27692B7500211D6D /* StoreKitError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */; };
 		57E2230727500BB1002DB06E /* AtomicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E2230627500BB1002DB06E /* AtomicTests.swift */; };
 		57EAE527274324C60060EB74 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE526274324C60060EB74 /* Lock.swift */; };
 		57EAE52B274332830060EB74 /* Obsoletions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE52A274332830060EB74 /* Obsoletions.swift */; };
@@ -267,6 +267,7 @@
 		B372EC54268FEDC60099171E /* PromotionalOffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B372EC53268FEDC60099171E /* PromotionalOffer.swift */; };
 		B372EC56268FEF020099171E /* ProductInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B372EC55268FEF020099171E /* ProductInfo.swift */; };
 		B3766F1E26BDA95100141450 /* IntroEligibilityResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3766F1D26BDA95100141450 /* IntroEligibilityResponse.swift */; };
+		B380D69B27726AB500984578 /* DNSCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B380D69A27726AB500984578 /* DNSCheckerTests.swift */; };
 		B3852FA026C1ED1F005384F8 /* IdentityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3852F9F26C1ED1F005384F8 /* IdentityManager.swift */; };
 		B390F5BA271DDC7400B64D65 /* PurchasesDeprecation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B390F5B9271DDC7400B64D65 /* PurchasesDeprecation.swift */; };
 		B39E811A268E849900D31189 /* AttributionNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = B39E8119268E849900D31189 /* AttributionNetwork.swift */; };
@@ -284,6 +285,7 @@
 		B3C4AAD526B8911300E1B3C8 /* Backend.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C4AAD426B8911300E1B3C8 /* Backend.swift */; };
 		B3DDB55926854865008CCF23 /* PurchaseOwnershipType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3DDB55826854865008CCF23 /* PurchaseOwnershipType.swift */; };
 		B3E26A4A26BE0A8E003ACCF3 /* Error+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E26A4926BE0A8E003ACCF3 /* Error+Extensions.swift */; };
+		B3F3E8DA277158FE0047A5B9 /* DNSChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F3E8D9277158FE0047A5B9 /* DNSChecker.swift */; };
 		B3F8418F26F3A93400E560FB /* ErrorCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3F8418E26F3A93400E560FB /* ErrorCodeTests.swift */; };
 		F530E4FF275646EF001AF6BD /* MacDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = F530E4FE275646EF001AF6BD /* MacDevice.swift */; };
 		F55FFA5A27634C3F00995146 /* MockTransactionsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55FFA5927634C3F00995146 /* MockTransactionsManager.swift */; };
@@ -561,16 +563,16 @@
 		570896BD27596E8800296F1C /* ObjCAPITester.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ObjCAPITester.xcodeproj; path = APITesters/ObjCAPITester/ObjCAPITester.xcodeproj; sourceTree = "<group>"; };
 		5746508B27586B2E0053AB09 /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
 		5746508D275949F20053AB09 /* DispatchTimeInterval+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchTimeInterval+Extensions.swift"; sourceTree = "<group>"; };
-		5791A1C72767FC9400C972AA /* ManageSubscriptionsHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionsHelperTests.swift; sourceTree = "<group>"; };
 		5791A1A92767E42A00C972AA /* SKProduct+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SKProduct+Extensions.swift"; sourceTree = "<group>"; };
+		5791A1C72767FC9400C972AA /* ManageSubscriptionsHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionsHelperTests.swift; sourceTree = "<group>"; };
 		5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = base64encoded_sandboxReceipt.txt; sourceTree = "<group>"; };
 		57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 		57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedUserDefaults.swift; sourceTree = "<group>"; };
-		57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoreKitError+Extensions.swift"; sourceTree = "<group>"; };
 		57A17726276A721D0052D3A8 /* Set+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Set+Extensions.swift"; sourceTree = "<group>"; };
 		57A1772A276A726C0052D3A8 /* SetExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetExtensionsTests.swift; sourceTree = "<group>"; };
 		57AC4C172770F55C00DDE30F /* SK2StoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreProduct.swift; sourceTree = "<group>"; };
 		57AC4C1B2770F56200DDE30F /* SK1StoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1StoreProduct.swift; sourceTree = "<group>"; };
+		57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoreKitError+Extensions.swift"; sourceTree = "<group>"; };
 		57E2230627500BB1002DB06E /* AtomicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicTests.swift; sourceTree = "<group>"; };
 		57EAE526274324C60060EB74 /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		57EAE52A274332830060EB74 /* Obsoletions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Obsoletions.swift; sourceTree = "<group>"; };
@@ -609,6 +611,7 @@
 		B372EC53268FEDC60099171E /* PromotionalOffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionalOffer.swift; sourceTree = "<group>"; };
 		B372EC55268FEF020099171E /* ProductInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInfo.swift; sourceTree = "<group>"; };
 		B3766F1D26BDA95100141450 /* IntroEligibilityResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroEligibilityResponse.swift; sourceTree = "<group>"; };
+		B380D69A27726AB500984578 /* DNSCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DNSCheckerTests.swift; sourceTree = "<group>"; };
 		B3852F9F26C1ED1F005384F8 /* IdentityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityManager.swift; sourceTree = "<group>"; };
 		B390F5B9271DDC7400B64D65 /* PurchasesDeprecation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesDeprecation.swift; sourceTree = "<group>"; };
 		B39E8119268E849900D31189 /* AttributionNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributionNetwork.swift; sourceTree = "<group>"; };
@@ -628,6 +631,7 @@
 		B3DDB55826854865008CCF23 /* PurchaseOwnershipType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseOwnershipType.swift; sourceTree = "<group>"; };
 		B3DF6A4F269524080030D57C /* IntroEligibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroEligibility.swift; sourceTree = "<group>"; };
 		B3E26A4926BE0A8E003ACCF3 /* Error+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+Extensions.swift"; sourceTree = "<group>"; };
+		B3F3E8D9277158FE0047A5B9 /* DNSChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DNSChecker.swift; sourceTree = "<group>"; };
 		B3F8418E26F3A93400E560FB /* ErrorCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorCodeTests.swift; sourceTree = "<group>"; };
 		EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsFetcherSK1.swift; sourceTree = "<group>"; };
 		F530E4FE275646EF001AF6BD /* MacDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacDevice.swift; sourceTree = "<group>"; };
@@ -1177,6 +1181,7 @@
 			isa = PBXGroup;
 			children = (
 				B3C4AAD426B8911300E1B3C8 /* Backend.swift */,
+				B3F3E8D9277158FE0047A5B9 /* DNSChecker.swift */,
 				35F6FD61267426D600ABCB53 /* ETagAndResponseWrapper.swift */,
 				35D832CC262A5B7500E60AC5 /* ETagManager.swift */,
 				35F82BB326A9A74D0051DF03 /* HTTPClient.swift */,
@@ -1194,6 +1199,7 @@
 				37E358BF58C99AC39073B96C /* BackendTests.swift */,
 				37E353CBE9CF2572A72A347F /* HTTPClientTests.swift */,
 				35D832FF262FAD8000E60AC5 /* ETagManagerTests.swift */,
+				B380D69A27726AB500984578 /* DNSCheckerTests.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -1865,6 +1871,7 @@
 				2DC19195255F36D10039389A /* Logger.swift in Sources */,
 				2DDF419F24F6F331005BC22D /* ReceiptParsingError.swift in Sources */,
 				2DDF419D24F6F331005BC22D /* IntroEligibilityCalculator.swift in Sources */,
+				B3F3E8DA277158FE0047A5B9 /* DNSChecker.swift in Sources */,
 				A525BF4B26C320D100C354C4 /* SubscriberAttributesManager.swift in Sources */,
 				B3E26A4A26BE0A8E003ACCF3 /* Error+Extensions.swift in Sources */,
 				57EAE52D274468900060EB74 /* RawDataContainer.swift in Sources */,
@@ -1977,6 +1984,7 @@
 				35F8B8FA26E02AE1003C3363 /* MockTrialOrIntroPriceEligibilityChecker.swift in Sources */,
 				35D83300262FAD8000E60AC5 /* ETagManagerTests.swift in Sources */,
 				351B514126D4498F00BD2BD7 /* MockBackend.swift in Sources */,
+				B380D69B27726AB500984578 /* DNSCheckerTests.swift in Sources */,
 				351B513B26D448F400BD2BD7 /* AttributionPosterTests.swift in Sources */,
 				351B51B526D450E800BD2BD7 /* ProductsFetcherSK1Tests.swift in Sources */,
 				2DDF41CC24F6F4C3005BC22D /* AppleReceiptBuilderTests.swift in Sources */,


### PR DESCRIPTION
api.revenuecat.com is falsely flagged as an ad-based domain. 
Let's detect this issue and log it. 
Note: if developers receive an error when making an API request, they can inspect `NSURLErrorFailingURLErrorKey` for the url. If they see `0.0.0.0` or `127.0.0.1`, the request was blocked at the DNS level.
