### PR TITLE
Rename `restoreTransactions` to `restorePurchases`

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -123,7 +123,7 @@ BOOL isAnonymous;
     [p getProductsWithIdentifiers:@[@""] completion:^(NSArray<SKProduct *> *products) { }];
     [p purchaseProduct:skp withCompletion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *error, BOOL userCancelled) { }];
     [p purchasePackage:pack withCompletion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];
-    [p restoreTransactionsWithCompletion:^(RCCustomerInfo *i, NSError *e) {}];
+    [p restorePurchasesWithCompletion:^(RCCustomerInfo *i, NSError *e) {}];
     [p syncPurchasesWithCompletion:^(RCCustomerInfo *i, NSError *e) {}];
     [p checkTrialOrIntroductoryPriceEligibility:@[@""] completion:^(NSDictionary<NSString *,RCIntroEligibility *> *d) { }];
     [p purchaseProduct:skp withDiscount:skmd completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -198,7 +198,7 @@ private func checkAsyncMethods(purchases: Purchases) async {
         let _: (StoreTransaction, CustomerInfo, Bool) = try await purchases.purchase(product: SKProduct(),
                                                                                      discount: discount)
         let _: CustomerInfo = try await purchases.customerInfo()
-        let _: CustomerInfo = try await purchases.restoreTransactions()
+        let _: CustomerInfo = try await purchases.restorePurchases()
         let _: CustomerInfo = try await purchases.syncPurchases()
 
         for try await _: CustomerInfo in purchases.customerInfoStream {}

--- a/BackendIntegrationTests/BackendIntegrationTests.swift
+++ b/BackendIntegrationTests/BackendIntegrationTests.swift
@@ -123,7 +123,7 @@ class BackendIntegrationTests: XCTestCase {
 
         expect(completionCalled).toEventually(beTrue(), timeout: .seconds(10))
 
-        Purchases.shared.restoreTransactions()
+        Purchases.shared.restorePurchases()
 
         waitUntilEntitlementsGoThrough()
     }
@@ -153,7 +153,7 @@ class BackendIntegrationTests: XCTestCase {
 
         expect(completionCalled).toEventually(beTrue(), timeout: .seconds(10))
 
-        Purchases.shared.restoreTransactions()
+        Purchases.shared.restorePurchases()
 
         waitUntilEntitlementsGoThrough()
     }

--- a/Purchases/Logging/Strings/RestoreStrings.swift
+++ b/Purchases/Logging/Strings/RestoreStrings.swift
@@ -17,7 +17,7 @@ import Foundation
 enum RestoreStrings {
 
     // swiftlint:disable identifier_name
-    case restoretransactions_called_with_allow_sharing_appstore_account_false_warning
+    case restorepurchases_called_with_allow_sharing_appstore_account_false_warning
     // swiftlint:enable identifier_name
 
 }
@@ -26,7 +26,7 @@ extension RestoreStrings: CustomStringConvertible {
 
     var description: String {
         switch self {
-        case .restoretransactions_called_with_allow_sharing_appstore_account_false_warning:
+        case .restorepurchases_called_with_allow_sharing_appstore_account_false_warning:
             return "allowSharingAppStoreAccount is set to false and restorePurchases has been called. " +
             "Are you sure you want to do this?"
         }

--- a/Purchases/Logging/Strings/RestoreStrings.swift
+++ b/Purchases/Logging/Strings/RestoreStrings.swift
@@ -27,7 +27,7 @@ extension RestoreStrings: CustomStringConvertible {
     var description: String {
         switch self {
         case .restoretransactions_called_with_allow_sharing_appstore_account_false_warning:
-            return "allowSharingAppStoreAccount is set to false and restoreTransactions has been called. " +
+            return "allowSharingAppStoreAccount is set to false and restorePurchases has been called. " +
             "Are you sure you want to do this?"
         }
     }

--- a/Purchases/Misc/Obsoletions.swift
+++ b/Purchases/Misc/Obsoletions.swift
@@ -19,6 +19,27 @@ import StoreKit
 public extension Purchases {
 
     /**
+     * This method will post all purchases associated with the current App Store account to RevenueCat and become
+     * associated with the current ``appUserID``. If the receipt is being used by an existing user, the current
+     * ``appUserID`` will be aliased together with the `appUserID` of the existing user.
+     *  Going forward, either `appUserID` will be able to reference the same user.
+     *
+     * You shouldn't use this method if you have your own account system. In that case "restoration" is provided
+     * by your app passing the same `appUserId` used to purchase originally.
+     *
+     * - Note: This may force your users to enter the App Store password so should only be performed on request of
+     * the user. Typically with a button in settings or near your purchase UI. Use
+     * ``Purchases/syncPurchases(completion:)`` if you need to restore transactions programmatically.
+     */
+    @available(iOS, obsoleted: 1, renamed: "restorePurchases(completion:)")
+    @available(tvOS, obsoleted: 1, renamed: "restorePurchases(completion:)")
+    @available(watchOS, obsoleted: 1, renamed: "restorePurchases(completion:)")
+    @available(macOS, obsoleted: 1, renamed: "restorePurchases(completion:)")
+    @objc func restoreTransactions(completion: ((CustomerInfo?, Error?) -> Void)? = nil) {
+        fatalError()
+    }
+
+    /**
      * Get latest available purchaser info.
      *
      * - Parameter completion: A completion block called when customer info is available and not stale.

--- a/Purchases/Public/CustomerInfo.swift
+++ b/Purchases/Public/CustomerInfo.swift
@@ -75,7 +75,7 @@ import Foundation
      * Returns the purchase date for the version of the application when the user bought the app.
      * Use this for grandfathering users when migrating to subscriptions.
      *
-     * - Note: This can be `nil`, see ``Purchases/restoreTransactions(completion:)``
+     * - Note: This can be `nil`, see ``Purchases/restorePurchases(completion:)``
      */
     @objc public let originalPurchaseDate: Date?
 
@@ -85,7 +85,7 @@ import Foundation
      * (in macOS) in the Info.plist file when the purchase was originally made. Use this for grandfathering users
      * when migrating to subscriptions.
      *
-     * - Note: This can be nil, see -`Purchases.restoreTransactions(completion:)`
+     * - Note: This can be nil, see -`Purchases.restorePurchases(completion:)`
      */
     @objc public let originalApplicationVersion: String?
 

--- a/Purchases/Public/Purchases+async.swift
+++ b/Purchases/Public/Purchases+async.swift
@@ -197,9 +197,9 @@ extension Purchases {
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func restoreTransactionsAsync() async throws -> CustomerInfo {
+    func restorePurchasesAsync() async throws -> CustomerInfo {
         return try await withCheckedThrowingContinuation { continuation in
-            restoreTransactions { maybeCustomerInfo, maybeError in
+            restorePurchases { maybeCustomerInfo, maybeError in
                 if let error = maybeError {
                     continuation.resume(throwing: error)
                     return

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1042,7 +1042,7 @@ public extension Purchases {
      *
      * - Note: This method will not trigger a login prompt from App Store. However, if the receipt currently
      * on the device does not contain subscriptions, but the user has made subscription purchases, this method
-     * won't be able to restore them. Use `restoreTransactions(completion:)` to cover those cases.
+     * won't be able to restore them. Use `restorePurchases(completion:)` to cover those cases.
      */
     @objc func syncPurchases(completion: ((CustomerInfo?, Error?) -> Void)?) {
         purchasesOrchestrator.syncPurchases(completion: completion)
@@ -1060,7 +1060,7 @@ public extension Purchases {
      *
      * - Note: This method will not trigger a login prompt from App Store. However, if the receipt currently
      * on the device does not contain subscriptions, but the user has made subscription purchases, this method
-     * won't be able to restore them. Use `restoreTransactions(completion:)` to cover those cases.
+     * won't be able to restore them. Use `restorePurchases(completion:)` to cover those cases.
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func syncPurchases() async throws -> CustomerInfo {
@@ -1080,8 +1080,8 @@ public extension Purchases {
      * the user. Typically with a button in settings or near your purchase UI. Use
      * ``Purchases/syncPurchases(completion:)`` if you need to restore transactions programmatically.
      */
-    @objc func restoreTransactions(completion: ((CustomerInfo?, Error?) -> Void)? = nil) {
-        purchasesOrchestrator.restoreTransactions(completion: completion)
+    @objc func restorePurchases(completion: ((CustomerInfo?, Error?) -> Void)? = nil) {
+        purchasesOrchestrator.restorePurchases(completion: completion)
     }
 
     /**
@@ -1098,8 +1098,8 @@ public extension Purchases {
      * ``Purchases/syncPurchases(completion:)`` if you need to restore transactions programmatically.
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func restoreTransactions() async throws -> CustomerInfo {
-        return try await restoreTransactionsAsync()
+    func restorePurchases() async throws -> CustomerInfo {
+        return try await restorePurchasesAsync()
     }
 
     /**
@@ -1267,7 +1267,7 @@ public extension Purchases {
      *
      * - Note: Use this initializer if your app does not have an account system.
      * `Purchases` will generate a unique identifier for the current device and persist it to `NSUserDefaults`.
-     * This also affects the behavior of ``Purchases/restoreTransactions(completion:)``.
+     * This also affects the behavior of ``Purchases/restorePurchases(completion:)``.
      *
      * - Parameter apiKey: The API Key generated for your app from https://app.revenuecat.com/
      *

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -95,7 +95,7 @@ class PurchasesOrchestrator {
         }
     }
 
-    func restoreTransactions(completion maybeCompletion: ((CustomerInfo?, Error?) -> Void)?) {
+    func restorePurchases(completion maybeCompletion: ((CustomerInfo?, Error?) -> Void)?) {
         syncPurchases(receiptRefreshPolicy: .always, isRestore: true, maybeCompletion: maybeCompletion)
     }
 

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -568,7 +568,7 @@ private extension PurchasesOrchestrator {
                        isRestore: Bool,
                        maybeCompletion: ((CustomerInfo?, Error?) -> Void)?) {
         if !self.allowSharingAppStoreAccount {
-            Logger.warn(Strings.restore.restoretransactions_called_with_allow_sharing_appstore_account_false_warning)
+            Logger.warn(Strings.restore.restorepurchases_called_with_allow_sharing_appstore_account_false_warning)
         }
 
         let currentAppUserID = appUserID

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -1161,7 +1161,7 @@ class PurchasesTests: XCTestCase {
 
     func testRestoringPurchasesPostsTheReceipt() {
         setupPurchases()
-        purchases!.restoreTransactions()
+        purchases!.restorePurchases()
         expect(self.backend.postReceiptDataCalled).to(beTrue())
     }
 
@@ -1185,7 +1185,7 @@ class PurchasesTests: XCTestCase {
         mockTransactionsManager.stubbedCustomerHasTransactionsCompletionParameter = false
 
         setupPurchases()
-        purchases!.restoreTransactions()
+        purchases!.restorePurchases()
 
         expect(self.backend.postReceiptDataCalled) == false
     }
@@ -1194,7 +1194,7 @@ class PurchasesTests: XCTestCase {
         mockTransactionsManager.stubbedCustomerHasTransactionsCompletionParameter = false
 
         setupPurchases()
-        purchases!.restoreTransactions()
+        purchases!.restorePurchases()
 
         expect(self.backend.postReceiptDataCalled) == true
     }
@@ -1219,7 +1219,7 @@ class PurchasesTests: XCTestCase {
         mockTransactionsManager.stubbedCustomerHasTransactionsCompletionParameter = true
 
         setupPurchases()
-        purchases!.restoreTransactions()
+        purchases!.restorePurchases()
 
         expect(self.backend.postReceiptDataCalled) == true
     }
@@ -1228,7 +1228,7 @@ class PurchasesTests: XCTestCase {
         mockTransactionsManager.stubbedCustomerHasTransactionsCompletionParameter = true
 
         setupPurchases()
-        purchases!.restoreTransactions()
+        purchases!.restorePurchases()
 
         expect(self.backend.postReceiptDataCalled) == true
     }
@@ -1236,20 +1236,20 @@ class PurchasesTests: XCTestCase {
     func testRestoringPurchasesAlwaysRefreshesAndPostsTheReceipt() {
         setupPurchases()
         self.receiptFetcher.shouldReturnReceipt = true
-        purchases!.restoreTransactions()
+        purchases!.restorePurchases()
 
         expect(self.receiptFetcher.receiptDataTimesCalled).to(equal(1))
     }
 
     func testRestoringPurchasesSetsIsRestore() {
         setupPurchases()
-        purchases!.restoreTransactions()
+        purchases!.restorePurchases()
         expect(self.backend.postedIsRestore!).to(beTrue())
     }
 
     func testRestoringPurchasesSetsIsRestoreForAnon() {
         setupAnonPurchases()
-        purchases!.restoreTransactions()
+        purchases!.restorePurchases()
 
         expect(self.backend.postedIsRestore!).to(beTrue())
     }
@@ -1262,7 +1262,7 @@ class PurchasesTests: XCTestCase {
 
         var receivedCustomerInfo: CustomerInfo?
 
-        purchases!.restoreTransactions { (info, _) in
+        purchases!.restorePurchases { (info, _) in
             receivedCustomerInfo = info
         }
 
@@ -1281,7 +1281,7 @@ class PurchasesTests: XCTestCase {
 
         var receivedError: Error?
 
-        purchases!.restoreTransactions { (_, newError) in
+        purchases!.restorePurchases { (_, newError) in
             receivedError = newError
         }
 
@@ -1564,7 +1564,7 @@ class PurchasesTests: XCTestCase {
 
         var receivedCustomerInfo: CustomerInfo?
 
-        purchases?.restoreTransactions { (info, _) in
+        purchases?.restorePurchases { (info, _) in
             receivedCustomerInfo = info
         }
 
@@ -1930,18 +1930,18 @@ class PurchasesTests: XCTestCase {
         setupPurchases()
         self.receiptFetcher.shouldReturnReceipt = false
         var receivedError: NSError?
-        self.purchases?.restoreTransactions { (_, error) in
+        self.purchases?.restorePurchases { (_, error) in
             receivedError = error as NSError?
         }
 
         expect(receivedError?.code).toEventually(be(ErrorCode.missingReceiptFileError.rawValue))
     }
 
-    func testRestoreTransactionsCallsCompletionOnMainThreadWhenMissingReceipts() {
+    func testRestorePurchasesCallsCompletionOnMainThreadWhenMissingReceipts() {
         setupPurchases()
         self.receiptFetcher.shouldReturnReceipt = false
         var receivedError: NSError?
-        self.purchases?.restoreTransactions { (_, error) in
+        self.purchases?.restorePurchases { (_, error) in
             receivedError = error as NSError?
         }
 

--- a/docs/V4_API_Updates.md
+++ b/docs/V4_API_Updates.md
@@ -363,7 +363,7 @@ Purchases.configure(
 		</tr>
 		<tr>
 			<td>restoreTransactions(_ completion:)</td>
-			<td>restoreTransactions(completion:)</td>
+			<td>restorePurchases(completion:)</td>
 		</tr>
 		<tr>
 			<td>syncPurchases(_ completion:)</td>

--- a/docs/V4_API_Updates.md
+++ b/docs/V4_API_Updates.md
@@ -146,6 +146,10 @@ Purchases.configure(
 			<td>invalidateCustomerInfoCache</td>
 		</tr>
 		<tr>
+			<td>Purchases -restoreTransactionsWithCompletion:</td>
+			<td>Purchases -restorePurchasesWithCompletion:</td>
+		</tr>
+		<tr>
 			<td>Purchases -offeringsWithCompletion:</td>
 			<td>Purchases -getOfferingsWithCompletion:</td>
 		</tr>


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Fixes [sc-12539]
`restoreTransactions` is typically referred to as `restorePurchases` (and is this way on other platforms) so making this consistent)

### Description
- Renamed `Purchases.restoreTransactions` to `Purchases.restorePurchases`
- Obsoleted `Purchases.restoreTransactions` (since we are bumping to a major version)
- Renamed `PurchasesOrchestrator.restoreTransactions` to `PurchasesOrchestrator.restorePurchases`
- Updated all comments that referred to `restoreTransactions` to `restorePurchases`
