### PR TITLE
Allow flavor and flavor version to be set on Purchases.configure

### DIFF
--- a/Purchases/Misc/PlatformInfo.swift
+++ b/Purchases/Misc/PlatformInfo.swift
@@ -1,0 +1,32 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PlatformInfo.swift
+//
+//  Created by Josh Holtz on 2/17/22.
+
+import Foundation
+
+// swiftlint:disable missing_docs
+public extension Purchases {
+
+    @objc(RCPlatformInfo)
+    final class PlatformInfo: NSObject {
+        let flavor: String
+        let version: String?
+
+        @objc public init(flavor: String, version: String?) {
+            self.flavor = flavor
+            self.version = version
+        }
+    }
+
+    @objc static var platformInfo: PlatformInfo?
+
+}

--- a/Purchases/Misc/PlatformInfo.swift
+++ b/Purchases/Misc/PlatformInfo.swift
@@ -19,9 +19,9 @@ extension Purchases {
     @objc(RCPlatformInfo)
     public final class PlatformInfo: NSObject {
         let flavor: String
-        let version: String?
+        let version: String
 
-        @objc public init(flavor: String, version: String?) {
+        @objc public init(flavor: String, version: String) {
             self.flavor = flavor
             self.version = version
         }

--- a/Purchases/Misc/PlatformInfo.swift
+++ b/Purchases/Misc/PlatformInfo.swift
@@ -14,10 +14,10 @@
 import Foundation
 
 // swiftlint:disable missing_docs
-public extension Purchases {
+extension Purchases {
 
     @objc(RCPlatformInfo)
-    final class PlatformInfo: NSObject {
+    public final class PlatformInfo: NSObject {
         let flavor: String
         let version: String?
 
@@ -27,6 +27,6 @@ public extension Purchases {
         }
     }
 
-    @objc static var platformInfo: PlatformInfo?
+    @objc public static var platformInfo: PlatformInfo?
 
 }

--- a/Purchases/Misc/SystemInfo.swift
+++ b/Purchases/Misc/SystemInfo.swift
@@ -116,21 +116,14 @@ class SystemInfo {
         return URL(string: defaultServerHostName)!
     }
 
-    init(platformFlavor: String?,
-         platformFlavorVersion: String?,
+    init(platformInfo: Purchases.PlatformInfo?,
          finishTransactions: Bool,
          bundle: Bundle = .main,
          useStoreKit2IfAvailable: Bool = false,
          dangerousSettings: DangerousSettings? = nil) throws {
-        self.platformFlavor = platformFlavor ?? "native"
-        self.platformFlavorVersion = platformFlavorVersion
+        self.platformFlavor = platformInfo?.flavor ?? "native"
+        self.platformFlavorVersion = platformInfo?.version
         self.bundle = bundle
-
-        if (platformFlavor == nil && platformFlavorVersion != nil) ||
-            (platformFlavor != nil && platformFlavorVersion == nil) {
-            Logger.error("RCSystemInfo initialized with non-matching platform flavor and platform flavor versions!")
-            throw SystemInfoError.invalidInitializationData
-        }
 
         self.finishTransactions = finishTransactions
         self.useStoreKit2IfAvailable = useStoreKit2IfAvailable

--- a/Purchases/Misc/SystemInfo.swift
+++ b/Purchases/Misc/SystemInfo.swift
@@ -37,11 +37,6 @@ class SystemInfo {
     static let platformHeaderConstant = "macOS"
     #endif
 
-    enum SystemInfoError: Error {
-
-        case invalidInitializationData
-    }
-
     let appleSubscriptionsURL = URL(string: "https://rev.cat/manage-apple-subscription")
 
     let useStoreKit2IfAvailable: Bool

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -251,8 +251,7 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
                      appUserID: String?,
                      userDefaults: UserDefaults? = nil,
                      observerMode: Bool = false,
-                     platformFlavor: String? = Purchases.platformInfo?.flavor,
-                     platformFlavorVersion: String? = Purchases.platformInfo?.version,
+                     platformInfo: PlatformInfo? = Purchases.platformInfo,
                      useStoreKit2IfAvailable: Bool = false,
                      dangerousSettings: DangerousSettings? = nil) {
         let operationDispatcher = OperationDispatcher()
@@ -261,8 +260,8 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
                                              operationDispatcher: operationDispatcher)
         let systemInfo: SystemInfo
         do {
-            systemInfo = try SystemInfo(platformFlavor: platformFlavor,
-                                        platformFlavorVersion: platformFlavorVersion,
+            systemInfo = try SystemInfo(platformFlavor: platformInfo?.flavor,
+                                        platformFlavorVersion: platformInfo?.version,
                                         finishTransactions: !observerMode,
                                         useStoreKit2IfAvailable: useStoreKit2IfAvailable,
                                         dangerousSettings: dangerousSettings)
@@ -1688,8 +1687,7 @@ public extension Purchases {
                                   appUserID: appUserID,
                                   userDefaults: userDefaults,
                                   observerMode: observerMode,
-                                  platformFlavor: nil,
-                                  platformFlavorVersion: nil,
+                                  platformInfo: nil,
                                   useStoreKit2IfAvailable: useStoreKit2IfAvailable,
                                   dangerousSettings: dangerousSettings)
         setDefaultInstance(purchases)

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -260,8 +260,7 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
                                              operationDispatcher: operationDispatcher)
         let systemInfo: SystemInfo
         do {
-            systemInfo = try SystemInfo(platformFlavor: platformInfo?.flavor,
-                                        platformFlavorVersion: platformInfo?.version,
+            systemInfo = try SystemInfo(platformInfo: platformInfo,
                                         finishTransactions: !observerMode,
                                         useStoreKit2IfAvailable: useStoreKit2IfAvailable,
                                         dangerousSettings: dangerousSettings)

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -251,8 +251,8 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
                      appUserID: String?,
                      userDefaults: UserDefaults? = nil,
                      observerMode: Bool = false,
-                     platformFlavor: String? = nil,
-                     platformFlavorVersion: String? = nil,
+                     platformFlavor: String? = Purchases.platformInfo?.flavor,
+                     platformFlavorVersion: String? = Purchases.platformInfo?.version,
                      useStoreKit2IfAvailable: Bool = false,
                      dangerousSettings: DangerousSettings? = nil) {
         let operationDispatcher = OperationDispatcher()

--- a/PurchasesTests/Attribution/AttributionPosterTests.swift
+++ b/PurchasesTests/Attribution/AttributionPosterTests.swift
@@ -29,9 +29,9 @@ class AttributionPosterTests: XCTestCase {
     var subscriberAttributesManager: MockSubscriberAttributesManager!
     var attributionFactory: AttributionTypeFactory! = MockAttributionTypeFactory()
     // swiftlint:disable:next force_try
-    var systemInfo: MockSystemInfo! = try! MockSystemInfo(platformFlavor: "iOS",
-                                                          platformFlavorVersion: "3.2.1",
-                                                          finishTransactions: true)
+    var systemInfo: MockSystemInfo! = try! MockSystemInfo(
+        platformInfo: Purchases.PlatformInfo(flavor: "iOS", version: "3.2.1"),
+        finishTransactions: true)
 
     let userDefaultsSuiteName = "testUserDefaults"
 

--- a/PurchasesTests/Attribution/AttributionPosterTests.swift
+++ b/PurchasesTests/Attribution/AttributionPosterTests.swift
@@ -30,7 +30,7 @@ class AttributionPosterTests: XCTestCase {
     var attributionFactory: AttributionTypeFactory! = MockAttributionTypeFactory()
     // swiftlint:disable:next force_try
     var systemInfo: MockSystemInfo! = try! MockSystemInfo(
-        platformInfo: Purchases.PlatformInfo(flavor: "iOS", version: "3.2.1"),
+        platformInfo: .init(flavor: "iOS", version: "3.2.1"),
         finishTransactions: true)
 
     let userDefaultsSuiteName = "testUserDefaults"

--- a/PurchasesTests/Misc/SystemInfoTests.swift
+++ b/PurchasesTests/Misc/SystemInfoTests.swift
@@ -27,53 +27,29 @@ class SystemInfoTests: XCTestCase {
 
     func testPlatformFlavor() throws {
         let flavor = "flavor"
-        let systemInfo = try SystemInfo(platformFlavor: flavor,
-                                        platformFlavorVersion: "foo",
+        let platformInfo = Purchases.PlatformInfo(flavor: flavor, version: "foo")
+        let systemInfo = try SystemInfo(platformInfo: platformInfo,
                                         finishTransactions: false)
         expect(systemInfo.platformFlavor) == flavor
     }
 
     func testPlatformFlavorVersion() throws {
         let flavorVersion = "flavorVersion"
-        let systemInfo = try SystemInfo(platformFlavor: "foo",
-                                        platformFlavorVersion: flavorVersion,
+        let platformInfo = Purchases.PlatformInfo(flavor: "foo", version: flavorVersion)
+        let systemInfo = try SystemInfo(platformInfo: platformInfo,
                                         finishTransactions: false)
         expect(systemInfo.platformFlavorVersion) == flavorVersion
     }
 
-    func testPlatformFlavorAndPlatformFlavorVersionMustSimultaneouslyExistOrNotExist() {
-        expect(try SystemInfo(platformFlavor: "a",
-                              platformFlavorVersion: "b",
-                              finishTransactions: true))
-            .toNot(throwError(SystemInfo.SystemInfoError.invalidInitializationData))
-
-        expect(try SystemInfo(platformFlavor: nil,
-                              platformFlavorVersion: "b",
-                              finishTransactions: true))
-            .to(throwError(SystemInfo.SystemInfoError.invalidInitializationData))
-
-        expect(try SystemInfo(platformFlavor: "a",
-                              platformFlavorVersion: nil,
-                              finishTransactions: true))
-            .to(throwError(SystemInfo.SystemInfoError.invalidInitializationData))
-
-        expect(try SystemInfo(platformFlavor: nil,
-                              platformFlavorVersion: nil,
-                              finishTransactions: true))
-            .toNot(throwError(SystemInfo.SystemInfoError.invalidInitializationData))
-    }
-
     func testFinishTransactions() throws {
         var finishTransactions = false
-        var systemInfo = try SystemInfo(platformFlavor: nil,
-                                        platformFlavorVersion: nil,
+        var systemInfo = try SystemInfo(platformInfo: nil,
                                         finishTransactions: finishTransactions)
         expect(systemInfo.finishTransactions) == finishTransactions
 
         finishTransactions = true
 
-        systemInfo = try SystemInfo(platformFlavor: nil,
-                                    platformFlavorVersion: nil,
+        systemInfo = try SystemInfo(platformInfo: nil,
                                     finishTransactions: finishTransactions)
         expect(systemInfo.finishTransactions) == finishTransactions
     }
@@ -92,16 +68,14 @@ class SystemInfoTests: XCTestCase {
 
     func testUseStoreKit2IfAvailable() throws {
         var useSK2 = false
-        var systemInfo = try SystemInfo(platformFlavor: nil,
-                                        platformFlavorVersion: nil,
+        var systemInfo = try SystemInfo(platformInfo: nil,
                                         finishTransactions: true,
                                         useStoreKit2IfAvailable: useSK2)
         expect(systemInfo.useStoreKit2IfAvailable) == useSK2
 
         useSK2 = true
 
-        systemInfo = try SystemInfo(platformFlavor: nil,
-                                    platformFlavorVersion: nil,
+        systemInfo = try SystemInfo(platformInfo: nil,
                                     finishTransactions: true,
                                     useStoreKit2IfAvailable: useSK2)
         expect(systemInfo.useStoreKit2IfAvailable) == useSK2
@@ -114,8 +88,7 @@ private extension SystemInfo {
         let bundle = MockBundle()
         bundle.receiptURLResult = result
 
-        return try SystemInfo(platformFlavor: nil,
-                              platformFlavorVersion: nil,
+        return try SystemInfo(platformInfo: nil,
                               finishTransactions: false,
                               bundle: bundle)
     }

--- a/PurchasesTests/Mocks/MockBackend.swift
+++ b/PurchasesTests/Mocks/MockBackend.swift
@@ -32,8 +32,7 @@ class MockBackend: Backend {
         completion: BackendCustomerInfoResponseHandler?)]()
 
     public convenience init() {
-        self.init(httpClient: MockHTTPClient(systemInfo: try! MockSystemInfo(platformFlavor: nil,
-                                                                             platformFlavorVersion: nil,
+        self.init(httpClient: MockHTTPClient(systemInfo: try! MockSystemInfo(platformInfo: nil,
                                                                              finishTransactions: false,
                                                                              dangerousSettings: nil),
                                              eTagManager: MockETagManager()),

--- a/PurchasesTests/Mocks/MockIdentityManager.swift
+++ b/PurchasesTests/Mocks/MockIdentityManager.swift
@@ -17,8 +17,7 @@ class MockIdentityManager: IdentityManager {
 
     init(mockAppUserID: String) {
         // swiftlint:disable:next force_try
-        let mockSystemInfo = try! MockSystemInfo(platformFlavor: nil,
-                                                 platformFlavorVersion: nil,
+        let mockSystemInfo = try! MockSystemInfo(platformInfo: nil,
                                                  finishTransactions: false,
                                                  dangerousSettings: nil)
         let mockDeviceCache = MockDeviceCache(systemInfo: mockSystemInfo)

--- a/PurchasesTests/Mocks/MockSystemInfo.swift
+++ b/PurchasesTests/Mocks/MockSystemInfo.swift
@@ -15,8 +15,7 @@ class MockSystemInfo: SystemInfo {
 
     convenience init(finishTransactions: Bool) {
         // swiftlint:disable:next force_try
-        try! self.init(platformFlavor: nil,
-                       platformFlavorVersion: nil,
+        try! self.init(platformInfo: nil,
                        finishTransactions: finishTransactions)
     }
 

--- a/PurchasesTests/Mocks/MockTrialOrIntroPriceEligibilityChecker.swift
+++ b/PurchasesTests/Mocks/MockTrialOrIntroPriceEligibilityChecker.swift
@@ -19,7 +19,8 @@
 class MockTrialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityChecker {
 
     convenience init() {
-        let systemInfo = try! MockSystemInfo(platformFlavor: "xyz", platformFlavorVersion: "123", finishTransactions: true)
+        let platformInfo = Purchases.PlatformInfo(flavor: "xyz", version: "123")
+        let systemInfo = try! MockSystemInfo(platformInfo: platformInfo, finishTransactions: true)
         let productsManager = MockProductsManager(systemInfo: systemInfo)
         self.init(receiptFetcher: MockReceiptFetcher(requestFetcher: MockRequestFetcher(), systemInfo: systemInfo),
                   introEligibilityCalculator: MockIntroEligibilityCalculator(productsManager: productsManager,

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -102,7 +102,7 @@ class BackendTests: XCTestCase {
     }
 
     // swiftlint:disable:next force_try
-    let systemInfo = try! SystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: true)
+    let systemInfo = try! SystemInfo(platformInfo: nil, finishTransactions: true)
     var httpClient: MockHTTPClient!
     let apiKey = "asharedsecret"
     let bundleID = "com.bundle.id"

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -453,8 +453,8 @@ class HTTPClientTests: XCTestCase {
             headerPresent = true
             return HTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
         }
-        let systemInfo = try SystemInfo(platformFlavor: "react-native",
-                                        platformFlavorVersion: "3.2.1",
+        let platformInfo = Purchases.PlatformInfo(flavor: "react-native", version: "3.2.1")
+        let systemInfo = try SystemInfo(platformInfo: platformInfo,
                                         finishTransactions: true)
         let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
         client.performPOSTRequest(serially: true,
@@ -474,8 +474,8 @@ class HTTPClientTests: XCTestCase {
             headerPresent = true
             return HTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
         }
-        let systemInfo = try SystemInfo(platformFlavor: "react-native",
-                                        platformFlavorVersion: "1.2.3",
+        let platformInfo = Purchases.PlatformInfo(flavor: "react-native", version: "1.2.3")
+        let systemInfo = try SystemInfo(platformInfo: platformInfo,
                                         finishTransactions: true)
         let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
 
@@ -496,7 +496,7 @@ class HTTPClientTests: XCTestCase {
             headerPresent = true
             return HTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
         }
-        let systemInfo = try SystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: true)
+        let systemInfo = try SystemInfo(platformInfo: nil, finishTransactions: true)
         let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
         client.performPOSTRequest(serially: true,
                                   path: path,
@@ -515,7 +515,7 @@ class HTTPClientTests: XCTestCase {
             headerPresent = true
             return HTTPStubsResponse(data: Data(), statusCode: 200, headers: nil)
         }
-        let systemInfo = try SystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: false)
+        let systemInfo = try SystemInfo(platformInfo: nil, finishTransactions: false)
         let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
         client.performPOSTRequest(serially: true,
                                   path: path,

--- a/PurchasesTests/Purchasing/IntroEligibilityCalculatorTests.swift
+++ b/PurchasesTests/Purchasing/IntroEligibilityCalculatorTests.swift
@@ -13,7 +13,8 @@ class IntroEligibilityCalculatorTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        systemInfo = try MockSystemInfo(platformFlavor: "xyz", platformFlavorVersion: "123", finishTransactions: true)
+        let platformInfo = Purchases.PlatformInfo(flavor: "iOS", version: "3.2.1")
+        systemInfo = try MockSystemInfo(platformInfo: platformInfo, finishTransactions: true)
         self.mockProductsManager = MockProductsManager(systemInfo: systemInfo)
         calculator = IntroEligibilityCalculator(productsManager: mockProductsManager,
                                                 receiptParser: mockReceiptParser)

--- a/PurchasesTests/Purchasing/OfferingsManagerTests.swift
+++ b/PurchasesTests/Purchasing/OfferingsManagerTests.swift
@@ -21,8 +21,7 @@ class OfferingsManagerTests: XCTestCase {
     var mockDeviceCache: MockDeviceCache!
     let mockOperationDispatcher = MockOperationDispatcher()
     // swiftlint:disable:next force_try
-    let mockSystemInfo = try! MockSystemInfo(platformFlavor: "iOS",
-                                             platformFlavorVersion: "3.2.1",
+    let mockSystemInfo = try! MockSystemInfo(platformInfo: Purchases.PlatformInfo(flavor: "iOS", version: "3.2.1"),
                                              finishTransactions: true)
     let mockBackend = MockBackend()
     let mockOfferingsFactory = MockOfferingsFactory()

--- a/PurchasesTests/Purchasing/OfferingsManagerTests.swift
+++ b/PurchasesTests/Purchasing/OfferingsManagerTests.swift
@@ -21,7 +21,7 @@ class OfferingsManagerTests: XCTestCase {
     var mockDeviceCache: MockDeviceCache!
     let mockOperationDispatcher = MockOperationDispatcher()
     // swiftlint:disable:next force_try
-    let mockSystemInfo = try! MockSystemInfo(platformInfo: Purchases.PlatformInfo(flavor: "iOS", version: "3.2.1"),
+    let mockSystemInfo = try! MockSystemInfo(platformInfo: .init(flavor: "iOS", version: "3.2.1"),
                                              finishTransactions: true)
     let mockBackend = MockBackend()
     let mockOfferingsFactory = MockOfferingsFactory()

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -40,8 +40,8 @@ class PurchasesTests: XCTestCase {
         mockReceiptParser = MockReceiptParser()
         mockIntroEligibilityCalculator = MockIntroEligibilityCalculator(productsManager: mockProductsManager,
                                                                         receiptParser: mockReceiptParser)
-        let systemInfoAttribution = try MockSystemInfo(platformFlavor: "iOS",
-                                                       platformFlavorVersion: "3.2.1",
+        let platformInfo = Purchases.PlatformInfo(flavor: "iOS", version: "3.2.1")
+        let systemInfoAttribution = try MockSystemInfo(platformInfo: platformInfo,
                                                        finishTransactions: true)
         receiptFetcher = MockReceiptFetcher(requestFetcher: requestFetcher, systemInfo: systemInfoAttribution)
         attributionFetcher = MockAttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
@@ -308,7 +308,7 @@ class PurchasesTests: XCTestCase {
     }
 
     func setupPurchasesObserverModeOn() throws {
-        systemInfo = try MockSystemInfo(platformFlavor: nil, platformFlavorVersion: nil, finishTransactions: false)
+        systemInfo = try MockSystemInfo(platformInfo: nil, finishTransactions: false)
         initializePurchasesInstance(appUserId: nil)
     }
 
@@ -1297,8 +1297,7 @@ class PurchasesTests: XCTestCase {
     }
 
     func testSyncPurchasesPostsTheReceiptIfAutoSyncPurchasesSettingIsOff() throws {
-        systemInfo = try MockSystemInfo(platformFlavor: nil,
-                                        platformFlavorVersion: nil,
+        systemInfo = try MockSystemInfo(platformInfo: nil,
                                         finishTransactions: false,
                                         dangerousSettings: DangerousSettings(autoSyncPurchases: false))
         initializePurchasesInstance(appUserId: nil)
@@ -2238,8 +2237,7 @@ class PurchasesTests: XCTestCase {
     }
 
     func testDoesntPostTransactionsIfAutoSyncPurchasesSettingIsOffInObserverMode() throws {
-        systemInfo = try MockSystemInfo(platformFlavor: nil,
-                                        platformFlavorVersion: nil,
+        systemInfo = try MockSystemInfo(platformInfo: nil,
                                         finishTransactions: false,
                                         dangerousSettings: DangerousSettings(autoSyncPurchases: false))
         initializePurchasesInstance(appUserId: nil)
@@ -2266,8 +2264,7 @@ class PurchasesTests: XCTestCase {
     }
 
     func testDoesntPostTransactionsIfAutoSyncPurchasesSettingIsOff() throws {
-        systemInfo = try MockSystemInfo(platformFlavor: nil,
-                                        platformFlavorVersion: nil,
+        systemInfo = try MockSystemInfo(platformInfo: nil,
                                         finishTransactions: true,
                                         dangerousSettings: DangerousSettings(autoSyncPurchases: false))
         initializePurchasesInstance(appUserId: nil)

--- a/PurchasesTests/Purchasing/ReceiptFetcherTests.swift
+++ b/PurchasesTests/Purchasing/ReceiptFetcherTests.swift
@@ -28,8 +28,7 @@ class ReceiptFetcherTests: XCTestCase {
 
         mockBundle = MockBundle()
         mockRequestFetcher = MockRequestFetcher()
-        mockSystemInfo = try MockSystemInfo(platformFlavor: nil,
-                                            platformFlavorVersion: nil,
+        mockSystemInfo = try MockSystemInfo(platformInfo: nil,
                                             finishTransactions: false,
                                             bundle: mockBundle)
         receiptFetcher = ReceiptFetcher(requestFetcher: mockRequestFetcher, systemInfo: mockSystemInfo)

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -35,7 +35,9 @@ class BackendSubscriberAttributesTests: XCTestCase {
     ]
 
     // swiftlint:disable:next force_try
-    let systemInfo = try! SystemInfo(platformFlavor: "Unity", platformFlavorVersion: "2.3.3", finishTransactions: true)
+    let systemInfo = try! SystemInfo(platformInfo: Purchases.PlatformInfo(flavor: "Unity",
+                                                                          version: "2.3.3"),
+                                     finishTransactions: true)
 
     override func setUp() {
         mockETagManager = MockETagManager(userDefaults: MockUserDefaults())

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -35,9 +35,7 @@ class BackendSubscriberAttributesTests: XCTestCase {
     ]
 
     // swiftlint:disable:next force_try
-    let systemInfo = try! SystemInfo(platformInfo: Purchases.PlatformInfo(flavor: "Unity",
-                                                                          version: "2.3.3"),
-                                     finishTransactions: true)
+    let systemInfo = try! SystemInfo(platformInfo: .init(flavor: "Unity", version: "2.3.3"), finishTransactions: true)
 
     override func setUp() {
         mockETagManager = MockETagManager(userDefaults: MockUserDefaults())

--- a/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -79,8 +79,8 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
         self.mockProductsManager = MockProductsManager(systemInfo: systemInfo)
         self.mockIntroEligibilityCalculator = MockIntroEligibilityCalculator(productsManager: mockProductsManager,
                                                                              receiptParser: mockReceiptParser)
-        let systemInfoAttribution = try MockSystemInfo(platformFlavor: "iOS",
-                                                       platformFlavorVersion: "3.2.1",
+        let platformInfo = Purchases.PlatformInfo(flavor: "iOS", version: "3.2.1")
+        let systemInfoAttribution = try MockSystemInfo(platformInfo: platformInfo,
                                                        finishTransactions: true)
         self.mockAttributionFetcher = MockAttributionFetcher(attributionFactory: AttributionTypeFactory(),
                                                              systemInfo: systemInfoAttribution)

--- a/PurchasesTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -29,8 +29,8 @@ class SubscriberAttributesManagerTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        let systemInfo = try MockSystemInfo(platformFlavor: "iOS",
-                                            platformFlavorVersion: "3.2.1",
+        let platformInfo = Purchases.PlatformInfo(flavor: "iOS", version: "3.2.1")
+        let systemInfo = try MockSystemInfo(platformInfo: platformInfo,
                                             finishTransactions: true)
 
         self.mockDeviceCache = MockDeviceCache(systemInfo: systemInfo)

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0313FD41268A506400168386 /* DateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0313FD40268A506400168386 /* DateProvider.swift */; };
 		2C0B98CD2797070B00C5874F /* PromotionalOffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C0B98CC2797070B00C5874F /* PromotionalOffer.swift */; };
+		2CB8CF9327BF538F00C34DE3 /* PlatformInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB8CF9227BF538F00C34DE3 /* PlatformInfo.swift */; };
 		2CD2C544278CE0E0005D1CC2 /* RevenueCat_IntegrationPurchaseTesterConfiguration.storekit in Resources */ = {isa = PBXBuildFile; fileRef = 2CD2C541278CE0E0005D1CC2 /* RevenueCat_IntegrationPurchaseTesterConfiguration.storekit */; };
 		2CD72942268A823900BFC976 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD72941268A823900BFC976 /* Data+Extensions.swift */; };
 		2CD72944268A826F00BFC976 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD72943268A826F00BFC976 /* Date+Extensions.swift */; };
@@ -414,6 +415,7 @@
 /* Begin PBXFileReference section */
 		0313FD40268A506400168386 /* DateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateProvider.swift; sourceTree = "<group>"; };
 		2C0B98CC2797070B00C5874F /* PromotionalOffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionalOffer.swift; sourceTree = "<group>"; };
+		2CB8CF9227BF538F00C34DE3 /* PlatformInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformInfo.swift; sourceTree = "<group>"; };
 		2CD2C541278CE0E0005D1CC2 /* RevenueCat_IntegrationPurchaseTesterConfiguration.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; name = RevenueCat_IntegrationPurchaseTesterConfiguration.storekit; path = IntegrationTests/PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit; sourceTree = SOURCE_ROOT; };
 		2CD72941268A823900BFC976 /* Data+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Extensions.swift"; sourceTree = "<group>"; };
 		2CD72943268A826F00BFC976 /* Date+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; };
@@ -990,6 +992,7 @@
 				57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */,
 				B3AA6237268B926F00894871 /* SystemInfo.swift */,
 				352B7D7827BD919B002A47DD /* DangerousSettings.swift */,
+				2CB8CF9227BF538F00C34DE3 /* PlatformInfo.swift */,
 			);
 			path = Misc;
 			sourceTree = "<group>";
@@ -1985,6 +1988,7 @@
 				B34605C8279A6E380031CA74 /* NoContentResponseHandler.swift in Sources */,
 				B33CEAA0268CDCC9008A3144 /* ISOPeriodFormatter.swift in Sources */,
 				2DDF41A324F6F331005BC22D /* ReceiptParser.swift in Sources */,
+				2CB8CF9327BF538F00C34DE3 /* PlatformInfo.swift in Sources */,
 				35D832F4262E606500E60AC5 /* HTTPResponse.swift in Sources */,
 				352B7D7927BD919B002A47DD /* DangerousSettings.swift in Sources */,
 				A56F9AB126990E9200AFC48F /* CustomerInfo.swift in Sources */,

--- a/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/StoreKitUnitTests/ProductsManagerTests.swift
@@ -68,10 +68,10 @@ class ProductsManagerTests: StoreKitConfigTestCase {
     }
 
     private func createManager(useStoreKit2IfAvailable: Bool) throws -> ProductsManager {
+        let platformInfo = Purchases.PlatformInfo(flavor: "xyz", version: "123")
         return ProductsManager(
             systemInfo: try MockSystemInfo(
-                platformFlavor: "xyz",
-                platformFlavorVersion: "123",
+                platformInfo: platformInfo,
                 finishTransactions: true,
                 useStoreKit2IfAvailable: useStoreKit2IfAvailable
             ),

--- a/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -79,8 +79,8 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     }
 
     fileprivate func setUpSystemInfo(finishTransactions: Bool = true) throws {
-        systemInfo = try MockSystemInfo(platformFlavor: "xyz",
-                                        platformFlavorVersion: "1.2.3",
+        let platformInfo = Purchases.PlatformInfo(flavor: "xyz", version: "1.2.3")
+        systemInfo = try MockSystemInfo(platformInfo: platformInfo,
                                         finishTransactions: finishTransactions)
     }
 

--- a/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
+++ b/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
@@ -28,8 +28,8 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        mockSystemInfo = try MockSystemInfo(platformFlavor: "xyz",
-                                            platformFlavorVersion: "123",
+        let platformInfo = Purchases.PlatformInfo(flavor: "xyz", version: "123")
+        mockSystemInfo = try MockSystemInfo(platformInfo: platformInfo,
                                             finishTransactions: true)
         receiptFetcher = MockReceiptFetcher(requestFetcher: MockRequestFetcher(), systemInfo: mockSystemInfo)
         self.mockProductsManager = MockProductsManager(systemInfo: mockSystemInfo)

--- a/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
+++ b/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
@@ -28,8 +28,8 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        mockSystemInfo = try MockSystemInfo(platformFlavor: "xyz",
-                                            platformFlavorVersion: "123",
+        let platformInfo = Purchases.PlatformInfo(flavor: "xyz", version: "123")
+        mockSystemInfo = try MockSystemInfo(platformInfo: platformInfo,
                                             finishTransactions: true)
 
         receiptFetcher = MockReceiptFetcher(requestFetcher: MockRequestFetcher(), systemInfo: mockSystemInfo)


### PR DESCRIPTION
### Motivation
- Needed a way to set `flavor` and `flavorVersion` from hybrid common

### Description
- Created a `Purchases.platformInfo` that takes a new `Purchases.PlatformInfo` object 
  - Has string value for `flavor` and `version`
- This is the same design as what Android has
- `SystemInfo` ends up taking in the `PlatformInfo` object now
  - This allowed the removal of a some safety checks that could throw a system setup error
- Updated a bunch of tests 
