### PR TITLE
Fix sk2 checkEligibility to return unknown status when error occurs

### DIFF
--- a/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -54,7 +54,11 @@ class TrialOrIntroPriceEligibilityChecker {
                     completion(try await sk2CheckEligibility(productIdentifiers))
                 } catch {
                     Logger.appleError(Strings.purchase.unable_to_get_intro_eligibility_for_user(error: error))
-                    completion([:])
+
+                    let introDict = productIdentifiers.reduce(into: [:]) { resultDict, productId in
+                        resultDict[productId] = IntroEligibility(eligibilityStatus: IntroEligibilityStatus.unknown)
+                    }
+                    completion(introDict)
                 }
             }
         } else {

--- a/PurchasesTests/Mocks/MockProductsManager.swift
+++ b/PurchasesTests/Mocks/MockProductsManager.swift
@@ -62,6 +62,26 @@ class MockProductsManager: ProductsManager {
         invokedCacheProductParameter = product
     }
 
+    var invokedSk2StoreProducts = false
+    var invokedSk2StoreProductsCount = 0
+    var invokedSk2StoreProductsParameter: Set<String>?
+
+    var stubbedSk2StoreProductsThrowsError = false
+    struct MockSk2StoreProductsError: Error {}
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    override func sk2StoreProducts(withIdentifiers identifiers: Set<String>) async throws -> Set<SK2StoreProduct> {
+        invokedSk2StoreProducts = true
+        invokedSk2StoreProductsCount += 1
+        invokedSk2StoreProductsParameter = identifiers
+
+        if stubbedSk2StoreProductsThrowsError {
+            throw MockSk2StoreProductsError()
+        } else {
+            return try await super.sk2StoreProducts(withIdentifiers: identifiers)
+        }
+    }
+
     func resetMock() {
         invokedProducts = false
         invokedProductsCount = 0


### PR DESCRIPTION
### Motivation
Fixes [sc-13232]
`checkEligibility` was returning an empty dictionary if an error occured when using StoreKit2. StoreKit1 returns a dictionary with all product identifiers but with the `.unknown` status

### Description
- Replaced empty dictionary with dictionary of all product identifiers (as keys) with `.unknown` status
- Updated tests to include a way to mock an error being thrown for sk2 checking
