### PR TITLE
`StoreProductAPI`: removed SwiftLint rule

### DIFF
--- a/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
@@ -9,7 +9,6 @@ import RevenueCat
 
 var product: StoreProduct!
 
-// swiftlint:disable:next function_body_length
 func checkStoreProductAPI() {
     let category: StoreProduct.ProductCategory = product.productCategory
     let productType: StoreProduct.ProductType = product.productType


### PR DESCRIPTION
No longer needed since #1309.