### PR TITLE
`TrialOrIntroPriceEligibilityChecker`: added warning if no identifiers were requested

### DIFF
--- a/Purchases/Logging/Strings/PurchaseStrings.swift
+++ b/Purchases/Logging/Strings/PurchaseStrings.swift
@@ -53,6 +53,7 @@ enum PurchaseStrings {
     case begin_refund_no_active_entitlement
     case begin_refund_customer_info_error(entitlementID: String?)
     case cached_app_user_id_deleted
+    case check_eligibility_no_identifiers
 
 }
 
@@ -186,6 +187,9 @@ extension PurchaseStrings: CustomStringConvertible {
                 entries in user defaults don't get deleted by anything other than the SDK.
                 More info: https://rev.cat/userdefaults-crash
                 """
+        case .check_eligibility_no_identifiers:
+            return "Requested trial or introductory price eligibility with no identifiers. " +
+            "This is likely a program error."
         }
     }
 

--- a/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -42,6 +42,12 @@ class TrialOrIntroPriceEligibilityChecker {
 
     func checkEligibility(productIdentifiers: [String],
                           completion: @escaping ReceiveIntroEligibilityBlock) {
+        guard !productIdentifiers.isEmpty else {
+            Logger.warn(Strings.purchase.check_eligibility_no_identifiers)
+            completion([:])
+            return
+        }
+
         if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
             _ = Task<Void, Never> {
                 do {


### PR DESCRIPTION
Fixes #715 and [sc-10229].