### PR TITLE
`APITester`s: disable some `SwiftLint` rules

### DIFF
--- a/APITesters/.swiftlint.yml
+++ b/APITesters/.swiftlint.yml
@@ -1,0 +1,4 @@
+disabled_rules:
+  - file_length
+  - type_body_length
+  - function_body_length


### PR DESCRIPTION
These aren't really relevant for `APITester`s.

Fixes https://circleci.com/gh/RevenueCat/purchases-ios/17927?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link