### PR TITLE
Use NSDecimalNumber instead of Decimal (Decimal doesn't bridge to Objective-C correctly)

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductAPI.m
@@ -16,7 +16,7 @@
 
     NSString *localizedDescription = product.localizedDescription;
     NSString *localizedTitle = product.localizedTitle;
-    NSDecimal price = product.price;
+    NSDecimalNumber *price = product.price;
     NSString *localizedPriceString = product.localizedPriceString;
     NSString *productIdentifier = product.productIdentifier;
     BOOL isFamilyShareable = product.isFamilyShareable;

--- a/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductDiscountAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductDiscountAPI.m
@@ -15,7 +15,7 @@
     RCStoreProductDiscount *discount;
 
     NSString *offerIdentifier = discount.offerIdentifier;
-    NSDecimal price = discount.price;
+    NSDecimalNumber *price = discount.price;
     RCPaymentMode paymentMode = discount.paymentMode;
     RCSubscriptionPeriod *period = discount.subscriptionPeriod;
 

--- a/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
@@ -11,7 +11,7 @@ var product: StoreProduct!
 func checkStoreProductAPI() {
     let localizedDescription: String = product.localizedDescription
     let localizedTitle: String = product.localizedTitle
-    let price: Decimal = product.price
+    let price: NSDecimalNumber = product.price
     let localizedPriceString: String = product.localizedPriceString
     let productIdentifier: String = product.productIdentifier
     let isFamilyShareable: Bool = product.isFamilyShareable

--- a/APITesters/SwiftAPITester/SwiftAPITester/StoreProductDiscountAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/StoreProductDiscountAPI.swift
@@ -11,7 +11,7 @@ var discount: StoreProductDiscount!
 
 func checkStoreProductDiscountAPI() {
     let offerIdentifier: String? = discount.offerIdentifier
-    let price: Decimal = discount.price
+    let price: NSDecimalNumber = discount.price
     let paymentMode: StoreProductDiscount.PaymentMode = discount.paymentMode
     let subscriptionPeriod: SubscriptionPeriod = discount.subscriptionPeriod
 

--- a/Purchases/Purchasing/ProductRequestData+Initialization.swift
+++ b/Purchases/Purchasing/ProductRequestData+Initialization.swift
@@ -33,11 +33,11 @@ extension ProductRequestData {
             productIdentifier: product.productIdentifier,
             paymentMode: paymentMode,
             currencyCode: product.priceFormatter?.currencyCode,
-            price: product.price as Decimal,
+            price: product.price,
             normalDuration: normalDuration,
             introDuration: introDuration,
             introDurationType: introDurationType,
-            introPrice: introPrice as Decimal?,
+            introPrice: introPrice,
             subscriptionGroup: subscriptionGroup,
             discounts: discounts
         )

--- a/Purchases/Purchasing/ProductRequestData.swift
+++ b/Purchases/Purchasing/ProductRequestData.swift
@@ -23,11 +23,11 @@ struct ProductRequestData {
     let productIdentifier: String
     let paymentMode: StoreProductDiscount.PaymentMode?
     let currencyCode: String?
-    let price: Decimal
+    let price: NSDecimalNumber
     let normalDuration: String?
     let introDuration: String?
     let introDurationType: StoreProductDiscount.PaymentMode?
-    let introPrice: Decimal?
+    let introPrice: NSDecimalNumber?
     let subscriptionGroup: String?
     let discounts: [StoreProductDiscount]?
 

--- a/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
@@ -23,7 +23,7 @@ internal struct SK1StoreProduct: StoreProductType {
 
     var localizedDescription: String { return underlyingSK1Product.localizedDescription }
 
-    var price: Decimal { return underlyingSK1Product.price as Decimal }
+    var price: NSDecimalNumber { return underlyingSK1Product.price }
 
     var localizedPriceString: String {
         return priceFormatter?.string(from: underlyingSK1Product.price) ?? ""

--- a/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
@@ -29,7 +29,7 @@ internal struct SK1StoreProductDiscount: StoreProductDiscountType {
         } else {
             self.offerIdentifier = nil
         }
-        self.price = sk1Discount.price as Decimal
+        self.price = sk1Discount.price
         self.paymentMode = paymentMode
         self.subscriptionPeriod = subscriptionPeriod
         self.type = type
@@ -38,7 +38,7 @@ internal struct SK1StoreProductDiscount: StoreProductDiscountType {
     let underlyingSK1Discount: SK1ProductDiscount
 
     let offerIdentifier: String?
-    let price: Decimal
+    let price: NSDecimalNumber
     let paymentMode: StoreProductDiscount.PaymentMode
     let subscriptionPeriod: SubscriptionPeriod
     let type: StoreProductDiscount.DiscountType

--- a/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
@@ -32,7 +32,7 @@ internal struct SK2StoreProduct: StoreProductType {
 
     var localizedDescription: String { underlyingSK2Product.description }
 
-    var price: Decimal { underlyingSK2Product.price }
+    var price: NSDecimalNumber { underlyingSK2Product.price as NSDecimalNumber }
 
     var localizedPriceString: String { underlyingSK2Product.displayPrice }
 

--- a/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProductDiscount.swift
@@ -25,7 +25,7 @@ internal struct SK2StoreProductDiscount: StoreProductDiscountType {
         self.underlyingSK2Discount = sk2Discount
 
         self.offerIdentifier = sk2Discount.id
-        self.price = sk2Discount.price
+        self.price = sk2Discount.price as NSDecimalNumber
         self.paymentMode = paymentMode
         self.subscriptionPeriod = subscriptionPeriod
         self.type = type
@@ -34,7 +34,7 @@ internal struct SK2StoreProductDiscount: StoreProductDiscountType {
     let underlyingSK2Discount: SK2ProductDiscount
 
     let offerIdentifier: String?
-    let price: Decimal
+    let price: NSDecimalNumber
     let paymentMode: StoreProductDiscount.PaymentMode
     let subscriptionPeriod: SubscriptionPeriod
     let type: StoreProductDiscount.DiscountType

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -65,7 +65,7 @@ public typealias SK2Product = StoreKit.Product
 
     @objc public var localizedTitle: String { self.product.localizedTitle }
 
-    @objc public var price: Decimal { self.product.price }
+    @objc public var price: NSDecimalNumber { self.product.price }
 
     @objc public var localizedPriceString: String { self.product.localizedPriceString}
 
@@ -107,7 +107,7 @@ internal protocol StoreProductType {
     /// The decimal representation of the cost of the product, in local currency.
     /// For a string representation of the price to display to customers, use ``localizedPriceString``.
     /// - SeeAlso: ``pricePerMonth``.
-    var price: Decimal { get }
+    var price: NSDecimalNumber { get }
 
     /// The price of this product using ``priceFormatter``.
     var localizedPriceString: String { get }
@@ -172,7 +172,7 @@ public extension StoreProduct {
     /// - Returns: `nil` if the product is not a subscription.
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
     @objc var pricePerMonth: NSDecimalNumber? {
-        return self.subscriptionPeriod?.pricePerMonth(withTotalPrice: self.price) as NSDecimalNumber?
+        return self.subscriptionPeriod?.pricePerMonth(withTotalPrice: self.price)
     }
 
     /// The price of the `introductoryPrice` formatted using ``priceFormatter``.

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -68,7 +68,7 @@ public final class StoreProductDiscount: NSObject, StoreProductDiscountType {
     // swiftlint:disable missing_docs
 
     @objc public var offerIdentifier: String? { self.discount.offerIdentifier }
-    @objc public var price: Decimal { self.discount.price }
+    @objc public var price: NSDecimalNumber { self.discount.price }
     @objc public var paymentMode: PaymentMode { self.discount.paymentMode }
     @objc public var subscriptionPeriod: SubscriptionPeriod { self.discount.subscriptionPeriod }
     @objc public var type: DiscountType { self.discount.type }
@@ -110,7 +110,7 @@ internal protocol StoreProductDiscountType {
     var offerIdentifier: String? { get }
 
     /// The discount price of the product in the local currency.
-    var price: Decimal { get }
+    var price: NSDecimalNumber { get }
 
     /// The payment mode for this product discount.
     var paymentMode: StoreProductDiscount.PaymentMode { get }

--- a/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
@@ -97,7 +97,7 @@ public extension SubscriptionPeriod {
 }
 
 extension SubscriptionPeriod {
-    func pricePerMonth(withTotalPrice price: Decimal) -> Decimal {
+    func pricePerMonth(withTotalPrice price: NSDecimalNumber) -> NSDecimalNumber {
         let periodsPerMonth: Decimal = {
             switch self.unit {
             case .day: return 1 / 30
@@ -109,7 +109,7 @@ extension SubscriptionPeriod {
 
         return (price as NSDecimalNumber)
             .dividing(by: periodsPerMonth as NSDecimalNumber,
-                      withBehavior: Self.roundingBehavior) as Decimal
+                      withBehavior: Self.roundingBehavior)
     }
 
     private static let roundingBehavior = NSDecimalNumberHandler(

--- a/PurchasesTests/Mocks/MockSK1Product.swift
+++ b/PurchasesTests/Mocks/MockSK1Product.swift
@@ -29,7 +29,7 @@ class MockSK1Product: SK1Product {
         return mockPriceLocale ?? Locale(identifier: "en_US")
     }
 
-    var mockPrice: Decimal?
+    var mockPrice: NSDecimalNumber?
     override var price: NSDecimalNumber {
         return (mockPrice ?? 2.99) as NSDecimalNumber
     }

--- a/PurchasesTests/Mocks/MockSKProductDiscount.swift
+++ b/PurchasesTests/Mocks/MockSKProductDiscount.swift
@@ -13,7 +13,7 @@ class MockSKProductDiscount: SKProductDiscount {
         return mockPaymentMode ?? SKProductDiscount.PaymentMode.payAsYouGo
     }
 
-    var mockPrice: Decimal?
+    var mockPrice: NSDecimalNumber?
     override var price: NSDecimalNumber {
         return (mockPrice as NSDecimalNumber?) ?? 1.99
     }

--- a/PurchasesTests/Mocks/MockStoreProductDiscount.swift
+++ b/PurchasesTests/Mocks/MockStoreProductDiscount.swift
@@ -15,7 +15,7 @@
 
 struct MockStoreProductDiscount: StoreProductDiscountType {
     let offerIdentifier: String?
-    let price: Decimal
+    let price: NSDecimalNumber
     let paymentMode: StoreProductDiscount.PaymentMode
     let subscriptionPeriod: SubscriptionPeriod
     let type: StoreProductDiscount.DiscountType

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -409,7 +409,7 @@ class BackendTests: XCTestCase {
 
         let productIdentifier = "a_great_product"
         let offeringIdentifier = "a_offering"
-        let price: Decimal = 10.98
+        let price: NSDecimalNumber = 10.98
         let group = "sub_group"
 
         let currencyCode = "BFD"
@@ -1258,7 +1258,7 @@ class BackendTests: XCTestCase {
         httpClient.mock(requestPath: "/receipts", response: response)
 
         let productIdentifier = "a_great_product"
-        let price: Decimal = 15.99
+        let price: NSDecimalNumber = 15.99
         let group = "sub_group"
         let currencyCode = "BFD"
         let paymentMode: StoreProductDiscount.PaymentMode? = nil

--- a/PurchasesTests/Purchasing/ProductRequestDataExtensions.swift
+++ b/PurchasesTests/Purchasing/ProductRequestDataExtensions.swift
@@ -10,11 +10,11 @@ extension ProductRequestData {
     static func createMockProductData(productIdentifier: String = "product_id",
                                       paymentMode: StoreProductDiscount.PaymentMode? = nil,
                                       currencyCode: String = "UYU",
-                                      price: Decimal = 15.99,
+                                      price: NSDecimalNumber = 15.99,
                                       normalDuration: String? = nil,
                                       introDuration: String? = nil,
                                       introDurationType: StoreProductDiscount.PaymentMode? = nil,
-                                      introPrice: Decimal? = nil,
+                                      introPrice: NSDecimalNumber? = nil,
                                       subscriptionGroup: String? = nil,
                                       discounts: [StoreProductDiscountType]? = nil) -> ProductRequestData {
         ProductRequestData(productIdentifier: productIdentifier,

--- a/PurchasesTests/Purchasing/ProductRequestDataInitializationTests.swift
+++ b/PurchasesTests/Purchasing/ProductRequestDataInitializationTests.swift
@@ -25,7 +25,7 @@ class ProductRequestDataSK1ProductInitializationTests: XCTestCase {
     }
 
     func testExtractInfoFromProductExtractsPrice() {
-        let price: Decimal = 10.99
+        let price: NSDecimalNumber = 10.99
         product.mockPrice = price
 
         let receivedProductData = self.extract()
@@ -159,7 +159,7 @@ class ProductRequestDataSK1ProductInitializationTests: XCTestCase {
             let mockDiscount = MockSKProductDiscount()
             let paymentMode: SKProductDiscount.PaymentMode = .freeTrial
             mockDiscount.mockPaymentMode = paymentMode
-            let price: Decimal = 10.99
+            let price: NSDecimalNumber = 10.99
             mockDiscount.mockPrice = price
             let discountID = "cool_discount"
             mockDiscount.mockIdentifier = discountID

--- a/PurchasesTests/Purchasing/ProductRequestDataTests.swift
+++ b/PurchasesTests/Purchasing/ProductRequestDataTests.swift
@@ -43,7 +43,7 @@ class ProductRequestDataTests: XCTestCase {
 
     func testAsDictionaryConvertsPriceCorrectly() throws {
         let price: NSDecimalNumber = 9.99
-        let productData: ProductRequestData = .createMockProductData(price: price as Decimal)
+        let productData: ProductRequestData = .createMockProductData(price: price)
         expect(try productData.asDictionary()["price"] as? String) == price.description
     }
 
@@ -79,7 +79,7 @@ class ProductRequestDataTests: XCTestCase {
 
     func testAsDictionaryConvertsIntroPriceCorrectly() throws {
         let introPrice: NSDecimalNumber = 6.99
-        let productData: ProductRequestData = .createMockProductData(introPrice: introPrice as Decimal)
+        let productData: ProductRequestData = .createMockProductData(introPrice: introPrice)
         expect(try productData.asDictionary()["introductory_price"] as? String) == introPrice.description
     }
 

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -117,9 +117,9 @@ class PurchasesTests: XCTestCase {
         var postedReceiptData: Data?
         var postedIsRestore: Bool?
         var postedProductID: String?
-        var postedPrice: Decimal?
+        var postedPrice: NSDecimalNumber?
         var postedPaymentMode: StoreProductDiscount.PaymentMode?
-        var postedIntroPrice: Decimal?
+        var postedIntroPrice: NSDecimalNumber?
         var postedCurrencyCode: String?
         var postedSubscriptionGroup: String?
         var postedDiscounts: [StoreProductDiscount]?
@@ -821,7 +821,7 @@ class PurchasesTests: XCTestCase {
             expect(self.backend.postedReceiptData).toNot(beNil())
 
             expect(self.backend.postedProductID).to(equal(product.productIdentifier))
-            expect(self.backend.postedPrice).to(equal(product.price as Decimal))
+            expect(self.backend.postedPrice).to(equal(product.price))
 
             if #available(iOS 11.2, tvOS 11.2, macOS 10.13.2, *) {
                 expect(self.backend.postedPaymentMode).to(equal(StoreProductDiscount.PaymentMode.payAsYouGo))
@@ -1486,7 +1486,7 @@ class PurchasesTests: XCTestCase {
 
         expect(self.backend.postReceiptDataCalled).to(beTrue())
         expect(self.backend.postedProductID).to(equal(product.productIdentifier))
-        expect(self.backend.postedPrice).to(equal(product.price as Decimal))
+        expect(self.backend.postedPrice).to(equal(product.price))
     }
 
     func testPromoPaymentDelegateMethodCachesProduct() {
@@ -1837,7 +1837,7 @@ class PurchasesTests: XCTestCase {
             expect(self.backend.postedReceiptData).toNot(beNil())
 
             expect(self.backend.postedProductID).to(equal(product.productIdentifier))
-            expect(self.backend.postedPrice).to(equal(product.price as Decimal))
+            expect(self.backend.postedPrice).to(equal(product.price))
             expect(self.backend.postedCurrencyCode).to(equal(product.priceLocale.currencyCode))
 
             expect(self.storeKitWrapper.finishCalled).toEventually(beTrue())

--- a/PurchasesTests/Purchasing/StoreKitAbstractions/SubscriptionPeriodTests.swift
+++ b/PurchasesTests/Purchasing/StoreKitAbstractions/SubscriptionPeriodTests.swift
@@ -46,7 +46,7 @@ class SubscriptionPeriodTests: XCTestCase {
     // Note: can't test creation from `StoreKit.Product.SubscriptionPeriod` because it has no public constructors.
 
     func testPricePerMonth() {
-        let expectations: [(period: SubscriptionPeriod, price: Decimal, expected: Decimal)] = [
+        let expectations: [(period: SubscriptionPeriod, price: NSDecimalNumber, expected: Decimal)] = [
             (p(1, .day), 2, 60),
             (p(15, .day), 5, 10),
             (p(1, .week), 10, 40),


### PR DESCRIPTION
### Motivation
- Hybrid common migration to v4 - https://github.com/RevenueCat/purchases-hybrid-common/pull/113
- `Decimal` bridges to `NSDecimal` when using Objective-C which is not usable (https://forums.swift.org/t/decimal-imported-as-nsdecimal-not-nsdecimalnumber-in-swift-3-to-objective-c/4498)

We'd expect `Decimal` to bridge to `NSDecimalNumber` but it does not

### Description
`StoreProduct` and `StoreProductDiscount` now use `NSDecimalNumber` for price instead of `Decimal`
