### PR TITLE
[CircleCI] Test iOS 12 simulators

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,6 +202,22 @@ jobs:
           path: fastlane/test_output/xctest
           destination: scan-test-output
 
+  run-test-ios-14:
+    <<: *base-job
+    steps:
+      - checkout
+      - install-dependencies
+      - run:
+          name: Run tests
+          command: bundle exec fastlane test_ios
+          environment:
+            SCAN_DEVICE: iPhone 8 (14.5)
+      - store_test_results:
+          path: fastlane/test_output
+      - store_artifacts:
+          path: fastlane/test_output/xctest
+          destination: scan-test-output
+
   run-test-ios-12:
     <<: *base-job
     steps:
@@ -214,7 +230,9 @@ jobs:
           sim-name: iPhone 6 (12.4)
       - run:
           name: Run tests
-          command: bundle exec fastlane test_ios devices:"iPhone 6 (12.4)"
+          command: bundle exec fastlane test_ios
+          environment:
+            SCAN_DEVICE: iPhone 6 (12.4)
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:
@@ -389,6 +407,8 @@ workflows:
       - run-test-ios:
           xcode_version: '13.2.1'
       - run-test-tvos:
+          xcode_version: '13.2.1'
+      - run-test-ios-14:
           xcode_version: '13.2.1'
       - run-test-ios-12:
           xcode_version: '13.2.1'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,36 @@ aliases:
         ignore: /^.*-SNAPSHOT/
       branches:
         ignore: /.*/
+  release-branches-and-main: &release-branches-and-main
+    filters:
+      tags:
+        ignore: /.*/
+      branches:
+        only:
+          - main
+          - /^release\/.*/
 
 commands:
+  install-and-create-sim:
+    parameters:
+      install-name:
+        type: string
+      sim-device-type:
+        type: string
+      sim-device-runtime:
+        type: string
+      sim-name:
+        type: string
+    steps:
+      - run:
+          name: Install xcode-install
+          command: gem install xcode-install
+      - run:
+          name: Install simulator
+          command: xcversion simulators --install="<< parameters.install-name >>"
+      - run:
+          name: Install xcode-install
+          command: xcrun simctl create '<< parameters.sim-name >>' com.apple.CoreSimulator.SimDeviceType.<< parameters.sim-device-type >> com.apple.CoreSimulator.SimRuntime.<< parameters.sim-device-runtime >>
   install-dependencies:
     parameters:
       directory:
@@ -164,15 +192,11 @@ jobs:
     steps:
       - checkout
       - install-dependencies
-      - run:
-          name: Install xcode-install
-          command: gem install xcode-install
-      - run:
-          name: Install simulator
-          command: xcversion simulators --install="iOS 12.4 Simulator"
-      - run:
-          name: Install xcode-install
-          command: xcrun simctl create 'iPhone 6 (12.4) JOSH' com.apple.CoreSimulator.SimDeviceType.iPhone-6 com.apple.CoreSimulator.SimRuntime.iOS-12-4
+      - install-and-create-sim:
+          install-name: iOS 12.4 Simulator
+          sim-device-type: iPhone-6
+          sim-device-runtime: iOS-12-4
+          sim-name: iPhone 6 (12.4)
       - run:
           name: Run tests
           command: bundle exec fastlane test ios_devices:"iPhone 6 (12.4)" skip_tvos:true
@@ -345,11 +369,11 @@ workflows:
   version: 2
   build-test:
     jobs:
-      - runtest_ios_12:
-          xcode_version: '13.2.1'
       - lint:
           xcode_version: '13.2.1'
       - runtest:
+          xcode_version: '13.2.1'
+      - runtest_ios_12:
           xcode_version: '13.2.1'
       - buildTvWatchAndMacOS:
           xcode_version: '13.2.1'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,7 +392,7 @@ workflows:
           xcode_version: '13.2.1'
       - run-test-ios-12:
           xcode_version: '13.2.1'
