### PR TITLE
Temporarily disable useStoreKit2IfAvailable

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -39,6 +39,11 @@ BOOL isAnonymous;
     [RCPurchases configureWithAPIKey:@"" appUserID:nil observerMode:false userDefaults:nil];
     [RCPurchases configureWithAPIKey:@"" appUserID:@"" observerMode:false userDefaults:[[NSUserDefaults alloc] init]];
     [RCPurchases configureWithAPIKey:@"" appUserID:nil observerMode:false userDefaults:[[NSUserDefaults alloc] init]];
+//    [RCPurchases configureWithAPIKey:@""
+//                           appUserID:nil
+//                        observerMode:false
+//                        userDefaults:[[NSUserDefaults alloc] init]
+//             useStoreKit2IfAvailable:true];
     
     [RCPurchases setLogHandler:^(RCLogLevel l, NSString *i) {}];
     canI = [RCPurchases canMakePayments];

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -28,6 +28,11 @@ func checkPurchasesAPI() {
     Purchases.configure(withAPIKey: "", appUserID: nil, observerMode: true, userDefaults: nil)
     Purchases.configure(withAPIKey: "", appUserID: "", observerMode: true, userDefaults: UserDefaults())
     Purchases.configure(withAPIKey: "", appUserID: nil, observerMode: true, userDefaults: UserDefaults())
+//    Purchases.configure(withAPIKey: "",
+//                        appUserID: nil,
+//                        observerMode: true,
+//                        userDefaults: UserDefaults(),
+//                        useStoreKit2IfAvailable: true)
 
     let finishTransactions: Bool = purch.finishTransactions
     let delegate: PurchasesDelegate? = purch.delegate

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1407,13 +1407,13 @@ public extension Purchases {
      *
      * - Returns: An instantiated `Purchases` object that has been set as a singleton.
      */
-    // todo: uncomment @objc name, remove private keyword, uncomment APITester calls, uncomment PurchasesTests
+    // todo: uncomment @objc name, remove private keyword, uncomment APITester calls
 //    @objc(configureWithAPIKey:appUserID:observerMode:userDefaults:useStoreKit2IfAvailable:)
-    @discardableResult private static func configure(withAPIKey apiKey: String,
-                                                     appUserID: String?,
-                                                     observerMode: Bool,
-                                                     userDefaults: UserDefaults?,
-                                                     useStoreKit2IfAvailable: Bool) -> Purchases {
+    @discardableResult internal static func configure(withAPIKey apiKey: String,
+                                                      appUserID: String?,
+                                                      observerMode: Bool,
+                                                      userDefaults: UserDefaults?,
+                                                      useStoreKit2IfAvailable: Bool) -> Purchases {
         let purchases = Purchases(apiKey: apiKey,
                                   appUserID: appUserID,
                                   userDefaults: userDefaults,

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1407,7 +1407,7 @@ public extension Purchases {
      *
      * - Returns: An instantiated `Purchases` object that has been set as a singleton.
      */
-    // todo: uncomment @objc name, remove private keyword, uncomment APITester calls
+    // todo: uncomment @objc name, remove private keyword, uncomment APITester calls, uncomment PurchasesTests
 //    @objc(configureWithAPIKey:appUserID:observerMode:userDefaults:useStoreKit2IfAvailable:)
     @discardableResult private static func configure(withAPIKey apiKey: String,
                                                      appUserID: String?,

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1407,12 +1407,12 @@ public extension Purchases {
      *
      * - Returns: An instantiated `Purchases` object that has been set as a singleton.
      */
-    @objc(configureWithAPIKey:appUserID:observerMode:userDefaults:useStoreKit2IfAvailable:)
-    @discardableResult static func configure(withAPIKey apiKey: String,
-                                             appUserID: String?,
-                                             observerMode: Bool,
-                                             userDefaults: UserDefaults?,
-                                             useStoreKit2IfAvailable: Bool) -> Purchases {
+//    @objc(configureWithAPIKey:appUserID:observerMode:userDefaults:useStoreKit2IfAvailable:)
+    @discardableResult private static func configure(withAPIKey apiKey: String,
+                                                     appUserID: String?,
+                                                     observerMode: Bool,
+                                                     userDefaults: UserDefaults?,
+                                                     useStoreKit2IfAvailable: Bool) -> Purchases {
         let purchases = Purchases(apiKey: apiKey,
                                   appUserID: appUserID,
                                   userDefaults: userDefaults,

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1407,6 +1407,7 @@ public extension Purchases {
      *
      * - Returns: An instantiated `Purchases` object that has been set as a singleton.
      */
+    // todo: uncomment @objc name, remove private keyword, uncomment APITester calls
 //    @objc(configureWithAPIKey:appUserID:observerMode:userDefaults:useStoreKit2IfAvailable:)
     @discardableResult private static func configure(withAPIKey apiKey: String,
                                                      appUserID: String?,

--- a/PurchasesTests/Misc/SystemInfoTests.swift
+++ b/PurchasesTests/Misc/SystemInfoTests.swift
@@ -89,6 +89,23 @@ class SystemInfoTests: XCTestCase {
     func testIsNotSandboxIfNoReceiptURL() throws {
         expect(try SystemInfo.withReceiptResult(.nilURL).isSandbox) == false
     }
+
+    func testUseStoreKit2IfAvailable() throws {
+        var useSK2 = false
+        var systemInfo = try SystemInfo(platformFlavor: nil,
+                                        platformFlavorVersion: nil,
+                                        finishTransactions: true,
+                                        useStoreKit2IfAvailable: useSK2)
+        expect(systemInfo.useStoreKit2IfAvailable) == useSK2
+
+        useSK2 = true
+
+        systemInfo = try SystemInfo(platformFlavor: nil,
+                                    platformFlavorVersion: nil,
+                                    finishTransactions: true,
+                                    useStoreKit2IfAvailable: useSK2)
+        expect(systemInfo.useStoreKit2IfAvailable) == useSK2
+    }
 }
 
 private extension SystemInfo {

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -1892,15 +1892,15 @@ class PurchasesTests: XCTestCase {
         expect(Purchases.shared.finishTransactions).toEventually(beTrue())
     }
 
-//    func testSharedInstanceIsSetWhenConfiguringWithAppUserIDAndUserDefaultsAndUseSK2() {
-//        let purchases = Purchases.configure(withAPIKey: "",
-//                                            appUserID: "",
-//                                            observerMode: false,
-//                                            userDefaults: nil,
-//                                            useStoreKit2IfAvailable: true)
-//        expect(Purchases.shared).toEventually(equal(purchases))
-//        expect(Purchases.shared.finishTransactions).toEventually(beTrue())
-//    }
+    func testSharedInstanceIsSetWhenConfiguringWithAppUserIDAndUserDefaultsAndUseSK2() {
+        let purchases = Purchases.configure(withAPIKey: "",
+                                            appUserID: "",
+                                            observerMode: false,
+                                            userDefaults: nil,
+                                            useStoreKit2IfAvailable: true)
+        expect(Purchases.shared).toEventually(equal(purchases))
+        expect(Purchases.shared.finishTransactions).toEventually(beTrue())
+    }
 
     func testWhenNoReceiptDataReceiptIsRefreshed() {
         setupPurchases()

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -1892,6 +1892,16 @@ class PurchasesTests: XCTestCase {
         expect(Purchases.shared.finishTransactions).toEventually(beTrue())
     }
 
+//    func testSharedInstanceIsSetWhenConfiguringWithAppUserIDAndUserDefaultsAndUseSK2() {
+//        let purchases = Purchases.configure(withAPIKey: "",
+//                                            appUserID: "",
+//                                            observerMode: false,
+//                                            userDefaults: nil,
+//                                            useStoreKit2IfAvailable: true)
+//        expect(Purchases.shared).toEventually(equal(purchases))
+//        expect(Purchases.shared.finishTransactions).toEventually(beTrue())
+//    }
+
     func testWhenNoReceiptDataReceiptIsRefreshed() {
         setupPurchases()
         receiptFetcher.shouldReturnReceipt = true


### PR DESCRIPTION
Resolves [sc-12137]

Makes the configure() with `useStoreKit2IfAvailable` private for our beta 3 launch, since promotional offers won't be ready. In doing so, I saw we don't have the APITester calls or unit tests, so I added them and commented out. 