### PR TITLE
`swiftlint.sh`: avoid error if SwiftLint not installed

### DIFF
--- a/scripts/swiftlint.sh
+++ b/scripts/swiftlint.sh
@@ -41,6 +41,6 @@ if which swiftlint >/dev/null; then
   echo "linter command: ${lint_command}"
   $lint_command
 else
-  echo "error: SwiftLint not installed in ${HOMEBREW_BINARY_DESTINATION}, download from https://github.com/realm/SwiftLint"
+  echo "Warning: SwiftLint not installed in ${HOMEBREW_BINARY_DESTINATION}, download from https://github.com/realm/SwiftLint"
 fi
 


### PR DESCRIPTION
Brought up by https://community.revenuecat.com/sdks-51/release-pre-built-xcframework-why-dsyms-are-separated-1025, when building `RevenueCat` target without having `SwiftLint` installed results in this error being printed. The script exists with code 0, but Xcode still fails:
> Command PhaseScriptExecution emitted errors but did not return a nonzero exit code to indicate failure

That's likely Xcode parsing the "Error" part of the message, which I don't think was done on purpose.

CircleCI doesn't use this script, and `fastlane run swiftlint` does fail if it's not installed, so this helps users build the framework even if they don't have it installed.