-          #<<: *release-branches-and-main
+          <<: *release-branches-and-main
       - build-tv-watch-and-macos:
           xcode_version: '13.2.1'
       - release-checks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 version: 2.1
 
 aliases:
-  base_job: &base_job
+  base-job: &base-job
     resource_class: macos.x86.medium.gen2
     macos:
       xcode: << parameters.xcode_version >>
@@ -61,6 +61,7 @@ commands:
       - run:
           name: Install xcode-install
           command: xcrun simctl create '<< parameters.sim-name >>' com.apple.CoreSimulator.SimDeviceType.<< parameters.sim-device-type >> com.apple.CoreSimulator.SimRuntime.<< parameters.sim-device-runtime >>
+
   install-dependencies:
     parameters:
       directory:
@@ -173,8 +174,8 @@ commands:
               bundle exec fastlane update_carthage_commit
 
 jobs:
-  runtest:
-    <<: *base_job
+  run-test:
+    <<: *base-job
     steps:
       - checkout
       - install-dependencies
@@ -187,8 +188,8 @@ jobs:
           path: fastlane/test_output/xctest
           destination: scan-test-output
 
-  runtest_ios_12:
-    <<: *base_job
+  run-test-ios-12:
+    <<: *base-job
     steps:
       - checkout
       - install-dependencies
@@ -206,8 +207,8 @@ jobs:
           path: fastlane/test_output/xctest
           destination: scan-test-output
 
-  buildTvWatchAndMacOS:
-    <<: *base_job
+  build-tv-watch-and-macos:
+    <<: *base-job
     steps:
       - checkout
       - run:
@@ -218,8 +219,8 @@ jobs:
           name: Build tvOS, watchOS and macOS
           command: bundle exec fastlane build_tv_watch_mac
 
-  backend_integration_tests:
-    <<: *base_job
+  backend-integration-tests:
+    <<: *base-job
     steps:
       - checkout
       - install-dependencies
@@ -236,7 +237,7 @@ jobs:
 
 
   release-checks: 
-    <<: *base_job
+    <<: *base-job
     steps:
       - checkout
       - trust-github-key
@@ -262,7 +263,7 @@ jobs:
           destination: test_report.html
           
   docs-deploy:
-    <<: *base_job
+    <<: *base-job
     steps:
       - checkout
       - install-dependencies
@@ -271,7 +272,7 @@ jobs:
           command: bundle exec fastlane deploy_docs
   
   make-release:
-    <<: *base_job
+    <<: *base-job
     steps:
       - checkout
       - trust-github-key
@@ -281,7 +282,7 @@ jobs:
           command: bundle exec fastlane release
 
   prepare-next-version:
-    <<: *base_job
+    <<: *base-job
     steps:
       - checkout
       - install-dependencies
@@ -291,7 +292,7 @@ jobs:
           command: bundle exec fastlane prepare_next_version
 
   integration-tests-cocoapods:
-    <<: *base_job
+    <<: *base-job
     steps:
       - checkout
       - install-dependencies
@@ -306,7 +307,7 @@ jobs:
           directory: IntegrationTests/CocoapodsIntegration
       
   integration-tests-swift-package-manager:
-    <<: *base_job
+    <<: *base-job
     steps:
       - checkout
       - trust-github-key
@@ -317,7 +318,7 @@ jobs:
           directory: IntegrationTests/SPMIntegration/
 
   integration-tests-carthage:
-    <<: *base_job
+    <<: *base-job
     steps:
       - checkout
       - trust-github-key
@@ -337,7 +338,7 @@ jobs:
           directory: IntegrationTests/CarthageIntegration/
 
   integration-tests-xcode-direct-integration:
-    <<: *base_job
+    <<: *base-job
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -347,7 +348,7 @@ jobs:
           directory: IntegrationTests/XcodeDirectIntegration/
 
   lint:
-    <<: *base_job
+    <<: *base-job
     working_directory: ~/purchases-ios/
     shell: /bin/bash --login -o pipefail
     steps:
