### PR TITLE
`StoreTransaction`: added deprecations for version 3.x properties

### DIFF
--- a/Documentation.docc/V4_API_Migration_guide.md
+++ b/Documentation.docc/V4_API_Migration_guide.md
@@ -134,6 +134,8 @@ These types replace native StoreKit types in all public API methods that used th
 | ------------ | ------------------------------------- | 
 | RCPurchaserInfo | RCCustomerInfo |
 | RCTransaction | RCStoreTransaction |
+| RCTransaction.productId | RCStoreTransaction.productIdentifier |
+| RCTransaction.revenueCatId | RCStoreTransaction.transactionIdentifier |
 | RCPackage.product | RCPackage.storeProduct |
 | (RCPurchasesErrorCode).RCOperationAlreadyInProgressError | RCOperationAlreadyInProgressForProductError |
 | RCPurchasesErrorDomain | RCPurchasesErrorCodeDomain |
@@ -185,6 +187,8 @@ These types replace native StoreKit types in all public API methods that used th
 | Purchases.Package | ``Package`` |
 | Purchases.PurchaserInfo | <strong>``CustomerInfo``</strong> |
 | Purchases.Transaction | ``StoreTransaction`` |
+| Purchases.Transaction.productId | ``StoreTransaction/productIdentifier`` |
+| Purchases.Transaction.revenueCatId | ``StoreTransaction/transactionIdentifier`` |
 | Purchases.EntitlementInfo | ``EntitlementInfo`` |
 | Purchases.EntitlementInfos | ``EntitlementInfos`` |
 | Purchases.PeriodType | ``PeriodType`` |

--- a/Purchases/Misc/Obsoletions.swift
+++ b/Purchases/Misc/Obsoletions.swift
@@ -521,6 +521,22 @@ public extension Purchases {
 @available(macOS, obsoleted: 1, renamed: "StoreTransaction")
 @objc(RCTransaction) public class Transaction: NSObject { }
 
+public extension StoreTransaction {
+
+    @available(iOS, obsoleted: 1, renamed: "productIdentifier")
+    @available(tvOS, obsoleted: 1, renamed: "productIdentifier")
+    @available(watchOS, obsoleted: 1, renamed: "productIdentifier")
+    @available(macOS, obsoleted: 1, renamed: "productIdentifier")
+    @objc var productId: String { fatalError() }
+
+    @available(iOS, obsoleted: 1, renamed: "transactionIdentifier")
+    @available(tvOS, obsoleted: 1, renamed: "transactionIdentifier")
+    @available(watchOS, obsoleted: 1, renamed: "transactionIdentifier")
+    @available(macOS, obsoleted: 1, renamed: "transactionIdentifier")
+    @objc var revenueCatId: String { fatalError() }
+
+}
+
 public extension Package {
     /**
      `SKProduct` assigned to this package. https://developer.apple.com/documentation/storekit/skproduct


### PR DESCRIPTION
Fixes [CF-232] and [CF-231].

[CF-232]: https://revenuecats.atlassian.net/browse/CF-232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CF-231]: https://revenuecats.atlassian.net/browse/CF-231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