### PR TITLE
ensure `checkEligibility` doesn't refresh the receipt

### DIFF
--- a/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -64,7 +64,7 @@ class TrialOrIntroPriceEligibilityChecker {
 
     func sk1CheckEligibility(_ productIdentifiers: [String],
                              completion: @escaping ReceiveIntroEligibilityBlock) {
-        receiptFetcher.receiptData(refreshPolicy: .onlyIfEmpty) { data in
+        receiptFetcher.receiptData(refreshPolicy: .never) { data in
             if #available(iOS 12.0, macOS 10.14, tvOS 12.0, watchOS 6.2, *),
                let data = data {
                 self.sk1CheckEligibility(with: data,

--- a/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
+++ b/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
@@ -52,11 +52,15 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
         }
     }
 
-    func testSK1CheckTrialOrIntroPriceEligibilityFetchesAReceipt() throws {
-        trialOrIntroPriceEligibilityChecker!.sk1CheckEligibility([]) { _ in
-        }
+    func testSK1CheckTrialOrIntroPriceEligibilityDoesntFetchAReceipt() throws {
+        self.receiptFetcher.shouldReturnReceipt = false
+
+        expect(self.receiptFetcher.receiptDataCalled) == false
+
+        trialOrIntroPriceEligibilityChecker!.sk1CheckEligibility([]) { _ in }
 
         expect(self.receiptFetcher.receiptDataCalled) == true
+        expect(self.receiptFetcher.receiptDataReceivedRefreshPolicy) == .never
     }
 
     func testSK1EligibilityIsCalculatedFromReceiptData() throws {


### PR DESCRIPTION
`checkTrialOrIntroDiscountEligibility` is meant to be called programmatically, and should therefore **never** trigger a refresh receipt request, since that could make App Store prompt for log in credentials. 
This PR ensures that we never refresh the receipt for that method. 

This is the v4 equivalent of #1264 