### PR TITLE
`GetCustomerInfoOperation`: improve logic for caching responses

### DIFF
--- a/Purchases/Networking/Caching/CallbackCache.swift
+++ b/Purchases/Networking/Caching/CallbackCache.swift
@@ -23,8 +23,8 @@ import Foundation
  */
 class CallbackCache<T> where T: CacheKeyProviding {
 
-    private var cachedCallbacksByKey: [String: [T]] = [:]
-    private let callbackQueue: DispatchQueue
+    private(set) var cachedCallbacksByKey: [String: [T]] = [:]
+    let callbackQueue: DispatchQueue
 
     init(callbackQueue: DispatchQueue) {
         self.callbackQueue = callbackQueue

--- a/Purchases/Networking/Caching/CustomerInfoCallback.swift
+++ b/Purchases/Networking/Caching/CustomerInfoCallback.swift
@@ -15,7 +15,16 @@ import Foundation
 
 struct CustomerInfoCallback: CacheKeyProviding {
 
+    typealias Completion = (CustomerInfo?, Error?) -> Void
+
     let cacheKey: String
-    let completion: (CustomerInfo?, Error?) -> Void
+    let source: NetworkOperation.Type
+    let completion: Completion
+
+    init(operation: CacheableNetworkOperation, completion: @escaping Completion) {
+        self.cacheKey = operation.cacheKey
+        self.source = type(of: operation)
+        self.completion = completion
+    }
 
 }

--- a/Purchases/Networking/Operations/GetCustomerInfoOperation.swift
+++ b/Purchases/Networking/Operations/GetCustomerInfoOperation.swift
@@ -26,7 +26,18 @@ class GetCustomerInfoOperation: CacheableNetworkOperation {
         self.customerInfoResponseHandler = customerInfoResponseHandler
         self.customerInfoCallbackCache = customerInfoCallbackCache
 
-        super.init(configuration: configuration, individualizedCacheKeyPart: configuration.appUserID)
+        var individualizedCacheKeyPart = configuration.appUserID
+
+        // If there is any enqueued `PostReceiptDataOperation` we don't want this new
+        // `GetCustomerInfoOperation` to share the same cache key.
+        // If it did, future `GetCustomerInfoOperation` would receive a cached value
+        // instead of an up-to-date `CustomerInfo` after those post receipt operations finish.
+        if customerInfoCallbackCache.hasPostReceiptOperations {
+            individualizedCacheKeyPart += "-\(customerInfoCallbackCache.numberOfGetCustomerInfoOperations)"
+        }
+
+        super.init(configuration: configuration,
+                   individualizedCacheKeyPart: individualizedCacheKeyPart)
     }
 
     override func begin(completion: @escaping () -> Void) {
@@ -60,6 +71,29 @@ private extension GetCustomerInfoOperation {
             }
 
             completion()
+        }
+    }
+
+}
+
+private extension CallbackCache where T == CustomerInfoCallback {
+
+    var numberOfGetCustomerInfoOperations: Int {
+        return self.callbacks(ofType: GetCustomerInfoOperation.self)
+    }
+
+    var hasPostReceiptOperations: Bool {
+        return self.callbacks(ofType: PostReceiptDataOperation.self) > 0
+    }
+
+    private func callbacks(ofType type: NetworkOperation.Type) -> Int {
+        return self.callbackQueue.sync {
+            self
+                .cachedCallbacksByKey
+                .lazy
+                .flatMap(\.value)
+                .filter { $0.source == type }
+                .count
         }
     }
 

--- a/Purchases/Networking/SubscribersAPI.swift
+++ b/Purchases/Networking/SubscribersAPI.swift
@@ -54,7 +54,7 @@ class SubscribersAPI {
         let operation = GetCustomerInfoOperation(configuration: config,
                                                  customerInfoCallbackCache: self.customerInfoCallbackCache)
 
-        let callback = CustomerInfoCallback(cacheKey: operation.cacheKey, completion: completion)
+        let callback = CustomerInfoCallback(operation: operation, completion: completion)
         let cacheStatus = self.customerInfoCallbackCache.add(callback: callback)
         operationQueue.addCacheableOperation(operation, cacheStatus: cacheStatus)
     }
@@ -93,7 +93,8 @@ class SubscribersAPI {
                                                             postData: postData,
                                                             customerInfoCallbackCache: self.customerInfoCallbackCache)
 
-        let callbackObject = CustomerInfoCallback(cacheKey: postReceiptOperation.cacheKey, completion: completion)
+        let callbackObject = CustomerInfoCallback(operation: postReceiptOperation, completion: completion)
+
         let cacheStatus = customerInfoCallbackCache.add(callback: callbackObject)
 
         operationQueue.addCacheableOperation(postReceiptOperation, cacheStatus: cacheStatus)

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -1919,7 +1919,7 @@ class BackendTests: XCTestCase {
         expect(firstCustomerInfo).toEventuallyNot(beNil())
 
         expect(secondCustomerInfo) == firstCustomerInfo
-        expect(self.httpClient.calls.count) == 1
+        expect(self.httpClient.calls.map { $0.path }) == ["/subscribers/\(self.userID)"]
     }
 
     func testGetsUpdatedSubscriberInfoAfterPost() {
@@ -2000,6 +2000,12 @@ class BackendTests: XCTestCase {
         expect(updatedSubscriberInfo).toNot(beNil())
         expect(updatedSubscriberInfo).to(equal(postSubscriberInfo))
         expect(updatedSubscriberInfo).toNot(equal(originalSubscriberInfo))
+
+        expect(self.httpClient.calls.map { $0.path }) == [
+            "/subscribers/\(self.userID)",
+            "/receipts",
+            "/subscribers/\(self.userID)"
+        ]
     }
 
 }

--- a/PurchasesTests/Networking/__Snapshots__/BackendTests/testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/PurchasesTests/Networking/__Snapshots__/BackendTests/testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -1,0 +1,6 @@
+{
+  "app_user_id" : "user",
+  "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+  "is_restore" : false,
+  "observer_mode" : true
+}


### PR DESCRIPTION
Fixes [sc-12802].

## Background

Before this change, the sequence illustrated by the new test `testGetsUpdatedSubscriberInfoAfterPost` (started in #1249, with a few modifications here) would fail:
- GET /subscribers/
- POST /receipts
- GET /subscribers/

#1261 fixed the race condition in the test, making it so that operations are actually run serially.
However, when the first GET request finished, the second one shared the cache key, so it received the (soon to be) outdated `CustomerInfo`.

## The fix

Unfortunately this fix is isolated for this specific issue, and not a generalized one. A more comprehensive rewrite of `HTTPClient` is needed ([sc-9521]).
I came up with several other alternatives, but what I ended up going with here involves the least amount of moving pieces.

If a `GetCustomerInfoOperation` request is enqueued with `PostReceiptDataOperation` in the queue, then a new unique cache key is created to avoid past `GetCustomerInfoOperation` to share outdated data.

If we simply added a random number to the `GetCustomerInfoOperation` cache key, the new test would have also passed. No other test verified the caching behavior, which is what the new `testGetSubscriberInfoDoesNotMakeTwoRequests` checks.