@@ -371,16 +372,16 @@ workflows:
     jobs:
       - lint:
           xcode_version: '13.2.1'
-      - runtest:
+      - run-test:
           xcode_version: '13.2.1'
-      - runtest_ios_12:
+      - run-test-ios-12:
           xcode_version: '13.2.1'
-      - buildTvWatchAndMacOS:
+      - build-tv-watch-and-macos:
           xcode_version: '13.2.1'
       - release-checks:
           xcode_version: '13.2.1'
           <<: *release-branches
-      - backend_integration_tests:
+      - backend-integration-tests:
           xcode_version: '13.2.1'
           filters:
               branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ commands:
           name: Install simulator
           command: xcversion simulators --install="<< parameters.install-name >>"
       - run:
-          name: Install xcode-install
+          name: Create simulator
           command: xcrun simctl create '<< parameters.sim-name >>' com.apple.CoreSimulator.SimDeviceType.<< parameters.sim-device-type >> com.apple.CoreSimulator.SimRuntime.<< parameters.sim-device-runtime >>
 
   install-dependencies:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,14 +174,28 @@ commands:
               bundle exec fastlane update_carthage_commit
 
 jobs:
-  run-test:
+  run-test-ios:
     <<: *base-job
     steps:
       - checkout
       - install-dependencies
       - run:
           name: Run tests
-          command: bundle exec fastlane test
+          command: bundle exec fastlane test_ios
+      - store_test_results:
+          path: fastlane/test_output
+      - store_artifacts:
+          path: fastlane/test_output/xctest
+          destination: scan-test-output
+
+  run-test-tvos:
+    <<: *base-job
+    steps:
+      - checkout
+      - install-dependencies
+      - run:
+          name: Run tests
+          command: bundle exec fastlane test_tvos
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:
@@ -200,7 +214,7 @@ jobs:
           sim-name: iPhone 6 (12.4)
       - run:
           name: Run tests
-          command: bundle exec fastlane test ios_devices:"iPhone 6 (12.4)" skip_tvos:true
+          command: bundle exec fastlane test devices:"iPhone 6 (12.4)"
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:
@@ -372,7 +386,9 @@ workflows:
     jobs:
       - lint:
           xcode_version: '13.2.1'
-      - run-test:
+      - run-test-ios:
+          xcode_version: '13.2.1'
+      - run-test-tvos:
           xcode_version: '13.2.1'
       - run-test-ios-12:
           xcode_version: '13.2.1'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,29 @@ jobs:
           path: fastlane/test_output/xctest
           destination: scan-test-output
 
+  runtest_ios_12:
+    <<: *base_job
+    steps:
+      - checkout
+      - install-dependencies
+      - run:
+          name: Install xcode-install
+          command: gem install xcode-install
+      - run:
+          name: Install simulator
+          command: xcversion simulators --install="iOS 12.4 Simulator"
+      - run:
+          name: Install xcode-install
+          command: xcrun simctl create 'iPhone 6 (12.4) JOSH' com.apple.CoreSimulator.SimDeviceType.iPhone-6 com.apple.CoreSimulator.SimRuntime.iOS-12-4
+      - run:
+          name: Run tests
+          command: bundle exec fastlane test ios_devices:"iPhone 6 (12.4)" skip_tvos:true
+      - store_test_results:
+          path: fastlane/test_output
+      - store_artifacts:
+          path: fastlane/test_output/xctest
+          destination: scan-test-output
+
   buildTvWatchAndMacOS:
     <<: *base_job
     steps:
@@ -322,6 +345,8 @@ workflows:
   version: 2
   build-test:
     jobs:
+      - runtest_ios_12:
+          xcode_version: '13.2.1'
       - lint:
           xcode_version: '13.2.1'
       - runtest:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,7 @@ jobs:
           sim-name: iPhone 6 (12.4)
       - run:
           name: Run tests
