### PR TITLE
Fixed 2 APITester warnings

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj/project.pbxproj
+++ b/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj/project.pbxproj
@@ -18,7 +18,6 @@
 		2DD77914270E23870079CBD4 /* RCOfferingAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614DF26EBE84F007DDB75 /* RCOfferingAPI.m */; };
 		2DD77915270E23870079CBD4 /* RCPackageAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614DE26EBE84F007DDB75 /* RCPackageAPI.m */; };
 		2DD77916270E23870079CBD4 /* RCTransactionAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614F426EBE84F007DDB75 /* RCTransactionAPI.m */; };
-		5738F41C27866E6F0096D623 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = A519264C26EBCEF6007D0BD1 /* main.m */; };
 		5738F428278672070096D623 /* RCStoreProductDiscountAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 5738F427278672070096D623 /* RCStoreProductDiscountAPI.m */; };
 		5738F42D278674710096D623 /* RCSubscriptionPeriodAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 5738F42C278674710096D623 /* RCSubscriptionPeriodAPI.m */; };
 		5738F42E2786755E0096D623 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = A519264C26EBCEF6007D0BD1 /* main.m */; };
@@ -250,7 +249,6 @@
 				2DD77916270E23870079CBD4 /* RCTransactionAPI.m in Sources */,
 				2DD7790F270E23870079CBD4 /* RCPurchasesAPI.m in Sources */,
 				5758EE5227864A8500B3B703 /* RCStoreProductAPI.m in Sources */,
-				5738F41C27866E6F0096D623 /* main.m in Sources */,
 				2DD77911270E23870079CBD4 /* RCEntitlementInfoAPI.m in Sources */,
 				2DD77912270E23870079CBD4 /* RCOfferingsAPI.m in Sources */,
 				2DD7790B270E23870079CBD4 /* RCCustomerInfoAPI.m in Sources */,

--- a/APITesters/SwiftAPITester/SwiftAPITester/SubscriptionPeriodAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/SubscriptionPeriodAPI.swift
@@ -10,7 +10,7 @@ import RevenueCat
 var period: SubscriptionPeriod!
 
 func checkSubscriptionPeriodAPI() {
-    let period2 = SubscriptionPeriod(value: 0, unit: .day)
+    _ = SubscriptionPeriod(value: 0, unit: .day)
 
     let value: Int = period.value
     let unit: SubscriptionPeriod.Unit = period.unit


### PR DESCRIPTION
### Changes:
- Removed duplicate `main.m` from compile phase, probably from a bad merge.
- Fixed unused variable warning