### PR TITLE
Follow up for https://github.com/RevenueCat/purchases-ios/pull/1159

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesErrorCodeAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesErrorCodeAPI.m
@@ -46,7 +46,9 @@
         case RCInvalidSubscriberAttributesError:
         case RCLogOutAnonymousUserError:
         case RCEmptySubscriberAttributesError:
+        case RCProductDiscountMissingIdentifierError:
         case RCMissingAppUserIDForAliasCreationError:
+        case RCProductDiscountMissingSubscriptionGroupIdentifierError:
         case RCConfigurationError:
         case RCUnsupportedError:
         case RCCustomerInfoError:

--- a/APITesters/SwiftAPITester/SwiftAPITester/ErrorCodesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/ErrorCodesAPI.swift
@@ -44,6 +44,8 @@ func checkPurchasesErrorCodeEnums() {
          .operationAlreadyInProgressForProductError,
          .emptySubscriberAttributes,
          .missingAppUserIDForAliasCreationError,
+         .productDiscountMissingIdentifierError,
+         .productDiscountMissingSubscriptionGroupIdentifierError,
          .customerInfoError,
          .systemInfoError,
          .beginRefundRequestError,


### PR DESCRIPTION
Add back enum cases in APITesters
