### PR TITLE
Add type to StoreProductDiscount

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductDiscountAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductDiscountAPI.m
@@ -38,4 +38,14 @@
     }
 }
 
++ (void)checkTypeEnum {
+    RCDiscountType paymentMode = RCDiscountTypeIntroductory;
+
+    switch (paymentMode) {
+        case RCDiscountTypeIntroductory:
+        case RCDiscountTypePromotional:
+            break;
+    }
+}
+
 @end

--- a/APITesters/SwiftAPITester/SwiftAPITester/StoreProductDiscountAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/StoreProductDiscountAPI.swift
@@ -36,3 +36,16 @@ func checkPaymentModeEnum() {
     @unknown default: fatalError()
     }
 }
+
+var type: StoreProductDiscount.DiscountType!
+
+func checkTypeEnum() {
+    switch type! {
+    case
+            .introductory,
+            .promotional:
+        break
+
+    @unknown default: fatalError()
+    }
+}

--- a/Purchases/Logging/Strings/AttributionStrings.swift
+++ b/Purchases/Logging/Strings/AttributionStrings.swift
@@ -38,6 +38,7 @@ enum AttributionStrings {
     case unsynced_attributes(unsyncedAttributes: SubscriberAttributeDict)
     case attribute_set_locally(attribute: String)
     case missing_advertiser_identifiers
+    case unknown_sk2_product_discount_type(rawValue: String)
 
 }
 
@@ -113,6 +114,9 @@ extension AttributionStrings: CustomStringConvertible {
 
         case .missing_advertiser_identifiers:
             return "Attribution error: identifierForAdvertisers is missing"
+
+        case .unknown_sk2_product_discount_type(let rawValue):
+            return "Failed to create StoreProductDiscount.DiscountType with unknown value: \(rawValue)"
 
         }
     }

