### PR TITLE
[fastlane] fail build if scan fails (trainer used to do this)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -49,8 +49,6 @@ platform :ios do
       testplan: "Coverage",
       prelaunch_simulator: true,
       output_types: 'junit',
-      fail_build: false,
-      result_bundle: true,
       number_of_retries: 5,
       output_directory: "fastlane/test_output/xctest/ios"
     )
@@ -62,12 +60,9 @@ platform :ios do
       testplan: "RevenueCat",
       prelaunch_simulator: true,
       output_types: 'junit',
-      fail_build: false,
-      result_bundle: true,
       number_of_retries: 5,
       output_directory: "fastlane/test_output/xctest/tvos"
     )
-    zip_xcresults if is_ci
   end
 
   desc "Replace version number in project and supporting files"
@@ -418,22 +413,9 @@ platform :ios do
     scan(
       scheme: "BackendIntegrationTests", 
       derived_data_path: "scan_derived_data",
-      output_types: '',
-      fail_build: false,
-      result_bundle: true,
+      output_types: 'junit',
       output_directory: "fastlane/test_output/xctest/ios"
     )
-    zip_xcresults if is_ci
-  end
-
-  lane :zip_xcresults do
-    UI.message "Zipping xcresults..."
-    Dir["test_output/**/*.xcresult"].each do |path|
-      path = File.absolute_path(path)
-      UI.message "Zipping and removing #{path}"
-      zip(path: path, output_path: "#{path}.zip")
-      FileUtils.remove_dir(path)
-    end
   end
 
   desc "Update swift package commit"


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
- CircleCI builds do not fail if uploaded junit test results have failures (to my surprise)
  - https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/5207/workflows/adf40d6a-9fea-4aa3-b849-729b95f26204/jobs/16740
- _fastlane_ needs to fail the build

### Description
- _fastlane_ used to fail the build when we needed to use `trainer`
- But since everything can be done with `scan`, we now need to remove `fail_build: false`
- The CircleCI job will now error out if `scan` detects a failure during its run

**Bonus:** we can now remove `result_bundle: true` (which was outputting `.xcresult` in the output directory). Scan will get the result bundle automatically from the derived data.
