### PR TITLE
`DangerousSettings`: added missing `import Foundation`

### DIFF
--- a/Purchases/Misc/DangerousSettings.swift
+++ b/Purchases/Misc/DangerousSettings.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2022 Purchases. All rights reserved.
 //
 
+import Foundation
+
 /**
  Only use a Dangerous Setting if suggested by RevenueCat support team.
  */


### PR DESCRIPTION
SPM integration will fail without this. `MagicWeather` for example isn't building.