### PR TITLE
`PeriodType`: refactored mapping to prevent forgetting a future case

### DIFF
--- a/Purchases/CodableExtensions/PeriodType+Extensions.swift
+++ b/Purchases/CodableExtensions/PeriodType+Extensions.swift
@@ -23,15 +23,25 @@ extension PeriodType: Decodable {
                                                   message: "Unable to extract a periodTypeString")
         }
 
-        switch periodTypeString {
-        case "normal":
-            self = .normal
-        case "intro":
-            self = .intro
-        case "trial":
-            self = .trial
-        default:
+        guard let type = Self.mapping[periodTypeString] else {
             throw CodableError.unexpectedValue(PeriodType.self)
+        }
+
+        self = type
+    }
+
+    private static let mapping: [String: Self] = Self.allCases
+        .dictionaryWithKeys { $0.name }
+
+}
+
+private extension PeriodType {
+
+    var name: String {
+        switch self {
+        case .normal: return "normal"
+        case .intro: return "intro"
+        case .trial: return "trial"
         }
     }
 

--- a/Purchases/Purchasing/EntitlementInfo.swift
+++ b/Purchases/Purchasing/EntitlementInfo.swift
@@ -54,6 +54,8 @@ import Foundation
     @objc(RCTrial) case trial = 2
 }
 
+extension PeriodType: CaseIterable {}
+
 /**
  The EntitlementInfo object gives you access to all of the information about the status of a user entitlement.
  */


### PR DESCRIPTION
Same as #1236.
If a new case is added, this will now fail to compile instead of throwing `CodableError.unexpectedValue`