### PR TITLE
Introduced `PromotionalOffer` to simplify purchasing with `StoreProductDiscount`

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -79,6 +79,7 @@ BOOL isAnonymous;
     RCCustomerInfo *pi = nil;
     RCStoreProduct *storeProduct = nil;
     RCStoreProductDiscount *stpd = nil;
+    RCPromotionalOffer *pro = nil;
     
     RCPackage *pack;
 
@@ -129,12 +130,12 @@ BOOL isAnonymous;
     [p syncPurchasesWithCompletion:^(RCCustomerInfo *i, NSError *e) {}];
     
     [p checkTrialOrIntroDiscountEligibility:@[@""] completion:^(NSDictionary<NSString *,RCIntroEligibility *> *d) { }];
-    [p checkPromotionalDiscountEligibilityForProductDiscount:stpd
-                                                 withProduct:storeProduct
-                                              withCompletion:^(RCPromotionalOfferEligibility status, NSError *error) { }];
+    [p getPromotionalOfferForProductDiscount:stpd
+                                 withProduct:storeProduct
+                              withCompletion:^(RCPromotionalOffer *offer, NSError *error) { }];
     
-    [p purchaseProduct:storeProduct withDiscount:stpd completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];
-    [p purchasePackage:pack withDiscount:stpd completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];
+    [p purchaseProduct:storeProduct withPromotionalOffer:pro completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];
+    [p purchasePackage:pack withPromotionalOffer:pro completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];
     
     [p logIn:@"" completion:^(RCCustomerInfo *i, BOOL created, NSError *e) { }];
     [p logOutWithCompletion:^(RCCustomerInfo *i, NSError *e) { }];

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -120,23 +120,22 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     let storeProduct: StoreProduct! = nil
     let discount: StoreProductDiscount! = nil
     let pack: Package! = nil
