### PR TITLE
ObjCAPITester: fixed warning by removing unused variable

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -77,7 +77,6 @@ BOOL isAnonymous;
     isAnonymous = [p isAnonymous];
     
     RCCustomerInfo *pi = nil;
-    SKProduct *skp = [[SKProduct alloc] init];
     RCStoreProduct *storeProduct = nil;
     RCStoreProductDiscount *stpd = nil;
     


### PR DESCRIPTION
`SKProduct` is no longer used in the API 🎉 