### PR TITLE
`HTTPClientTests`: fixed data races

### DIFF
--- a/PurchasesTests/Mocks/MockDNSChecker.swift
+++ b/PurchasesTests/Mocks/MockDNSChecker.swift
@@ -16,46 +16,46 @@ import Foundation
 
 enum MockDNSChecker: DNSCheckerType {
 
-    static var invokedIsBlockedAPIError = false
-    static var stubbedIsBlockedAPIErrorResult = false
+    static let invokedIsBlockedAPIError: Atomic<Bool> = .init(false)
+    static let stubbedIsBlockedAPIErrorResult: Atomic<Bool> = .init(false)
     static func isBlockedAPIError(_ error: Error?) -> Bool {
-        Self.invokedIsBlockedAPIError = true
-        return Self.stubbedIsBlockedAPIErrorResult
+        Self.invokedIsBlockedAPIError.value = true
+        return Self.stubbedIsBlockedAPIErrorResult.value
     }
 
-    static var invokedErrorWithBlockedHostFromError = false
-    static var stubbedErrorWithBlockedHostFromErrorResult: DNSError?
+    static let invokedErrorWithBlockedHostFromError: Atomic<Bool> = .init(false)
+    static let stubbedErrorWithBlockedHostFromErrorResult: Atomic<DNSError?> = .init(nil)
     static func errorWithBlockedHostFromError(_ error: Error?) -> DNSError? {
-        Self.invokedErrorWithBlockedHostFromError = true
-        return Self.stubbedErrorWithBlockedHostFromErrorResult
+        Self.invokedErrorWithBlockedHostFromError.value = true
+        return Self.stubbedErrorWithBlockedHostFromErrorResult.value
     }
 
-    static var invokedIsBlockedURL = false
-    static var stubbedIsBlockedURLResult = false
+    static let invokedIsBlockedURL: Atomic<Bool> = .init(false)
+    static let stubbedIsBlockedURLResult: Atomic<Bool> = .init(false)
     static func isBlockedURL(_ url: URL) -> Bool {
-        Self.invokedIsBlockedURL = true
-        return Self.stubbedIsBlockedURLResult
+        Self.invokedIsBlockedURL.value = true
+        return Self.stubbedIsBlockedURLResult.value
     }
 
-    static var invokedResolvedHostFromURL = false
-    static var stubbedResolvedHostFromURLResult: String?
+    static let invokedResolvedHostFromURL: Atomic<Bool> = .init(false)
+    static let stubbedResolvedHostFromURLResult: Atomic<String?> = .init(nil)
     static func resolvedHost(fromURL url: URL) -> String? {
-        Self.invokedResolvedHostFromURL = true
-        return Self.stubbedResolvedHostFromURLResult
+        Self.invokedResolvedHostFromURL.value = true
+        return Self.stubbedResolvedHostFromURLResult.value
     }
 
     static func resetData() {
-        Self.invokedIsBlockedAPIError = false
-        Self.stubbedIsBlockedAPIErrorResult = false
+        Self.invokedIsBlockedAPIError.value = false
+        Self.stubbedIsBlockedAPIErrorResult.value = false
 
-        Self.invokedErrorWithBlockedHostFromError = false
-        Self.stubbedErrorWithBlockedHostFromErrorResult = nil
+        Self.invokedErrorWithBlockedHostFromError.value = false
+        Self.stubbedErrorWithBlockedHostFromErrorResult.value = nil
 
-        Self.invokedIsBlockedURL = false
-        Self.stubbedIsBlockedURLResult = false
+        Self.invokedIsBlockedURL.value = false
+        Self.stubbedIsBlockedURLResult.value = false
 
-        Self.invokedResolvedHostFromURL = false
-        Self.stubbedResolvedHostFromURLResult = nil
+        Self.invokedResolvedHostFromURL.value = false
+        Self.stubbedResolvedHostFromURLResult.value = nil
     }
 
 }


### PR DESCRIPTION
`OHHTTPStubs`' `stub` response method and `HTTPClient` completions are called in a background thread, so when running `HTTPClientTests` with tsan enabled all of these tests produced warnings.

Example:
<img width="1173" alt="Screen Shot 2022-02-17 at 13 31 32" src="https://user-images.githubusercontent.com/685609/154592332-3def9437-ce72-441a-a3fb-6367424b5ea2.png">

### Alternatives considered:

- I'm thinking that `HTTPClient` could always call completion blocks in the main thread, which would eliminate a few of these. Unfortunately we can't change `OHHTTPStubs` method. I tried adding an overload that would do it, but the callback needs to run synchronously in order to produce the response.