### PR TITLE
Add identifable to models (mainly for SwiftUI)

### DIFF
--- a/Purchases/Purchasing/EntitlementInfo.swift
+++ b/Purchases/Purchasing/EntitlementInfo.swift
@@ -358,3 +358,5 @@ extension EntitlementInfo {
     }
 
 }
+
+extension EntitlementInfo: Identifiable {}

--- a/Purchases/Purchasing/Offering.swift
+++ b/Purchases/Purchasing/Offering.swift
@@ -151,3 +151,5 @@ import Foundation
     }
 
 }
+
+extension Offering: Identifiable {}

--- a/Purchases/Purchasing/Package.swift
+++ b/Purchases/Purchasing/Package.swift
@@ -149,3 +149,5 @@ private extension PackageType {
     }
 
 }
+
+extension Package: Identifiable {}

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -163,4 +163,6 @@ extension StoreProductDiscount: Encodable {
 
 }
 
-extension StoreProductDiscount.PaymentMode: Encodable { }
+extension StoreProductDiscount.PaymentMode: Encodable {}
+
+extension StoreProductDiscount: Identifiable {}

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreTransaction.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreTransaction.swift
@@ -103,3 +103,5 @@ extension StoreTransaction {
     }
 
 }
+
+extension StoreTransaction: Identifiable {}


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Fixes [sc-12884]
SwiftUI (kind of) requires these models conform to `Identifable` to more easily use them with `ForEach` and `List`

### Description
Adds extensions to a bunch of models
