### PR TITLE
`PurchasesOrchestrator`: added support for SK2 discounts

### DIFF
--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -199,12 +199,12 @@ private func checkAsyncMethods(purchases: Purchases) async {
 
         let _: [StoreProduct] = await purchases.products([])
         let discount: StoreProductDiscount! = nil
-        let _: (StoreTransaction, CustomerInfo, Bool) = try await purchases.purchase(package: pack)
-        let _: (StoreTransaction, CustomerInfo, Bool) = try await purchases.purchase(package: pack,
-                                                                                     discount: discount)
-        let _: (StoreTransaction, CustomerInfo, Bool) = try await purchases.purchase(product: stp)
-        let _: (StoreTransaction, CustomerInfo, Bool) = try await purchases.purchase(product: stp,
-                                                                                     discount: discount)
+        let _: (StoreTransaction?, CustomerInfo, Bool) = try await purchases.purchase(package: pack)
+        let _: (StoreTransaction?, CustomerInfo, Bool) = try await purchases.purchase(package: pack,
+                                                                                      discount: discount)
+        let _: (StoreTransaction?, CustomerInfo, Bool) = try await purchases.purchase(product: stp)
+        let _: (StoreTransaction?, CustomerInfo, Bool) = try await purchases.purchase(product: stp,
+                                                                                      discount: discount)
         let _: CustomerInfo = try await purchases.customerInfo()
         let _: CustomerInfo = try await purchases.restorePurchases()
         let _: CustomerInfo = try await purchases.syncPurchases()

--- a/Purchases/Logging/Strings/StoreKitStrings.swift
+++ b/Purchases/Logging/Strings/StoreKitStrings.swift
@@ -28,6 +28,8 @@ enum StoreKitStrings {
 
     case skunknown_payment_mode(String)
 
+    case sk2_purchasing_added_promotional_offer_option(String)
+
 }
 
 extension StoreKitStrings: CustomStringConvertible {
@@ -56,6 +58,8 @@ extension StoreKitStrings: CustomStringConvertible {
         case let .skunknown_payment_mode(name):
             return "Unrecognized PaymentMode: \(name)"
 
+        case let .sk2_purchasing_added_promotional_offer_option(discountIdentifier):
+            return "Adding Product.PurchaseOption for discount '\(discountIdentifier)'"
         }
     }
 

--- a/Purchases/Misc/Obsoletions.swift
+++ b/Purchases/Misc/Obsoletions.swift
@@ -189,9 +189,7 @@ public extension Purchases {
     @available(watchOS, introduced: 6.2, unavailable, renamed: "purchase(package:)")
     @available(macOS, introduced: 10.15, unavailable, renamed: "purchase(package:)")
     @available(macCatalyst, introduced: 13.0, unavailable, renamed: "purchase(package:)")
-    func purchasePackage(_ package: Package) async throws ->
-    // swiftlint:disable:next large_tuple
-    (transaction: StoreTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
+    func purchasePackage(_ package: Package) async throws -> PurchaseResultData {
         fatalError()
     }
 
@@ -234,9 +232,7 @@ public extension Purchases {
     @available(macOS, introduced: 10.15, unavailable, renamed: "purchase(package:discount:)")
     @available(macCatalyst, introduced: 13.0, unavailable, renamed: "purchase(package:discount:)")
     func purchasePackage(_ package: Package,
-                         discount: SKPaymentDiscount) async throws ->
-    // swiftlint:disable:next large_tuple
-    (transaction: StoreTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
+                         discount: SKPaymentDiscount) async throws -> PurchaseResultData {
         fatalError()
     }
 

--- a/Purchases/Misc/Purchases+async.swift
+++ b/Purchases/Misc/Purchases+async.swift
@@ -100,9 +100,6 @@ extension Purchases {
                 guard let customerInfo = customerInfo else {
                     fatalError("Expected non-nil result 'customerInfo' for nil error")
                 }
-                guard let transaction = transaction else {
-                    fatalError("Expected non-nil result 'transaction' for nil error")
-                }
 
                 continuation.resume(returning: (transaction, customerInfo, userCancelled))
             }
@@ -119,9 +116,6 @@ extension Purchases {
                 }
                 guard let customerInfo = customerInfo else {
                     fatalError("Expected non-nil result 'customerInfo' for nil error")
-                }
-                guard let transaction = transaction else {
-                    fatalError("Expected non-nil result 'transaction' for nil error")
                 }
 
                 continuation.resume(returning: (transaction, customerInfo, userCancelled))
@@ -141,9 +135,6 @@ extension Purchases {
                 guard let customerInfo = customerInfo else {
                     fatalError("Expected non-nil result 'customerInfo' for nil error")
                 }
-                guard let transaction = transaction else {
-                    fatalError("Expected non-nil result 'transaction' for nil error")
-                }
 
                 continuation.resume(returning: (transaction, customerInfo, userCancelled))
             }
@@ -161,9 +152,6 @@ extension Purchases {
                 }
                 guard let customerInfo = customerInfo else {
                     fatalError("Expected non-nil result 'customerInfo' for nil error")
-                }
-                guard let transaction = transaction else {
-                    fatalError("Expected non-nil result 'transaction' for nil error")
                 }
 
                 continuation.resume(returning: (transaction, customerInfo, userCancelled))

--- a/Purchases/Misc/Purchases+async.swift
+++ b/Purchases/Misc/Purchases+async.swift
@@ -90,9 +90,7 @@ extension Purchases {
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func purchaseAsync(product: StoreProduct) async throws ->
-    // swiftlint:disable:next large_tuple
-    (transaction: StoreTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
+    func purchaseAsync(product: StoreProduct) async throws -> PurchaseResultData {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(product: product) { transaction, customerInfo, error, userCancelled in
                 if let error = error {
@@ -112,9 +110,7 @@ extension Purchases {
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func purchaseAsync(package: Package) async throws ->
-    // swiftlint:disable:next large_tuple
-    (transaction: StoreTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
+    func purchaseAsync(package: Package) async throws -> PurchaseResultData {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(package: package) { transaction, customerInfo, error, userCancelled in
                 if let error = error {
@@ -134,9 +130,7 @@ extension Purchases {
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func purchaseAsync(product: StoreProduct, discount: StoreProductDiscount) async throws ->
-    // swiftlint:disable:next large_tuple
-    (transaction: StoreTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
+    func purchaseAsync(product: StoreProduct, discount: StoreProductDiscount) async throws -> PurchaseResultData {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(product: product,
                      discount: discount) { transaction, customerInfo, error, userCancelled in
@@ -157,9 +151,7 @@ extension Purchases {
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func purchaseAsync(package: Package, discount: StoreProductDiscount) async throws ->
-    // swiftlint:disable:next large_tuple
-    (transaction: StoreTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
+    func purchaseAsync(package: Package, discount: StoreProductDiscount) async throws -> PurchaseResultData {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(package: package,
                      discount: discount) { transaction, customerInfo, error, userCancelled in

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -17,6 +17,14 @@ import Foundation
 import StoreKit
 
 // MARK: Block definitions
+
+/**
+ Result for ``Purchases/purchase(product:)``
+ */
+public typealias PurchaseResultData = (transaction: StoreTransaction?,
+                                       customerInfo: CustomerInfo?,
+                                       userCancelled: Bool)
+
 /**
  Completion block for ``Purchases/purchase(product:completion:)``
  */
@@ -955,9 +963,7 @@ public extension Purchases {
      * If the user cancelled, `userCancelled` will be `true`.
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func purchase(product: StoreProduct) async throws ->
-    // swiftlint:disable:next large_tuple
-    (transaction: StoreTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
+    func purchase(product: StoreProduct) async throws -> PurchaseResultData {
         return try await purchaseAsync(product: product)
     }
 
@@ -997,9 +1003,7 @@ public extension Purchases {
      * If the user cancelled, `userCancelled` will be `true`.
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func purchase(package: Package) async throws ->
-    // swiftlint:disable:next large_tuple
-    (transaction: StoreTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
+    func purchase(package: Package) async throws -> PurchaseResultData {
         return try await purchaseAsync(package: package)
     }
 
@@ -1052,9 +1056,7 @@ public extension Purchases {
      * If the user cancelled, `userCancelled` will be `true`.
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func purchase(product: StoreProduct, discount: StoreProductDiscount) async throws ->
-    // swiftlint:disable:next large_tuple
-    (transaction: StoreTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
+    func purchase(product: StoreProduct, discount: StoreProductDiscount) async throws -> PurchaseResultData {
         return try await purchaseAsync(product: product, discount: discount)
     }
 
@@ -1100,9 +1102,7 @@ public extension Purchases {
      * If the user cancelled, `userCancelled` will be `true`.
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func purchase(package: Package, discount: StoreProductDiscount) async throws ->
-    // swiftlint:disable:next large_tuple
-    (transaction: StoreTransaction, customerInfo: CustomerInfo, userCancelled: Bool) {
+    func purchase(package: Package, discount: StoreProductDiscount) async throws -> PurchaseResultData {
         return try await purchaseAsync(package: package, discount: discount)
     }
 

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -815,9 +815,6 @@ public extension Purchases {
      *
      * ``Offerings`` will be fetched and cached on instantiation so that, by the time they are needed,
      * your prices are loaded for your purchase flow. Time is money.
-     *
-     * - Parameter completion: A completion block called when offerings are available.
-     * Called immediately if offerings are cached. ``Offerings`` will be `nil` if an error occurred.
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func offerings() async throws -> Offerings {
@@ -958,7 +955,6 @@ public extension Purchases {
      * handle this for you.
      *
      * - Parameter product: The ``StoreProduct`` the user intends to purchase
-     * - Parameter completion: A completion block that is called when the purchase completes.
      *
      * If the user cancelled, `userCancelled` will be `true`.
      */
@@ -998,7 +994,6 @@ public extension Purchases {
      * handle this for you.
      *
      * - Parameter package: The ``Package`` the user intends to purchase
-     * - Parameter completion: A completion block that is called when the purchase completes.
      *
      * If the user cancelled, `userCancelled` will be `true`.
      */
@@ -1051,7 +1046,6 @@ public extension Purchases {
      *
      * - Parameter product: The ``StoreProduct`` the user intends to purchase
      * - Parameter discount: The ``StoreProductDiscount`` to apply to the purchase
-     * - Parameter completion: A completion block that is called when the purchase completes.
      *
      * If the user cancelled, `userCancelled` will be `true`.
      */
@@ -1097,7 +1091,6 @@ public extension Purchases {
      *
      * - Parameter package: The ``Package`` the user intends to purchase
      * - Parameter discount: The ``StoreProductDiscount`` to apply to the purchase
-     * - Parameter completion: A completion block that is called when the purchase completes.
      *
      * If the user cancelled, `userCancelled` will be `true`.
      */
@@ -1220,7 +1213,6 @@ public extension Purchases {
      * version of iOS so that the subscription group can be collected by the SDK.
      *
      * - Parameter productIdentifiers: Array of product identifiers for which you want to compute eligibility
-     * - Parameter completion: A block that receives a dictionary of `product_id` -> ``IntroEligibility``.
      */
     @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
     func checkTrialOrIntroDiscountEligibility(_ productIdentifiers: [String]) async -> [String: IntroEligibility] {
@@ -1286,8 +1278,6 @@ public extension Purchases {
      *
      * - Parameter discount: The ``StoreProductDiscount`` to apply to the product.
      * - Parameter product: The ``StoreProduct`` the user intends to purchase.
-     * - Parameter completion: A completion block that is called when the ``PromotionalOfferEligibility`` is returned.
-     * If it was not successful, there will be an `Error`.
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func checkPromotionalDiscountEligibility(forProductDiscount discount: StoreProductDiscount,
@@ -1322,17 +1312,11 @@ public extension Purchases {
     /**
      * Use this function to open the manage subscriptions modal.
      *
-     * - Parameter completion: A completion block that is called when the modal is opened.
      * - throws: an `Error` will be thrown if the current window scene couldn't be opened,
      * or the ``CustomerInfo/managementURL`` couldn't be obtained.
      * If the manage subscriptions page can't be opened, the ``CustomerInfo/managementURL`` in
      * the ``CustomerInfo`` will be opened. If ``CustomerInfo/managementURL`` is not available,
      * the App Store's subscription management section will be opened.
-     *
-     * The `completion` block will be called when the modal is opened, not when it's actually closed.
-     * This is because of an undocumented change in StoreKit's behavior between iOS 15.0 and 15.2,
-     * where 15.0 would return when the modal was closed,
-     * and 15.2 returns when the modal is opened.
      */
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -1272,13 +1272,8 @@ public extension Purchases {
     func checkPromotionalDiscountEligibility(forProductDiscount discount: StoreProductDiscount,
                                              product: StoreProduct,
                                              completion: @escaping (PromotionalOfferEligibility, Error?) -> Void) {
-        guard let sk1Product = product.sk1Product else {
-            // todo: add support for SK2 discounts
-            fatalError("StoreKit2 not supported yet")
-        }
-
         purchasesOrchestrator.promotionalOffer(forProductDiscount: discount,
-                                               product: sk1Product) { promotionalOffer, error in
+                                               product: product) { promotionalOffer, error in
             completion(promotionalOffer == nil ? .ineligible : .eligible, error)
         }
     }

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -19,7 +19,8 @@ import StoreKit
 // MARK: Block definitions
 
 /**
- Result for ``Purchases/purchase(product:)``
+ Result for ``Purchases/purchase(product:)``.
+ Counterpart of `PurchaseCompletedBlock` for `async` APIs.
  */
 public typealias PurchaseResultData = (transaction: StoreTransaction?,
                                        customerInfo: CustomerInfo?,

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -23,7 +23,7 @@ import StoreKit
  Counterpart of `PurchaseCompletedBlock` for `async` APIs.
  */
 public typealias PurchaseResultData = (transaction: StoreTransaction?,
-                                       customerInfo: CustomerInfo?,
+                                       customerInfo: CustomerInfo,
                                        userCancelled: Bool)
 
 /**

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -732,6 +732,8 @@ private extension PurchasesOrchestrator {
                     forProductDiscount: discount,
                     product: StoreProduct(sk2Product: sk2Product)
                 )
+
+                Logger.debug(Strings.storeKit.sk2_purchasing_added_promotional_offer_option(discount.identifier))
                 options.insert(try discount.sk2PurchaseOption)
             }
 

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -335,7 +335,7 @@ class PurchasesOrchestrator {
             throw error
         case .success(let (customerInfo, userCancelled)):
             if userCancelled {
-                return (nil, nil, userCancelled)
+                return (nil, customerInfo, userCancelled)
             } else {
                 // todo: change API and send transaction
                 return (nil, customerInfo, userCancelled)

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -732,7 +732,7 @@ private extension PurchasesOrchestrator {
                     forProductDiscount: discount,
                     product: StoreProduct(sk2Product: sk2Product)
                 )
-                options.insert(discount.sk2PurchaseOption)
+                options.insert(try discount.sk2PurchaseOption)
             }
 
             let result = try await sk2Product.purchase(options: options)

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -240,7 +240,7 @@ class PurchasesOrchestrator {
         self.promotionalOffer(
             forProductDiscount: discount,
             product: StoreProduct(sk1Product: sk1Product)
-        ) { [unowned self] promotionalOffer, error in
+        ) { promotionalOffer, error in
             guard let promotionalOffer = promotionalOffer else {
                 completion(nil, nil, error, false)
                 return

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -343,6 +343,25 @@ class PurchasesOrchestrator {
         }
     }
 
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func promotionalOffer(
+        forProductDiscount discount: StoreProductDiscountType,
+        product: StoreProductType
+    ) async throws -> PromotionalOffer {
+        return try await withCheckedThrowingContinuation { continuation in
+            self.promotionalOffer(forProductDiscount: discount,
+                                  product: product) { offer, error in
+                if let offer = offer {
+                    continuation.resume(with: .success(offer))
+                } else if let error = error {
+                    continuation.resume(with: .failure(error))
+                } else {
+                    fatalError("Unexpectedly got no result or error")
+                }
+            }
+        }
+    }
+
 #if os(iOS) || os(macOS)
 
     @available(watchOS, unavailable)
@@ -746,22 +765,4 @@ private extension PurchasesOrchestrator {
                  completion: completion)
     }
 
-    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    private func promotionalOffer(
-        forProductDiscount discount: StoreProductDiscountType,
-        product: StoreProductType
-    ) async throws -> PromotionalOffer {
-        return try await withCheckedThrowingContinuation { continuation in
-            self.promotionalOffer(forProductDiscount: discount,
-                                  product: product) { offer, error in
-                if let offer = offer {
-                    continuation.resume(with: .success(offer))
-                } else if let error = error {
-                    continuation.resume(with: .failure(error))
-                } else {
-                    fatalError("Unexpectedly got no result or error")
-                }
-            }
-        }
-    }
 }

--- a/Purchases/Purchasing/StoreKitAbstractions/PromotionalOffer.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/PromotionalOffer.swift
@@ -33,6 +33,17 @@ extension PromotionalOffer {
                                  signature: self.signature,
                                  timestamp: self.timestamp as NSNumber)
     }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    var sk2PurchaseOption: Product.PurchaseOption {
+        return .promotionalOffer(
+            offerID: self.identifier,
+            keyID: self.keyIdentifier,
+            nonce: self.nonce,
+            signature: self.signature.data(using: .utf8)!, // todo: is this correct?
+            timestamp: self.timestamp
+        )
+    }
 }
 
 /**

--- a/Purchases/Purchasing/StoreKitAbstractions/PromotionalOffer.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/PromotionalOffer.swift
@@ -34,16 +34,42 @@ extension PromotionalOffer {
                                  timestamp: self.timestamp as NSNumber)
     }
 
+    /// - Throws: ``ErrorCode/unexpectedBackendResponseError`` if the signature cannot be encoded in UTF8
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     var sk2PurchaseOption: Product.PurchaseOption {
-        return .promotionalOffer(
-            offerID: self.identifier,
-            keyID: self.keyIdentifier,
-            nonce: self.nonce,
-            signature: self.signature.data(using: .utf8)!,
-            timestamp: self.timestamp
-        )
+        get throws {
+            guard let signatureData = self.signature.data(using: .utf8) else {
+                throw ErrorUtils.unexpectedBackendResponse(
+                    withSubError: Self.Error.invalidSignature(self.signature)
+                )
+            }
+
+            return .promotionalOffer(
+                offerID: self.identifier,
+                keyID: self.keyIdentifier,
+                nonce: self.nonce,
+                signature: signatureData,
+                timestamp: self.timestamp
+            )
+        }
     }
+}
+
+extension PromotionalOffer {
+
+    enum Error: DescribableError {
+
+        case invalidSignature(String)
+
+        var description: String {
+            switch self {
+            case let .invalidSignature(signature):
+                return "PromotionalOffer.signature cannot be encoded in UTF8: '\(signature)'"
+            }
+        }
+
+    }
+
 }
 
 /**

--- a/Purchases/Purchasing/StoreKitAbstractions/PromotionalOffer.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/PromotionalOffer.swift
@@ -40,7 +40,7 @@ extension PromotionalOffer {
             offerID: self.identifier,
             keyID: self.keyIdentifier,
             nonce: self.nonce,
-            signature: self.signature.data(using: .utf8)!, // todo: is this correct?
+            signature: self.signature.data(using: .utf8)!,
             timestamp: self.timestamp
         )
     }

--- a/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -336,12 +336,8 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                                                             paymentMode: .payAsYouGo,
                                                             subscriptionPeriod: .init(value: 1, unit: .month))
 
-        _ = await withCheckedContinuation { continuation in
-            orchestrator.promotionalOffer(forProductDiscount: storeProductDiscount,
-                                          product: StoreProduct(sk2Product: product)) { paymentDiscount, error in
-                continuation.resume(returning: (paymentDiscount, error))
-            }
-        }
+        _ = try await orchestrator.promotionalOffer(forProductDiscount: storeProductDiscount,
+                                                    product: StoreProduct(sk2Product: product))
 
         expect(self.backend.invokedPostOfferCount) == 1
         expect(self.backend.invokedPostOfferParameters?.offerIdentifier) == storeProductDiscount.offerIdentifier

--- a/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -146,6 +146,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         }
 
         expect(self.backend.invokedPostOfferCount) == 1
+        expect(self.backend.invokedPostOfferParameters?.offerIdentifier) == storeProductDiscount.offerIdentifier
     }
 
     func testPurchaseSK1PackageWithDiscountSendsReceiptToBackendIfSuccessful() async throws {
@@ -167,7 +168,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         _ = await withCheckedContinuation { continuation in
             orchestrator.purchase(sk1Product: product,
-                                  storeProductDiscount: storeProductDiscount,
+                                  discount: storeProductDiscount,
                                   package: package) { transaction, customerInfo, error, userCancelled in
                 continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
             }
@@ -242,18 +243,9 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
         backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
 
-        let storeProduct = StoreProduct.from(product: try await fetchSk2StoreProduct())
-        let package = Package(identifier: "package",
-                              packageType: .monthly,
-                              storeProduct: storeProduct,
-                              offeringIdentifier: "offering")
+        let product = try await fetchSk2Product()
 
-        _ = await withCheckedContinuation { continuation in
-            orchestrator.purchase(product: storeProduct,
-                                  package: package) { transaction, customerInfo, error, userCancelled in
-                continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
-            }
-        }
+        _ = try await orchestrator.purchase(sk2Product: product, discount: nil)
 
         expect(self.backend.invokedPostReceiptDataCount) == 1
     }
@@ -266,26 +258,20 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
         backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
 
-        let storeProduct = StoreProduct.from(product: try await fetchSk2StoreProduct())
-        let package = Package(identifier: "package",
-                              packageType: .monthly,
-                              storeProduct: storeProduct,
-                              offeringIdentifier: "offering")
+        let product = try await fetchSk2Product()
+        let storeProductDiscount = MockStoreProductDiscount(offerIdentifier: "offerid1",
+                                                            price: 11.1,
+                                                            paymentMode: .payAsYouGo,
+                                                            subscriptionPeriod: .init(value: 1, unit: .month))
 
-        let (transaction, customerInfo, error, userCancelled) = await withCheckedContinuation { continuation in
-            orchestrator.purchase(product: storeProduct,
-                                  package: package) { transaction, customerInfo, error, userCancelled in
-                continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
-            }
+        do {
+            _ = try await orchestrator.purchase(sk2Product: product, discount: storeProductDiscount)
+            XCTFail("Expected error")
+        } catch {
+            expect(self.backend.invokedPostReceiptData) == false
+            let mockListener = try XCTUnwrap(orchestrator.storeKit2Listener as? MockStoreKit2TransactionListener)
+            expect(mockListener.invokedHandle) == false
         }
-
-        expect(transaction).to(beNil())
-        expect(userCancelled) == false
-        expect(customerInfo).to(beNil())
-        expect(error).toNot(beNil())
-        expect(self.backend.invokedPostReceiptData) == false
-        let mockListener = try XCTUnwrap(orchestrator.storeKit2Listener as? MockStoreKit2TransactionListener)
-        expect(mockListener.invokedHandle) == false
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
@@ -295,26 +281,18 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         receiptFetcher.shouldReturnReceipt = false
         let expectedError = ErrorUtils.missingReceiptFileError()
 
-        let storeProduct = StoreProduct.from(product: try await fetchSk2StoreProduct())
-        let package = Package(identifier: "package",
-                              packageType: .monthly,
-                              storeProduct: storeProduct,
-                              offeringIdentifier: "offering")
+        let product = try await fetchSk2Product()
 
-        let (transaction, customerInfo, error, userCancelled) = await withCheckedContinuation { continuation in
-            orchestrator.purchase(product: storeProduct,
-                                  package: package) { transaction, customerInfo, error, userCancelled in
-                continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
-            }
+        do {
+            _ = try await orchestrator.purchase(sk2Product: product, discount: nil)
+
+            XCTFail("Expected error")
+        } catch {
+            expect(error).to(matchError(expectedError))
+
+            let mockListener = try XCTUnwrap(orchestrator.storeKit2Listener as? MockStoreKit2TransactionListener)
+            expect(mockListener.invokedHandle) == true
         }
-
-        expect(transaction).to(beNil())
-        expect(userCancelled) == false
-        expect(customerInfo).to(beNil())
-        expect(error).toNot(beNil())
-        expect(error).to(matchError(expectedError))
-        let mockListener = try XCTUnwrap(orchestrator.storeKit2Listener as? MockStoreKit2TransactionListener)
-        expect(mockListener.invokedHandle) == true
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
@@ -341,6 +319,32 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         expect(self.backend.invokedPostReceiptData).to(beTrue())
         expect(self.backend.invokedPostReceiptDataParameters?.isRestore).to(beTrue())
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testPurchaseSK2PromotionalOffer() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
+        backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
+        backend.stubbedPostOfferCompetionResult = ("signature", "identifier", UUID(), 12345, nil)
+
+        let product = try await fetchSk2Product()
+
+        let storeProductDiscount = MockStoreProductDiscount(offerIdentifier: "offerid1",
+                                                            price: 11.1,
+                                                            paymentMode: .payAsYouGo,
+                                                            subscriptionPeriod: .init(value: 1, unit: .month))
+
+        _ = await withCheckedContinuation { continuation in
+            orchestrator.promotionalOffer(forProductDiscount: storeProductDiscount,
+                                          product: StoreProduct(sk2Product: product)) { paymentDiscount, error in
+                continuation.resume(returning: (paymentDiscount, error))
+            }
+        }
+
+        expect(self.backend.invokedPostOfferCount) == 1
+        expect(self.backend.invokedPostOfferParameters?.offerIdentifier) == storeProductDiscount.offerIdentifier
     }
 
     func testShowManageSubscriptionsCallsCompletionWithErrorIfThereIsAFailure() {
@@ -453,8 +457,9 @@ private extension PurchasesOrchestratorTests {
     @MainActor
     func fetchSk1Product() async throws -> SK1Product {
         return MockSK1Product(
-            mockProductIdentifier: "com.revenuecat.monthly_4.99.1_week_intro",
-            mockSubscriptionGroupIdentifier: "group1")
+            mockProductIdentifier: Self.productID,
+            mockSubscriptionGroupIdentifier: "group1"
+        )
     }
 
     @MainActor

--- a/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -140,7 +140,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         _ = await withCheckedContinuation { continuation in
             orchestrator.promotionalOffer(forProductDiscount: storeProductDiscount,
-                                          product: product) { paymentDiscount, error in
+                                          product: StoreProduct(sk1Product: product)) { paymentDiscount, error in
                 continuation.resume(returning: (paymentDiscount, error))
             }
         }

--- a/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -462,24 +462,6 @@ private extension PurchasesOrchestratorTests {
         return try await SK1StoreProduct(sk1Product: fetchSk1Product())
     }
 
-    @MainActor
-    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    func fetchSk2Product() async throws -> SK2Product {
-        let products: [Any] = try await StoreKit.Product.products(for: ["com.revenuecat.monthly_4.99.1_week_intro"])
-        let firstProduct = try XCTUnwrap(products.first)
-        return try XCTUnwrap(firstProduct as? SK2Product)
-    }
-
-    @MainActor
-    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    func fetchSk2StoreProduct() async throws -> SK2StoreProduct {
-        // can't store Storekit.Product directly because it causes linking issues on OS versions
-        // older than iOS 15.0 (and equivalent)
-        // https://openradar.appspot.com/radar?id=4970535809187840
-        let sk2Product: Any = try await fetchSk2Product()
-        return SK2StoreProduct(sk2Product: try XCTUnwrap(sk2Product as? SK2Product))
-    }
-
     var mockCustomerInfo: CustomerInfo {
         // swiftlint:disable:next force_try
         try! CustomerInfo(data: [

--- a/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
+++ b/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
@@ -44,10 +44,17 @@ extension StoreKitConfigTestCase {
     }
 
     @MainActor
-    private func fetchSk2Product() async throws -> SK2Product {
+    func fetchSk2Product() async throws -> SK2Product {
         let products: [Any] = try await StoreKit.Product.products(for: [Self.productID])
         return try XCTUnwrap(products.first as? SK2Product)
     }
+
+    @MainActor
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func fetchSk2StoreProduct() async throws -> SK2StoreProduct {
+        return SK2StoreProduct(sk2Product: try await fetchSk2Product())
+    }
+
 }
 
 extension StoreKitConfigTestCase {


### PR DESCRIPTION
Fixes [sc-7665]
~~Depends on #1216.~~

## New:
- `Purchases.purchase(product: StoreProduct, discount: StoreProductDiscount)` now supports `SK2`
- Added `PurchaseResultData` as a counterpart of `PurchaseCompletedBlock` for `async` APIs, greatly simplifying a lot of methods that returned the same tuple. See #1234 for how the type provides consistency across several layers.

## Bug fixes:
- Cancelling an SK2 purchase was returning both `userCancelled` `true` but also throwing `ErrorUtils.purchaseCancelledError`, which is against what the method documented. Now cancelling a purchase won't `throw`, but instead return `userCancelled` `true`.
- `PurchaseResultData` now has an `Optional` `Transaction` because `Product.PurchaseResult` does not provide a `Transaction` if the purchase is cancelled. This would have been a crash.

## Other changes:
- Removed `completionBlock` parameter from all `async` method documentation
- Changed `YES` to `true` in docs
- Added an `async` overload of `PurchasesOrchestrator.purchase(sk2Product:discount:)` to simplify a lot of tests, not needing the `withCheckedContinuation` "dance"
- Moved `PurchasesOrchestratorTests` helpers to `StoreKitTestHelpers` to remove duplicated code.

## Notes:
- Unfortunately I couldn't make an SK2 counterpart of `testPurchaseSK1PackageWithDiscountSendsReceiptToBackendIfSuccessful` pass because we can’t mock `SK2Product`, since they’re `struct`s. The test fails with `StoreKit.Product.PurchaseError.ineligibleForOffer`, and AFAIK we can't have a `StoreProductDiscount` in `StoreKitUnitTests` that wouldn’t fail.

## TODO:
 - [x] Add tests
 - [x] Verify `PromotionalOffer` -> `Product.PurchaseOption` is correct