### PR TITLE
[Circle-CI] Explicit iOS 15 job name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ commands:
               bundle exec fastlane update_carthage_commit
 
 jobs:
-  run-test-ios:
+  run-test-ios-15:
     <<: *base-job
     steps:
       - checkout
@@ -182,6 +182,8 @@ jobs:
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios
+          environment:
+            SCAN_DEVICE: iPhone 12 (15.2)
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:
@@ -404,7 +406,7 @@ workflows:
     jobs:
       - lint:
           xcode_version: '13.2.1'
-      - run-test-ios:
+      - run-test-ios-15:
           xcode_version: '13.2.1'
       - run-test-tvos:
           xcode_version: '13.2.1'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -44,7 +44,7 @@ platform :ios do
       step_name: "scan - iPhone", 
       device: ENV['SCAN_DEVICE'] || "iPhone 12 (15.2)",
       scheme: "RevenueCat",
-      testplan: "Coverage",
+      testplan: "AllTests",
       prelaunch_simulator: true,
       output_types: 'junit',
       number_of_retries: 5,


### PR DESCRIPTION
## Changes:
- Renamed job to `run-test-ios-15` to be explicit and match format from `run-test-ios-14` and `run-test-ios-12`.
- Explicit `SCAN_DEVICE` on `run-test-ios-15` instead of relying on default in Fastlane lane
- Changed Test Plan to `AllTests`, which runs `RevenueCat` tests in parallel (we can run coverage separately once we parse that).