-          command: bundle exec fastlane test devices:"iPhone 6 (12.4)"
+          command: bundle exec fastlane test_ios devices:"iPhone 6 (12.4)"
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:
@@ -392,6 +392,7 @@ workflows:
           xcode_version: '13.2.1'
       - run-test-ios-12:
           xcode_version: '13.2.1'
+          #<<: *release-branches-and-main
       - build-tv-watch-and-macos:
           xcode_version: '13.2.1'
       - release-checks:

--- a/Purchases/Purchasing/EntitlementInfo.swift
+++ b/Purchases/Purchasing/EntitlementInfo.swift
@@ -359,5 +359,4 @@ extension EntitlementInfo {
 
 }
 
-//@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension EntitlementInfo: Identifiable {}

--- a/Purchases/Purchasing/EntitlementInfo.swift
+++ b/Purchases/Purchasing/EntitlementInfo.swift
@@ -359,4 +359,5 @@ extension EntitlementInfo {
 
 }
 
+//@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension EntitlementInfo: Identifiable {}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -40,6 +40,7 @@ platform :ios do
 
   desc "Runs all the tests"
   lane :test do |options|
+    # Used by CircleCI when wanting to test other devices
     ios_devices = options[:ios_devices]&.split(',')
     tvos_devices = options[:tvos_devices]&.split(',')
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -40,12 +40,9 @@ platform :ios do
 
   desc "Runs all the iOS tests"
   lane :test_ios do |options|
-    devices = options[:devices]&.split(',')
-    devices ||= ["iPhone 8 (14.5)", "iPhone 12 (15.2)"]
-
     scan(
       step_name: "scan - iPhone", 
-      devices: devices,
+      device: ENV['SCAN_DEVICE'] || "iPhone 12 (15.2)",
       scheme: "RevenueCat",
       testplan: "Coverage",
       prelaunch_simulator: true,
@@ -57,12 +54,9 @@ platform :ios do
 
   desc "Runs all the tvOS tests"
   lane :test_tvos do |options|
-    devices = options[:devices]&.split(',')
-    devices ||= ["Apple TV (15.2)"]
-
     scan(
       step_name: "scan - Apple TV",
-      devices: devices,
+      device: ENV['SCAN_DEVICE'] || "Apple TV (15.2)",
       scheme: "RevenueCat",
       testplan: "RevenueCat",
       prelaunch_simulator: true,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -40,29 +40,35 @@ platform :ios do
 
   desc "Runs all the tests"
   lane :test do |options|
+    ios_devices = options[:ios_devices]&.split(',')
+    tvos_devices = options[:tvos_devices]&.split(',')
+
+    ios_devices ||= ["iPhone 8 (14.5)", "iPhone 12 (15.2)"]
+    tvos_devices ||= ["Apple TV (15.2)"]
+    
     # Scan can't target two different platforms in devices
     # Need to run scan multiple times
     scan(
       step_name: "scan - iPhone", 
-      devices: ["iPhone 8 (14.5)", "iPhone 12 (15.2)"],
+      devices: ios_devices,
       scheme: "RevenueCat",
       testplan: "Coverage",
       prelaunch_simulator: true,
       output_types: 'junit',
       number_of_retries: 5,
       output_directory: "fastlane/test_output/xctest/ios"
-    )
+    ) unless options[:skip_ios]
 
     scan(
       step_name: "scan - Apple TV",
-      devices: ["Apple TV (15.2)"],
+      devices: tvos_devices,
       scheme: "RevenueCat",
       testplan: "RevenueCat",
       prelaunch_simulator: true,
       output_types: 'junit',
       number_of_retries: 5,
       output_directory: "fastlane/test_output/xctest/tvos"
-    )
+    ) unless options[:skip_tvos]
   end
 
   desc "Replace version number in project and supporting files"
@@ -531,7 +537,7 @@ def carthage_archive
   end
 end
 
