### PR TITLE
`Purchases.shared`: changed `note` to `warning`

### DIFF
--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -46,9 +46,10 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
 #endif
 
     /// Returns the already configured instance of `Purchases`.
-    /// - Note: this method will crash with `fatalError` if `Purchases` has not been initialized through `configure()`.
-    ///         If there's a chance that may have not happened yet, you can use ``isConfigured``
-    ///         to check if it's safe to call.
+    /// - Warning: this method will crash with `fatalError` if `Purchases` has not been
+    ///            initialized through `configure()`.
+    ///            If there's a chance that may have not happened yet, you can use ``isConfigured``
+    ///            to check if it's safe to call.
     /// - SeeAlso: ``isConfigured``.
     @objc(sharedPurchases)
     public static var shared: Purchases {


### PR DESCRIPTION
<img width="764" alt="Screen Shot 2022-01-31 at 13 22 47" src="https://user-images.githubusercontent.com/685609/151875353-324f98f4-b2b6-446f-aaf6-9bb2f79c6206.png">
