### PR TITLE
Fixed `watchOS` availability annotations from `6.0` to `6.2`

### DIFF
--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -42,7 +42,7 @@ func checkPurchasesAPI() {
     checkPurchasesPurchasingAPI(purchases: purch)
     checkPurchasesSupportAPI(purchases: purch)
 
-    if #available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *) {
+    if #available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *) {
         _ = Task.init {
             await checkAsyncMethods(purchases: purch)
         }

--- a/Purchases/Identity/CustomerInfoManager.swift
+++ b/Purchases/Identity/CustomerInfoManager.swift
@@ -166,7 +166,7 @@ class CustomerInfoManager {
         }
     }
 
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     var customerInfoStream: AsyncStream<CustomerInfo> {
         return AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
             let disposable = self.monitorChanges { continuation.yield($0) }

--- a/Purchases/Public/Purchases+async.swift
+++ b/Purchases/Public/Purchases+async.swift
@@ -17,7 +17,7 @@ import StoreKit
 /// This extension holds the biolerplate logic to convert methods with completion blocks into async / await syntax.
 extension Purchases {
 
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func logInAsync(_ appUserID: String) async throws -> (customerInfo: CustomerInfo, created: Bool) {
         return try await withCheckedThrowingContinuation { continuation in
             logIn(appUserID) { maybeCustomerInfo, created, maybeError in
@@ -33,7 +33,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func logOutAsync() async throws -> CustomerInfo {
         return try await withCheckedThrowingContinuation { continuation in
             logOut { maybeCustomerInfo, maybeError in
@@ -49,7 +49,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func offeringsAsync() async throws -> Offerings {
         return try await withCheckedThrowingContinuation { continuation in
             getOfferings { maybeOfferings, maybeError in
@@ -65,7 +65,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func customerInfoAsync() async throws -> CustomerInfo {
         return try await withCheckedThrowingContinuation { continuation in
             getCustomerInfo { maybeCustomerInfo, maybeError in
@@ -81,7 +81,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func productsAsync(_ productIdentifiers: [String]) async -> [SKProduct] {
         return await withCheckedContinuation { continuation in
             getProducts(productIdentifiers) { result in
@@ -90,7 +90,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func purchaseAsync(product: SKProduct) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
@@ -112,7 +112,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func purchaseAsync(package: Package) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
@@ -134,7 +134,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func purchaseAsync(product: SKProduct, discount: SKPaymentDiscount) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
@@ -158,7 +158,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func purchaseAsync(package: Package, discount: SKPaymentDiscount) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
@@ -181,7 +181,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func syncPurchasesAsync() async throws -> CustomerInfo {
         return try await withCheckedThrowingContinuation { continuation in
             syncPurchases { maybeCustomerInfo, maybeError in
@@ -197,7 +197,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func restoreTransactionsAsync() async throws -> CustomerInfo {
         return try await withCheckedThrowingContinuation { continuation in
             restoreTransactions { maybeCustomerInfo, maybeError in
@@ -213,7 +213,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func checkTrialOrIntroductoryPriceEligibilityAsync(_ productIdentifiers: [String]) async
     -> [String: IntroEligibility] {
         return await withCheckedContinuation { continuation in
@@ -223,7 +223,7 @@ extension Purchases {
         }
     }
 
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func paymentDiscountAsync(forProductDiscount discount: SKProductDiscount,
                               product: SKProduct) async throws -> SKPaymentDiscount {
         return try await withCheckedThrowingContinuation { continuation in

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -679,7 +679,7 @@ public extension Purchases {
      * indicating whether the user was created for the first time in the RevenueCat backend.
      * See https://docs.revenuecat.com/docs/user-ids
      */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func logIn(_ appUserID: String) async throws -> (customerInfo: CustomerInfo, created: Bool) {
         return try await logInAsync(appUserID)
     }
@@ -711,7 +711,7 @@ public extension Purchases {
      * If this method is called and the current user is anonymous, it will return an error.
      * See https://docs.revenuecat.com/docs/user-ids
      */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func logOut() async throws -> CustomerInfo {
         return try await logOutAsync()
     }
@@ -742,7 +742,7 @@ public extension Purchases {
      * - Parameter completion: A completion block called when offerings are available.
      * Called immediately if offerings are cached. Offerings will be nil if an error occurred.
      */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func offerings() async throws -> Offerings {
         return try await offeringsAsync()
     }
@@ -768,7 +768,7 @@ public extension Purchases {
      *
      * - Seealso `Purchases.customerInfoStream`
      */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func customerInfo() async throws -> CustomerInfo {
         return try await customerInfoAsync()
     }
@@ -778,7 +778,7 @@ public extension Purchases {
     /// - Seealso `PurchasesDelegate.purchases(_ purchases: Purchases, didReceiveUpdated:)`
     /// - Seealso `Purchases.customerInfo()`
     /// - Note: this method is not thread-safe.
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     var customerInfoStream: AsyncStream<CustomerInfo> {
         return self.customerInfoManager.customerInfoStream
     }
@@ -824,7 +824,7 @@ public extension Purchases {
      * - Parameter completion: An @escaping callback that is called with the loaded products.
      * If the fetch fails for any reason it will return an empty array.
      */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func products(_ productIdentifiers: [String]) async -> [SKProduct] {
         return await productsAsync(productIdentifiers)
     }
@@ -875,7 +875,7 @@ public extension Purchases {
      *
      * If the user cancelled, `userCancelled` will be `YES`.
      */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func purchase(product: SKProduct) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
@@ -921,7 +921,7 @@ public extension Purchases {
      *
      * If the user cancelled, `userCancelled` will be `true`.
      */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func purchase(package: Package) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
@@ -977,7 +977,7 @@ public extension Purchases {
      * If the purchase was not successful, there will be an `Error`.
      * If the user cancelled, `userCancelled` will be `true`.
      */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func purchase(product: SKProduct, discount: SKPaymentDiscount) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
@@ -1034,7 +1034,7 @@ public extension Purchases {
      * If the purchase was not successful, there will be an `Error`.
      * If the user cancelled, `userCancelled` will be `true`.
      */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func purchase(package: Package, discount: SKPaymentDiscount) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: SKPaymentTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
@@ -1073,7 +1073,7 @@ public extension Purchases {
      * on the device does not contain subscriptions, but the user has made subscription purchases, this method
      * won't be able to restore them. Use `restoreTransactions(completion:)` to cover those cases.
      */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func syncPurchases() async throws -> CustomerInfo {
         return try await syncPurchasesAsync()
     }
@@ -1108,7 +1108,7 @@ public extension Purchases {
      * the user. Typically with a button in settings or near your purchase UI. Use
      * ``Purchases/syncPurchases(completion:)`` if you need to restore transactions programmatically.
      */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func restoreTransactions() async throws -> CustomerInfo {
         return try await restoreTransactionsAsync()
     }
@@ -1148,7 +1148,7 @@ public extension Purchases {
      * - Parameter productIdentifiers: Array of product identifiers for which you want to compute eligibility
      * - Parameter completion: A block that receives a dictionary of product_id -> ``IntroEligibility``.
      */
-    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
     func checkTrialOrIntroductoryPriceEligibility(_ productIdentifiers: [String]) async -> [String: IntroEligibility] {
         return await checkTrialOrIntroductoryPriceEligibilityAsync(productIdentifiers)
     }
@@ -1204,7 +1204,7 @@ public extension Purchases {
      * - Parameter completion: A completion block that is called when the `SKPaymentDiscount` is returned.
      * If it was not successful, there will be an `Error`.
      */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func paymentDiscount(forProductDiscount discount: SKProductDiscount,
                          product: SKProduct) async throws -> SKPaymentDiscount {
         return try await paymentDiscountAsync(forProductDiscount: discount, product: product)

--- a/Purchases/Purchasing/ProductsManager.swift
+++ b/Purchases/Purchasing/ProductsManager.swift
@@ -55,7 +55,7 @@ class ProductsManager: NSObject {
         }
     }
 
-    @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+    @available(iOS 13.0, tvOS 13.0, watchOS 6.2, macOS 10.15, *)
     func productsFromOptimalStoreKitVersion(
         withIdentifiers identifiers: Set<String>
     ) async throws -> Set<StoreProduct> {

--- a/Purchases/Purchasing/StoreKit1/ProductsFetcherSK1.swift
+++ b/Purchases/Purchasing/StoreKit1/ProductsFetcherSK1.swift
@@ -90,7 +90,7 @@ class ProductsFetcherSK1: NSObject {
         }
     }
 
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func products(withIdentifiers identifiers: Set<String>) async throws -> Set<SK1StoreProduct> {
         return try await withCheckedThrowingContinuation { continuation in
             products(withIdentifiers: identifiers) { result in

--- a/PurchasesTests/Mocks/MockProductsManager.swift
+++ b/PurchasesTests/Mocks/MockProductsManager.swift
@@ -47,7 +47,7 @@ class MockProductsManager: ProductsManager {
     var invokedProductsFromOptimalStoreKitVersionParameters: (identifiers: Set<String>, Void)?
     var invokedProductsFromOptimalStoreKitVersionParametersList = [(identifiers: Set<String>, Void)]()
 
-    @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+    @available(iOS 13.0, tvOS 13.0, watchOS 6.2, macOS 10.15, *)
     override func productsFromOptimalStoreKitVersion(
         withIdentifiers identifiers: Set<String>
     ) async -> Set<StoreProduct> {

--- a/StoreKitUnitTests/AvailabilityChecks.swift
+++ b/StoreKitUnitTests/AvailabilityChecks.swift
@@ -20,7 +20,7 @@ import XCTest
 enum AvailabilityChecks {
 
     static func iOS13APIAvailableOrSkipTest() throws {
-        guard #available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *) else {
+        guard #available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *) else {
             throw XCTSkip("Required API is not available for this test.")
         }
     }

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -184,7 +184,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(priceFormatter.string(from: productPrice)) == "$4.99"
     }
 
-    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
     func testSk1PriceFormatterFormatsCorrectly() async throws {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
@@ -199,7 +199,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(priceFormatter.string(from: productPrice)) == "$4.99"
     }
 
-    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, *)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
     func testSk1PriceFormatterReactsToStorefrontChanges() async throws {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 


### PR DESCRIPTION
Brought up [here](https://github.com/RevenueCat/purchases-ios/pull/1100#discussion_r779831690).
> min deployment target on `watchOS` is 6.2 since previous versions didn't even have IAP