### PR TITLE
Update public `purchase(product:)` methods with `StoreProduct`

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -78,7 +78,8 @@ BOOL isAnonymous;
     
     RCCustomerInfo *pi = nil;
     SKProduct *skp = [[SKProduct alloc] init];
-    SKPaymentDiscount *skmd = [[SKPaymentDiscount alloc] init];
+    RCStoreProduct *stp = nil;
+    RCStoreProductDiscount *stpd = nil;
     
     RCPackage *pack;
 
@@ -121,13 +122,13 @@ BOOL isAnonymous;
     [p getCustomerInfoWithCompletion:^(RCCustomerInfo *info, NSError *error) {}];
     [p getOfferingsWithCompletion:^(RCOfferings *info, NSError *error) {}];
     [p getProductsWithIdentifiers:@[@""] completion:^(NSArray<SKProduct *> *products) { }];
-    [p purchaseProduct:skp withCompletion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *error, BOOL userCancelled) { }];
+    [p purchaseProduct:stp withCompletion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *error, BOOL userCancelled) { }];
     [p purchasePackage:pack withCompletion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];
     [p restoreTransactionsWithCompletion:^(RCCustomerInfo *i, NSError *e) {}];
     [p syncPurchasesWithCompletion:^(RCCustomerInfo *i, NSError *e) {}];
     [p checkTrialOrIntroductoryPriceEligibility:@[@""] completion:^(NSDictionary<NSString *,RCIntroEligibility *> *d) { }];
-    [p purchaseProduct:skp withDiscount:skmd completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];
-    [p purchasePackage:pack withDiscount:skmd completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];
+    [p purchaseProduct:stp withDiscount:stpd completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];
+    [p purchasePackage:pack withDiscount:stpd completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];
     
     [p logIn:@"" completion:^(RCCustomerInfo *i, BOOL created, NSError *e) { }];
     [p logOutWithCompletion:^(RCCustomerInfo *i, NSError *e) { }];

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -118,10 +118,11 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.getProducts([String]()) { _ in }
 
     let skp: SKProduct = SKProduct()
+    let stp: StoreProduct! = nil
     let discount: StoreProductDiscount! = nil
     let pack: Package! = nil
 
-    purchases.purchase(product: skp) { _, _, _, _  in }
+    purchases.purchase(product: stp) { _, _, _, _  in }
     purchases.purchase(package: pack) { _, _, _, _  in }
     purchases.syncPurchases { _, _ in }
 
@@ -129,7 +130,7 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.checkTrialOrIntroductoryPriceEligibility([String](), completion: checkEligComplete)
     purchases.checkTrialOrIntroductoryPriceEligibility([String]()) { _ in }
 
-    purchases.purchase(product: skp, discount: discount) { _, _, _, _  in }
+    purchases.purchase(product: stp, discount: discount) { _, _, _, _  in }
     purchases.purchase(package: pack, discount: discount) { _, _, _, _  in }
     purchases.invalidateCustomerInfoCache()
 
