### PR TITLE
Avoid logging user IDs

### DIFF
--- a/Purchases/Caching/DeviceCache.swift
+++ b/Purchases/Caching/DeviceCache.swift
@@ -68,14 +68,7 @@ class DeviceCache {
         }
 
         if appUserIDHasBeenSet && Self.cachedAppUserID(userDefaults) == nil {
-            fatalError(
-                """
-                [\(Logger.frameworkDescription)] - Cached appUserID has been deleted from user defaults.
-                This leaves the SDK in an undetermined state. Please make sure that RevenueCat
-                entries in user defaults don't get deleted by anything other than the SDK.
-                More info: https://rev.cat/userdefaults-crash
-                """
-            )
+            fatalError(Strings.purchase.cached_app_user_id_deleted.description)
         }
     }
 
@@ -267,7 +260,7 @@ class DeviceCache {
             var groupedAttributes = Self.storedAttributesForAllUsers($0)
             let attibutesForAppUserID = groupedAttributes.removeValue(forKey: appUserID)
             guard attibutesForAppUserID != nil else {
-                Logger.warn("Attempt to delete synced attributes for \(appUserID), but there were none to delete")
+                Logger.warn(Strings.identity.deleting_synced_attributes_none_found)
                 return
             }
             $0.setValue(groupedAttributes, forKey: CacheKeys.subscriberAttributes)

--- a/Purchases/Identity/IdentityManager.swift
+++ b/Purchases/Identity/IdentityManager.swift
@@ -58,7 +58,7 @@ class IdentityManager {
             ?? deviceCache.cachedLegacyAppUserID
             ?? Self.generateRandomID()
 
-        Logger.user(Strings.identity.identifying_app_user_id(appUserID: appUserID))
+        Logger.user(Strings.identity.identifying_app_user_id)
 
         deviceCache.cache(appUserID: appUserID)
         deviceCache.cleanupSubscriberAttributes()
@@ -93,7 +93,7 @@ class IdentityManager {
     }
 
     func logOut(completion: (Error?) -> Void) {
-        Logger.info(Strings.identity.log_out_called_for_user(appUserID: currentAppUserID))
+        Logger.info(Strings.identity.log_out_called_for_user)
 
         if currentUserIsAnonymous {
             completion(ErrorUtils.logOutAnonymousUserError())

--- a/Purchases/Logging/Strings/ConfigureStrings.swift
+++ b/Purchases/Logging/Strings/ConfigureStrings.swift
@@ -31,7 +31,7 @@ enum ConfigureStrings {
 
     case purchase_instance_already_set
 
-    case initial_app_user_id(appUserID: String?)
+    case initial_app_user_id(isSet: Bool)
 
     case no_singleton_instance
 
@@ -59,8 +59,10 @@ extension ConfigureStrings: CustomStringConvertible {
         case .purchase_instance_already_set:
             return "Purchases instance already set. Did you mean to configure " +
                 "two Purchases objects?"
-        case .initial_app_user_id(let appUserID):
-            return "Initial App User ID - \(appUserID ?? "nil appUserID")"
+        case .initial_app_user_id(let isSet):
+            return isSet
+                ? "Initial App User ID set"
+                : "No initial App User ID"
         case .no_singleton_instance:
             return "There is no singleton instance. Make sure you configure Purchases before " +
                 "trying to get the default instance. More info here: https://errors.rev.cat/configuring-sdk"

--- a/Purchases/Logging/Strings/IdentityStrings.swift
+++ b/Purchases/Logging/Strings/IdentityStrings.swift
@@ -16,8 +16,6 @@ import Foundation
 // swiftlint:disable identifier_name
 enum IdentityStrings {
 
-    case changing_app_user_id(from: String, to: String)
-
     case logging_in_with_empty_appuserid
 
     case logging_in_with_same_appuserid
@@ -26,17 +24,17 @@ enum IdentityStrings {
 
     case login_success
 
-    case log_out_called_for_user(appUserID: String)
+    case log_out_called_for_user
 
     case log_out_success
 
-    case creating_alias(userA: String, userB: String)
+    case creating_alias
 
-    case identifying_anon_id(appUserID: String)
-
-    case identifying_app_user_id(appUserID: String)
+    case identifying_app_user_id
 
     case null_currentappuserid
+
+    case deleting_synced_attributes_none_found
 
 }
 
@@ -44,8 +42,6 @@ extension IdentityStrings: CustomStringConvertible {
 
     var description: String {
         switch self {
-        case .changing_app_user_id(let from, let to):
-            return "Changing App User ID: \(from) -> \(to)"
         case .logging_in_with_empty_appuserid:
             return "The appUserID is empty. " +
                 "This method should only be called with non-empty values."
@@ -56,18 +52,18 @@ extension IdentityStrings: CustomStringConvertible {
             return "Alias created"
         case .login_success:
             return "Log in successful"
-        case .log_out_called_for_user(let appUserID):
-            return "Log out called for user \(appUserID)"
+        case .log_out_called_for_user:
+            return "Log out called for user"
         case .log_out_success:
             return "Log out successful"
-        case .creating_alias(let userA, let userB):
-            return "Creating an alias between current appUserID \(userA) and \(userB)"
-        case .identifying_anon_id(let appUserID):
-            return "Identifying from an anonymous ID: \(appUserID). An alias will be created."
-        case .identifying_app_user_id(let appUserID):
-            return "Identifying App User ID: \(appUserID)"
+        case .creating_alias:
+            return "Creating an alias for current appUserID"
+        case .identifying_app_user_id:
+            return "Identifying App User ID"
         case .null_currentappuserid:
             return "currentAppUserID is nil. This might happen if the cache in UserDefaults is unintentionally cleared."
+        case .deleting_synced_attributes_none_found:
+            return "Attempt to delete synced attributes for user, but there were none to delete"
         }
     }
 

--- a/Purchases/Logging/Strings/PurchaseStrings.swift
+++ b/Purchases/Logging/Strings/PurchaseStrings.swift
@@ -52,6 +52,7 @@ enum PurchaseStrings {
     case begin_refund_no_entitlement_found(entitlementID: String?)
     case begin_refund_no_active_entitlement
     case begin_refund_customer_info_error(entitlementID: String?)
+    case cached_app_user_id_deleted
 
 }
 
@@ -178,6 +179,13 @@ extension PurchaseStrings: CustomStringConvertible {
         case .begin_refund_customer_info_error(let entitlementID):
             return "Failed to get CustomerInfo to proceed with refund for " +
                 "\(entitlementID.flatMap { "entitlement with ID " + $0 } ?? "active entitlement")."
+        case .cached_app_user_id_deleted:
+            return """
+                [\(Logger.frameworkDescription)] - Cached appUserID has been deleted from user defaults.
+                This leaves the SDK in an undetermined state. Please make sure that RevenueCat
+                entries in user defaults don't get deleted by anything other than the SDK.
+                More info: https://rev.cat/userdefaults-crash
+                """
         }
     }
 

--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -68,7 +68,7 @@ class Backend {
             return
         }
 
-        Logger.user(Strings.identity.creating_alias(userA: appUserID, userB: newAppUserID))
+        Logger.user(Strings.identity.creating_alias)
         httpClient.performPOSTRequest(serially: true,
                                       path: "/subscribers/\(appUserID)/alias",
                                       requestBody: ["new_app_user_id": newAppUserID],

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -358,7 +358,7 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
             Logger.info(Strings.configure.store_kit_2_enabled, fileName: nil)
         }
         Logger.debug(Strings.configure.sdk_version(sdkVersion: Self.frameworkVersion), fileName: nil)
-        Logger.user(Strings.configure.initial_app_user_id(appUserID: appUserID), fileName: nil)
+        Logger.user(Strings.configure.initial_app_user_id(isSet: appUserID != nil), fileName: nil)
 
         self.requestFetcher = requestFetcher
         self.receiptFetcher = receiptFetcher


### PR DESCRIPTION
Fixes https://github.com/RevenueCat/purchases-ios/issues/746 and [sc-10311].

After reviewing the conversations around the issue, I think we can all agree that this is the best solution.
We could make this optional for only `DEBUG` builds, but if a user has a debug build of `RevenueCat` in their app in production, with debug logs enabled (either the default handler or their own), these IDs would be leaking.

### Other changes:
- Moved a few strings into Strings file
- Removed unused strings