### PR TITLE
add `is_prerelease` param to GH releases

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -109,6 +109,8 @@ platform :ios do
     commit_hash = last_git_commit[:commit_hash]
     puts commit_hash
 
+    is_prerelease = new_version_number.split("-").length > 1
+
     set_github_release(
       repository_name: "revenuecat/purchases-ios",
       api_token: ENV["GITHUB_TOKEN"],
@@ -117,7 +119,8 @@ platform :ios do
       description: changelog,
       commitish: commit_hash,
       upload_assets: ["RevenueCat.framework.zip", "RevenueCat.xcframework.zip"],
-      is_draft: false
+      is_draft: false,
+      is_prerelease: is_prerelease
   )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -109,7 +109,7 @@ platform :ios do
     commit_hash = last_git_commit[:commit_hash]
     puts commit_hash
 
-    is_prerelease = new_version_number.split("-").length > 1
+    is_prerelease = new_version_number.include?("-")
 
     set_github_release(
       repository_name: "revenuecat/purchases-ios",


### PR DESCRIPTION
Currently, our beta GitHub releases aren't automatically marked as pre-release. 

We can do this automatically with fastlane, so I just added the param. 
