### PR TITLE
update `PurchasesDelegate` method to use `StoreProduct` instead of `SKProduct`

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -78,7 +78,7 @@ BOOL isAnonymous;
     
     RCCustomerInfo *pi = nil;
     SKProduct *skp = [[SKProduct alloc] init];
-    RCStoreProduct *stp = nil;
+    RCStoreProduct *storeProduct = nil;
     RCStoreProductDiscount *stpd = nil;
     
     RCPackage *pack;
@@ -122,12 +122,12 @@ BOOL isAnonymous;
     [p getCustomerInfoWithCompletion:^(RCCustomerInfo *info, NSError *error) {}];
     [p getOfferingsWithCompletion:^(RCOfferings *info, NSError *error) {}];
     [p getProductsWithIdentifiers:@[@""] completion:^(NSArray<RCStoreProduct *> *products) { }];
-    [p purchaseProduct:stp withCompletion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *error, BOOL userCancelled) { }];
+    [p purchaseProduct:storeProduct withCompletion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *error, BOOL userCancelled) { }];
     [p purchasePackage:pack withCompletion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];
     [p restorePurchasesWithCompletion:^(RCCustomerInfo *i, NSError *e) {}];
     [p syncPurchasesWithCompletion:^(RCCustomerInfo *i, NSError *e) {}];
     [p checkTrialOrIntroductoryPriceEligibility:@[@""] completion:^(NSDictionary<NSString *,RCIntroEligibility *> *d) { }];
-    [p purchaseProduct:stp withDiscount:stpd completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];
+    [p purchaseProduct:storeProduct withDiscount:stpd completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];
     [p purchasePackage:pack withDiscount:stpd completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];
     
     [p logIn:@"" completion:^(RCCustomerInfo *i, BOOL created, NSError *e) { }];
