### PR TITLE
enabled `docs_deploy` job for beta releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,4 +382,4 @@ workflows:
     jobs:
       - make-release: *release-tags
       # - prepare-next-version: *release-tags Disabled for beta releases.
-      # - docs-deploy: *release-tags Disabled for beta releases.
+      - docs-deploy: *release-tags


### PR DESCRIPTION
We had disabled the `docs_deploy` job for v4 releases because it would overwrite our v3 docs, with v3 being the currently stable version. 

However, since #1226, we're now deploying v4 docs to a separate site, so we can have both versions concurrently without issues. 
