### PR TITLE
`ProductInfo`: replaced manual encoding with `Encodable` implementation

### DIFF
--- a/Purchases/FoundationExtensions/JSONDecoder+Extensions.swift
+++ b/Purchases/FoundationExtensions/JSONDecoder+Extensions.swift
@@ -115,3 +115,18 @@ private extension ErrorUtils {
      }
 
 }
+
+extension Encodable {
+
+    func asDictionary() throws -> [String: Any] {
+        let data = try JSONEncoder().encode(self)
+        let result = try JSONSerialization.jsonObject(with: data, options: [])
+
+        guard let result = result as? [String: Any] else {
+            throw CodableError.unexpectedValue(type(of: result))
+        }
+
+        return result
+    }
+
+}

--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -113,7 +113,12 @@ class Backend {
         }
 
         if let productInfo = productInfo {
-            body.merge(productInfo.asDictionary()) { _, new in new }
+            do {
+                body.merge(try productInfo.asDictionary()) { _, new in new }
+            } catch {
+                completion(nil, error)
+                return
+            }
         }
 
         if let subscriberAttributesByKey = subscriberAttributesByKey {

--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -114,7 +114,7 @@ class Backend {
 
         if let productInfo = productInfo {
             do {
-                body.merge(try productInfo.asDictionary()) { _, new in new }
+                body += try productInfo.asDictionary()
             } catch {
                 completion(nil, error)
                 return

--- a/Purchases/Purchasing/ProductInfo.swift
+++ b/Purchases/Purchasing/ProductInfo.swift
@@ -64,6 +64,8 @@ extension ProductInfo: Encodable {
 
     }
 
+    // Note: prices are encoded price as `String` (using `NSDecimalNumber.description`)
+    // to preserve precision and avoid values like "1.89999999"
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 

--- a/Purchases/Purchasing/ProductInfo.swift
+++ b/Purchases/Purchasing/ProductInfo.swift
@@ -73,11 +73,12 @@ extension ProductInfo: Encodable {
             try container.encode(self.paymentMode, forKey: .paymentMode)
         }
         try container.encode(self.currencyCode, forKey: .currencyCode)
-        try container.encode(self.price, forKey: .price)
+        try container.encode((self.price as NSDecimalNumber).description, forKey: .price)
         try container.encodeIfPresent(self.subscriptionGroup, forKey: .subscriptionGroup)
         try container.encodeIfPresent(self.discounts, forKey: .discounts)
 
-        try container.encodeIfPresent(self.introPrice, forKey: .introPrice)
+        try container.encodeIfPresent((self.introPrice as NSDecimalNumber?)?.description,
+                                      forKey: .introPrice)
 
         try container.encodeIfPresent(self.normalDuration, forKey: .normalDuration)
 

--- a/Purchases/Purchasing/ProductInfoExtractor.swift
+++ b/Purchases/Purchasing/ProductInfoExtractor.swift
@@ -32,11 +32,11 @@ enum ProductInfoExtractor {
             productIdentifier: product.productIdentifier,
             paymentMode: paymentMode,
             currencyCode: product.priceLocale.rc_currencyCode(),
-            price: product.price,
+            price: product.price as Decimal,
             normalDuration: normalDuration,
             introDuration: introDuration,
             introDurationType: introDurationType,
-            introPrice: introPrice,
+            introPrice: introPrice as Decimal?,
             subscriptionGroup: subscriptionGroup,
             discounts: discounts
         )

--- a/Purchases/Purchasing/PromotionalOffer.swift
+++ b/Purchases/Purchasing/PromotionalOffer.swift
@@ -124,3 +124,21 @@ extension PromotionalOffer.PaymentMode {
         }
     }
 }
+
+// MARK: - Encodable
+
+extension PromotionalOffer: Encodable {
+
+    private enum CodingKeys: String, CodingKey {
+
+        case offerIdentifier = "offer_identifier"
+        case price = "price"
+        case paymentMode = "payment_mode"
+        case subscriptionPeriod = "subscription_period"
+
+    }
+
+}
+
+extension PromotionalOffer.PaymentMode: Encodable { }
+extension PromotionalOffer.IntroDurationType: Encodable { }

--- a/Purchases/Purchasing/PromotionalOffer.swift
+++ b/Purchases/Purchasing/PromotionalOffer.swift
@@ -141,6 +141,8 @@ extension PromotionalOffer: Encodable {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         try container.encode(self.offerIdentifier, forKey: .offerIdentifier)
+        // Note: price is encoded price as `String` (using `NSDecimalNumber.description`)
+        // to preserve precision and avoid values like "1.89999999"
         try container.encode((self.price as NSDecimalNumber).description, forKey: .price)
         try container.encode(self.paymentMode, forKey: .paymentMode)
     }

--- a/Purchases/Purchasing/PromotionalOffer.swift
+++ b/Purchases/Purchasing/PromotionalOffer.swift
@@ -134,7 +134,6 @@ extension PromotionalOffer: Encodable {
         case offerIdentifier = "offer_identifier"
         case price = "price"
         case paymentMode = "payment_mode"
-        case subscriptionPeriod = "subscription_period"
 
     }
 

--- a/Purchases/Purchasing/PromotionalOffer.swift
+++ b/Purchases/Purchasing/PromotionalOffer.swift
@@ -137,6 +137,14 @@ extension PromotionalOffer: Encodable {
 
     }
 
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(self.offerIdentifier, forKey: .offerIdentifier)
+        try container.encode((self.price as NSDecimalNumber).description, forKey: .price)
+        try container.encode(self.paymentMode, forKey: .paymentMode)
+    }
+
 }
 
 extension PromotionalOffer.PaymentMode: Encodable { }

