### PR TITLE
`Store`: refactored mapping to prevent forgetting a future case

### DIFF
--- a/Purchases/CodableExtensions/Store+Extensions.swift
+++ b/Purchases/CodableExtensions/Store+Extensions.swift
@@ -22,19 +22,30 @@ extension Store: Decodable {
             throw decoder.throwValueNotFoundError(expectedType: Store.self, message: "Unable to extract a storeString")
         }
 
-        switch storeString {
-        case "app_store":
-            self = .appStore
-        case "mac_app_store":
-            self = .macAppStore
-        case "play_store":
-            self = .playStore
-        case "stripe":
-            self = .stripe
-        case "promotional":
-            self = .promotional
-        default:
+        guard let type = Self.mapping[storeString] else {
             throw CodableError.unexpectedValue(Store.self)
+        }
+
+        self = type
+    }
+
+    private static let mapping: [String: Self] = Self.allCases
+        .reduce(into: [:]) { result, store in
+            if let name = store.name { result[name] = store }
+        }
+
+}
+
+private extension Store {
+
+    var name: String? {
+        switch self {
+        case .appStore: return "app_store"
+        case .macAppStore: return "mac_app_store"
+        case .playStore: return "play_store"
+        case .stripe: return "stripe"
+        case .promotional: return "promotional"
+        case .unknownStore: return nil
         }
     }
 

--- a/Purchases/Purchasing/EntitlementInfo.swift
+++ b/Purchases/Purchasing/EntitlementInfo.swift
@@ -39,6 +39,8 @@ import Foundation
 
 }
 
+extension Store: CaseIterable {}
+
 /**
  Enum of supported period types for an entitlement.
  */


### PR DESCRIPTION
Same as #1236.
If a new case is added, this will now fail to compile instead of throwing `CodableError.unexpectedValue`