+    let offer: PromotionalOffer! = nil
 
     purchases.purchase(product: storeProduct) { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
     purchases.purchase(package: pack) { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
     purchases.syncPurchases { (_: CustomerInfo?, _: Error?) in }
 
     purchases.checkTrialOrIntroDiscountEligibility([String]()) { (_: [String: IntroEligibility]) in }
-    purchases.checkPromotionalDiscountEligibility(
+    purchases.getPromotionalOffer(
         forProductDiscount: discount,
         product: storeProduct
-    ) { (_: PromotionalOfferEligibility, _: Error?) in
-
-    }
+    ) { (_: PromotionalOffer?, _: Error?) in }
 
     purchases.purchase(product: storeProduct,
-                       discount: discount) { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
+                       promotionalOffer: offer) { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
     purchases.purchase(package: pack,
-                       discount: discount) { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
+                       promotionalOffer: offer) { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
     purchases.invalidateCustomerInfoCache()
 
 #if os(iOS)
@@ -187,11 +186,12 @@ private func checkAsyncMethods(purchases: Purchases) async {
     let pack: Package! = nil
     let stp: StoreProduct! = nil
     let discount: StoreProductDiscount! = nil
+    let offer: PromotionalOffer! = nil
 
     do {
         let _: (CustomerInfo, Bool) = try await purchases.logIn("")
         let _: [String: IntroEligibility] = await purchases.checkTrialOrIntroDiscountEligibility([])
-        let _: PromotionalOfferEligibility = try await purchases.checkPromotionalDiscountEligibility(
+        let _: PromotionalOffer = try await purchases.getPromotionalOffer(
             forProductDiscount: discount,
             product: stp
         )
@@ -199,13 +199,12 @@ private func checkAsyncMethods(purchases: Purchases) async {
         let _: Offerings = try await purchases.offerings()
 
         let _: [StoreProduct] = await purchases.products([])
-        let discount: StoreProductDiscount! = nil
         let _: (StoreTransaction?, CustomerInfo, Bool) = try await purchases.purchase(package: pack)
         let _: (StoreTransaction?, CustomerInfo, Bool) = try await purchases.purchase(package: pack,
-                                                                                      discount: discount)
+                                                                                      promotionalOffer: offer)
         let _: (StoreTransaction?, CustomerInfo, Bool) = try await purchases.purchase(product: stp)
         let _: (StoreTransaction?, CustomerInfo, Bool) = try await purchases.purchase(product: stp,
-                                                                                      discount: discount)
+                                                                                      promotionalOffer: offer)
         let _: CustomerInfo = try await purchases.customerInfo()
         let _: CustomerInfo = try await purchases.restorePurchases()
         let _: CustomerInfo = try await purchases.syncPurchases()
@@ -218,7 +217,7 @@ private func checkAsyncMethods(purchases: Purchases) async {
         let _: RefundRequestStatus = try await purchases.beginRefundRequest(forEntitlement: "")
         let _: RefundRequestStatus = try await purchases.beginRefundRequestForActiveEntitlement()
 
-        let _: [StoreProductDiscount] = await purchases.getEligibleDiscounts(forProduct: stp)
+        let _: [PromotionalOffer] = await purchases.getEligiblePromotionalOffers(forProduct: stp)
         #endif
     } catch {}
 }

--- a/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
@@ -53,5 +53,5 @@ func checkStoreProductAPI() {
 }
 
 func checkStoreProductAsyncAPI() async {
-    let _: [StoreProductDiscount] = await product.getEligibleDiscounts()
+    let _: [PromotionalOffer] = await product.getEligiblePromotionalOffers()
 }

--- a/Documentation.docc/Purchases.md
+++ b/Documentation.docc/Purchases.md
@@ -44,12 +44,12 @@ Most features require configuring the SDK before using it.
 ### Making Purchases with Subscription Offers
 - ``Purchases/checkTrialOrIntroDiscountEligibility(_:)``
 - ``Purchases/checkTrialOrIntroDiscountEligibility(_:completion:)``
-- ``Purchases/checkPromotionalDiscountEligibility(forProductDiscount:product:)``
-- ``Purchases/checkPromotionalDiscountEligibility(forProductDiscount:product:completion:)``
-- ``Purchases/purchase(package:discount:)``
-- ``Purchases/purchase(package:discount:completion:)``
-- ``Purchases/purchase(product:discount:)``
-- ``Purchases/purchase(product:discount:completion:)``
+- ``Purchases/getPromotionalOffer(forProductDiscount:product:)``
+- ``Purchases/getPromotionalOffer(forProductDiscount:product:completion:)``
+- ``Purchases/purchase(package:promotionalOffer:)``
+- ``Purchases/purchase(package:promotionalOffer:completion:)``
+- ``Purchases/purchase(product:promotionalOffer:)``
+- ``Purchases/purchase(product:promotionalOffer:completion:)``
 - ``Purchases/presentCodeRedemptionSheet()``
 
 ### Subscription Status

--- a/Documentation.docc/RevenueCat.md
+++ b/Documentation.docc/RevenueCat.md
@@ -81,17 +81,17 @@ Or browse our iOS sample apps:
 
 ### Making Purchases with Subscription Offers
 - ``IntroEligibility``
-- ``PromotionalOfferEligibility``
+- ``PromotionalOffer``
 - ``StoreProductDiscount``
 
 - ``Purchases/checkTrialOrIntroDiscountEligibility(_:)``
 - ``Purchases/checkTrialOrIntroDiscountEligibility(_:completion:)``
-- ``Purchases/checkPromotionalDiscountEligibility(forProductDiscount:product:)``
-- ``Purchases/checkPromotionalDiscountEligibility(forProductDiscount:product:completion:)``
-- ``Purchases/purchase(package:discount:)``
-- ``Purchases/purchase(package:discount:completion:)``
-- ``Purchases/purchase(product:discount:)``
-- ``Purchases/purchase(product:discount:completion:)``
+- ``Purchases/getPromotionalOffer(forProductDiscount:product:)``
+- ``Purchases/getPromotionalOffer(forProductDiscount:product:completion:)``
+- ``Purchases/purchase(package:promotionalOffer:)``
+- ``Purchases/purchase(package:promotionalOffer:completion:)``
+- ``Purchases/purchase(product:promotionalOffer:)``
+- ``Purchases/purchase(product:promotionalOffer:completion:)``
 
 ### Subscription Status
 - ``CustomerInfo``

--- a/Documentation.docc/V4_API_Migration_guide.md
+++ b/Documentation.docc/V4_API_Migration_guide.md
@@ -164,7 +164,9 @@ These types replace native StoreKit types in all public API methods that used th
 | Purchases -restoreTransactionsWithCompletion: | Purchases -restorePurchasesWithCompletion: |
 | Purchases -offeringsWithCompletion: | Purchases -getOfferingsWithCompletion: |
 | Purchases -productsWithIdentifiers:completion: | Purchases -getProductsWithIdentifiers:completion: |
-| Purchases -paymentDiscountForProductDiscount:product:completion: | REMOVED - Check eligibility for a discount using `checkPromotionalOfferEligibility:`, then pass the discount directly to `purchasePackage:withDiscount:completion:` or `purchaseProduct:withDiscount:completion:` |
+| Purchases -paymentDiscountForProductDiscount:product:completion: | REMOVED - Check eligibility for a discount using `getPromotionalOffer:forProductDiscount:product:completion:`, then pass the promotional offer directly to `purchasePackage:withPromotionalOffer:completion:` or `purchaseProduct:withPromotionalOffer:completion:` |
+| Purchases -purchaseProduct(_:discount:_) | Purchases -purchaseProduct:withPromotionalOffer:completion: |
+| Purchases -purchasePackage(_:discount:_) | Purchases -purchasePackage:withPromotionalOffer:completion: |
 | Purchases -createAlias: | Purchases -logIn: |
 | Purchases -identify: | Purchases -logIn: |
 | Purchases -reset: | Purchases -logOut: |
@@ -229,9 +231,9 @@ These types replace native StoreKit types in all public API methods that used th
 | purchasePackage(_ package:, _ completion:) | ``Purchases/purchase(package:completion:)`` |
 | restoreTransactions(_ completion:) | ``Purchases/restorePurchases(completion:)`` |
 | syncPurchases(_ completion:) | ``Purchases/syncPurchases(completion:)`` |
-| paymentDiscount(for:product:completion:) | REMOVED - Check eligibility for a discount using ``Purchases/checkPromotionalDiscountEligibility(forProductDiscount:product:)``, then pass the discount directly to ``Purchases/purchase(package:discount:)`` or ``Purchases/purchase(product:discount:)`` |
-| purchaseProduct(_:discount:_) | ``Purchases/purchase(product:discount:completion:)`` |
-| purchasePackage(_:discount:_) | ``Purchases/purchase(package:discount:completion:)`` |
+| paymentDiscount(for:product:completion:) | REMOVED - Get eligibility for a discount using ``Purchases/getPromotionalOffer(forProductDiscount:product:)``, then pass the offer directly to ``Purchases/purchase(package:promotionalOffer:)`` or ``Purchases/purchase(product:promotionalOffer:)`` |
+| purchaseProduct(_:discount:_) | ``Purchases/purchase(product:promotionalOffer:completion:)`` |
+| purchasePackage(_:discount:_) | ``Purchases/purchase(package:promotionalOffer:completion:)`` |
 
 #### PurchasesDelegate
 | v3 | v4 |

--- a/Purchases/Misc/Obsoletions.swift
+++ b/Purchases/Misc/Obsoletions.swift
@@ -208,11 +208,11 @@ public extension Purchases {
      * If the purchase was not successful, there will be an `NSError`.
      * If the user cancelled, `userCancelled` will be `YES`.
      */
-    @available(iOS, introduced: 12.2, unavailable, renamed: "purchase(package:discount:completion:)")
-    @available(tvOS, introduced: 12.2, unavailable, renamed: "purchase(package:discount:completion:)")
-    @available(watchOS, introduced: 6.2, unavailable, renamed: "purchase(package:discount:completion:)")
-    @available(macOS, introduced: 10.14.4, unavailable, renamed: "purchase(package:discount:completion:)")
-    @available(macCatalyst, introduced: 13.0, unavailable, renamed: "purchase(package:discount:completion:)")
+    @available(iOS, introduced: 12.2, unavailable, renamed: "purchase(package:promotionalOffer:completion:)")
+    @available(tvOS, introduced: 12.2, unavailable, renamed: "purchase(package:promotionalOffer:completion:)")
+    @available(watchOS, introduced: 6.2, unavailable, renamed: "purchase(package:promotionalOffer:completion:)")
+    @available(macOS, introduced: 10.14.4, unavailable, renamed: "purchase(package:promotionalOffer:completion:)")
+    @available(macCatalyst, introduced: 13.0, unavailable, renamed: "purchase(package:promotionalOffer:completion:)")
     @objc(purchasePackage:withDiscount:completionBlock:)
     func purchasePackage(_ package: Package,
                          discount: SKPaymentDiscount,
@@ -228,11 +228,11 @@ public extension Purchases {
      * Purchases will handle this for you.
      * - Parameter package: The `Package` the user intends to purchase
      */
-    @available(iOS, introduced: 13.0, unavailable, renamed: "purchase(package:discount:)")
-    @available(tvOS, introduced: 13.0, unavailable, renamed: "purchase(package:discount:)")
-    @available(watchOS, introduced: 6.2, unavailable, renamed: "purchase(package:discount:)")
-    @available(macOS, introduced: 10.15, unavailable, renamed: "purchase(package:discount:)")
-    @available(macCatalyst, introduced: 13.0, unavailable, renamed: "purchase(package:discount:)")
+    @available(iOS, introduced: 13.0, unavailable, renamed: "purchase(package:promotionalOffer:)")
+    @available(tvOS, introduced: 13.0, unavailable, renamed: "purchase(package:promotionalOffer:)")
+    @available(watchOS, introduced: 6.2, unavailable, renamed: "purchase(package:promotionalOffer:)")
+    @available(macOS, introduced: 10.15, unavailable, renamed: "purchase(package:promotionalOffer:)")
+    @available(macCatalyst, introduced: 13.0, unavailable, renamed: "purchase(package:promotionalOffer:)")
     func purchasePackage(_ package: Package,
                          discount: SKPaymentDiscount) async throws -> PurchaseResultData {
         fatalError()
@@ -294,11 +294,11 @@ public extension Purchases {
      * If the purchase was not successful, there will be an `NSError`.
      * If the user cancelled, `userCancelled` will be `YES`.
      */
-    @available(iOS, introduced: 12.2, unavailable, renamed: "purchase(product:discount:completion:)")
-    @available(tvOS, introduced: 12.2, unavailable, renamed: "purchase(product:discount:completion:)")
-    @available(watchOS, introduced: 6.2, unavailable, renamed: "purchase(product:discount:completion:)")
-    @available(macOS, introduced: 10.14.4, unavailable, renamed: "purchase(product:discount:completion:)")
-    @available(macCatalyst, introduced: 13.0, unavailable, renamed: "purchase(product:discount:completion:)")
+    @available(iOS, introduced: 12.2, unavailable, renamed: "purchase(product:promotionalOffer:completion:)")
+    @available(tvOS, introduced: 12.2, unavailable, renamed: "purchase(product:promotionalOffer:completion:)")
+    @available(watchOS, introduced: 6.2, unavailable, renamed: "purchase(product:promotionalOffer:completion:)")
+    @available(macOS, introduced: 10.14.4, unavailable, renamed: "purchase(product:promotionalOffer:completion:)")
+    @available(macCatalyst, introduced: 13.0, unavailable, renamed: "purchase(product:promotionalOffer:completion:)")
     @objc(purchaseProduct:withDiscount:completionBlock:)
     func purchaseProduct(_ product: SKProduct,
                          discount: SKPaymentDiscount,
@@ -316,12 +316,73 @@ public extension Purchases {
      * Purchases will handle this for you.
      * - Parameter product: The `SKProduct` the user intends to purchase
      */
-    @available(iOS, introduced: 13.0, unavailable, renamed: "purchase(product:discount:)")
-    @available(tvOS, introduced: 13.0, unavailable, renamed: "purchase(product:discount:)")
-    @available(watchOS, introduced: 6.2, unavailable, renamed: "purchase(product:discount:)")
-    @available(macOS, introduced: 10.15, unavailable, renamed: "purchase(product:discount:)")
-    @available(macCatalyst, introduced: 13.0, unavailable, renamed: "purchase(product:discount:)")
+    @available(iOS, introduced: 13.0, unavailable, renamed: "purchase(product:promotionalOffer:)")
+    @available(tvOS, introduced: 13.0, unavailable, renamed: "purchase(product:promotionalOffer:)")
+    @available(watchOS, introduced: 6.2, unavailable, renamed: "purchase(product:promotionalOffer:)")
+    @available(macOS, introduced: 10.15, unavailable, renamed: "purchase(product:promotionalOffer:)")
+    @available(macCatalyst, introduced: 13.0, unavailable, renamed: "purchase(product:promotionalOffer:)")
     func purchaseProduct(_ product: SKProduct, discount: SKPaymentDiscount) async throws {
+        fatalError()
+    }
+
+    @available(iOS, introduced: 13.0, unavailable, renamed: "purchase(package:promotionalOffer:)")
+    @available(tvOS, introduced: 13.0, unavailable, renamed: "purchase(package:promotionalOffer:)")
+    @available(watchOS, introduced: 6.2, unavailable, renamed: "purchase(package:promotionalOffer:)")
+    @available(macOS, introduced: 10.15, unavailable, renamed: "purchase(package:promotionalOffer:)")
+    @available(macCatalyst, introduced: 13.0, unavailable, renamed: "purchase(package:promotionalOffer:)")
+    func purchase(package: Package, discount: StoreProductDiscount) async throws -> PurchaseResultData {
+        fatalError()
+    }
+
+    @available(iOS, introduced: 12.2, unavailable, renamed: "purchase(package:promotionalOffer:completion:)")
+    @available(tvOS, introduced: 12.2, unavailable, renamed: "purchase(package:promotionalOffer:completion:)")
+    @available(watchOS, introduced: 6.2, unavailable, renamed: "purchase(package:promotionalOffer:completion:)")
+    @available(macOS, introduced: 10.14.4, unavailable, renamed: "purchase(package:promotionalOffer:completion:)")
+    @available(macCatalyst, introduced: 12.2, unavailable, renamed: "purchase(package:promotionalOffer:completion:)")
+    func purchase(package: Package, discount: StoreProductDiscount, completion: @escaping PurchaseCompletedBlock) {
+        fatalError()
+    }
+
+    @available(iOS, introduced: 13.0, unavailable, renamed: "purchase(package:promotionalOffer:)")
+    @available(tvOS, introduced: 13.0, unavailable, renamed: "purchase(package:promotionalOffer:)")
+    @available(watchOS, introduced: 6.2, unavailable, renamed: "purchase(package:promotionalOffer:)")
+    @available(macOS, introduced: 10.15, unavailable, renamed: "purchase(package:promotionalOffer:)")
+    @available(macCatalyst, introduced: 13.0, unavailable, renamed: "purchase(package:promotionalOffer:)")
+    func purchase(product: StoreProduct, discount: StoreProductDiscount) async throws -> PurchaseResultData {
+        fatalError()
+    }
+
+    @available(iOS, introduced: 12.2, unavailable, renamed: "purchase(package:promotionalOffer:completion:)")
+    @available(tvOS, introduced: 12.2, unavailable, renamed: "purchase(package:promotionalOffer:completion:)")
+    @available(watchOS, introduced: 6.2, unavailable, renamed: "purchase(package:promotionalOffer:completion:)")
+    @available(macOS, introduced: 10.14.4, unavailable, renamed: "purchase(package:promotionalOffer:completion:)")
+    @available(macCatalyst, introduced: 12.2, unavailable, renamed: "purchase(package:promotionalOffer:completion:)")
+    func purchase(product: StoreProduct, discount: StoreProductDiscount, completion: @escaping PurchaseCompletedBlock) {
+        fatalError()
+    }
+
+    @available(iOS, introduced: 13.0, unavailable, renamed: "getPromotionalOffer(forProductDiscount:product:)")
+    @available(tvOS, introduced: 13.0, unavailable, renamed: "getPromotionalOffer(forProductDiscount:product:)")
+    @available(watchOS, introduced: 6.2, unavailable, renamed: "getPromotionalOffer(forProductDiscount:product:)")
+    @available(macOS, introduced: 10.15, unavailable, renamed: "getPromotionalOffer(forProductDiscount:product:)")
+    @available(macCatalyst, introduced: 13.0, unavailable, renamed: "getPromotionalOffer(forProductDiscount:product:)")
+    func checkPromotionalDiscountEligibility(forProductDiscount: StoreProductDiscount, product: StoreProduct) {
+        fatalError()
+    }
+
+    @available(iOS, introduced: 12.2, unavailable,
+               renamed: "getPromotionalOffer(forProductDiscount:product:completion:)")
+    @available(tvOS, introduced: 12.2, unavailable,
+               renamed: "getPromotionalOffer(forProductDiscount:product:completion:)")
+    @available(watchOS, introduced: 6.2, unavailable,
+               renamed: "getPromotionalOffer(forProductDiscount:product:completion:)")
+    @available(macOS, introduced: 10.14.4, unavailable,
+               renamed: "getPromotionalOffer(forProductDiscount:product:completion:)")
+    @available(macCatalyst, introduced: 12.2, unavailable,
+               renamed: "getPromotionalOffer(forProductDiscount:product:completion:)")
+    func checkPromotionalDiscountEligibility(forProductDiscount: StoreProductDiscount,
+                                             product: StoreProduct,
+                                             completion: @escaping (AnyObject, Error?) -> Void) {
         fatalError()
     }
 
@@ -363,15 +424,15 @@ public extension Purchases {
      * If it was not successful, there will be an `Error`.
      */
     @available(iOS, introduced: 12.2, unavailable,
-               message: "Check eligibility for a discount using checkPromotionalOfferEligibility:")
+               message: "Check eligibility for a discount using getPromotionalOffer:")
     @available(tvOS, introduced: 12.2, unavailable,
-               message: "Check eligibility for a discount using checkPromotionalOfferEligibility:")
+               message: "Check eligibility for a discount using getPromotionalOffer:")
     @available(watchOS, introduced: 6.2, unavailable,
-               message: "Check eligibility for a discount using checkPromotionalOfferEligibility:")
+               message: "Check eligibility for a discount using getPromotionalOffer:")
     @available(macOS, introduced: 10.14.4, unavailable,
-               message: "Check eligibility for a discount using checkPromotionalOfferEligibility:")
+               message: "Check eligibility for a discount using getPromotionalOffer:")
     @available(macCatalyst, introduced: 13.0, unavailable,
-               message: "Check eligibility for a discount using checkPromotionalOfferEligibility:")
+               message: "Check eligibility for a discount using getPromotionalOffer:")
     @objc(paymentDiscountForProductDiscount:product:completion:)
     func paymentDiscount(for discount: SKProductDiscount,
                          product: SKProduct,
@@ -386,15 +447,15 @@ public extension Purchases {
      * - Parameter product: The `SKProduct` the user intends to purchase.
      */
     @available(iOS, introduced: 13.0, unavailable,
-               message: "Check eligibility for a discount using checkPromotionalOfferEligibility:")
+               message: "Check eligibility for a discount using getPromotionalOffer:")
     @available(tvOS, introduced: 13.0, unavailable,
-               message: "Check eligibility for a discount using checkPromotionalOfferEligibility:")
+               message: "Check eligibility for a discount using getPromotionalOffer:")
     @available(watchOS, introduced: 6.2, unavailable,
-               message: "Check eligibility for a discount using checkPromotionalOfferEligibility:")
+               message: "Check eligibility for a discount using getPromotionalOffer:")
     @available(macOS, introduced: 10.15, unavailable,
-               message: "Check eligibility for a discount using checkPromotionalOfferEligibility:")
+               message: "Check eligibility for a discount using getPromotionalOffer:")
     @available(macCatalyst, introduced: 13.0, unavailable,
-               message: "Check eligibility for a discount using checkPromotionalOfferEligibility:")
+               message: "Check eligibility for a discount using getPromotionalOffer:")
     func paymentDiscount(for discount: SKProductDiscount,
                          product: SKProduct) async throws -> SKPaymentDiscount {
         fatalError()
@@ -490,6 +551,14 @@ public extension StoreProductDiscount.PaymentMode {
 @available(macOS, obsoleted: 1, renamed: "StoreProductDiscount.PaymentMode")
 @available(macCatalyst, obsoleted: 1, renamed: "StoreProductDiscount.PaymentMode")
 public enum RCPaymentMode {}
+
+@available(iOS, obsoleted: 1, message: "Use PromotionalOffer instead")
+@available(tvOS, obsoleted: 1, message: "Use PromotionalOffer instead")
+@available(watchOS, obsoleted: 1, message: "Use PromotionalOffer instead")
+@available(macOS, obsoleted: 1, message: "Use PromotionalOffer instead")
+@available(macCatalyst, obsoleted: 1, message: "Use PromotionalOffer instead")
+@objc(RCPromotionalOfferEligibility)
+public class PromotionalOfferEligibility: NSObject {}
 
 /// `NSErrorDomain` for errors occurring within the scope of the Purchases SDK.
 @available(iOS, obsoleted: 1, message: "Use ErrorCode instead")

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -1081,17 +1081,14 @@ public extension Purchases {
     }
 
     /**
-     * Initiates a purchase of a ``StoreProduct`` with a ``StoreProductDiscount``.
+     * Initiates a purchase of a ``StoreProduct`` with a ``PromotionalOffer``.
      *
      * Use this function if you are not using the Offerings system to purchase a ``StoreProduct`` with an
-     * applied ``StoreProductDiscount``.
-     * If you are using the Offerings system, use ``Purchases/purchase(package:discount:completion:)`` instead.
+     * applied ``PromotionalOffer``.
+     * If you are using the Offerings system, use ``Purchases/purchase(package:promotionalOffer:completion:)`` instead.
      *
      * - Important: Call this method when a user has decided to purchase a product with an applied discount.
      * Only call this in direct response to user input.
-     *
-     * - Important: Before calling this method, check that the user is eligible for the discount
-     * by calling ``checkPromotionalDiscountEligibility(forProductDiscount:product:)``. 
      *
      * From here ``Purchases`` will handle the purchase with `StoreKit` and call the ``PurchaseCompletedBlock``.
      *
@@ -1099,25 +1096,33 @@ public extension Purchases {
      * this for you.
      *
      * - Parameter product: The ``StoreProduct`` the user intends to purchase.
-     * - Parameter discount: The ``StoreProductDiscount`` to apply to the purchase.
+     * - Parameter promotionalOffer: The ``PromotionalOffer`` to apply to the purchase.
      * - Parameter completion: A completion block that is called when the purchase completes.
      *
      * If the purchase was successful there will be a ``StoreTransaction`` and a ``CustomerInfo``.
      * If the purchase was not successful, there will be an `Error`.
      * If the user cancelled, `userCancelled` will be `true`.
+     *
+     * #### Related Symbols
+     * - ``StoreProduct/discounts``
+     * - ``StoreProduct/getEligiblePromotionalOffers()``
+     * - ``getPromotionalOffer(forProductDiscount:product:)``
      */
     @available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvOS 12.2, *)
-    @objc(purchaseProduct:withDiscount:completion:)
+    @objc(purchaseProduct:withPromotionalOffer:completion:)
     func purchase(product: StoreProduct,
-                  discount: StoreProductDiscount,
+                  promotionalOffer: PromotionalOffer,
                   completion: @escaping PurchaseCompletedBlock) {
-        purchasesOrchestrator.purchase(product: product, package: nil, discount: discount, completion: completion)
+        purchasesOrchestrator.purchase(product: product,
+                                       package: nil,
+                                       promotionalOffer: promotionalOffer,
+                                       completion: completion)
     }
 
     /**
      * Use this function if you are not using the Offerings system to purchase a ``StoreProduct`` with an
-     * applied ``StoreProductDiscount``.
-     * If you are using the Offerings system, use ``Purchases/purchase(package:discount:completion:)`` instead.
+     * applied ``PromotionalOffer``.
+     * If you are using the Offerings system, use ``Purchases/purchase(package:promotionalOffer:completion:)`` instead.
      *
      * Call this method when a user has decided to purchase a product with an applied discount.
      * Only call this in direct response to user input.
@@ -1128,13 +1133,13 @@ public extension Purchases {
      * this for you.
      *
      * - Parameter product: The ``StoreProduct`` the user intends to purchase
-     * - Parameter discount: The ``StoreProductDiscount`` to apply to the purchase
+     * - Parameter promotionalOffer: The ``PromotionalOffer`` to apply to the purchase
      *
      * If the user cancelled, `userCancelled` will be `true`.
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func purchase(product: StoreProduct, discount: StoreProductDiscount) async throws -> PurchaseResultData {
-        return try await purchaseAsync(product: product, discount: discount)
+    func purchase(product: StoreProduct, promotionalOffer: PromotionalOffer) async throws -> PurchaseResultData {
+        return try await purchaseAsync(product: product, promotionalOffer: promotionalOffer)
     }
 
     /**
@@ -1147,7 +1152,7 @@ public extension Purchases {
      * this for you.
      *
      * - Parameter package: The ``Package`` the user intends to purchase
-     * - Parameter discount: The ``StoreProductDiscount`` to apply to the purchase
+     * - Parameter promotionalOffer: The ``PromotionalOffer`` to apply to the purchase
      * - Parameter completion: A completion block that is called when the purchase completes.
      *
      * If the purchase was successful there will be a ``StoreTransaction`` and a ``CustomerInfo``.
@@ -1155,11 +1160,11 @@ public extension Purchases {
      * If the user cancelled, `userCancelled` will be `true`.
      */
     @available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvOS 12.2, *)
-    @objc(purchasePackage:withDiscount:completion:)
-    func purchase(package: Package, discount: StoreProductDiscount, completion: @escaping PurchaseCompletedBlock) {
+    @objc(purchasePackage:withPromotionalOffer:completion:)
+    func purchase(package: Package, promotionalOffer: PromotionalOffer, completion: @escaping PurchaseCompletedBlock) {
         purchasesOrchestrator.purchase(product: package.storeProduct,
                                        package: package,
-                                       discount: discount,
+                                       promotionalOffer: promotionalOffer,
                                        completion: completion)
     }
 
@@ -1173,13 +1178,13 @@ public extension Purchases {
      * this for you.
      *
      * - Parameter package: The ``Package`` the user intends to purchase
-     * - Parameter discount: The ``StoreProductDiscount`` to apply to the purchase
+     * - Parameter promotionalOffer: The ``PromotionalOffer`` to apply to the purchase
      *
      * If the user cancelled, `userCancelled` will be `true`.
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func purchase(package: Package, discount: StoreProductDiscount) async throws -> PurchaseResultData {
-        return try await purchaseAsync(package: package, discount: discount)
+    func purchase(package: Package, promotionalOffer: PromotionalOffer) async throws -> PurchaseResultData {
+        return try await purchaseAsync(package: package, promotionalOffer: promotionalOffer)
     }
 
     /**
@@ -1261,7 +1266,7 @@ public extension Purchases {
      * [iOS Introductory  Offers](https://docs.revenuecat.com/docs/ios-subscription-offers).
      *
      * - Note: If you're looking to use Promotional Offers instead,
-     * use ``Purchases/checkPromotionalDiscountEligibility(forProductDiscount:product:completion:)``.
+     * use ``Purchases/getPromotionalOffer(forProductDiscount:product:completion:)``.
      *
      * - Note: Subscription groups are automatically collected for determining eligibility. If RevenueCat can't
      * definitively compute the eligibility, most likely because of missing group information, it will return
@@ -1287,7 +1292,7 @@ public extension Purchases {
      * [iOS Introductory  Offers](https://docs.revenuecat.com/docs/ios-subscription-offers).
      *
      * - Note: If you're looking to use Promotional Offers instead,
-     * use ``Purchases/checkPromotionalDiscountEligibility(forProductDiscount:product:completion:)``.
+     * use ``Purchases/getPromotionalOffer(forProductDiscount:product:completion:)``.
      *
      * - Note: Subscription groups are automatically collected for determining eligibility. If RevenueCat can't
      * definitively compute the eligibility, most likely because of missing group information, it will return
@@ -1332,24 +1337,25 @@ public extension Purchases {
 #endif
 
     /**
-     * Use this method to find eligibility for this user for
+     * Use this method to fetch ``PromotionalOffer``
+     *  to use in ``purchase(package:promotionalOffer:)`` or ``purchase(product:promotionalOffer:)``.
      * [iOS Promotional Offers](https://docs.revenuecat.com/docs/ios-subscription-offers#promotional-offers).
      * - Note: If you're looking to use free trials or Introductory Offers instead,
      * use ``Purchases/checkTrialOrIntroDiscountEligibility(_:completion:)``.
      *
      * - Parameter discount: The ``StoreProductDiscount`` to apply to the product.
      * - Parameter product: The ``StoreProduct`` the user intends to purchase.
-     * - Parameter completion: A completion block that is called when the ``PromotionalOfferEligibility`` is returned.
+     * - Parameter completion: A completion block that is called when the ``PromotionalOffer`` is returned.
      * If it was not successful, there will be an `Error`.
      */
     @available(iOS 12.2, macOS 10.14.4, macCatalyst 13.0, tvOS 12.2, watchOS 6.2, *)
-    @objc(checkPromotionalDiscountEligibilityForProductDiscount:withProduct:withCompletion:)
-    func checkPromotionalDiscountEligibility(forProductDiscount discount: StoreProductDiscount,
-                                             product: StoreProduct,
-                                             completion: @escaping (PromotionalOfferEligibility, Error?) -> Void) {
+    @objc(getPromotionalOfferForProductDiscount:withProduct:withCompletion:)
+    func getPromotionalOffer(forProductDiscount discount: StoreProductDiscount,
+                             product: StoreProduct,
+                             completion: @escaping (PromotionalOffer?, Error?) -> Void) {
         purchasesOrchestrator.promotionalOffer(forProductDiscount: discount,
                                                product: product) { promotionalOffer, error in
-            completion(promotionalOffer == nil ? .ineligible : .eligible, error)
+            completion(promotionalOffer, error)
         }
     }
 
@@ -1363,21 +1369,23 @@ public extension Purchases {
      * - Parameter product: The ``StoreProduct`` the user intends to purchase.
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func checkPromotionalDiscountEligibility(forProductDiscount discount: StoreProductDiscount,
-                                             product: StoreProduct) async throws -> PromotionalOfferEligibility {
-        return try await checkPromotionalDiscountEligibilityAsync(forProductDiscount: discount, product: product)
+    func getPromotionalOffer(forProductDiscount discount: StoreProductDiscount,
+                             product: StoreProduct) async throws -> PromotionalOffer {
+        return try await getPromotionalOfferAsync(forProductDiscount: discount, product: product)
     }
 
     /// Finds the subset of ``StoreProduct/discounts`` that's eligible for the current user.
+    ///
     /// - Parameter product: the product to filter discounts from.
     /// - Note: if checking for eligibility for a `StoreProductDiscount` fails (for example, if network is down),
     ///   that discount will fail silently and be considered not eligible.
     /// #### Related Symbols
-    /// - ``StoreProduct/getEligibleDiscounts()``
+    /// - ``getPromotionalOffer(forProductDiscount:product:)``
+    /// - ``StoreProduct/getEligiblePromotionalOffers()``
     /// - ``StoreProduct/discounts``
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func getEligibleDiscounts(forProduct product: StoreProduct) async -> [StoreProductDiscount] {
-        return await getEligibleDiscountsAsync(forProduct: product)
+    func getEligiblePromotionalOffers(forProduct product: StoreProduct) async -> [PromotionalOffer] {
+        return await getEligiblePromotionalOffersAsync(forProduct: product)
     }
 
 #if os(iOS) || os(macOS)

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -158,9 +158,10 @@ internal protocol StoreProductType {
     /// An array of subscription offers available for the auto-renewable subscription.
     /// - Note: the current user may or may not be eligible for some of these.
     /// #### Related Symbols
-    /// - ``Purchases/checkPromotionalDiscountEligibility(forProductDiscount:product:)``
-    /// - ``Purchases/checkPromotionalDiscountEligibility(forProductDiscount:product:completion:)``
-    /// - ``StoreProduct/getEligibleDiscounts()``
+    /// - ``Purchases/getPromotionalOffer(forProductDiscount:product:)``
+    /// - ``Purchases/getPromotionalOffer(forProductDiscount:product:completion:)``
+    /// - ``Purchases/getEligiblePromotionalOffers(forProduct:)``
+    /// - ``StoreProduct/getEligiblePromotionalOffers()``
     @available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *)
     var discounts: [StoreProductDiscount] { get }
 
@@ -198,8 +199,8 @@ public extension StoreProduct {
     /// - Warning: this method implicitly relies on ``Purchases`` already being initialized.
     /// #### Related Symbols
     /// - ``discounts``
-    func getEligibleDiscounts() async -> [StoreProductDiscount] {
-        return await Purchases.shared.getEligibleDiscounts(forProduct: self)
+    func getEligiblePromotionalOffers() async -> [PromotionalOffer] {
+        return await Purchases.shared.getEligiblePromotionalOffers(forProduct: self)
     }
 }
 

--- a/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -167,15 +167,21 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                               storeProduct: storeProduct,
                               offeringIdentifier: "offering")
 
-        let storeProductDiscount = MockStoreProductDiscount(offerIdentifier: "offerid1",
-                                                            price: 11.1,
-                                                            paymentMode: .payAsYouGo,
-                                                            subscriptionPeriod: .init(value: 1, unit: .month),
-                                                            type: .promotional)
+        let discount = MockStoreProductDiscount(offerIdentifier: "offerid1",
+                                                price: 11.1,
+                                                paymentMode: .payAsYouGo,
+                                                subscriptionPeriod: .init(value: 1, unit: .month),
+                                                type: .promotional)
+        let offer = PromotionalOffer(discount: discount,
+                                     signedData: .init(identifier: "",
+                                                       keyIdentifier: "",
+                                                       nonce: UUID(),
+                                                       signature: "",
+                                                       timestamp: 0))
 
         _ = await withCheckedContinuation { continuation in
             orchestrator.purchase(sk1Product: product,
-                                  discount: storeProductDiscount,
+                                  promotionalOffer: offer,
                                   package: package) { transaction, customerInfo, error, userCancelled in
                 continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
             }
@@ -197,7 +203,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         let product = try await self.fetchSk2Product()
 
         let (transaction, customerInfo, userCancelled) = try await orchestrator.purchase(sk2Product: product,
-                                                                                         discount: nil)
+                                                                                         promotionalOffer: nil)
 
         expect(transaction?.sk2Transaction) == mockTransaction
         expect(userCancelled) == false
@@ -246,7 +252,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         let product = try await fetchSk2Product()
 
-        _ = try await orchestrator.purchase(sk2Product: product, discount: nil)
+        _ = try await orchestrator.purchase(sk2Product: product, promotionalOffer: nil)
 
         expect(self.backend.invokedPostReceiptDataCount) == 1
     }
@@ -260,14 +266,20 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
 
         let product = try await fetchSk2Product()
-        let storeProductDiscount = MockStoreProductDiscount(offerIdentifier: "offerid1",
-                                                            price: 11.1,
-                                                            paymentMode: .payAsYouGo,
-                                                            subscriptionPeriod: .init(value: 1, unit: .month),
-                                                            type: .promotional)
+        let discount = MockStoreProductDiscount(offerIdentifier: "offerid1",
+                                                price: 11.1,
+                                                paymentMode: .payAsYouGo,
+                                                subscriptionPeriod: .init(value: 1, unit: .month),
+                                                type: .promotional)
+        let offer = PromotionalOffer(discount: discount,
+                                     signedData: .init(identifier: "",
+                                                       keyIdentifier: "",
+                                                       nonce: UUID(),
+                                                       signature: "",
+                                                       timestamp: 0))
 
         do {
-            _ = try await orchestrator.purchase(sk2Product: product, discount: storeProductDiscount)
+            _ = try await orchestrator.purchase(sk2Product: product, promotionalOffer: offer)
             XCTFail("Expected error")
         } catch {
             expect(self.backend.invokedPostReceiptData) == false
@@ -286,7 +298,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         let product = try await fetchSk2Product()
 
         do {
-            _ = try await orchestrator.purchase(sk2Product: product, discount: nil)
+            _ = try await orchestrator.purchase(sk2Product: product, promotionalOffer: nil)
 
             XCTFail("Expected error")
         } catch {


### PR DESCRIPTION
Fixes [sc-13355].

Before this PR, users had to call `Purchases.checkPromotionalDiscountEligibility`, and if eligible, then call `Purchases.purchase(product:discount:)` (or their equivalents).
However, as pointed out by @aboedo, this had 2 downsides:
- If `Purchases.checkPromotionalDiscountEligibility` wasn't called, it was possible to call `Purchases.purchase(product:discount:)` with an illegible discount, and it would just fail.
- Doing it right meant the SDK would make 2 redundant API requests to get the signed discount data.

With this change, both issues are resolved.
`checkPromotionalDiscountEligibilityForProductDiscount` is replaced with `getPromotionalOffer`. The returned `PromotionalOffer` already contains the necessary data to make the payment.

I've updated all docs and obsoletions (from version 3, and RC3) to reflect the new APIs.
I've also changed `getEligibleDiscounts` to `getEligiblePromotionalOffers`.

This also obsoletes `PromotionalOfferEligibility`, which is no longer needed.