### PR TITLE
Improve docs

### DIFF
--- a/Documentation.docc/Documentation.md
+++ b/Documentation.docc/Documentation.md
@@ -71,7 +71,7 @@ Or browse our iOS sample apps:
 - ``Purchases/purchase(product:)``
 - ``Purchases/purchase(product:completion:)``
 
-### Making Purchases with Promotional Offers
+### Making Purchases with Subscription Offers
 - ``IntroEligibility``
 - ``PromotionalOfferEligibility``
 - ``StoreProductDiscount``
@@ -93,6 +93,7 @@ Or browse our iOS sample apps:
 
 - ``Purchases/getCustomerInfo(completion:)``
 - ``Purchases/customerInfo()``
+- ``Purchases/customerInfoStream``
 
 ### Identifying Users
 - ``Purchases/logIn(_:)``
@@ -124,6 +125,7 @@ Or browse our iOS sample apps:
 - ``Purchases/setMediaSource(_:)``
 - ``Purchases/setPhoneNumber(_:)``
 - ``Purchases/setAttributes(_:)``
+- ``Purchases/collectDeviceIdentifiers()``
 
 ### Integrations
 - ``Purchases/setAdjustID(_:)``

--- a/Documentation.docc/Purchases.md
+++ b/Documentation.docc/Purchases.md
@@ -1,0 +1,110 @@
+# ``RevenueCat/Purchases``
+
+@Metadata {
+    @DocumentationExtension(mergeBehavior: override)
+}
+
+``Purchases`` is the main entry point of the `RevenueCat` SDK. 
+It provides access to all its features. 
+
+## Overview
+
+The ``Purchases`` class can be used to access all the features of the `RevenueCat` SDK. 
+Most features require configuring the SDK before using it. 
+
+## Topics
+
+### Interacting with the SDK
+- ``Purchases/shared``
+- ``Purchases/isConfigured``
+- ``Purchases/delegate``
+- ``Purchases/logLevel``
+- ``Purchases/logHandler``
+
+### Configuring the SDK
+- ``Purchases/configure(withAPIKey:)``
+- ``Purchases/configure(withAPIKey:appUserID:)``
+- ``Purchases/configure(withAPIKey:appUserID:observerMode:)``
+- ``Purchases/configure(withAPIKey:appUserID:observerMode:userDefaults:)``
+
+### Displaying Products
+- ``Purchases/offerings()``
+- ``Purchases/getOfferings(completion:)``
+- ``Purchases/products(_:)``
+- ``Purchases/getProducts(_:completion:)``
+
+### Making Purchases
+- ``Purchases/purchase(package:)``
+- ``Purchases/purchase(package:completion:)``
+- ``Purchases/purchase(product:)``
+- ``Purchases/purchase(product:completion:)``
+- ``Purchases/simulatesAskToBuyInSandbox``
+- ``Purchases/canMakePayments()``
+
+### Making Purchases with Subscription Offers
+- ``Purchases/checkTrialOrIntroDiscountEligibility(_:)``
+- ``Purchases/checkTrialOrIntroDiscountEligibility(_:completion:)``
+- ``Purchases/checkPromotionalDiscountEligibility(forProductDiscount:product:)``
+- ``Purchases/checkPromotionalDiscountEligibility(forProductDiscount:product:completion:)``
+- ``Purchases/purchase(package:discount:)``
+- ``Purchases/purchase(package:discount:completion:)``
+- ``Purchases/purchase(product:discount:)``
+- ``Purchases/purchase(product:discount:completion:)``
+- ``Purchases/presentCodeRedemptionSheet()``
+
+### Subscription Status
+- ``Purchases/getCustomerInfo(completion:)``
+- ``Purchases/customerInfo()``
+- ``Purchases/customerInfoStream``
+
+### Identifying Users
+- ``Purchases/appUserID``
+- ``Purchases/isAnonymous``
+- ``Purchases/logIn(_:)``
+- ``Purchases/logIn(_:completion:)``
+- ``Purchases/logOut()``
+- ``Purchases/logOut(completion:)``
+
+### Managing Subscriptions
+- ``Purchases/syncPurchases()``
+- ``Purchases/syncPurchases(completion:)``
+- ``Purchases/restorePurchases()``
+- ``Purchases/restorePurchases(completion:)``
+- ``Purchases/beginRefundRequestForActiveEntitlement()``
+- ``Purchases/beginRefundRequest(forEntitlement:)``
+- ``Purchases/beginRefundRequest(forProduct:)``
+- ``Purchases/showManageSubscriptions()``
+- ``Purchases/showManageSubscriptions(completion:)``
+
+### Subscriber Attributes
+- ``Purchases/setAttributes(_:)``
+- ``Purchases/setAd(_:)``
+- ``Purchases/setEmail(_:)``
+- ``Purchases/setDisplayName(_:)``
+- ``Purchases/setKeyword(_:)``
+- ``Purchases/setCampaign(_:)``
+- ``Purchases/setCreative(_:)``
+- ``Purchases/setAdGroup(_:)``
+- ``Purchases/setPushToken(_:)``
+- ``Purchases/setMediaSource(_:)``
+- ``Purchases/setPhoneNumber(_:)``
+- ``Purchases/setAttributes(_:)``
+- ``Purchases/collectDeviceIdentifiers()``
+
+### Integrations
+- ``Purchases/setAdjustID(_:)``
+- ``Purchases/setAppsflyerID(_:)``
+- ``Purchases/setAirshipChannelID(_:)``
+- ``Purchases/setMparticleID(_:)``
+- ``Purchases/setOnesignalID(_:)``
+- ``Purchases/setFBAnonymousID(_:)``
+
+### Advanced Configuration
+- ``Purchases/allowSharingAppStoreAccount``
+- ``Purchases/finishTransactions``
+- ``Purchases/invalidateCustomerInfoCache()``
+- ``Purchases/forceUniversalAppStore``
+- ``Purchases/automaticAppleSearchAdsAttributionCollection``
+- ``Purchases/proxyURL``
+- ``Purchases/verboseLogs``
+- ``Purchases/verboseLogHandler``

