### PR TITLE
fix link in changelog

### DIFF
--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,7 +1,7 @@
 - Ninth beta for RevenueCat framework 🎉
     100% Swift framework + ObjC support.
 
-[Full Changelog](https://github.com/revenuecat/purchases-ios/compare/4.0.0-beta.8...HEAD)
+[Full Changelog](https://github.com/revenuecat/purchases-ios/compare/4.0.0-beta.8...4.0.0-beta.9)
 - See our [RevenueCat V4 API update doc](docs/V4_API_Updates.md) for API updates.
 
 ### Breaking changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Ninth beta for RevenueCat framework 🎉
     100% Swift framework + ObjC support.
 
-[Full Changelog](https://github.com/revenuecat/purchases-ios/compare/4.0.0-beta.8...HEAD)
+[Full Changelog](https://github.com/revenuecat/purchases-ios/compare/4.0.0-beta.8...4.0.0-beta.9)
 - See our [RevenueCat V4 API update doc](docs/V4_API_Updates.md) for API updates.
 
 ### Breaking changes:


### PR DESCRIPTION
From comments [here](https://github.com/RevenueCat/purchases-ios/pull/1132#discussion_r779515931), the link to the diff compares against `main` instead of the release tag. This fixes that link. 