### PR TITLE
`TransactionsManagerSK2Tests`: fixed runtime warning for purchasing without listening to transaction updates

### DIFF
--- a/StoreKitUnitTests/TransactionsManagerSK2Tests.swift
+++ b/StoreKitUnitTests/TransactionsManagerSK2Tests.swift
@@ -21,6 +21,16 @@ class TransactionsManagerSK2Tests: StoreKitConfigTestCase {
     var mockReceiptParser: MockReceiptParser!
     var transactionsManager: TransactionsManager!
 
+    override class func setUp() {
+        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            _ = Task {
+                // Silence warning in tests:
+                // "Making a purchase without listening for transaction updates risks missing successful purchases.
+                for await _ in Transaction.updates {}
+            }
+        }
+    }
+
     override func setUpWithError() throws {
         try super.setUpWithError()
 


### PR DESCRIPTION
> Making a purchase without listening for transaction updates risks missing successful purchases. Create a Task to iterate Transaction.updates at launch.

This silences the warning by at least monitoring updates in the test.

<img width="415" alt="Screen Shot 2021-12-29 at 21 33 00" src="https://user-images.githubusercontent.com/685609/147724336-fdb4e995-18d9-400f-8d52-d3ceb7102a74.png">
