### PR TITLE
Added `StoreProduct.ProductType` and `StoreProduct.ProductCategory`

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductAPI.m
@@ -49,12 +49,12 @@
       );
 }
 
-+ (void)checkSubscriptionType {
-    RCStoreProductSubscriptionType type = RCStoreProductSubscriptionTypeSubscription;
++ (void)checkProductCategory {
+    RCStoreProductCategory category = RCStoreProductCategorySubscription;
 
-    switch (type) {
-        case RCStoreProductSubscriptionTypeSubscription: break;
-        case RCStoreProductSubscriptionTypeNonSubscription: break;
+    switch (category) {
+        case RCStoreProductCategorySubscription: break;
+        case RCStoreProductCategoryNonSubscription: break;
     }
 }
 

--- a/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductAPI.m
@@ -54,7 +54,7 @@
 
     switch (type) {
         case RCStoreProductSubscriptionTypeSubscription: break;
-        case RCStoreProductSubscriptionTypeInAppPurchase: break;
+        case RCStoreProductSubscriptionTypeNonSubscription: break;
     }
 }
 

--- a/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductAPI.m
@@ -49,4 +49,24 @@
       );
 }
 
++ (void)checkSubscriptionType {
+    RCStoreProductSubscriptionType type = RCStoreProductSubscriptionTypeSubscription;
+
+    switch (type) {
+        case RCStoreProductSubscriptionTypeSubscription: break;
+        case RCStoreProductSubscriptionTypeInAppPurchase: break;
+    }
+}
+
++ (void)checkProductType {
+    RCStoreProductType type = RCStoreProductTypeNonRenewableSubscription;
+
+    switch (type) {
+        case RCStoreProductTypeConsumable: break;
+        case RCStoreProductTypeNonConsumable: break;
+        case RCStoreProductTypeNonRenewableSubscription: break;
+        case RCStoreProductTypeAutoRenewableSubscription: break;
+    }
+}
+
 @end

