### PR TITLE
added missing `import Foundation` for `MacDevice`

### DIFF
--- a/Purchases/Misc/MacDevice.swift
+++ b/Purchases/Misc/MacDevice.swift
@@ -12,6 +12,7 @@
 //  Created by Juanpe Catalán on 30/11/21.
 
 #if os(macOS) || targetEnvironment(macCatalyst)
+import Foundation
 
 #if canImport(IOKit)
 import IOKit


### PR DESCRIPTION
Originally reported by @teeeeeegz in [this comment](https://github.com/RevenueCat/purchases-ios/pull/1006#issuecomment-1009976006). 

We were missing an `import Foundation` on `MacDevice`, which would make imports fail on macOS when importing through SPM. 

I added the missing import and double-checked that it now works correctly. 