### PR TITLE
StoreKitUnitTests: add `Transactions` listener to all tests

### DIFF
--- a/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -45,6 +45,25 @@ class StoreKitConfigTestCase: XCTestCase {
         userDefaults.removePersistentDomain(forName: suiteName)
     }
 
+    // MARK: - Transactions observation
+
+    private static var transactionsObservation: Task<Void, Never>?
+
+    override class func setUp() {
+        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            Self.transactionsObservation?.cancel()
+            Self.transactionsObservation = Task {
+                // Silence warning in tests:
+                // "Making a purchase without listening for transaction updates risks missing successful purchases.
+                for await _ in Transaction.updates {}
+            }
+        }
+    }
+
+    override class func tearDown() {
+        Self.transactionsObservation?.cancel()
+    }
+
 }
 
 private extension StoreKitConfigTestCase {

--- a/StoreKitUnitTests/TransactionsManagerSK2Tests.swift
+++ b/StoreKitUnitTests/TransactionsManagerSK2Tests.swift
@@ -21,16 +21,6 @@ class TransactionsManagerSK2Tests: StoreKitConfigTestCase {
     var mockReceiptParser: MockReceiptParser!
     var transactionsManager: TransactionsManager!
 
-    override class func setUp() {
-        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
-            _ = Task {
-                // Silence warning in tests:
-                // "Making a purchase without listening for transaction updates risks missing successful purchases.
-                for await _ in Transaction.updates {}
-            }
-        }
-    }
-
     override func setUpWithError() throws {
         try super.setUpWithError()
 


### PR DESCRIPTION
### Changes:

- Moved observation to `StoreKitConfigTestCase`. A future PR will make purchases without observing `Transaction.updates`, so it will benefit from the change in #1121 as well.
- Cancelling `Task` at the end of the test.