### PR TITLE
Update to gen2 circleCI machines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,6 +111,7 @@ commands:
 
 jobs:
   runtest:
+    resource_class: macos.x86.medium.gen2
     macos:
       xcode: "13.2.0"
     working_directory: ~/purchases-ios
@@ -129,6 +130,7 @@ jobs:
           path: fastlane/test_output/xctest
           destination: scan-test-output
   buildTvWatchAndMacOS:
+    resource_class: macos.x86.medium.gen2
     macos:
       xcode: "13.2.0"
     working_directory: ~/purchases-ios
@@ -144,6 +146,7 @@ jobs:
           command: bundle exec fastlane build_tv_watch_mac
 
   backend_integration_tests:
+    resource_class: macos.x86.medium.gen2
     macos:
       xcode: "13.2.0"
     working_directory: ~/purchases-ios
@@ -165,6 +168,7 @@ jobs:
 
 
   release-checks: 
+    resource_class: macos.x86.medium.gen2
     macos:
       xcode: "13.2.0"
     working_directory: ~/purchases-ios
@@ -197,6 +201,7 @@ jobs:
           destination: test_report.html
           
   docs-deploy:
+    resource_class: macos.x86.medium.gen2
     macos:
       xcode: "13.2.0"
     working_directory: ~/purchases-ios
@@ -221,6 +226,7 @@ jobs:
           command: aws cloudfront create-invalidation --distribution-id EPTW7F3CB566V --paths "/*"
   
   make-release:
+    resource_class: macos.x86.medium.gen2
     macos:
       xcode: "13.2.0"
     working_directory: ~/purchases-ios/
@@ -234,6 +240,7 @@ jobs:
           command: bundle exec fastlane release
 
   prepare-next-version:
+    resource_class: macos.x86.medium.gen2
     macos:
       xcode: "13.2.0"
     working_directory: ~/purchases-ios/
@@ -247,6 +254,7 @@ jobs:
           command: bundle exec fastlane prepare_next_version
 
   integration-tests-cocoapods:
+    resource_class: macos.x86.medium.gen2
     macos:
       xcode: "13.2.0"
     working_directory: ~/purchases-ios/
@@ -268,6 +276,7 @@ jobs:
           directory: IntegrationTests/CocoapodsIntegration
       
   integration-tests-swift-package-manager:
+    resource_class: macos.x86.medium.gen2
     macos:
       xcode: "13.2.0"
     working_directory: ~/purchases-ios/
@@ -280,6 +289,7 @@ jobs:
           directory: IntegrationTests/SPMIntegration/
 
   integration-tests-carthage:
+    resource_class: macos.x86.medium.gen2
     macos:
       xcode: "13.2.0"
     working_directory: ~/purchases-ios/
@@ -310,6 +320,7 @@ jobs:
           directory: IntegrationTests/CarthageIntegration/
 
   integration-tests-xcode-direct-integration:
+    resource_class: macos.x86.medium.gen2
     macos:
       xcode: "13.2.0"
     working_directory: ~/purchases-ios/
@@ -321,6 +332,7 @@ jobs:
           directory: IntegrationTests/XcodeDirectIntegration/
 
   lint:
+    resource_class: macos.x86.medium.gen2
     macos:
       xcode: "13.2.0"
     working_directory: ~/purchases-ios/


### PR DESCRIPTION
CircleCI has a new [executor type available](https://circleci.com/docs/2.0/executor-types/#using-macos). 
These machines are based on newer machines, I believe including SSDs. 
This should significantly improve our build times. 

Here's a quick sample, but take it with a grain of salt because I only ran tests once, didn't bother to run them multiple times and get averages. 



| Before | After |
| :-: | :-: |
| <img width="511" alt="Screen Shot 2021-12-29 at 6 23 59 PM" src="https://user-images.githubusercontent.com/3922667/147704470-ff5d6279-49e7-4568-bbd1-0916d590638f.png"> |  <img width="637" alt="Screen Shot 2021-12-29 at 6 24 07 PM" src="https://user-images.githubusercontent.com/3922667/147704491-df3d8d86-d90f-49f2-bf2a-d8a770a6e7e8.png"> |
| <img width="501" alt="Screen Shot 2021-12-29 at 6 25 11 PM" src="https://user-images.githubusercontent.com/3922667/147704541-63f09b7a-f2ad-45a1-b7f9-5119f526df41.png"> | <img width="637" alt="Screen Shot 2021-12-29 at 6 25 01 PM" src="https://user-images.githubusercontent.com/3922667/147704531-e6c71d24-9c24-45ad-84f0-6450c1a11cae.png"> |
| <img width="499" alt="Screen Shot 2021-12-29 at 6 25 56 PM" src="https://user-images.githubusercontent.com/3922667/147704606-a1864719-4786-4292-aec2-34ac0d0b78d4.png"> | <img width="615" alt="Screen Shot 2021-12-29 at 6 26 03 PM" src="https://user-images.githubusercontent.com/3922667/147704599-59192c2f-09d0-499e-b75a-8585705fb33d.png"> |
| <img width="521" alt="Screen Shot 2021-12-29 at 6 27 06 PM" src="https://user-images.githubusercontent.com/3922667/147704679-38c80076-b1e5-48aa-8f90-856ced49074e.png"> | <img width="637" alt="Screen Shot 2021-12-29 at 6 27 02 PM" src="https://user-images.githubusercontent.com/3922667/147704686-c6cd0766-3a73-4d28-82a1-88fc3aca91c6.png"> |

