### PR TITLE
`PurchasesTests`: using `AvailabilityChecks`

### DIFF
--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -2572,15 +2572,16 @@ class PurchasesTests: XCTestCase {
         expect(receivedError?.code).toEventually(equal(ErrorCode.paymentPendingError.rawValue))
     }
 
-    func testSyncsPurchasesIfEntitlementsRevokedForProductIDs() {
-        if #available(iOS 14.0, macOS 14.0, tvOS 14.0, watchOS 7.0, *) {
-            setupPurchases()
-            guard purchases != nil else { fatalError() }
-            expect(self.backend.postReceiptDataCalled).to(beFalse())
-            (purchasesOrchestrator as StoreKitWrapperDelegate)
-                .storeKitWrapper(storeKitWrapper, didRevokeEntitlementsForProductIdentifiers: ["a", "b"])
-            expect(self.backend.postReceiptDataCalled).to(beTrue())
-        }
+    @available(iOS 14.0, macOS 14.0, tvOS 14.0, watchOS 7.0, *)
+    func testSyncsPurchasesIfEntitlementsRevokedForProductIDs() throws {
+        try AvailabilityChecks.iOS14APIAvailableOrSkipTest()
+
+        setupPurchases()
+        guard purchases != nil else { fatalError() }
+        expect(self.backend.postReceiptDataCalled).to(beFalse())
+        (purchasesOrchestrator as StoreKitWrapperDelegate)
+            .storeKitWrapper(storeKitWrapper, didRevokeEntitlementsForProductIdentifiers: ["a", "b"])
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
     }
 
     @available(*, deprecated) // Ignore deprecation warnings

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		57536A2627851FFE00E2AE7F /* SK1StoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57536A2527851FFE00E2AE7F /* SK1StoreTransaction.swift */; };
 		57536A28278522B400E2AE7F /* SK2StoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57536A27278522B400E2AE7F /* SK2StoreTransaction.swift */; };
 		575A17AB2773A59300AA6F22 /* CurrentTestCaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */; };
+		578FB10E27ADDA8000F70709 /* AvailabilityChecks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE0263275942D500915B4C /* AvailabilityChecks.swift */; };
 		5791A1AA2767E42B00C972AA /* SKProduct+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791A1A92767E42A00C972AA /* SKProduct+Extensions.swift */; };
 		5791A1C82767FC9400C972AA /* ManageSubscriptionsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791A1C72767FC9400C972AA /* ManageSubscriptionsHelperTests.swift */; };
 		5791CE80273F26A000E50C4B /* base64encoded_sandboxReceipt.txt in Resources */ = {isa = PBXBuildFile; fileRef = 5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */; };
@@ -2110,6 +2111,7 @@
 				2DDF41E124F6F527005BC22D /* MockReceiptParser.swift in Sources */,
 				351B514D26D44A8600BD2BD7 /* MockHTTPClient.swift in Sources */,
 				351B516926D44C9500BD2BD7 /* BackendTests.swift in Sources */,
+				578FB10E27ADDA8000F70709 /* AvailabilityChecks.swift in Sources */,
 				35F82BB226A98EC50051DF03 /* AttributionDataMigratorTests.swift in Sources */,
 				351B51BF26D450E800BD2BD7 /* StoreKitRequestFetcherTests.swift in Sources */,
 				2DDF41E224F6F527005BC22D /* MockProductsRequest.swift in Sources */,


### PR DESCRIPTION
Also added `AvailabilityChecks.swift` to `RevenueCatTests` target.