### PR TITLE
`Purchases.presentCodeRedemptionSheet`: disable on Catalyst

### DIFF
--- a/Purchases/Logging/Strings/PurchaseStrings.swift
+++ b/Purchases/Logging/Strings/PurchaseStrings.swift
@@ -26,6 +26,7 @@ enum PurchaseStrings {
     case paymentqueue_revoked_entitlements_for_product_identifiers(productIdentifiers: [String])
     case paymentqueue_updatedtransaction(transaction: SKPaymentTransaction)
     case presenting_code_redemption_sheet
+    case unable_to_present_redemption_sheet
     case purchases_synced
     case purchasing_product_from_package(productIdentifier: String, offeringIdentifier: String)
     case purchasing_product(productIdentifier: String)
@@ -105,6 +106,10 @@ extension PurchaseStrings: CustomStringConvertible {
 
         case .presenting_code_redemption_sheet:
             return "Presenting code redemption sheet."
+
+        case .unable_to_present_redemption_sheet:
+            return "SKPaymentQueue.presentCodeRedemptionSheet is not available in the current platform, " +
+            "this is an Apple bug."
 
         case .purchases_synced:
             return "Purchases synced."

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1154,6 +1154,7 @@ public extension Purchases {
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     @available(macOS, unavailable)
+    @available(macCatalyst, unavailable)
     @objc func presentCodeRedemptionSheet() {
         storeKitWrapper.presentCodeRedemptionSheet()
     }

--- a/Purchases/Purchasing/StoreKit1/StoreKitWrapper.swift
+++ b/Purchases/Purchasing/StoreKit1/StoreKitWrapper.swift
@@ -71,9 +71,18 @@ class StoreKitWrapper: NSObject, SKPaymentTransactionObserver {
     @available(macOS, unavailable)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
+    @available(macCatalyst, unavailable)
     func presentCodeRedemptionSheet() {
-        Logger.debug(Strings.purchase.presenting_code_redemption_sheet)
-        paymentQueue.presentCodeRedemptionSheet()
+        // Even though the docs in `SKPaymentQueue.presentCodeRedemptionSheet`
+        // say that it's available on Catalyst 14.0, there is a note:
+        // This function doesn’t affect Mac apps built with Mac Catalyst.
+        // It crashes when called both from Catalyst and also when running as "Designed for iPad".
+        if paymentQueue.responds(to: #selector(SKPaymentQueue.presentCodeRedemptionSheet)) {
+            Logger.debug(Strings.purchase.presenting_code_redemption_sheet)
+            paymentQueue.presentCodeRedemptionSheet()
+        } else {
+            Logger.appleError(Strings.purchase.unable_to_present_redemption_sheet)
+        }
     }
 
     func payment(withProduct product: SK1Product) -> SKMutablePayment {


### PR DESCRIPTION
Fixes [sc-10766]. The issue described there is supposed to be fixed in Xcode 13.2. This seems to be isolated to this particular method.
Even though the docs in [`SKPaymentQueue.presentCodeRedemptionSheet`](https://developer.apple.com/documentation/storekit/skpaymentqueue/3566726-presentcoderedemptionsheet) say that it's available on Catalyst 14.0, there is a note:

> This function doesn’t affect Mac apps built with Mac Catalyst.

It crashes when called both from Catalyst and also when running as "Designed for iPad".

To address that, this PR has 2 fixes:
- Disable API for Catalyst: this makes it impossible to call the method on "regular" Catalyst apps
- Disable call at runtime on "Designed for iPad" apps: because they're still "iOS" apps, it's still possible to call the method, but at runtime a new error is logged instead of crashing