### PR TITLE
Lowered `StoreProduct.introductoryDiscount` availability to `iOS 11.2`

### DIFF
--- a/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
@@ -54,7 +54,7 @@ internal struct SK1StoreProduct: StoreProductType {
         return SubscriptionPeriod.from(sk1SubscriptionPeriod: skSubscriptionPeriod)
     }
 
-    @available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *)
+    @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
     var introductoryDiscount: StoreProductDiscount? {
         return self.underlyingSK1Product.introductoryPrice
             .map(StoreProductDiscount.init)

--- a/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
@@ -13,13 +13,17 @@
 
 import StoreKit
 
-@available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *)
+@available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
 internal struct SK1StoreProductDiscount: StoreProductDiscountType {
 
     init(sk1Discount: SK1ProductDiscount) {
         self.underlyingSK1Discount = sk1Discount
 
-        self.offerIdentifier = sk1Discount.identifier
+        if #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *) {
+            self.offerIdentifier = sk1Discount.identifier
+        } else {
+            self.offerIdentifier = nil
+        }
         self.price = sk1Discount.price as Decimal
         self.paymentMode = .init(skProductDiscountPaymentMode: sk1Discount.paymentMode)
         self.subscriptionPeriod = .from(sk1SubscriptionPeriod: sk1Discount.subscriptionPeriod)

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -80,7 +80,7 @@ public typealias SK2Product = StoreKit.Product
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
     @objc public var subscriptionPeriod: SubscriptionPeriod? { self.product.subscriptionPeriod }
 
-    @available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *)
+    @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
     @objc public var introductoryDiscount: StoreProductDiscount? { self.product.introductoryDiscount }
 
     @available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *)
@@ -148,7 +148,7 @@ internal protocol StoreProductType {
     /// Before displaying UI that offers the introductory price,
     /// you must first determine if the user is eligible to receive it.
     /// - Seealso: `Purchases.checkTrialOrIntroductoryPriceEligibility` to  determine eligibility.
-    @available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *)
+    @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
     var introductoryDiscount: StoreProductDiscount? { get }
 
     /// An array of subscription offers available for the auto-renewable subscription.

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -16,7 +16,7 @@ import Foundation
 import StoreKit
 
 /// TypeAlias to StoreKit 1's Discount type, called `SKProductDiscount`
-@available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *)
+@available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
 public typealias SK1ProductDiscount = SKProductDiscount
 
 /// TypeAlias to StoreKit 2's Discount type, called `StoreKit.Product.SubscriptionOffer`
@@ -98,7 +98,7 @@ internal protocol StoreProductDiscountType {
 
 extension StoreProductDiscount {
 
-    @available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *)
+    @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
     internal convenience init(sk1Discount: SK1ProductDiscount) {
         self.init(SK1StoreProductDiscount(sk1Discount: sk1Discount))
     }


### PR DESCRIPTION
### Motivation

`SKProductDiscount` was introduced in iOS 11.2, but its `identifier` was only available from iOS 12.2. Instead of making the latter the minimum version, this takes advantage of `StoreProductDiscountType.offerIdentifier` being `Optional`.

This is necessary for the change in #1184, so that `TrialOrIntroPriceEligibilityChecker` can continue to work from iOS 11.2.