### PR TITLE
`Package`: implement `isEqual`/`hash`

### DIFF
--- a/Purchases/Purchasing/Package.swift
+++ b/Purchases/Purchasing/Package.swift
@@ -91,6 +91,27 @@ private extension PackageType {
         self.offeringIdentifier = offeringIdentifier
     }
 
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? Package else { return false }
+
+        return (
+            self.identifier == other.identifier &&
+            self.packageType == other.packageType &&
+            self.storeProduct == other.storeProduct &&
+            self.offeringIdentifier == other.offeringIdentifier
+        )
+    }
+
+    public override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(self.identifier)
+        hasher.combine(self.packageType)
+        hasher.combine(self.storeProduct)
+        hasher.combine(self.offeringIdentifier)
+
+        return hasher.finalize()
+    }
+
 }
 
 @objc public extension Package {


### PR DESCRIPTION
I'm going through the migration from 3.x to 4.0-rc1 in my app, and noticed that I relied on `Package` implementing `Equatable`/ `Hashable`. The old `Objective-C` type didn't override these, so it's not a regression, but it's nice to have.