### PR TITLE
Tests: delay `MockIdentityManager` initialization to `setUp`

### DIFF
--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -38,6 +38,7 @@ class PurchasesTests: XCTestCase {
         mockProductsManager = MockProductsManager(systemInfo: systemInfo)
         mockOperationDispatcher = MockOperationDispatcher()
         mockReceiptParser = MockReceiptParser()
+        identityManager = MockIdentityManager(mockAppUserID: "app_user")
         mockIntroEligibilityCalculator = MockIntroEligibilityCalculator(productsManager: mockProductsManager,
                                                                         receiptParser: mockReceiptParser)
         let systemInfoAttribution = try MockSystemInfo(platformFlavor: "iOS",
@@ -274,7 +275,7 @@ class PurchasesTests: XCTestCase {
     let offeringsFactory = MockOfferingsFactory()
     var deviceCache: MockDeviceCache!
     var subscriberAttributesManager: MockSubscriberAttributesManager!
-    let identityManager = MockIdentityManager(mockAppUserID: "app_user")
+    var identityManager: MockIdentityManager!
     var systemInfo: MockSystemInfo!
     var mockOperationDispatcher: MockOperationDispatcher!
     var mockIntroEligibilityCalculator: MockIntroEligibilityCalculator!

--- a/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -27,7 +27,7 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
     var userDefaults: UserDefaults! = nil
     let mockOfferingsFactory = MockOfferingsFactory()
     var mockDeviceCache: MockDeviceCache!
-    let mockIdentityManager = MockIdentityManager(mockAppUserID: "app_user")
+    var mockIdentityManager: MockIdentityManager!
     var mockSubscriberAttributesManager: MockSubscriberAttributesManager!
     var subscriberAttributeHeight: SubscriberAttribute!
     var subscriberAttributeWeight: SubscriberAttribute!
@@ -89,6 +89,7 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
             deviceCache: self.mockDeviceCache,
             attributionFetcher: self.mockAttributionFetcher,
             attributionDataMigrator: AttributionDataMigrator())
+        self.mockIdentityManager = MockIdentityManager(mockAppUserID: "app_user")
         self.mockAttributionPoster = AttributionPoster(deviceCache: mockDeviceCache,
                                                        identityManager: mockIdentityManager,
                                                        backend: mockBackend,


### PR DESCRIPTION
All these tests were eagerly initializing `MockIdentityManger`, which lead to the console flooding with the log `"Identifying App User ID"`, even when these tests weren't running.