### PR TITLE
add obsoletion for `product` in `package`

### DIFF
--- a/Purchases/Misc/Obsoletions.swift
+++ b/Purchases/Misc/Obsoletions.swift
@@ -285,12 +285,10 @@ public extension Package {
     /**
      `SKProduct` assigned to this package. https://developer.apple.com/documentation/storekit/skproduct
     */
-    @available(iOS, introduced: 11.0, obsoleted: 11.0, renamed: "storeProduct", message: "Use storeProduct instead")
-    @available(tvOS, introduced: 11.0, obsoleted: 11.0, renamed: "storeProduct", message: "Use storeProduct instead")
-    @available(watchOS, introduced: 6.2, obsoleted: 6.2, renamed: "storeProduct", message: "Use storeProduct instead")
-    @available(macOS, introduced: 10.13.4, obsoleted: 10.13.4,
-               renamed: "storeProduct", message: "Use storeProduct instead")
-    @available(macCatalyst, introduced: 13.0, obsoleted: 13.0, renamed: "storeProduct",
-               message: "Use storeProduct instead")
+    @available(iOS, obsoleted: 1, renamed: "storeProduct", message: "Use storeProduct instead")
+    @available(tvOS, obsoleted: 1, renamed: "storeProduct", message: "Use storeProduct instead")
+    @available(watchOS, obsoleted: 1, renamed: "storeProduct", message: "Use storeProduct instead")
+    @available(macOS, obsoleted: 1, renamed: "storeProduct", message: "Use storeProduct instead")
+    @available(macCatalyst, obsoleted: 1, renamed: "storeProduct", message: "Use storeProduct instead")
         var product: SKProduct { fatalError() }
 }

