### PR TITLE
`MagicWeatherSwiftUI`: display error when purchase fails

### DIFF
--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/Views/PaywallView.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/Views/PaywallView.swift
@@ -26,6 +26,9 @@ struct PaywallView: View {
     
     private let footerText = "Don't forget to add your subscription terms and conditions. Read more about this here: https://www.revenuecat.com/blog/schedule-2-section-3-8-b"
     
+    @State private var error: NSError?
+    @State private var displayError: Bool = false
+
     var body: some View {
         NavigationView {
             ZStack {
@@ -47,6 +50,9 @@ struct PaywallView: View {
                                     /// - If the user didn't cancel and there wasn't an error with the purchase, close the paywall
                                     if !userCancelled, error == nil {
                                         isPresented = false
+                                    } else if let error = error {
+                                        self.error = error as NSError
+                                        self.displayError = true
                                     }
                                 }
                             }
@@ -68,6 +74,16 @@ struct PaywallView: View {
         }
         .navigationViewStyle(StackNavigationViewStyle())
         .colorScheme(.dark)
+        .alert(
+            isPresented: self.$displayError,
+            error: self.error,
+            actions: { _ in
+                Button(role: .cancel,
+                       action: { self.displayError = false },
+                       label: { Text("OK") })
+            },
+            message: { Text($0.recoverySuggestion ?? "Please try again") }
+        )
     }
 }
 
@@ -106,4 +122,12 @@ struct PackageCellView: View {
             onSelection(package)
         }
     }
+}
+
+extension NSError: LocalizedError {
+
+    public var errorDescription: String? {
+        return self.localizedDescription
+    }
+
 }


### PR DESCRIPTION
Very simple and crude UI, but it's something. Currently the error was only logged to the console.
![Simulator Screen Shot - iPhone 12 Pro Max - 2022-01-24 at 14 32 47](https://user-images.githubusercontent.com/685609/150876151-ea7df79e-4a76-4542-aec0-a6296385ba22.png)

