### PR TITLE
`Obsoletions`: added all missing types inside `Purchases.` namespace that were renamed or removed

### DIFF
--- a/Documentation.docc/V4_API_Migration_guide.md
+++ b/Documentation.docc/V4_API_Migration_guide.md
@@ -105,9 +105,9 @@ These types replace native StoreKit types in all public API methods that used th
 | Purchases.ErrorCode.Code | See error handling below |
 | Purchases.Package | ``Package`` |
 | Purchases.PurchaserInfo | <strong>``CustomerInfo``</strong> |
-| Purchases.EntitlementInfos | ``EntitlementInfos`` |
 | Purchases.Transaction | ``StoreTransaction`` |
 | Purchases.EntitlementInfo | ``EntitlementInfo`` |
+| Purchases.EntitlementInfos | ``EntitlementInfos`` |
 | Purchases.PeriodType | ``PeriodType`` |
 | Purchases.Store | ``Store`` |
 | RCPurchaseOwnershipType | ``PurchaseOwnershipType`` |
@@ -119,6 +119,8 @@ These types replace native StoreKit types in all public API methods that used th
 | Purchases.LogLevel | ``LogLevel`` |
 | Purchases.Offerings | ``Offerings`` |
 | Purchases.PackageType | ``PackageType`` |
+| Purchases.Errors | ``ErrorCode`` |
+| Purchases.ErrorCode | ``ErrorCode`` |
 | Package.product | ``Package/storeProduct`` |
 | Package.product.price: NSDecimalNumber | ``StoreProduct/price``: Decimal |
 | Package.localizedIntroductoryPriceString: String | ``Package/localizedIntroductoryPriceString``: String? |

--- a/Purchases/Misc/Obsoletions.swift
+++ b/Purchases/Misc/Obsoletions.swift
@@ -497,3 +497,119 @@ public enum RCPaymentMode {}
 @available(macCatalyst, obsoleted: 1, message: "Use ErrorCode instead")
 // swiftlint:disable:next identifier_name
 public var ErrorDomain: NSErrorDomain { fatalError() }
+
+@available(iOS, obsoleted: 1, message: "Use ErrorCode instead")
+@available(tvOS, obsoleted: 1, message: "Use ErrorCode instead")
+@available(watchOS, obsoleted: 1, message: "Use ErrorCode instead")
+@available(macOS, obsoleted: 1, message: "Use ErrorCode instead")
+@available(macCatalyst, obsoleted: 1, message: "Use ErrorCode instead")
+public enum RCBackendErrorCode {}
+
+@available(iOS, obsoleted: 1)
+@available(tvOS, obsoleted: 1)
+@available(watchOS, obsoleted: 1)
+@available(macOS, obsoleted: 1)
+@available(macCatalyst, obsoleted: 1)
+public class RCPurchasesErrorUtils: NSObject {}
+
+public extension Purchases {
+
+    @available(iOS, obsoleted: 1, renamed: "ErrorCode")
+    @available(tvOS, obsoleted: 1, renamed: "ErrorCode")
+    @available(watchOS, obsoleted: 1, renamed: "ErrorCode")
+    @available(macOS, obsoleted: 1, renamed: "ErrorCode")
+    @available(macCatalyst, obsoleted: 1, renamed: "ErrorCode")
+    enum Errors {}
+
+    @available(iOS, obsoleted: 1)
+    @available(tvOS, obsoleted: 1)
+    @available(watchOS, obsoleted: 1)
+    @available(macOS, obsoleted: 1)
+    @available(macCatalyst, obsoleted: 1)
+    enum FinishableKey {}
+
+    @available(iOS, obsoleted: 1)
+    @available(tvOS, obsoleted: 1)
+    @available(watchOS, obsoleted: 1)
+    @available(macOS, obsoleted: 1)
+    @available(macCatalyst, obsoleted: 1)
+    enum ReadableErrorCodeKey {}
+
+    @available(iOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(tvOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(watchOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(macOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(macCatalyst, obsoleted: 1, message: "Remove `Purchases.`")
+    enum ErrorCode {}
+
+    @available(iOS, obsoleted: 1)
+    @available(tvOS, obsoleted: 1)
+    @available(watchOS, obsoleted: 1)
+    @available(macOS, obsoleted: 1)
+    @available(macCatalyst, obsoleted: 1)
+    enum RevenueCatBackendErrorCode {}
+
+    @available(iOS, obsoleted: 1, renamed: "StoreTransaction")
+    @available(tvOS, obsoleted: 1, renamed: "StoreTransaction")
+    @available(watchOS, obsoleted: 1, renamed: "StoreTransaction")
+    @available(macOS, obsoleted: 1, renamed: "StoreTransaction")
+    @available(macCatalyst, obsoleted: 1, renamed: "StoreTransaction")
+    enum Transaction {}
+
+    @available(iOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(tvOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(watchOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(macOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(macCatalyst, obsoleted: 1, message: "Remove `Purchases.`")
+    enum EntitlementInfo {}
+
+    @available(iOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(tvOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(watchOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(macOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(macCatalyst, obsoleted: 1, message: "Remove `Purchases.`")
+    enum EntitlementInfos {}
+
+    @available(iOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(tvOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(watchOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(macOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(macCatalyst, obsoleted: 1, message: "Remove `Purchases.`")
+    enum PackageType {}
+
+    @available(iOS, obsoleted: 1, renamed: "CustomerInfo")
+    @available(tvOS, obsoleted: 1, renamed: "CustomerInfo")
+    @available(watchOS, obsoleted: 1, renamed: "CustomerInfo")
+    @available(macOS, obsoleted: 1, renamed: "CustomerInfo")
+    @available(macCatalyst, obsoleted: 1, renamed: "CustomerInfo")
+    enum PurchaserInfo {}
+
+    @available(iOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(tvOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(watchOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(macOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(macCatalyst, obsoleted: 1, message: "Remove `Purchases.`")
+    enum Offering {}
+
+    @available(iOS, obsoleted: 1)
+    @available(tvOS, obsoleted: 1)
+    @available(watchOS, obsoleted: 1)
+    @available(macOS, obsoleted: 1)
+    @available(macCatalyst, obsoleted: 1)
+    enum ErrorUtils {}
+
+    @available(iOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(tvOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(watchOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(macOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(macCatalyst, obsoleted: 1, message: "Remove `Purchases.`")
+    enum Store {}
+
+    @available(iOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(tvOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(watchOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(macOS, obsoleted: 1, message: "Remove `Purchases.`")
+    @available(macCatalyst, obsoleted: 1, message: "Remove `Purchases.`")
+    enum PeriodType {}
+
+}


### PR DESCRIPTION
Fixes [sc-13020].
Currently we only had fix-its for Objective-C names, but in Version 3 the Swift names were namespaced with `Purchases`. Therefore, this adds obsoletions to all types inside `Purchases`.

Note that a few are missing that would conflict with the new types when used inside the `Purchases` class. For example, if we added `Offerings` here, all references to `Offerings` inside of Purchases` would find this new obsoleted type instead of the valid type in the global namespace. The way to address that would be to reference these types with the fully-qualified `RevenueCat.Offerings`, but after consulting with the team everyone agreed that it was not worth the pain moving forward, and therefore some of these are only documented in the migration guide. As for the rest, included here, they will improve the migration experience.