### PR TITLE
`StoreProductTests`: clarify `ProductsFetcherSK1` behavior

### DIFF
--- a/Purchases/Purchasing/StoreKit1/ProductsFetcherSK1.swift
+++ b/Purchases/Purchasing/StoreKit1/ProductsFetcherSK1.swift
@@ -20,6 +20,8 @@ class ProductsFetcherSK1: NSObject {
 
     private let productsRequestFactory: ProductsRequestFactory
 
+    // Note: the cached products don't get invalidated when the Storefront changes,
+    // so their localized data might be outdated.
     private var cachedProductsByIdentifier: [String: SK1Product] = [:]
     private let queue = DispatchQueue(label: "ProductsFetcherSK1")
     private var productsByRequests: [SKRequest: ProductRequest] = [:]

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -202,7 +202,7 @@ class StoreProductTests: StoreKitConfigTestCase {
     }
 
     @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
-    func testSk1PriceFormatterReactsToStorefrontChanges() async throws {
+    func testSk1PriceFormatterUsesCurrentStorefront() async throws {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
         testSession.locale = Locale(identifier: "es_ES")
@@ -222,6 +222,9 @@ class StoreProductTests: StoreKitConfigTestCase {
         testSession.locale = Locale(identifier: "en_EN")
         await changeStorefront("USA")
 
+        // Note: this test passes only because the fetcher is recreated
+        // therefore clearing the cache. `ProductsFetcherSK1` does not
+        // detect Storefront changes to invalidate the cache like `ProductsFetcherSK2` does.
         sk1Fetcher = ProductsFetcherSK1()
 
         storeProductSet = try await sk1Fetcher.products(withIdentifiers: Set([productIdentifier]))


### PR DESCRIPTION
`ProductsFetcherSK2` was fixed in #1123. We could do the same in `ProductsFetcherSK1`,
but `Storefront.current` is iOS 15 only, so solving it wouldn't be quite as trivial.

For now at least this documents the behavior.

Filed future task: https://app.shortcut.com/revenuecat/story/12350/invalidate-productsfetchersk1-cache-when-storefront-changes