-def check_pods
+lane :check_pods do
   pod_lib_lint(verbose: true, podspec:'RevenueCat.podspec')
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -38,38 +38,38 @@ platform :ios do
     end
   end
 
-  desc "Runs all the tests"
-  lane :test do |options|
-    # Used by CircleCI when wanting to test other devices
-    ios_devices = options[:ios_devices]&.split(',')
-    tvos_devices = options[:tvos_devices]&.split(',')
+  desc "Runs all the iOS tests"
+  lane :test_ios do |options|
+    devices = options[:devices]&.split(',')
+    devices ||= ["iPhone 8 (14.5)", "iPhone 12 (15.2)"]
 
-    ios_devices ||= ["iPhone 8 (14.5)", "iPhone 12 (15.2)"]
-    tvos_devices ||= ["Apple TV (15.2)"]
-    
-    # Scan can't target two different platforms in devices
-    # Need to run scan multiple times
     scan(
       step_name: "scan - iPhone", 
-      devices: ios_devices,
+      devices: devices,
       scheme: "RevenueCat",
       testplan: "Coverage",
       prelaunch_simulator: true,
       output_types: 'junit',
       number_of_retries: 5,
       output_directory: "fastlane/test_output/xctest/ios"
-    ) unless options[:skip_ios]
+    )
+  end
+
+  desc "Runs all the tvOS tests"
+  lane :test_tvos do |options|
+    devices = options[:devices]&.split(',')
+    devices ||= ["Apple TV (15.2)"]
 
     scan(
       step_name: "scan - Apple TV",
-      devices: tvos_devices,
+      devices: devices,
       scheme: "RevenueCat",
       testplan: "RevenueCat",
       prelaunch_simulator: true,
       output_types: 'junit',
       number_of_retries: 5,
       output_directory: "fastlane/test_output/xctest/tvos"
-    ) unless options[:skip_tvos]
+    )
   end
 
   desc "Replace version number in project and supporting files"

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -13,6 +13,17 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 # Available Actions
 
+### check_pods
+
+```sh
+[bundle exec] fastlane check_pods
+```
+
+
+
+----
+
+
 ## iOS
 
 ### ios setup_dev
@@ -54,14 +65,6 @@ Increment build number and update changelog
 ```
 
 Make github release
-
-### ios create_sandbox_account
-
-```sh
-[bundle exec] fastlane ios create_sandbox_account
-```
-
-Create sandbox account
 
 ### ios release_checks
 


### PR DESCRIPTION
⚠️  Depends on #1273

### Motivation
iOS 12 simulators don't run on M1 machines so next easiest way to test is installing iOS 12 simulators on CircleCI

### Description
- New `install-and-create-sim` command
  - Installs new iOS simulator verion with `xcode-install`
  - Creates new simulator with `xcrun`
- New `run-test-ios-12` job
  - Passes iOS 12 simulator name into _fastlane_ to `scan` uses newly created sim
- Fixed naming on jobs so all uses consistent stylings
- Split `:test` lane into `:test_ios` and `:test_tvos` and new `run-test-ios-14` job
  - `:test` was taking almost 11 minutes which felt really long
    - `:test_tvos` now takes 3 minutes
    - `:test_ios` with iOS 14 and iOS 14 now each takes 4 minutes
    - We were actually using same or more time combining them... Not saving time 🤷‍♂️ 

👇 Link to `run-test-ios-12` since it won't appear in this PR due to rules
https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/5324/workflows/507ddf8c-92f1-48fc-af83-729cca585dde/jobs/17205

#### With `:test`
![Screen Shot 2022-02-08 at 8 44 21 PM](https://user-images.githubusercontent.com/401294/153115216-775b189a-6b87-4df9-832f-9e4cf26e2792.png)

#### With `:test_ios` and `:test_tvos`
![Screen Shot 2022-02-08 at 9 04 15 PM](https://user-images.githubusercontent.com/401294/153115234-0f660344-bdd4-430a-99df-3c3b7b305e61.png)
