### PR TITLE
Replace a random number with an unreachable `fatalError` 

### DIFF
--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -822,10 +822,8 @@ private extension HTTPClientTests {
                                                                                  options: []) as? [String: Any])
             return try XCTUnwrap(requestBodyDict["requestNumber"] as? Int)
         } catch {
-            XCTFail(error.localizedDescription)
+            fatalError("Couldn't extract the request number from the URLRequest")
         }
-
-        fatalError("Unreachable")
     }
 
 }

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -825,7 +825,7 @@ private extension HTTPClientTests {
             XCTFail(error.localizedDescription)
         }
 
-        return -999
+        fatalError("Unreachable")
     }
 
 }

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -815,14 +815,15 @@ class HTTPClientTests: XCTestCase {
 
 private extension HTTPClientTests {
 
-    func extractRequestNumber(from urlRequest: URLRequest) -> Int {
+    func extractRequestNumber(from urlRequest: URLRequest) -> Int? {
         do {
             let requestData = urlRequest.ohhttpStubs_httpBody!
             let requestBodyDict = try XCTUnwrap(try JSONSerialization.jsonObject(with: requestData,
                                                                                  options: []) as? [String: Any])
             return try XCTUnwrap(requestBodyDict["requestNumber"] as? Int)
         } catch {
-            fatalError("Couldn't extract the request number from the URLRequest")
+            XCTFail("Couldn't extract the request number from the URLRequest")
+            return nil
         }
     }
 


### PR DESCRIPTION
After [this review comment ](https://github.com/RevenueCat/purchases-ios/pull/1124#discussion_r781401934)

> Feel free to do this in another PR, but to document that I would replace it with `fatalError("Unreachable")`

Tiny PR to replace a random number with a `fatalError` in an unreachable return sentence.