### PR TITLE
Improve the way to handle the error if `purchase(sk2Product)` fails due to an error when posting the receipt

### DIFF
--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -201,8 +201,10 @@ class PurchasesOrchestrator {
                 let result = await purchase(sk2Product: product)
                 DispatchQueue.main.async {
                     switch result {
-                    case .failure(let error):
+                    case .failure(let error) where error is StoreKitError:
                         completion(nil, nil, ErrorUtils.purchasesError(withStoreKitError: error), false)
+                    case .failure(let error):
+                        completion(nil, nil, error, false)
                     case .success(let (customerInfo, userCancelled)):
                         // todo: change API and send transaction
                         if userCancelled {

--- a/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -226,7 +226,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         expect(userCancelled) == false
         expect(customerInfo).to(beNil())
         expect(error).toNot(beNil())
-        expect(error?.localizedDescription).to(equal(expectedError.localizedDescription))
+        expect(error).to(matchError(expectedError))
         let mockListener = try XCTUnwrap(orchestrator.storeKit2Listener as? MockStoreKit2TransactionListener)
         expect(mockListener.invokedHandle) == true
     }

--- a/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -207,7 +207,6 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     func testPurchaseSK2PackageReturnsMissingReceiptErrorIfSendReceiptFailed() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        testSession.failTransactionsEnabled = false
         receiptFetcher.shouldReturnReceipt = false
         let expectedError = ErrorUtils.missingReceiptFileError()
 

--- a/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -204,6 +204,35 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testPurchaseSK2PackageReturnsMissingReceiptErrorIfSendReceiptFailed() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        testSession.failTransactionsEnabled = false
+        receiptFetcher.shouldReturnReceipt = false
+        let expectedError = ErrorUtils.missingReceiptFileError()
+
+        let storeProduct = try await fetchSk2StoreProduct()
+        let package = Package(identifier: "package",
+                              packageType: .monthly,
+                              storeProduct: storeProduct,
+                              offeringIdentifier: "offering")
+
+        let (transaction, customerInfo, error, userCancelled) = await withCheckedContinuation { continuation in
+            orchestrator.purchase(package: package) { transaction, customerInfo, error, userCancelled in
+                continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
+            }
+        }
+
+        expect(transaction).to(beNil())
+        expect(userCancelled) == false
+        expect(customerInfo).to(beNil())
+        expect(error).toNot(beNil())
+        expect(error?.localizedDescription).to(equal(expectedError.localizedDescription))
+        let mockListener = try XCTUnwrap(orchestrator.storeKit2Listener as? MockStoreKit2TransactionListener)
+        expect(mockListener.invokedHandle) == true
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testStoreKit2TransactionListenerDelegate() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
@@ -215,7 +244,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         expect(self.backend.invokedPostReceiptDataParameters?.isRestore).to(beFalse())
     }
 
-    func testStoreKit2TransactionListenerDelegateWithObesrverMode() async throws {
+    func testStoreKit2TransactionListenerDelegateWithObserverMode() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         try setUpSystemInfo(finishTransactions: false)


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Resolves #1114 

Now, if `purchase(sk2Product:)` fails because of an error when posting the receipt, the method returns `ErrorCode.unknownError` because it assumes it always receives a `StoreKitError`. The goal of this PR is to improve the way to handle the error.

### Description
- Add a `where` condition to know if the error type is `StoreKitError`, if not the method returns the error received.
- Add a new test method to validate this logic.
