### PR TITLE
prepare CHANGELOG.latest.md for RC

### DIFF
--- a/CHANGELOG.latest.md
+++ b/CHANGELOG.latest.md
@@ -1,23 +1,32 @@
-- Tenth beta for RevenueCat framework 🎉
+- First RC for RevenueCat framework v4 🎉
     100% Swift framework + ObjC support.
 
-[Full Changelog](https://github.com/revenuecat/purchases-ios/compare/4.0.0-beta.9...4.0.0-beta.10)
+[Full Changelog](https://github.com/revenuecat/purchases-ios/compare/4.0.0-beta.10...4.0.0-rc.1)
 - See our [RevenueCat V4 API update doc](docs/V4_API_Updates.md) for API updates.
 
-Beta 10 introduces the following updates:
+RC 1 introduces the following updates:
 
-### Breaking changes:
-- A new type, `StoreTransaction`, replaces `SKPaymentTransaction` in the return types of the following methods:
+### API changes:
+
+- `Purchases.paymentDiscount(forProductDiscount:product:completion:)` and `Purchases.paymentDiscount(forProductDiscount:product:)` have been removed. Now, instead of obtaining the `SKPaymentDiscount` from a `SKProductDiscount` to then call `purchase(package:discount:)`, you can obtain the `StoreProductDiscount` directly from the `StoreProduct` and pass that into `purchase(package:discount:)`. 
+
+- `StoreProduct` and `StoreProductDiscount`, replace `SKProduct` and `SKProductDiscount` in the following methods:
+    - `Purchases.getProducts(_:completion:)`
+    - `Purchases.products(_:)`
     - `Purchases.purchase(product:completion:)`
-    - `Purchases.purchase(package:completion:)`
+    - `Purchases.purchase(product:)`
+    - `Purchases.purchase(product:discount:completion:)`
+    - `Purchases.purchase(product:discount:)`
     - `Purchases.purchase(package:discount:completion:)`
-    - `Purchases.purchase(package:discount:completion:)`
+    - `Purchases.purchase(package:discount:)`
     - `PurchasesDelegate.purchases(shouldPurchasePromoProduct:defermentBlock:)`
-    - `CustomerInfo.nonSubscriptionTransactions`
-- `StoreProduct.PromotionalOffer` has been renamed to `StoreProduct.StoreProductDiscount`.
+- `StoreProduct.introductoryPrice` has been renamed to `StoreProduct.introductoryDiscount`
+- `StoreTransaction` now includes `quantity`
+- Renamed `Purchases.restoreTransactions` to `Purchases.restorePurchases`
+- Lowered `StoreProduct.introductoryDiscount` availability to iOS 11.2 and equivalent OS versions
+- Added several `@available` annotations for automatic migration from StoreKit types
 
-In addition to all of the changes from beta 9, [listed here.](
-https://github.com/RevenueCat/purchases-ios/blob/4.0.0-beta.9/CHANGELOG.latest.md)
+In addition to all of the changes from beta 10, [listed here.](https://github.com/RevenueCat/purchases-ios/blob/4.0.0-beta.10/CHANGELOG.latest.md)
 
 
 ### Other changes: 

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -783,7 +783,7 @@ public extension Purchases {
     }
 
     /**
-     * Fetches the `StorePRoducts` for your IAPs for given `productIdentifiers`.
+     * Fetches the `StoreProducts` for your IAPs for given `productIdentifiers`.
      * Use this method if you aren't using `getOfferings(completion:)`.
      * You should use getOfferings though.
      *


### PR DESCRIPTION
Since the CHANGELOG is cumbersome to compile, I figured I'd do it as a separate PR. 
This updates it to the current changes