### PR TITLE
swiftlint.sh: simplified script to make it equivalent to `fastlane run swiftlint`

### DIFF
--- a/scripts/swiftlint.sh
+++ b/scripts/swiftlint.sh
@@ -12,36 +12,18 @@ PATH="${HOMEBREW_BINARY_DESTINATION}:${PATH}"
 
 if which swiftlint >/dev/null; then
   script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-  config_path="${script_path}/../.swiftlint.yml"
   source_path="${script_path}/../"
-  test_config_path="${script_path}/../PurchasesTests/.swiftlint.yml"
-  test_source_path="${script_path}/../PurchasesTests"
   swiftlint_path="$(which swiftlint)"
+
   echo "linter path:"
   echo $swiftlint_path
 
-  # Want different options for just your environment? Create a `.swiftlint.options.local` file in the same directory as
-  # `.swiftlint.yml` to override options. Leave the file empty to suppress default options.
-  options_path="${script_path}/../.swiftlint.options.local"
-  options=""
-
-  # Use --strict if you want warnings to be errors... it's kinda aggressive, I wouldn't.
-  # strict_option="--strict"
-  strict_option=""
-
-  # If the `.swiftlint.options.local` file exists, check to see if the options are supported in it.
-  if [[ -f "$options_path" ]]; then
-    if grep -- "$strict_option" "$options_path" > /dev/null 2>&1; then
-      options="$options $strict_option"
-    fi
-  # Otherwise set the default options.
-  else
-    options="$strict_option"
-  fi
-
-  lint_command="${swiftlint_path} lint ${options} --config ${config_path} ${source_path} --config ${test_config_path} ${test_source_path}"
+  lint_command="${swiftlint_path} lint"
   echo "linter command: ${lint_command}"
+  
+  pushd "${source_path}"
   $lint_command
+  popd
 else
   echo "Warning: SwiftLint not installed in ${HOMEBREW_BINARY_DESTINATION}, download from https://github.com/realm/SwiftLint"
 fi


### PR DESCRIPTION
#1124 introduced a change to disable some rules for `PurchasesTests`.

This lead to lint issues being found by `swiftlint` that `swiftlint.sh` (and therefore Xcode) wasn't reporting.

To fix that, and simplify the logic at the same time, I removed the custom parameters and instead made the script call `swiftlint` from the root directory (by using `pushd`/`popd`).