### PR TITLE
`IntegrationTests`: running on both SK1 and SK2

### DIFF
--- a/BackendIntegrationTests/BackendIntegrationTests.swift
+++ b/BackendIntegrationTests/BackendIntegrationTests.swift
@@ -26,11 +26,19 @@ class TestPurchaseDelegate: NSObject, PurchasesDelegate {
     }
 }
 
-class BackendIntegrationTests: XCTestCase {
+class BackendIntegrationSK2Tests: BackendIntegrationSK1Tests {
 
-    var testSession: SKTestSession!
-    var userDefaults: UserDefaults!
-    var purchasesDelegate: TestPurchaseDelegate!
+    override class var sk2Enabled: Bool { return true }
+
+}
+
+class BackendIntegrationSK1Tests: XCTestCase {
+
+    private var testSession: SKTestSession!
+    private var userDefaults: UserDefaults!
+    private var purchasesDelegate: TestPurchaseDelegate!
+
+    class var sk2Enabled: Bool { return false }
 
     private static let timeout: DispatchTimeInterval = .seconds(10)
 
@@ -46,6 +54,8 @@ class BackendIntegrationTests: XCTestCase {
         }
 
         configurePurchases()
+
+        try super.setUpWithError()
     }
 
     func testCanGetOfferings() throws {
@@ -285,7 +295,7 @@ class BackendIntegrationTests: XCTestCase {
     
 }
 
-private extension BackendIntegrationTests {
+private extension BackendIntegrationSK1Tests {
 
     func purchaseMonthlyOffering(completion: ((CustomerInfo?, Error?) -> Void)? = nil) {
         Purchases.shared.getOfferings { offerings, error in
@@ -315,7 +325,8 @@ private extension BackendIntegrationTests {
         Purchases.configure(withAPIKey: Constants.apiKey,
                             appUserID: nil,
                             observerMode: false,
-                            userDefaults: userDefaults)
+                            userDefaults: userDefaults,
+                            useStoreKit2IfAvailable: Self.sk2Enabled)
         Purchases.logLevel = .debug
         Purchases.shared.delegate = purchasesDelegate
     }


### PR DESCRIPTION
### Tests:
<img width="591" alt="Screen Shot 2022-02-20 at 13 40 27" src="https://user-images.githubusercontent.com/685609/154901239-078ba692-8c7e-427a-9383-4bdfa9ad3d9d.png">

See [**results**](https://circle-production-customer-artifacts.s3.amazonaws.com/picard/5a677352c9e77c0001541fa5/6213305f20e8a32d08f17992-0-build/artifacts/scan-test-output/ios/report.junit?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20220221T063327Z&X-Amz-SignedHeaders=host&X-Amz-Expires=60&X-Amz-Credential=AKIAJR3Q6CR467H7Z55A%2F20220221%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=d9d322f65c40d915bb90ae52706eaa3ad7b14a43120ad68a43c4af59a7662819)