### PR TITLE
Added catalyst and tvOS support for SPM integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,7 +359,7 @@ workflows:
               # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
               ignore: /pull\/[0-9]+/
       - integration-tests-cocoapods: *release-tags-and-branches
-      - integration-tests-swift-package-manager: *release-tags-and-branches
+      - integration-tests-swift-package-manager
       - integration-tests-carthage: *release-tags-and-branches
       - integration-tests-xcode-direct-integration: *release-tags-and-branches
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,29 @@ commands:
           working_directory: << parameters.directory >>
           command: |
               bundle exec fastlane archive
+
+  scan-and-archive-all-platforms:
+    parameters:
+      directory:
+        type: string
+    steps:
+      - run:
+          name: Replace API key
+          command: bundle exec fastlane replace_api_key_integration_tests
+      - run:
+          name: Run tests
+          working_directory: << parameters.directory >>
+          command: bundle exec fastlane scan
+      - store_test_results:
+          path: fastlane/test_output
+      - store_artifacts:
+          path: fastlane/test_output/report.html
+          destination: test_report.html
+      - run:
+          name: Archive all platforms
+          working_directory: << parameters.directory >>
+          command: |
+              bundle exec fastlane archive_all_platforms
   
   install-dependencies-scan-and-archive:
     parameters:
@@ -285,7 +308,9 @@ jobs:
       - checkout
       - trust-github-key
       - update-spm-integration-commit
-      - install-dependencies-scan-and-archive:
+      - install-dependencies:
+          directory: IntegrationTests/SPMIntegration/
+      - scan-and-archive-all-platforms:
           directory: IntegrationTests/SPMIntegration/
 
   integration-tests-carthage:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,7 +384,7 @@ workflows:
               # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
               ignore: /pull\/[0-9]+/
       - integration-tests-cocoapods: *release-tags-and-branches
-      - integration-tests-swift-package-manager
+      - integration-tests-swift-package-manager: *release-tags-and-branches
       - integration-tests-carthage: *release-tags-and-branches
       - integration-tests-xcode-direct-integration: *release-tags-and-branches
   deploy:

--- a/IntegrationTests/SPMIntegration/SPMIntegration.entitlements
+++ b/IntegrationTests/SPMIntegration/SPMIntegration.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/IntegrationTests/SPMIntegration/SPMIntegration.xcodeproj/project.pbxproj
+++ b/IntegrationTests/SPMIntegration/SPMIntegration.xcodeproj/project.pbxproj
@@ -429,6 +429,7 @@
 				DEVELOPMENT_TEAM = 8SXR2327BM;
 				INFOPLIST_FILE = ../CommonFiles/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -457,10 +458,12 @@
 				DEVELOPMENT_TEAM = 8SXR2327BM;
 				INFOPLIST_FILE = ../CommonFiles/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 11.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.SPMIntegration;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.revenuecat.SPMIntegration";
@@ -486,6 +489,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 11.2;
 				OTHER_SWIFT_FLAGS = "-DSPM_INTEGRATION";
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.SPMIntegrationTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -512,6 +516,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 11.2;
 				OTHER_SWIFT_FLAGS = "-DSPM_INTEGRATION";
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.SPMIntegrationTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/IntegrationTests/SPMIntegration/SPMIntegration.xcodeproj/project.pbxproj
+++ b/IntegrationTests/SPMIntegration/SPMIntegration.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2D1D5739278DC9B000359BB1 /* SPMIntegration.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SPMIntegration.entitlements; sourceTree = "<group>"; };
 		2D6C02042549F5600039CB92 /* SPMIntegration.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SPMIntegration.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D6C021F2549F5620039CB92 /* SPMIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SPMIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D6C02252549F5620039CB92 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -78,6 +79,7 @@
 		2D6C01FB2549F5600039CB92 = {
 			isa = PBXGroup;
 			children = (
+				2D1D5739278DC9B000359BB1 /* SPMIntegration.entitlements */,
 				2D6C02422549F5920039CB92 /* CommonFiles */,
 				2D6C02222549F5620039CB92 /* SPMIntegrationTests */,
 				2D6C02052549F5600039CB92 /* Products */,
@@ -420,6 +422,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = SPMIntegration.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
@@ -433,6 +436,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.SPMIntegration;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.revenuecat.SPMIntegration";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "SPMIntegration-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -446,6 +450,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = SPMIntegration.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
@@ -459,6 +464,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.SPMIntegration;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.revenuecat.SPMIntegration";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "SPMIntegration-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/IntegrationTests/SPMIntegration/SPMIntegration.xcodeproj/project.pbxproj
+++ b/IntegrationTests/SPMIntegration/SPMIntegration.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -11,8 +11,8 @@
 		2D6C02532549F5920039CB92 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2D6C02452549F5920039CB92 /* Assets.xcassets */; };
 		2D6C02542549F5920039CB92 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D6C02462549F5920039CB92 /* ViewController.m */; };
 		2D6C02552549F5920039CB92 /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D6C02472549F5920039CB92 /* SceneDelegate.m */; };
