### PR TITLE
`StoreProductDiscount.PaymentMode`: obsoleted `.none`

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductDiscountAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductDiscountAPI.m
@@ -28,10 +28,9 @@
 }
 
 + (void)checkPaymentModeEnum {
-    RCPaymentMode paymentMode = RCPaymentModeNone;
+    RCPaymentMode paymentMode = RCPaymentModePayAsYouGo;
 
     switch (paymentMode) {
-        case RCPaymentModeNone:
         case RCPaymentModePayAsYouGo:
         case RCPaymentModePayUpFront:
         case RCPaymentModeFreeTrial:

--- a/APITesters/SwiftAPITester/SwiftAPITester/StoreProductDiscountAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/StoreProductDiscountAPI.swift
@@ -28,7 +28,6 @@ var mode: StoreProductDiscount.PaymentMode!
 func checkPaymentModeEnum() {
     switch mode! {
     case
-            .none,
             .payAsYouGo,
             .payUpFront,
             .freeTrial:

--- a/Documentation.docc/V4_API_Migration_guide.md
+++ b/Documentation.docc/V4_API_Migration_guide.md
@@ -69,6 +69,7 @@ These types replace native StoreKit types in all public API methods that used th
 | RCPurchaseCompletedBlock | <i>REMOVED</i> |
 | RCDeferredPromotionalPurchaseBlock | <i>REMOVED</i> |
 | RCPaymentDiscountBlock | <i>REMOVED</i> |
+| RCPaymentModeNone | <i>REMOVED</i> |
 
 #### PurchasesDelegate
 | v3 | v4 |
@@ -109,6 +110,8 @@ These types replace native StoreKit types in all public API methods that used th
 | RCAttributionNetwork | ``AttributionNetwork`` |
 | RCIntroEligibility | ``IntroEligibility`` |
 | RCIntroEligibilityStatus | ``IntroEligibilityStatus`` |
+| RCPaymentMode | ``StoreProductDiscount.PaymentMode`` |
+| RCPaymentModeNone | <i>REMOVED</i> |
 | Purchases.LogLevel | ``LogLevel`` |
 | Purchases.Offerings | ``Offerings`` |
 | Purchases.PackageType | ``PackageType`` |

--- a/Purchases/Logging/Strings/StoreKitStrings.swift
+++ b/Purchases/Logging/Strings/StoreKitStrings.swift
@@ -26,6 +26,8 @@ enum StoreKitStrings {
 
     case skproductsrequest_received_response
 
+    case skunknown_payment_mode(String)
+
 }
 
 extension StoreKitStrings: CustomStringConvertible {
@@ -50,6 +52,9 @@ extension StoreKitStrings: CustomStringConvertible {
 
         case .skproductsrequest_received_response:
             return "SKProductsRequest request received response"
+
+        case let .skunknown_payment_mode(name):
+            return "Unrecognized PaymentMode: \(name)"
 
         }
     }

--- a/Purchases/Misc/Obsoletions.swift
+++ b/Purchases/Misc/Obsoletions.swift
@@ -474,6 +474,16 @@ public extension Package {
     @objc var product: SKProduct { fatalError() }
 }
 
+public extension StoreProductDiscount.PaymentMode {
+    /// No payment mode specified
+    @available(iOS, obsoleted: 1, message: "This option no longer exists. PaymentMode would be nil instead.")
+    @available(tvOS, obsoleted: 1, message: "This option no longer exists. PaymentMode would be nil instead.")
+    @available(watchOS, obsoleted: 1, message: "This option no longer exists. PaymentMode would be nil instead.")
+    @available(macOS, obsoleted: 1, message: "This option no longer exists. PaymentMode would be nil instead.")
+    @available(macCatalyst, obsoleted: 1, message: "This option no longer exists. PaymentMode would be nil instead.")
+    static var none: StoreProductDiscount.PaymentMode { fatalError() }
+}
+
 /// `NSErrorDomain` for errors occurring within the scope of the Purchases SDK.
 @available(iOS, obsoleted: 1, message: "Use ErrorCode instead")
 @available(tvOS, obsoleted: 1, message: "Use ErrorCode instead")

--- a/Purchases/Misc/Obsoletions.swift
+++ b/Purchases/Misc/Obsoletions.swift
@@ -485,7 +485,7 @@ public extension StoreProductDiscount.PaymentMode {
 }
 
 // Note: `RCPaymentMode` is still available to Objective-C through `StoreProductDiscount.PaymentMode`.
-/// todo: add
+/// The payment mode for a `StoreProductDiscount`
 @available(iOS, obsoleted: 1, renamed: "StoreProductDiscount.PaymentMode")
 @available(tvOS, obsoleted: 1, renamed: "StoreProductDiscount.PaymentMode")
 @available(watchOS, obsoleted: 1, renamed: "StoreProductDiscount.PaymentMode")

--- a/Purchases/Misc/Obsoletions.swift
+++ b/Purchases/Misc/Obsoletions.swift
@@ -484,6 +484,15 @@ public extension StoreProductDiscount.PaymentMode {
     static var none: StoreProductDiscount.PaymentMode { fatalError() }
 }
 
+// Note: `RCPaymentMode` is still available to Objective-C through `StoreProductDiscount.PaymentMode`.
+/// todo: add
+@available(iOS, obsoleted: 1, renamed: "StoreProductDiscount.PaymentMode")
+@available(tvOS, obsoleted: 1, renamed: "StoreProductDiscount.PaymentMode")
+@available(watchOS, obsoleted: 1, renamed: "StoreProductDiscount.PaymentMode")
+@available(macOS, obsoleted: 1, renamed: "StoreProductDiscount.PaymentMode")
+@available(macCatalyst, obsoleted: 1, renamed: "StoreProductDiscount.PaymentMode")
+public enum RCPaymentMode {}
+
 /// `NSErrorDomain` for errors occurring within the scope of the Purchases SDK.
 @available(iOS, obsoleted: 1, message: "Use ErrorCode instead")
 @available(tvOS, obsoleted: 1, message: "Use ErrorCode instead")

--- a/Purchases/Purchasing/ProductRequestData+Initialization.swift
+++ b/Purchases/Purchasing/ProductRequestData+Initialization.swift
@@ -49,12 +49,12 @@ extension ProductRequestData {
 
 private extension ProductRequestData {
 
-    static func extractIntroDurationType(for product: StoreProduct) -> StoreProductDiscount.PaymentMode {
+    static func extractIntroDurationType(for product: StoreProduct) -> StoreProductDiscount.PaymentMode? {
         if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *),
            let discount = product.introductoryDiscount {
             return discount.paymentMode
         } else {
-            return .none
+            return nil
         }
     }
 
@@ -74,11 +74,11 @@ private extension ProductRequestData {
         }
     }
 
-    static func extractPaymentMode(for product: StoreProduct) -> StoreProductDiscount.PaymentMode {
+    static func extractPaymentMode(for product: StoreProduct) -> StoreProductDiscount.PaymentMode? {
         if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *), let discount = product.introductoryDiscount {
            return discount.paymentMode
         } else {
-            return .none
+            return nil
         }
     }
 

--- a/Purchases/Purchasing/ProductRequestData.swift
+++ b/Purchases/Purchasing/ProductRequestData.swift
@@ -21,20 +21,20 @@ import StoreKit
 struct ProductRequestData {
 
     let productIdentifier: String
-    let paymentMode: StoreProductDiscount.PaymentMode
+    let paymentMode: StoreProductDiscount.PaymentMode?
     let currencyCode: String?
     let price: Decimal
     let normalDuration: String?
     let introDuration: String?
-    let introDurationType: StoreProductDiscount.PaymentMode
+    let introDurationType: StoreProductDiscount.PaymentMode?
     let introPrice: Decimal?
     let subscriptionGroup: String?
     let discounts: [StoreProductDiscount]?
 
     var cacheKey: String {
         var key = """
-        \(productIdentifier)-\(price)-\(currencyCode ?? "")-\(paymentMode.rawValue)-\(introPrice ?? 0)-\
-        \(subscriptionGroup ?? "")-\(normalDuration ?? "")-\(introDuration ?? "")-\(introDurationType.rawValue)
+        \(productIdentifier)-\(price)-\(currencyCode ?? "")-\(paymentMode?.rawValue ?? -1)-\(introPrice ?? 0)-\
+        \(subscriptionGroup ?? "")-\(normalDuration ?? "")-\(introDuration ?? "")-\(introDurationType?.rawValue ?? -1)
         """
 
         guard let discounts = discounts else {
@@ -73,9 +73,7 @@ extension ProductRequestData: Encodable {
 
         try container.encode(self.productIdentifier, forKey: .productIdentifier)
 
-        if self.paymentMode != .none {
-            try container.encode(self.paymentMode, forKey: .paymentMode)
-        }
+        try container.encodeIfPresent(self.paymentMode, forKey: .paymentMode)
         try container.encode(self.currencyCode, forKey: .currencyCode)
         try container.encode((self.price as NSDecimalNumber).description, forKey: .price)
         try container.encodeIfPresent(self.subscriptionGroup, forKey: .subscriptionGroup)

--- a/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
@@ -58,13 +58,13 @@ internal struct SK1StoreProduct: StoreProductType {
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
     var introductoryDiscount: StoreProductDiscount? {
         return self.underlyingSK1Product.introductoryPrice
-            .map(StoreProductDiscount.init)
+            .flatMap(StoreProductDiscount.init)
     }
 
     @available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *)
     var discounts: [StoreProductDiscount] {
         return self.underlyingSK1Product.discounts
-            .map(StoreProductDiscount.init)
+            .compactMap(StoreProductDiscount.init)
     }
 
 }

--- a/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
@@ -16,7 +16,10 @@ import StoreKit
 @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
 internal struct SK1StoreProductDiscount: StoreProductDiscountType {
 
-    init(sk1Discount: SK1ProductDiscount) {
+    init?(sk1Discount: SK1ProductDiscount) {
+        guard let paymentMode = StoreProductDiscount.PaymentMode(skProductDiscountPaymentMode: sk1Discount.paymentMode)
+        else { return nil }
+
         self.underlyingSK1Discount = sk1Discount
 
         if #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *) {
@@ -25,7 +28,7 @@ internal struct SK1StoreProductDiscount: StoreProductDiscountType {
             self.offerIdentifier = nil
         }
         self.price = sk1Discount.price as Decimal
-        self.paymentMode = .init(skProductDiscountPaymentMode: sk1Discount.paymentMode)
+        self.paymentMode = paymentMode
         self.subscriptionPeriod = .from(sk1SubscriptionPeriod: sk1Discount.subscriptionPeriod)
     }
 
@@ -41,7 +44,7 @@ internal struct SK1StoreProductDiscount: StoreProductDiscountType {
 private extension StoreProductDiscount.PaymentMode {
 
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
-    init(skProductDiscountPaymentMode paymentMode: SKProductDiscount.PaymentMode) {
+    init?(skProductDiscountPaymentMode paymentMode: SKProductDiscount.PaymentMode) {
         switch paymentMode {
         case .payUpFront:
             self = .payUpFront
@@ -50,7 +53,8 @@ private extension StoreProductDiscount.PaymentMode {
         case .freeTrial:
             self = .freeTrial
         @unknown default:
-            self = .none
+            Logger.appleWarning(Strings.storeKit.skunknown_payment_mode(String.init(describing: paymentMode)))
+            return nil
         }
     }
 

--- a/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
@@ -76,7 +76,7 @@ internal struct SK2StoreProduct: StoreProductType {
 
     var introductoryDiscount: StoreProductDiscount? {
         self.underlyingSK2Product.subscription?.introductoryOffer
-            .map(StoreProductDiscount.init)
+            .flatMap(StoreProductDiscount.init)
     }
 
     var discounts: [StoreProductDiscount] {

--- a/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProductDiscount.swift
@@ -16,12 +16,15 @@ import StoreKit
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 internal struct SK2StoreProductDiscount: StoreProductDiscountType {
 
-    init(sk2Discount: SK2ProductDiscount) {
+    init?(sk2Discount: SK2ProductDiscount) {
+        guard let paymentMode = StoreProductDiscount.PaymentMode(subscriptionOfferPaymentMode: sk2Discount.paymentMode)
+        else { return nil }
+
         self.underlyingSK2Discount = sk2Discount
 
         self.offerIdentifier = sk2Discount.id
         self.price = sk2Discount.price
-        self.paymentMode = .init(subscriptionOfferPaymentMode: sk2Discount.paymentMode)
+        self.paymentMode = paymentMode
         self.subscriptionPeriod = .from(sk2SubscriptionPeriod: sk2Discount.period)
     }
 
@@ -37,7 +40,7 @@ internal struct SK2StoreProductDiscount: StoreProductDiscountType {
 private extension StoreProductDiscount.PaymentMode {
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-    init(subscriptionOfferPaymentMode paymentMode: Product.SubscriptionOffer.PaymentMode) {
+    init?(subscriptionOfferPaymentMode paymentMode: Product.SubscriptionOffer.PaymentMode) {
         switch paymentMode {
         case .payUpFront:
             self = .payUpFront
@@ -46,7 +49,8 @@ private extension StoreProductDiscount.PaymentMode {
         case .freeTrial:
             self = .freeTrial
         default:
-            self = .none
+            Logger.appleWarning(Strings.storeKit.skunknown_payment_mode(String.init(describing: paymentMode)))
+            return nil
         }
     }
 

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -29,7 +29,6 @@ public final class StoreProductDiscount: NSObject, StoreProductDiscountType {
     @objc(RCPaymentMode)
     public enum PaymentMode: Int {
 
-        case none = -1
         case payAsYouGo = 0
         case payUpFront = 1
         case freeTrial = 2
@@ -99,13 +98,17 @@ internal protocol StoreProductDiscountType {
 extension StoreProductDiscount {
 
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
-    internal convenience init(sk1Discount: SK1ProductDiscount) {
-        self.init(SK1StoreProductDiscount(sk1Discount: sk1Discount))
+    internal convenience init?(sk1Discount: SK1ProductDiscount) {
+        guard let discount = SK1StoreProductDiscount(sk1Discount: sk1Discount) else { return nil }
+
+        self.init(discount)
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    internal convenience init(sk2Discount: SK2ProductDiscount) {
-        self.init(SK2StoreProductDiscount(sk2Discount: sk2Discount))
+    internal convenience init?(sk2Discount: SK2ProductDiscount) {
+        guard let discount = SK2StoreProductDiscount(sk2Discount: sk2Discount) else { return nil }
+
+        self.init(discount)
     }
 
     /// Returns the `SK1ProductDiscount` if this `StoreProductDiscount` represents a `SKProductDiscount`.

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -26,11 +26,16 @@ public typealias SK2ProductDiscount = StoreKit.Product.SubscriptionOffer
 @objc(RCStoreProductDiscount)
 public final class StoreProductDiscount: NSObject, StoreProductDiscountType {
 
+    /// The payment mode for a `StoreProductDiscount`
+    /// Indicates how the product discount price is charged.
     @objc(RCPaymentMode)
     public enum PaymentMode: Int {
 
+        /// Price is charged one or more times
         case payAsYouGo = 0
+        /// Price is charged once in advance
         case payUpFront = 1
+        /// No initial charge
         case freeTrial = 2
 
     }

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -414,7 +414,7 @@ class BackendTests: XCTestCase {
 
         let currencyCode = "BFD"
 
-        let paymentMode: StoreProductDiscount.PaymentMode = .none
+        let paymentMode: StoreProductDiscount.PaymentMode? = nil
 
         var completionCalled = false
         let productData: ProductRequestData = .createMockProductData(productIdentifier: productIdentifier,
@@ -1260,7 +1260,7 @@ class BackendTests: XCTestCase {
         let price: Decimal = 15.99
         let group = "sub_group"
         let currencyCode = "BFD"
-        let paymentMode: StoreProductDiscount.PaymentMode = .none
+        let paymentMode: StoreProductDiscount.PaymentMode? = nil
         var completionCalled = false
         let discount = MockStoreProductDiscount(offerIdentifier: "offerid",
                                                 price: 12.1,

--- a/PurchasesTests/Purchasing/ProductRequestDataExtensions.swift
+++ b/PurchasesTests/Purchasing/ProductRequestDataExtensions.swift
@@ -8,12 +8,12 @@ import Foundation
 
 extension ProductRequestData {
     static func createMockProductData(productIdentifier: String = "product_id",
-                                      paymentMode: StoreProductDiscount.PaymentMode = .none,
+                                      paymentMode: StoreProductDiscount.PaymentMode? = nil,
                                       currencyCode: String = "UYU",
                                       price: Decimal = 15.99,
                                       normalDuration: String? = nil,
                                       introDuration: String? = nil,
-                                      introDurationType: StoreProductDiscount.PaymentMode = .none,
+                                      introDurationType: StoreProductDiscount.PaymentMode? = nil,
                                       introPrice: Decimal? = nil,
                                       subscriptionGroup: String? = nil,
                                       discounts: [StoreProductDiscountType]? = nil) -> ProductRequestData {

--- a/PurchasesTests/Purchasing/ProductRequestDataInitializationTests.swift
+++ b/PurchasesTests/Purchasing/ProductRequestDataInitializationTests.swift
@@ -54,11 +54,11 @@ class ProductRequestDataSK1ProductInitializationTests: XCTestCase {
 
             let receivedProductData = self.extract()
 
-            expect(receivedProductData.paymentMode.rawValue) == StoreProductDiscount.PaymentMode.freeTrial.rawValue
+            expect(receivedProductData.paymentMode) == .freeTrial
         } else {
             let receivedProductData = self.extract()
 
-            expect(receivedProductData.paymentMode) == StoreProductDiscount.PaymentMode.none
+            expect(receivedProductData.paymentMode).to(beNil())
         }
     }
 
@@ -135,7 +135,7 @@ class ProductRequestDataSK1ProductInitializationTests: XCTestCase {
         } else {
             let receivedProductData = self.extract()
 
-            expect(receivedProductData.introDurationType) == StoreProductDiscount.PaymentMode.none
+            expect(receivedProductData.introDurationType).to(beNil())
         }
     }
 

--- a/PurchasesTests/Purchasing/ProductRequestDataTests.swift
+++ b/PurchasesTests/Purchasing/ProductRequestDataTests.swift
@@ -12,7 +12,7 @@ class ProductRequestDataTests: XCTestCase {
     }
 
     func testAsDictionaryConvertsPaymentModeCorrectly() throws {
-        var paymentMode: StoreProductDiscount.PaymentMode = .none
+        var paymentMode: StoreProductDiscount.PaymentMode?
         var productData: ProductRequestData = .createMockProductData(paymentMode: paymentMode)
         expect(try productData.asDictionary()["payment_mode"]).to(beNil())
 
@@ -20,19 +20,19 @@ class ProductRequestDataTests: XCTestCase {
         productData = .createMockProductData(paymentMode: paymentMode)
 
         var receivedPaymentMode = (try productData.asDictionary()["payment_mode"] as? NSNumber)?.intValue
-        expect(receivedPaymentMode) == paymentMode.rawValue
+        expect(receivedPaymentMode) == paymentMode?.rawValue
 
         paymentMode = .freeTrial
         productData = .createMockProductData(paymentMode: paymentMode)
 
         receivedPaymentMode = (try productData.asDictionary()["payment_mode"] as? NSNumber)?.intValue
-        expect(receivedPaymentMode) == paymentMode.rawValue
+        expect(receivedPaymentMode) == paymentMode?.rawValue
 
         paymentMode = .payUpFront
         productData = .createMockProductData(paymentMode: paymentMode)
 
         receivedPaymentMode = (try productData.asDictionary()["payment_mode"] as? NSNumber)?.intValue
-        expect(receivedPaymentMode) == paymentMode.rawValue
+        expect(receivedPaymentMode) == paymentMode?.rawValue
     }
 
     func testAsDictionaryConvertsCurrencyCodeCorrectly() throws {
@@ -69,10 +69,10 @@ class ProductRequestDataTests: XCTestCase {
         expect(try productData.asDictionary()["trial_duration"]).to(beNil())
     }
 
-    func testAsDictionaryDoesntAddIntroDurationIfDurationTypeNone() throws {
+    func testAsDictionaryDoesntAddIntroDurationIfDurationTypeUnknown() throws {
         let introDuration = "P3M"
         let productData: ProductRequestData = .createMockProductData(introDuration: introDuration,
-                                                                     introDurationType: .none)
+                                                                     introDurationType: nil)
         expect(try productData.asDictionary()["trial_duration"]).to(beNil())
         expect(try productData.asDictionary()["intro_duration"]).to(beNil())
     }

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -827,7 +827,7 @@ class PurchasesTests: XCTestCase {
                 expect(self.backend.postedPaymentMode).to(equal(StoreProductDiscount.PaymentMode.payAsYouGo))
                 expect(self.backend.postedIntroPrice).to(equal(product.introductoryDiscount?.price))
             } else {
-                expect(self.backend.postedPaymentMode).to(equal(StoreProductDiscount.PaymentMode.none))
+                expect(self.backend.postedPaymentMode).to(beNil())
                 expect(self.backend.postedIntroPrice).to(beNil())
             }
 


### PR DESCRIPTION
### Reason for `.none` existing in the first place
- Was used prior to #1181 to indicate no intro durations when encoded in `ProductRequestData` (the old `ProductInfo`)
- When `IntroDurationType` was removed in favor of only one enum, `PaymentMode` (#1045), `.none` was required to accommodate for that
- Because neither SK1 and SK2's `PaymentMode`s aren't `@frozen`, RevenueCat needs to handle `@unknown default` cases when converting from that type. `.none` was repurposed for this reason.

### Motivation for removing it:
`StoreProduct` already has optional `StoreProductDiscount`s (`introductoryDiscount` and potentially empty `discounts` `Array`).
If users get a `StoreProductDiscount`, it's unnecessary to make them handle the case of `PaymentMode.none`, when we can instead fail to parse it and not include it as part of the product.