### PR TITLE
Add noIntroOfferExists as an IntroEligibilityStatus

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester/RCIntroEligibilityAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCIntroEligibilityAPI.m
@@ -22,6 +22,7 @@
     RCIntroEligibilityStatus s = RCIntroEligibilityStatusUnknown;
     switch(s) {
         case RCIntroEligibilityStatusUnknown:
+        case RCIntroEligibilityStatusNoIntroOfferExists:
         case RCIntroEligibilityStatusIneligible:
         case RCIntroEligibilityStatusEligible:
             NSLog(@"%ld", (long)s);

--- a/APITesters/SwiftAPITester/SwiftAPITester/IntroEligibilityAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/IntroEligibilityAPI.swift
@@ -25,10 +25,10 @@ var status: IntroEligibilityStatus!
 func checkIntroEligibilityEnums() {
     switch status! {
     case .unknown,
+    .noIntroOfferExists,
     .ineligible,
     .eligible:
         print(status!)
-
     @unknown default: fatalError()
     }
 }

--- a/Purchases/Purchasing/IntroEligibility.swift
+++ b/Purchases/Purchasing/IntroEligibility.swift
@@ -38,6 +38,11 @@ import Foundation
      */
     case eligible
 
+    /**
+     There is no free trial or intro pricing for this product.
+     */
+    case noIntroOfferExists
+
 }
 
 extension IntroEligibilityStatus: CaseIterable {}
