### PR TITLE
Add currency code to store product and store product discount

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductAPI.m
@@ -16,6 +16,7 @@
 
     NSString *localizedDescription = product.localizedDescription;
     NSString *localizedTitle = product.localizedTitle;
+    NSString *currencyCode = product.currencyCode;
     NSDecimal price = product.price;
     NSString *localizedPriceString = product.localizedPriceString;
     NSString *productIdentifier = product.productIdentifier;
@@ -34,6 +35,7 @@
           product,
           localizedDescription,
           localizedTitle,
+          currencyCode,
           price,
           localizedPriceString,
           productIdentifier,

--- a/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductDiscountAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductDiscountAPI.m
@@ -15,12 +15,14 @@
     RCStoreProductDiscount *discount;
 
     NSString *offerIdentifier = discount.offerIdentifier;
+    NSString *currencyCode = discount.currencyCode;
     NSDecimal price = discount.price;
     RCPaymentMode paymentMode = discount.paymentMode;
     RCSubscriptionPeriod *period = discount.subscriptionPeriod;
 
     NSLog(
           offerIdentifier,
+          currencyCode,
           price,
           paymentMode,
           period

--- a/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
@@ -11,6 +11,7 @@ var product: StoreProduct!
 func checkStoreProductAPI() {
     let localizedDescription: String = product.localizedDescription
     let localizedTitle: String = product.localizedTitle
+    let currencyCode: String? = product.currencyCode
     let price: Decimal = product.price
     let localizedPriceString: String = product.localizedPriceString
     let productIdentifier: String = product.productIdentifier
@@ -36,6 +37,7 @@ func checkStoreProductAPI() {
         product!,
         localizedDescription,
         localizedTitle,
+        currencyCode!,
         price,
         localizedPriceString,
         productIdentifier,

--- a/APITesters/SwiftAPITester/SwiftAPITester/StoreProductDiscountAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/StoreProductDiscountAPI.swift
@@ -11,12 +11,14 @@ var discount: StoreProductDiscount!
 
 func checkStoreProductDiscountAPI() {
     let offerIdentifier: String? = discount.offerIdentifier
+    let currentyCode: String? = discount.currencyCode
     let price: Decimal = discount.price
     let paymentMode: StoreProductDiscount.PaymentMode = discount.paymentMode
     let subscriptionPeriod: SubscriptionPeriod = discount.subscriptionPeriod
 
     print(
         offerIdentifier!,
+        currentyCode!,
         price,
         paymentMode,
         subscriptionPeriod

--- a/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
@@ -23,6 +23,8 @@ internal struct SK1StoreProduct: StoreProductType {
 
     var localizedDescription: String { return underlyingSK1Product.localizedDescription }
 
+    var currencyCode: String? { return underlyingSK1Product.priceLocale.currencyCode }
+
     var price: Decimal { return underlyingSK1Product.price as Decimal }
 
     var localizedPriceString: String {

--- a/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
@@ -29,6 +29,7 @@ internal struct SK1StoreProductDiscount: StoreProductDiscountType {
         } else {
             self.offerIdentifier = nil
         }
+        self.currencyCode = sk1Discount.priceLocale.currencyCode
         self.price = sk1Discount.price as Decimal
         self.paymentMode = paymentMode
         self.subscriptionPeriod = subscriptionPeriod
@@ -38,6 +39,7 @@ internal struct SK1StoreProductDiscount: StoreProductDiscountType {
     let underlyingSK1Discount: SK1ProductDiscount
 
     let offerIdentifier: String?
+    let currencyCode: String?
     let price: Decimal
     let paymentMode: StoreProductDiscount.PaymentMode
     let subscriptionPeriod: SubscriptionPeriod

--- a/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
@@ -80,12 +80,12 @@ internal struct SK2StoreProduct: StoreProductType {
 
     var introductoryDiscount: StoreProductDiscount? {
         self.underlyingSK2Product.subscription?.introductoryOffer
-            .flatMap({ StoreProductDiscount(sk2Discount: $0, currencyCode: self.currencyCode)  })
+            .flatMap { StoreProductDiscount(sk2Discount: $0, currencyCode: self.currencyCode)  }
     }
 
     var discounts: [StoreProductDiscount] {
         (self.underlyingSK2Product.subscription?.promotionalOffers ?? [])
-            .compactMap({ StoreProductDiscount(sk2Discount: $0, currencyCode: self.currencyCode)  })
+            .compactMap { StoreProductDiscount(sk2Discount: $0, currencyCode: self.currencyCode)  }
     }
 
 }

--- a/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
@@ -80,12 +80,12 @@ internal struct SK2StoreProduct: StoreProductType {
 
     var introductoryDiscount: StoreProductDiscount? {
         self.underlyingSK2Product.subscription?.introductoryOffer
-            .flatMap { StoreProductDiscount(sk2Discount: $0, currencyCode: self.currencyCode)  }
+            .flatMap { StoreProductDiscount(sk2Discount: $0, currencyCode: self.currencyCode) }
     }
 
     var discounts: [StoreProductDiscount] {
         (self.underlyingSK2Product.subscription?.promotionalOffers ?? [])
-            .compactMap { StoreProductDiscount(sk2Discount: $0, currencyCode: self.currencyCode)  }
+            .compactMap { StoreProductDiscount(sk2Discount: $0, currencyCode: self.currencyCode) }
     }
 
 }

--- a/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
@@ -32,6 +32,14 @@ internal struct SK2StoreProduct: StoreProductType {
 
     var localizedDescription: String { underlyingSK2Product.description }
 
+    var currencyCode: String? {
+        // note: if we ever need more information from the jsonRepresentation object, we
+        // should use Codable or another decoding method to clean up this code.
+        let attributes = jsonDict["attributes"] as? [String: Any]
+        let offers = attributes?["offers"] as? [[String: Any]]
+        return offers?.first?["currencyCode"] as? String
+    }
+
     var price: Decimal { underlyingSK2Product.price }
 
     var localizedPriceString: String { underlyingSK2Product.displayPrice }
@@ -43,14 +51,10 @@ internal struct SK2StoreProduct: StoreProductType {
     var localizedTitle: String { underlyingSK2Product.displayName }
 
     var priceFormatter: NumberFormatter? {
-        // note: if we ever need more information from the jsonRepresentation object, we
-        // should use Codable or another decoding method to clean up this code.
-        guard let attributes = jsonDict["attributes"] as? [String: Any],
-              let offers = attributes["offers"] as? [[String: Any]],
-              let currencyCode: String = offers.first?["currencyCode"] as? String else {
-                  Logger.appleError("Can't initialize priceFormatter for SK2 product! Could not find the currency code")
-                  return nil
-              }
+        guard let currencyCode = self.currencyCode else {
+          Logger.appleError("Can't initialize priceFormatter for SK2 product! Could not find the currency code")
+          return nil
+      }
         let formatter = NumberFormatter()
         formatter.numberStyle = .currency
         formatter.currencyCode = currencyCode
@@ -76,12 +80,12 @@ internal struct SK2StoreProduct: StoreProductType {
 
     var introductoryDiscount: StoreProductDiscount? {
         self.underlyingSK2Product.subscription?.introductoryOffer
-            .flatMap(StoreProductDiscount.init)
+            .flatMap({ StoreProductDiscount(sk2Discount: $0, currencyCode: self.currencyCode)  })
     }
 
     var discounts: [StoreProductDiscount] {
         (self.underlyingSK2Product.subscription?.promotionalOffers ?? [])
-            .compactMap(StoreProductDiscount.init)
+            .compactMap({ StoreProductDiscount(sk2Discount: $0, currencyCode: self.currencyCode)  })
     }
 
 }

--- a/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProductDiscount.swift
@@ -40,6 +40,7 @@ internal struct SK2StoreProductDiscount: StoreProductDiscountType {
     let paymentMode: StoreProductDiscount.PaymentMode
     let subscriptionPeriod: SubscriptionPeriod
     let type: StoreProductDiscount.DiscountType
+
 }
 
 private extension StoreProductDiscount.PaymentMode {

--- a/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/SK2StoreProductDiscount.swift
@@ -16,7 +16,7 @@ import StoreKit
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 internal struct SK2StoreProductDiscount: StoreProductDiscountType {
 
-    init?(sk2Discount: SK2ProductDiscount) {
+    init?(sk2Discount: SK2ProductDiscount, currencyCode: String?) {
         guard let paymentMode = StoreProductDiscount.PaymentMode(subscriptionOfferPaymentMode: sk2Discount.paymentMode),
               let subscriptionPeriod = SubscriptionPeriod.from(sk2SubscriptionPeriod: sk2Discount.period),
               let type = StoreProductDiscount.DiscountType.from(sk2Discount: sk2Discount)
@@ -25,6 +25,7 @@ internal struct SK2StoreProductDiscount: StoreProductDiscountType {
         self.underlyingSK2Discount = sk2Discount
 
         self.offerIdentifier = sk2Discount.id
+        self.currencyCode = currencyCode
         self.price = sk2Discount.price
         self.paymentMode = paymentMode
         self.subscriptionPeriod = subscriptionPeriod
@@ -34,11 +35,11 @@ internal struct SK2StoreProductDiscount: StoreProductDiscountType {
     let underlyingSK2Discount: SK2ProductDiscount
 
     let offerIdentifier: String?
+    let currencyCode: String?
     let price: Decimal
     let paymentMode: StoreProductDiscount.PaymentMode
     let subscriptionPeriod: SubscriptionPeriod
     let type: StoreProductDiscount.DiscountType
-
 }
 
 private extension StoreProductDiscount.PaymentMode {

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -65,6 +65,8 @@ public typealias SK2Product = StoreKit.Product
 
     @objc public var localizedTitle: String { self.product.localizedTitle }
 
+    @objc public var currencyCode: String? { self.product.currencyCode }
+
     @objc public var price: Decimal { self.product.price }
 
     @objc public var localizedPriceString: String { self.product.localizedPriceString}
@@ -103,6 +105,9 @@ internal protocol StoreProductType {
     /// - Note: The title's language is determined by the storefront that the user's device is connected to,
     /// not the preferred language set on the device.
     var localizedTitle: String { get }
+
+    /// The ccurrency of the product's price.
+    var currencyCode: String? { get }
 
     /// The decimal representation of the cost of the product, in local currency.
     /// For a string representation of the price to display to customers, use ``localizedPriceString``.

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -110,7 +110,7 @@ internal protocol StoreProductDiscountType {
     /// A string used to uniquely identify a discount offer for a product.
     var offerIdentifier: String? { get }
 
-    /// The ccurrency of the product's price.
+    /// The currency of the product's price.
     var currencyCode: String? { get }
 
     /// The discount price of the product in the local currency.

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -68,6 +68,7 @@ public final class StoreProductDiscount: NSObject, StoreProductDiscountType {
     // swiftlint:disable missing_docs
 
     @objc public var offerIdentifier: String? { self.discount.offerIdentifier }
+    @objc public var currencyCode: String? { self.discount.currencyCode }
     @objc public var price: Decimal { self.discount.price }
     @objc public var paymentMode: PaymentMode { self.discount.paymentMode }
     @objc public var subscriptionPeriod: SubscriptionPeriod { self.discount.subscriptionPeriod }
@@ -109,6 +110,9 @@ internal protocol StoreProductDiscountType {
     /// A string used to uniquely identify a discount offer for a product.
     var offerIdentifier: String? { get }
 
+    /// The ccurrency of the product's price.
+    var currencyCode: String? { get }
+
     /// The discount price of the product in the local currency.
     var price: Decimal { get }
 
@@ -135,8 +139,9 @@ extension StoreProductDiscount {
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    internal convenience init?(sk2Discount: SK2ProductDiscount) {
-        guard let discount = SK2StoreProductDiscount(sk2Discount: sk2Discount) else { return nil }
+    internal convenience init?(sk2Discount: SK2ProductDiscount, currencyCode: String?) {
+        guard let discount = SK2StoreProductDiscount(sk2Discount: sk2Discount,
+                                                     currencyCode: currencyCode) else { return nil }
 
         self.init(discount)
     }

--- a/PurchasesTests/Mocks/MockSKProductDiscount.swift
+++ b/PurchasesTests/Mocks/MockSKProductDiscount.swift
@@ -13,6 +13,11 @@ class MockSKProductDiscount: SKProductDiscount {
         return mockPaymentMode ?? SKProductDiscount.PaymentMode.payAsYouGo
     }
 
+    var mockLocale: Locale?
+    override var priceLocale: Locale {
+        return mockLocale ?? Locale(identifier: "USD")
+    }
+
     var mockPrice: Decimal?
     override var price: NSDecimalNumber {
         return (mockPrice as NSDecimalNumber?) ?? 1.99

--- a/PurchasesTests/Mocks/MockStoreProductDiscount.swift
+++ b/PurchasesTests/Mocks/MockStoreProductDiscount.swift
@@ -15,6 +15,7 @@
 
 struct MockStoreProductDiscount: StoreProductDiscountType {
     let offerIdentifier: String?
+    let currencyCode: String?
     let price: Decimal
     let paymentMode: StoreProductDiscount.PaymentMode
     let subscriptionPeriod: SubscriptionPeriod

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -1237,6 +1237,7 @@ class BackendTests: XCTestCase {
         })
 
         let discount = MockStoreProductDiscount(offerIdentifier: "offerid",
+                                                currencyCode: "USD",
                                                 price: 12,
                                                 paymentMode: .payAsYouGo,
                                                 subscriptionPeriod: .init(value: 10, unit: .month),
@@ -1269,6 +1270,7 @@ class BackendTests: XCTestCase {
         let paymentMode: StoreProductDiscount.PaymentMode? = nil
         var completionCalled = false
         let discount = MockStoreProductDiscount(offerIdentifier: "offerid",
+                                                currencyCode: currencyCode,
                                                 price: 12.1,
                                                 paymentMode: .payAsYouGo,
                                                 subscriptionPeriod: .init(value: 1, unit: .year),

--- a/PurchasesTests/Purchasing/ProductRequestDataTests.swift
+++ b/PurchasesTests/Purchasing/ProductRequestDataTests.swift
@@ -91,18 +91,21 @@ class ProductRequestDataTests: XCTestCase {
 
     func testAsDictionaryConvertsDiscountsCorrectly() throws {
         let discount1 = MockStoreProductDiscount(offerIdentifier: "offerid1",
+                                                 currencyCode: "USD",
                                                  price: 11.1,
                                                  paymentMode: .payAsYouGo,
                                                  subscriptionPeriod: .init(value: 1, unit: .month),
                                                  type: .promotional)
 
         let discount2 = MockStoreProductDiscount(offerIdentifier: "offerid2",
+                                                 currencyCode: "USD",
                                                  price: 12.2,
                                                  paymentMode: .payUpFront,
                                                  subscriptionPeriod: .init(value: 5, unit: .week),
                                                  type: .promotional)
 
         let discount3 = MockStoreProductDiscount(offerIdentifier: "offerid3",
+                                                 currencyCode: "USD",
                                                  price: 13.3,
                                                  paymentMode: .freeTrial,
                                                  subscriptionPeriod: .init(value: 3, unit: .month),
@@ -128,18 +131,21 @@ class ProductRequestDataTests: XCTestCase {
 
     func testEncoding() throws {
         let discount1 = MockStoreProductDiscount(offerIdentifier: "offerid1",
+                                                 currencyCode: "USD",
                                                  price: 11.2,
                                                  paymentMode: .payAsYouGo,
                                                  subscriptionPeriod: .init(value: 1, unit: .month),
                                                  type: .promotional)
 
         let discount2 = MockStoreProductDiscount(offerIdentifier: "offerid2",
+                                                 currencyCode: "USD",
                                                  price: 12.2,
                                                  paymentMode: .payUpFront,
                                                  subscriptionPeriod: .init(value: 2, unit: .year),
                                                  type: .promotional)
 
         let discount3 = MockStoreProductDiscount(offerIdentifier: "offerid3",
+                                                 currencyCode: "USD",
                                                  price: 13.3,
                                                  paymentMode: .freeTrial,
                                                  subscriptionPeriod: .init(value: 3, unit: .day),
@@ -163,18 +169,21 @@ class ProductRequestDataTests: XCTestCase {
         guard #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *) else { return }
 
         let discount1 = MockStoreProductDiscount(offerIdentifier: "offerid1",
+                                                 currencyCode: "USD",
                                                  price: 11,
                                                  paymentMode: .payAsYouGo,
                                                  subscriptionPeriod: .init(value: 1, unit: .month),
                                                  type: .promotional)
 
         let discount2 = MockStoreProductDiscount(offerIdentifier: "offerid2",
+                                                 currencyCode: "USD",
                                                  price: 12,
                                                  paymentMode: .payUpFront,
                                                  subscriptionPeriod: .init(value: 2, unit: .year),
                                                  type: .promotional)
 
         let discount3 = MockStoreProductDiscount(offerIdentifier: "offerid3",
+                                                 currencyCode: "USD",
                                                  price: 13,
                                                  paymentMode: .freeTrial,
                                                  subscriptionPeriod: .init(value: 3, unit: .day),

--- a/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -139,6 +139,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         let product = try await fetchSk1Product()
 
         let storeProductDiscount = MockStoreProductDiscount(offerIdentifier: "offerid1",
+                                                            currencyCode: product.priceLocale.currencyCode,
                                                             price: 11.1,
                                                             paymentMode: .payAsYouGo,
                                                             subscriptionPeriod: .init(value: 1, unit: .month),
@@ -168,6 +169,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                               offeringIdentifier: "offering")
 
         let discount = MockStoreProductDiscount(offerIdentifier: "offerid1",
+                                                currencyCode: storeProduct.currencyCode,
                                                 price: 11.1,
                                                 paymentMode: .payAsYouGo,
                                                 subscriptionPeriod: .init(value: 1, unit: .month),
@@ -266,7 +268,9 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
 
         let product = try await fetchSk2Product()
+        let storeProduct = StoreProduct(sk2Product: product)
         let discount = MockStoreProductDiscount(offerIdentifier: "offerid1",
+                                                currencyCode: storeProduct.currencyCode,
                                                 price: 11.1,
                                                 paymentMode: .payAsYouGo,
                                                 subscriptionPeriod: .init(value: 1, unit: .month),
@@ -344,8 +348,10 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         backend.stubbedPostOfferCompetionResult = ("signature", "identifier", UUID(), 12345, nil)
 
         let product = try await fetchSk2Product()
+        let storeProduct = StoreProduct(sk2Product: product)
 
         let storeProductDiscount = MockStoreProductDiscount(offerIdentifier: "offerid1",
+                                                            currencyCode: storeProduct.currencyCode,
                                                             price: 11.1,
                                                             paymentMode: .payAsYouGo,
                                                             subscriptionPeriod: .init(value: 1, unit: .month),

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -231,6 +231,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         var productPrice = storeProduct.price as NSNumber
 
         expect(priceFormatter.string(from: productPrice)) == "4,99 €"
+        expect(storeProduct.currencyCode) == "EUR"
 
         testSession.locale = Locale(identifier: "en_EN")
         await changeStorefront("USA")
@@ -247,6 +248,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         productPrice = storeProduct.price as NSNumber
 
         expect(priceFormatter.string(from: productPrice)) == "$4.99"
+        expect(storeProduct.currencyCode) == "USD"
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -267,6 +269,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         var productPrice = storeProduct.price as NSNumber
 
         expect(priceFormatter.string(from: productPrice)) == "€4.99"
+        expect(storeProduct.currencyCode) == "EUR"
 
         testSession.locale = Locale(identifier: "en_EN")
         await changeStorefront("USA")
@@ -278,6 +281,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         productPrice = storeProduct.price as NSNumber
 
         expect(priceFormatter.string(from: productPrice)) == "$4.99"
+        expect(storeProduct.currencyCode) == "USD"
     }
 
     private func expectEqualProducts(_ productA: StoreProductType, _ productB: StoreProductType) {

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -91,6 +91,7 @@ class StoreProductTests: StoreKitConfigTestCase {
 
         expect(storeProduct.productIdentifier) == "com.revenuecat.monthly_4.99.1_week_intro"
         expect(storeProduct.localizedDescription) == "Monthly subscription with a 1-week free trial"
+        expect(storeProduct.currencyCode) == "USD"
         expect(storeProduct.price.description) == "4.99"
         expect(storeProduct.localizedPriceString) == "$4.99"
         expect(storeProduct.productIdentifier) == productIdentifier
@@ -143,6 +144,7 @@ class StoreProductTests: StoreKitConfigTestCase {
 
         expect(storeProduct.productIdentifier) == "com.revenuecat.monthly_4.99.1_week_intro"
         expect(storeProduct.localizedDescription) == "Monthly subscription with a 1-week free trial"
+        expect(storeProduct.currencyCode) == "USD"
         expect(storeProduct.price.description) == "4.99"
         expect(storeProduct.localizedPriceString) == "$4.99"
         expect(storeProduct.productIdentifier) == productIdentifier


### PR DESCRIPTION
### Motivation
- Needed for hybrid common migration
  - https://github.com/RevenueCat/purchases-hybrid-common/pull/113

### Description
- Added as `String?` because it never seemed like it was guaranteed anywhere 😬 
- Added `currencyCode` to `StoreProduct`
- Added `currencyCode` to `StoreProductDiscount`
  - `SK2StoreProductDiscount` takes `currencyCode` in initializer as currency code can only be fetched from `SK2StoreProduct`