### PR TITLE
Added `StoreProduct.getEligibleDiscounts()` and `Purchases.getEligibleDiscounts(forProduct:)`

### DIFF
--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -216,6 +216,8 @@ private func checkAsyncMethods(purchases: Purchases) async {
         let _: RefundRequestStatus = try await purchases.beginRefundRequest(forProduct: "")
         let _: RefundRequestStatus = try await purchases.beginRefundRequest(forEntitlement: "")
         let _: RefundRequestStatus = try await purchases.beginRefundRequestForActiveEntitlement()
+
+        let _: [StoreProductDiscount] = await purchases.getEligibleDiscounts(forProduct: stp)
         #endif
     } catch {}
 }

--- a/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
@@ -26,6 +26,12 @@ func checkStoreProductAPI() {
     let sk1Product: SK1Product? = product.sk1Product
     let sk2Product: SK2Product? = product.sk2Product
 
+    if #available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *) {
+        _ = Task.init {
+            await checkStoreProductAsyncAPI()
+        }
+    }
+
     print(
         product!,
         localizedDescription,
@@ -44,4 +50,8 @@ func checkStoreProductAPI() {
         sk1Product!,
         sk2Product!
     )
+}
+
+func checkStoreProductAsyncAPI() async {
+    let _: [StoreProductDiscount] = await product.getEligibleDiscounts()
 }

--- a/Purchases/Logging/Strings/PurchaseStrings.swift
+++ b/Purchases/Logging/Strings/PurchaseStrings.swift
@@ -58,6 +58,7 @@ enum PurchaseStrings {
     case begin_refund_customer_info_error(entitlementID: String?)
     case cached_app_user_id_deleted
     case check_eligibility_no_identifiers
+    case check_eligibility_failed(productIdentifier: String, error: Error)
 
 }
 
@@ -208,6 +209,10 @@ extension PurchaseStrings: CustomStringConvertible {
         case .check_eligibility_no_identifiers:
             return "Requested trial or introductory price eligibility with no identifiers. " +
             "This is likely a program error."
+
+        case let .check_eligibility_failed(productIdentifier, error):
+            return "Error checking discount eligibility for product '\(productIdentifier)': \(error).\n" +
+            "Will be considered not eligible."
         }
     }
 