--- a/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
@@ -135,3 +135,8 @@ fileprivate extension SubscriptionPeriod.Unit {
     }
 
 }
+
+// MARK: - Encodable
+
+extension SubscriptionPeriod.Unit: Encodable { }
+extension SubscriptionPeriod: Encodable { }

--- a/PurchasesTests/Mocks/MockSK1Product.swift
+++ b/PurchasesTests/Mocks/MockSK1Product.swift
@@ -28,9 +28,9 @@ class MockSK1Product: SK1Product {
         return mockPriceLocale ?? Locale(identifier: "en_US")
     }
 
-    var mockPrice: NSDecimalNumber?
+    var mockPrice: Decimal?
     override var price: NSDecimalNumber {
-        return mockPrice ?? 2.99 as NSDecimalNumber
+        return (mockPrice ?? 2.99) as NSDecimalNumber
     }
 
     @available(iOS 11.2, macCatalyst 13.0, tvOS 11.2, macOS 10.13.2, *)

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -370,7 +370,7 @@ class BackendTests: XCTestCase {
 
         let productIdentifier = "a_great_product"
         let offeringIdentifier = "a_offering"
-        let price = 4.99 as NSDecimalNumber
+        let price: Decimal = 4.99
         let group = "sub_group"
 
         let currencyCode = "BFD"
@@ -420,7 +420,7 @@ class BackendTests: XCTestCase {
 
             expect(call.path).to(equal(expectedCall.path))
             expect(call.HTTPMethod).to(equal(expectedCall.HTTPMethod))
-            XCTAssert(call.body!.keys == expectedCall.body!.keys)
+            expect(call.body!.keys) == expectedCall.body!.keys
 
             expect(call.headers["Authorization"]).toNot(beNil())
             expect(call.headers["Authorization"]).to(equal(expectedCall.headers["Authorization"]))
@@ -1238,7 +1238,7 @@ class BackendTests: XCTestCase {
         httpClient.mock(requestPath: "/receipts", response: response)
         
         let productIdentifier = "a_great_product"
-        let price = 4.99 as NSDecimalNumber
+        let price: Decimal = 4.99
         let group = "sub_group"
         let currencyCode = "BFD"
         let paymentMode: PromotionalOffer.PaymentMode = .none

--- a/PurchasesTests/Purchasing/ProductInfoExtensions.swift
+++ b/PurchasesTests/Purchasing/ProductInfoExtensions.swift
@@ -10,11 +10,11 @@ extension ProductInfo {
     static func createMockProductInfo(productIdentifier: String = "product_id",
                                       paymentMode: PromotionalOffer.PaymentMode = .none,
                                       currencyCode: String = "UYU",
-                                      price: NSDecimalNumber = 15.99,
+                                      price: Decimal = 15.99,
                                       normalDuration: String? = nil,
                                       introDuration: String? = nil,
                                       introDurationType: PromotionalOffer.IntroDurationType = .none,
-                                      introPrice: NSDecimalNumber? = nil,
+                                      introPrice: Decimal? = nil,
                                       subscriptionGroup: String? = nil,
                                       discounts: [PromotionalOffer]? = nil) -> ProductInfo {
         ProductInfo(productIdentifier: productIdentifier,

--- a/PurchasesTests/Purchasing/ProductInfoExtractorTests.swift
+++ b/PurchasesTests/Purchasing/ProductInfoExtractorTests.swift
@@ -24,7 +24,7 @@ class ProductInfoExtractorTests: XCTestCase {
     }
 
     func testExtractInfoFromProductExtractsPrice() {
-        let price: NSDecimalNumber = 10.99
+        let price: Decimal = 10.99
         product.mockPrice = price
 
         let receivedProductInfo = self.extract()

--- a/PurchasesTests/Purchasing/ProductInfoTests.swift
+++ b/PurchasesTests/Purchasing/ProductInfoTests.swift
@@ -44,7 +44,7 @@ class ProductInfoTests: XCTestCase {
     func testAsDictionaryConvertsPriceCorrectly() throws {
         let price: NSDecimalNumber = 9.99
         let productInfo: ProductInfo = .createMockProductInfo(price: price as Decimal)
-        expect(try productInfo.asDictionary()["price"] as? NSNumber) == price
+        expect(try productInfo.asDictionary()["price"] as? String) == price.description
     }
 
     func testAsDictionaryConvertsNormalDurationCorrectly() throws {
@@ -80,7 +80,7 @@ class ProductInfoTests: XCTestCase {
     func testAsDictionaryConvertsIntroPriceCorrectly() throws {
         let introPrice: NSDecimalNumber = 6.99
         let productInfo: ProductInfo = .createMockProductInfo(introPrice: introPrice as Decimal)
-        expect(try productInfo.asDictionary()["introductory_price"] as? NSNumber) == introPrice
+        expect(try productInfo.asDictionary()["introductory_price"]) as? String == introPrice.description
     }
 
     func testAsDictionaryConvertsSubscriptionGroupCorrectly() {
@@ -111,15 +111,15 @@ class ProductInfoTests: XCTestCase {
         let receivedOffers = try XCTUnwrap(dictionary["offers"] as? [[String: NSObject]])
 
         expect(receivedOffers[0]["offer_identifier"] as? String) == discount1.offerIdentifier
-        expect(receivedOffers[0]["price"] as? NSNumber) == discount1.price as NSDecimalNumber
+        expect(receivedOffers[0]["price"] as? String) == discount1.price.description
         expect((receivedOffers[0]["payment_mode"] as? NSNumber)?.intValue) == discount1.paymentMode.rawValue
         
         expect(receivedOffers[1]["offer_identifier"] as? String) == discount2.offerIdentifier
-        expect(receivedOffers[1]["price"] as? NSNumber) == discount2.price as NSDecimalNumber
+        expect(receivedOffers[1]["price"] as? String) == discount2.price.description
         expect((receivedOffers[1]["payment_mode"] as? NSNumber)?.intValue) == discount2.paymentMode.rawValue
         
         expect(receivedOffers[2]["offer_identifier"] as? String) == discount3.offerIdentifier
-        expect(receivedOffers[2]["price"] as? NSNumber) == discount3.price as NSDecimalNumber
+        expect(receivedOffers[2]["price"] as? String) == discount3.price.description
         expect((receivedOffers[2]["payment_mode"] as? NSNumber)?.intValue) == discount3.paymentMode.rawValue
     }
     
@@ -146,7 +146,7 @@ class ProductInfoTests: XCTestCase {
                                                               normalDuration: "P3Y",
                                                               introDuration: "P3W",
                                                               introDurationType: .freeTrial,
-                                                              introPrice: 0,
+                                                              introPrice: 15.13,
                                                               subscriptionGroup: "cool_group",
                                                               discounts: [discount1, discount2, discount3])
 

--- a/PurchasesTests/Purchasing/ProductInfoTests.swift
+++ b/PurchasesTests/Purchasing/ProductInfoTests.swift
@@ -5,124 +5,122 @@ import SnapshotTesting
 @testable import RevenueCat
 
 class ProductInfoTests: XCTestCase {
-    func testAsDictionaryConvertsProductIdentifierCorrectly() {
+    func testAsDictionaryConvertsProductIdentifierCorrectly() throws {
         let productIdentifier = "cool_product"
         let productInfo: ProductInfo = .createMockProductInfo(productIdentifier: productIdentifier)
-        expect(productInfo.asDictionary()["product_id"] as? String) == productIdentifier
+        expect(try productInfo.asDictionary()["product_id"] as? String) == productIdentifier
     }
 
-    func testAsDictionaryConvertsPaymentModeCorrectly() {
+    func testAsDictionaryConvertsPaymentModeCorrectly() throws {
         var paymentMode: PromotionalOffer.PaymentMode = .none
         var productInfo: ProductInfo = .createMockProductInfo(paymentMode: paymentMode)
-        expect(productInfo.asDictionary()["payment_mode"]).to(beNil())
+        expect(try productInfo.asDictionary()["payment_mode"]).to(beNil())
 
         paymentMode = .payAsYouGo
         productInfo = .createMockProductInfo(paymentMode: paymentMode)
 
-        var receivedPaymentMode = (productInfo.asDictionary()["payment_mode"] as? NSNumber)?.intValue
+        var receivedPaymentMode = (try productInfo.asDictionary()["payment_mode"] as? NSNumber)?.intValue
         expect(receivedPaymentMode) == paymentMode.rawValue
 
         paymentMode = .freeTrial
         productInfo = .createMockProductInfo(paymentMode: paymentMode)
 
-        receivedPaymentMode = (productInfo.asDictionary()["payment_mode"] as? NSNumber)?.intValue
+        receivedPaymentMode = (try productInfo.asDictionary()["payment_mode"] as? NSNumber)?.intValue
         expect(receivedPaymentMode) == paymentMode.rawValue
 
         paymentMode = .payUpFront
         productInfo = .createMockProductInfo(paymentMode: paymentMode)
 
-        receivedPaymentMode = (productInfo.asDictionary()["payment_mode"] as? NSNumber)?.intValue
+        receivedPaymentMode = (try productInfo.asDictionary()["payment_mode"] as? NSNumber)?.intValue
         expect(receivedPaymentMode) == paymentMode.rawValue
     }
 
-    func testAsDictionaryConvertsCurrencyCodeCorrectly() {
+    func testAsDictionaryConvertsCurrencyCodeCorrectly() throws {
         let currencyCode = "USD"
         let productInfo: ProductInfo = .createMockProductInfo(currencyCode: currencyCode)
-        expect(productInfo.asDictionary()["currency"] as? String) == currencyCode
+        expect(try productInfo.asDictionary()["currency"] as? String) == currencyCode
     }
 
-    func testAsDictionaryConvertsPriceCorrectly() {
+    func testAsDictionaryConvertsPriceCorrectly() throws {
         let price: NSDecimalNumber = 9.99
-        let productInfo: ProductInfo = .createMockProductInfo(price: price)
-        expect(productInfo.asDictionary()["price"] as? NSDecimalNumber) == price
+        let productInfo: ProductInfo = .createMockProductInfo(price: price as Decimal)
+        expect(try productInfo.asDictionary()["price"] as? NSNumber) == price
     }
 
-    func testAsDictionaryConvertsNormalDurationCorrectly() {
+    func testAsDictionaryConvertsNormalDurationCorrectly() throws {
         let normalDuration = "P3Y"
         let productInfo: ProductInfo = .createMockProductInfo(normalDuration: normalDuration)
-        expect(productInfo.asDictionary()["normal_duration"] as? String) == normalDuration
+        expect(try productInfo.asDictionary()["normal_duration"] as? String) == normalDuration
     }
 
-    func testAsDictionaryConvertsIntroDurationCorrectlyForFreeTrial() {
+    func testAsDictionaryConvertsIntroDurationCorrectlyForFreeTrial() throws {
         let trialDuration = "P3M"
         let productInfo: ProductInfo = .createMockProductInfo(introDuration: trialDuration,
                                                                 introDurationType: .freeTrial)
-        expect(productInfo.asDictionary()["trial_duration"] as? String) == trialDuration
-        expect(productInfo.asDictionary()["intro_duration"]).to(beNil())
+        expect(try productInfo.asDictionary()["trial_duration"] as? String) == trialDuration
+        expect(try productInfo.asDictionary()["intro_duration"]).to(beNil())
     }
 
-    func testAsDictionaryConvertsIntroDurationCorrectlyForIntroPrice() {
+    func testAsDictionaryConvertsIntroDurationCorrectlyForIntroPrice() throws {
         let introDuration = "P3M"
         let productInfo: ProductInfo = .createMockProductInfo(introDuration: introDuration,
-                                                                introDurationType: .introPrice)
-        expect(productInfo.asDictionary()["intro_duration"] as? String) == introDuration
-        expect(productInfo.asDictionary()["trial_duration"]).to(beNil())
+                                               introDurationType: .introPrice)
+        expect(try productInfo.asDictionary()["intro_duration"] as? String) == introDuration
+        expect(try productInfo.asDictionary()["trial_duration"]).to(beNil())
     }
 
-    func testAsDictionaryDoesntAddIntroDurationIfDurationTypeNone() {
+    func testAsDictionaryDoesntAddIntroDurationIfDurationTypeNone() throws {
         let introDuration = "P3M"
         let productInfo: ProductInfo = .createMockProductInfo(introDuration: introDuration,
-                                                                introDurationType: .none)
-        expect(productInfo.asDictionary()["trial_duration"]).to(beNil())
-        expect(productInfo.asDictionary()["intro_duration"]).to(beNil())
+                                               introDurationType: .none)
+        expect(try productInfo.asDictionary()["trial_duration"]).to(beNil())
+        expect(try productInfo.asDictionary()["intro_duration"]).to(beNil())
     }
 
-    func testAsDictionaryConvertsIntroPriceCorrectly() {
+    func testAsDictionaryConvertsIntroPriceCorrectly() throws {
         let introPrice: NSDecimalNumber = 6.99
-        let productInfo: ProductInfo = .createMockProductInfo(introPrice: 6.99)
-        expect(productInfo.asDictionary()["introductory_price"] as? NSDecimalNumber) == introPrice
+        let productInfo: ProductInfo = .createMockProductInfo(introPrice: introPrice as Decimal)
+        expect(try productInfo.asDictionary()["introductory_price"] as? NSNumber) == introPrice
     }
 
     func testAsDictionaryConvertsSubscriptionGroupCorrectly() {
         let subscriptionGroup = "cool_group"
         let productInfo: ProductInfo = .createMockProductInfo(subscriptionGroup: subscriptionGroup)
-        expect(productInfo.asDictionary()["subscription_group_id"] as? String) == subscriptionGroup
+        expect(try productInfo.asDictionary()["subscription_group_id"] as? String) == subscriptionGroup
     }
 
     func testAsDictionaryConvertsDiscountsCorrectly() throws {
-        guard #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *) else { return }
         let discount1 = PromotionalOffer(offerIdentifier: "offerid1",
-                                         price: 11,
+                                         price: 11.1,
                                          paymentMode: .payAsYouGo,
                                          subscriptionPeriod: .init(value: 1, unit: .month))
         
         let discount2 = PromotionalOffer(offerIdentifier: "offerid2",
-                                         price: 12,
+                                         price: 12.2,
                                          paymentMode: .payUpFront,
                                          subscriptionPeriod: .init(value: 5, unit: .week))
         
         let discount3 = PromotionalOffer(offerIdentifier: "offerid3",
-                                         price: 13,
+                                         price: 13.3,
                                          paymentMode: .freeTrial,
                                          subscriptionPeriod: .init(value: 3, unit: .month))
         
         let productInfo: ProductInfo = .createMockProductInfo(discounts: [discount1, discount2, discount3])
-        
-        expect(productInfo.asDictionary()["offers"] as? [[String: NSObject]]).toNot(beNil())
-        let receivedOffers = try XCTUnwrap(productInfo.asDictionary()["offers"] as? [[String: NSObject]])
+
+        let dictionary = try productInfo.asDictionary()
+        let receivedOffers = try XCTUnwrap(dictionary["offers"] as? [[String: NSObject]])
 
         expect(receivedOffers[0]["offer_identifier"] as? String) == discount1.offerIdentifier
-        expect(receivedOffers[0]["price"] as? Decimal) == discount1.price
+        expect(receivedOffers[0]["price"] as? NSNumber) == discount1.price as NSDecimalNumber
         expect((receivedOffers[0]["payment_mode"] as? NSNumber)?.intValue) == discount1.paymentMode.rawValue
         
         expect(receivedOffers[1]["offer_identifier"] as? String) == discount2.offerIdentifier
-        expect(receivedOffers[1]["price"] as? Decimal) == discount2.price
+        expect(receivedOffers[1]["price"] as? NSNumber) == discount2.price as NSDecimalNumber
         expect((receivedOffers[1]["payment_mode"] as? NSNumber)?.intValue) == discount2.paymentMode.rawValue
         
         expect(receivedOffers[2]["offer_identifier"] as? String) == discount3.offerIdentifier
-        expect(receivedOffers[2]["price"] as? Decimal) == discount3.price
+        expect(receivedOffers[2]["price"] as? NSNumber) == discount3.price as NSDecimalNumber
         expect((receivedOffers[2]["payment_mode"] as? NSNumber)?.intValue) == discount3.paymentMode.rawValue
-        
     }
     
     func testEncoding() throws {

--- a/PurchasesTests/Purchasing/ProductInfoTests.swift
+++ b/PurchasesTests/Purchasing/ProductInfoTests.swift
@@ -125,17 +125,17 @@ class ProductInfoTests: XCTestCase {
     
     func testEncoding() throws {
         let discount1 = PromotionalOffer(offerIdentifier: "offerid1",
-                                         price: 11,
+                                         price: 11.2,
                                          paymentMode: .payAsYouGo,
                                          subscriptionPeriod: .init(value: 1, unit: .month))
 
         let discount2 = PromotionalOffer(offerIdentifier: "offerid2",
-                                         price: 12,
+                                         price: 12.2,
                                          paymentMode: .payUpFront,
                                          subscriptionPeriod: .init(value: 2, unit: .year))
 
         let discount3 = PromotionalOffer(offerIdentifier: "offerid3",
-                                         price: 13,
+                                         price: 13.3,
                                          paymentMode: .freeTrial,
                                          subscriptionPeriod: .init(value: 3, unit: .day))
 

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -115,9 +115,9 @@ class PurchasesTests: XCTestCase {
         var postedReceiptData: Data?
         var postedIsRestore: Bool?
         var postedProductID: String?
-        var postedPrice: NSDecimalNumber?
+        var postedPrice: Decimal?
         var postedPaymentMode: PromotionalOffer.PaymentMode?
-        var postedIntroPrice: NSDecimalNumber?
+        var postedIntroPrice: Decimal?
         var postedCurrencyCode: String?
         var postedSubscriptionGroup: String?
         var postedDiscounts: Array<PromotionalOffer>?
@@ -812,11 +812,11 @@ class PurchasesTests: XCTestCase {
             expect(self.backend.postedReceiptData).toNot(beNil())
 
             expect(self.backend.postedProductID).to(equal(product.productIdentifier))
-            expect(self.backend.postedPrice).to(equal(product.price))
+            expect(self.backend.postedPrice).to(equal(product.price as Decimal))
 
             if #available(iOS 11.2, tvOS 11.2, macOS 10.13.2, *) {
                 expect(self.backend.postedPaymentMode).to(equal(PromotionalOffer.PaymentMode.payAsYouGo))
-                expect(self.backend.postedIntroPrice).to(equal(product.introductoryPrice?.price))
+                expect(self.backend.postedIntroPrice).to(equal(product.introductoryPrice?.price as Decimal?))
             } else {
                 expect(self.backend.postedPaymentMode).to(equal(PromotionalOffer.PaymentMode.none))
                 expect(self.backend.postedIntroPrice).to(beNil())
@@ -1476,7 +1476,7 @@ class PurchasesTests: XCTestCase {
 
         expect(self.backend.postReceiptDataCalled).to(beTrue())
         expect(self.backend.postedProductID).to(equal(product.productIdentifier))
-        expect(self.backend.postedPrice).to(equal(product.price))
+        expect(self.backend.postedPrice).to(equal(product.price as Decimal))
     }
 
     func testPromoPaymentDelegateMethodCachesProduct() {
@@ -1825,7 +1825,7 @@ class PurchasesTests: XCTestCase {
             expect(self.backend.postedReceiptData).toNot(beNil())
 
             expect(self.backend.postedProductID).to(equal(product.productIdentifier))
-            expect(self.backend.postedPrice).to(equal(product.price))
+            expect(self.backend.postedPrice).to(equal(product.price as Decimal))
             expect(self.backend.postedCurrencyCode).to(equal(product.priceLocale.currencyCode))
 
             expect(self.storeKitWrapper.finishCalled).toEventually(beTrue())
@@ -2410,7 +2410,7 @@ class PurchasesTests: XCTestCase {
             expect(self.backend.postedReceiptData).toNot(beNil())
 
             expect(self.backend.postedProductID).to(equal(package.storeProduct.productIdentifier))
-            expect(self.backend.postedPrice) == package.storeProduct.price as NSDecimalNumber
+            expect(self.backend.postedPrice) == package.storeProduct.price
             expect(self.backend.postedOfferingIdentifier).to(equal("base"))
             expect(self.storeKitWrapper.finishCalled).toEventually(beTrue())
         }

--- a/PurchasesTests/Purchasing/__Snapshots__/ProductInfoTests/testEncoding.1.json
+++ b/PurchasesTests/Purchasing/__Snapshots__/ProductInfoTests/testEncoding.1.json
@@ -1,26 +1,26 @@
 {
   "currency" : "UYU",
-  "introductory_price" : 0,
+  "introductory_price" : "15.13",
   "normal_duration" : "P3Y",
   "offers" : [
     {
       "offer_identifier" : "offerid1",
       "payment_mode" : 0,
-      "price" : 11.199999999999999
+      "price" : "11.2"
     },
     {
       "offer_identifier" : "offerid2",
       "payment_mode" : 1,
-      "price" : 12.199999999999999
+      "price" : "12.2"
     },
     {
       "offer_identifier" : "offerid3",
       "payment_mode" : 2,
-      "price" : 13.300000000000001
+      "price" : "13.3"
     }
   ],
   "payment_mode" : 1,
-  "price" : 49.990000000000002,
+  "price" : "49.99",
   "product_id" : "cool_product",
   "subscription_group_id" : "cool_group",
   "trial_duration" : "P3W"

--- a/PurchasesTests/Purchasing/__Snapshots__/ProductInfoTests/testEncoding.1.json
+++ b/PurchasesTests/Purchasing/__Snapshots__/ProductInfoTests/testEncoding.1.json
@@ -6,17 +6,17 @@
     {
       "offer_identifier" : "offerid1",
       "payment_mode" : 0,
-      "price" : 11
+      "price" : 11.199999999999999
     },
     {
       "offer_identifier" : "offerid2",
       "payment_mode" : 1,
-      "price" : 12
+      "price" : 12.199999999999999
     },
     {
       "offer_identifier" : "offerid3",
       "payment_mode" : 2,
-      "price" : 13
+      "price" : 13.300000000000001
     }
   ],
   "payment_mode" : 1,

--- a/PurchasesTests/Purchasing/__Snapshots__/ProductInfoTests/testEncoding.1.json
+++ b/PurchasesTests/Purchasing/__Snapshots__/ProductInfoTests/testEncoding.1.json
@@ -20,7 +20,7 @@
     }
   ],
   "payment_mode" : 1,
-  "price" : 49.99,
+  "price" : 49.990000000000002,
   "product_id" : "cool_product",
   "subscription_group_id" : "cool_group",
   "trial_duration" : "P3W"


### PR DESCRIPTION
First step towards #1045.

I've run the new test introduced in #1109 and this is backwards compatible.