### PR TITLE
CircleCI: updated Orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ release-tags: &release-tags
       ignore: /.*/
 
 orbs:
-   macos: circleci/macos@dev:25cb9bd
+   macos: circleci/macos@2.0.1
 
 version: 2.1
 commands:


### PR DESCRIPTION
Fixes:
> The dev version of circleci/macos@dev:25cb9bd has expired. Dev versions of orbs are only valid for 90 days after publishing.

See failure: https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/4662/workflows/09dbb7dd-bb2a-4cf7-8f11-7e8e9d1b6155/jobs/14399