### PR TITLE
Improved `StoreProduct.price` and `StoreProductDiscount.price` type for Objective-C

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductAPI.m
@@ -17,7 +17,7 @@
     NSString *localizedDescription = product.localizedDescription;
     NSString *localizedTitle = product.localizedTitle;
     NSString *currencyCode = product.currencyCode;
-    NSDecimal price = product.price;
+    NSDecimalNumber *price = product.price;
     NSString *localizedPriceString = product.localizedPriceString;
     NSString *productIdentifier = product.productIdentifier;
     BOOL isFamilyShareable = product.isFamilyShareable;

--- a/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductDiscountAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductDiscountAPI.m
@@ -16,7 +16,7 @@
 
     NSString *offerIdentifier = discount.offerIdentifier;
     NSString *currencyCode = discount.currencyCode;
-    NSDecimal price = discount.price;
+    NSDecimalNumber *price = discount.price;
     NSString *localizedPriceString = discount.localizedPriceString;
     RCPaymentMode paymentMode = discount.paymentMode;
     RCSubscriptionPeriod *period = discount.subscriptionPeriod;

--- a/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
@@ -17,6 +17,8 @@ func checkStoreProductAPI() {
     let localizedTitle: String = product.localizedTitle
     let currencyCode: String? = product.currencyCode
     let price: Decimal = product.price
+    // This is mainly for Objective-C
+    let decimalPrice: NSDecimalNumber = product.priceDecimalNumber
     let localizedPriceString: String = product.localizedPriceString
     let productIdentifier: String = product.productIdentifier
     let isFamilyShareable: Bool = product.isFamilyShareable
@@ -45,6 +47,7 @@ func checkStoreProductAPI() {
         localizedTitle,
         currencyCode!,
         price,
+        decimalPrice,
         localizedPriceString,
         productIdentifier,
         isFamilyShareable,

--- a/APITesters/SwiftAPITester/SwiftAPITester/StoreProductDiscountAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/StoreProductDiscountAPI.swift
@@ -13,6 +13,8 @@ func checkStoreProductDiscountAPI() {
     let offerIdentifier: String? = discount.offerIdentifier
     let currentyCode: String? = discount.currencyCode
     let price: Decimal = discount.price
+    // This is mainly for Objective-C
+    let decimalPrice: NSDecimalNumber = discount.priceDecimalNumber
     let localizedPriceString: String = discount.localizedPriceString
     let paymentMode: StoreProductDiscount.PaymentMode = discount.paymentMode
     let priceFormatter: NumberFormatter? = product.priceFormatter
@@ -22,6 +24,7 @@ func checkStoreProductDiscountAPI() {
         offerIdentifier!,
         currentyCode!,
         price,
+        decimalPrice,
         localizedPriceString,
         paymentMode,
         priceFormatter!,

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -71,7 +71,8 @@ public typealias SK2Product = StoreKit.Product
 
     @objc public var currencyCode: String? { self.product.currencyCode }
 
-    @objc public var price: Decimal { self.product.price }
+    // See also `priceDecimalNumber` for Objective-C
+    public var price: Decimal { self.product.price }
 
     @objc public var localizedPriceString: String { self.product.localizedPriceString}
 
@@ -190,6 +191,14 @@ internal protocol StoreProductType {
 }
 
 public extension StoreProduct {
+
+    /// The decimal representation of the cost of the product, in local currency.
+    /// For a string representation of the price to display to customers, use ``localizedPriceString``.
+    /// - Note: this is meant for  Objective-C. For Swift, use ``price`` instead.
+    /// - SeeAlso: ``pricePerMonth``.
+    @objc(price) var priceDecimalNumber: NSDecimalNumber {
+        return self.price as NSDecimalNumber
+    }
 
     /// Calculates the price of this subscription product per month.
     /// - Returns: `nil` if the product is not a subscription.

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -69,7 +69,8 @@ public final class StoreProductDiscount: NSObject, StoreProductDiscountType {
 
     @objc public var offerIdentifier: String? { self.discount.offerIdentifier }
     @objc public var currencyCode: String? { self.discount.currencyCode }
-    @objc public var price: Decimal { self.discount.price }
+    // See also `priceDecimalNumber` for Objective-C
+    public var price: Decimal { self.discount.price }
     @objc public var localizedPriceString: String { self.discount.localizedPriceString }
     @objc public var paymentMode: PaymentMode { self.discount.paymentMode }
     @objc public var subscriptionPeriod: SubscriptionPeriod { self.discount.subscriptionPeriod }
@@ -101,6 +102,16 @@ public final class StoreProductDiscount: NSObject, StoreProductDiscountType {
         hasher.combine(self.subscriptionPeriod)
 
         return hasher.finalize()
+    }
+
+}
+
+public extension StoreProductDiscount {
+
+    /// The discount price of the product in the local currency.
+    /// - Note: this is meant for  Objective-C. For Swift, use ``price`` instead.
+    @objc(price) var priceDecimalNumber: NSDecimalNumber {
+        return self.price as NSDecimalNumber
     }
 
 }

--- a/StoreKitUnitTests/StoreProductTests.swift
+++ b/StoreKitUnitTests/StoreProductTests.swift
@@ -91,6 +91,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(storeProduct.localizedDescription) == "Monthly subscription with a 1-week free trial"
         expect(storeProduct.currencyCode) == "USD"
         expect(storeProduct.price.description) == "4.99"
+        expect(storeProduct.priceDecimalNumber).to(beCloseTo(4.99))
         expect(storeProduct.localizedPriceString) == "$4.99"
         expect(storeProduct.isFamilyShareable) == true
         expect(storeProduct.localizedTitle) == "Monthly Free Trial"
@@ -103,6 +104,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         let intro = try XCTUnwrap(storeProduct.introductoryDiscount)
 
         expect(intro.price) == 0.0
+        expect(intro.priceDecimalNumber) == 0.0
         expect(intro.paymentMode) == .freeTrial
         expect(intro.offerIdentifier).to(beNil())
         expect(intro.subscriptionPeriod) == SubscriptionPeriod(value: 3, unit: .month)
@@ -111,11 +113,13 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(offers).to(haveCount(2))
 
         expect(offers[0].price) == 40.99
+        expect(offers[0].priceDecimalNumber).to(beCloseTo(40.99))
         expect(offers[0].paymentMode) == .payUpFront
         expect(offers[0].offerIdentifier) == "com.revenuecat.monthly_4.99.1_week_intro.year_discount"
         expect(offers[0].subscriptionPeriod) == SubscriptionPeriod(value: 1, unit: .year)
 
         expect(offers[1].price) == 20.15
+        expect(offers[1].priceDecimalNumber).to(beCloseTo(20.15))
         expect(offers[1].paymentMode) == .payAsYouGo
         expect(offers[1].offerIdentifier) == "com.revenuecat.monthly_4.99.1_week_intro.pay_as_you_go"
 
@@ -139,6 +143,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(storeProduct.localizedDescription) == "Monthly subscription with a 1-week free trial"
         expect(storeProduct.currencyCode) == "USD"
         expect(storeProduct.price.description) == "4.99"
+        expect(storeProduct.priceDecimalNumber).to(beCloseTo(4.99))
         expect(storeProduct.localizedPriceString) == "$4.99"
         expect(storeProduct.isFamilyShareable) == true
         expect(storeProduct.localizedTitle) == "Monthly Free Trial"
@@ -151,6 +156,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         let intro = try XCTUnwrap(storeProduct.introductoryDiscount)
 
         expect(intro.price) == 0.0
+        expect(intro.priceDecimalNumber) == 0.0
         expect(intro.paymentMode) == .freeTrial
         expect(intro.type) == .introductory
         expect(intro.offerIdentifier).to(beNil())
@@ -160,12 +166,14 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(offers).to(haveCount(2))
 
         expect(offers[0].price) == 40.99
+        expect(offers[0].priceDecimalNumber).to(beCloseTo(40.99))
         expect(offers[0].paymentMode) == .payUpFront
         expect(offers[0].type) == .promotional
         expect(offers[0].offerIdentifier) == "com.revenuecat.monthly_4.99.1_week_intro.year_discount"
         expect(offers[0].subscriptionPeriod) == SubscriptionPeriod(value: 1, unit: .year)
 
         expect(offers[1].price) == 20.15
+        expect(offers[1].priceDecimalNumber).to(beCloseTo(20.15))
         expect(offers[1].paymentMode) == .payAsYouGo
         expect(offers[0].type) == .promotional
         expect(offers[1].offerIdentifier) == "com.revenuecat.monthly_4.99.1_week_intro.pay_as_you_go"


### PR DESCRIPTION
`NSDecimal` is a fairly useless `struct` in Objective-C, but that's how `Decimal` is bridged from Swift.
Kudos to @aboedo for the idea!

Fixes [sc-13447].