--- a/Purchases/Attribution/AttributionNetwork.swift
+++ b/Purchases/Attribution/AttributionNetwork.swift
@@ -14,6 +14,9 @@
 
 import Foundation
 
+/**
+ Enum of supported attribution networks
+ */
 @objc(RCAttributionNetwork) public enum AttributionNetwork: Int {
 
     /**

--- a/Purchases/Identity/CustomerInfo.swift
+++ b/Purchases/Identity/CustomerInfo.swift
@@ -16,7 +16,8 @@
 import Foundation
 
 /**
- A container for the most recent customer info returned from `Purchases`. These objects are non-mutable and do not update automatically.
+ A container for the most recent customer info returned from `Purchases`.
+ These objects are non-mutable and do not update automatically.
  */
 @objc(RCCustomerInfo) public class CustomerInfo: NSObject {
 

--- a/Purchases/Identity/CustomerInfo.swift
+++ b/Purchases/Identity/CustomerInfo.swift
@@ -15,6 +15,9 @@
 // swiftlint:disable file_length
 import Foundation
 
+/**
+ A container for the most recent customer info returned from `Purchases`. These objects are non-mutable and do not update automatically.
+ */
 @objc(RCCustomerInfo) public class CustomerInfo: NSObject {
 
     /// ``EntitlementInfos`` attached to this customer info.

--- a/Purchases/Purchasing/EntitlementInfo.swift
+++ b/Purchases/Purchasing/EntitlementInfo.swift
@@ -54,6 +54,9 @@ import Foundation
     @objc(RCTrial) case trial = 2
 }
 
+/**
+ The EntitlementInfo object gives you access to all of the information about the status of a user entitlement.
+ */
 @objc(RCEntitlementInfo) public class EntitlementInfo: NSObject {
 
     /**

--- a/Purchases/Purchasing/Offering.swift
+++ b/Purchases/Purchasing/Offering.swift
@@ -14,6 +14,9 @@
 
 import Foundation
 
+/**
+ An offering is a collection of Packages (`RCPackage`) available for the user to purchase. For more info see https://docs.revenuecat.com/docs/entitlements
+ */
 @objc(RCOffering) public class Offering: NSObject {
 
     /**

--- a/Purchases/Purchasing/Offering.swift
+++ b/Purchases/Purchasing/Offering.swift
@@ -15,7 +15,8 @@
 import Foundation
 
 /**
- An offering is a collection of Packages (`RCPackage`) available for the user to purchase. For more info see https://docs.revenuecat.com/docs/entitlements
+ An offering is a collection of Packages (`RCPackage`) available for the user to purchase.
+ For more info, see [our docs on Entitlements](https://docs.revenuecat.com/docs/entitlements)
  */
 @objc(RCOffering) public class Offering: NSObject {
 

--- a/Purchases/Purchasing/Package.swift
+++ b/Purchases/Purchasing/Package.swift
@@ -121,7 +121,8 @@ private extension PackageType {
 }
 
 /**
- Contains information about the product available for the user to purchase. For more info see https://docs.revenuecat.com/docs/entitlements
+ Contains information about the product available for the user to purchase.
+ For more info, see [our docs on Packages](https://docs.revenuecat.com/docs/entitlements)
 */
 @objc public extension Package {
 

--- a/Purchases/Purchasing/Package.swift
+++ b/Purchases/Purchasing/Package.swift
@@ -36,6 +36,9 @@ import Foundation
          weekly
 }
 
+/**
+ Enumeration of all possible Package types.
+*/
 private extension PackageType {
 
     var description: String? {
@@ -66,6 +69,9 @@ private extension PackageType {
     }
 }
 
+/**
+ Enumeration of all possible Package types.
+*/
 @objc(RCPackage) public class Package: NSObject {
 
     @objc public let identifier: String
@@ -114,6 +120,9 @@ private extension PackageType {
 
 }
 
+/**
+ Contains information about the product available for the user to purchase. For more info see https://docs.revenuecat.com/docs/entitlements
+*/
 @objc public extension Package {
 
     /**

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -776,7 +776,15 @@ public extension Purchases {
     ///
     /// - Seealso `PurchasesDelegate.purchases(_ purchases: Purchases, didReceiveUpdated:)`
     /// - Seealso `Purchases.customerInfo()`
-    /// - Note: this method is not thread-safe.
+    ///  #### Example:
+    /// ```swift
+    ///     for await customerInfo in Purchases.shared.customerInfoStream {
+    ///       // this gets called whenever new CustomerInfo is available
+    ///       let entitlements = customerInfo.entitlements
+    ///       ...
+    ///     }
+    /// ```
+    /// - note: this method is not thread-safe.
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     var customerInfoStream: AsyncStream<CustomerInfo> {
         return self.customerInfoManager.customerInfoStream

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -23,6 +23,8 @@ public typealias SK1ProductDiscount = SKProductDiscount
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 public typealias SK2ProductDiscount = StoreKit.Product.SubscriptionOffer
 
+/// Type that wraps `StoreKit.Product.SubscriptionOffer` and `SKProductDiscount`
+/// and provides access to their properties.
 @objc(RCStoreProductDiscount)
 public final class StoreProductDiscount: NSObject, StoreProductDiscountType {
 


### PR DESCRIPTION
- Added a Documentation Extension so we can provide detailed docs for the Purchases class. This somewhat overlaps with the main SDK's docs, which is somewhat expected, with the main difference being that this is very specific to the Purchases class, and it lists all of its methods. 
- Added docs that were missing from a few public classes. I mostly just grabbed the copy from the existing v3 docs. 