@@ -182,6 +183,7 @@ private func checkPurchasesSubscriberAttributesAPI(purchases: Purchases) {
 
 private func checkAsyncMethods(purchases: Purchases) async {
     let pack: Package! = nil
+    let stp: StoreProduct! = nil
 
     do {
         let _: (CustomerInfo, Bool) = try await purchases.logIn("")
@@ -194,8 +196,8 @@ private func checkAsyncMethods(purchases: Purchases) async {
         let _: (StoreTransaction, CustomerInfo, Bool) = try await purchases.purchase(package: pack)
         let _: (StoreTransaction, CustomerInfo, Bool) = try await purchases.purchase(package: pack,
                                                                                      discount: discount)
-        let _: (StoreTransaction, CustomerInfo, Bool) = try await purchases.purchase(product: SKProduct())
-        let _: (StoreTransaction, CustomerInfo, Bool) = try await purchases.purchase(product: SKProduct(),
+        let _: (StoreTransaction, CustomerInfo, Bool) = try await purchases.purchase(product: stp)
+        let _: (StoreTransaction, CustomerInfo, Bool) = try await purchases.purchase(product: stp,
                                                                                      discount: discount)
         let _: CustomerInfo = try await purchases.customerInfo()
         let _: CustomerInfo = try await purchases.restoreTransactions()

--- a/Purchases/Public/Purchases+async.swift
+++ b/Purchases/Public/Purchases+async.swift
@@ -91,7 +91,7 @@ extension Purchases {
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func purchaseAsync(product: SKProduct) async throws ->
+    func purchaseAsync(product: StoreProduct) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: StoreTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
         return try await withCheckedThrowingContinuation { continuation in
@@ -135,7 +135,7 @@ extension Purchases {
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func purchaseAsync(product: SKProduct, discount: StoreProductDiscount) async throws ->
+    func purchaseAsync(product: StoreProduct, discount: StoreProductDiscount) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: StoreTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
         return try await withCheckedThrowingContinuation { continuation in

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -192,34 +192,42 @@ class PurchasesOrchestrator {
         }
     }
 
-    func purchase(package: Package, completion: @escaping PurchaseCompletedBlock) {
-        // todo: clean up, move to new class along with the private funcs below, remove
-        // swiftlint disable for length warning
-        if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *),
-           let product = package.storeProduct.sk2Product {
-            _ = Task<Void, Never> {
-                let result = await purchase(sk2Product: product)
-                DispatchQueue.main.async {
-                    switch result {
-                    case .failure(let error) where error is StoreKitError:
-                        completion(nil, nil, ErrorUtils.purchasesError(withStoreKitError: error), false)
-                    case .failure(let error):
-                        completion(nil, nil, error, false)
-                    case .success(let (customerInfo, userCancelled)):
-                        // todo: change API and send transaction
-                        if userCancelled {
-                            completion(nil, nil, ErrorUtils.purchaseCancelledError(), userCancelled)
-                        } else {
-                            completion(nil, customerInfo, nil, userCancelled)
-                        }
-                    }
-                }
-            }
+    func purchase(product: StoreProduct,
+                  package: Package?,
+                  completion: @escaping PurchaseCompletedBlock) {
+        if let sk1Product = product.sk1Product {
+            let payment = storeKitWrapper.payment(withProduct: sk1Product)
+
+            purchase(sk1Product: sk1Product,
+                     payment: payment,
+                     package: package,
+                     completion: completion)
+        } else if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *),
+                  let sk2Product = product.sk2Product {
+            purchase(sk2Product: sk2Product,
+                     completion: completion)
         } else {
-            guard let product = package.storeProduct.sk1Product else {
-                fatalError("could not identify StoreKit version to use! StoreProduct: \(package.storeProduct)")
-            }
-            purchase(sk1Product: product, package: package, completion: completion)
+            fatalError("Unrecognized product: \(product)")
+        }
+    }
+
+    @available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvOS 12.2, *)
+    func purchase(product: StoreProduct,
+                  package: Package?,
+                  discount: StoreProductDiscountType,
+                  completion: @escaping PurchaseCompletedBlock) {
+        if let sk1Product = product.sk1Product {
+            purchase(sk1Product: sk1Product,
+                     storeProductDiscount: discount,
+                     package: package,
+                     completion: completion)
+        } else if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *),
+                  let sk2Product = product.sk2Product {
+            // todo: add support for SK2 discounts
+            purchase(sk2Product: sk2Product,
+                     completion: completion)
+        } else {
+            fatalError("Unrecognized product: \(product)")
         }
     }
 
@@ -291,6 +299,28 @@ class PurchasesOrchestrator {
         }
         purchaseCompleteCallbacksByProductID[productIdentifier] = completion
         storeKitWrapper.add(payment)
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func purchase(sk2Product product: SK2Product, completion: @escaping PurchaseCompletedBlock) {
+        _ = Task<Void, Never> {
+            let result = await purchase(sk2Product: product)
+            DispatchQueue.main.async {
+                switch result {
+                case .failure(let error) where error is StoreKitError:
+                    completion(nil, nil, ErrorUtils.purchasesError(withStoreKitError: error), false)
+                case .failure(let error):
+                    completion(nil, nil, error, false)
+                case .success(let (customerInfo, userCancelled)):
+                    // todo: change API and send transaction
+                    if userCancelled {
+                        completion(nil, nil, ErrorUtils.purchaseCancelledError(), userCancelled)
+                    } else {
+                        completion(nil, customerInfo, nil, userCancelled)
+                    }
+                }
+            }
+        }
     }
 
 #if os(iOS) || os(macOS)

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreTransaction.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreTransaction.swift
@@ -53,7 +53,6 @@ public typealias SK2Transaction = StoreKit.Transaction
         hasher.combine(self.transactionIdentifier)
 
         return hasher.finalize()
-
     }
 
 }

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -582,7 +582,7 @@ class PurchasesTests: XCTestCase {
 
     func testDelegateIsNotCalledIfBlockPassed() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in
 
         }
@@ -620,7 +620,7 @@ class PurchasesTests: XCTestCase {
 
     func testAddsPaymentToWrapper() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in
 
         }
@@ -631,13 +631,14 @@ class PurchasesTests: XCTestCase {
 
     func testPurchaseProductCachesProduct() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let sk1Product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: sk1Product)
         self.purchases?.purchase(product: product) { (_, _, _, _) in
 
         }
 
         expect(self.mockProductsManager.invokedCacheProduct) == true
-        expect(self.mockProductsManager.invokedCacheProductParameter) == product
+        expect(self.mockProductsManager.invokedCacheProductParameter) == sk1Product
     }
 
     func testDoesntFetchProductDataIfEmptyList() {
@@ -653,7 +654,7 @@ class PurchasesTests: XCTestCase {
 
     func testTransitioningToPurchasing() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in
 
         }
@@ -669,7 +670,7 @@ class PurchasesTests: XCTestCase {
 
     func testTransitioningToPurchasedSendsToBackend() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in
 
         }
@@ -689,7 +690,7 @@ class PurchasesTests: XCTestCase {
 
     func testReceiptsSendsAsRestoreWhenAnon() {
         setupAnonPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in
 
         }
@@ -711,7 +712,7 @@ class PurchasesTests: XCTestCase {
         setupAnonPurchases()
         var deprecated = purchases.deprecated
         deprecated.allowSharingAppStoreAccount = false
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in
 
         }
@@ -733,7 +734,7 @@ class PurchasesTests: XCTestCase {
         setupPurchases()
         var deprecated = purchases.deprecated
         deprecated.allowSharingAppStoreAccount = true
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in
 
         }
@@ -753,7 +754,7 @@ class PurchasesTests: XCTestCase {
 
     func testFinishesTransactionsIfSentToBackendCorrectly() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in
 
         }
@@ -776,7 +777,7 @@ class PurchasesTests: XCTestCase {
     func testDoesntFinishTransactionsIfFinishingDisabled() {
         setupPurchases()
         self.purchases?.finishTransactions = false
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in
 
         }
@@ -801,7 +802,7 @@ class PurchasesTests: XCTestCase {
         let productIdentifiers = ["com.product.id1", "com.product.id2"]
         purchases!.getProducts(productIdentifiers) { (newProducts) in
             let product = newProducts[0]
-            self.purchases?.purchase(product: product) { (_, _, _, _) in
+            self.purchases?.purchase(product: StoreProduct(sk1Product: newProducts[0])) { (_, _, _, _) in
 
             }
 
@@ -852,10 +853,11 @@ class PurchasesTests: XCTestCase {
     func testFetchesProductDataIfNotCached() {
         systemInfo.stubbedIsApplicationBackgrounded = true
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let sk1Product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: sk1Product)
 
         let transaction = MockTransaction()
-        storeKitWrapper.payment = SKPayment(product: product)
+        storeKitWrapper.payment = SKPayment(product: sk1Product)
         transaction.mockPayment = self.storeKitWrapper.payment!
 
         transaction.mockState = SKPaymentTransactionState.purchasing
@@ -882,7 +884,7 @@ class PurchasesTests: XCTestCase {
 
     func testAfterSendingDoesntFinishTransactionIfBackendError() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in
 
         }
@@ -902,7 +904,7 @@ class PurchasesTests: XCTestCase {
 
     func testAfterSendingFinishesFromBackendErrorIfAppropriate() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in
 
         }
@@ -923,7 +925,7 @@ class PurchasesTests: XCTestCase {
 
     func testNotifiesIfTransactionFailsFromBackend() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in
 
         }
@@ -945,7 +947,7 @@ class PurchasesTests: XCTestCase {
 
     func testNotifiesIfTransactionFailsFromStoreKit() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         var receivedError: Error?
         self.purchases?.purchase(product: product) { (_, _, error, _) in
             receivedError = error
@@ -967,7 +969,7 @@ class PurchasesTests: XCTestCase {
 
     func testCallsDelegateAfterBackendResponse() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
 
         var customerInfo: CustomerInfo?
         var receivedError: Error?
@@ -987,7 +989,7 @@ class PurchasesTests: XCTestCase {
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "app_user_id",
                 "subscriptions": [:],
-                "non_subscriptions": [product.mockProductIdentifier: []]
+                "non_subscriptions": [product.productIdentifier: []]
             ]])
         self.backend.overrideCustomerInfo = customerInfoBeforePurchase
         self.backend.postReceiptCustomerInfo = customerInfoAfterPurchase
@@ -1012,7 +1014,7 @@ class PurchasesTests: XCTestCase {
 
     func testCompletionBlockOnlyCalledOnce() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
 
         var callCount = 0
 
@@ -1035,7 +1037,7 @@ class PurchasesTests: XCTestCase {
 
     func testCompletionBlockNotCalledForDifferentProducts() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         let otherProduct = MockSK1Product(mockProductIdentifier: "com.product.id2")
 
         var callCount = 0
@@ -1058,7 +1060,7 @@ class PurchasesTests: XCTestCase {
 
     func testCallingPurchaseWhileSameProductPendingIssuesError() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
 
         // First one "works"
         self.purchases?.purchase(product: product) { (_, _, _, _) in
@@ -1606,7 +1608,7 @@ class PurchasesTests: XCTestCase {
                 "other_purchases": [:]
             ]])
 
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in
 
         }
@@ -1816,7 +1818,7 @@ class PurchasesTests: XCTestCase {
         self.purchases?.getOfferings { (newOfferings, _) in
             let storeProduct = newOfferings!["base"]!.monthly!.storeProduct
             let product = storeProduct.sk1Product!
-            self.purchases?.purchase(product: product) { (_, _, _, _) in
+            self.purchases?.purchase(product: storeProduct) { (_, _, _, _) in
 
             }
 
@@ -1914,7 +1916,7 @@ class PurchasesTests: XCTestCase {
     }
 
     private func makeAPurchase() {
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
 
         guard let purchases = purchases else { fatalError("purchases is not initialized") }
         purchases.purchase(product: product) { _, _, _, _ in }
@@ -1951,7 +1953,7 @@ class PurchasesTests: XCTestCase {
 
     func testUserCancelledFalseIfPurchaseSuccessful() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         var receivedUserCancelled: Bool?
 
         self.purchases?.purchase(product: product) { (_, _, _, userCancelled) in
@@ -1968,7 +1970,7 @@ class PurchasesTests: XCTestCase {
 
     func testUnknownErrorCurrentlySubscribedIsParsedCorrectly() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         var receivedUserCancelled: Bool?
         var receivedError: NSError?
         var receivedUnderlyingError: NSError?
@@ -2008,7 +2010,7 @@ class PurchasesTests: XCTestCase {
 
     func testUserCancelledTrueIfPurchaseCancelled() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         var receivedUserCancelled: Bool?
         var receivedError: NSError?
         var receivedUnderlyingError: NSError?
@@ -2038,7 +2040,7 @@ class PurchasesTests: XCTestCase {
         setupPurchases()
         self.receiptFetcher.shouldReturnReceipt = false
 
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         var receivedUserCancelled: Bool?
         var receivedError: NSError?
 
@@ -2182,7 +2184,7 @@ class PurchasesTests: XCTestCase {
 
     func testObserverModeSetToFalseSetFinishTransactions() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in
 
         }
@@ -2204,7 +2206,7 @@ class PurchasesTests: XCTestCase {
 
     func testDoesntFinishTransactionsIfObserverModeIsSet() throws {
         try setupPurchasesObserverModeOn()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in
 
         }
@@ -2226,7 +2228,7 @@ class PurchasesTests: XCTestCase {
 
     func testRestoredPurchasesArePosted() throws {
         try setupPurchasesObserverModeOn()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in
 
         }
@@ -2243,7 +2245,7 @@ class PurchasesTests: XCTestCase {
 
     func testNilProductIdentifier() {
         setupPurchases()
-        let product = SK1Product()
+        let product = StoreProduct(sk1Product: SK1Product())
         var receivedError: Error?
         self.purchases?.purchase(product: product) { (_, _, error, _) in
             receivedError = error
@@ -2254,7 +2256,7 @@ class PurchasesTests: XCTestCase {
 
     func testNoCrashIfPaymentIsMissing() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in
         }
 
@@ -2407,7 +2409,7 @@ class PurchasesTests: XCTestCase {
 
     func testReceiptsSendsObserverModeWhenObserverMode() throws {
         try setupPurchasesObserverModeOn()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in
 
         }
@@ -2427,7 +2429,7 @@ class PurchasesTests: XCTestCase {
 
     func testReceiptsSendsObserverModeOffWhenObserverModeOff() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in
 
         }
@@ -2551,7 +2553,7 @@ class PurchasesTests: XCTestCase {
 
     func testNotifiesIfTransactionIsDeferredFromStoreKit() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         var receivedError: NSError?
         self.purchases?.purchase(product: product) { (_, _, error, _) in
             receivedError = error as NSError?

--- a/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -594,7 +594,7 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
     @available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvOS 12.2, *)
     func testPostReceiptMarksSubscriberAttributesSyncedIfBackendSuccessful() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in }
         mockSubscriberAttributesManager.stubbedUnsyncedAttributesByKeyResult = mockAttributes
 
@@ -620,7 +620,7 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
     @available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvOS 12.2, *)
     func testPostReceiptMarksSubscriberAttributesSyncedIfBackendSuccessfullySynced() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in }
         mockSubscriberAttributesManager.stubbedUnsyncedAttributesByKeyResult = mockAttributes
 
@@ -650,7 +650,7 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
     @available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvOS 12.2, *)
     func testPostReceiptDoesntMarkSubscriberAttributesSyncedIfBackendNotSuccessfullySynced() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases?.purchase(product: product) { (_, _, _, _) in }
         mockSubscriberAttributesManager.stubbedUnsyncedAttributesByKeyResult = mockAttributes
 

--- a/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -154,7 +154,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
 
         let product = try await fetchSk1Product()
-        let storeProduct = try await fetchSk1StoreProduct()
+        let storeProduct = StoreProduct(sk1Product: product)
         let package = Package(identifier: "package",
                               packageType: .monthly,
                               storeProduct: storeProduct,
@@ -183,14 +183,15 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
         backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
 
-        let storeProduct = try await fetchSk2StoreProduct()
+        let storeProduct = StoreProduct.from(product: try await fetchSk2StoreProduct())
         let package = Package(identifier: "package",
                               packageType: .monthly,
                               storeProduct: storeProduct,
                               offeringIdentifier: "offering")
 
         let (transaction, customerInfo, error, userCancelled) = await withCheckedContinuation { continuation in
-            orchestrator.purchase(package: package) { transaction, customerInfo, error, userCancelled in
+            orchestrator.purchase(product: storeProduct,
+                                  package: package) { transaction, customerInfo, error, userCancelled in
                 continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
             }
         }
@@ -217,14 +218,15 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
         backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
 
-        let storeProduct = try await fetchSk2StoreProduct()
+        let storeProduct = StoreProduct.from(product: try await fetchSk2StoreProduct())
         let package = Package(identifier: "package",
                               packageType: .monthly,
                               storeProduct: storeProduct,
                               offeringIdentifier: "offering")
 
         _ = await withCheckedContinuation { continuation in
-            orchestrator.purchase(package: package) { transaction, customerInfo, error, userCancelled in
+            orchestrator.purchase(product: storeProduct,
+                                  package: package) { transaction, customerInfo, error, userCancelled in
                 continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
             }
         }
@@ -240,14 +242,15 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
         backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
 
-        let storeProduct = try await fetchSk2StoreProduct()
+        let storeProduct = StoreProduct.from(product: try await fetchSk2StoreProduct())
         let package = Package(identifier: "package",
                               packageType: .monthly,
                               storeProduct: storeProduct,
                               offeringIdentifier: "offering")
 
         _ = await withCheckedContinuation { continuation in
-            orchestrator.purchase(package: package) { transaction, customerInfo, error, userCancelled in
+            orchestrator.purchase(product: storeProduct,
+                                  package: package) { transaction, customerInfo, error, userCancelled in
                 continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
             }
         }
@@ -263,14 +266,15 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
         backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
 
-        let storeProduct = try await fetchSk2StoreProduct()
+        let storeProduct = StoreProduct.from(product: try await fetchSk2StoreProduct())
         let package = Package(identifier: "package",
                               packageType: .monthly,
                               storeProduct: storeProduct,
                               offeringIdentifier: "offering")
 
         let (transaction, customerInfo, error, userCancelled) = await withCheckedContinuation { continuation in
-            orchestrator.purchase(package: package) { transaction, customerInfo, error, userCancelled in
+            orchestrator.purchase(product: storeProduct,
+                                  package: package) { transaction, customerInfo, error, userCancelled in
                 continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
             }
         }
@@ -291,14 +295,15 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         receiptFetcher.shouldReturnReceipt = false
         let expectedError = ErrorUtils.missingReceiptFileError()
 
-        let storeProduct = try await fetchSk2StoreProduct()
+        let storeProduct = StoreProduct.from(product: try await fetchSk2StoreProduct())
         let package = Package(identifier: "package",
                               packageType: .monthly,
                               storeProduct: storeProduct,
                               offeringIdentifier: "offering")
 
         let (transaction, customerInfo, error, userCancelled) = await withCheckedContinuation { continuation in
-            orchestrator.purchase(package: package) { transaction, customerInfo, error, userCancelled in
+            orchestrator.purchase(product: storeProduct,
+                                  package: package) { transaction, customerInfo, error, userCancelled in
                 continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
             }
         }

--- a/docs/V4_API_Updates.md
+++ b/docs/V4_API_Updates.md
@@ -45,6 +45,14 @@ Purchases.configure(
 )
 ```
 
+### New Types
+
+To better support `StoreKit 2`, `RevenueCat v4` introduces several new types to encapsulate data from `StoreKit 1` and `StoreKit 2`:
+
+- `StoreProduct` / `RCStoreProduct`: wraps a `StoreKit.SKProduct` or `StoreKit.Product`
+- `StoreTransaction` / `RCStoreTransaction`: wraps a `StoreKit.SKPaymentTransaction` or `StoreKit.Transaction`
+- `StoreProductDiscount` / `RCStoreProductDiscount`: wraps a `StoreKit.SKProductDiscount` or `StoreKit.Product.SubscriptionOffer`
+
 ### ObjC type changes
 
 `@import Purchases` is now `@import RevenueCat`


### PR DESCRIPTION
Fixes [sc-12293] and #1055.

### Changes:
- Replaced `SK1Product` with `StoreProduct` in all `Purchases.purchase(product:)` methods.
- Unified all logic into a single (well, two unfortunately _(1)_) method in `PurchasesOrchestrator` that checks the underlying product inside `StoreProduct`.
- Added docs for new types in `docs/V4_API_Updates.md`

_(1) `SKPaymentDiscount` is only available from `iOS 12.2`, so we can't consolidate both methods while being able to call it from iOS 11. This introduces a small amount of duplication unfortunately_.

### Alternatives considered:
- Adding `purchase(product:)` overloads with deprecation warnings. That was my first approach, and I don't think think that's necessary and worth the duplication because all methods will be returning `StoreProduct`s.