### PR TITLE
`StoreKit2TransactionListener`: cancel task on `deinit`

### DIFF
--- a/Purchases/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
+++ b/Purchases/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
@@ -29,11 +29,16 @@ class StoreKit2TransactionListener {
     }
 
     func listenForTransactions() {
+        self.taskHandle?.cancel()
         self.taskHandle = Task {
             for await result in StoreKit.Transaction.updates {
                 await handle(transactionResult: result)
             }
         }
+    }
+
+    deinit {
+        self.taskHandle?.cancel()
     }
 
     func handle(purchaseResult: StoreKit.Product.PurchaseResult) async -> Bool {

--- a/Purchases/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
+++ b/Purchases/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
@@ -21,7 +21,7 @@ protocol StoreKit2TransactionListenerDelegate: AnyObject {
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
 class StoreKit2TransactionListener {
 
-    private var taskHandle: Task<Void, Error>?
+    private(set) var taskHandle: Task<Void, Never>?
     weak var delegate: StoreKit2TransactionListenerDelegate?
 
     init(delegate: StoreKit2TransactionListenerDelegate?) {
@@ -30,15 +30,18 @@ class StoreKit2TransactionListener {
 
     func listenForTransactions() {
         self.taskHandle?.cancel()
-        self.taskHandle = Task {
+        self.taskHandle = Task { [weak self] in
             for await result in StoreKit.Transaction.updates {
-                await handle(transactionResult: result)
+                guard let self = self else { break }
+
+                await self.handle(transactionResult: result)
             }
         }
     }
 
     deinit {
         self.taskHandle?.cancel()
+        self.taskHandle = nil
     }
 
     func handle(purchaseResult: StoreKit.Product.PurchaseResult) async -> Bool {

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 		57AC4C182770F55C00DDE30F /* SK2StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AC4C172770F55C00DDE30F /* SK2StoreProduct.swift */; };
 		57AC4C1C2770F56200DDE30F /* SK1StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AC4C1B2770F56200DDE30F /* SK1StoreProduct.swift */; };
 		57BD50AA27692B7500211D6D /* StoreKitError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */; };
+		57C381B72791E593009E3940 /* StoreKit2TransactionListenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381B62791E593009E3940 /* StoreKit2TransactionListenerTests.swift */; };
 		57E0473B277260DE0082FE91 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 57E0473A277260DE0082FE91 /* SnapshotTesting */; };
 		57E2230727500BB1002DB06E /* AtomicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E2230627500BB1002DB06E /* AtomicTests.swift */; };
 		57EAE527274324C60060EB74 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE526274324C60060EB74 /* Lock.swift */; };
@@ -581,6 +582,7 @@
 		57AC4C172770F55C00DDE30F /* SK2StoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreProduct.swift; sourceTree = "<group>"; };
 		57AC4C1B2770F56200DDE30F /* SK1StoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1StoreProduct.swift; sourceTree = "<group>"; };
 		57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoreKitError+Extensions.swift"; sourceTree = "<group>"; };
+		57C381B62791E593009E3940 /* StoreKit2TransactionListenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2TransactionListenerTests.swift; sourceTree = "<group>"; };
 		57E0474B27729A1E0082FE91 /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		57E2230627500BB1002DB06E /* AtomicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicTests.swift; sourceTree = "<group>"; };
 		57EAE526274324C60060EB74 /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
@@ -847,6 +849,7 @@
 				F55FFA662763FAC300995146 /* TransactionsManagerSK2Tests.swift */,
 				5791A1C72767FC9400C972AA /* ManageSubscriptionsHelperTests.swift */,
 				5738F46D278CAC520096D623 /* StoreTransactionTests.swift */,
+				57C381B62791E593009E3940 /* StoreKit2TransactionListenerTests.swift */,
 			);
 			path = StoreKitUnitTests;
 			sourceTree = "<group>";
@@ -1805,6 +1808,7 @@
 				5738F489278CC2500096D623 /* MockTransaction.swift in Sources */,
 				2D90F8C826FD2225009B9142 /* MockAppleReceiptBuilder.swift in Sources */,
 				F55FFA672763FAC300995146 /* TransactionsManagerSK2Tests.swift in Sources */,
+				57C381B72791E593009E3940 /* StoreKit2TransactionListenerTests.swift in Sources */,
 				2D90F8C026FD20DF009B9142 /* MockAttributionDataMigrator.swift in Sources */,
 				F55FFA5D27634E1900995146 /* MockTransactionsManager.swift in Sources */,
 				2D90F8B826FD20AA009B9142 /* MockReceiptFetcher.swift in Sources */,

--- a/StoreKitUnitTests/StoreKit2TransactionListenerTests.swift
+++ b/StoreKitUnitTests/StoreKit2TransactionListenerTests.swift
@@ -1,0 +1,40 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  StoreKit2TransactionListenerTests.swift
+//
+//  Created by Nacho Soto on 1/14/22.
+
+import Nimble
+@testable import RevenueCat
+import StoreKitTest
+import XCTest
+
+class StoreKit2TransactionListenerTests: StoreKitConfigTestCase {
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func testStopsListeningToTransactions() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        var listener: StoreKit2TransactionListener? = .init(delegate: nil)
+        var handle: Task<Void, Never>?
+
+        expect(listener!.taskHandle).to(beNil())
+
+        listener!.listenForTransactions()
+        handle = listener!.taskHandle
+
+        expect(handle).toNot(beNil())
+        expect(handle?.isCancelled) == false
+
+        listener = nil
+        expect(handle?.isCancelled) == true
+    }
+
+}

--- a/SwiftStyleGuide.swift
+++ b/SwiftStyleGuide.swift
@@ -184,6 +184,11 @@ guard 1 == 1,
 // use _ = Task<Void, Never> for task initialization, so that if a part of the
 // Task throws, the compiler forces us to handle the exception
 // More info here: https://rev.cat/catching-exceptions-from-tasks
-_ = Task<Void, Never> {
-    try await myMethodThatThrows()
+_ = Task<Void, Never> { // Note: this implicitly captures `self`, so have to think about retain cycles.
+    try await self.myMethodThatThrows()
+}
+// Alternatively, if possible, store a reference to the task to call `cancel()`
+// on `deinit`.
+self.taskHandle = Task { [weak self] in
+    try await self?.myMethod()
 }


### PR DESCRIPTION
Currently the `Task` was outliving `StoreKit2TransactionListener`.