### PR TITLE
[skip-ci] `MagicWeatherSwiftUI`: removed reference to `SubscriptionPeriod.Unit.unknown`

### DIFF
--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/Helpers/Extensions.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/Helpers/Extensions.swift
@@ -38,7 +38,6 @@ extension SubscriptionPeriod {
         case .week: return "week"
         case .month: return "month"
         case .year: return "year"
-        case .unknown: fallthrough
         @unknown default: return "Unknown"
         }
     }


### PR DESCRIPTION
Was removed in #1235.