### PR TITLE
`ErrorDomain`: added obsoletion with message to direct users to `ErrorCode`

### DIFF
--- a/Purchases/Misc/Obsoletions.swift
+++ b/Purchases/Misc/Obsoletions.swift
@@ -434,3 +434,12 @@ public extension Package {
     @available(macCatalyst, obsoleted: 1, renamed: "storeProduct", message: "Use StoreProduct instead")
     @objc var product: SKProduct { fatalError() }
 }
+
+/// `NSErrorDomain` for errors occurring within the scope of the Purchases SDK.
+@available(iOS, obsoleted: 1, message: "Use ErrorCode instead")
+@available(tvOS, obsoleted: 1, message: "Use ErrorCode instead")
+@available(watchOS, obsoleted: 1, message: "Use ErrorCode instead")
+@available(macOS, obsoleted: 1, message: "Use ErrorCode instead")
+@available(macCatalyst, obsoleted: 1, message: "Use ErrorCode instead")
+// swiftlint:disable:next identifier_name
+public var ErrorDomain: NSErrorDomain { fatalError() }


### PR DESCRIPTION
This matches the guidance in `V4_API_Migration_guide`. The domain is still available in `Objective-C`, but for Swift `ErrorCode` is the new way to handle errors.