### PR TITLE
`ProductFetcherSK2`: fixed product cache

### DIFF
--- a/Purchases/Logging/Strings/OfferingStrings.swift
+++ b/Purchases/Logging/Strings/OfferingStrings.swift
@@ -27,6 +27,7 @@ enum OfferingStrings {
     case offerings_stale_updating_in_background
     case offerings_stale_updating_in_foreground
     case products_already_cached(identifiers: Set<String>)
+    case product_cache_invalid_for_storefront_change
     case vending_offerings_cache
     case retrieved_products(products: [SKProduct])
     case list_products(productIdentifier: String, product: SKProduct)
@@ -79,6 +80,9 @@ extension OfferingStrings: CustomStringConvertible {
         case .products_already_cached(let identifiers):
             return "Skipping products request because products were already " +
                 "cached. products: \(identifiers)"
+
+        case .product_cache_invalid_for_storefront_change:
+            return "Storefront change detected. Invalidating product cache."
 
         case .vending_offerings_cache:
             return "Vending Offerings from cache"

--- a/Purchases/Purchasing/StoreKit2/ProductsFetcherSK2.swift
+++ b/Purchases/Purchasing/StoreKit2/ProductsFetcherSK2.swift
@@ -24,24 +24,63 @@ actor ProductsFetcherSK2 {
     }
 
     private var cachedProductsByIdentifier: [String: SK2StoreProduct] = [:]
+    private var cachedProductsStorefrontIdentifier: String?
 
     func products(identifiers: Set<String>) async throws -> Set<SK2StoreProduct> {
         do {
-            // todo: also cache requests, so that if a request is in flight for the same products,
-            // we don't need to make a new one
-            let productsAlreadyCached = self.cachedProductsByIdentifier.filter { key, _ in identifiers.contains(key) }
-            if productsAlreadyCached.count == identifiers.count {
-                let productsAlreadyCachedSet = Set(productsAlreadyCached.values)
-                Logger.debug(Strings.offering.products_already_cached(identifiers: identifiers))
-                return productsAlreadyCachedSet
+            if let cachedProducts = await self.cachedProducts(withIdentifiers: identifiers) {
+                return cachedProducts
             }
 
             let storeKitProducts = try await StoreKit.Product.products(for: identifiers)
-            let sk2StoreProduct = storeKitProducts.map { SK2StoreProduct(sk2Product: $0) }
-            return Set(sk2StoreProduct)
+            let sk2StoreProducts = Set(storeKitProducts.map { SK2StoreProduct(sk2Product: $0) })
+
+            await self.cache(products: sk2StoreProducts)
+
+            return sk2StoreProducts
         } catch {
             throw Error.productsRequestError(innerError: error)
         }
+    }
+
+    private func cachedProducts(withIdentifiers identifiers: Set<String>) async -> Set<SK2StoreProduct>? {
+        guard await self.cachedProductsStorefrontIdentifier == self.currentStorefrontIdentifier else {
+            if !self.cachedProductsByIdentifier.isEmpty {
+                Logger.debug(Strings.offering.product_cache_invalid_for_storefront_change)
+            }
+
+            return nil
+        }
+
+        let productsAlreadyCached = self.cachedProductsByIdentifier.filter { key, _ in identifiers.contains(key) }
+        if productsAlreadyCached.count == identifiers.count {
+            Logger.debug(Strings.offering.products_already_cached(identifiers: identifiers))
+            return Set(productsAlreadyCached.values)
+        } else {
+            return nil
+        }
+    }
+
+    private func cache(products: Set<SK2StoreProduct>) async {
+        let storeFrontIdentifier = await self.currentStorefrontIdentifier
+
+        // Invalidate outdated products
+        if storeFrontIdentifier != self.cachedProductsStorefrontIdentifier {
+            self.clearCache()
+        }
+
+        self.cachedProductsStorefrontIdentifier = storeFrontIdentifier
+        self.cachedProductsByIdentifier += products.dictionaryWithKeys {
+            $0.productIdentifier
+        }
+    }
+
+    private func clearCache() {
+        self.cachedProductsByIdentifier.removeAll(keepingCapacity: false)
+    }
+
+    private var currentStorefrontIdentifier: String? {
+        get async { await Storefront.current?.id }
     }
 
 }

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -182,6 +182,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         let productPrice = storeProduct.price as NSNumber
 
         expect(priceFormatter.string(from: productPrice)) == "$4.99"
+        expect(storeProduct.localizedPriceString) == "$4.99"
     }
 
     @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
@@ -197,6 +198,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         let productPrice = storeProduct.price as NSNumber
 
         expect(priceFormatter.string(from: productPrice)) == "$4.99"
+        expect(storeProduct.localizedPriceString) == "$4.99"
     }
 
     @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
@@ -229,8 +231,6 @@ class StoreProductTests: StoreKitConfigTestCase {
         productPrice = storeProduct.price as NSNumber
 
         expect(priceFormatter.string(from: productPrice)) == "$4.99"
-
-        testSession.locale = Locale(identifier: "es_ES")
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -240,8 +240,9 @@ class StoreProductTests: StoreKitConfigTestCase {
         testSession.locale = Locale(identifier: "es_ES")
         testSession.storefront = "ESP"
 
+        let sk2Fetcher = ProductsFetcherSK2()
+
         let productIdentifier = "com.revenuecat.monthly_4.99.1_week_intro"
-        var sk2Fetcher = ProductsFetcherSK2()
 
         var storeProductSet = try await sk2Fetcher.products(identifiers: Set([productIdentifier]))
 
@@ -254,8 +255,6 @@ class StoreProductTests: StoreKitConfigTestCase {
         testSession.locale = Locale(identifier: "en_EN")
         testSession.storefront = "USA"
 
-        sk2Fetcher = ProductsFetcherSK2()
-
         storeProductSet = try await sk2Fetcher.products(identifiers: Set([productIdentifier]))
 
         storeProduct = try XCTUnwrap(storeProductSet.first)
@@ -263,8 +262,6 @@ class StoreProductTests: StoreKitConfigTestCase {
         productPrice = storeProduct.price as NSNumber
 
         expect(priceFormatter.string(from: productPrice)) == "$4.99"
-
-        testSession.locale = Locale(identifier: "es_ES")
     }
 
     private func expectEqualProducts(_ productA: StoreProductType, _ productB: StoreProductType) {


### PR DESCRIPTION
### Changes:
- `ProductFetcherSK2` was checking its internal `cachedProductsByIdentifier`, but it was never populated. It now is.
- The test `testSk2PriceFormatterReactsToStorefrontChanges` only worked because the `ProductFetcherSK2` instance was recreated, invalidating the cache. `ProductFetcherSK2` now invalidates its cache when the `Storefront` changes instead.
- Tests in `StoreProductTests` no longer manually reset the `testSession.locale`, that's done by `StoreKitConfigTestCase` calling `resetToDefaultState` on setUp.

### Alternatives considered:
- Listening to `Storefront.updates` is what I tried first, but due to race conditions the update never arrives on time for the test to detect it and clear the cache.
- This also introduced challenges with the way listening to those updates must be done, requiring to either make `ProductFetcherSK2.init` `async` or needing to call a method after initialization, neither of which were great solutions.