### PR TITLE
`Purchases.customerInfoStream`: improved docs and start emitting current `CustomerInfo`

### DIFF
--- a/Purchases/Identity/CustomerInfoManager.swift
+++ b/Purchases/Identity/CustomerInfoManager.swift
@@ -169,6 +169,10 @@ class CustomerInfoManager {
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     var customerInfoStream: AsyncStream<CustomerInfo> {
         return AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
+            if let lastSentCustomerInfo = self.lastSentCustomerInfo {
+                continuation.yield(lastSentCustomerInfo)
+            }
+
             let disposable = self.monitorChanges { continuation.yield($0) }
 
             continuation.onTermination = { @Sendable _ in disposable() }

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -849,7 +849,7 @@ public extension Purchases {
         return try await customerInfoAsync()
     }
 
-    /// Returns an `AsyncStream` of ``CustomerInfo`` changes.
+    /// Returns an `AsyncStream` of ``CustomerInfo`` changes, starting from the last known value.
     ///
     /// #### Related Symbols
     /// - ``PurchasesDelegate/purchases(_:receivedUpdated:)``
@@ -863,7 +863,8 @@ public extension Purchases {
     ///   ...
     /// }
     /// ```
-    /// - note: this method is not thread-safe.
+    /// - Note: an alternative way of getting ``CustomerInfo`` updates is using ``PurchasesDelegate``
+    /// - Note: this method is not thread-safe.
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     var customerInfoStream: AsyncStream<CustomerInfo> {
         return self.customerInfoManager.customerInfoStream

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -863,7 +863,8 @@ public extension Purchases {
     ///   ...
     /// }
     /// ```
-    /// - Note: an alternative way of getting ``CustomerInfo`` updates is using ``PurchasesDelegate``
+    /// - Note: an alternative way of getting ``CustomerInfo`` updates
+    /// is using ``PurchasesDelegate/purchases(_:receivedUpdated:)``
     /// - Note: this method is not thread-safe.
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     var customerInfoStream: AsyncStream<CustomerInfo> {


### PR DESCRIPTION
Fixes [sc-13029] and [sc-13030].