--- a/Purchases/Misc/Purchases+async.swift
+++ b/Purchases/Misc/Purchases+async.swift
@@ -222,8 +222,8 @@ extension Purchases {
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-     func checkPromotionalDiscountEligibilityAsync(forProductDiscount discount: StoreProductDiscount,
-                                                   product: StoreProduct) async throws -> PromotionalOfferEligibility {
+    func checkPromotionalDiscountEligibilityAsync(forProductDiscount discount: StoreProductDiscount,
+                                                  product: StoreProduct) async throws -> PromotionalOfferEligibility {
          return try await withCheckedThrowingContinuation { continuation in
              checkPromotionalDiscountEligibility(forProductDiscount: discount, product: product) { isEligible, error in
                  if let error = error {
@@ -234,6 +234,44 @@ extension Purchases {
              }
          }
      }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func getEligibleDiscountsAsync(forProduct product: StoreProduct) async -> [StoreProductDiscount] {
+        let discounts = product.discounts
+
+        return await withTaskGroup(of: Optional<StoreProductDiscount>.self) { group in
+            for discount in discounts {
+                group.addTask {
+                    do {
+                        let eligibility = try await self.checkPromotionalDiscountEligibility(
+                            forProductDiscount: discount,
+                            product: product
+                        )
+
+                        return eligibility.isEligible ? discount : nil
+                    } catch {
+                        Logger.error(
+                            Strings.purchase.check_eligibility_failed(
+                                productIdentifier: product.productIdentifier,
+                                error: error
+                            )
+                        )
+                        return nil
+                    }
+                }
+            }
+
+            var result: [StoreProductDiscount] = []
+
+            for await discount in group {
+                if let discount = discount {
+                    result.append(discount)
+                }
+            }
+
+            return result
+        }
+    }
 
 #if os(iOS) || os(macOS)
 

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -1301,9 +1301,12 @@ public extension Purchases {
     }
 
     /// Finds the subset of ``StoreProduct/discounts`` that's eligible for the current user.
-    /// - Seealso: ``StoreProduct/getEligibleDiscounts()``
+    /// - Parameter product: the product to filter discounts from.
     /// - Note: if checking for eligibility for a `StoreProductDiscount` fails (for example, if network is down),
     ///   that discount will fail silently and be considered not eligible.
+    /// #### Related Symbols
+    /// - ``StoreProduct/getEligibleDiscounts()``
+    /// - ``StoreProduct/discounts``
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func getEligibleDiscounts(forProduct product: StoreProduct) async -> [StoreProductDiscount] {
         return await getEligibleDiscountsAsync(forProduct: product)

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -1300,6 +1300,15 @@ public extension Purchases {
         return try await checkPromotionalDiscountEligibilityAsync(forProductDiscount: discount, product: product)
     }
 
+    /// Finds the subset of ``StoreProduct/discounts`` that's eligible for the current user.
+    /// - Seealso: ``StoreProduct/getEligibleDiscounts()``
+    /// - Note: if checking for eligibility for a `StoreProductDiscount` fails (for example, if network is down),
+    ///   that discount will fail silently and be considered not eligible.
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func getEligibleDiscounts(forProduct product: StoreProduct) async -> [StoreProductDiscount] {
+        return await getEligibleDiscountsAsync(forProduct: product)
+    }
+
 #if os(iOS) || os(macOS)
 
     /**

--- a/Purchases/Purchasing/StoreKitAbstractions/PromotionalOffer.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/PromotionalOffer.swift
@@ -56,3 +56,13 @@ extension PromotionalOffer {
 }
 
 extension PromotionalOfferEligibility: CaseIterable {}
+
+public extension PromotionalOfferEligibility {
+    /// - Returns: `true` if the offer is eligible.
+    var isEligible: Bool {
+        switch self {
+        case .eligible: return true
+        case .ineligible: return false
+        }
+    }
+}

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -191,48 +191,12 @@ public extension StoreProduct {
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 public extension StoreProduct {
     /// Finds the subset of ``discounts`` that's eligible for the current user.
-    /// - Parameter purchases: the instance of `Purchases` to use when determining eligibility.
     /// - Seealso: ``discounts``
     /// - Note: if checking for eligibility for a `StoreProductDiscount` fails (for example, if network is down),
     ///   that discount will fail silently and be considered not eligible.
     /// - Warning: this method implicitly relies on ``Purchases`` already being initialized.
     func getEligibleDiscounts() async -> [StoreProductDiscount] {
-        let purchases = Purchases.shared
-        let discounts = self.discounts
-        let product = self
-
-        return await withTaskGroup(of: Optional<StoreProductDiscount>.self) { group in
-            for discount in discounts {
-                group.addTask {
-                    do {
-                        let eligibility = try await purchases.checkPromotionalDiscountEligibility(
-                            forProductDiscount: discount,
-                            product: product
-                        )
-
-                        return eligibility.isEligible ? discount : nil
-                    } catch {
-                        Logger.error(
-                            Strings.purchase.check_eligibility_failed(
-                                productIdentifier: product.productIdentifier,
-                                error: error
-                            )
-                        )
-                        return nil
-                    }
-                }
-            }
-
-            var result: [StoreProductDiscount] = []
-
-            for await discount in group {
-                if let discount = discount {
-                    result.append(discount)
-                }
-            }
-
-            return result
-        }
+        return await Purchases.shared.getEligibleDiscounts(forProduct: self)
     }
 }
 

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -156,7 +156,7 @@ internal protocol StoreProductType {
     var introductoryDiscount: StoreProductDiscount? { get }
 
     /// An array of subscription offers available for the auto-renewable subscription.
-    /// - Note: the currenet user may or may not be eligible for some of these.
+    /// - Note: the current user may or may not be eligible for some of these.
     /// #### Related Symbols
     /// - ``Purchases/checkPromotionalDiscountEligibility(forProductDiscount:product:)``
     /// - ``Purchases/checkPromotionalDiscountEligibility(forProductDiscount:product:completion:)``

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -157,8 +157,8 @@ internal protocol StoreProductType {
     /// An array of subscription offers available for the auto-renewable subscription.
     /// - Note: the currenet user may or may not be eligible for some of these.
     /// - Seealso: ``Purchases/checkPromotionalDiscountEligibility(forProductDiscount:product:)``
-    /// - Seealso: ``Purchases/checkPromotionalDiscountEligibility(forProductDiscount:product:completion:)`
-    /// - Seealso: ``StoreProduct/eligibleDiscounts(withPurchases:)``
+    /// - Seealso: ``Purchases/checkPromotionalDiscountEligibility(forProductDiscount:product:completion:)``
+    /// - Seealso: ``StoreProduct/getEligibleDiscounts()``
     @available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *)
     var discounts: [StoreProductDiscount] { get }
 
@@ -190,12 +190,14 @@ public extension StoreProduct {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 public extension StoreProduct {
-    /// Asynchronously determines the subset of ``discounts`` that's eligible for the current user.
+    /// Finds the subset of ``discounts`` that's eligible for the current user.
     /// - Parameter purchases: the instance of `Purchases` to use when determining eligibility.
     /// - Seealso: ``discounts``
     /// - Note: if checking for eligibility for a `StoreProductDiscount` fails (for example, if network is down),
-    /// that discount will fail silently and be considered not eligible.
-    func eligibleDiscounts(withPurchases purchases: Purchases) async -> [StoreProductDiscount] {
+    ///   that discount will fail silently and be considered not eligible.
+    /// - Warning: this method implicitly relies on ``Purchases`` already being initialized.
+    func getEligibleDiscounts() async -> [StoreProductDiscount] {
+        let purchases = Purchases.shared
         let discounts = self.discounts
         let product = self
 

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -150,15 +150,17 @@ internal protocol StoreProductType {
     ///
     /// Before displaying UI that offers the introductory price,
     /// you must first determine if the user is eligible to receive it.
-    /// - Seealso: ``Purchases/checkTrialOrIntroDiscountEligibility(_:)`` to  determine eligibility.
+    /// #### Related Symbols
+    /// - ``Purchases/checkTrialOrIntroDiscountEligibility(_:)`` to  determine eligibility.
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
     var introductoryDiscount: StoreProductDiscount? { get }
 
     /// An array of subscription offers available for the auto-renewable subscription.
     /// - Note: the currenet user may or may not be eligible for some of these.
-    /// - Seealso: ``Purchases/checkPromotionalDiscountEligibility(forProductDiscount:product:)``
-    /// - Seealso: ``Purchases/checkPromotionalDiscountEligibility(forProductDiscount:product:completion:)``
-    /// - Seealso: ``StoreProduct/getEligibleDiscounts()``
+    /// #### Related Symbols
+    /// - ``Purchases/checkPromotionalDiscountEligibility(forProductDiscount:product:)``
+    /// - ``Purchases/checkPromotionalDiscountEligibility(forProductDiscount:product:completion:)``
+    /// - ``StoreProduct/getEligibleDiscounts()``
     @available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *)
     var discounts: [StoreProductDiscount] { get }
 
@@ -191,10 +193,11 @@ public extension StoreProduct {
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 public extension StoreProduct {
     /// Finds the subset of ``discounts`` that's eligible for the current user.
-    /// - Seealso: ``discounts``
     /// - Note: if checking for eligibility for a `StoreProductDiscount` fails (for example, if network is down),
     ///   that discount will fail silently and be considered not eligible.
     /// - Warning: this method implicitly relies on ``Purchases`` already being initialized.
+    /// #### Related Symbols
+    /// - ``discounts``
     func getEligibleDiscounts() async -> [StoreProductDiscount] {
         return await Purchases.shared.getEligibleDiscounts(forProduct: self)
     }


### PR DESCRIPTION
This simplifies the API and allows users to use only one method to determine which `StoreProductDiscount`s to display in the UI.