### PR TITLE
clean up obsoletion of `numberOfUnits`

### DIFF
--- a/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
@@ -72,10 +72,10 @@ public class SubscriptionPeriod: NSObject {
 public extension SubscriptionPeriod {
 
     /// The number of units per subscription period
-    @available(iOS, obsoleted: 1, renamed: "value")
-    @available(tvOS, obsoleted: 1, renamed: "value")
-    @available(watchOS, obsoleted: 1, renamed: "value")
-    @available(macOS, obsoleted: 1, renamed: "value")
+    @available(iOS, unavailable, renamed: "value")
+    @available(tvOS, unavailable, renamed: "value")
+    @available(watchOS, unavailable, renamed: "value")
+    @available(macOS, unavailable, renamed: "value")
     @objc var numberOfUnits: Int { fatalError() }
 
 }


### PR DESCRIPTION
From [this comment](https://github.com/RevenueCat/purchases-ios/pull/1194#pullrequestreview-857391851), this cleans up so that it's marked as `unavailable` instead of `obsolete`, which is more accurate since it was never available