### PR TITLE
`MagicWeatherSwiftUI` improvements

### DIFF
--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/Lifecycle/MagicWeatherApp.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/Lifecycle/MagicWeatherApp.swift
@@ -34,7 +34,6 @@ struct MagicWeatherApp: App {
         
         /* Fetch the available offerings */
         Purchases.shared.getOfferings { (offerings, error) in
-            UserViewModel.shared.objectWillChange.send()
             UserViewModel.shared.offerings = offerings
         }
     }

--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/ViewModels/UserViewModel.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/ViewModels/UserViewModel.swift
@@ -10,7 +10,7 @@ import RevenueCat
 import SwiftUI
 
 /* Static shared model for UserView */
-class UserViewModel: NSObject, ObservableObject {
+class UserViewModel: ObservableObject {
     static let shared = UserViewModel()
     
     /* The latest CustomerInfo from RevenueCat. Updated by PurchasesDelegate whenever the Purchases SDK updates the cache */

--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/Views/PaywallView.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/Views/PaywallView.swift
@@ -18,13 +18,13 @@ struct PaywallView: View {
     @Binding var isPresented: Bool
     
     /// - State for displaying an overlay view
-    @State var isPurchasing: Bool = false
+    @State
+    private(set) var isPurchasing: Bool = false
     
     /// - The current offering saved from PurchasesDelegateHandler
-    var offering: Offering? = UserViewModel.shared.offerings?.current
+    private(set) var offering: Offering? = UserViewModel.shared.offerings?.current
     
-    #warning("Modify this value to reflect your app's Privacy Policy and Terms & Conditions agreements. Required to make it through App Review.")
-    var footerText = "Don't forget to add your subscription terms and conditions. Read more about this here: https://www.revenuecat.com/blog/schedule-2-section-3-8-b"
+    private let footerText = "Don't forget to add your subscription terms and conditions. Read more about this here: https://www.revenuecat.com/blog/schedule-2-section-3-8-b"
     
     var body: some View {
         NavigationView {


### PR DESCRIPTION
- `UserViewModel.offerings` is `@Published`, so no need to call `objectWillChange.send()` manually
- `UserViewModel` doesn't need to inherit `NSObject`
- `@State` setters shouldn't be `public`