@@ -90,6 +95,8 @@ private extension IntroEligibilityStatus {
             return "Eligible for trial or introductory price."
         case .ineligible:
             return "Not eligible for trial or introductory price."
+        case .noIntroOfferExists:
+            return "Product does not have trial or introductory price."
 
         case .unknown: fallthrough
         @unknown default:

--- a/Purchases/Purchasing/IntroEligibilityCalculator.swift
+++ b/Purchases/Purchasing/IntroEligibilityCalculator.swift
@@ -30,7 +30,6 @@ class IntroEligibilityCalculator {
     func checkEligibility(with receiptData: Data,
                           productIdentifiers candidateProductIdentifiers: Set<String>,
                           completion: @escaping ([String: IntroEligibilityStatus], Error?) -> Void) {
-
         guard candidateProductIdentifiers.count > 0 else {
             completion([:], nil)
             return

--- a/Purchases/Purchasing/IntroEligibilityCalculator.swift
+++ b/Purchases/Purchasing/IntroEligibilityCalculator.swift
@@ -30,6 +30,7 @@ class IntroEligibilityCalculator {
     func checkEligibility(with receiptData: Data,
                           productIdentifiers candidateProductIdentifiers: Set<String>,
                           completion: @escaping ([String: IntroEligibilityStatus], Error?) -> Void) {
+
         guard candidateProductIdentifiers.count > 0 else {
             completion([:], nil)
             return
@@ -94,10 +95,13 @@ private extension IntroEligibilityCalculator {
                     return foundByGroupId
                 }
 
-            let hasIntroductoryPrice = candidate.introductoryDiscount != nil
-            result[candidate.productIdentifier] = !hasIntroductoryPrice || usedIntroForProductIdentifier
-                ? IntroEligibilityStatus.ineligible
-                : IntroEligibilityStatus.eligible
+            if candidate.introductoryDiscount == nil {
+                result[candidate.productIdentifier] = .noIntroOfferExists
+            } else {
+                result[candidate.productIdentifier] = usedIntroForProductIdentifier
+                    ? IntroEligibilityStatus.ineligible
+                    : IntroEligibilityStatus.eligible
+            }
         }
         return result
     }

--- a/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -148,7 +148,7 @@ fileprivate extension TrialOrIntroPriceEligibilityChecker {
 
                 self.getIntroEligibilityFromBackend(with: receiptData,
                                                     productIdentifiers: nilProductIdentifiers) { backendResults in
-                    let results = onDeviceResults.merging(backendResults)
+                    let results = onDeviceResults + backendResults
                     completion(results)
                 }
             }
@@ -161,7 +161,7 @@ fileprivate extension TrialOrIntroPriceEligibilityChecker {
 
 }
 
-internal extension TrialOrIntroPriceEligibilityChecker {
+extension TrialOrIntroPriceEligibilityChecker {
 
     @available(iOS 11.2, macOS 10.13.2, macCatalyst 13.0, tvOS 11.2, watchOS 6.2, *)
     func productsWithKnownIntroEligibilityStatus(productIdentifiers: [String],

--- a/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -160,7 +160,7 @@ internal extension TrialOrIntroPriceEligibilityChecker {
                                          completion: @escaping ReceiveIntroEligibilityBlock) {
         self.productsManager.products(withIdentifiers: Set(productIdentifiers)) { products in
             let eligibility: [(String, IntroEligibility)] = Array(products.value ?? [])
-                .map({ storeProduct in
+                .map { storeProduct in
                     let status: IntroEligibilityStatus
                     if storeProduct.introductoryDiscount == nil {
                         status = .noIntroOfferExists
@@ -168,7 +168,7 @@ internal extension TrialOrIntroPriceEligibilityChecker {
                         status = .eligible
                     }
                     return (storeProduct.productIdentifier, IntroEligibility(eligibilityStatus: status))
-                })
+                }
 
             let productIdsToIntroEligibleStatus = Dictionary(uniqueKeysWithValues: eligibility)
             completion(productIdsToIntroEligibleStatus)

--- a/PurchasesTests/Purchasing/IntroEligibilityCalculatorTests.swift
+++ b/PurchasesTests/Purchasing/IntroEligibilityCalculatorTests.swift
@@ -121,7 +121,7 @@ class IntroEligibilityCalculatorTests: XCTestCase {
         ]
     }
 
-    func testCheckTrialOrIntroDiscountEligibilityForProductWithoutIntroTrialReturnsIneligible() {
+    func testCheckTrialOrIntroDiscountEligibilityForProductWithoutIntroTrialReturnsNoIntroOfferExists() {
         var receivedError: Error?
         var receivedEligibility: [String: IntroEligibilityStatus]?
         var completionCalled = false
@@ -145,7 +145,7 @@ class IntroEligibilityCalculatorTests: XCTestCase {
         expect(completionCalled).toEventually(beTrue())
         expect(receivedError).to(beNil())
         expect(receivedEligibility) == [
-            "com.revenuecat.product1": IntroEligibilityStatus.ineligible
+            "com.revenuecat.product1": IntroEligibilityStatus.noIntroOfferExists
         ]
     }
 

--- a/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
+++ b/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
@@ -59,7 +59,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
         let expected = ["product_id": IntroEligibilityStatus.unknown,
                         "com.revenuecat.monthly_4.99.1_week_intro": IntroEligibilityStatus.eligible,
                         "com.revenuecat.annual_39.99.2_week_intro": IntroEligibilityStatus.eligible,
-                        "lifetime": IntroEligibilityStatus.unknown]
+                        "lifetime": IntroEligibilityStatus.noIntroOfferExists]
 
         let eligibilities = try await trialOrIntroPriceEligibilityChecker.sk2CheckEligibility(products)
         let receivedEligibilities = try XCTUnwrap(eligibilities)
@@ -81,7 +81,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
         let expected = ["product_id": IntroEligibilityStatus.unknown,
                         "com.revenuecat.monthly_4.99.1_week_intro": IntroEligibilityStatus.eligible,
                         "com.revenuecat.annual_39.99.2_week_intro": IntroEligibilityStatus.eligible,
-                        "lifetime": IntroEligibilityStatus.unknown]
+                        "lifetime": IntroEligibilityStatus.noIntroOfferExists]
 
         var completionCalled = false
         var eligibilities: [String: IntroEligibility]?


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Fixes [sc-10961]
Intro offer eligibility was only using `eligible` or `ineligible`. This meant that `ineligible` was even being used for products that didn't have an intro offer attached to it. This PR adds `noIntroOfferExists` for those cases.

👟 This also stomps a bug where `productsWithIntroOffers` was filtering out products that didn't have an intro offer. This was bug was introduced in v4.

### Description
- Added new `IntroEligibilityStatus. noIntroOfferExists`
- StoreKit 1 (on device)
  - Renamed `productsWithIntroOffers` to `productsWithKnownIntroEligibilityStatus` 
    - Maps products no intro offer to `noIntroOfferExists`
  - Reworked `getIntroEligibility` in [this commit](https://github.com/RevenueCat/purchases-ios/pull/1267/commits/8f24508aad9fedb827075459a44c4f15631860b6) to...
    - Step 1: Filter out products without introductory discount and give .noIntroOfferExists status
    - Step 2: Send products without eligibility status to backend
    - Step 3: Merge results from step 1 and step 2
- StoreKit 2 (on device)
  - Updates `TrialOrIntroPriceEligibilityChecker/sk2CheckEligibility` to return `. noIntroOfferExists` if `sk2Product.subscription` is `nil`