### PR TITLE
`AllTests.xctestplan`: changed to run RevenueCat tests in parallel

### DIFF
--- a/TestPlans/AllTests.xctestplan
+++ b/TestPlans/AllTests.xctestplan
@@ -20,6 +20,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:RevenueCat.xcodeproj",
         "identifier" : "2DC5621D24EC63430031F69B",


### PR DESCRIPTION
We currently have 3 (+1 for test coverage) test plans:
- `RevenueCat`
- `UnitTests`
- `AllTests`

`RevenueCat` tests are already set to run in parallel, while `UnitTests` aren't to avoid issues with the `StoreKit` test environment.
This PR makes `RevenueCat` tests inside of `AllTests` also run in parallel.

The different on my computer is 7 seconds versus 11 seconds.