### PR TITLE
`V4_API_Migration_guide.md`: fixed `StoreProductDiscount.PaymentMode` reference

### DIFF
--- a/Documentation.docc/V4_API_Migration_guide.md
+++ b/Documentation.docc/V4_API_Migration_guide.md
@@ -110,7 +110,7 @@ These types replace native StoreKit types in all public API methods that used th
 | RCAttributionNetwork | ``AttributionNetwork`` |
 | RCIntroEligibility | ``IntroEligibility`` |
 | RCIntroEligibilityStatus | ``IntroEligibilityStatus`` |
-| RCPaymentMode | ``StoreProductDiscount.PaymentMode`` |
+| RCPaymentMode | ``StoreProductDiscount/PaymentMode-swift.enum`` |
 | RCPaymentModeNone | <i>REMOVED</i> |
 | Purchases.LogLevel | ``LogLevel`` |
 | Purchases.Offerings | ``Offerings`` |


### PR DESCRIPTION
Did this wrong on #1220, I forgot this requires the new Docc format.
<img width="749" alt="Screen Shot 2022-01-29 at 14 12 26" src="https://user-images.githubusercontent.com/685609/151679203-0bda433c-6cf3-4573-84f0-eed6cfa5c2fd.png">

