### PR TITLE
Added docstring for `CustomerInfoManager.customerInfoObserversByIdentifier`

### DIFF
--- a/Purchases/Identity/CustomerInfoManager.swift
+++ b/Purchases/Identity/CustomerInfoManager.swift
@@ -175,6 +175,9 @@ class CustomerInfoManager {
         }
     }
 
+    /// Observers keyed by a monotonically increasing identifier.
+    /// This allows cancelling observations by deleting them from this dictionary.
+    /// These observers are used both for ``customerInfoStream`` and `PurchasesDelegate.purchases(_:receivedUpdated:)`.
     private var customerInfoObserversByIdentifier: [Int: (CustomerInfo) -> Void] = [:]
 
     /// Allows monitoring changes to the active `CustomerInfo`.


### PR DESCRIPTION
Requested [here](https://github.com/RevenueCat/purchases-ios/pull/1100#discussion_r779832767).