### PR TITLE
updated the only api call that was outdated in purchaseTester, althou…

### DIFF
--- a/IntegrationTests/PurchaseTester/PurchaseTester/AppDelegate.swift
+++ b/IntegrationTests/PurchaseTester/PurchaseTester/AppDelegate.swift
@@ -21,8 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Purchases.configure(withAPIKey: Constants.apiKey,
                             appUserID: nil,
                             observerMode: false,
-                            userDefaults: nil,
-                            useStoreKit2IfAvailable: true)
+                            userDefaults: nil)
 
         Purchases.logLevel = .debug
         // set attributes to store additional, structured information for a user in RevenueCat.

--- a/IntegrationTests/PurchaseTester/PurchaseTester/AppDelegate.swift
+++ b/IntegrationTests/PurchaseTester/PurchaseTester/AppDelegate.swift
@@ -18,10 +18,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
-        Purchases.configure(withAPIKey: Constants.apiKey,
-                            appUserID: nil,
-                            observerMode: false,
-                            userDefaults: nil)
+        Purchases.configure(withAPIKey: Constants.apiKey)
 
         Purchases.logLevel = .debug
         // set attributes to store additional, structured information for a user in RevenueCat.


### PR DESCRIPTION
There was only one thing that was outdated in purchaseTester, which was using sk2 when available. We'll bring this back shortly, but I'd like to make sure that the version that gets released is consistent with the codebase. 