### PR TITLE
Replace `SeeAlso` with links

### DIFF
--- a/Purchases/Error Handling/ErrorUtils.swift
+++ b/Purchases/Error Handling/ErrorUtils.swift
@@ -294,7 +294,8 @@ enum ErrorUtils {
     /**
      * Constructs an Error with the ``ErrorCode/productNotAvailableForPurchaseError`` code.
      *
-     * - SeeAlso: `StoreKitError.notAvailableInStorefront`
+     * #### Related Articles
+     * - [`StoreKitError.notAvailableInStorefront`](https://rev.cat/storekit-error-not-available-in-storefront)
      */
     static func productNotAvailableForPurchaseError(
         error: Error? = nil,

--- a/Purchases/Logging/Logger.swift
+++ b/Purchases/Logging/Logger.swift
@@ -14,8 +14,10 @@
 
 import Foundation
 
-/// Enumeration of the different verbosity levels
-/// - Seealso: ``Purchases/logLevel``
+/// Enumeration of the different verbosity levels.
+///
+/// #### Related Symbols
+/// - ``Purchases/logLevel``
 @objc(RCLogLevel) public enum LogLevel: Int, CustomStringConvertible {
 
     // swiftlint:disable:next missing_docs

--- a/Purchases/Purchasing/EntitlementInfos.swift
+++ b/Purchases/Purchasing/EntitlementInfos.swift
@@ -32,7 +32,8 @@ import Foundation
         return self.all.filter { $0.value.isActive }
     }
 
-    /// - Seealso: ``all``
+    /// #### Related Symbols
+    /// `- `all``
     @objc public subscript(key: String) -> EntitlementInfo? {
         return self.all[key]
     }

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -49,7 +49,8 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
     /// - Warning: this method will crash with `fatalError` if ``Purchases`` has not been initialized through
     /// ``configure(withAPIKey:)`` or one of its overloads. If there's a chance that may have not happened yet,
     /// you can use ``isConfigured`` to check if it's safe to call.
-    /// - SeeAlso: ``isConfigured``.
+    /// ### Related symbols
+    /// - ``isConfigured``
     @objc(sharedPurchases)
     public static var shared: Purchases {
         guard let purchases = purchases else {
@@ -97,8 +98,9 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
     /**
      * Used to set the log level. Useful for debugging issues with the lovely team @RevenueCat
      *
-     * - SeeAlso: ``logHandler``
-     * - SeeAlso: ``verboseLogHandler``
+     * #### Related Symbols
+     * - ``logHandler``
+     * - ``verboseLogHandler``
      */
     @objc public static var logLevel: LogLevel {
         get { Logger.logLevel }
@@ -127,7 +129,8 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
     /**
      * Set this property to true *only* when testing the ask-to-buy / SCA purchases flow.
      * More information [available here](https://rev.cat/ask-to-buy).
-     * - SeeAlso: [Approve what kids buy with Ask to Buy](https://rev.cat/approve-kids-purchases-apple)
+     * #### Related Articles
+     * -  [Approve what kids buy with Ask to Buy](https://rev.cat/approve-kids-purchases-apple)
      */
     @available(iOS 8.0, macOS 10.14, watchOS 6.2, macCatalyst 13.0, *)
     @objc public static var simulatesAskToBuyInSandbox: Bool {
@@ -148,8 +151,9 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
      *
      * - Note:``verboseLogHandler`` provides additional information.
      *
-     * - SeeAlso: ``verboseLogHandler``
-     * - SeeAlso: ``logLevel``
+     * #### Related Symbols
+     * - ``verboseLogHandler``
+     * - ``logLevel``
      */
     @objc public static var logHandler: LogHandler {
         get {
@@ -172,8 +176,9 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
      *
      * - Note: you can use ``logHandler`` if you don't need filename information.
      *
-     * - SeeAlso: ``logHandler``
-     * - SeeAlso: ``logLevel``
+     * #### Related Symbols
+     * - ``logHandler``
+     * - ``logLevel``
      */
     @objc public static var verboseLogHandler: VerboseLogHandler {
         get { Logger.logHandler }
@@ -185,8 +190,9 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
      *  Filename, line, and method data.
      * You can also access that information for your own logging system by using ``verboseLogHandler``.
      *
-     * - SeeAlso: ``verboseLogHandler``
-     * - SeeAlso: ``logLevel``
+     * #### Related Symbols
+     * - ``verboseLogHandler``
+     * - ``logLevel``
      */
     @objc public static var verboseLogs: Bool {
         get { return Logger.verbose }
@@ -414,7 +420,9 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
 
     /**
      * Automatically collect subscriber attributes associated with the device identifiers
-     * $idfa, $idfv, $ip
+     * - `$idfa`
+     * - `$idfv`
+     * - `$ip`
      */
     @objc public func collectDeviceIdentifiers() {
         subscriberAttributesManager.collectDeviceIdentifiers(forAppUserID: appUserID)
@@ -465,7 +473,8 @@ extension Purchases {
     /**
      * Subscriber attribute associated with the email address for the user.
      *
-     * - SeeAlso: [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
+     * #### Related Articles
+     * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
      * - Parameter email: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setEmail(_ email: String?) {
@@ -475,7 +484,8 @@ extension Purchases {
     /**
      * Subscriber attribute associated with the phone number for the user.
      *
-     * - SeeAlso: [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
+     * #### Related Articles
+     * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
      * - Parameter phoneNumber: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setPhoneNumber(_ phoneNumber: String?) {
@@ -485,7 +495,8 @@ extension Purchases {
     /**
      * Subscriber attribute associated with the display name for the user.
      *
-     * - SeeAlso: [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
+     * #### Related Articles
+     * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
      * - Parameter displayName: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setDisplayName(_ displayName: String?) {
@@ -495,7 +506,8 @@ extension Purchases {
     /**
      * Subscriber attribute associated with the push token for the user.
      *
-     * - SeeAlso: [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
+     * #### Related Articles
+     * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
      * - Parameter pushToken: `nil` will delete the subscriber attribute..
      */
     @objc public func setPushToken(_ pushToken: Data?) {
@@ -572,7 +584,8 @@ extension Purchases {
     /**
      * Subscriber attribute associated with the install media source for the user.
      *
-     * - SeeAlso: [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
+     * #### Related Articles
+     * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
      * - Parameter mediaSource: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setMediaSource(_ mediaSource: String?) {
@@ -582,7 +595,8 @@ extension Purchases {
     /**
      * Subscriber attribute associated with the install campaign for the user.
      *
-     * - SeeAlso: [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
+     * #### Related Articles
+     * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
      * - Parameter campaign: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setCampaign(_ campaign: String?) {
@@ -592,7 +606,8 @@ extension Purchases {
     /**
      * Subscriber attribute associated with the install ad group for the user
      *
-     * - SeeAlso: [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
+     * #### Related Articles
+     * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
      * - Parameter adGroup: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setAdGroup(_ adGroup: String?) {
@@ -602,7 +617,8 @@ extension Purchases {
     /**
      * Subscriber attribute associated with the install ad for the user
      *
-     * - SeeAlso: [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
+     * #### Related Articles
+     * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
      * - Parameter installAd: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setAd(_ installAd: String?) {
@@ -612,7 +628,8 @@ extension Purchases {
     /**
      * Subscriber attribute associated with the install keyword for the user
      *
-     * - SeeAlso: [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
+     * #### Related Articles
+     * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
      * - Parameter keyword: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setKeyword(_ keyword: String?) {
@@ -622,7 +639,8 @@ extension Purchases {
     /**
      * Subscriber attribute associated with the install ad creative for the user.
      *
-     * - SeeAlso: [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
+     * #### Related Articles
+     * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
      * - Parameter creative: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setCreative(_ creative: String?) {

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -1328,9 +1328,8 @@ public extension Purchases {
      * Use this function to open the manage subscriptions modal.
      *
      * - Parameter completion: A completion block that is called when the modal is opened.
-     * - throws: an Error will be thrown if the current window scene couldn't be opened,
+     * - throws: an `Error` will be thrown if the current window scene couldn't be opened,
      * or the ``CustomerInfo/managementURL`` couldn't be obtained.
-
      * If the manage subscriptions page can't be opened, the ``CustomerInfo/managementURL`` in
      * the ``CustomerInfo`` will be opened. If ``CustomerInfo/managementURL`` is not available,
      * the App Store's subscription management section will be opened.

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -475,6 +475,7 @@ extension Purchases {
      *
      * #### Related Articles
      * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
+     * 
      * - Parameter email: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setEmail(_ email: String?) {
@@ -486,6 +487,7 @@ extension Purchases {
      *
      * #### Related Articles
      * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
+     *
      * - Parameter phoneNumber: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setPhoneNumber(_ phoneNumber: String?) {
@@ -497,6 +499,7 @@ extension Purchases {
      *
      * #### Related Articles
      * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
+     *
      * - Parameter displayName: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setDisplayName(_ displayName: String?) {
@@ -508,6 +511,7 @@ extension Purchases {
      *
      * #### Related Articles
      * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
+     *
      * - Parameter pushToken: `nil` will delete the subscriber attribute..
      */
     @objc public func setPushToken(_ pushToken: Data?) {
@@ -518,8 +522,10 @@ extension Purchases {
      * Subscriber attribute associated with the Adjust Id for the user.
      * Required for the RevenueCat Adjust integration.
      *
-     * - SeeAlso: [Adjust RevenueCat Integration](https://docs.revenuecat.com/docs/adjust)
-     * - Parameter adjustID: Empty String or `nil` will delete the subscriber attribute..
+     * #### Related Articles
+     * - [Adjust RevenueCat Integration](https://docs.revenuecat.com/docs/adjust)
+     *
+     *- Parameter adjustID: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setAdjustID(_ adjustID: String?) {
         subscriberAttributesManager.setAdjustID(adjustID, appUserID: appUserID)
@@ -529,8 +535,10 @@ extension Purchases {
      * Subscriber attribute associated with the Appsflyer Id for the user.
      * Required for the RevenueCat Appsflyer integration.
      *
-     * - SeeAlso: [AppsFlyer RevenueCat Integration](https://docs.revenuecat.com/docs/appsflyer)
-     * - Parameter appsflyerID: Empty String or `nil` will delete the subscriber attribute..
+     * #### Related Articles
+     * - [AppsFlyer RevenueCat Integration](https://docs.revenuecat.com/docs/appsflyer)
+     *
+     *- Parameter appsflyerID: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setAppsflyerID(_ appsflyerID: String?) {
         subscriberAttributesManager.setAppsflyerID(appsflyerID, appUserID: appUserID)
@@ -540,8 +548,10 @@ extension Purchases {
      * Subscriber attribute associated with the Facebook SDK Anonymous Id for the user.
      * Recommended for the RevenueCat Facebook integration.
      *
-     * - SeeAlso: [Facebook Ads RevenueCat Integration](https://docs.revenuecat.com/docs/facebook-ads)
-     * - Parameter fbAnonymousID: Empty String or `nil` will delete the subscriber attribute..
+     * #### Related Articles
+     * - [Facebook Ads RevenueCat Integration](https://docs.revenuecat.com/docs/facebook-ads)
+     *
+     *- Parameter fbAnonymousID: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setFBAnonymousID(_ fbAnonymousID: String?) {
         subscriberAttributesManager.setFBAnonymousID(fbAnonymousID, appUserID: appUserID)
@@ -551,8 +561,10 @@ extension Purchases {
      * Subscriber attribute associated with the mParticle Id for the user.
      * Recommended for the RevenueCat mParticle integration.
      *
-     * - SeeAlso: [mParticle RevenueCat Integration](https://docs.revenuecat.com/docs/mparticle)
-     * - Parameter mparticleID: Empty String or `nil` will delete the subscriber attribute..
+     * #### Related Articles
+     * - [mParticle RevenueCat Integration](https://docs.revenuecat.com/docs/mparticle)
+     *
+     *- Parameter mparticleID: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setMparticleID(_ mparticleID: String?) {
         subscriberAttributesManager.setMparticleID(mparticleID, appUserID: appUserID)
@@ -562,9 +574,10 @@ extension Purchases {
      * Subscriber attribute associated with the OneSignal Player ID for the user.
      * Required for the RevenueCat OneSignal integration.
      *
-     * - SeeAlso:
-     * [mParticle RevenueCat Integration](https://docs.revenuecat.com/docs/onesignal)
-     * - Parameter onesignalID: Empty String or `nil` will delete the subscriber attribute..
+     * #### Related Articles
+     * - [mParticle RevenueCat Integration](https://docs.revenuecat.com/docs/onesignal)
+     *
+     *- Parameter onesignalID: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setOnesignalID(_ onesignalID: String?) {
         subscriberAttributesManager.setOnesignalID(onesignalID, appUserID: appUserID)
@@ -574,8 +587,10 @@ extension Purchases {
      * Subscriber attribute associated with the Airship Channel ID for the user.
      * Required for the RevenueCat Airship integration.
      *
-     * [AirShip RevenueCat Integration](https://docs.revenuecat.com/docs/airship)
-     * - Parameter airshipChannelID: Empty String or `nil` will delete the subscriber attribute..
+     * #### Related Articles
+     * - [AirShip RevenueCat Integration](https://docs.revenuecat.com/docs/airship)
+     *
+     *- Parameter airshipChannelID: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setAirshipChannelID(_ airshipChannelID: String?) {
         subscriberAttributesManager.setAirshipChannelID(airshipChannelID, appUserID: appUserID)
@@ -586,6 +601,7 @@ extension Purchases {
      *
      * #### Related Articles
      * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
+     *
      * - Parameter mediaSource: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setMediaSource(_ mediaSource: String?) {
@@ -597,6 +613,7 @@ extension Purchases {
      *
      * #### Related Articles
      * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
+     *
      * - Parameter campaign: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setCampaign(_ campaign: String?) {
@@ -608,6 +625,7 @@ extension Purchases {
      *
      * #### Related Articles
      * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
+     *
      * - Parameter adGroup: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setAdGroup(_ adGroup: String?) {
@@ -619,6 +637,7 @@ extension Purchases {
      *
      * #### Related Articles
      * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
+     *
      * - Parameter installAd: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setAd(_ installAd: String?) {
@@ -630,6 +649,7 @@ extension Purchases {
      *
      * #### Related Articles
      * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
+     *
      * - Parameter keyword: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setKeyword(_ keyword: String?) {
@@ -641,6 +661,7 @@ extension Purchases {
      *
      * #### Related Articles
      * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
+     *
      * - Parameter creative: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setCreative(_ creative: String?) {

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -475,7 +475,7 @@ extension Purchases {
      *
      * #### Related Articles
      * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
-     * 
+     *
      * - Parameter email: Empty String or `nil` will delete the subscriber attribute..
      */
     @objc public func setEmail(_ email: String?) {
@@ -575,7 +575,7 @@ extension Purchases {
      * Required for the RevenueCat OneSignal integration.
      *
      * #### Related Articles
-     * - [mParticle RevenueCat Integration](https://docs.revenuecat.com/docs/onesignal)
+     * - [OneSignal RevenueCat Integration](https://docs.revenuecat.com/docs/onesignal)
      *
      *- Parameter onesignalID: Empty String or `nil` will delete the subscriber attribute..
      */

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -753,7 +753,8 @@ public extension Purchases {
      * This will generate a random user id and save it in the cache.
      * If this method is called and the current user is anonymous, it will return an error.
      * See [Identifying Users](https://docs.revenuecat.com/docs/user-ids).
-     * - SeeAlso: ``isAnonymous``
+     * #### Related Symbols
+     * - ``isAnonymous``
      */
     @objc func logOut(completion: ((CustomerInfo?, Error?) -> Void)?) {
         identityManager.logOut { error in
@@ -776,7 +777,8 @@ public extension Purchases {
      * This will generate a random user id and save it in the cache.
      * If this method is called and the current user is anonymous, it will return an error.
      * See [Identifying Users](https://docs.revenuecat.com/docs/user-ids).
-     * - SeeAlso: ``isAnonymous``
+     * #### Related Symbols
+     * - ``isAnonymous``
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func logOut() async throws -> CustomerInfo {
@@ -833,7 +835,8 @@ public extension Purchases {
      * Get latest available customer  info.
      * Returns a value immediately if ``CustomerInfo`` is cached.
      *
-     * - SeeAlso: ``Purchases/customerInfoStream``
+     * #### Related Symbols
+     * - ``Purchases/customerInfoStream``
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func customerInfo() async throws -> CustomerInfo {
@@ -842,15 +845,17 @@ public extension Purchases {
 
     /// Returns an `AsyncStream` of ``CustomerInfo`` changes.
     ///
-    /// - SeeAlso: ``PurchasesDelegate/purchases(_:receivedUpdated:)``
-    /// - SeeAlso: ``Purchases/customerInfo()``
-    ///  #### Example:
+    /// #### Related Symbols
+    /// - ``PurchasesDelegate/purchases(_:receivedUpdated:)``
+    /// - ``Purchases/customerInfo()``
+    ///
+    /// #### Example:
     /// ```swift
-    ///     for await customerInfo in Purchases.shared.customerInfoStream {
-    ///       // this gets called whenever new CustomerInfo is available
-    ///       let entitlements = customerInfo.entitlements
-    ///       ...
-    ///     }
+    /// for await customerInfo in Purchases.shared.customerInfoStream {
+    ///   // this gets called whenever new CustomerInfo is available
+    ///   let entitlements = customerInfo.entitlements
+    ///   ...
+    /// }
     /// ```
     /// - note: this method is not thread-safe.
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)


### PR DESCRIPTION
It seems that `SeeAlso` doesn't work with DocC. 

It doesn't actually affect the outcome of the automated `See Also` section, and it doesn't render links either. 

So I replaced them with either `Related Symbols` or `Related Articles` so that at least something is rendered. 

<img width="865" alt="image" src="https://user-images.githubusercontent.com/3922667/152237661-17d57e07-aae4-48e7-a5db-28fbbd45af30.png">
