### PR TITLE
v4: Fix .xcframework not including dSYMs

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -348,7 +348,8 @@ platform :ios do
       xcframework_output_directory: output_directory,
       # bitcode produces issues with Catalyst when validating builds, 
       # with a message: "object not signed at all".
-      enable_bitcode: false
+      enable_bitcode: false,
+      include_debug_symbols: true
     )
     # sh runs from the Fastfile's location, but other commands run from the project root.
     output_directory_for_sh = "../#{output_directory}"


### PR DESCRIPTION
V4 equivalent of #1117 

Related [community post here](https://community.revenuecat.com/sdks-51/release-pre-built-xcframework-why-dsyms-are-separated-1025)

Our `.xcframework` folder didn't include .dSYMs. This could be a problem depending on the package manager being used. In particular, for Carthage, when using `carthage update --use-xcframeworks`, the `.xcframework` that got pulled in and built would never have the `dSYM`s. Only workaround would be to copy them from the checkouts folder. 

The plugin that we're using has an `include_debug_symbol` parameter that defaults to `true`, if omitted, it doesn't work. 
I've filed an [issue](https://github.com/bielikb/fastlane-plugin-create_xcframework/issues/16) and a [PR with a fix](https://github.com/bielikb/fastlane-plugin-create_xcframework/pull/17), but in the meantime, we can pass the parameter in to fix the issue on our side. 

| Before | After |
| :-: | :-: |
| <img width="382" alt="Screen Shot 2021-12-29 at 4 28 51 PM" src="https://user-images.githubusercontent.com/3922667/147698621-0479b823-6058-47f5-8a67-6c892d7fd146.png"> | <img width="376" alt="Screen Shot 2021-12-29 at 4 31 36 PM" src="https://user-images.githubusercontent.com/3922667/147698615-18a4b6ec-bb6f-4f7d-b90b-46ee8fe964ef.png"> |

**Note:** I'm making the PR against `release/3.13.1` so that if we release another hotfix, we can branch off of that one and have the `.xcframework` file fixed. 