### PR TITLE
`StoreKitUnitTests`: disable the same lint rules as `PurchasesTests`

### DIFF
--- a/StoreKitUnitTests/.swiftlint.yml
+++ b/StoreKitUnitTests/.swiftlint.yml
@@ -1,0 +1,4 @@
+disabled_rules:
+  - file_length
+  - type_body_length
+  - function_body_length

--- a/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
+++ b/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
@@ -18,7 +18,6 @@ import XCTest
 
 @testable import RevenueCat
 
-// swiftlint:disable type_body_length
 class BeginRefundRequestHelperTests: XCTestCase {
 
     private var systemInfo: MockSystemInfo!

--- a/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -17,7 +17,6 @@ import Nimble
 import StoreKit
 import XCTest
 
-// swiftlint:disable type_body_length
 class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
     var productsManager: MockProductsManager!


### PR DESCRIPTION
Same rules disabled there in #1124.
This change will also need #1154 so that `scripts/swiftlint.sh` can parse `.swiftlint.yml` recursively.