### PR TITLE
README: clarify V4 is Objective-C compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Swift Package Manager (SPM) integration is currently not working as expected. If
 
 **Purchases** is the currently supported, production-ready, open source framework that provides a wrapper around `StoreKit` and the RevenueCat backend to make implementing in-app subscriptions in `Swift` or `Objective-C` easy - receipt validation and status tracking included! 
 
-**RevenueCat** is our next big release (what we've been calling Purchases V4). It is a rename of `Purchases` to `RevenueCat`, and now, 100% Swift. It contains all the same functionality (and almost exactly the same API) as `Purchases`. It's not a brand-new framework, but rather, a migration of the ObjC bits over to Swift with improved nullability, various bug fixes, and some new features. You can see what's changed in the [API updates doc](https://rev.cat/uet).
+**RevenueCat** is our next big release (what we've been calling Purchases V4). It is a rename of `Purchases` to `RevenueCat`, and now, 100% `Swift` (while maintaining `Objective-C` compatibility). It contains all the same functionality (and almost exactly the same API) as `Purchases`. It's not a brand-new framework, but rather, a migration of the ObjC bits over to Swift with improved nullability, various bug fixes, and some new features. You can see what's changed in the [API updates doc](https://rev.cat/uet).
 
 It also includes `StoreKit2` support! You can enable it when setting up the framework:
 ```swift


### PR DESCRIPTION
I was going through the README and realized that this currently reads as if `RevenueCat.framework` is only compatible with `Swift`.