### PR TITLE
`NetworkOperation`s are asynchronous

### DIFF
--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -120,7 +120,7 @@ class Backend {
                                                                                  receiptData: receiptData)
         let postOfferForSigningOperation = PostOfferForSigningOperation(configuration: config,
                                                                         postOfferForSigningData: postOfferData,
-                                                                        completion: completion)
+                                                                        responseHandler: completion)
         self.operationQueue.addOperation(postOfferForSigningOperation)
     }
 
@@ -134,7 +134,7 @@ class Backend {
         let postAttributionDataOperation = PostAttributionDataOperation(configuration: config,
                                                                         attributionData: attributionData,
                                                                         network: network,
-                                                                        completion: completion)
+                                                                        responseHandler: completion)
         self.operationQueue.addOperation(postAttributionDataOperation)
     }
 
@@ -177,7 +177,7 @@ class Backend {
         let getIntroEligibilityOperation = GetIntroEligibilityOperation(configuration: config,
                                                                         receiptData: receiptData,
                                                                         productIdentifiers: productIdentifiers,
-                                                                        completion: completion)
+                                                                        responseHandler: completion)
         self.operationQueue.addOperation(getIntroEligibilityOperation)
     }
 

--- a/Purchases/Networking/Operations/CreateAliasOperation.swift
+++ b/Purchases/Networking/Operations/CreateAliasOperation.swift
@@ -32,21 +32,21 @@ class CreateAliasOperation: CacheableNetworkOperation {
         super.init(configuration: configuration, individualizedCacheKeyPart: configuration.appUserID + newAppUserID)
     }
 
-    override func begin() {
-        createAlias()
+    override func begin(completion: @escaping () -> Void) {
+        createAlias(completion: completion)
     }
 
 }
 
 private extension CreateAliasOperation {
 
-    func createAlias() {
+    func createAlias(completion: @escaping () -> Void) {
         guard let appUserID = try? configuration.appUserID.escapedOrError() else {
             self.aliasCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 callback.completion?(ErrorUtils.missingAppUserIDError())
             }
 
-            self.finish()
+            completion()
             return
         }
         Logger.user(Strings.identity.creating_alias)
@@ -68,7 +68,7 @@ private extension CreateAliasOperation {
                                                        completion: completion)
             }
 
-            self.finish()
+            completion()
         }
     }
 

--- a/Purchases/Networking/Operations/CreateAliasOperation.swift
+++ b/Purchases/Networking/Operations/CreateAliasOperation.swift
@@ -45,6 +45,8 @@ private extension CreateAliasOperation {
             self.aliasCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 callback.completion?(ErrorUtils.missingAppUserIDError())
             }
+
+            self.finish()
             return
         }
         Logger.user(Strings.identity.creating_alias)
@@ -65,6 +67,8 @@ private extension CreateAliasOperation {
                                                        error: error,
                                                        completion: completion)
             }
+
+            self.finish()
         }
     }
 

--- a/Purchases/Networking/Operations/GetCustomerInfoOperation.swift
+++ b/Purchases/Networking/Operations/GetCustomerInfoOperation.swift
@@ -29,20 +29,20 @@ class GetCustomerInfoOperation: CacheableNetworkOperation {
         super.init(configuration: configuration, individualizedCacheKeyPart: configuration.appUserID)
     }
 
-    override func begin() {
-        self.getCustomerInfo()
+    override func begin(completion: @escaping () -> Void) {
+        self.getCustomerInfo(completion: completion)
     }
 
 }
 
 private extension GetCustomerInfoOperation {
 
-    func getCustomerInfo() {
+    func getCustomerInfo(completion: @escaping () -> Void) {
         guard let appUserID = try? configuration.appUserID.escapedOrError() else {
             self.customerInfoCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 callback.completion(nil, ErrorUtils.missingAppUserIDError())
             }
-            self.finish()
+            completion()
 
             return
         }
@@ -59,7 +59,7 @@ private extension GetCustomerInfoOperation {
                                                         completion: callback.completion)
             }
 
-            self.finish()
+            completion()
         }
     }
 