--- a/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
@@ -9,6 +9,8 @@ import RevenueCat
 
 var product: StoreProduct!
 func checkStoreProductAPI() {
+    let subType: StoreProduct.SubscriptionType = product.subscriptionType
+    let productType: StoreProduct.ProductType = product.productType
     let localizedDescription: String = product.localizedDescription
     let localizedTitle: String = product.localizedTitle
     let price: Decimal = product.price
@@ -34,6 +36,8 @@ func checkStoreProductAPI() {
 
     print(
         product!,
+        subType,
+        productType,
         localizedDescription,
         localizedTitle,
         price,
@@ -50,6 +54,22 @@ func checkStoreProductAPI() {
         sk1Product!,
         sk2Product!
     )
+}
+
+func checkSubscriptionType(_ type: StoreProduct.SubscriptionType) {
+    switch type {
+    case .subscription: break
+    case .inAppPurchase: break
+    }
+}
+
+func checkProductType(_ type: StoreProduct.ProductType) {
+    switch type {
+    case .consumable: break
+    case .nonConsumable: break
+    case .nonRenewableSubscription: break
+    case .autoRenewableSubscription: break
+    }
 }
 
 func checkStoreProductAsyncAPI() async {

--- a/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
@@ -59,7 +59,7 @@ func checkStoreProductAPI() {
 func checkSubscriptionType(_ type: StoreProduct.SubscriptionType) {
     switch type {
     case .subscription: break
-    case .inAppPurchase: break
+    case .nonSubscription: break
     }
 }
 

--- a/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
@@ -9,7 +9,7 @@ import RevenueCat
 
 var product: StoreProduct!
 func checkStoreProductAPI() {
-    let subType: StoreProduct.SubscriptionType = product.subscriptionType
+    let category: StoreProduct.ProductCategory = product.productCategory
     let productType: StoreProduct.ProductType = product.productType
     let localizedDescription: String = product.localizedDescription
     let localizedTitle: String = product.localizedTitle
@@ -36,7 +36,7 @@ func checkStoreProductAPI() {
 
     print(
         product!,
-        subType,
+        category,
         productType,
         localizedDescription,
         localizedTitle,
@@ -56,8 +56,8 @@ func checkStoreProductAPI() {
     )
 }
 
-func checkSubscriptionType(_ type: StoreProduct.SubscriptionType) {
-    switch type {
+func checkProductCategory(_ category: StoreProduct.ProductCategory) {
+    switch category {
     case .subscription: break
     case .nonSubscription: break
     }

--- a/Purchases/Logging/Strings/StoreKitStrings.swift
+++ b/Purchases/Logging/Strings/StoreKitStrings.swift
@@ -70,7 +70,7 @@ extension StoreKitStrings: CustomStringConvertible {
 
         case .sk1_no_known_product_type:
             return "This StoreProduct represents an SK1 product, the type of product cannot be determined, " +
-            "the value will be undefined. Use `StoreProduct.subscriptionType` instead."
+            "the value will be undefined. Use `StoreProduct.productCategory` instead."
         }
     }
 

--- a/Purchases/Logging/Strings/StoreKitStrings.swift
+++ b/Purchases/Logging/Strings/StoreKitStrings.swift
@@ -30,6 +30,10 @@ enum StoreKitStrings {
 
     case sk2_purchasing_added_promotional_offer_option(String)
 
+    case sk2_unknown_product_type(String)
+
+    case sk1_no_known_product_type
+
 }
 
 extension StoreKitStrings: CustomStringConvertible {
@@ -60,6 +64,13 @@ extension StoreKitStrings: CustomStringConvertible {
 
         case let .sk2_purchasing_added_promotional_offer_option(discountIdentifier):
             return "Adding Product.PurchaseOption for discount '\(discountIdentifier)'"
+
+        case let .sk2_unknown_product_type(type):
+            return "Product.ProductType '\(type)' unknown, the product type will be undefined."
+
+        case .sk1_no_known_product_type:
+            return "This StoreProduct represents an SK1 product, the type of product cannot be determined, " +
+            "the value will be undefined. Use `StoreProduct.subscriptionType` instead."
         }
     }
 

--- a/Purchases/Purchasing/StoreKitAbstractions/ProductType.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/ProductType.swift
@@ -1,0 +1,90 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ProductType.swift
+//
+//  Created by Nacho Soto on 2/15/22.
+
+import StoreKit
+
+extension StoreProduct {
+
+    /// The type of subscription of a product, whether a subscription or a one-time purchase.
+    ///
+    /// ### Related Symbols
+    /// - ``StoreProduct/ProductType-swift.enum``
+    @objc(RCStoreProductSubscriptionType)
+    public enum SubscriptionType: Int {
+
+        /// A non-renewable or auto-renewable subscription.
+        case subscription
+
+        /// A consumable or non-consumable in-app purchase.
+        case inAppPurchase
+
+    }
+
+    /// The type of product, equivalent to StoreKit's `Product.ProductType`.
+    ///
+    /// ### Related Symbols
+    /// - ``StoreProduct/SubscriptionType-swift.enum``
+    @objc(RCStoreProductType)
+    public enum ProductType: Int {
+
+        /// A consumable in-app purchase.
+        case consumable
+
+        /// A non-consumable in-app purchase.
+        case nonConsumable
+
+        /// A non-renewing subscription.
+        case nonRenewableSubscription
+
+        /// An auto-renewable subscription.
+        case autoRenewableSubscription
+
+    }
+
+}
+
+extension StoreProduct.ProductType {
+
+    var subscriptionType: StoreProduct.SubscriptionType {
+        switch self {
+        case .consumable: return .inAppPurchase
+        case .nonConsumable: return .inAppPurchase
+        case .nonRenewableSubscription: return .subscription
+        case .autoRenewableSubscription: return .subscription
+        }
+    }
+
+    /// Used as a placeholder when the type of product cannot be determined.
+    /// This value is considered undefined behavior.
+    static let defaultType: Self = .nonConsumable
+
+}
+
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+extension StoreProduct.ProductType {
+
+    init(_ type: SK2Product.ProductType) {
+        switch type {
+        case .consumable: self = .consumable
+        case .nonConsumable: self = .nonConsumable
+        case .nonRenewable: self = .nonRenewableSubscription
+        case .autoRenewable: self = .autoRenewableSubscription
+
+        default:
+            Logger.warn(Strings.storeKit.sk2_unknown_product_type(String(describing: type)))
+
+            self = .defaultType
+        }
+    }
+
+}

--- a/Purchases/Purchasing/StoreKitAbstractions/ProductType.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/ProductType.swift
@@ -15,12 +15,12 @@ import StoreKit
 
 extension StoreProduct {
 
-    /// The type of subscription of a product, whether a subscription or a one-time purchase.
+    /// The category of a product, whether a subscription or a one-time purchase.
     ///
     /// ### Related Symbols
     /// - ``StoreProduct/ProductType-swift.enum``
-    @objc(RCStoreProductSubscriptionType)
-    public enum SubscriptionType: Int {
+    @objc(RCStoreProductCategory)
+    public enum ProductCategory: Int {
 
         /// A non-renewable or auto-renewable subscription.
         case subscription
@@ -33,7 +33,7 @@ extension StoreProduct {
     /// The type of product, equivalent to StoreKit's `Product.ProductType`.
     ///
     /// ### Related Symbols
-    /// - ``StoreProduct/SubscriptionType-swift.enum``
+    /// - ``StoreProduct/ProductCategory``
     @objc(RCStoreProductType)
     public enum ProductType: Int {
 
@@ -55,7 +55,7 @@ extension StoreProduct {
 
 extension StoreProduct.ProductType {
 
-    var subscriptionType: StoreProduct.SubscriptionType {
+    var productCategory: StoreProduct.ProductCategory {
         switch self {
         case .consumable: return .nonSubscription
         case .nonConsumable: return .nonSubscription

--- a/Purchases/Purchasing/StoreKitAbstractions/ProductType.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/ProductType.swift
@@ -26,7 +26,7 @@ extension StoreProduct {
         case subscription
 
         /// A consumable or non-consumable in-app purchase.
-        case inAppPurchase
+        case nonSubscription
 
     }
 
@@ -57,8 +57,8 @@ extension StoreProduct.ProductType {
 
     var subscriptionType: StoreProduct.SubscriptionType {
         switch self {
-        case .consumable: return .inAppPurchase
-        case .nonConsumable: return .inAppPurchase
+        case .consumable: return .nonSubscription
+        case .nonConsumable: return .nonSubscription
         case .nonRenewableSubscription: return .subscription
         case .autoRenewableSubscription: return .subscription
         }

--- a/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
@@ -23,11 +23,11 @@ internal struct SK1StoreProduct: StoreProductType {
 
     var subscriptionType: StoreProduct.SubscriptionType {
         guard #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *) else {
-            return .inAppPurchase
+            return .nonSubscription
         }
 
         return self.subscriptionPeriod == nil
-            ? .inAppPurchase
+            ? .nonSubscription
             : .subscription
     }
 

--- a/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
@@ -21,7 +21,7 @@ internal struct SK1StoreProduct: StoreProductType {
 
     let underlyingSK1Product: SK1Product
 
-    var subscriptionType: StoreProduct.SubscriptionType {
+    var productCategory: StoreProduct.ProductCategory {
         guard #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *) else {
             return .nonSubscription
         }

--- a/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
@@ -21,6 +21,22 @@ internal struct SK1StoreProduct: StoreProductType {
 
     let underlyingSK1Product: SK1Product
 
+    var subscriptionType: StoreProduct.SubscriptionType {
+        guard #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *) else {
+            return .inAppPurchase
+        }
+
+        return self.subscriptionPeriod == nil
+            ? .inAppPurchase
+            : .subscription
+    }
+
+    var productType: StoreProduct.ProductType {
+        Logger.warn(Strings.storeKit.sk1_no_known_product_type)
+
+        return .defaultType
+    }
+
     var localizedDescription: String { return underlyingSK1Product.localizedDescription }
 
     var price: Decimal { return underlyingSK1Product.price as Decimal }

--- a/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
@@ -30,8 +30,8 @@ internal struct SK2StoreProduct: StoreProductType {
         _underlyingSK2Product as! SK2Product
     }
 
-    var subscriptionType: StoreProduct.SubscriptionType {
-        return self.productType.subscriptionType
+    var productCategory: StoreProduct.ProductCategory {
+        return self.productType.productCategory
     }
 
     var productType: StoreProduct.ProductType {

--- a/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
@@ -30,6 +30,14 @@ internal struct SK2StoreProduct: StoreProductType {
         _underlyingSK2Product as! SK2Product
     }
 
+    var subscriptionType: StoreProduct.SubscriptionType {
+        return self.productType.subscriptionType
+    }
+
+    var productType: StoreProduct.ProductType {
+        return .init(self.underlyingSK2Product.type)
+    }
+
     var localizedDescription: String { underlyingSK2Product.description }
 
     var price: Decimal { underlyingSK2Product.price }

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -63,7 +63,7 @@ public typealias SK2Product = StoreKit.Product
 
     @objc public var productType: ProductType { self.product.productType }
 
-    @objc public var subscriptionType: SubscriptionType { self.product.subscriptionType }
+    @objc public var productCategory: ProductCategory { self.product.productCategory }
 
     @objc public var localizedDescription: String { self.product.localizedDescription }
 
@@ -98,17 +98,17 @@ public typealias SK2Product = StoreKit.Product
 /// Type that provides access to all of `StoreKit`'s product type's properties.
 internal protocol StoreProductType {
 
-    /// The type of subscription of a product, whether a subscription or a one-time purchase.
+    /// The category of this product, whether a subscription or a one-time purchase.
 
     /// ### Related Symbols:
     /// - ``StoreProduct/productType-swift.property``
-    var subscriptionType: StoreProduct.SubscriptionType { get }
+    var productCategory: StoreProduct.ProductCategory { get }
 
     /// The type of product.
     /// - Important: `StoreProduct`s backing SK1 products cannot determine the type.
     ///
     /// ### Related Symbols:
-    /// - ``StoreProduct/subscriptionType-swift.property``
+    /// - ``StoreProduct/productCategory-swift.property``
     var productType: StoreProduct.ProductType { get }
 
     /// A description of the product.

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -61,6 +61,10 @@ public typealias SK2Product = StoreKit.Product
     // Note: this class inherits its docs from `StoreProductType`
     // swiftlint:disable missing_docs
 
+    @objc public var productType: ProductType { self.product.productType }
+
+    @objc public var subscriptionType: SubscriptionType { self.product.subscriptionType }
+
     @objc public var localizedDescription: String { self.product.localizedDescription }
 
     @objc public var localizedTitle: String { self.product.localizedTitle }
@@ -93,6 +97,19 @@ public typealias SK2Product = StoreKit.Product
 
 /// Type that provides access to all of `StoreKit`'s product type's properties.
 internal protocol StoreProductType {
+
+    /// The type of subscription of a product, whether a subscription or a one-time purchase.
+
+    /// ### Related Symbols:
+    /// - ``StoreProduct/productType-swift.property``
+    var subscriptionType: StoreProduct.SubscriptionType { get }
+
+    /// The type of product.
+    /// - Important: `StoreProduct`s backing SK1 products cannot determine the type.
+    ///
+    /// ### Related Symbols:
+    /// - ``StoreProduct/subscriptionType-swift.property``
+    var productType: StoreProduct.ProductType { get }
 
     /// A description of the product.
     /// - Note: The description's language is determined by the storefront that the user's device is connected to,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -235,6 +235,7 @@
 		57EAE527274324C60060EB74 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE526274324C60060EB74 /* Lock.swift */; };
 		57EAE52B274332830060EB74 /* Obsoletions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE52A274332830060EB74 /* Obsoletions.swift */; };
 		57EAE52D274468900060EB74 /* RawDataContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE52C274468900060EB74 /* RawDataContainer.swift */; };
+		57EFDC6B27BC1F370057EC39 /* ProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EFDC6A27BC1F370057EC39 /* ProductType.swift */; };
 		6E38843A0CAFD551013D0A3F /* StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECF627761D375C8431EB866 /* StoreProduct.swift */; };
 		805B60C97993B311CEC93EAF /* ProductsFetcherSK2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3628C1F100BB3C1782860D24 /* ProductsFetcherSK2.swift */; };
 		80E80EF226970E04008F245A /* ReceiptFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E80EF026970DC3008F245A /* ReceiptFetcher.swift */; };
@@ -623,6 +624,7 @@
 		57EAE526274324C60060EB74 /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		57EAE52A274332830060EB74 /* Obsoletions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Obsoletions.swift; sourceTree = "<group>"; };
 		57EAE52C274468900060EB74 /* RawDataContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawDataContainer.swift; sourceTree = "<group>"; };
+		57EFDC6A27BC1F370057EC39 /* ProductType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductType.swift; sourceTree = "<group>"; };
 		80E80EF026970DC3008F245A /* ReceiptFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptFetcher.swift; sourceTree = "<group>"; };
 		84C3F1AC1D7E1E64341D3936 /* Pods_RevenueCat_PurchasesTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RevenueCat_PurchasesTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A65DFDD258AD60A00DE00B0 /* LogIntent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogIntent.swift; sourceTree = "<group>"; };
@@ -820,6 +822,7 @@
 			children = (
 				FECF627761D375C8431EB866 /* StoreProduct.swift */,
 				2D1015DD275A57FC0086173F /* SubscriptionPeriod.swift */,
+				57EFDC6A27BC1F370057EC39 /* ProductType.swift */,
 				57AC4C1B2770F56200DDE30F /* SK1StoreProduct.swift */,
 				57AC4C172770F55C00DDE30F /* SK2StoreProduct.swift */,
 				2D1015D9275959840086173F /* StoreTransaction.swift */,
@@ -1941,6 +1944,7 @@
 				B34605C3279A6E380031CA74 /* PostOfferForSigningOperation.swift in Sources */,
 				B34605C7279A6E380031CA74 /* SubscriberAttributesMarshaller.swift in Sources */,
 				5791A1AA2767E42B00C972AA /* SKProduct+Extensions.swift in Sources */,
+				57EFDC6B27BC1F370057EC39 /* ProductType.swift in Sources */,
 				B3022072272B3DDC008F1A0D /* DescribableError.swift in Sources */,
 				57BD50AA27692B7500211D6D /* StoreKitError+Extensions.swift in Sources */,
 				F5C0196926E880800005D61E /* StoreKitStrings.swift in Sources */,

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -87,7 +87,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(storeProduct.sk1Product) === sk1Product.underlyingSK1Product
 
         expect(storeProduct.productIdentifier) == Self.productID
-        expect(storeProduct.subscriptionType) == .subscription
+        expect(storeProduct.productCategory) == .subscription
         expect(storeProduct.localizedDescription) == "Monthly subscription with a 1-week free trial"
         expect(storeProduct.price.description) == "4.99"
         expect(storeProduct.localizedPriceString) == "$4.99"
@@ -133,7 +133,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(storeProduct.sk2Product) == storeProduct.sk2Product
 
         expect(storeProduct.productIdentifier) == Self.productID
-        expect(storeProduct.subscriptionType) == .subscription
+        expect(storeProduct.productCategory) == .subscription
         expect(storeProduct.productType) == .autoRenewableSubscription
         expect(storeProduct.localizedDescription) == "Monthly subscription with a 1-week free trial"
         expect(storeProduct.price.description) == "4.99"
@@ -266,12 +266,12 @@ class StoreProductTests: StoreKitConfigTestCase {
         _ = product.productType
     }
 
-    func testSK1SubscriptionType() async throws {
+    func testSK1ProductCategory() async throws {
         let subscription = try await self.sk1Fetcher.product(withIdentifier: Self.productID)
         let nonSubscription = try await self.sk1Fetcher.product(withIdentifier: Self.lifetimeProductID)
 
-        expect(subscription.subscriptionType) == .subscription
-        expect(nonSubscription.subscriptionType) == .nonSubscription
+        expect(subscription.productCategory) == .subscription
+        expect(nonSubscription.productCategory) == .nonSubscription
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -292,7 +292,7 @@ class StoreProductTests: StoreKitConfigTestCase {
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-    func testSK2SubscriptionType() async throws {
+    func testSK2ProductCategory() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         let fetcher = ProductsFetcherSK2()
@@ -300,8 +300,8 @@ class StoreProductTests: StoreKitConfigTestCase {
         let subscription = try await fetcher.product(withIdentifier: Self.productID)
         let nonSubscription = try await fetcher.product(withIdentifier: Self.lifetimeProductID)
 
-        expect(subscription.subscriptionType) == .subscription
-        expect(nonSubscription.subscriptionType) == .nonSubscription
+        expect(subscription.productCategory) == .subscription
+        expect(nonSubscription.productCategory) == .nonSubscription
     }
 
 }
@@ -311,7 +311,7 @@ private extension StoreProductTests {
     func expectEqualProducts(_ productA: StoreProductType, _ productB: StoreProductType) {
         expect(productA.productIdentifier) == productB.productIdentifier
         // Note: can't compare productTypes because SK1 doesn't have full information
-        expect(productA.subscriptionType) == productB.subscriptionType
+        expect(productA.productCategory) == productB.productCategory
         expect(productA.localizedDescription) == productB.localizedDescription
         expect(productA.price) == productB.price
         expect(productA.localizedPriceString) == productB.localizedPriceString

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -54,8 +54,7 @@ class StoreProductTests: StoreKitConfigTestCase {
     }
 
     func testSK1AndStoreProductDetailsAreEquivalent() async throws {
-        let products = try await self.sk1Fetcher.products(withIdentifiers: ["com.revenuecat.monthly_4.99.1_week_intro"])
-        let product = try XCTUnwrap(products.first)
+        let product = try await self.sk1Fetcher.product(withIdentifier: Self.productID)
 
         expectEqualProducts(product, StoreProduct.from(product: product))
     }
@@ -64,18 +63,16 @@ class StoreProductTests: StoreKitConfigTestCase {
     func testSK2AndStoreProductDetailsAreEquivalent() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        let products = try await ProductsFetcherSK2()
-            .products(identifiers: ["com.revenuecat.monthly_4.99.1_week_intro"])
-        let product = try XCTUnwrap(products.first)
+        let product = try await ProductsFetcherSK2()
+            .product(withIdentifier: Self.productID)
 
         expectEqualProducts(product, StoreProduct.from(product: product))
     }
 
     func testSk1DetailsWrapsCorrectly() throws {
-        let productIdentifier = "com.revenuecat.monthly_4.99.1_week_intro"
-        var result: Result<Set<SK1StoreProduct>, Error>!
+        var result: Result<Set<SK1StoreProduct>, Swift.Error>!
 
-        self.sk1Fetcher.products(withIdentifiers: Set([productIdentifier])) { products in
+        self.sk1Fetcher.products(withIdentifiers: Set([Self.productID])) { products in
             result = products
         }
 
@@ -89,11 +86,11 @@ class StoreProductTests: StoreKitConfigTestCase {
 
         expect(storeProduct.sk1Product) === sk1Product.underlyingSK1Product
 
-        expect(storeProduct.productIdentifier) == "com.revenuecat.monthly_4.99.1_week_intro"
+        expect(storeProduct.productIdentifier) == Self.productID
+        expect(storeProduct.subscriptionType) == .subscription
         expect(storeProduct.localizedDescription) == "Monthly subscription with a 1-week free trial"
         expect(storeProduct.price.description) == "4.99"
         expect(storeProduct.localizedPriceString) == "$4.99"
-        expect(storeProduct.productIdentifier) == productIdentifier
         expect(storeProduct.isFamilyShareable) == true
         expect(storeProduct.localizedTitle) == "Monthly Free Trial"
         // open the StoreKit Config file as source code to see the expected value
@@ -128,24 +125,19 @@ class StoreProductTests: StoreKitConfigTestCase {
     func testSk2DetailsWrapsCorrectly() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        let productIdentifier = "com.revenuecat.monthly_4.99.1_week_intro"
         let sk2Fetcher = ProductsFetcherSK2()
 
-        let storeProductSet = try await sk2Fetcher.products(identifiers: Set([productIdentifier]))
-
-        expect(storeProductSet).to(haveCount(1))
-
-        let sk2Product = try XCTUnwrap(storeProductSet.first)
-        let storeProduct = StoreProduct.from(product: sk2Product)
+        let storeProduct = try await sk2Fetcher.product(withIdentifier: Self.productID)
 
         // Can't use `===` because `SK2Product` is a `struct`
-        expect(storeProduct.sk2Product) == sk2Product.underlyingSK2Product
+        expect(storeProduct.sk2Product) == storeProduct.sk2Product
 
-        expect(storeProduct.productIdentifier) == "com.revenuecat.monthly_4.99.1_week_intro"
+        expect(storeProduct.productIdentifier) == Self.productID
+        expect(storeProduct.subscriptionType) == .subscription
+        expect(storeProduct.productType) == .autoRenewableSubscription
         expect(storeProduct.localizedDescription) == "Monthly subscription with a 1-week free trial"
         expect(storeProduct.price.description) == "4.99"
         expect(storeProduct.localizedPriceString) == "$4.99"
-        expect(storeProduct.productIdentifier) == productIdentifier
         expect(storeProduct.isFamilyShareable) == true
         expect(storeProduct.localizedTitle) == "Monthly Free Trial"
         // open the StoreKit Config file as source code to see the expected value
@@ -183,12 +175,10 @@ class StoreProductTests: StoreKitConfigTestCase {
     func testSk2PriceFormatterFormatsCorrectly() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        let productIdentifier = "com.revenuecat.monthly_4.99.1_week_intro"
         let sk2Fetcher = ProductsFetcherSK2()
 
-        let storeProductSet = try await sk2Fetcher.products(identifiers: Set([productIdentifier]))
+        let storeProduct = try await sk2Fetcher.product(withIdentifier: Self.productID)
 
-        let storeProduct = try XCTUnwrap(storeProductSet.first)
         let priceFormatter = try XCTUnwrap(storeProduct.priceFormatter)
         let productPrice = storeProduct.price as NSNumber
 
@@ -200,11 +190,8 @@ class StoreProductTests: StoreKitConfigTestCase {
     func testSk1PriceFormatterFormatsCorrectly() async throws {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
-        let productIdentifier = "com.revenuecat.monthly_4.99.1_week_intro"
+        let storeProduct = try await self.sk1Fetcher.product(withIdentifier: Self.productID)
 
-        let storeProductSet = try await self.sk1Fetcher.products(withIdentifiers: Set([productIdentifier]))
-
-        let storeProduct = try XCTUnwrap(storeProductSet.first)
         let priceFormatter = try XCTUnwrap(storeProduct.priceFormatter)
         let productPrice = storeProduct.price as NSNumber
 
@@ -219,12 +206,10 @@ class StoreProductTests: StoreKitConfigTestCase {
         testSession.locale = Locale(identifier: "es_ES")
         await changeStorefront("ESP")
 
-        let productIdentifier = "com.revenuecat.monthly_4.99.1_week_intro"
         var sk1Fetcher = ProductsFetcherSK1()
 
-        var storeProductSet = try await sk1Fetcher.products(withIdentifiers: Set([productIdentifier]))
+        var storeProduct = try await sk1Fetcher.product(withIdentifier: Self.productID)
 
-        var storeProduct = try XCTUnwrap(storeProductSet.first)
         var priceFormatter = try XCTUnwrap(storeProduct.priceFormatter)
         var productPrice = storeProduct.price as NSNumber
 
@@ -238,9 +223,8 @@ class StoreProductTests: StoreKitConfigTestCase {
         // detect Storefront changes to invalidate the cache like `ProductsFetcherSK2` does.
         sk1Fetcher = ProductsFetcherSK1()
 
-        storeProductSet = try await sk1Fetcher.products(withIdentifiers: Set([productIdentifier]))
+        storeProduct = try await sk1Fetcher.product(withIdentifier: Self.productID)
 
-        storeProduct = try XCTUnwrap(storeProductSet.first)
         priceFormatter = try XCTUnwrap(storeProduct.priceFormatter)
         productPrice = storeProduct.price as NSNumber
 
@@ -256,11 +240,8 @@ class StoreProductTests: StoreKitConfigTestCase {
 
         let sk2Fetcher = ProductsFetcherSK2()
 
-        let productIdentifier = "com.revenuecat.monthly_4.99.1_week_intro"
+        var storeProduct = try await sk2Fetcher.product(withIdentifier: Self.productID)
 
-        var storeProductSet = try await sk2Fetcher.products(identifiers: Set([productIdentifier]))
-
-        var storeProduct = try XCTUnwrap(storeProductSet.first)
         var priceFormatter = try XCTUnwrap(storeProduct.priceFormatter)
         var productPrice = storeProduct.price as NSNumber
 
@@ -269,17 +250,68 @@ class StoreProductTests: StoreKitConfigTestCase {
         testSession.locale = Locale(identifier: "en_EN")
         await changeStorefront("USA")
 
-        storeProductSet = try await sk2Fetcher.products(identifiers: Set([productIdentifier]))
+        storeProduct = try await sk2Fetcher.product(withIdentifier: Self.productID)
 
-        storeProduct = try XCTUnwrap(storeProductSet.first)
         priceFormatter = try XCTUnwrap(storeProduct.priceFormatter)
         productPrice = storeProduct.price as NSNumber
 
         expect(priceFormatter.string(from: productPrice)) == "$4.99"
     }
 
-    private func expectEqualProducts(_ productA: StoreProductType, _ productB: StoreProductType) {
+    func testSK1ProductTypeDoesNotCrash() async throws {
+        let products = try await self.sk1Fetcher.products(withIdentifiers: [Self.productID])
+        let product = try XCTUnwrap(products.first)
+
+        // The value is undefined so we don't need to check it, just making sure this does not crash
+        _ = product.productType
+    }
+
+    func testSK1SubscriptionType() async throws {
+        let subscription = try await self.sk1Fetcher.product(withIdentifier: Self.productID)
+        let inApp = try await self.sk1Fetcher.product(withIdentifier: Self.lifetimeProductID)
+
+        expect(subscription.subscriptionType) == .subscription
+        expect(inApp.subscriptionType) == .inAppPurchase
+    }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func testSK2ProductType() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        let fetcher = ProductsFetcherSK2()
+
+        let consumable = try await fetcher.product(withIdentifier: "com.revenuecat.consumable")
+        let nonConsumable = try await fetcher.product(withIdentifier: Self.lifetimeProductID)
+        let nonRenewable = try await fetcher.product(withIdentifier: "com.revenuecat.non_renewable")
+        let autoRenewable = try await fetcher.product(withIdentifier: Self.productID)
+
+        expect(consumable.productType) == .consumable
+        expect(nonConsumable.productType) == .nonConsumable
+        expect(nonRenewable.productType) == .nonRenewableSubscription
+        expect(autoRenewable.productType) == .autoRenewableSubscription
+    }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func testSK2SubscriptionType() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        let fetcher = ProductsFetcherSK2()
+
+        let subscription = try await fetcher.product(withIdentifier: Self.productID)
+        let inApp = try await fetcher.product(withIdentifier: Self.lifetimeProductID)
+
+        expect(subscription.subscriptionType) == .subscription
+        expect(inApp.subscriptionType) == .inAppPurchase
+    }
+
+}
+
+private extension StoreProductTests {
+
+    func expectEqualProducts(_ productA: StoreProductType, _ productB: StoreProductType) {
         expect(productA.productIdentifier) == productB.productIdentifier
+        // Note: can't compare productTypes because SK1 doesn't have full information
+        expect(productA.subscriptionType) == productB.subscriptionType
         expect(productA.localizedDescription) == productB.localizedDescription
         expect(productA.price) == productB.price
         expect(productA.localizedPriceString) == productB.localizedPriceString
@@ -313,7 +345,7 @@ class StoreProductTests: StoreKitConfigTestCase {
     /// Updates `SKTestSession.storefront` and waits for `Storefront.current` to reflect the change
     /// This is necessary because the change is aynchronous within `StoreKit`, and otherwise code that depends
     /// on the change might not see it in time, resulting in race conditions and flaky tests.
-    private func changeStorefront(_ new: String) async {
+    func changeStorefront(_ new: String) async {
         testSession.storefront = new
 
         if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
@@ -340,4 +372,46 @@ class StoreProductTests: StoreKitConfigTestCase {
             expect(detected).to(beTrue(), description: "Storefront change not detected")
         }
     }
+
+}
+
+private extension StoreProductTests {
+
+    enum Error: Swift.Error {
+
+        case noProductsFound
+        case multipleProductsFound
+
+    }
+
+}
+
+private extension ProductsFetcherSK1 {
+
+    func product(withIdentifier identifier: String) async throws -> StoreProduct {
+        let products = try await self.products(withIdentifiers: Set([identifier]))
+
+        switch products.count {
+        case 0: throw StoreProductTests.Error.noProductsFound
+        case 1: return StoreProduct.from(product: products.first!)
+        default: throw StoreProductTests.Error.multipleProductsFound
+        }
+    }
+
+}
+
+@MainActor
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+private extension ProductsFetcherSK2 {
+
+    func product(withIdentifier identifier: String) async throws -> StoreProduct {
+        let products = try await self.products(identifiers: Set([identifier]))
+
+        switch products.count {
+        case 0: throw StoreProductTests.Error.noProductsFound
+        case 1: return StoreProduct.from(product: products.first!)
+        default: throw StoreProductTests.Error.multipleProductsFound
+        }
+    }
+
 }

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -268,10 +268,10 @@ class StoreProductTests: StoreKitConfigTestCase {
 
     func testSK1SubscriptionType() async throws {
         let subscription = try await self.sk1Fetcher.product(withIdentifier: Self.productID)
-        let inApp = try await self.sk1Fetcher.product(withIdentifier: Self.lifetimeProductID)
+        let nonSubscription = try await self.sk1Fetcher.product(withIdentifier: Self.lifetimeProductID)
 
         expect(subscription.subscriptionType) == .subscription
-        expect(inApp.subscriptionType) == .inAppPurchase
+        expect(nonSubscription.subscriptionType) == .nonSubscription
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -298,10 +298,10 @@ class StoreProductTests: StoreKitConfigTestCase {
         let fetcher = ProductsFetcherSK2()
 
         let subscription = try await fetcher.product(withIdentifier: Self.productID)
-        let inApp = try await fetcher.product(withIdentifier: Self.lifetimeProductID)
+        let nonSubscription = try await fetcher.product(withIdentifier: Self.lifetimeProductID)
 
         expect(subscription.subscriptionType) == .subscription
-        expect(inApp.subscriptionType) == .inAppPurchase
+        expect(nonSubscription.subscriptionType) == .nonSubscription
     }
 
 }

--- a/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
+++ b/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
@@ -60,5 +60,6 @@ extension StoreKitConfigTestCase {
 extension StoreKitConfigTestCase {
 
     static let productID = "com.revenuecat.monthly_4.99.1_week_intro"
+    static let lifetimeProductID = "lifetime"
 
 }

--- a/StoreKitUnitTests/UnitTestsConfiguration.storekit
+++ b/StoreKitUnitTests/UnitTestsConfiguration.storekit
@@ -1,7 +1,21 @@
 {
   "identifier" : "B495CDA2",
   "nonRenewingSubscriptions" : [
-
+    {
+      "displayPrice" : "1.69",
+      "familyShareable" : false,
+      "internalID" : "DD970C3E",
+      "localizations" : [
+        {
+          "description" : "Non Renewable Subscription",
+          "displayName" : "Non Renewable Subscription",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "com.revenuecat.non_renewable",
+      "referenceName" : "Non Renewable",
+      "type" : "NonRenewingSubscription"
+    }
   ],
   "products" : [
     {
@@ -18,6 +32,21 @@
       "productID" : "lifetime",
       "referenceName" : "lifetime",
       "type" : "NonConsumable"
+    },
+    {
+      "displayPrice" : "1.49",
+      "familyShareable" : false,
+      "internalID" : "9CF3BDC4",
+      "localizations" : [
+        {
+          "description" : "",
+          "displayName" : "",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "com.revenuecat.consumable",
+      "referenceName" : "Consumable IAP",
+      "type" : "Consumable"
     }
   ],
   "settings" : {


### PR DESCRIPTION
Fixes [sc-13369] and #1295.

The two types provide different levels of information. For SK1, `SubscriptionType` is all the information that we can determine, but for SK2 `ProductType` provides more granularity.