### PR TITLE
Provide explicit `Identifiable` implementation

### DIFF
--- a/Purchases/Purchasing/EntitlementInfo.swift
+++ b/Purchases/Purchasing/EntitlementInfo.swift
@@ -359,4 +359,9 @@ extension EntitlementInfo {
 
 }
 
-extension EntitlementInfo: Identifiable {}
+extension EntitlementInfo: Identifiable {
+
+    /// The stable identity of the entity associated with this instance.
+    public var id: String { return self.identifier }
+
+}

--- a/Purchases/Purchasing/Offering.swift
+++ b/Purchases/Purchasing/Offering.swift
@@ -166,4 +166,9 @@ import Foundation
 
 }
 
-extension Offering: Identifiable {}
+extension Offering: Identifiable {
+
+    /// The stable identity of the entity associated with this instance.
+    public var id: String { return self.identifier }
+
+}

--- a/Purchases/Purchasing/Package.swift
+++ b/Purchases/Purchasing/Package.swift
@@ -158,4 +158,9 @@ private extension PackageType {
 
 }
 
-extension Package: Identifiable {}
+extension Package: Identifiable {
+
+    /// The stable identity of the entity associated with this instance.
+    public var id: String { return self.identifier }
+
+}

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -119,6 +119,8 @@ public extension StoreProductDiscount {
 /// The details of an introductory offer or a promotional offer for an auto-renewable subscription.
 internal protocol StoreProductDiscountType {
 
+    // Note: this is only `nil` for SK1 products before iOS 12.2.
+    // It can become `String` once it's not longer supported.
     /// A string used to uniquely identify a discount offer for a product.
     var offerIdentifier: String? { get }
 

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -233,4 +233,9 @@ extension StoreProductDiscount.DiscountType {
 
 extension StoreProductDiscount.PaymentMode: Encodable {}
 
-extension StoreProductDiscount: Identifiable {}
+extension StoreProductDiscount: Identifiable {
+
+    /// The stable identity of the entity associated with this instance.
+    public var id: String? { return self.offerIdentifier }
+
+}

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -86,22 +86,13 @@ public final class StoreProductDiscount: NSObject, StoreProductDiscountType {
     }
 
     public override func isEqual(_ object: Any?) -> Bool {
-        guard let other = object as? StoreProductDiscount else { return false }
+        guard let other = object as? StoreProductDiscountType else { return false }
 
-        return self.offerIdentifier == other.offerIdentifier
-            && self.price == other.price
-            && self.paymentMode == other.paymentMode
-            && self.subscriptionPeriod == other.subscriptionPeriod
+        return Data(discount: self) == Data(discount: other)
     }
 
     public override var hash: Int {
-        var hasher = Hasher()
-        hasher.combine(self.offerIdentifier)
-        hasher.combine(self.price)
-        hasher.combine(self.paymentMode)
-        hasher.combine(self.subscriptionPeriod)
-
-        return hasher.finalize()
+        return Data(discount: self).hashValue
     }
 
 }
@@ -112,6 +103,31 @@ public extension StoreProductDiscount {
     /// - Note: this is meant for  Objective-C. For Swift, use ``price`` instead.
     @objc(price) var priceDecimalNumber: NSDecimalNumber {
         return self.price as NSDecimalNumber
+    }
+
+}
+
+extension StoreProductDiscount {
+
+    /// Used to represent `StoreProductDiscount/id`. Not for public use.
+    public struct Data: Hashable {
+        private var offerIdentifier: String?
+        private var currencyCode: String?
+        private var price: Decimal
+        private var localizedPriceString: String
+        private var paymentMode: StoreProductDiscount.PaymentMode
+        private var subscriptionPeriod: SubscriptionPeriod
+        private var type: StoreProductDiscount.DiscountType
+
+        fileprivate init(discount: StoreProductDiscountType) {
+            self.offerIdentifier = discount.offerIdentifier
+            self.currencyCode = discount.currencyCode
+            self.price = discount.price
+            self.localizedPriceString = discount.localizedPriceString
+            self.paymentMode = discount.paymentMode
+            self.subscriptionPeriod = discount.subscriptionPeriod
+            self.type = discount.type
+        }
     }
 
 }
@@ -238,6 +254,6 @@ extension StoreProductDiscount.PaymentMode: Encodable {}
 extension StoreProductDiscount: Identifiable {
 
     /// The stable identity of the entity associated with this instance.
-    public var id: String? { return self.offerIdentifier }
+    public var id: Data { return Data(discount: self) }
 
 }

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreTransaction.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreTransaction.swift
@@ -104,4 +104,9 @@ extension StoreTransaction {
 
 }
 
-extension StoreTransaction: Identifiable {}
+extension StoreTransaction: Identifiable {
+
+    /// The stable identity of the entity associated with this instance.
+    public var id: String { return self.transactionIdentifier }
+
+}


### PR DESCRIPTION
Follow up to #1268.

The `Identifiable` protocol has a default implementation for `AnyObject`:
```swift
@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
extension Identifiable where Self : AnyObject {

    /// The stable identity of the entity associated with this instance.
    public var id: ObjectIdentifier { get }
}
```

Basically the instance pointer becomes the identity by default.
But these types have their own overridden `isEqual` and `hash` implementations, so we want their identities to be defined by their own identifiers.