### PR TITLE
Removed `PromotionalOffer.IntroDurationType` in favor of `PaymentMode`

### DIFF
--- a/Purchases/Purchasing/ProductInfo.swift
+++ b/Purchases/Purchasing/ProductInfo.swift
@@ -24,7 +24,7 @@ struct ProductInfo {
     let price: Decimal
     let normalDuration: String?
     let introDuration: String?
-    let introDurationType: PromotionalOffer.IntroDurationType
+    let introDurationType: PromotionalOffer.PaymentMode
     let introPrice: Decimal?
     let subscriptionGroup: String?
     let discounts: [PromotionalOffer]?
@@ -86,7 +86,7 @@ extension ProductInfo: Encodable {
 
         if let introDuration = self.introDuration {
             switch self.introDurationType {
-            case .introPrice:
+            case .payUpFront:
                 try container.encode(introDuration, forKey: .introDuration)
 
             case .freeTrial:

--- a/Purchases/Purchasing/ProductInfoExtractor.swift
+++ b/Purchases/Purchasing/ProductInfoExtractor.swift
@@ -48,10 +48,10 @@ enum ProductInfoExtractor {
 
 private extension ProductInfoExtractor {
 
-    static func extractIntroDurationType(for product: SK1Product) -> PromotionalOffer.IntroDurationType {
+    static func extractIntroDurationType(for product: SK1Product) -> PromotionalOffer.PaymentMode {
         if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *),
            let paymentMode = product.introductoryPrice?.paymentMode {
-            return paymentMode == .freeTrial ? .freeTrial : .introPrice
+            return .init(skProductDiscountPaymentMode: paymentMode)
         } else {
             return .none
         }

--- a/Purchases/Purchasing/PromotionalOffer.swift
+++ b/Purchases/Purchasing/PromotionalOffer.swift
@@ -28,15 +28,6 @@ public class PromotionalOffer: NSObject {
 
     }
 
-    // Fixme: remove in favor of `PaymentMode`: https://github.com/RevenueCat/purchases-ios/issues/1045
-    internal enum IntroDurationType: Int {
-
-        case none = -1
-        case freeTrial = 0
-        case introPrice = 1
-
-    }
-
     public let offerIdentifier: String?
     public let price: Decimal
     public let paymentMode: PaymentMode
@@ -150,4 +141,3 @@ extension PromotionalOffer: Encodable {
 }
 
 extension PromotionalOffer.PaymentMode: Encodable { }
-extension PromotionalOffer.IntroDurationType: Encodable { }

--- a/PurchasesTests/Purchasing/ProductInfoExtensions.swift
+++ b/PurchasesTests/Purchasing/ProductInfoExtensions.swift
@@ -13,7 +13,7 @@ extension ProductInfo {
                                       price: Decimal = 15.99,
                                       normalDuration: String? = nil,
                                       introDuration: String? = nil,
-                                      introDurationType: PromotionalOffer.IntroDurationType = .none,
+                                      introDurationType: PromotionalOffer.PaymentMode = .none,
                                       introPrice: Decimal? = nil,
                                       subscriptionGroup: String? = nil,
                                       discounts: [PromotionalOffer]? = nil) -> ProductInfo {

--- a/PurchasesTests/Purchasing/ProductInfoExtractorTests.swift
+++ b/PurchasesTests/Purchasing/ProductInfoExtractorTests.swift
@@ -134,7 +134,7 @@ class ProductInfoExtractorTests: XCTestCase {
         } else {
             let receivedProductInfo = self.extract()
 
-            expect(receivedProductInfo.introDurationType) == PromotionalOffer.IntroDurationType.none
+            expect(receivedProductInfo.introDurationType) == PromotionalOffer.PaymentMode.none
         }
     }
 

--- a/PurchasesTests/Purchasing/ProductInfoTests.swift
+++ b/PurchasesTests/Purchasing/ProductInfoTests.swift
@@ -64,7 +64,7 @@ class ProductInfoTests: XCTestCase {
     func testAsDictionaryConvertsIntroDurationCorrectlyForIntroPrice() throws {
         let introDuration = "P3M"
         let productInfo: ProductInfo = .createMockProductInfo(introDuration: introDuration,
-                                               introDurationType: .introPrice)
+                                               introDurationType: .payUpFront)
         expect(try productInfo.asDictionary()["intro_duration"] as? String) == introDuration
         expect(try productInfo.asDictionary()["trial_duration"]).to(beNil())
     }
@@ -181,7 +181,7 @@ class ProductInfoTests: XCTestCase {
                                                               introPrice: 0,
                                                               subscriptionGroup: "cool_group",
                                                               discounts: [discount1, discount2, discount3])
-        expect(productInfo.cacheKey) == "cool_product-49.99-UYU-1-0-cool_group-P3Y-P3W-0-offerid1-offerid2-offerid3"
+        expect(productInfo.cacheKey) == "cool_product-49.99-UYU-1-0-cool_group-P3Y-P3W-2-offerid1-offerid2-offerid3"
     }
 }
 


### PR DESCRIPTION
See #1045.
Depends on #1107.