### PR TITLE
`ProductInfoTests`: added snapshot test

### DIFF
--- a/PurchasesTests/Purchasing/ProductInfoTests.swift
+++ b/PurchasesTests/Purchasing/ProductInfoTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Nimble
+import SnapshotTesting
 
 @testable import RevenueCat
 
@@ -124,6 +125,36 @@ class ProductInfoTests: XCTestCase {
         
     }
     
+    func testEncoding() throws {
+        let discount1 = PromotionalOffer(offerIdentifier: "offerid1",
+                                         price: 11,
+                                         paymentMode: .payAsYouGo,
+                                         subscriptionPeriod: .init(value: 1, unit: .month))
+
+        let discount2 = PromotionalOffer(offerIdentifier: "offerid2",
+                                         price: 12,
+                                         paymentMode: .payUpFront,
+                                         subscriptionPeriod: .init(value: 2, unit: .year))
+
+        let discount3 = PromotionalOffer(offerIdentifier: "offerid3",
+                                         price: 13,
+                                         paymentMode: .freeTrial,
+                                         subscriptionPeriod: .init(value: 3, unit: .day))
+
+        let productInfo: ProductInfo = .createMockProductInfo(productIdentifier: "cool_product",
+                                                              paymentMode: .payUpFront,
+                                                              currencyCode: "UYU",
+                                                              price: 49.99,
+                                                              normalDuration: "P3Y",
+                                                              introDuration: "P3W",
+                                                              introDurationType: .freeTrial,
+                                                              introPrice: 0,
+                                                              subscriptionGroup: "cool_group",
+                                                              discounts: [discount1, discount2, discount3])
+
+        try assertSnapshot(matching: productInfo.asDictionary(), as: .json)
+    }
+
     func testCacheKey() {
         guard #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *) else { return }
         
@@ -153,5 +184,21 @@ class ProductInfoTests: XCTestCase {
                                                               subscriptionGroup: "cool_group",
                                                               discounts: [discount1, discount2, discount3])
         expect(productInfo.cacheKey) == "cool_product-49.99-UYU-1-0-cool_group-P3Y-P3W-0-offerid1-offerid2-offerid3"
+    }
+}
+
+extension Snapshotting where Value == Any, Format == String {
+    static var json: Snapshotting {
+        let options: JSONSerialization.WritingOptions = [
+            .prettyPrinted,
+            .sortedKeys
+        ]
+
+        var snapshotting = SimplySnapshotting.lines.pullback { (data: Value) in
+            try! String(decoding: JSONSerialization.data(withJSONObject: data,
+                                                         options: options), as: UTF8.self)
+        }
+        snapshotting.pathExtension = "json"
+        return snapshotting
     }
 }

--- a/PurchasesTests/Purchasing/ProductInfoTests.swift
+++ b/PurchasesTests/Purchasing/ProductInfoTests.swift
@@ -187,6 +187,7 @@ class ProductInfoTests: XCTestCase {
     }
 }
 
+// Remove once https://github.com/pointfreeco/swift-snapshot-testing/pull/552 is available in a release.
 extension Snapshotting where Value == Any, Format == String {
     static var json: Snapshotting {
         let options: JSONSerialization.WritingOptions = [

--- a/PurchasesTests/Purchasing/__Snapshots__/ProductInfoTests/testEncoding.1.json
+++ b/PurchasesTests/Purchasing/__Snapshots__/ProductInfoTests/testEncoding.1.json
@@ -1,0 +1,39 @@
+{
+  "currency" : "UYU",
+  "introductory_price" : 0,
+  "normal_duration" : "P3Y",
+  "offers" : [
+    {
+      "offer_identifier" : "offerid1",
+      "payment_mode" : 0,
+      "price" : 11,
+      "subscription_period" : {
+        "unit" : 2,
+        "value" : 1
+      }
+    },
+    {
+      "offer_identifier" : "offerid2",
+      "payment_mode" : 1,
+      "price" : 12,
+      "subscription_period" : {
+        "unit" : 3,
+        "value" : 2
+      }
+    },
+    {
+      "offer_identifier" : "offerid3",
+      "payment_mode" : 2,
+      "price" : 13,
+      "subscription_period" : {
+        "unit" : 0,
+        "value" : 3
+      }
+    }
+  ],
+  "payment_mode" : 1,
+  "price" : 49.990000000000002,
+  "product_id" : "cool_product",
+  "subscription_group_id" : "cool_group",
+  "trial_duration" : "P3W"
+}

--- a/PurchasesTests/Purchasing/__Snapshots__/ProductInfoTests/testEncoding.1.json
+++ b/PurchasesTests/Purchasing/__Snapshots__/ProductInfoTests/testEncoding.1.json
@@ -6,33 +6,21 @@
     {
       "offer_identifier" : "offerid1",
       "payment_mode" : 0,
-      "price" : 11,
-      "subscription_period" : {
-        "unit" : 2,
-        "value" : 1
-      }
+      "price" : 11
     },
     {
       "offer_identifier" : "offerid2",
       "payment_mode" : 1,
-      "price" : 12,
-      "subscription_period" : {
-        "unit" : 3,
-        "value" : 2
-      }
+      "price" : 12
     },
     {
       "offer_identifier" : "offerid3",
       "payment_mode" : 2,
-      "price" : 13,
-      "subscription_period" : {
-        "unit" : 0,
-        "value" : 3
-      }
+      "price" : 13
     }
   ],
   "payment_mode" : 1,
-  "price" : 49.990000000000002,
+  "price" : 49.99,
   "product_id" : "cool_product",
   "subscription_group_id" : "cool_group",
   "trial_duration" : "P3W"

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -574,6 +574,7 @@
 		57AC4C172770F55C00DDE30F /* SK2StoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreProduct.swift; sourceTree = "<group>"; };
 		57AC4C1B2770F56200DDE30F /* SK1StoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1StoreProduct.swift; sourceTree = "<group>"; };
 		57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoreKitError+Extensions.swift"; sourceTree = "<group>"; };
+		57E0474B27729A1E0082FE91 /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		57E2230627500BB1002DB06E /* AtomicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicTests.swift; sourceTree = "<group>"; };
 		57EAE526274324C60060EB74 /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		57EAE52A274332830060EB74 /* Obsoletions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Obsoletions.swift; sourceTree = "<group>"; };
@@ -1138,6 +1139,7 @@
 		354235D624C11160008C84EE /* Purchasing */ = {
 			isa = PBXGroup;
 			children = (
+				57E0474B27729A1E0082FE91 /* __Snapshots__ */,
 				2D1015DF275A67560086173F /* StoreKitAbstractions */,
 				37E3582920E16E065502E5FC /* EntitlementInfosTests.swift */,
 				B3F8418E26F3A93400E560FB /* ErrorCodeTests.swift */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -219,6 +219,7 @@
 		57AC4C182770F55C00DDE30F /* SK2StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AC4C172770F55C00DDE30F /* SK2StoreProduct.swift */; };
 		57AC4C1C2770F56200DDE30F /* SK1StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AC4C1B2770F56200DDE30F /* SK1StoreProduct.swift */; };
 		57BD50AA27692B7500211D6D /* StoreKitError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */; };
+		57E0473B277260DE0082FE91 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 57E0473A277260DE0082FE91 /* SnapshotTesting */; };
 		57E2230727500BB1002DB06E /* AtomicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E2230627500BB1002DB06E /* AtomicTests.swift */; };
 		57EAE527274324C60060EB74 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE526274324C60060EB74 /* Lock.swift */; };
 		57EAE52B274332830060EB74 /* Obsoletions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE52A274332830060EB74 /* Obsoletions.swift */; };
