### PR TITLE
Clean up xcode version stuff on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,3 @@
-release-tags-and-branches: &release-tags-and-branches
-  filters:
-    tags:
-      ignore: /^.*-SNAPSHOT/
-    branches:
-      only: /^release\/.*/
-
-release-branches: &release-branches
-  filters:
-    tags:
-      ignore: /.*/
-    branches:
-      only: /^release\/.*/
-
-release-tags: &release-tags
-  filters: 
-    tags:
-      ignore: /^.*-SNAPSHOT/
-    branches:
-      ignore: /.*/
-
 orbs:
    macos: circleci/macos@2.0.1
 
@@ -135,11 +114,36 @@ commands:
           command: |
               bundle exec fastlane update_carthage_commit
 
-jobs:
-  runtest:
+aliases:
+  base_job: &base_job
     resource_class: macos.x86.medium.gen2
     macos:
-      xcode: "13.2.1"
+      xcode: << parameters.xcode_version >>
+    parameters:
+      xcode_version:
+        type: string
+  release-tags-and-branches: &release-tags-and-branches
+    filters:
+      tags:
+        ignore: /^.*-SNAPSHOT/
+      branches:
+        only: /^release\/.*/
+  release-branches: &release-branches
+    filters:
+      tags:
+        ignore: /.*/
+      branches:
+        only: /^release\/.*/
+  release-tags: &release-tags
+    filters: 
+      tags:
+        ignore: /^.*-SNAPSHOT/
+      branches:
+        ignore: /.*/
+
+jobs:
+  runtest:
+    <<: *base_job
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
     steps:
@@ -156,9 +160,7 @@ jobs:
           path: fastlane/test_output/xctest
           destination: scan-test-output
   buildTvWatchAndMacOS:
-    resource_class: macos.x86.medium.gen2
-    macos:
-      xcode: "13.2.1"
+    <<: *base_job
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
     steps:
@@ -172,9 +174,7 @@ jobs:
           command: bundle exec fastlane build_tv_watch_mac
 
   backend_integration_tests:
-    resource_class: macos.x86.medium.gen2
-    macos:
-      xcode: "13.2.1"
+    <<: *base_job
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
     steps:
@@ -194,9 +194,7 @@ jobs:
 
 
   release-checks: 
-    resource_class: macos.x86.medium.gen2
-    macos:
-      xcode: "13.2.1"
+    <<: *base_job
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
     steps:
@@ -227,9 +225,7 @@ jobs:
           destination: test_report.html
           
   docs-deploy:
-    resource_class: macos.x86.medium.gen2
-    macos:
-      xcode: "13.2.1"
+    <<: *base_job
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
     steps:
@@ -240,9 +236,7 @@ jobs:
           command: bundle exec fastlane deploy_docs
   
   make-release:
-    resource_class: macos.x86.medium.gen2
-    macos:
-      xcode: "13.2.1"
+    <<: *base_job
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -254,9 +248,7 @@ jobs:
           command: bundle exec fastlane release
 
   prepare-next-version:
-    resource_class: macos.x86.medium.gen2
-    macos:
-      xcode: "13.2.1"
+    <<: *base_job
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -268,9 +260,7 @@ jobs:
           command: bundle exec fastlane prepare_next_version
 
   integration-tests-cocoapods:
-    resource_class: macos.x86.medium.gen2
-    macos:
-      xcode: "13.2.1"
+    <<: *base_job
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -290,9 +280,7 @@ jobs:
           directory: IntegrationTests/CocoapodsIntegration
       
   integration-tests-swift-package-manager:
-    resource_class: macos.x86.medium.gen2
-    macos:
-      xcode: "13.2.1"
+    <<: *base_job
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -305,9 +293,7 @@ jobs:
           directory: IntegrationTests/SPMIntegration/
 
   integration-tests-carthage:
-    resource_class: macos.x86.medium.gen2
-    macos:
-      xcode: "13.2.1"
+    <<: *base_job
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -329,9 +315,7 @@ jobs:
           directory: IntegrationTests/CarthageIntegration/
 
   integration-tests-xcode-direct-integration:
-    resource_class: macos.x86.medium.gen2
-    macos:
-      xcode: "13.2.1"
+    <<: *base_job
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -341,9 +325,7 @@ jobs:
           directory: IntegrationTests/XcodeDirectIntegration/
 
   lint:
-    resource_class: macos.x86.medium.gen2
-    macos:
-      xcode: "13.2.1"
+    <<: *base_job
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -365,21 +347,39 @@ workflows:
   version: 2
   build-test:
     jobs:
-      - lint
-      - runtest
-      - buildTvWatchAndMacOS
-      - release-checks: *release-branches
+      - lint:
+          xcode_version: '13.2.1'
+      - runtest:
+          xcode_version: '13.2.1'
+      - buildTvWatchAndMacOS:
+          xcode_version: '13.2.1'
+      - release-checks:
+          xcode_version: '13.2.1'
+          <<: *release-branches
       - backend_integration_tests:
-        filters:
-            branches:
-              # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-              ignore: /pull\/[0-9]+/
-      - integration-tests-cocoapods: *release-tags-and-branches
-      - integration-tests-swift-package-manager: *release-tags-and-branches
-      - integration-tests-carthage: *release-tags-and-branches
-      - integration-tests-xcode-direct-integration: *release-tags-and-branches
+          xcode_version: '13.2.1'
+          filters:
+              branches:
+                # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+                ignore: /pull\/[0-9]+/
+      - integration-tests-cocoapods:
+          xcode_version: '13.2.1'
+          <<: *release-tags-and-branches
+      - integration-tests-swift-package-manager:
+          xcode_version: '13.2.1'
+          <<: *release-tags-and-branches
+      - integration-tests-carthage:
+          xcode_version: '13.2.1'
+          <<: *release-tags-and-branches
+      - integration-tests-xcode-direct-integration:
+          xcode_version: '13.2.1'
+          <<: *release-tags-and-branches
   deploy:
     jobs:
-      - make-release: *release-tags
+      - make-release:
+          xcode_version: '13.2.1'
+          <<: *release-tags
       # - prepare-next-version: *release-tags Disabled for beta releases.
-      - docs-deploy: *release-tags
+      - docs-deploy:
+          xcode_version: '13.2.1'
+          <<: *release-tags


### PR DESCRIPTION
### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
I wanted to make it easier to update Xcode versions in the future. This new format can also be used to run tests on multiple different Xcode versions if we need to.

### Description
1. Moves filters for tags and branches into `aliases` section
2. Added `base_job` to `aliases` section
    - Added `xcode_version` parameter
3. All jobs inherit from `base_job`