-		2D6C02562549F5920039CB92 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2D6C02482549F5920039CB92 /* LaunchScreen.storyboard */; };
-		2D6C02572549F5920039CB92 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2D6C024A2549F5920039CB92 /* Main.storyboard */; };
+		2D6C02562549F5920039CB92 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2D6C02482549F5920039CB92 /* LaunchScreen.storyboard */; platformFilters = (ios, maccatalyst, macos, watchos, ); };
+		2D6C02572549F5920039CB92 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2D6C024A2549F5920039CB92 /* Main.storyboard */; platformFilters = (ios, maccatalyst, macos, watchos, ); };
 		2D6C02582549F5920039CB92 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D6C024D2549F5920039CB92 /* main.m */; };
 		2D6C02592549F5920039CB92 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D6C024E2549F5920039CB92 /* AppDelegate.m */; };
 		2D6C02C22549F98C0039CB92 /* RCIntegrationRunner.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D6C024C2549F5920039CB92 /* RCIntegrationRunner.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -438,6 +438,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.SPMIntegration;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.revenuecat.SPMIntegration";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=appletvos*]" = "match AppStore com.revenuecat.SPMIntegration tvos";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "match AppStore com.revenuecat.SPMIntegration catalyst";
 				SDKROOT = "";
 				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos";
 				SUPPORTS_MACCATALYST = YES;
@@ -472,6 +474,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.SPMIntegration;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.revenuecat.SPMIntegration";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=appletvos*]" = "match AppStore com.revenuecat.SPMIntegration tvos";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "match AppStore com.revenuecat.SPMIntegration catalyst";
 				SDKROOT = "";
 				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos";
 				SUPPORTS_MACCATALYST = YES;

--- a/IntegrationTests/SPMIntegration/SPMIntegration.xcodeproj/project.pbxproj
+++ b/IntegrationTests/SPMIntegration/SPMIntegration.xcodeproj/project.pbxproj
@@ -419,6 +419,7 @@
 		2D6C02342549F5620039CB92 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
@@ -429,25 +430,30 @@
 				DEVELOPMENT_TEAM = 8SXR2327BM;
 				INFOPLIST_FILE = ../CommonFiles/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.SPMIntegration;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.revenuecat.SPMIntegration";
+				SDKROOT = "";
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos";
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "SPMIntegration-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
+				TVOS_DEPLOYMENT_TARGET = 11.0;
+				WATCHOS_DEPLOYMENT_TARGET = 6.2;
 			};
 			name = Debug;
 		};
 		2D6C02352549F5620039CB92 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_ENABLE_MODULES = YES;
@@ -458,19 +464,22 @@
 				DEVELOPMENT_TEAM = 8SXR2327BM;
 				INFOPLIST_FILE = ../CommonFiles/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.2;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.SPMIntegration;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.revenuecat.SPMIntegration";
+				SDKROOT = "";
+				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos";
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "SPMIntegration-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
+				TVOS_DEPLOYMENT_TARGET = 11.0;
+				WATCHOS_DEPLOYMENT_TARGET = 6.2;
 			};
 			name = Release;
 		};

--- a/IntegrationTests/SPMIntegration/fastlane/Scanfile
+++ b/IntegrationTests/SPMIntegration/fastlane/Scanfile
@@ -1,0 +1,1 @@
+devices(["iPhone 11 Pro", "My Mac (Mac Catalyst)"])

--- a/IntegrationTests/SPMIntegration/fastlane/Scanfile
+++ b/IntegrationTests/SPMIntegration/fastlane/Scanfile
@@ -1,1 +1,1 @@
-devices(["iPhone 11 Pro", "Any Mac"])
+catalyst_platform('macos')

--- a/IntegrationTests/SPMIntegration/fastlane/Scanfile
+++ b/IntegrationTests/SPMIntegration/fastlane/Scanfile
@@ -1,1 +1,1 @@
-devices(["iPhone 11 Pro", "My Mac (Mac Catalyst)"])
+devices(["iPhone 11 Pro", "Any Mac"])

--- a/IntegrationTests/SPMIntegration/fastlane/Scanfile
+++ b/IntegrationTests/SPMIntegration/fastlane/Scanfile
@@ -1,1 +1,0 @@
-catalyst_platform('macos')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -171,6 +171,20 @@ platform :ios do
     gym(export_method: "app-store")
   end
 
+  desc "archive all platforms"
+  lane :archive_all_platforms do
+    platforms = {
+      'ios' => 'generic/platform=ios',
+       'tvos' => 'generic/platform=tvos', 
+       'catalyst' => 'generic/platform=macOS,variant=Mac Catalyst'
+    }
+    
+    platforms.each do |platform, destination|
+      match(type: "appstore", platform: platform)
+      gym(export_method: "app-store", destination: destination)
+    end
+  end
+
   desc "build Swift API tester"
   lane :build_swift_api_tester do
     xcodebuild(


### PR DESCRIPTION
#1162 highlights the fact that we're not testing for macOS compatibility in SPM integration tests, so stuff could fall through the cracks. 

This adds `catalyst` and `tvOS` support so that tests would fail if we've messed up macOS compatibility on SPM.
See https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/4883/workflows/358209fb-3643-406e-987d-24325ed18ac1/jobs/15354

# TODO:
- [x] Disable integration tests when not on a release branch.