### PR TITLE
Rename PromotionalOffer -> StoreProductDiscount

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductAPI.m
@@ -23,8 +23,8 @@
     NSString *subscriptionGroupIdentifier = product.subscriptionGroupIdentifier;
     NSNumberFormatter *priceFormatter = product.priceFormatter;
     RCSubscriptionPeriod *subscriptionPeriod = product.subscriptionPeriod;
-    RCPromotionalOffer *introductoryPrice = product.introductoryPrice;
-    NSArray<RCPromotionalOffer *> *discounts = product.discounts;
+    RCStoreProductDiscount *introductoryPrice = product.introductoryPrice;
+    NSArray<RCStoreProductDiscount *> *discounts = product.discounts;
     NSDecimalNumber *pricePerMonth = product.pricePerMonth;
     NSString *localizedIntroductoryPriceString = product.localizedIntroductoryPriceString;
 

--- a/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
@@ -18,8 +18,8 @@ func checkStoreProductAPI() {
     let subscriptionGroupIdentifier: String? = product.subscriptionGroupIdentifier
     let priceFormatter: NumberFormatter? = product.priceFormatter
     let subscriptionPeriod: SubscriptionPeriod? = product.subscriptionPeriod
-    let introductoryPrice: PromotionalOffer? = product.introductoryPrice
-    let discounts: [PromotionalOffer] = product.discounts
+    let introductoryPrice: StoreProductDiscount? = product.introductoryPrice
+    let discounts: [StoreProductDiscount] = product.discounts
 
     let pricePerMonth: NSDecimalNumber? = product.pricePerMonth
     let localizedIntroductoryPriceString: String? = product.localizedIntroductoryPriceString

--- a/Purchases/Purchasing/ProductRequestData+Initialization.swift
+++ b/Purchases/Purchasing/ProductRequestData+Initialization.swift
@@ -49,7 +49,7 @@ extension ProductRequestData {
 
 private extension ProductRequestData {
 
-    static func extractIntroDurationType(for product: SK1Product) -> PromotionalOffer.PaymentMode {
+    static func extractIntroDurationType(for product: SK1Product) -> StoreProductDiscount.PaymentMode {
         if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *),
            let paymentMode = product.introductoryPrice?.paymentMode {
             return .init(skProductDiscountPaymentMode: paymentMode)
@@ -66,18 +66,18 @@ private extension ProductRequestData {
         }
     }
 
-    static func extractDiscounts(for product: SK1Product) -> [PromotionalOffer]? {
+    static func extractDiscounts(for product: SK1Product) -> [StoreProductDiscount]? {
         if #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *) {
-            return product.discounts.map(PromotionalOffer.init(with:))
+            return product.discounts.map(StoreProductDiscount.init(with:))
         } else {
             return nil
         }
     }
 
-    static func extractPaymentMode(for product: SK1Product) -> PromotionalOffer.PaymentMode {
+    static func extractPaymentMode(for product: SK1Product) -> StoreProductDiscount.PaymentMode {
         if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *),
            let paymentMode = product.introductoryPrice?.paymentMode {
-            return PromotionalOffer.PaymentMode(skProductDiscountPaymentMode: paymentMode)
+            return StoreProductDiscount.PaymentMode(skProductDiscountPaymentMode: paymentMode)
         } else {
             return .none
         }

--- a/Purchases/Purchasing/ProductRequestData.swift
+++ b/Purchases/Purchasing/ProductRequestData.swift
@@ -21,15 +21,15 @@ import StoreKit
 struct ProductRequestData {
 
     let productIdentifier: String
-    let paymentMode: PromotionalOffer.PaymentMode
+    let paymentMode: StoreProductDiscount.PaymentMode
     let currencyCode: String?
     let price: Decimal
     let normalDuration: String?
     let introDuration: String?
-    let introDurationType: PromotionalOffer.PaymentMode
+    let introDurationType: StoreProductDiscount.PaymentMode
     let introPrice: Decimal?
     let subscriptionGroup: String?
-    let discounts: [PromotionalOffer]?
+    let discounts: [StoreProductDiscount]?
 
     var cacheKey: String {
         var key = """

--- a/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
@@ -55,15 +55,15 @@ internal struct SK1StoreProduct: StoreProductType {
     }
 
     @available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *)
-    var introductoryPrice: PromotionalOffer? {
+    var introductoryPrice: StoreProductDiscount? {
         return self.underlyingSK1Product.introductoryPrice
-            .map(PromotionalOffer.init)
+            .map(StoreProductDiscount.init)
     }
 
     @available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *)
-    var discounts: [PromotionalOffer] {
+    var discounts: [StoreProductDiscount] {
         return self.underlyingSK1Product.discounts
-            .map(PromotionalOffer.init)
+            .map(StoreProductDiscount.init)
     }
 
 }

--- a/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
@@ -74,14 +74,14 @@ internal struct SK2StoreProduct: StoreProductType {
         return SubscriptionPeriod.from(sk2SubscriptionPeriod: skSubscriptionPeriod)
     }
 
-    var introductoryPrice: PromotionalOffer? {
+    var introductoryPrice: StoreProductDiscount? {
         self.underlyingSK2Product.subscription?.introductoryOffer
-            .map(PromotionalOffer.init)
+            .map(StoreProductDiscount.init)
     }
 
-    var discounts: [PromotionalOffer] {
+    var discounts: [StoreProductDiscount] {
         (self.underlyingSK2Product.subscription?.promotionalOffers ?? [])
-            .compactMap(PromotionalOffer.init)
+            .compactMap(StoreProductDiscount.init)
     }
 
 }

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -81,10 +81,10 @@ public typealias SK2Product = StoreKit.Product
     @objc public var subscriptionPeriod: SubscriptionPeriod? { self.product.subscriptionPeriod }
 
     @available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *)
-    @objc public var introductoryPrice: PromotionalOffer? { self.product.introductoryPrice }
+    @objc public var introductoryPrice: StoreProductDiscount? { self.product.introductoryPrice }
 
     @available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *)
-    @objc public var discounts: [PromotionalOffer] { self.product.discounts }
+    @objc public var discounts: [StoreProductDiscount] { self.product.discounts }
 
 }
 
@@ -149,11 +149,11 @@ internal protocol StoreProductType {
     /// you must first determine if the user is eligible to receive it.
     /// - Seealso: `Purchases.checkTrialOrIntroductoryPriceEligibility` to  determine eligibility.
     @available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *)
-    var introductoryPrice: PromotionalOffer? { get }
+    var introductoryPrice: StoreProductDiscount? { get }
 
     /// An array of subscription offers available for the auto-renewable subscription.
     @available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *)
-    var discounts: [PromotionalOffer] { get }
+    var discounts: [StoreProductDiscount] { get }
 
 }
 

--- a/Purchases/Purchasing/StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreProductDiscount.swift
@@ -7,7 +7,7 @@
 //
 //      https://opensource.org/licenses/MIT
 //
-//  PromotionalOffer.swift
+//  StoreProductDiscount.swift
 //
 //  Created by Joshua Liebowitz on 7/2/21.
 //
@@ -15,8 +15,8 @@
 import Foundation
 import StoreKit
 
-@objc(RCPromotionalOffer)
-public class PromotionalOffer: NSObject {
+@objc(RCStoreProductDiscount)
+public class StoreProductDiscount: NSObject {
 
     @objc(RCPaymentMode)
     public enum PaymentMode: Int {
@@ -66,7 +66,7 @@ public class PromotionalOffer: NSObject {
     }
 
     public override func isEqual(_ object: Any?) -> Bool {
-        guard let other = object as? PromotionalOffer else { return false }
+        guard let other = object as? StoreProductDiscount else { return false }
 
         return self.offerIdentifier == other.offerIdentifier
             && self.price == other.price
@@ -86,7 +86,7 @@ public class PromotionalOffer: NSObject {
 
 }
 
-extension PromotionalOffer.PaymentMode {
+extension StoreProductDiscount.PaymentMode {
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
     init(skProductDiscountPaymentMode paymentMode: SKProductDiscount.PaymentMode) {
         switch paymentMode {
@@ -118,7 +118,7 @@ extension PromotionalOffer.PaymentMode {
 
 // MARK: - Encodable
 
-extension PromotionalOffer: Encodable {
+extension StoreProductDiscount: Encodable {
 
     private enum CodingKeys: String, CodingKey {
 
@@ -140,4 +140,4 @@ extension PromotionalOffer: Encodable {
 
 }
 
-extension PromotionalOffer.PaymentMode: Encodable { }
+extension StoreProductDiscount.PaymentMode: Encodable { }

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -375,7 +375,7 @@ class BackendTests: XCTestCase {
 
         let currencyCode = "BFD"
 
-        let paymentMode: PromotionalOffer.PaymentMode = .none
+        let paymentMode: StoreProductDiscount.PaymentMode = .none
 
         var completionCalled = false
         let productData: ProductRequestData = .createMockProductData(productIdentifier: productIdentifier,
@@ -454,7 +454,7 @@ class BackendTests: XCTestCase {
         expect(call.body!["price"]).toNot(beNil())
     }
 
-    func postPaymentMode(paymentMode: PromotionalOffer.PaymentMode) {
+    func postPaymentMode(paymentMode: StoreProductDiscount.PaymentMode) {
         var completionCalled = false
 
         let productData: ProductRequestData = .createMockProductData(paymentMode: paymentMode)
@@ -1212,7 +1212,7 @@ class BackendTests: XCTestCase {
             completionCalled += 1
         })
 
-        let discount = PromotionalOffer(offerIdentifier: "offerid",
+        let discount = StoreProductDiscount(offerIdentifier: "offerid",
                                         price: 12,
                                         paymentMode: .payAsYouGo,
                                         subscriptionPeriod: .init(value: 10, unit: .month))
@@ -1241,9 +1241,9 @@ class BackendTests: XCTestCase {
         let price: Decimal = 4.99
         let group = "sub_group"
         let currencyCode = "BFD"
-        let paymentMode: PromotionalOffer.PaymentMode = .none
+        let paymentMode: StoreProductDiscount.PaymentMode = .none
         var completionCalled = false
-        let discount = PromotionalOffer(offerIdentifier: "offerid",
+        let discount = StoreProductDiscount(offerIdentifier: "offerid",
                                         price: 12,
                                         paymentMode: .payAsYouGo,
                                         subscriptionPeriod: .init(value: 1, unit: .year))

--- a/PurchasesTests/Purchasing/ProductRequestDataExtensions.swift
+++ b/PurchasesTests/Purchasing/ProductRequestDataExtensions.swift
@@ -8,15 +8,15 @@ import Foundation
 
 extension ProductRequestData {
     static func createMockProductData(productIdentifier: String = "product_id",
-                                      paymentMode: PromotionalOffer.PaymentMode = .none,
+                                      paymentMode: StoreProductDiscount.PaymentMode = .none,
                                       currencyCode: String = "UYU",
                                       price: Decimal = 15.99,
                                       normalDuration: String? = nil,
                                       introDuration: String? = nil,
-                                      introDurationType: PromotionalOffer.PaymentMode = .none,
+                                      introDurationType: StoreProductDiscount.PaymentMode = .none,
                                       introPrice: Decimal? = nil,
                                       subscriptionGroup: String? = nil,
-                                      discounts: [PromotionalOffer]? = nil) -> ProductRequestData {
+                                      discounts: [StoreProductDiscount]? = nil) -> ProductRequestData {
         ProductRequestData(productIdentifier: productIdentifier,
                            paymentMode: paymentMode,
                            currencyCode: currencyCode,

--- a/PurchasesTests/Purchasing/ProductRequestDataInitializationTests.swift
+++ b/PurchasesTests/Purchasing/ProductRequestDataInitializationTests.swift
@@ -53,11 +53,11 @@ class ProductRequestDataSK1ProductInitializationTests: XCTestCase {
 
             let receivedProductData = self.extract()
 
-            expect(receivedProductData.paymentMode.rawValue) == PromotionalOffer.PaymentMode.freeTrial.rawValue
+            expect(receivedProductData.paymentMode.rawValue) == StoreProductDiscount.PaymentMode.freeTrial.rawValue
         } else {
             let receivedProductData = self.extract()
 
-            expect(receivedProductData.paymentMode) == PromotionalOffer.PaymentMode.none
+            expect(receivedProductData.paymentMode) == StoreProductDiscount.PaymentMode.none
         }
     }
 
@@ -134,7 +134,7 @@ class ProductRequestDataSK1ProductInitializationTests: XCTestCase {
         } else {
             let receivedProductData = self.extract()
 
-            expect(receivedProductData.introDurationType) == PromotionalOffer.PaymentMode.none
+            expect(receivedProductData.introDurationType) == StoreProductDiscount.PaymentMode.none
         }
     }
 

--- a/PurchasesTests/Purchasing/ProductRequestDataTests.swift
+++ b/PurchasesTests/Purchasing/ProductRequestDataTests.swift
@@ -12,7 +12,7 @@ class ProductRequestDataTests: XCTestCase {
     }
 
     func testAsDictionaryConvertsPaymentModeCorrectly() throws {
-        var paymentMode: PromotionalOffer.PaymentMode = .none
+        var paymentMode: StoreProductDiscount.PaymentMode = .none
         var productData: ProductRequestData = .createMockProductData(paymentMode: paymentMode)
         expect(try productData.asDictionary()["payment_mode"]).to(beNil())
 
@@ -90,17 +90,17 @@ class ProductRequestDataTests: XCTestCase {
     }
 
     func testAsDictionaryConvertsDiscountsCorrectly() throws {
-        let discount1 = PromotionalOffer(offerIdentifier: "offerid1",
+        let discount1 = StoreProductDiscount(offerIdentifier: "offerid1",
                                          price: 11.1,
                                          paymentMode: .payAsYouGo,
                                          subscriptionPeriod: .init(value: 1, unit: .month))
         
-        let discount2 = PromotionalOffer(offerIdentifier: "offerid2",
+        let discount2 = StoreProductDiscount(offerIdentifier: "offerid2",
                                          price: 12.2,
                                          paymentMode: .payUpFront,
                                          subscriptionPeriod: .init(value: 5, unit: .week))
         
-        let discount3 = PromotionalOffer(offerIdentifier: "offerid3",
+        let discount3 = StoreProductDiscount(offerIdentifier: "offerid3",
                                          price: 13.3,
                                          paymentMode: .freeTrial,
                                          subscriptionPeriod: .init(value: 3, unit: .month))
@@ -124,17 +124,17 @@ class ProductRequestDataTests: XCTestCase {
     }
     
     func testEncoding() throws {
-        let discount1 = PromotionalOffer(offerIdentifier: "offerid1",
+        let discount1 = StoreProductDiscount(offerIdentifier: "offerid1",
                                          price: 11.2,
                                          paymentMode: .payAsYouGo,
                                          subscriptionPeriod: .init(value: 1, unit: .month))
 
-        let discount2 = PromotionalOffer(offerIdentifier: "offerid2",
+        let discount2 = StoreProductDiscount(offerIdentifier: "offerid2",
                                          price: 12.2,
                                          paymentMode: .payUpFront,
                                          subscriptionPeriod: .init(value: 2, unit: .year))
 
-        let discount3 = PromotionalOffer(offerIdentifier: "offerid3",
+        let discount3 = StoreProductDiscount(offerIdentifier: "offerid3",
                                          price: 13.3,
                                          paymentMode: .freeTrial,
                                          subscriptionPeriod: .init(value: 3, unit: .day))
@@ -156,17 +156,17 @@ class ProductRequestDataTests: XCTestCase {
     func testCacheKey() {
         guard #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *) else { return }
         
-        let discount1 = PromotionalOffer(offerIdentifier: "offerid1",
+        let discount1 = StoreProductDiscount(offerIdentifier: "offerid1",
                                          price: 11,
                                          paymentMode: .payAsYouGo,
                                          subscriptionPeriod: .init(value: 1, unit: .month))
         
-        let discount2 = PromotionalOffer(offerIdentifier: "offerid2",
+        let discount2 = StoreProductDiscount(offerIdentifier: "offerid2",
                                          price: 12,
                                          paymentMode: .payUpFront,
                                          subscriptionPeriod: .init(value: 2, unit: .year))
         
-        let discount3 = PromotionalOffer(offerIdentifier: "offerid3",
+        let discount3 = StoreProductDiscount(offerIdentifier: "offerid3",
                                          price: 13,
                                          paymentMode: .freeTrial,
                                          subscriptionPeriod: .init(value: 3, unit: .day))

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -118,11 +118,11 @@ class PurchasesTests: XCTestCase {
         var postedIsRestore: Bool?
         var postedProductID: String?
         var postedPrice: Decimal?
-        var postedPaymentMode: PromotionalOffer.PaymentMode?
+        var postedPaymentMode: StoreProductDiscount.PaymentMode?
         var postedIntroPrice: Decimal?
         var postedCurrencyCode: String?
         var postedSubscriptionGroup: String?
-        var postedDiscounts: Array<PromotionalOffer>?
+        var postedDiscounts: Array<StoreProductDiscount>?
         var postedOfferingIdentifier: String?
         var postedObserverMode: Bool?
 
@@ -817,10 +817,10 @@ class PurchasesTests: XCTestCase {
             expect(self.backend.postedPrice).to(equal(product.price as Decimal))
 
             if #available(iOS 11.2, tvOS 11.2, macOS 10.13.2, *) {
-                expect(self.backend.postedPaymentMode).to(equal(PromotionalOffer.PaymentMode.payAsYouGo))
+                expect(self.backend.postedPaymentMode).to(equal(StoreProductDiscount.PaymentMode.payAsYouGo))
                 expect(self.backend.postedIntroPrice).to(equal(product.introductoryPrice?.price as Decimal?))
             } else {
-                expect(self.backend.postedPaymentMode).to(equal(PromotionalOffer.PaymentMode.none))
+                expect(self.backend.postedPaymentMode).to(equal(StoreProductDiscount.PaymentMode.none))
                 expect(self.backend.postedIntroPrice).to(beNil())
             }
 
@@ -830,10 +830,10 @@ class PurchasesTests: XCTestCase {
 
             if #available(iOS 12.2, *) {
                 expect(self.backend.postedDiscounts?.count).to(equal(1))
-                let postedDiscount: PromotionalOffer = self.backend.postedDiscounts![0]
+                let postedDiscount: StoreProductDiscount = self.backend.postedDiscounts![0]
                 expect(postedDiscount.offerIdentifier).to(equal("discount_id"))
                 expect(postedDiscount.price).to(equal(1.99))
-                expect(postedDiscount.paymentMode.rawValue).to(equal(PromotionalOffer.PaymentMode.payAsYouGo.rawValue))
+                expect(postedDiscount.paymentMode.rawValue).to(equal(StoreProductDiscount.PaymentMode.payAsYouGo.rawValue))
             }
 
             expect(self.backend.postedCurrencyCode).to(equal(product.priceLocale.currencyCode))

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -264,7 +264,7 @@
 		B3645F3D26E042B9002C490E /* RevenueCat.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DC5621824EC63430031F69B /* RevenueCat.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B36824BE268FBC5B00957E4C /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B36824BD268FBC5B00957E4C /* XCTest.framework */; };
 		B36824BF268FBC8700957E4C /* SubscriberAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8DB34A24072AAE00BE3D31 /* SubscriberAttributeTests.swift */; };
-		B372EC54268FEDC60099171E /* PromotionalOffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B372EC53268FEDC60099171E /* PromotionalOffer.swift */; };
+		B372EC54268FEDC60099171E /* StoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = B372EC53268FEDC60099171E /* StoreProductDiscount.swift */; };
 		B372EC56268FEF020099171E /* ProductRequestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B372EC55268FEF020099171E /* ProductRequestData.swift */; };
 		B3766F1E26BDA95100141450 /* IntroEligibilityResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3766F1D26BDA95100141450 /* IntroEligibilityResponse.swift */; };
 		B380D69B27726AB500984578 /* DNSCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B380D69A27726AB500984578 /* DNSCheckerTests.swift */; };
@@ -608,7 +608,7 @@
 		B35042C526CDD3B100905B95 /* PurchasesDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesDelegate.swift; sourceTree = "<group>"; };
 		B35F9E0826B4BEED00095C3F /* String+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		B36824BD268FBC5B00957E4C /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		B372EC53268FEDC60099171E /* PromotionalOffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionalOffer.swift; sourceTree = "<group>"; };
+		B372EC53268FEDC60099171E /* StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProductDiscount.swift; sourceTree = "<group>"; };
 		B372EC55268FEF020099171E /* ProductRequestData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRequestData.swift; sourceTree = "<group>"; };
 		B3766F1D26BDA95100141450 /* IntroEligibilityResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroEligibilityResponse.swift; sourceTree = "<group>"; };
 		B380D69A27726AB500984578 /* DNSCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DNSCheckerTests.swift; sourceTree = "<group>"; };
@@ -1122,7 +1122,7 @@
 				F5BE424126965F9F00254A30 /* ProductRequestData+Initialization.swift */,
 				37E35C7060D7E486F5958BED /* ProductsManager.swift */,
 				37E35E8DCF998D9DB63850F8 /* ProductsRequestFactory.swift */,
-				B372EC53268FEDC60099171E /* PromotionalOffer.swift */,
+				B372EC53268FEDC60099171E /* StoreProductDiscount.swift */,
 				2D9F4A5426C30CA800B07B43 /* PurchasesOrchestrator.swift */,
 				80E80EF026970DC3008F245A /* ReceiptFetcher.swift */,
 				F5BE423F26962ACF00254A30 /* ReceiptRefreshPolicy.swift */,
@@ -1924,7 +1924,7 @@
 				B34D2AA0269606E400D88C3A /* IntroEligibility.swift in Sources */,
 				B302206E2728B798008F1A0D /* BackendErrorStrings.swift in Sources */,
 				35D0E5D026A5886C0099EAD8 /* ErrorUtils.swift in Sources */,
-				B372EC54268FEDC60099171E /* PromotionalOffer.swift in Sources */,
+				B372EC54268FEDC60099171E /* StoreProductDiscount.swift in Sources */,
 				9A65DFDE258AD60A00DE00B0 /* LogIntent.swift in Sources */,
 				B35042C626CDD3B100905B95 /* PurchasesDelegate.swift in Sources */,
 				0313FD41268A506400168386 /* DateProvider.swift in Sources */,


### PR DESCRIPTION
[sc-12282]

Our PromotionalOffer currently maps to SK1’s SKProductDiscount and SK2's Product.SubscriptionOffer (https://developer.apple.com/documentation/storekit/product/subscriptionoffer).

Confusingly, the method promotionalOffer() from SK2 does not return a Product.SubscriptionOffer, but rather a PurchaseOption
https://developer.apple.com/documentation/storekit/product/purchaseoption/3749444-promotionaloffer

We will use the `PromotionalOffer` naming for the SKPaymentDiscount/SubscriptionOffer instead