### PR TITLE
SK2 Purchases: return original `Transaction`

### DIFF
--- a/PurchasesTests/Mocks/MockStoreKit2TransactionListener.swift
+++ b/PurchasesTests/Mocks/MockStoreKit2TransactionListener.swift
@@ -30,6 +30,8 @@ class MockStoreKit2TransactionListener: StoreKit2TransactionListener {
     var invokedDelegateGetterCount = 0
     weak var stubbedDelegate: StoreKit2TransactionListenerDelegate!
 
+    var mockTransaction: SK2Transaction?
+
     override var delegate: StoreKit2TransactionListenerDelegate? {
         get {
             invokedDelegateGetter = true
@@ -60,11 +62,13 @@ class MockStoreKit2TransactionListener: StoreKit2TransactionListener {
     var invokedHandleParameters: (purchaseResult: Any, Void)?
     var invokedHandleParametersList = [(purchaseResult: Any, Void)]()
 
-    override func handle(purchaseResult: StoreKit.Product.PurchaseResult) async throws -> Bool {
+    override func handle(
+        purchaseResult: StoreKit.Product.PurchaseResult
+    ) async throws -> (userCancelled: Bool, transaction: SK2Transaction?) {
         invokedHandle = true
         invokedHandleCount += 1
         invokedHandleParameters = (purchaseResult, ())
         invokedHandleParametersList.append((purchaseResult, ()))
-        return false
+        return (false, mockTransaction)
     }
 }

--- a/PurchasesTests/Mocks/MockStoreKit2TransactionListener.swift
+++ b/PurchasesTests/Mocks/MockStoreKit2TransactionListener.swift
@@ -30,7 +30,9 @@ class MockStoreKit2TransactionListener: StoreKit2TransactionListener {
     var invokedDelegateGetterCount = 0
     weak var stubbedDelegate: StoreKit2TransactionListenerDelegate!
 
-    var mockTransaction: SK2Transaction?
+    // StoreKit.Transaction but we can't store it directly as a property.
+    // see https://openradar.appspot.com/radar?id=4970535809187840 / https://bugs.swift.org/browse/SR-15825.
+    var mockTransaction: Any?
 
     override var delegate: StoreKit2TransactionListenerDelegate? {
         get {
@@ -69,6 +71,8 @@ class MockStoreKit2TransactionListener: StoreKit2TransactionListener {
         invokedHandleCount += 1
         invokedHandleParameters = (purchaseResult, ())
         invokedHandleParametersList.append((purchaseResult, ()))
-        return (false, mockTransaction)
+
+        // swiftlint:disable:next force_cast
+        return (false, mockTransaction as! StoreKit.Transaction?)
     }
 }

--- a/StoreKitUnitTests/StoreKit2TransactionListenerTests.swift
+++ b/StoreKitUnitTests/StoreKit2TransactionListenerTests.swift
@@ -46,11 +46,24 @@ class StoreKit2TransactionListenerTests: StoreKitConfigTestCase {
 
     // MARK: -
 
+    func testVerifiedTransactionReturnsOriginalTransaction() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        let fakeTransaction = try await createTransactionWithPurchase()
+
+        let (isCancelled, transaction) = try await self.listener.handle(
+            purchaseResult: .success(.verified(fakeTransaction))
+        )
+        expect(isCancelled) == false
+        expect(transaction) == fakeTransaction
+    }
+
     func testIsCancelledIsTrueWhenPurchaseIsCancelled() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        let isCancelled = try await self.listener.handle(purchaseResult: .userCancelled)
+        let (isCancelled, transaction) = try await self.listener.handle(purchaseResult: .userCancelled)
         expect(isCancelled) == true
+        expect(transaction).to(beNil())
     }
 
     func testPendingTransactionsReturnPaymentPendingError() async throws {


### PR DESCRIPTION
This was the last TODO for SK2 purchases. Made much cleaner thanks to the new `PurchaseResultData` introduced in #1217.

## Other changes:
- Added test to verify transaction is returned
- Combined 2 redundant `PurchasesOrchestrator.purchase(sk2Product:discount:)` methods