--- a/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
@@ -32,7 +32,7 @@ internal struct SK1StoreProductDiscount: StoreProductDiscountType {
         self.paymentMode = paymentMode
         self.subscriptionPeriod = subscriptionPeriod
 
-        if #available(iOSApplicationExtension 12.2, *) {
+        if #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *) {
             switch sk1Discount.type {
             case .introductory:
                 self.type = .introductory

--- a/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
@@ -31,6 +31,19 @@ internal struct SK1StoreProductDiscount: StoreProductDiscountType {
         self.price = sk1Discount.price as Decimal
         self.paymentMode = paymentMode
         self.subscriptionPeriod = subscriptionPeriod
+
+        if #available(iOSApplicationExtension 12.2, *) {
+            switch sk1Discount.type {
+            case .introductory:
+                self.type = .introductory
+            case .subscription:
+                self.type = .promotional
+            @unknown default:
+                return nil
+            }
+        } else {
+            return nil
+        }
     }
 
     let underlyingSK1Discount: SK1ProductDiscount
@@ -39,6 +52,7 @@ internal struct SK1StoreProductDiscount: StoreProductDiscountType {
     let price: Decimal
     let paymentMode: StoreProductDiscount.PaymentMode
     let subscriptionPeriod: SubscriptionPeriod
+    let type: StoreProductDiscount.DiscountType
 
 }
 

--- a/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
@@ -18,7 +18,8 @@ internal struct SK1StoreProductDiscount: StoreProductDiscountType {
 
     init?(sk1Discount: SK1ProductDiscount) {
         guard let paymentMode = StoreProductDiscount.PaymentMode(skProductDiscountPaymentMode: sk1Discount.paymentMode),
-              let subscriptionPeriod = SubscriptionPeriod.from(sk1SubscriptionPeriod: sk1Discount.subscriptionPeriod)
+              let subscriptionPeriod = SubscriptionPeriod.from(sk1SubscriptionPeriod: sk1Discount.subscriptionPeriod),
+              let type = StoreProductDiscount.DiscountType.from(sk1Discount: sk1Discount)
         else { return nil }
 
         self.underlyingSK1Discount = sk1Discount
@@ -31,19 +32,7 @@ internal struct SK1StoreProductDiscount: StoreProductDiscountType {
         self.price = sk1Discount.price as Decimal
         self.paymentMode = paymentMode
         self.subscriptionPeriod = subscriptionPeriod
-
-        if #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *) {
-            switch sk1Discount.type {
-            case .introductory:
-                self.type = .introductory
-            case .subscription:
-                self.type = .promotional
-            @unknown default:
-                return nil
-            }
-        } else {
-            return nil
-        }
+        self.type = type
     }
 
     let underlyingSK1Discount: SK1ProductDiscount

--- a/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
@@ -32,7 +32,7 @@ internal struct SK1StoreProductDiscount: StoreProductDiscountType {
         self.paymentMode = paymentMode
         self.subscriptionPeriod = subscriptionPeriod
 
-        if #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *) {
+        if #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *) {
             switch sk1Discount.type {
             case .introductory:
                 self.type = .introductory

--- a/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProductDiscount.swift
@@ -27,6 +27,15 @@ internal struct SK2StoreProductDiscount: StoreProductDiscountType {
         self.price = sk2Discount.price
         self.paymentMode = paymentMode
         self.subscriptionPeriod = subscriptionPeriod
+
+        switch sk2Discount.type {
+        case SK2ProductDiscount.OfferType.introductory:
+            self.type = .introductory
+        case SK2ProductDiscount.OfferType.promotional:
+            self.type = .promotional
+        default:
+            return nil
+        }
     }
 
     let underlyingSK2Discount: SK2ProductDiscount
@@ -35,6 +44,7 @@ internal struct SK2StoreProductDiscount: StoreProductDiscountType {
     let price: Decimal
     let paymentMode: StoreProductDiscount.PaymentMode
     let subscriptionPeriod: SubscriptionPeriod
+    let type: StoreProductDiscount.DiscountType
 
 }
 

--- a/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProductDiscount.swift
@@ -18,7 +18,8 @@ internal struct SK2StoreProductDiscount: StoreProductDiscountType {
 
     init?(sk2Discount: SK2ProductDiscount) {
         guard let paymentMode = StoreProductDiscount.PaymentMode(subscriptionOfferPaymentMode: sk2Discount.paymentMode),
-              let subscriptionPeriod = SubscriptionPeriod.from(sk2SubscriptionPeriod: sk2Discount.period)
+              let subscriptionPeriod = SubscriptionPeriod.from(sk2SubscriptionPeriod: sk2Discount.period),
+              let type = StoreProductDiscount.DiscountType.from(sk2Discount: sk2Discount)
         else { return nil }
 
         self.underlyingSK2Discount = sk2Discount
@@ -27,15 +28,7 @@ internal struct SK2StoreProductDiscount: StoreProductDiscountType {
         self.price = sk2Discount.price
         self.paymentMode = paymentMode
         self.subscriptionPeriod = subscriptionPeriod
-
-        switch sk2Discount.type {
-        case SK2ProductDiscount.OfferType.introductory:
-            self.type = .introductory
-        case SK2ProductDiscount.OfferType.promotional:
-            self.type = .promotional
-        default:
-            return nil
-        }
+        self.type = type
     }
 
     let underlyingSK2Discount: SK2ProductDiscount

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -205,6 +205,7 @@ extension StoreProductDiscount.DiscountType {
         case SK2ProductDiscount.OfferType.promotional:
             return .promotional
         default:
+            Logger.warn(Strings.attribution.unknown_sk2_product_discount_type(rawValue: sk2Discount.type.rawValue))
             return nil
         }
     }

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -177,6 +177,36 @@ extension StoreProductDiscount: Encodable {
 
 }
 
+extension StoreProductDiscount.DiscountType {
+    @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
+    static func from(sk1Discount: SK1ProductDiscount) -> Self? {
+        if #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, *) {
+            switch sk1Discount.type {
+            case .introductory:
+                return .introductory
+            case .subscription:
+                return .promotional
+            @unknown default:
+                return nil
+            }
+        } else {
+            return nil
+        }
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    static func from(sk2Discount: SK2ProductDiscount) -> Self? {
+        switch sk2Discount.type {
+        case SK2ProductDiscount.OfferType.introductory:
+            return .introductory
+        case SK2ProductDiscount.OfferType.promotional:
+            return .promotional
+        default:
+            return nil
+        }
+    }
+}
+
 extension StoreProductDiscount.PaymentMode: Encodable {}
 
 extension StoreProductDiscount: Identifiable {}

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -43,7 +43,10 @@ public final class StoreProductDiscount: NSObject, StoreProductDiscountType {
 
     }
 
-    /// The discount type for a `StoreProductDiscount`g
+    /// The discount type for a `StoreProductDiscount`
+    /// Wraps `SKProductDiscount.Type` if this `StoreProductDiscount` represents a `SKProductDiscount`.
+    /// Wraps  `Product.SubscriptionOffer.OfferType` if this `StoreProductDiscount` represents
+    /// a `Product.SubscriptionOffer`.
     @objc(RCDiscountType)
     public enum DiscountType: Int {
 

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -43,8 +43,7 @@ public final class StoreProductDiscount: NSObject, StoreProductDiscountType {
 
     }
 
-    /// The discount type for a `StoreProductDiscount`
-    /// Indicates how the type of discount.
+    /// The discount type for a `StoreProductDiscount`g
     @objc(RCDiscountType)
     public enum DiscountType: Int {
 

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -43,6 +43,36 @@ public final class StoreProductDiscount: NSObject, StoreProductDiscountType {
 
     }
 
+    /// The discount type for a `StoreProductDiscount`
+    /// Indicates how the type of discount.
+    @objc(RCDiscountType)
+    public enum DiscountType: Int {
+
+        /// Intro
+        case introductory = 0
+        /// Sub
+        case promotional = 1
+    }
+
+//    enum Type {
+//
+//        @available(iOSApplicationExtension 15.0, *)
+//        func storeProduct() {
+//            let sk1ProductDiscount: SK1ProductDiscount! = nil
+//
+//            switch sk1ProductDiscount.type {
+//            case .introductory: ()
+//            case .subscription: ()
+//            @unknown default: ()
+//            }
+//
+//            let sk2ProductDiscount: SK2ProductDiscount! = nil
+//            if sk2ProductDiscount.type == SK2ProductDiscount.OfferType.introductory {
+//
+//            }
+//        }
+//    }
+
     private let discount: StoreProductDiscountType
 
     init(_ discount: StoreProductDiscountType) {
@@ -58,6 +88,7 @@ public final class StoreProductDiscount: NSObject, StoreProductDiscountType {
     @objc public var price: Decimal { self.discount.price }
     @objc public var paymentMode: PaymentMode { self.discount.paymentMode }
     @objc public var subscriptionPeriod: SubscriptionPeriod { self.discount.subscriptionPeriod }
+    @objc public var type: DiscountType { self.discount.type }
 
     // swiftlint:enable missing_docs
 
@@ -103,6 +134,9 @@ internal protocol StoreProductDiscountType {
 
     /// The period for the product discount.
     var subscriptionPeriod: SubscriptionPeriod { get }
+
+    /// The type of product discount.
+    var type: StoreProductDiscount.DiscountType { get }
 
 }
 

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -48,30 +48,11 @@ public final class StoreProductDiscount: NSObject, StoreProductDiscountType {
     @objc(RCDiscountType)
     public enum DiscountType: Int {
 
-        /// Intro
+        /// Introductory offer
         case introductory = 0
-        /// Sub
+        /// Promotional offer for subscriptions
         case promotional = 1
     }
-
-//    enum Type {
-//
-//        @available(iOSApplicationExtension 15.0, *)
-//        func storeProduct() {
-//            let sk1ProductDiscount: SK1ProductDiscount! = nil
-//
-//            switch sk1ProductDiscount.type {
-//            case .introductory: ()
-//            case .subscription: ()
-//            @unknown default: ()
-//            }
-//
-//            let sk2ProductDiscount: SK2ProductDiscount! = nil
-//            if sk2ProductDiscount.type == SK2ProductDiscount.OfferType.introductory {
-//
-//            }
-//        }
-//    }
 
     private let discount: StoreProductDiscountType
 

--- a/PurchasesTests/Mocks/MockStoreProductDiscount.swift
+++ b/PurchasesTests/Mocks/MockStoreProductDiscount.swift
@@ -18,4 +18,5 @@ struct MockStoreProductDiscount: StoreProductDiscountType {
     let price: Decimal
     let paymentMode: StoreProductDiscount.PaymentMode
     let subscriptionPeriod: SubscriptionPeriod
+    let type: StoreProductDiscount.DiscountType
 }

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -1234,7 +1234,8 @@ class BackendTests: XCTestCase {
         let discount = MockStoreProductDiscount(offerIdentifier: "offerid",
                                                 price: 12,
                                                 paymentMode: .payAsYouGo,
-                                                subscriptionPeriod: .init(value: 10, unit: .month))
+                                                subscriptionPeriod: .init(value: 10, unit: .month),
+                                                type: .promotional)
         let productData: ProductRequestData = .createMockProductData(discounts: [discount])
         backend.post(receiptData: receiptData,
                      appUserID: userID,
@@ -1265,7 +1266,8 @@ class BackendTests: XCTestCase {
         let discount = MockStoreProductDiscount(offerIdentifier: "offerid",
                                                 price: 12.1,
                                                 paymentMode: .payAsYouGo,
-                                                subscriptionPeriod: .init(value: 1, unit: .year))
+                                                subscriptionPeriod: .init(value: 1, unit: .year),
+                                                type: .promotional)
         let productData: ProductRequestData = .createMockProductData(productIdentifier: productIdentifier,
                                                                      paymentMode: paymentMode,
                                                                      currencyCode: currencyCode,

--- a/PurchasesTests/Purchasing/ProductRequestDataTests.swift
+++ b/PurchasesTests/Purchasing/ProductRequestDataTests.swift
@@ -93,17 +93,20 @@ class ProductRequestDataTests: XCTestCase {
         let discount1 = MockStoreProductDiscount(offerIdentifier: "offerid1",
                                                  price: 11.1,
                                                  paymentMode: .payAsYouGo,
-                                                 subscriptionPeriod: .init(value: 1, unit: .month))
+                                                 subscriptionPeriod: .init(value: 1, unit: .month),
+                                                 type: .promotional)
 
         let discount2 = MockStoreProductDiscount(offerIdentifier: "offerid2",
                                                  price: 12.2,
                                                  paymentMode: .payUpFront,
-                                                 subscriptionPeriod: .init(value: 5, unit: .week))
+                                                 subscriptionPeriod: .init(value: 5, unit: .week),
+                                                 type: .promotional)
 
         let discount3 = MockStoreProductDiscount(offerIdentifier: "offerid3",
                                                  price: 13.3,
                                                  paymentMode: .freeTrial,
-                                                 subscriptionPeriod: .init(value: 3, unit: .month))
+                                                 subscriptionPeriod: .init(value: 3, unit: .month),
+                                                 type: .promotional)
 
         let productData: ProductRequestData = .createMockProductData(discounts: [discount1, discount2, discount3])
 
@@ -127,17 +130,20 @@ class ProductRequestDataTests: XCTestCase {
         let discount1 = MockStoreProductDiscount(offerIdentifier: "offerid1",
                                                  price: 11.2,
                                                  paymentMode: .payAsYouGo,
-                                                 subscriptionPeriod: .init(value: 1, unit: .month))
+                                                 subscriptionPeriod: .init(value: 1, unit: .month),
+                                                 type: .promotional)
 
         let discount2 = MockStoreProductDiscount(offerIdentifier: "offerid2",
                                                  price: 12.2,
                                                  paymentMode: .payUpFront,
-                                                 subscriptionPeriod: .init(value: 2, unit: .year))
+                                                 subscriptionPeriod: .init(value: 2, unit: .year),
+                                                 type: .promotional)
 
         let discount3 = MockStoreProductDiscount(offerIdentifier: "offerid3",
                                                  price: 13.3,
                                                  paymentMode: .freeTrial,
-                                                 subscriptionPeriod: .init(value: 3, unit: .day))
+                                                 subscriptionPeriod: .init(value: 3, unit: .day),
+                                                 type: .promotional)
 
         let productData: ProductRequestData = .createMockProductData(productIdentifier: "cool_product",
                                                                      paymentMode: .payUpFront,
@@ -159,17 +165,20 @@ class ProductRequestDataTests: XCTestCase {
         let discount1 = MockStoreProductDiscount(offerIdentifier: "offerid1",
                                                  price: 11,
                                                  paymentMode: .payAsYouGo,
-                                                 subscriptionPeriod: .init(value: 1, unit: .month))
+                                                 subscriptionPeriod: .init(value: 1, unit: .month),
+                                                 type: .promotional)
 
         let discount2 = MockStoreProductDiscount(offerIdentifier: "offerid2",
                                                  price: 12,
                                                  paymentMode: .payUpFront,
-                                                 subscriptionPeriod: .init(value: 2, unit: .year))
+                                                 subscriptionPeriod: .init(value: 2, unit: .year),
+                                                 type: .promotional)
 
         let discount3 = MockStoreProductDiscount(offerIdentifier: "offerid3",
                                                  price: 13,
                                                  paymentMode: .freeTrial,
-                                                 subscriptionPeriod: .init(value: 3, unit: .day))
+                                                 subscriptionPeriod: .init(value: 3, unit: .day),
+                                                 type: .promotional)
 
         let productData: ProductRequestData = .createMockProductData(productIdentifier: "cool_product",
                                                                      paymentMode: .payUpFront,

--- a/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -141,7 +141,8 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         let storeProductDiscount = MockStoreProductDiscount(offerIdentifier: "offerid1",
                                                             price: 11.1,
                                                             paymentMode: .payAsYouGo,
-                                                            subscriptionPeriod: .init(value: 1, unit: .month))
+                                                            subscriptionPeriod: .init(value: 1, unit: .month),
+                                                            type: .promotional)
 
         _ = await withCheckedContinuation { continuation in
             orchestrator.promotionalOffer(forProductDiscount: storeProductDiscount,
@@ -169,7 +170,8 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         let storeProductDiscount = MockStoreProductDiscount(offerIdentifier: "offerid1",
                                                             price: 11.1,
                                                             paymentMode: .payAsYouGo,
-                                                            subscriptionPeriod: .init(value: 1, unit: .month))
+                                                            subscriptionPeriod: .init(value: 1, unit: .month),
+                                                            type: .promotional)
 
         _ = await withCheckedContinuation { continuation in
             orchestrator.purchase(sk1Product: product,
@@ -261,7 +263,8 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         let storeProductDiscount = MockStoreProductDiscount(offerIdentifier: "offerid1",
                                                             price: 11.1,
                                                             paymentMode: .payAsYouGo,
-                                                            subscriptionPeriod: .init(value: 1, unit: .month))
+                                                            subscriptionPeriod: .init(value: 1, unit: .month),
+                                                            type: .promotional)
 
         do {
             _ = try await orchestrator.purchase(sk2Product: product, discount: storeProductDiscount)
@@ -333,7 +336,8 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         let storeProductDiscount = MockStoreProductDiscount(offerIdentifier: "offerid1",
                                                             price: 11.1,
                                                             paymentMode: .payAsYouGo,
-                                                            subscriptionPeriod: .init(value: 1, unit: .month))
+                                                            subscriptionPeriod: .init(value: 1, unit: .month),
+                                                            type: .promotional)
 
         _ = try await orchestrator.promotionalOffer(forProductDiscount: storeProductDiscount,
                                                     product: StoreProduct(sk2Product: product))

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -158,6 +158,7 @@ class StoreProductTests: StoreKitConfigTestCase {
 
         expect(intro.price) == 0.0
         expect(intro.paymentMode) == .freeTrial
+        expect(intro.type) == .introductory
         expect(intro.offerIdentifier).to(beNil())
         expect(intro.subscriptionPeriod) == SubscriptionPeriod(value: 3, unit: .month)
 
@@ -166,11 +167,13 @@ class StoreProductTests: StoreKitConfigTestCase {
 
         expect(offers[0].price) == 40.99
         expect(offers[0].paymentMode) == .payUpFront
+        expect(offers[0].type) == .promotional
         expect(offers[0].offerIdentifier) == "com.revenuecat.monthly_4.99.1_week_intro.year_discount"
         expect(offers[0].subscriptionPeriod) == SubscriptionPeriod(value: 1, unit: .year)
 
         expect(offers[1].price) == 20.15
         expect(offers[1].paymentMode) == .payAsYouGo
+        expect(offers[0].type) == .promotional
         expect(offers[1].offerIdentifier) == "com.revenuecat.monthly_4.99.1_week_intro.pay_as_you_go"
 
         expect(offers[1].subscriptionPeriod) == SubscriptionPeriod(value: 1, unit: .month)


### PR DESCRIPTION
### Motivation
Fixes [sc-13183]
Address #1277

`StoreProductDiscount` was missing a reference discount type to underlying StoreKit1 and StoreKit2 discount types

### Description
- Added `type: DiscountType` to `StoreProductDiscount`
  - `introductory`
  - `promotional`