--- a/Purchases/Misc/Obsoletions.swift
+++ b/Purchases/Misc/Obsoletions.swift
@@ -285,10 +285,10 @@ public extension Package {
     /**
      `SKProduct` assigned to this package. https://developer.apple.com/documentation/storekit/skproduct
     */
-    @available(iOS, introduced: 12.2, obsoleted: 12.2, renamed: "storeProduct", message: "Use storeProduct instead")
-    @available(tvOS, introduced: 12.2, obsoleted: 12.2, renamed: "storeProduct", message: "Use storeProduct instead")
+    @available(iOS, introduced: 11.0, obsoleted: 11.0, renamed: "storeProduct", message: "Use storeProduct instead")
+    @available(tvOS, introduced: 11.0, obsoleted: 11.0, renamed: "storeProduct", message: "Use storeProduct instead")
     @available(watchOS, introduced: 6.2, obsoleted: 6.2, renamed: "storeProduct", message: "Use storeProduct instead")
-    @available(macOS, introduced: 10.14.4, obsoleted: 10.14.4,
+    @available(macOS, introduced: 10.13.4, obsoleted: 10.13.4,
                renamed: "storeProduct", message: "Use storeProduct instead")
     @available(macCatalyst, introduced: 13.0, obsoleted: 13.0, renamed: "storeProduct",
                message: "Use storeProduct instead")

--- a/Purchases/Misc/Obsoletions.swift
+++ b/Purchases/Misc/Obsoletions.swift
@@ -290,5 +290,5 @@ public extension Package {
     @available(watchOS, obsoleted: 1, renamed: "storeProduct", message: "Use storeProduct instead")
     @available(macOS, obsoleted: 1, renamed: "storeProduct", message: "Use storeProduct instead")
     @available(macCatalyst, obsoleted: 1, renamed: "storeProduct", message: "Use storeProduct instead")
-    var product: SKProduct { fatalError() }
+    @objc var product: SKProduct { fatalError() }
 }

--- a/Purchases/Misc/Obsoletions.swift
+++ b/Purchases/Misc/Obsoletions.swift
@@ -280,3 +280,17 @@ public extension Purchases {
 @available(watchOS, obsoleted: 1, renamed: "StoreTransaction")
 @available(macOS, obsoleted: 1, renamed: "StoreTransaction")
 @objc(RCTransaction) public class Transaction: NSObject { }
+
+public extension Package {
+    /**
+     `SKProduct` assigned to this package. https://developer.apple.com/documentation/storekit/skproduct
+    */
+    @available(iOS, introduced: 12.2, obsoleted: 12.2, renamed: "storeProduct", message: "Use storeProduct instead")
+    @available(tvOS, introduced: 12.2, obsoleted: 12.2, renamed: "storeProduct", message: "Use storeProduct instead")
+    @available(watchOS, introduced: 6.2, obsoleted: 6.2, renamed: "storeProduct", message: "Use storeProduct instead")
+    @available(macOS, introduced: 10.14.4, obsoleted: 10.14.4,
+               renamed: "storeProduct", message: "Use storeProduct instead")
+    @available(macCatalyst, introduced: 13.0, obsoleted: 13.0, renamed: "storeProduct",
+               message: "Use storeProduct instead")
+        var product: SKProduct { fatalError() }
+}

--- a/Purchases/Misc/Obsoletions.swift
+++ b/Purchases/Misc/Obsoletions.swift
@@ -284,11 +284,11 @@ public extension Purchases {
 public extension Package {
     /**
      `SKProduct` assigned to this package. https://developer.apple.com/documentation/storekit/skproduct
-    */
+     */
     @available(iOS, obsoleted: 1, renamed: "storeProduct", message: "Use storeProduct instead")
     @available(tvOS, obsoleted: 1, renamed: "storeProduct", message: "Use storeProduct instead")
     @available(watchOS, obsoleted: 1, renamed: "storeProduct", message: "Use storeProduct instead")
     @available(macOS, obsoleted: 1, renamed: "storeProduct", message: "Use storeProduct instead")
     @available(macCatalyst, obsoleted: 1, renamed: "storeProduct", message: "Use storeProduct instead")
-        var product: SKProduct { fatalError() }
+    var product: SKProduct { fatalError() }
 }

--- a/Purchases/Misc/Obsoletions.swift
+++ b/Purchases/Misc/Obsoletions.swift
@@ -285,10 +285,10 @@ public extension Package {
     /**
      `SKProduct` assigned to this package. https://developer.apple.com/documentation/storekit/skproduct
      */
-    @available(iOS, obsoleted: 1, renamed: "storeProduct", message: "Use storeProduct instead")
-    @available(tvOS, obsoleted: 1, renamed: "storeProduct", message: "Use storeProduct instead")
-    @available(watchOS, obsoleted: 1, renamed: "storeProduct", message: "Use storeProduct instead")
-    @available(macOS, obsoleted: 1, renamed: "storeProduct", message: "Use storeProduct instead")
-    @available(macCatalyst, obsoleted: 1, renamed: "storeProduct", message: "Use storeProduct instead")
+    @available(iOS, obsoleted: 1, renamed: "storeProduct", message: "Use StoreProduct instead")
+    @available(tvOS, obsoleted: 1, renamed: "storeProduct", message: "Use StoreProduct instead")
+    @available(watchOS, obsoleted: 1, renamed: "storeProduct", message: "Use StoreProduct instead")
+    @available(macOS, obsoleted: 1, renamed: "storeProduct", message: "Use StoreProduct instead")
+    @available(macCatalyst, obsoleted: 1, renamed: "storeProduct", message: "Use StoreProduct instead")
     @objc var product: SKProduct { fatalError() }
 }

--- a/docs/V4_API_Updates.md
+++ b/docs/V4_API_Updates.md
@@ -74,6 +74,10 @@ To better support `StoreKit 2`, `RevenueCat v4` introduces several new types to 
 			<td>RCStoreTransaction</td>
 		</tr>
 		<tr>
+			<td>RCPackage.product</td>
+			<td>RCPackage.storeProduct</td>
+		</tr>
+		<tr>
 			<td>(RCPurchasesErrorCode).RCOperationAlreadyInProgressError</td>
 			<td>RCOperationAlreadyInProgressForProductError</td>
 		</tr>


### PR DESCRIPTION
I realized that if you're using `package.product`, there's no obsoletion in place for an auto-fix it, so I added it