### PR TITLE
`isRestore` respects observer mode when syncing purchases in `StoreKit2TransactionListenerDelegate`

### DIFF
--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -425,8 +425,9 @@ private extension PurchasesOrchestrator {
 extension PurchasesOrchestrator: StoreKit2TransactionListenerDelegate {
 
     func transactionsUpdated() {
-        // todo: should isRestore here be set to observer mode?
-        syncPurchases(receiptRefreshPolicy: .always, isRestore: false, maybeCompletion: nil)
+        // Need to restore if using observer mode (which is inverse of finishTransactions)
+        let isRestore = !systemInfo.finishTransactions
+        syncPurchases(receiptRefreshPolicy: .always, isRestore: isRestore, maybeCompletion: nil)
     }
 
 }


### PR DESCRIPTION
## Motivation 
`isRestore` should be set to `false` when using observer mode since user/developer is handling transactions

## Description
- Passing `!systemInfo.finishTransactions` (which is observer mode) into `syncPurchases` 
- Added new tests for `StoreKit2TransactionListenerDelegate` to test with and without observer mode