### PR TITLE
Add Purchases.shared.setCleverTapID

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -104,6 +104,8 @@ BOOL isAnonymous;
     [p setMparticleID: @""];
     [p setOnesignalID: nil];
     [p setOnesignalID: @""];
+    [p setCleverTapID: nil];
+    [p setCleverTapID: @""];
     [p setMediaSource: nil];
     [p setMediaSource: @""];
     [p setCampaign: nil];

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -173,6 +173,7 @@ private func checkPurchasesSubscriberAttributesAPI(purchases: Purchases) {
     purchases.setFBAnonymousID("")
     purchases.setMparticleID("")
     purchases.setOnesignalID("")
+    purchases.setCleverTapID("")
     purchases.setMediaSource("")
     purchases.setCampaign("")
     purchases.setAdGroup("")

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -485,7 +485,7 @@ extension Purchases {
      * #### Related Articles
      * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
      *
-     * - Parameter email: Empty String or `nil` will delete the subscriber attribute..
+     * - Parameter email: Empty String or `nil` will delete the subscriber attribute.
      */
     @objc public func setEmail(_ email: String?) {
         subscriberAttributesManager.setEmail(email, appUserID: appUserID)
@@ -497,7 +497,7 @@ extension Purchases {
      * #### Related Articles
      * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
      *
-     * - Parameter phoneNumber: Empty String or `nil` will delete the subscriber attribute..
+     * - Parameter phoneNumber: Empty String or `nil` will delete the subscriber attribute.
      */
     @objc public func setPhoneNumber(_ phoneNumber: String?) {
         subscriberAttributesManager.setPhoneNumber(phoneNumber, appUserID: appUserID)
@@ -509,7 +509,7 @@ extension Purchases {
      * #### Related Articles
      * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
      *
-     * - Parameter displayName: Empty String or `nil` will delete the subscriber attribute..
+     * - Parameter displayName: Empty String or `nil` will delete the subscriber attribute.
      */
     @objc public func setDisplayName(_ displayName: String?) {
         subscriberAttributesManager.setDisplayName(displayName, appUserID: appUserID)
@@ -521,7 +521,7 @@ extension Purchases {
      * #### Related Articles
      * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
      *
-     * - Parameter pushToken: `nil` will delete the subscriber attribute..
+     * - Parameter pushToken: `nil` will delete the subscriber attribute.
      */
     @objc public func setPushToken(_ pushToken: Data?) {
         subscriberAttributesManager.setPushToken(pushToken, appUserID: appUserID)
@@ -534,7 +534,7 @@ extension Purchases {
      * #### Related Articles
      * - [Adjust RevenueCat Integration](https://docs.revenuecat.com/docs/adjust)
      *
-     *- Parameter adjustID: Empty String or `nil` will delete the subscriber attribute..
+     *- Parameter adjustID: Empty String or `nil` will delete the subscriber attribute.
      */
     @objc public func setAdjustID(_ adjustID: String?) {
         subscriberAttributesManager.setAdjustID(adjustID, appUserID: appUserID)
@@ -547,7 +547,7 @@ extension Purchases {
      * #### Related Articles
      * - [AppsFlyer RevenueCat Integration](https://docs.revenuecat.com/docs/appsflyer)
      *
-     *- Parameter appsflyerID: Empty String or `nil` will delete the subscriber attribute..
+     *- Parameter appsflyerID: Empty String or `nil` will delete the subscriber attribute.
      */
     @objc public func setAppsflyerID(_ appsflyerID: String?) {
         subscriberAttributesManager.setAppsflyerID(appsflyerID, appUserID: appUserID)
@@ -560,7 +560,7 @@ extension Purchases {
      * #### Related Articles
      * - [Facebook Ads RevenueCat Integration](https://docs.revenuecat.com/docs/facebook-ads)
      *
-     *- Parameter fbAnonymousID: Empty String or `nil` will delete the subscriber attribute..
+     *- Parameter fbAnonymousID: Empty String or `nil` will delete the subscriber attribute.
      */
     @objc public func setFBAnonymousID(_ fbAnonymousID: String?) {
         subscriberAttributesManager.setFBAnonymousID(fbAnonymousID, appUserID: appUserID)
@@ -573,7 +573,7 @@ extension Purchases {
      * #### Related Articles
      * - [mParticle RevenueCat Integration](https://docs.revenuecat.com/docs/mparticle)
      *
-     *- Parameter mparticleID: Empty String or `nil` will delete the subscriber attribute..
+     *- Parameter mparticleID: Empty String or `nil` will delete the subscriber attribute.
      */
     @objc public func setMparticleID(_ mparticleID: String?) {
         subscriberAttributesManager.setMparticleID(mparticleID, appUserID: appUserID)
@@ -586,7 +586,7 @@ extension Purchases {
      * #### Related Articles
      * - [OneSignal RevenueCat Integration](https://docs.revenuecat.com/docs/onesignal)
      *
-     *- Parameter onesignalID: Empty String or `nil` will delete the subscriber attribute..
+     *- Parameter onesignalID: Empty String or `nil` will delete the subscriber attribute.
      */
     @objc public func setOnesignalID(_ onesignalID: String?) {
         subscriberAttributesManager.setOnesignalID(onesignalID, appUserID: appUserID)
@@ -599,7 +599,7 @@ extension Purchases {
      * #### Related Articles
      * - [AirShip RevenueCat Integration](https://docs.revenuecat.com/docs/airship)
      *
-     *- Parameter airshipChannelID: Empty String or `nil` will delete the subscriber attribute..
+     *- Parameter airshipChannelID: Empty String or `nil` will delete the subscriber attribute.
      */
     @objc public func setAirshipChannelID(_ airshipChannelID: String?) {
         subscriberAttributesManager.setAirshipChannelID(airshipChannelID, appUserID: appUserID)
@@ -612,7 +612,7 @@ extension Purchases {
      * #### Related Articles
      * - [CleverTap RevenueCat Integration](https://docs.revenuecat.com/docs/clevertap)
      *
-     *- Parameter airshipChannelID: Empty String or `nil` will delete the subscriber attribute..
+     *- Parameter airshipChannelID: Empty String or `nil` will delete the subscriber attribute.
      */
     @objc public func setCleverTapID(_ cleveTapID: String?) {
         subscriberAttributesManager.setCleverTapID(cleveTapID, appUserID: appUserID)
@@ -624,7 +624,7 @@ extension Purchases {
      * #### Related Articles
      * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
      *
-     * - Parameter mediaSource: Empty String or `nil` will delete the subscriber attribute..
+     * - Parameter mediaSource: Empty String or `nil` will delete the subscriber attribute.
      */
     @objc public func setMediaSource(_ mediaSource: String?) {
         subscriberAttributesManager.setMediaSource(mediaSource, appUserID: appUserID)
@@ -636,7 +636,7 @@ extension Purchases {
      * #### Related Articles
      * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
      *
-     * - Parameter campaign: Empty String or `nil` will delete the subscriber attribute..
+     * - Parameter campaign: Empty String or `nil` will delete the subscriber attribute.
      */
     @objc public func setCampaign(_ campaign: String?) {
         subscriberAttributesManager.setCampaign(campaign, appUserID: appUserID)
@@ -648,7 +648,7 @@ extension Purchases {
      * #### Related Articles
      * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
      *
-     * - Parameter adGroup: Empty String or `nil` will delete the subscriber attribute..
+     * - Parameter adGroup: Empty String or `nil` will delete the subscriber attribute.
      */
     @objc public func setAdGroup(_ adGroup: String?) {
         subscriberAttributesManager.setAdGroup(adGroup, appUserID: appUserID)
@@ -660,7 +660,7 @@ extension Purchases {
      * #### Related Articles
      * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
      *
-     * - Parameter installAd: Empty String or `nil` will delete the subscriber attribute..
+     * - Parameter installAd: Empty String or `nil` will delete the subscriber attribute.
      */
     @objc public func setAd(_ installAd: String?) {
         subscriberAttributesManager.setAd(installAd, appUserID: appUserID)
@@ -672,7 +672,7 @@ extension Purchases {
      * #### Related Articles
      * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
      *
-     * - Parameter keyword: Empty String or `nil` will delete the subscriber attribute..
+     * - Parameter keyword: Empty String or `nil` will delete the subscriber attribute.
      */
     @objc public func setKeyword(_ keyword: String?) {
         subscriberAttributesManager.setKeyword(keyword, appUserID: appUserID)
@@ -684,7 +684,7 @@ extension Purchases {
      * #### Related Articles
      * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
      *
-     * - Parameter creative: Empty String or `nil` will delete the subscriber attribute..
+     * - Parameter creative: Empty String or `nil` will delete the subscriber attribute.
      */
     @objc public func setCreative(_ creative: String?) {
         subscriberAttributesManager.setCreative(creative, appUserID: appUserID)

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -606,6 +606,19 @@ extension Purchases {
     }
 
     /**
+     * Subscriber attribute associated with the CleverTap ID for the user.
+     * Required for the RevenueCat CleverTap integration.
+     *
+     * #### Related Articles
+     * - [CleverTap RevenueCat Integration](https://docs.revenuecat.com/docs/clevertap)
+     *
+     *- Parameter airshipChannelID: Empty String or `nil` will delete the subscriber attribute..
+     */
+    @objc public func setCleverTapID(_ cleveTapID: String?) {
+        subscriberAttributesManager.setCleverTapID(cleveTapID, appUserID: appUserID)
+    }
+
+    /**
      * Subscriber attribute associated with the install media source for the user.
      *
      * #### Related Articles

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -612,7 +612,7 @@ extension Purchases {
      * #### Related Articles
      * - [CleverTap RevenueCat Integration](https://docs.revenuecat.com/docs/clevertap)
      *
-     *- Parameter airshipChannelID: Empty String or `nil` will delete the subscriber attribute.
+     *- Parameter cleverTapID: Empty String or `nil` will delete the subscriber attribute.
      */
     @objc public func setCleverTapID(_ cleverTapID: String?) {
         subscriberAttributesManager.setCleverTapID(cleverTapID, appUserID: appUserID)

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -614,8 +614,8 @@ extension Purchases {
      *
      *- Parameter airshipChannelID: Empty String or `nil` will delete the subscriber attribute.
      */
-    @objc public func setCleverTapID(_ cleveTapID: String?) {
-        subscriberAttributesManager.setCleverTapID(cleveTapID, appUserID: appUserID)
+    @objc public func setCleverTapID(_ cleverTapID: String?) {
+        subscriberAttributesManager.setCleverTapID(cleverTapID, appUserID: appUserID)
     }
 
     /**

--- a/Purchases/SubscriberAttributes/ReservedSubscriberAttributes.swift
+++ b/Purchases/SubscriberAttributes/ReservedSubscriberAttributes.swift
@@ -36,6 +36,7 @@ enum ReservedSubscriberAttribute: String {
     case mpParticleID = "$mparticleId"
     case oneSignalID = "$onesignalId"
     case airshipChannelID = "$airshipChannelId"
+    case cleverTapID = "$clevertapId"
 
     case mediaSource = "$mediaSource"
     case campaign = "$campaign"

--- a/Purchases/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Purchases/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -83,6 +83,10 @@ class SubscriberAttributesManager {
         setAttributionID(airshipChannelID, forNetworkID: .airshipChannelID, appUserID: appUserID)
     }
 
+    func setCleverTapID(_ cleverTapID: String?, appUserID: String) {
+        setAttributionID(cleverTapID, forNetworkID: .cleverTapID, appUserID: appUserID)
+    }
+
     func setMediaSource(_ mediaSource: String?, appUserID: String) {
         setReservedAttribute(.mediaSource, value: mediaSource, appUserID: appUserID)
     }

--- a/PurchasesTests/Mocks/MockSubscriberAttributesManager.swift
+++ b/PurchasesTests/Mocks/MockSubscriberAttributesManager.swift
@@ -154,6 +154,18 @@ class MockSubscriberAttributesManager: SubscriberAttributesManager {
         invokedSetAirshipChannelIDParametersList.append((airshipChannelID, appUserID))
     }
 
+    var invokedSetCleverTapID = false
+    var invokedSetCleverTapIDCount = 0
+    var invokedSetCleverTapIDParameters: (CleverTapID: String?, appUserID: String?)?
+    var invokedSetCleverTapIDParametersList = [(CleverTapID: String?, appUserID: String?)]()
+
+    override func setCleverTapID(_ cleverTapID: String?, appUserID: String) {
+        invokedSetCleverTapID = true
+        invokedSetCleverTapIDCount += 1
+        invokedSetCleverTapIDParameters = (cleverTapID, appUserID)
+        invokedSetCleverTapIDParametersList.append((cleverTapID, appUserID))
+    }
+
     var invokedSetMediaSource = false
     var invokedSetMediaSourceCount = 0
     var invokedSetMediaSourceParameters: (mediaSource: String?, appUserID: String?)?

--- a/PurchasesTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -918,7 +918,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
         checkDeviceIdentifiersAreSet()
     }
     // endregion
-    // region OnesignalID
+    // region AirshipChannelID
     func testSetAirshipChannelID() throws {
         let airshipChannelID = "airshipChannelID"
 
@@ -984,6 +984,79 @@ class SubscriberAttributesManagerTests: XCTestCase {
     func testSetAirshipChannelIDSetsDeviceIdentifiers() {
         let airshipChannelID = "airshipChannelID"
         self.subscriberAttributesManager.setAirshipChannelID(airshipChannelID, appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 4
+
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 4
+
+        checkDeviceIdentifiersAreSet()
+    }
+    // endregion
+    // region CleverTapID
+    func testSetCleverTapID() throws {
+        let cleverTapID = "cleverTapID"
+
+        self.subscriberAttributesManager.setAirshipChannelID(cleverTapID, appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 4
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$airshipChannelId"
+        expect(receivedAttribute.value) == cleverTapID
+        expect(receivedAttribute.isSynced) == false
+    }
+
+    func testSetCleverTapIDSetsEmptyIfNil() throws {
+        let cleverTapID = "cleverTapID"
+
+        self.subscriberAttributesManager.setAirshipChannelID(cleverTapID, appUserID: "kratos")
+        self.subscriberAttributesManager.setAirshipChannelID(nil, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 8
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$airshipChannelId"
+        expect(receivedAttribute.value) == ""
+        expect(receivedAttribute.isSynced) == false
+    }
+
+    func testSetCleverTapIDSkipsIfSameValue() {
+        let cleverTapID = "cleverTapID"
+
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$airshipChannelId",
+                                                                                    value: cleverTapID)
+        self.subscriberAttributesManager.setAirshipChannelID(cleverTapID, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 3
+    }
+
+    func testSetCleverTapIDOverwritesIfNewValue() throws {
+        let oldSyncTime = Date()
+        let cleverTapID = "cleverTapID"
+
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$airshipChannelId",
+                                                                                    value: "old_id",
+                                                                                    isSynced: true,
+                                                                                    setTime: oldSyncTime)
+
+        self.subscriberAttributesManager.setAirshipChannelID(cleverTapID, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 4
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$airshipChannelId"
+        expect(receivedAttribute.value) == cleverTapID
+        expect(receivedAttribute.isSynced) == false
+        expect(receivedAttribute.setTime) > oldSyncTime
+    }
+
+    func testSetCleverTapIDSetsDeviceIdentifiers() {
+        let cleverTapID = "cleverTapID"
+        self.subscriberAttributesManager.setAirshipChannelID(cleverTapID, appUserID: "kratos")
         expect(self.mockDeviceCache.invokedStoreCount) == 4
 
         expect(self.mockDeviceCache.invokedStoreParametersList.count) == 4

--- a/PurchasesTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -995,13 +995,13 @@ class SubscriberAttributesManagerTests: XCTestCase {
     func testSetCleverTapID() throws {
         let cleverTapID = "cleverTapID"
 
-        self.subscriberAttributesManager.setAirshipChannelID(cleverTapID, appUserID: "kratos")
+        self.subscriberAttributesManager.setCleverTapID(cleverTapID, appUserID: "kratos")
         expect(self.mockDeviceCache.invokedStoreCount) == 4
 
         let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
         let receivedAttribute = invokedParams.attribute
 
-        expect(receivedAttribute.key) == "$airshipChannelId"
+        expect(receivedAttribute.key) == "$clevertapId"
         expect(receivedAttribute.value) == cleverTapID
         expect(receivedAttribute.isSynced) == false
     }
@@ -1009,15 +1009,15 @@ class SubscriberAttributesManagerTests: XCTestCase {
     func testSetCleverTapIDSetsEmptyIfNil() throws {
         let cleverTapID = "cleverTapID"
 
-        self.subscriberAttributesManager.setAirshipChannelID(cleverTapID, appUserID: "kratos")
-        self.subscriberAttributesManager.setAirshipChannelID(nil, appUserID: "kratos")
+        self.subscriberAttributesManager.setCleverTapID(cleverTapID, appUserID: "kratos")
+        self.subscriberAttributesManager.setCleverTapID(nil, appUserID: "kratos")
 
         expect(self.mockDeviceCache.invokedStoreCount) == 8
 
         let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
         let receivedAttribute = invokedParams.attribute
 
-        expect(receivedAttribute.key) == "$airshipChannelId"
+        expect(receivedAttribute.key) == "$clevertapId"
         expect(receivedAttribute.value) == ""
         expect(receivedAttribute.isSynced) == false
     }
@@ -1025,9 +1025,9 @@ class SubscriberAttributesManagerTests: XCTestCase {
     func testSetCleverTapIDSkipsIfSameValue() {
         let cleverTapID = "cleverTapID"
 
-        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$airshipChannelId",
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$clevertapId",
                                                                                     value: cleverTapID)
-        self.subscriberAttributesManager.setAirshipChannelID(cleverTapID, appUserID: "kratos")
+        self.subscriberAttributesManager.setCleverTapID(cleverTapID, appUserID: "kratos")
 
         expect(self.mockDeviceCache.invokedStoreCount) == 3
     }
@@ -1036,19 +1036,19 @@ class SubscriberAttributesManagerTests: XCTestCase {
         let oldSyncTime = Date()
         let cleverTapID = "cleverTapID"
 
-        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$airshipChannelId",
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$clevertapId",
                                                                                     value: "old_id",
                                                                                     isSynced: true,
                                                                                     setTime: oldSyncTime)
 
-        self.subscriberAttributesManager.setAirshipChannelID(cleverTapID, appUserID: "kratos")
+        self.subscriberAttributesManager.setCleverTapID(cleverTapID, appUserID: "kratos")
 
         expect(self.mockDeviceCache.invokedStoreCount) == 4
 
         let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
         let receivedAttribute = invokedParams.attribute
 
-        expect(receivedAttribute.key) == "$airshipChannelId"
+        expect(receivedAttribute.key) == "$clevertapId"
         expect(receivedAttribute.value) == cleverTapID
         expect(receivedAttribute.isSynced) == false
         expect(receivedAttribute.setTime) > oldSyncTime
@@ -1056,7 +1056,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
 
     func testSetCleverTapIDSetsDeviceIdentifiers() {
         let cleverTapID = "cleverTapID"
-        self.subscriberAttributesManager.setAirshipChannelID(cleverTapID, appUserID: "kratos")
+        self.subscriberAttributesManager.setCleverTapID(cleverTapID, appUserID: "kratos")
         expect(self.mockDeviceCache.invokedStoreCount) == 4
 
         expect(self.mockDeviceCache.invokedStoreParametersList.count) == 4


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Fixes [sc-12973]
Noticed when making PurchaseTester for v4 testing tha `setCleverTapID` was missing and was forcing users to manually set `Purchases.shared.setAttributes(["$clevertapId" : clevertapId])`

### Description
Some quick copy/paste/edit from other integrations.
