### PR TITLE
Throw error if multiple active entitlements for beginRefundRequestForActiveEntitlement

### DIFF
--- a/Purchases/Logging/Strings/PurchaseStrings.swift
+++ b/Purchases/Logging/Strings/PurchaseStrings.swift
@@ -55,6 +55,7 @@ enum PurchaseStrings {
     case begin_refund_for_entitlement_nil_customer_info(entitlementID: String?)
     case begin_refund_no_entitlement_found(entitlementID: String?)
     case begin_refund_no_active_entitlement
+    case begin_refund_multiple_active_entitlements
     case begin_refund_customer_info_error(entitlementID: String?)
     case cached_app_user_id_deleted
     case check_eligibility_no_identifiers
@@ -196,6 +197,8 @@ extension PurchaseStrings: CustomStringConvertible {
                 " for refund."
         case .begin_refund_no_active_entitlement:
             return "Could not begin refund request. No active entitlement."
+        case .begin_refund_multiple_active_entitlements:
+            return "Could not begin refund request. Multiple active entitlements."
         case .begin_refund_customer_info_error(let entitlementID):
             return "Failed to get CustomerInfo to proceed with refund for " +
                 "\(entitlementID.flatMap { "entitlement with ID " + $0 } ?? "active entitlement")."

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -1401,7 +1401,8 @@ public extension Purchases {
      * - returns ``RefundRequestStatus``: The status of the refund request.
      * Keep in mind the status could be ``RefundRequestStatus/userCancelled``
      *
-     * If the request was unsuccessful or no active entitlements could be found for the user, an `Error` will be thrown.
+     * If the request was unsuccessful, no active entitlements could be found for the user,
+     * or multiple active entitlements were found for the user, an `Error` will be thrown.
      */
     @available(iOS 15.0, *)
     @available(macOS, unavailable)

--- a/Purchases/Support/BeginRefundRequestHelper.swift
+++ b/Purchases/Support/BeginRefundRequestHelper.swift
@@ -121,6 +121,13 @@ private extension BeginRefundRequestHelper {
                     return
                 }
 
+                guard customerInfo.entitlements.active.count < 2 else {
+                    let message = Strings.purchase.begin_refund_multiple_active_entitlements.description
+                    continuation.resume(throwing: ErrorUtils.beginRefundRequestError(withMessage: message))
+                    Logger.error(message)
+                    return
+                }
+
                 guard let activeEntitlement = customerInfo.entitlements.active.first?.value else {
                     let message = Strings.purchase.begin_refund_no_active_entitlement.description
                     continuation.resume(throwing: ErrorUtils.beginRefundRequestError(withMessage: message))


### PR DESCRIPTION
### Motivation
Fixes [sc-13015]

### Description
- Throws an new error if multiple active entitlements
