### PR TITLE
Adds more exempt labels to stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -19,6 +19,9 @@ exemptLabels:
   - do-not-lock
   - swift migration
   - test backfill
+  - pinned
+  - you can do this!
+  - triaged
 
 # Set to true to ignore issues in a project (defaults to false)
 #exemptProjects: false


### PR DESCRIPTION
### Motivation
Our stalebot needs a few more labels to be sure we aren’t automatically closing issues that shouldn’t be closed.

### Description
New exempt labels are:
- pinned
- you can do this!
- triaged
