### PR TITLE
use StoreProductDiscount instead of SKPaymentDiscount in public api

### DIFF
--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -118,7 +118,7 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.getProducts([String]()) { _ in }
 
     let skp: SKProduct = SKProduct()
-    let paymentDiscount: SKPaymentDiscount = SKPaymentDiscount()
+    let discount: StoreProductDiscount! = nil
     let pack: Package! = nil
 
     purchases.purchase(product: skp) { _, _, _, _  in }
@@ -129,8 +129,8 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.checkTrialOrIntroductoryPriceEligibility([String](), completion: checkEligComplete)
     purchases.checkTrialOrIntroductoryPriceEligibility([String]()) { _ in }
 
-    purchases.purchase(product: skp, discount: paymentDiscount) { _, _, _, _  in }
-    purchases.purchase(package: pack, discount: paymentDiscount) { _, _, _, _  in }
+    purchases.purchase(product: skp, discount: discount) { _, _, _, _  in }
+    purchases.purchase(package: pack, discount: discount) { _, _, _, _  in }
     purchases.invalidateCustomerInfoCache()
 
 #if os(iOS)
@@ -190,12 +190,13 @@ private func checkAsyncMethods(purchases: Purchases) async {
         let _: Offerings = try await purchases.offerings()
 
         let _: [SKProduct] = await purchases.products([])
+        let discount: StoreProductDiscount! = nil
         let _: (StoreTransaction, CustomerInfo, Bool) = try await purchases.purchase(package: pack)
         let _: (StoreTransaction, CustomerInfo, Bool) = try await purchases.purchase(package: pack,
-                                                                                     discount: SKPaymentDiscount())
+                                                                                     discount: discount)
         let _: (StoreTransaction, CustomerInfo, Bool) = try await purchases.purchase(product: SKProduct())
         let _: (StoreTransaction, CustomerInfo, Bool) = try await purchases.purchase(product: SKProduct(),
-                                                                                     discount: SKPaymentDiscount())
+                                                                                     discount: discount)
         let _: CustomerInfo = try await purchases.customerInfo()
         let _: CustomerInfo = try await purchases.restoreTransactions()
         let _: CustomerInfo = try await purchases.syncPurchases()

