### PR TITLE
`PurchaseOwnershipType`: refactored mapping to prevent forgetting a future case

### DIFF
--- a/Purchases/CodableExtensions/PurchaseOwnershipType+Extensions.swift
+++ b/Purchases/CodableExtensions/PurchaseOwnershipType+Extensions.swift
@@ -23,14 +23,27 @@ extension PurchaseOwnershipType: Decodable {
                                                   message: "Unable to extract an purchaseOwnershipTypeString")
         }
 
-        switch purchaseOwnershipTypeString {
-        case "PURCHASED":
-            self = .purchased
-        case "FAMILY_SHARED":
-            self = .familyShared
-        default:
+        if let type = Self.mapping[purchaseOwnershipTypeString] {
+            self = type
+        } else {
             Logger.error(Strings.codable.unexpectedValueError(type: PurchaseOwnershipType.self))
             self = .unknown
+        }
+    }
+
+    private static let mapping: [String: Self] = Self.allCases
+        .filter { $0.name != nil }
+        .dictionaryWithKeys { $0.name! }
+
+}
+
+private extension PurchaseOwnershipType {
+
+    var name: String? {
+        switch self {
+        case .purchased: return "PURCHASED"
+        case .familyShared: return "FAMILY_SHARED"
+        case .unknown: return nil
         }
     }
 

--- a/Purchases/CodableExtensions/PurchaseOwnershipType+Extensions.swift
+++ b/Purchases/CodableExtensions/PurchaseOwnershipType+Extensions.swift
@@ -32,8 +32,9 @@ extension PurchaseOwnershipType: Decodable {
     }
 
     private static let mapping: [String: Self] = Self.allCases
-        .filter { $0.name != nil }
-        .dictionaryWithKeys { $0.name! }
+        .reduce(into: [:]) { result, type in
+            if let name = type.name { result[name] = type }
+        }
 
 }
 

--- a/Purchases/Purchasing/PurchaseOwnershipType.swift
+++ b/Purchases/Purchasing/PurchaseOwnershipType.swift
@@ -33,3 +33,5 @@ import Foundation
     case unknown = 2
 
 }
+
+extension PurchaseOwnershipType: CaseIterable {}


### PR DESCRIPTION
If a new `case` is added, this will now fail to compile instead of being parsed as `.unknown`.