--- a/Purchases/Networking/Operations/GetCustomerInfoOperation.swift
+++ b/Purchases/Networking/Operations/GetCustomerInfoOperation.swift
@@ -42,6 +42,8 @@ private extension GetCustomerInfoOperation {
             self.customerInfoCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 callback.completion(nil, ErrorUtils.missingAppUserIDError())
             }
+            self.finish()
+
             return
         }
 
@@ -56,6 +58,8 @@ private extension GetCustomerInfoOperation {
                                                         error: error,
                                                         completion: callback.completion)
             }
+
+            self.finish()
         }
     }
 

--- a/Purchases/Networking/Operations/GetIntroEligibilityOperation.swift
+++ b/Purchases/Networking/Operations/GetIntroEligibilityOperation.swift
@@ -43,6 +43,8 @@ private extension GetIntroEligibilityOperation {
     func getIntroEligibility() {
         guard self.productIdentifiers.count > 0 else {
             self.completion([:], nil)
+            self.finish()
+
             return
         }
 
@@ -58,6 +60,8 @@ private extension GetIntroEligibilityOperation {
             }
 
             completion(eligibilities, nil)
+            self.finish()
+
             return
         }
 
@@ -72,6 +76,8 @@ private extension GetIntroEligibilityOperation {
 
         guard let appUserID = try? self.configuration.appUserID.escapedOrError() else {
             self.completion(unknownEligibilityClosure(), ErrorUtils.missingAppUserIDError())
+            self.finish()
+
             return
         }
 
@@ -95,6 +101,10 @@ private extension GetIntroEligibilityOperation {
     }
 
     func handleIntroEligibility(response: IntroEligibilityResponse) {
+        defer {
+            self.finish()
+        }
+
         var eligibilitiesByProductIdentifier = response.response
         if response.statusCode >= HTTPStatusCodes.redirect.rawValue || response.error != nil {
             eligibilitiesByProductIdentifier = [:]

--- a/Purchases/Networking/Operations/GetOfferingsOperation.swift
+++ b/Purchases/Networking/Operations/GetOfferingsOperation.swift
@@ -26,20 +26,20 @@ class GetOfferingsOperation: CacheableNetworkOperation {
         super.init(configuration: configuration, individualizedCacheKeyPart: configuration.appUserID)
     }
 
-    override func begin() {
-        self.getOfferings()
+    override func begin(completion: @escaping () -> Void) {
+        self.getOfferings(completion: completion)
     }
 
 }
 
 private extension GetOfferingsOperation {
 
-    func getOfferings() {
+    func getOfferings(completion: @escaping () -> Void) {
         guard let appUserID = try? configuration.appUserID.escapedOrError() else {
             self.offeringsCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 callback.completion(nil, ErrorUtils.missingAppUserIDError())
             }
-            self.finish()
+            completion()
 
             return
         }
@@ -49,7 +49,7 @@ private extension GetOfferingsOperation {
                                      path: path,
                                      headers: authHeaders) { statusCode, response, error in
             defer {
-                self.finish()
+                completion()
             }
 
             if error == nil && statusCode < HTTPStatusCodes.redirect.rawValue {

--- a/Purchases/Networking/Operations/GetOfferingsOperation.swift
+++ b/Purchases/Networking/Operations/GetOfferingsOperation.swift
@@ -39,6 +39,8 @@ private extension GetOfferingsOperation {
             self.offeringsCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 callback.completion(nil, ErrorUtils.missingAppUserIDError())
             }
+            self.finish()
+
             return
         }
 
@@ -46,6 +48,10 @@ private extension GetOfferingsOperation {
         httpClient.performGETRequest(serially: true,
                                      path: path,
                                      headers: authHeaders) { statusCode, response, error in
+            defer {
+                self.finish()
+            }
+
             if error == nil && statusCode < HTTPStatusCodes.redirect.rawValue {
                 self.offeringsCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callbackObject in
                     callbackObject.completion(response, nil)

--- a/Purchases/Networking/Operations/LogInOperation.swift
+++ b/Purchases/Networking/Operations/LogInOperation.swift
@@ -29,20 +29,20 @@ class LogInOperation: CacheableNetworkOperation {
         super.init(configuration: configuration, individualizedCacheKeyPart: configuration.appUserID + newAppUserID)
     }
 
-    override func begin() {
-        self.logIn()
+    override func begin(completion: @escaping () -> Void) {
+        self.logIn(completion: completion)
     }
 
 }
 
 private extension LogInOperation {
 
-    func logIn() {
+    func logIn(completion: @escaping () -> Void) {
         guard let newAppUserID = try? self.newAppUserID.trimmedOrError() else {
             self.loginCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 callback.completion(nil, false, ErrorUtils.missingAppUserIDError())
             }
-            self.finish()
+            completion()
 
             return
         }
@@ -59,7 +59,7 @@ private extension LogInOperation {
                                  completion: callbackObject.completion)
             }
 
-            self.finish()
+            completion()
         }
     }
 

--- a/Purchases/Networking/Operations/LogInOperation.swift
+++ b/Purchases/Networking/Operations/LogInOperation.swift
@@ -42,6 +42,8 @@ private extension LogInOperation {
             self.loginCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 callback.completion(nil, false, ErrorUtils.missingAppUserIDError())
             }
+            self.finish()
+
             return
         }
 
@@ -56,6 +58,8 @@ private extension LogInOperation {
                                  error: error,
                                  completion: callbackObject.completion)
             }
+
+            self.finish()
         }
     }
 

--- a/Purchases/Networking/Operations/NetworkOperation.swift
+++ b/Purchases/Networking/Operations/NetworkOperation.swift
@@ -89,7 +89,9 @@ class NetworkOperation: Operation {
         self.isExecuting = true
 
         Self.log("Started")
-        self.begin()
+        self.begin {
+            self.finish()
+        }
     }
 
     override final func cancel() {
@@ -100,19 +102,19 @@ class NetworkOperation: Operation {
         Self.log("Cancelled")
     }
 
-    /// Called by subclasses to complete this operation
-    final func finish() {
+    /// Overriden by subclasses to define the body of the operation
+    /// - Parameter completion: must be called when the operation has finished.
+    func begin(completion: @escaping () -> Void) {
+        fatalError("Subclasses must override this method")
+    }
+
+    private final func finish() {
         assert(!self.isFinished, "Operation \(type(of: self)) (\(self)) was already finished")
 
         Self.log("Finished")
 
         self.isExecuting = false
         self.isFinished = true
-    }
-
-    /// Overriden by subclasses to define the body of the operation
-    func begin() {
-        fatalError("Subclasses must override this method")
     }
 
     // MARK: -

--- a/Purchases/Networking/Operations/NetworkOperation.swift
+++ b/Purchases/Networking/Operations/NetworkOperation.swift
@@ -37,6 +37,42 @@ class NetworkOperation: Operation {
     let httpClient: HTTPClient
     let authHeaders: [String: String]
 
+    private var _isExecuting: Atomic<Bool> = .init(false)
+    private(set) override final var isExecuting: Bool {
+        get {
+            return self._isExecuting.value
+        }
+        set {
+            self.willChangeValue(for: \.isExecuting)
+            self._isExecuting.value = newValue
+            self.didChangeValue(for: \.isExecuting)
+        }
+    }
+
+    private var _isFinished: Atomic<Bool> = .init(false)
+    private(set) override final var isFinished: Bool {
+        get {
+            return self._isFinished.value
+        }
+        set {
+            self.willChangeValue(for: \.isFinished)
+            self._isFinished.value = newValue
+            self.didChangeValue(for: \.isFinished)
+        }
+    }
+
+    private var _isCancelled: Atomic<Bool> = .init(false)
+    private(set) override final var isCancelled: Bool {
+        get {
+            return self._isCancelled.value
+        }
+        set {
+            self.willChangeValue(for: \.isCancelled)
+            self._isCancelled.value = newValue
+            self.didChangeValue(for: \.isCancelled)
+        }
+    }
+
     init(configuration: NetworkConfiguration) {
         self.httpClient = configuration.httpClient
         self.authHeaders = configuration.authHeaders
@@ -45,16 +81,53 @@ class NetworkOperation: Operation {
     }
 
     override final func main() {
-        if isCancelled == true {
+        if self.isCancelled {
+            self.isFinished = true
             return
         }
 
-        begin()
+        self.isExecuting = true
+
+        Self.log("Started")
+        self.begin()
     }
 
+    override final func cancel() {
+        self.isCancelled = true
+        self.isExecuting = false
+        self.isFinished = true
+
+        Self.log("Cancelled")
+    }
+
+    /// Called by subclasses to complete this operation
+    final func finish() {
+        assert(!self.isFinished, "Operation \(type(of: self)) (\(self)) was already finished")
+
+        Self.log("Finished")
+
+        self.isExecuting = false
+        self.isFinished = true
+    }
+
+    /// Overriden by subclasses to define the body of the operation
     func begin() {
         fatalError("Subclasses must override this method")
     }
+
+    // MARK: -
+
+    final override var isAsynchronous: Bool {
+        return true
+    }
+
+    // MARK: -
+
+    private static func log(_ message: String) {
+        Logger.debug("\(type(of: self)): \(message)")
+    }
+
+    // MARK: -
 
     struct Configuration: NetworkConfiguration {
 

--- a/Purchases/Networking/Operations/PostAttributionDataOperation.swift
+++ b/Purchases/Networking/Operations/PostAttributionDataOperation.swift
@@ -42,6 +42,8 @@ class PostAttributionDataOperation: NetworkOperation {
     private func post() {
         guard let appUserID = try? self.configuration.appUserID.escapedOrError() else {
             self.completion?(ErrorUtils.missingAppUserIDError())
+            self.finish()
+
             return
         }
 
@@ -51,6 +53,10 @@ class PostAttributionDataOperation: NetworkOperation {
                                            path: path,
                                            requestBody: body,
                                            headers: self.authHeaders) { statusCode, response, error in
+            defer {
+                self.finish()
+            }
+
             guard let completion = self.completion else {
                 return
             }

--- a/Purchases/Networking/Operations/PostOfferForSigningOperation.swift
+++ b/Purchases/Networking/Operations/PostOfferForSigningOperation.swift
@@ -42,6 +42,7 @@ class PostOfferForSigningOperation: NetworkOperation {
         self.post()
     }
 
+    // swiftlint:disable:next function_body_length
     private func post() {
         let requestBody: [String: Any] = ["app_user_id": self.configuration.appUserID,
                                           "fetch_token": self.postOfferData.receiptData.asFetchToken,
@@ -56,6 +57,10 @@ class PostOfferForSigningOperation: NetworkOperation {
                                            path: "/offers",
                                            requestBody: requestBody,
                                            headers: authHeaders) { statusCode, response, error in
+            defer {
+                self.finish()
+            }
+
             if let error = error {
                 self.completion(nil, nil, nil, nil, ErrorUtils.networkError(withUnderlyingError: error))
                 return

--- a/Purchases/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Purchases/Networking/Operations/PostReceiptDataOperation.swift
@@ -54,11 +54,11 @@ class PostReceiptDataOperation: CacheableNetworkOperation {
         super.init(configuration: configuration, individualizedCacheKeyPart: cacheKey)
     }
 
-    override func begin() {
-        self.post()
+    override func begin(completion: @escaping () -> Void) {
+        self.post(completion: completion)
     }
 
-    private func post() {
+    private func post(completion: @escaping () -> Void) {
         let fetchToken = self.postData.receiptData.asFetchToken
         var body: [String: Any] = [
             "fetch_token": fetchToken,
@@ -75,7 +75,7 @@ class PostReceiptDataOperation: CacheableNetworkOperation {
                     callback.completion(nil, error)
                 }
 
-                self.finish()
+                completion()
                 return
             }
         }
@@ -101,7 +101,7 @@ class PostReceiptDataOperation: CacheableNetworkOperation {
                                                         completion: callbackObject.completion)
             }
 
-            self.finish()
+            completion()
         }
     }
 

--- a/Purchases/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Purchases/Networking/Operations/PostReceiptDataOperation.swift
@@ -74,6 +74,8 @@ class PostReceiptDataOperation: CacheableNetworkOperation {
                 self.customerInfoCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                     callback.completion(nil, error)
                 }
+
+                self.finish()
                 return
             }
         }
@@ -98,6 +100,8 @@ class PostReceiptDataOperation: CacheableNetworkOperation {
                                                         error: error,
                                                         completion: callbackObject.completion)
             }
+
+            self.finish()
         }
     }
 

--- a/Purchases/Networking/Operations/PostSubscriberAttributesOperation.swift
+++ b/Purchases/Networking/Operations/PostSubscriberAttributesOperation.swift
@@ -43,11 +43,15 @@ class PostSubscriberAttributesOperation: NetworkOperation {
         guard self.subscriberAttributes.count > 0 else {
             Logger.warn(Strings.attribution.empty_subscriber_attributes)
             completion?(ErrorCode.emptySubscriberAttributes)
+            self.finish()
+
             return
         }
 
         guard let appUserID = try? self.configuration.appUserID.escapedOrError() else {
             completion?(ErrorUtils.missingAppUserIDError())
+            self.finish()
+
             return
         }
 
@@ -59,6 +63,10 @@ class PostSubscriberAttributesOperation: NetworkOperation {
                                       path: path,
                                       requestBody: ["attributes": attributesInBackendFormat],
                                       headers: self.authHeaders) { statusCode, response, error in
+            defer {
+                self.finish()
+            }
+
             guard let completion = self.completion else {
                 return
             }

--- a/Purchases/Networking/Operations/PostSubscriberAttributesOperation.swift
+++ b/Purchases/Networking/Operations/PostSubscriberAttributesOperation.swift
@@ -19,7 +19,7 @@ class PostSubscriberAttributesOperation: NetworkOperation {
     private let subscriberAttributeHandler: SubscriberAttributeHandler
     private let configuration: UserSpecificConfiguration
     private let subscriberAttributes: SubscriberAttributeDict
-    private let completion: SimpleResponseHandler?
+    private let responseHandler: SimpleResponseHandler?
 
     init(configuration: UserSpecificConfiguration,
          subscriberAttributes: SubscriberAttributeDict,
@@ -28,29 +28,29 @@ class PostSubscriberAttributesOperation: NetworkOperation {
          subscriberAttributeHandler: SubscriberAttributeHandler = SubscriberAttributeHandler()) {
         self.configuration = configuration
         self.subscriberAttributes = subscriberAttributes
-        self.completion = completion
+        self.responseHandler = completion
         self.subscriberAttributesMarshaller = subscriberAttributesMarshaller
         self.subscriberAttributeHandler = subscriberAttributeHandler
 
         super.init(configuration: configuration)
     }
 
-    override func begin() {
-        post()
+    override func begin(completion: @escaping () -> Void) {
+        post(completion: completion)
     }
 
-    private func post() {
+    private func post(completion: @escaping () -> Void) {
         guard self.subscriberAttributes.count > 0 else {
             Logger.warn(Strings.attribution.empty_subscriber_attributes)
-            completion?(ErrorCode.emptySubscriberAttributes)
-            self.finish()
+            self.responseHandler?(ErrorCode.emptySubscriberAttributes)
+            completion()
 
             return
         }
 
         guard let appUserID = try? self.configuration.appUserID.escapedOrError() else {
-            completion?(ErrorUtils.missingAppUserIDError())
-            self.finish()
+            self.responseHandler?(ErrorUtils.missingAppUserIDError())
+            completion()
 
             return
         }
@@ -64,17 +64,17 @@ class PostSubscriberAttributesOperation: NetworkOperation {
                                       requestBody: ["attributes": attributesInBackendFormat],
                                       headers: self.authHeaders) { statusCode, response, error in
             defer {
-                self.finish()
+                completion()
             }
 
-            guard let completion = self.completion else {
+            guard let responseHandler = self.responseHandler else {
                 return
             }
 
             self.subscriberAttributeHandler.handleSubscriberAttributesResult(statusCode: statusCode,
                                                                              response: response,
                                                                              error: error,
-                                                                             completion: completion)
+                                                                             completion: responseHandler)
         }
     }
 


### PR DESCRIPTION
Fixes https://app.shortcut.com/revenuecat/story/12888/api-calls-are-not-always-executed-in-order

Initial step towards fixing https://app.shortcut.com/revenuecat/story/12802/api-cache-too-aggressive
See also https://app.shortcut.com/revenuecat/story/9521/rewrite-httpclient-for-purchases-ios

### Other changes
- Overridden `isAsynchronous` to tell `OperationQueue` that operations run in the background
- Manually calling KVO methods as required by `Operation`
- Manually completing `NetworkOperation`s when all work is completed