--- a/Purchases/Public/Purchases+async.swift
+++ b/Purchases/Public/Purchases+async.swift
@@ -135,7 +135,7 @@ extension Purchases {
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func purchaseAsync(product: SKProduct, discount: SKPaymentDiscount) async throws ->
+    func purchaseAsync(product: SKProduct, discount: StoreProductDiscount) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: StoreTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
         return try await withCheckedThrowingContinuation { continuation in
@@ -158,7 +158,7 @@ extension Purchases {
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func purchaseAsync(package: Package, discount: SKPaymentDiscount) async throws ->
+    func purchaseAsync(package: Package, discount: StoreProductDiscount) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: StoreTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
         return try await withCheckedThrowingContinuation { continuation in

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -922,7 +922,7 @@ public extension Purchases {
 
     /**
      * Use this function if you are not using the Offerings system to purchase an `SKProduct` with an
-     * applied `SKPaymentDiscount`.
+     * applied `StoreProductDiscount`.
      * If you are using the Offerings system, use ``Purchases/purchase(package:discount:completion:)`` instead.
      *
      * Call this method when a user has decided to purchase a product with an applied discount.
@@ -934,7 +934,7 @@ public extension Purchases {
      * this for you.
      *
      * - Parameter product: The `SKProduct` the user intends to purchase
-     * - Parameter discount: The `SKPaymentDiscount` to apply to the purchase
+     * - Parameter discount: The `StoreProductDiscount` to apply to the purchase
      * - Parameter completion: A completion block that is called when the purchase completes.
      *
      * If the purchase was successful there will be a `StoreTransaction` and a ``CustomerInfo``.
@@ -943,14 +943,16 @@ public extension Purchases {
      */
     @available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvOS 12.2, *)
     @objc(purchaseProduct:withDiscount:completion:)
-    func purchase(product: SKProduct, discount: SKPaymentDiscount, completion: @escaping PurchaseCompletedBlock) {
-        let payment = storeKitWrapper.payment(withProduct: product, discount: discount)
-        purchase(product: product, payment: payment, presentedOfferingIdentifier: nil, completion: completion)
+    func purchase(product: SKProduct, discount: StoreProductDiscount, completion: @escaping PurchaseCompletedBlock) {
+        purchasesOrchestrator.purchase(sk1Product: product,
+                                       storeProductDiscount: discount,
+                                       presentedOfferingIdentifier: nil,
+                                       completion: completion)
     }
 
     /**
      * Use this function if you are not using the Offerings system to purchase an `SKProduct` with an
-     * applied `SKPaymentDiscount`.
+     * applied `StoreProductDiscount`.
      * If you are using the Offerings system, use ``Purchases/purchase(package:discount:completion:)`` instead.
      *
      * Call this method when a user has decided to purchase a product with an applied discount.
@@ -962,13 +964,13 @@ public extension Purchases {
      * this for you.
      *
      * - Parameter product: The `SKProduct` the user intends to purchase
-     * - Parameter discount: The `SKPaymentDiscount` to apply to the purchase
+     * - Parameter discount: The `StoreProductDiscount` to apply to the purchase
      * - Parameter completion: A completion block that is called when the purchase completes.
      *
      * If the user cancelled, `userCancelled` will be `true`.
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func purchase(product: SKProduct, discount: SKPaymentDiscount) async throws ->
+    func purchase(product: SKProduct, discount: StoreProductDiscount) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: StoreTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
         return try await purchaseAsync(product: product, discount: discount)
@@ -993,18 +995,17 @@ public extension Purchases {
      */
     @available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvOS 12.2, *)
     @objc(purchasePackage:withDiscount:completion:)
-    func purchase(package: Package, discount: SKPaymentDiscount, completion: @escaping PurchaseCompletedBlock) {
+    func purchase(package: Package, discount: StoreProductDiscount, completion: @escaping PurchaseCompletedBlock) {
         // todo: add support for SK2 with discounts, move to new class
         // https://github.com/RevenueCat/purchases-ios/issues/1055
         guard let sk1Product = package.storeProduct.sk1Product else {
             return
         }
-        let payment = storeKitWrapper.payment(withProduct: sk1Product,
-                                              discount: discount)
-        purchase(product: sk1Product,
-                 payment: payment,
-                 presentedOfferingIdentifier: package.offeringIdentifier,
-                 completion: completion)
+
+        purchasesOrchestrator.purchase(sk1Product: sk1Product,
+                                       storeProductDiscount: discount,
+                                       presentedOfferingIdentifier: package.offeringIdentifier,
+                                       completion: completion)
     }
 
     /**
@@ -1017,13 +1018,13 @@ public extension Purchases {
      * this for you.
      *
      * - Parameter package: The ``Package`` the user intends to purchase
-     * - Parameter discount: The `SKPaymentDiscount` to apply to the purchase
+     * - Parameter discount: The `StoreProductDiscount` to apply to the purchase
      * - Parameter completion: A completion block that is called when the purchase completes.
      *
      * If the user cancelled, `userCancelled` will be `true`.
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func purchase(package: Package, discount: SKPaymentDiscount) async throws ->
+    func purchase(package: Package, discount: StoreProductDiscount) async throws ->
     // swiftlint:disable:next large_tuple
     (transaction: StoreTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
         return try await purchaseAsync(package: package, discount: discount)

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -852,7 +852,7 @@ public extension Purchases {
     @objc(purchaseProduct:withCompletion:)
     func purchase(product: SKProduct, completion: @escaping PurchaseCompletedBlock) {
         let payment: SKMutablePayment = storeKitWrapper.payment(withProduct: product)
-        purchase(product: product, payment: payment, presentedOfferingIdentifier: nil, completion: completion)
+        purchase(product: product, payment: payment, package: nil, completion: completion)
     }
 
     /**
@@ -946,7 +946,7 @@ public extension Purchases {
     func purchase(product: SKProduct, discount: StoreProductDiscount, completion: @escaping PurchaseCompletedBlock) {
         purchasesOrchestrator.purchase(sk1Product: product,
                                        storeProductDiscount: discount,
-                                       presentedOfferingIdentifier: nil,
+                                       package: nil,
                                        completion: completion)
     }
 
@@ -1004,7 +1004,7 @@ public extension Purchases {
 
         purchasesOrchestrator.purchase(sk1Product: sk1Product,
                                        storeProductDiscount: discount,
-                                       presentedOfferingIdentifier: package.offeringIdentifier,
+                                       package: package,
                                        completion: completion)
     }
 
@@ -1543,11 +1543,11 @@ private extension Purchases {
 
     func purchase(product: SKProduct,
                   payment: SKMutablePayment,
-                  presentedOfferingIdentifier: String?,
+                  package: Package?,
                   completion: @escaping PurchaseCompletedBlock) {
         purchasesOrchestrator.purchase(sk1Product: product,
                                        payment: payment,
-                                       presentedOfferingIdentifier: presentedOfferingIdentifier,
+                                       package: package,
                                        completion: completion)
     }
 

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -224,7 +224,7 @@ class PurchasesOrchestrator {
     @available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvOS 12.2, *)
     func purchase(sk1Product: SK1Product,
                   storeProductDiscount: StoreProductDiscount,
-                  presentedOfferingIdentifier maybePresentedOfferingIdentifier: String?,
+                  package: Package?,
                   completion: @escaping PurchaseCompletedBlock) {
         self.paymentDiscount(forProductDiscount: storeProductDiscount,
                              product: sk1Product) { [unowned self] discount, error in
@@ -236,14 +236,14 @@ class PurchasesOrchestrator {
             let payment = self.storeKitWrapper.payment(withProduct: sk1Product, discount: discount)
             self.purchase(sk1Product: sk1Product,
                           payment: payment,
-                          presentedOfferingIdentifier: nil,
+                          package: package,
                           completion: completion)
         }
     }
 
     func purchase(sk1Product: SK1Product,
                   payment: SKMutablePayment,
-                  presentedOfferingIdentifier maybePresentedOfferingIdentifier: String?,
+                  package: Package?,
                   completion: @escaping PurchaseCompletedBlock) {
         Logger.debug(String(format: "Make purchase called: %@", #function))
         guard let productIdentifier = sk1Product.extractProductIdentifier(withPayment: payment) else {
@@ -260,7 +260,7 @@ class PurchasesOrchestrator {
         payment.applicationUsername = appUserID
         preventPurchasePopupCallFromTriggeringCacheRefresh(appUserID: appUserID)
 
-        if let presentedOfferingIdentifier = maybePresentedOfferingIdentifier {
+        if let presentedOfferingIdentifier = package?.offeringIdentifier {
             Logger.purchase(
                 Strings.purchase.purchasing_product_from_package(
                     productIdentifier: productIdentifier,
@@ -677,7 +677,7 @@ private extension PurchasesOrchestrator {
         let payment = storeKitWrapper.payment(withProduct: sk1Product)
         purchase(sk1Product: sk1Product,
                  payment: payment,
-                 presentedOfferingIdentifier: package.offeringIdentifier,
+                 package: package,
                  completion: completion)
     }
 

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -221,6 +221,26 @@ class PurchasesOrchestrator {
         }
     }
 
+    @available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvOS 12.2, *)
+    func purchase(sk1Product: SK1Product,
+                  storeProductDiscount: StoreProductDiscount,
+                  presentedOfferingIdentifier maybePresentedOfferingIdentifier: String?,
+                  completion: @escaping PurchaseCompletedBlock) {
+        self.paymentDiscount(forProductDiscount: storeProductDiscount,
+                             product: sk1Product) { [unowned self] discount, error in
+            guard let discount = discount else {
+                completion(nil, nil, error, false)
+                return
+            }
+
+            let payment = self.storeKitWrapper.payment(withProduct: sk1Product, discount: discount)
+            self.purchase(sk1Product: sk1Product,
+                          payment: payment,
+                          presentedOfferingIdentifier: nil,
+                          completion: completion)
+        }
+    }
+
     func purchase(sk1Product: SK1Product,
                   payment: SKMutablePayment,
                   presentedOfferingIdentifier maybePresentedOfferingIdentifier: String?,

--- a/PurchasesTests/Mocks/MockBackend.swift
+++ b/PurchasesTests/Mocks/MockBackend.swift
@@ -166,6 +166,7 @@ class MockBackend: Backend {
         data: Data?,
         applicationUsername: String?,
         completion: OfferSigningResponseHandler?)]()
+    var stubbedPostOfferCompetionResult: (String?, String?, UUID?, Int?, Error?)?
 
     override func post(offerIdForSigning offerIdentifier: String,
                        productIdentifier: String,
@@ -187,6 +188,11 @@ class MockBackend: Backend {
                                                   receiptData,
                                                   appUserID,
                                                   completion))
+        if let result = stubbedPostOfferCompetionResult {
+            completion(result.0, result.1, result.2, result.3, result.4)
+        } else {
+            completion(nil, nil, nil, nil, nil)
+        }
     }
 
     var invokedPostSubscriberAttributes = false

--- a/PurchasesTests/Mocks/MockStoreKitWrapper.swift
+++ b/PurchasesTests/Mocks/MockStoreKitWrapper.swift
@@ -10,9 +10,19 @@ class MockStoreKitWrapper: StoreKitWrapper {
     var payment: SKPayment?
     var addPaymentCallCount = 0
 
+    var mockAddPaymentTransactionState: SKPaymentTransactionState = .purchasing
+    var mockCallUpdatedTransactionInstantly = false
+
     override func add(_ newPayment: SKPayment) {
         payment = newPayment
         addPaymentCallCount += 1
+
+        if mockCallUpdatedTransactionInstantly {
+            let transaction = MockTransaction()
+            transaction.mockPayment = newPayment
+            transaction.mockState = mockAddPaymentTransactionState
+            delegate?.storeKitWrapper(self, updatedTransaction: transaction)
+        }
     }
 
     var finishCalled = false

--- a/PurchasesTests/Mocks/MockTransaction.swift
+++ b/PurchasesTests/Mocks/MockTransaction.swift
@@ -31,5 +31,4 @@ class MockTransaction: SKPaymentTransaction {
     override var transactionIdentifier: String? {
         mockTransactionIdentifier
     }
-
 }

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -2090,28 +2090,6 @@ class PurchasesTests: XCTestCase {
         expect(completionCalled).toEventually(beTrue())
     }
 
-    func testAddsDiscountToWrapper() {
-        if #available(iOS 12.2, tvOS 12.2, macOS 10.14.4, *) {
-            setupPurchases()
-            let product = MockSK1Product(mockProductIdentifier: "com.product.id1")
-            let discount = SKPaymentDiscount(
-                identifier: "discount",
-                keyIdentifier: "TIKAMASALA1",
-                nonce: UUID(),
-                signature: "Base64 encoded signature",
-                timestamp: NSNumber(value: Int64(123413232131))
-            )
-
-            self.purchases?.purchase(product: product, discount: discount) { (_, _, _, _) in
-
-            }
-
-            expect(self.storeKitWrapper.payment).toNot(beNil())
-            expect(self.storeKitWrapper.payment?.productIdentifier).to(equal(product.productIdentifier))
-            expect(self.storeKitWrapper.payment?.paymentDiscount).to(equal(discount))
-        }
-    }
-
     func testAttributionDataIsPostponedIfThereIsNoInstance() {
         let data = ["yo": "dog", "what": 45, "is": ["up"]] as [String: Any]
 

--- a/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -39,7 +39,6 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         try super.setUpWithError()
         try setUpSystemInfo()
         productsManager = MockProductsManager(systemInfo: systemInfo)
-        
         operationDispatcher = MockOperationDispatcher()
         receiptFetcher = MockReceiptFetcher(requestFetcher: MockRequestFetcher(), systemInfo: systemInfo)
         deviceCache = MockDeviceCache(systemInfo: systemInfo)


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Fixes [sc-12407]

### Description
- Replaces `SKPaymentDiscount` with `StoreProductDiscount` in Public API
- Orchestrator does the `StoreProductDiscount` to `SKPyamentDiscount` so end user doesn't need to worry about that step anymore
- Updated `PuchaseOrchestrator.purchase` to take a `package: Package?` instead of a `presentedOfferingIdentifier maybePresentedOfferingIdentifier: String?`