### PR TITLE
fixed `seeAlso` use

### DIFF
--- a/Purchases/Error Handling/ErrorUtils.swift
+++ b/Purchases/Error Handling/ErrorUtils.swift
@@ -294,7 +294,7 @@ enum ErrorUtils {
     /**
      * Constructs an Error with the ``ErrorCode/productNotAvailableForPurchaseError`` code.
      *
-     * - Seealso: `StoreKitError.notAvailableInStorefront`
+     * - SeeAlso: `StoreKitError.notAvailableInStorefront`
      */
     static func productNotAvailableForPurchaseError(
         error: Error? = nil,

--- a/Purchases/Error Handling/StoreKitError+Extensions.swift
+++ b/Purchases/Error Handling/StoreKitError+Extensions.swift
@@ -13,7 +13,7 @@
 
 import StoreKit
 
-/// - Seealso: SKError+Extensions
+/// - SeeAlso: SKError+Extensions
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 extension StoreKitError {
 

--- a/Purchases/Misc/SynchronizedUserDefaults.swift
+++ b/Purchases/Misc/SynchronizedUserDefaults.swift
@@ -15,7 +15,7 @@ import Foundation
 
 /// A `UserDefaults` wrapper to synchronize access and writes.
 ///
-/// - Seealso: ``Atomic``.
+/// - SeeAlso: `Atomic`.
 internal class SynchronizedUserDefaults {
 
     private let atomic: Atomic<UserDefaults>

--- a/Purchases/Purchasing/ProductRequestData.swift
+++ b/Purchases/Purchasing/ProductRequestData.swift
@@ -17,7 +17,7 @@ import StoreKit
 
 /// Encapsulates ``StoreProductType`` information to be sent to the backend
 /// when posting receipts.
-/// - Seealso: `Backend/post(receiptData:appUserID:isRestore:productData:...`
+/// - SeeAlso: `Backend/post(receiptData:appUserID:isRestore:productData:...`
 struct ProductRequestData {
 
     let productIdentifier: String

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -49,7 +49,7 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
     /// - Note: this method will crash with `fatalError` if `Purchases` has not been initialized through `configure()`.
     ///         If there's a chance that may have not happened yet, you can use ``isConfigured``
     ///         to check if it's safe to call.
-    /// - Seealso: ``isConfigured``.
+    /// - SeeAlso: ``isConfigured``.
     @objc(sharedPurchases)
     public static var shared: Purchases {
         guard let purchases = purchases else {
@@ -96,8 +96,8 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
     /**
      * Used to set the log level. Useful for debugging issues with the lovely team @RevenueCat
      *
-     * - Seealso ``logHandler``
-     * - Seealso ``verboseLogHandler``
+     * - SeeAlso: ``logHandler``
+     * - SeeAlso: ``verboseLogHandler``
      */
     @objc public static var logLevel: LogLevel {
         get { Logger.logLevel }
@@ -124,9 +124,9 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
     }
 
     /**
-     * Set this property to true *only* when testing the ask-to-buy / SCA purchases flow. More information:
-     * http://rev.cat/ask-to-buy
-     * - Seealso: https://support.apple.com/en-us/HT201089
+     * Set this property to true *only* when testing the ask-to-buy / SCA purchases flow.
+     * More information [available here](http://rev.cat/ask-to-buy).
+     * - SeeAlso: [Approve what kids buy with Ask to Buy](https://support.apple.com/en-us/HT201089)
      */
     @available(iOS 8.0, macOS 10.14, watchOS 6.2, macCatalyst 13.0, *)
     @objc public static var simulatesAskToBuyInSandbox: Bool {
@@ -146,8 +146,8 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
      *
      * - Note:``verboseLogHandler`` provides additional information.
      *
-     * - Seealso: ``verboseLogHandler``
-     * - Seealso: ``logLevel``
+     * - SeeAlso: ``verboseLogHandler``
+     * - SeeAlso: ``logLevel``
      */
     @objc public static var logHandler: LogHandler {
         get {
@@ -170,8 +170,8 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
      *
      * - Note: you can use ``logHandler`` if you don't need filename information.
      *
-     * - Seealso: ``logHandler``
-     * - Seealso: ``logLevel``
+     * - SeeAlso: ``logHandler``
+     * - SeeAlso: ``logLevel``
      */
     @objc public static var verboseLogHandler: VerboseLogHandler {
         get { Logger.logHandler }
@@ -183,8 +183,8 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
      *  Filename, line, and method data.
      * You can also access that information for your own logging system by using ``verboseLogHandler``.
      *
-     * - Seealso: ``verboseLogHandler``
-     * - Seealso: ``logLevel``
+     * - SeeAlso: ``verboseLogHandler``
+     * - SeeAlso: ``logLevel``
      */
     @objc public static var verboseLogs: Bool {
         get { return Logger.verbose }
@@ -765,7 +765,7 @@ public extension Purchases {
      * Get latest available customer  info.
      * Returns a value immediately if ``CustomerInfo`` is cached.
      *
-     * - Seealso ``Purchases/customerInfoStream``
+     * - SeeAlso: ``Purchases/customerInfoStream``
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func customerInfo() async throws -> CustomerInfo {
@@ -774,8 +774,8 @@ public extension Purchases {
 
     /// Returns an `AsyncStream` of ``CustomerInfo`` changes.
     ///
-    /// - Seealso ``PurchasesDelegate/purchases(_:receivedUpdated:)
-    /// - Seealso ``Purchases/customerInfo()``
+    /// - SeeAlso: ``PurchasesDelegate/purchases(_:receivedUpdated:)``
+    /// - SeeAlso: ``Purchases/customerInfo()``
     ///  #### Example:
     /// ```swift
     ///     for await customerInfo in Purchases.shared.customerInfoStream {

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -30,7 +30,7 @@ public typealias SK2Product = StoreKit.Product
     let product: StoreProductType
 
     /// Designated initializer.
-    /// - Seealso: ``StoreProduct.from(product:)`` to wrap an instance of `StoreProduct`
+    /// - SeeAlso: ``StoreProduct.from(product:)`` to wrap an instance of `StoreProduct`
     private init(_ product: StoreProductType) {
         self.product = product
 
@@ -103,7 +103,7 @@ internal protocol StoreProductType {
 
     /// The decimal representation of the cost of the product, in local currency.
     /// For a string representation of the price to display to customers, use ``localizedPriceString``.
-    /// - Seealso: ``pricePerMonth``.
+    /// - SeeAlso: ``pricePerMonth``.
     var price: Decimal { get }
 
     /// The price of this product using ``priceFormatter``.
@@ -120,7 +120,7 @@ internal protocol StoreProductType {
     ///
     /// Configure your in-app purchases to allow Family Sharing in App Store Connect.
     /// For more information about setting up Family Sharing, see Turn-on Family Sharing for in-app purchases.
-    /// - Seealso: https://support.apple.com/en-us/HT201079
+    /// - SeeAlso: https://support.apple.com/en-us/HT201079
     @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 8.0, *)
     var isFamilyShareable: Bool { get }
 


### PR DESCRIPTION
We were using `seeAlso` wrong in a couple of places. I also took the opportunity to standardize the syntax to reference format here: https://developer.apple.com/library/archive/documentation/Xcode/Reference/xcode_markup_formatting_ref/SeeAlso.html

This fixes a few places were it looked a bit odd in the docs. 
Weirdly, it doesn't seem to do anything, at least in the preview ¯\\_(ツ)_/¯. But I still feel better using the correct format. 

| Before | After |
| :-: | :-: |
| <img width="811" alt="Screen Shot 2022-01-31 at 2 35 29 PM" src="https://user-images.githubusercontent.com/3922667/151844619-4a649eb4-9e3e-4918-96b3-93df912d5016.png"> | <img width="1041" alt="Screen Shot 2022-01-31 at 2 35 45 PM" src="https://user-images.githubusercontent.com/3922667/151844593-f04268ab-a8f5-4f20-9859-dd8e95ac7367.png"> |