### PR TITLE
updated migration guide link for clarity

### DIFF
--- a/Documentation.docc/RevenueCat.md
+++ b/Documentation.docc/RevenueCat.md
@@ -33,15 +33,20 @@ Sign up to [get started for free](https://app.revenuecat.com/signup).
 - Important: You're viewing the documentation for RevenueCat iOS SDK version 4.
 For documentation on version 3, visit [the docs for RevenueCat iOS SDK version 3.](https://sdk.revenuecat.com/ios/index.html)
 
+## Migrating from Purchases v3
+When transitioning between our V3 SDK, we ported our entire SDK into Swift. 
+Migrating from Objective-C to Swift required a number of API changes, but we feel that the
+changes resulted in the SDK having a more natural feel for developers. In addition,
+we introduced several new types and APIs.
+
+Our <doc:V4_API_Migration_guide> provides information on how to migrate from V3 to V4. 
+
 ## Getting Started
 For more detailed information, you can view our complete documentation at [docs.revenuecat.com](https://docs.revenuecat.com/docs).
 
 Or browse our iOS sample apps:
 - [MagicWeather](Examples/MagicWeather)
 - [MagicWeather SwiftUI](Examples/MagicWeatherSwiftUI)
-
-## Migrating from Purchases v3
-- <doc:V4_API_Migration_guide>
 
 ## Topics
 


### PR DESCRIPTION
[sc-13006]

Updated the Migration Guide section in the main SDK Docs to make it clearer that the migration guide is a separate page, and the topics underneath are unrelated. I also moved it a little bit to make it even clearer. 

| Before | After |
| :-: | :-: |
| <img width="804" alt="Screen Shot 2022-02-10 at 1 02 33 PM" src="https://user-images.githubusercontent.com/3922667/153447059-b7c0aa3a-6064-4531-9019-fc0629aac88b.png"> | <img width="818" alt="Screen Shot 2022-02-10 at 1 05 26 PM" src="https://user-images.githubusercontent.com/3922667/153447228-0239444b-589e-41b8-b45a-8a0b3084a320.png"> |

The difference in background color in the screenshots is just because one was taken through Xcode's developer documentation and the other one from the actual docs website, but it's unrelated. 