@@ -687,6 +688,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				57E0473B277260DE0082FE91 /* SnapshotTesting in Frameworks */,
 				B36824BE268FBC5B00957E4C /* XCTest.framework in Frameworks */,
 				2D9C5ED326F2816F0057FC45 /* OHHTTPStubsSwift in Frameworks */,
 				2D9C5ED126F2816F0057FC45 /* OHHTTPStubs in Frameworks */,
@@ -1534,6 +1536,7 @@
 				2D803F6226F144830069D717 /* Nimble */,
 				2D9C5ED026F2816F0057FC45 /* OHHTTPStubs */,
 				2D9C5ED226F2816F0057FC45 /* OHHTTPStubsSwift */,
+				57E0473A277260DE0082FE91 /* SnapshotTesting */,
 			);
 			productName = PurchasesTests;
 			productReference = 2DC5621E24EC63430031F69B /* RevenueCatTests.xctest */;
@@ -1644,6 +1647,7 @@
 			packageReferences = (
 				2D803F6126F144830069D717 /* XCRemoteSwiftPackageReference "nimble" */,
 				2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */,
+				57E04739277260DE0082FE91 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */,
 			);
 			productRefGroup = 352629FF1F7C4B9100C04F2C /* Products */;
 			projectDirPath = "";
@@ -2712,6 +2716,14 @@
 				minimumVersion = 9.0.0;
 			};
 		};
+		57E04739277260DE0082FE91 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pointfreeco/swift-snapshot-testing";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.9.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -2749,6 +2761,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */;
 			productName = OHHTTPStubsSwift;
+		};
+		57E0473A277260DE0082FE91 /* SnapshotTesting */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 57E04739277260DE0082FE91 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
+			productName = SnapshotTesting;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/RevenueCat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/RevenueCat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -36,6 +36,15 @@
           "revision": "12f19662426d0434d6c330c6974d53e2eb10ecd9",
           "version": "9.1.0"
         }
+      },
+      {
+        "package": "SnapshotTesting",
+        "repositoryURL": "https://github.com/pointfreeco/swift-snapshot-testing",
+        "state": {
+          "branch": null,
+          "revision": "f8a9c997c3c1dab4e216a8ec9014e23144cbab37",
+          "version": "1.9.0"
+        }
       }
     ]
   },


### PR DESCRIPTION
For #1045.
Snapshot testing is a more maintainable and readable way to ensure that the output format doesn't change.
In this case, I'm using it to test `ProductInfo.asDictionary()`, as a way to ensure that #1107 doesn't introduce changes.
We can use this to check other types in the future, like `SubscriberAttribute`, `ETagAndResponseWrapper`, etc.


This uses [`swift-snapshot-testing`](https://github.com/pointfreeco/swift-snapshot-testing).
The simple line `try assertSnapshot(matching: productInfo.asDictionary(), as: .json)` automatically checks against a stored file (`PurchasesTests/Purchasing/__Snapshots__/ProductInfoTests/testEncoding.1.json`). If the output changes, the test error is very readable:
<img width="228" alt="Screen Shot 2021-12-21 at 15 27 57" src="https://user-images.githubusercontent.com/685609/147010663-88eddc69-b106-46f5-a8b5-0ee927882282.png">

I've added the snapshot folder as a reference folder in Xcode, which makes looking at the expected output much easier than a bunch of Swift lines checking each value in a dictionary:
<img width="178" alt="Screen Shot 2021-12-21 at 15 26 31" src="https://user-images.githubusercontent.com/685609/147010570-dd68f1ec-b0b0-4570-b59f-8451dcaf05e2.png">

I've also submitted a PR (https://github.com/pointfreeco/swift-snapshot-testing/pull/552) based on the small extension added here.