### PR TITLE
Fix github_release pre-releases

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -112,7 +112,7 @@ platform :ios do
     commit_hash = last_git_commit[:commit_hash]
     puts commit_hash
 
-    is_prerelease = new_version_number.include?("-")
+    is_prerelease = release_version.include?("-")
 
     set_github_release(
       repository_name: "revenuecat/purchases-ios",


### PR DESCRIPTION
The CircleCI job for deploys in purchases-android broke because a wrong variable name was used and I noticed we had the same issue in iOS too.