### PR TITLE
[skip-ci] `MagicWeatherSwiftUI`: removed redundant `Package: Identifiable` conformance

### DIFF
--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/Helpers/Extensions.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/Helpers/Extensions.swift
@@ -9,12 +9,6 @@ import Foundation
 import RevenueCat
 import StoreKit
 
-/* The `Package` class needs to be identifiable to work with a List */
-
-extension Package: Identifiable {
-    public var id: String { self.identifier }
-}
-
 /* Some methods to make displaying subscription terms easier */
 
 extension Package {


### PR DESCRIPTION
Already exposed by #1268.