### PR TITLE
Removed `ErrorUtils` `generatedBy` parameter

### DIFF
--- a/Purchases/Error Handling/ErrorDetails.swift
+++ b/Purchases/Error Handling/ErrorDetails.swift
@@ -18,7 +18,6 @@ class ErrorDetails: NSObject {
 
     static let finishableKey: NSError.UserInfoKey = "finishable"
     static let readableErrorCodeKey: NSError.UserInfoKey = "readable_error_code"
-    static let generatedByKey: NSError.UserInfoKey = "generated_by"
     static let extraContextKey: NSError.UserInfoKey = "extra_context"
     static let fileKey: NSError.UserInfoKey = "source_file"
     static let functionKey: NSError.UserInfoKey = "source_function"

--- a/Purchases/Error Handling/ErrorUtils.swift
+++ b/Purchases/Error Handling/ErrorUtils.swift
@@ -29,10 +29,10 @@ enum ErrorUtils {
      * is an `NSJSONSerialization` error.
      */
     static func networkError(
-        withUnderlyingError underlyingError: Error, generatedBy: String? = nil,
+        withUnderlyingError underlyingError: Error,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
     ) -> Error {
-        return error(with: .networkError, underlyingError: underlyingError, generatedBy: generatedBy,
+        return error(with: .networkError, underlyingError: underlyingError,
                      fileName: fileName, functionName: functionName, line: line)
     }
 
@@ -105,12 +105,10 @@ enum ErrorUtils {
      */
     static func unexpectedBackendResponse(
         withSubError maybeSubError: Error?,
-        generatedBy maybeGeneratedBy: String? = nil,
         extraContext maybeExtraContext: String? = nil,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
     ) -> Error {
         return backendResponseError(withSubError: maybeSubError,
-                                    generatedBy: maybeGeneratedBy,
                                     extraContext: maybeExtraContext,
                                     fileName: fileName, functionName: functionName, line: line)
     }
@@ -405,7 +403,6 @@ private extension ErrorUtils {
     static func error(with code: ErrorCode,
                       message: String? = nil,
                       underlyingError: Error? = nil,
-                      generatedBy: String? = nil,
                       extraUserInfo: [NSError.UserInfoKey: Any]? = nil,
                       fileName: String = #fileID,
                       functionName: String = #function,
@@ -415,7 +412,6 @@ private extension ErrorUtils {
         if let maybeUnderlyingError = underlyingError {
             userInfo[NSUnderlyingErrorKey as NSError.UserInfoKey] = maybeUnderlyingError
         }
-        userInfo[ErrorDetails.generatedByKey] = generatedBy
         userInfo[ErrorDetails.readableErrorCodeKey] = code.codeName
         userInfo[ErrorDetails.fileKey] = "\(fileName):\(line)"
         userInfo[ErrorDetails.functionKey] = functionName
@@ -432,7 +428,6 @@ private extension ErrorUtils {
 
     static func backendResponseError(
         withSubError maybeSubError: Error?,
-        generatedBy maybeGeneratedBy: String?,
         extraContext maybeExtraContext: String?,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
     ) -> Error {
@@ -442,7 +437,6 @@ private extension ErrorUtils {
         userInfo[NSLocalizedDescriptionKey as NSError.UserInfoKey] = errorDescription
         userInfo[NSUnderlyingErrorKey as NSError.UserInfoKey] = maybeSubError
         userInfo[ErrorDetails.readableErrorCodeKey] = ErrorCode.unexpectedBackendResponseError.codeName
-        userInfo[ErrorDetails.generatedByKey] = maybeGeneratedBy
         userInfo[ErrorDetails.extraContextKey] = maybeExtraContext
         userInfo[ErrorDetails.fileKey] = "\(fileName):\(line)"
         userInfo[ErrorDetails.functionKey] = functionName

--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -602,9 +602,11 @@ private extension Backend {
                 maybeError: Error?,
                 file: String = #fileID,
                 function: String = #function,
+                line: UInt = #line,
                 completion: BackendCustomerInfoResponseHandler) {
         if let error = maybeError {
-            completion(nil, ErrorUtils.networkError(withUnderlyingError: error, generatedBy: "\(file) \(function)"))
+            completion(nil, ErrorUtils.networkError(withUnderlyingError: error,
+                                                    fileName: file, functionName: function, line: line))
             return
         }
         let isErrorStatusCode = statusCode >= HTTPStatusCodes.redirect.rawValue
@@ -629,8 +631,8 @@ private extension Backend {
         if !isErrorStatusCode && maybeCustomerInfo == nil {
             let extraContext = "statusCode: \(statusCode), json:\(maybeResponse.debugDescription)"
             completion(nil, ErrorUtils.unexpectedBackendResponse(withSubError: maybeCustomerInfoError,
-                                                                 generatedBy: "\(file) \(function)",
-                                                                 extraContext: extraContext))
+                                                                 extraContext: extraContext,
+                                                                 fileName: file, functionName: function, line: line))
             return
         }
 


### PR DESCRIPTION
This was only used in a couple isolated places. #1078 introduced a more general approach.