@@ -135,7 +135,7 @@ BOOL isAnonymous;
 
     [p.delegate purchases:p receivedUpdatedCustomerInfo:pi];
     [p.delegate purchases:p
-shouldPurchasePromoProduct:skp
+shouldPurchasePromoProduct:storeProduct
            defermentBlock:^(void (^ _Nonnull completion)(RCStoreTransaction * _Nullable transaction,
                                                          RCCustomerInfo * _Nullable info,
                                                          NSError * _Nullable error,

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -117,18 +117,17 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.getOfferings { (_: Offerings?, _: Error?) in }
     purchases.getProducts([String]()) { (_: [StoreProduct]) in }
 
-    let skp: SKProduct = SKProduct()
-    let stp: StoreProduct! = nil
+    let storeProduct: StoreProduct! = nil
     let discount: StoreProductDiscount! = nil
     let pack: Package! = nil
 
-    purchases.purchase(product: stp) { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
+    purchases.purchase(product: storeProduct) { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
     purchases.purchase(package: pack) { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
     purchases.syncPurchases { (_: CustomerInfo?, _: Error?) in }
 
     purchases.checkTrialOrIntroductoryPriceEligibility([String]()) { (_: [String: IntroEligibility]) in }
 
-    purchases.purchase(product: stp,
+    purchases.purchase(product: storeProduct,
                        discount: discount) { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
     purchases.purchase(package: pack,
                        discount: discount) { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
@@ -143,7 +142,7 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.delegate?.purchases?(purchases, receivedUpdated: customerInfo!)
 
     let defermentBlock = { (_: (StoreTransaction?, CustomerInfo?, Error?, Bool) -> Void) in }
-    purchases.delegate?.purchases?(purchases, shouldPurchasePromoProduct: skp, defermentBlock: defermentBlock)
+    purchases.delegate?.purchases?(purchases, shouldPurchasePromoProduct: storeProduct, defermentBlock: defermentBlock)
 }
 
 private func checkIdentity(purchases: Purchases) {

--- a/Purchases/Public/Package.swift
+++ b/Purchases/Public/Package.swift
@@ -13,7 +13,6 @@
 //
 
 import Foundation
-import StoreKit
 
 @objc(RCPackageType) public enum PackageType: Int {
 

--- a/Purchases/Public/Purchases+async.swift
+++ b/Purchases/Public/Purchases+async.swift
@@ -12,7 +12,6 @@
 //  Created by Andrés Boedo on 24/11/21.
 
 import Foundation
-import StoreKit
 
 /// This extension holds the biolerplate logic to convert methods with completion blocks into async / await syntax.
 extension Purchases {

--- a/Purchases/Public/Purchases.swift
+++ b/Purchases/Public/Purchases.swift
@@ -1401,10 +1401,10 @@ extension Purchases: PurchasesOrchestratorDelegate {
      * If the purchase should never be made, you don't need to ever call the defermentBlock and `Purchases`
      * will not proceed with promotional purchases.
      *
-     * - Parameter product: `SKProduct` the product that was selected from the app store.
+     * - Parameter product: `StoreProduct` the product that was selected from the app store.
      */
     @objc
-    public func shouldPurchasePromoProduct(_ product: SKProduct,
+    public func shouldPurchasePromoProduct(_ product: StoreProduct,
                                            defermentBlock: @escaping DeferredPromotionalPurchaseBlock) {
         guard let delegate = delegate else {
             return

--- a/Purchases/Public/PurchasesDelegate.swift
+++ b/Purchases/Public/PurchasesDelegate.swift
@@ -13,7 +13,6 @@
 //
 
 import Foundation
-import StoreKit
 
 /**
  * Delegate for ``Purchases`` responsible for handling updating your app's state in response to updated customer info
@@ -53,10 +52,10 @@ import StoreKit
      * If the purchase should never be made, you don't need to ever call the defermentBlock and
      * ``Purchases`` will not proceed with promotional purchases.
 
-     * - Parameter product: `SKProduct` the product that was selected from the app store
+     * - Parameter product: `StoreProduct` the product that was selected from the app store
      */
     @objc optional func purchases(_ purchases: Purchases,
-                                  shouldPurchasePromoProduct product: SKProduct,
+                                  shouldPurchasePromoProduct product: StoreProduct,
                                   defermentBlock makeDeferredPurchase: @escaping DeferredPromotionalPurchaseBlock)
 
 }

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -16,7 +16,7 @@ import StoreKit
 
 @objc protocol PurchasesOrchestratorDelegate {
 
-    func shouldPurchasePromoProduct(_ product: SK1Product,
+    func shouldPurchasePromoProduct(_ product: StoreProduct,
                                     defermentBlock: @escaping DeferredPromotionalPurchaseBlock)
 
 }
@@ -398,8 +398,9 @@ extension PurchasesOrchestrator: StoreKitWrapperDelegate {
         productsManager.cacheProduct(product)
         guard let delegate = maybeDelegate else { return false }
 
+        let storeProduct = StoreProduct(sk1Product: product)
         lock.lock()
-        delegate.shouldPurchasePromoProduct(product) { completion in
+        delegate.shouldPurchasePromoProduct(storeProduct) { completion in
             self.purchaseCompleteCallbacksByProductID[product.productIdentifier] = completion
             storeKitWrapper.add(payment)
         }

--- a/PurchasesTests/Mocks/MockPurchasesDelegate.swift
+++ b/PurchasesTests/Mocks/MockPurchasesDelegate.swift
@@ -17,11 +17,11 @@ public class MockPurchasesDelegate: NSObject, PurchasesDelegate {
         self.customerInfo = customerInfo
     }
 
-    var promoProduct: SK1Product?
+    var promoProduct: StoreProduct?
     var makeDeferredPurchase: DeferredPromotionalPurchaseBlock?
 
     public func purchases(_ purchases: Purchases,
-                          shouldPurchasePromoProduct product: SK1Product,
+                          shouldPurchasePromoProduct product: StoreProduct,
                           defermentBlock makeDeferredPurchase: @escaping (@escaping PurchaseCompletedBlock) -> Void) {
         promoProduct = product
         self.makeDeferredPurchase = makeDeferredPurchase

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -1444,14 +1444,14 @@ class PurchasesTests: XCTestCase {
 
     func testCallsShouldAddPromoPaymentDelegateMethod() {
         setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "mock_product")
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "mock_product"))
         let payment = SKPayment()
 
         _ = storeKitWrapper.delegate?.storeKitWrapper(storeKitWrapper,
                                                       shouldAddStorePayment: payment,
-                                                      for: product)
+                                                      for: product.sk1Product!)
 
-        expect(self.purchasesDelegate.promoProduct).to(be(product))
+        expect(self.purchasesDelegate.promoProduct) == product
     }
 
     func testShouldAddPromoPaymentDelegateMethodReturnsFalse() {


### PR DESCRIPTION
There was one method still referencing `SKProduct`, an optional method from `PurchasesDelegate`. 

I updated it and its tests. 

I'm somewhat torn because since it's an optional method, this won't break compilation, but it'll issue a build warning saying that you have a method that closely matches the signature of the method but not quite. 