### PR TITLE
Removed unnecessary `SubscriptionPeriod.Unit.unknown`

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester/RCSubscriptionPeriodAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCSubscriptionPeriodAPI.m
@@ -21,10 +21,9 @@
 }
 
 + (void)checkUnitEnum {
-    RCSubscriptionPeriodUnit unit = RCSubscriptionPeriodUnitUnknown;
+    RCSubscriptionPeriodUnit unit = RCSubscriptionPeriodUnitDay;
 
     switch (unit) {
-        case RCSubscriptionPeriodUnitUnknown:
         case RCSubscriptionPeriodUnitDay:
         case RCSubscriptionPeriodUnitWeek:
         case RCSubscriptionPeriodUnitMonth:

--- a/APITesters/SwiftAPITester/SwiftAPITester/SubscriptionPeriodAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/SubscriptionPeriodAPI.swift
@@ -19,11 +19,10 @@ func checkSubscriptionPeriodAPI() {
 }
 
 func checkSubscriptionPeriodUnit() {
-    let unit: SubscriptionPeriod.Unit = .unknown
+    let unit: SubscriptionPeriod.Unit = .day
 
     switch unit {
     case
-            .unknown,
             .day,
             .week,
             .month,

--- a/Purchases/Misc/ISOPeriodFormatter.swift
+++ b/Purchases/Misc/ISOPeriodFormatter.swift
@@ -34,7 +34,6 @@ enum ISOPeriodFormatter {
             return "M"
         case .year:
             return "Y"
-        case .unknown: fallthrough
         @unknown default:
             fatalError("New SKProduct.PeriodUnit \(unit) unaccounted for")
         }

--- a/Purchases/Purchasing/ProductRequestData+Initialization.swift
+++ b/Purchases/Purchasing/ProductRequestData+Initialization.swift
@@ -93,7 +93,6 @@ private extension ProductRequestData {
     static func extractNormalDuration(for product: StoreProduct) -> String? {
         if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *),
            let subscriptionPeriod = product.subscriptionPeriod,
-           product.subscriptionPeriod?.unit != .unknown,
            subscriptionPeriod.value != 0 {
             return ISOPeriodFormatter.string(fromProductSubscriptionPeriod: subscriptionPeriod)
         } else {

--- a/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
@@ -17,7 +17,8 @@ import StoreKit
 internal struct SK1StoreProductDiscount: StoreProductDiscountType {
 
     init?(sk1Discount: SK1ProductDiscount) {
-        guard let paymentMode = StoreProductDiscount.PaymentMode(skProductDiscountPaymentMode: sk1Discount.paymentMode)
+        guard let paymentMode = StoreProductDiscount.PaymentMode(skProductDiscountPaymentMode: sk1Discount.paymentMode),
+              let subscriptionPeriod = SubscriptionPeriod.from(sk1SubscriptionPeriod: sk1Discount.subscriptionPeriod)
         else { return nil }
 
         self.underlyingSK1Discount = sk1Discount
@@ -29,7 +30,7 @@ internal struct SK1StoreProductDiscount: StoreProductDiscountType {
         }
         self.price = sk1Discount.price as Decimal
         self.paymentMode = paymentMode
-        self.subscriptionPeriod = .from(sk1SubscriptionPeriod: sk1Discount.subscriptionPeriod)
+        self.subscriptionPeriod = subscriptionPeriod
     }
 
     let underlyingSK1Discount: SK1ProductDiscount

--- a/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProductDiscount.swift
@@ -17,7 +17,8 @@ import StoreKit
 internal struct SK2StoreProductDiscount: StoreProductDiscountType {
 
     init?(sk2Discount: SK2ProductDiscount) {
-        guard let paymentMode = StoreProductDiscount.PaymentMode(subscriptionOfferPaymentMode: sk2Discount.paymentMode)
+        guard let paymentMode = StoreProductDiscount.PaymentMode(subscriptionOfferPaymentMode: sk2Discount.paymentMode),
+              let subscriptionPeriod = SubscriptionPeriod.from(sk2SubscriptionPeriod: sk2Discount.period)
         else { return nil }
 
         self.underlyingSK2Discount = sk2Discount
@@ -25,7 +26,7 @@ internal struct SK2StoreProductDiscount: StoreProductDiscountType {
         self.offerIdentifier = sk2Discount.id
         self.price = sk2Discount.price
         self.paymentMode = paymentMode
-        self.subscriptionPeriod = .from(sk2SubscriptionPeriod: sk2Discount.period)
+        self.subscriptionPeriod = subscriptionPeriod
     }
 
     let underlyingSK2Discount: SK2ProductDiscount

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -163,12 +163,7 @@ public extension StoreProduct {
     /// - Returns: `nil` if the product is not a subscription.
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
     @objc var pricePerMonth: NSDecimalNumber? {
-        guard let period = self.subscriptionPeriod,
-              period.unit != .unknown else {
-                  return nil
-              }
-
-        return period.pricePerMonth(withTotalPrice: self.price) as NSDecimalNumber?
+        return self.subscriptionPeriod?.pricePerMonth(withTotalPrice: self.price) as NSDecimalNumber?
     }
 
     /// The price of the `introductoryPrice` formatted using ``priceFormatter``.

--- a/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
@@ -30,7 +30,6 @@ public class SubscriptionPeriod: NSObject {
     @objc(RCSubscriptionPeriodUnit)
     public enum Unit: Int {
 
-        case unknown = -1
         case day = 0
         case week = 1
         case month = 2
@@ -39,15 +38,21 @@ public class SubscriptionPeriod: NSObject {
     }
 
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
-    static func from(sk1SubscriptionPeriod: SKProductSubscriptionPeriod) -> SubscriptionPeriod {
-        return .init(value: sk1SubscriptionPeriod.numberOfUnits,
-                     unit: SubscriptionPeriod.Unit.from(sk1PeriodUnit: sk1SubscriptionPeriod.unit))
+    static func from(sk1SubscriptionPeriod: SKProductSubscriptionPeriod) -> SubscriptionPeriod? {
+        guard let unit = SubscriptionPeriod.Unit.from(sk1PeriodUnit: sk1SubscriptionPeriod.unit) else {
+            return nil
+        }
+
+        return .init(value: sk1SubscriptionPeriod.numberOfUnits, unit: unit)
     }
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8, *)
-    static func from(sk2SubscriptionPeriod: StoreKit.Product.SubscriptionPeriod) -> SubscriptionPeriod {
-        return .init(value: sk2SubscriptionPeriod.value,
-                     unit: SubscriptionPeriod.Unit.from(sk2PeriodUnit: sk2SubscriptionPeriod.unit))
+    static func from(sk2SubscriptionPeriod: StoreKit.Product.SubscriptionPeriod) -> SubscriptionPeriod? {
+        guard let unit = SubscriptionPeriod.Unit.from(sk2PeriodUnit: sk2SubscriptionPeriod.unit) else {
+            return nil
+        }
+
+        return .init(value: sk2SubscriptionPeriod.value, unit: unit)
     }
 
     public override func isEqual(_ object: Any?) -> Bool {
@@ -88,7 +93,6 @@ extension SubscriptionPeriod {
             case .week: return 1 / 4
             case .month: return 1
             case .year: return 12
-            case .unknown: return 1
             }
         }() * Decimal(self.value)
 
@@ -110,7 +114,6 @@ extension SubscriptionPeriod {
 extension SubscriptionPeriod.Unit: CustomDebugStringConvertible {
     public var debugDescription: String {
         switch self {
-        case .unknown: return "unknown"
         case .day: return "day"
         case .week: return "week"
         case .month: return "month"
@@ -128,24 +131,24 @@ extension SubscriptionPeriod {
 fileprivate extension SubscriptionPeriod.Unit {
 
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
-    static func from(sk1PeriodUnit: SK1Product.PeriodUnit) -> Self {
+    static func from(sk1PeriodUnit: SK1Product.PeriodUnit) -> Self? {
         switch sk1PeriodUnit {
         case .day: return .day
         case .week: return .week
         case .month: return .month
         case .year: return .year
-        @unknown default: return .unknown
+        @unknown default: return nil
         }
     }
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8, *)
-    static func from(sk2PeriodUnit: StoreKit.Product.SubscriptionPeriod.Unit) -> Self {
+    static func from(sk2PeriodUnit: StoreKit.Product.SubscriptionPeriod.Unit) -> Self? {
         switch sk2PeriodUnit {
         case .day: return .day
         case .week: return .week
         case .month: return .month
         case .year: return .year
-        @unknown default: return .unknown
+        @unknown default: return nil
         }
     }
 

--- a/PurchasesTests/Purchasing/StoreKitAbstractions/SubscriptionPeriodTests.swift
+++ b/PurchasesTests/Purchasing/StoreKitAbstractions/SubscriptionPeriodTests.swift
@@ -25,19 +25,19 @@ class SubscriptionPeriodTests: XCTestCase {
         }
 
         var sk1Period = SKProductSubscriptionPeriod(numberOfUnits: 1, unit: .month)
-        var subscriptionPeriod = SubscriptionPeriod.from(sk1SubscriptionPeriod: sk1Period)
+        var subscriptionPeriod = try XCTUnwrap(SubscriptionPeriod.from(sk1SubscriptionPeriod: sk1Period))
 
         expect(subscriptionPeriod.value) == 1
         expect(subscriptionPeriod.unit) == .month
 
         sk1Period = SKProductSubscriptionPeriod(numberOfUnits: 3, unit: .year)
-        subscriptionPeriod = SubscriptionPeriod.from(sk1SubscriptionPeriod: sk1Period)
+        subscriptionPeriod = try XCTUnwrap(SubscriptionPeriod.from(sk1SubscriptionPeriod: sk1Period))
 
         expect(subscriptionPeriod.value) == 3
         expect(subscriptionPeriod.unit) == .year
 
         sk1Period = SKProductSubscriptionPeriod(numberOfUnits: 5, unit: .week)
-        subscriptionPeriod = SubscriptionPeriod.from(sk1SubscriptionPeriod: sk1Period)
+        subscriptionPeriod = try XCTUnwrap(SubscriptionPeriod.from(sk1SubscriptionPeriod: sk1Period))
 
         expect(subscriptionPeriod.value) == 5
         expect(subscriptionPeriod.unit) == .week


### PR DESCRIPTION
Follow up to #1220.
In the same way that we obsoleted `StoreProductDiscount.PaymentMode.none`, this follows the same pattern of failing to initialize the `StoreProductDiscount` if the unit is not recognized, instead of exposing an invalid discount.

The type is new in V4, so I think it's safe to not have this in the `V4_API_Migration_guide`, and no obsoletion needed.