### PR TITLE
add obsoletion for `numberOfUnits` in `SubscriptionPeriod`

### DIFF
--- a/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
@@ -76,7 +76,7 @@ public extension SubscriptionPeriod {
     @available(tvOS, obsoleted: 1, renamed: "value")
     @available(watchOS, obsoleted: 1, renamed: "value")
     @available(macOS, obsoleted: 1, renamed: "value")
-    @objc var numberOfUnits: UInt { fatalError() }
+    @objc var numberOfUnits: Int { fatalError() }
 
 }
 

--- a/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
@@ -66,6 +66,20 @@ public class SubscriptionPeriod: NSObject {
 
 }
 
+// MARK: - Renames
+
+// @available annotations to help users migrating from `SKProductSubscriptionPeriod` to `SubscriptionPeriod`
+public extension SubscriptionPeriod {
+
+    /// The number of units per subscription period
+    @available(iOS, obsoleted: 1, renamed: "value")
+    @available(tvOS, obsoleted: 1, renamed: "value")
+    @available(watchOS, obsoleted: 1, renamed: "value")
+    @available(macOS, obsoleted: 1, renamed: "value")
+    @objc var numberOfUnits: UInt { fatalError() }
+
+}
+
 extension SubscriptionPeriod {
     func pricePerMonth(withTotalPrice price: Decimal) -> Decimal {
         let periodsPerMonth: Decimal = {


### PR DESCRIPTION
If you're using `numberOfUnits` of `SKProductSubscriptionPeriod`, there was no auto-fix-it to update to `value` in `SubscriptionPeriod`, so similarly to #1191 this adds a fake obsoletion to make it easier to migrate