### PR TITLE
Added `HTTPRequest` and `HTTPRequest.Path` to abstract all request information

### DIFF
--- a/Purchases/Identity/CustomerInfoManager.swift
+++ b/Purchases/Identity/CustomerInfoManager.swift
@@ -37,7 +37,7 @@ class CustomerInfoManager {
                                    completion: ((CustomerInfo?, Error?) -> Void)?) {
         deviceCache.setCacheTimestampToNowToPreventConcurrentCustomerInfoUpdates(appUserID: appUserID)
         operationDispatcher.dispatchOnWorkerThread(withRandomDelay: isAppBackgrounded) {
-            self.backend.getSubscriberData(appUserID: appUserID) { customerInfo, error in
+            self.backend.getCustomerInfo(appUserID: appUserID) { customerInfo, error in
                 if let error = error {
                     self.deviceCache.clearCustomerInfoCacheTimestamp(appUserID: appUserID)
                     Logger.warn(Strings.customerInfo.customerinfo_updated_from_network_error(error: error))

--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -72,8 +72,8 @@ class Backend {
         self.httpClient.clearCaches()
     }
 
-    func getSubscriberData(appUserID: String, completion: @escaping BackendCustomerInfoResponseHandler) {
-        self.subscribersAPI.getSubscriberData(appUserID: appUserID, completion: completion)
+    func getCustomerInfo(appUserID: String, completion: @escaping BackendCustomerInfoResponseHandler) {
+        self.subscribersAPI.getCustomerInfo(appUserID: appUserID, completion: completion)
     }
 
     // swiftlint:disable:next function_parameter_count

--- a/Purchases/Networking/HTTPClient.swift
+++ b/Purchases/Networking/HTTPClient.swift
@@ -263,8 +263,7 @@ private extension HTTPClient {
     }
 
     func convert(request: Request) -> URLRequest? {
-        guard let requestURL = URL(string: request.httpRequest.path.relativePath,
-                                   relativeTo: SystemInfo.serverHostURL) else {
+        guard let requestURL = request.httpRequest.path.url else {
             return nil
         }
 
@@ -298,8 +297,13 @@ private extension HTTPClient {
 
 extension HTTPRequest.Path {
 
+    var url: URL? {
+        return URL(string: self.relativePath,
+                   relativeTo: SystemInfo.serverHostURL)
+    }
+
     var relativePath: String {
-        return "\(Self.pathPrefix)\(self.description)"
+        return "\(Self.pathPrefix)/\(self.description)"
     }
 
     private static let pathPrefix: String = "/v1"

--- a/Purchases/Networking/HTTPRequest.swift
+++ b/Purchases/Networking/HTTPRequest.swift
@@ -1,0 +1,114 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  HTTPRequest.swift
+//
+//  Created by Nacho Soto on 2/27/22.
+
+/// A request to be made by ``HTTPClient``
+struct HTTPRequest {
+
+    let method: Method
+    let path: Path
+
+}
+
+// MARK: - Method
+
+extension HTTPRequest {
+
+    typealias Body = [String: Any]
+
+    enum Method {
+
+        case get
+        case post(body: Body)
+
+    }
+
+}
+
+extension HTTPRequest {
+
+    var requestBody: Body? {
+        switch self.method {
+        case let .post(body): return body
+        case .get: return nil
+        }
+    }
+
+}
+
+extension HTTPRequest.Method {
+
+    var httpMethod: String {
+        switch self {
+        case .get: return "GET"
+        case .post: return "POST"
+        }
+    }
+
+}
+
+// MARK: - Path
+
+extension HTTPRequest {
+
+    enum Path {
+
+        case getCustomerInfo(appUserID: String)
+        case getOfferings(appUserID: String)
+        case getIntroEligibility(appUserID: String)
+        case logIn
+        case createAlias(appUserID: String)
+        case postAttributionData(appUserID: String)
+        case postOfferForSigning
+        case postReceiptData
+        case postSubscriberAttributes(appUserID: String)
+
+    }
+
+}
+
+extension HTTPRequest.Path: Hashable {}
+
+extension HTTPRequest.Path: CustomStringConvertible {
+
+    var description: String {
+        switch self {
+        case let .getCustomerInfo(appUserID):
+            return "/subscribers/\(appUserID)"
+
+        case let .getOfferings(appUserID):
+            return "/subscribers/\(appUserID)/offerings"
+
+        case let .getIntroEligibility(appUserID):
+            return "/subscribers/\(appUserID)/intro_eligibility"
+
+        case .logIn:
+            return "/subscribers/identify"
+
+        case let .createAlias(appUserID):
+            return "/subscribers/\(appUserID)/alias"
+
+        case let .postAttributionData(appUserID):
+            return "/subscribers/\(appUserID)/attribution"
+
+        case .postOfferForSigning:
+            return "/offers"
+
+        case .postReceiptData:
+            return "/receipts"
+
+        case let .postSubscriberAttributes(appUserID):
+            return "/subscribers/\(appUserID)/attributes"
+        }
+    }
+
+}

--- a/Purchases/Networking/HTTPRequest.swift
+++ b/Purchases/Networking/HTTPRequest.swift
@@ -83,31 +83,31 @@ extension HTTPRequest.Path: CustomStringConvertible {
     var description: String {
         switch self {
         case let .getCustomerInfo(appUserID):
-            return "/subscribers/\(appUserID)"
+            return "subscribers/\(appUserID)"
 
         case let .getOfferings(appUserID):
-            return "/subscribers/\(appUserID)/offerings"
+            return "subscribers/\(appUserID)/offerings"
 
         case let .getIntroEligibility(appUserID):
-            return "/subscribers/\(appUserID)/intro_eligibility"
+            return "subscribers/\(appUserID)/intro_eligibility"
 
         case .logIn:
-            return "/subscribers/identify"
+            return "subscribers/identify"
 
         case let .createAlias(appUserID):
-            return "/subscribers/\(appUserID)/alias"
+            return "subscribers/\(appUserID)/alias"
 
         case let .postAttributionData(appUserID):
-            return "/subscribers/\(appUserID)/attribution"
+            return "subscribers/\(appUserID)/attribution"
 
         case .postOfferForSigning:
-            return "/offers"
+            return "offers"
 
         case .postReceiptData:
-            return "/receipts"
+            return "receipts"
 
         case let .postSubscriberAttributes(appUserID):
-            return "/subscribers/\(appUserID)/attributes"
+            return "subscribers/\(appUserID)/attributes"
         }
     }
 

--- a/Purchases/Networking/Operations/CreateAliasOperation.swift
+++ b/Purchases/Networking/Operations/CreateAliasOperation.swift
@@ -51,10 +51,10 @@ private extension CreateAliasOperation {
         }
         Logger.user(Strings.identity.creating_alias)
 
-        let path = "/subscribers/\(appUserID)/alias"
-        httpClient.performPOSTRequest(path: path,
-                                      requestBody: ["new_app_user_id": newAppUserID],
-                                      headers: authHeaders) { statusCode, response, error in
+        let request = HTTPRequest(method: .post(body: ["new_app_user_id": newAppUserID]),
+                                  path: .createAlias(appUserID: appUserID))
+
+        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
             self.aliasCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { aliasCallback in
 
                 guard let completion = aliasCallback.completion else {

--- a/Purchases/Networking/Operations/GetCustomerInfoOperation.swift
+++ b/Purchases/Networking/Operations/GetCustomerInfoOperation.swift
@@ -58,10 +58,9 @@ private extension GetCustomerInfoOperation {
             return
         }
 
-        let path = "/subscribers/\(appUserID)"
+        let request = HTTPRequest(method: .get, path: .getCustomerInfo(appUserID: appUserID))
 
-        httpClient.performGETRequest(path: path,
-                                     headers: authHeaders) { statusCode, response, error in
+        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
             self.customerInfoCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 self.customerInfoResponseHandler.handle(customerInfoResponse: response,
                                                         statusCode: statusCode,

--- a/Purchases/Networking/Operations/GetIntroEligibilityOperation.swift
+++ b/Purchases/Networking/Operations/GetIntroEligibilityOperation.swift
@@ -82,14 +82,11 @@ private extension GetIntroEligibilityOperation {
             return
         }
 
-        let fetchToken = self.receiptData.asFetchToken
-        let path = "/subscribers/\(appUserID)/intro_eligibility"
-        let body: [String: Any] = ["product_identifiers": self.productIdentifiers,
-                                   "fetch_token": fetchToken]
+        let request = HTTPRequest(method: .post(body: ["product_identifiers": self.productIdentifiers,
+                                                       "fetch_token": self.receiptData.asFetchToken]),
+                                  path: .getIntroEligibility(appUserID: appUserID))
 
-        httpClient.performPOSTRequest(path: path,
-                                      requestBody: body,
-                                      headers: authHeaders) { statusCode, response, error in
+        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
             let eligibilityResponse = IntroEligibilityResponse(response: response,
                                                                statusCode: statusCode,
                                                                error: error,

--- a/Purchases/Networking/Operations/GetOfferingsOperation.swift
+++ b/Purchases/Networking/Operations/GetOfferingsOperation.swift
@@ -44,9 +44,9 @@ private extension GetOfferingsOperation {
             return
         }
 
-        let path = "/subscribers/\(appUserID)/offerings"
-        httpClient.performGETRequest(path: path,
-                                     headers: authHeaders) { statusCode, response, error in
+        let request = HTTPRequest(method: .get, path: .getOfferings(appUserID: appUserID))
+
+        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
             defer {
                 completion()
             }

--- a/Purchases/Networking/Operations/LogInOperation.swift
+++ b/Purchases/Networking/Operations/LogInOperation.swift
@@ -47,10 +47,11 @@ private extension LogInOperation {
             return
         }
 
-        let requestBody = ["app_user_id": self.configuration.appUserID, "new_app_user_id": newAppUserID]
-        self.httpClient.performPOSTRequest(path: "/subscribers/identify",
-                                           requestBody: requestBody,
-                                           headers: self.authHeaders) { statusCode, response, error in
+        let request = HTTPRequest(method: .post(body: ["app_user_id": self.configuration.appUserID,
+                                                       "new_app_user_id": newAppUserID]),
+                                  path: .logIn)
+
+        self.httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
             self.loginCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callbackObject in
                 self.handleLogin(response: response,
                                  statusCode: statusCode,

--- a/Purchases/Networking/Operations/PostAttributionDataOperation.swift
+++ b/Purchases/Networking/Operations/PostAttributionDataOperation.swift
@@ -47,11 +47,10 @@ class PostAttributionDataOperation: NetworkOperation {
             return
         }
 
-        let path = "/subscribers/\(appUserID)/attribution"
-        let body: [String: Any] = ["network": self.network.rawValue, "data": self.attributionData]
-        self.httpClient.performPOSTRequest(path: path,
-                                           requestBody: body,
-                                           headers: self.authHeaders) { statusCode, response, error in
+        let request = HTTPRequest(method: .post(body: ["network": self.network.rawValue, "data": self.attributionData]),
+                                  path: .postAttributionData(appUserID: appUserID))
+
+        self.httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
             defer {
                 completion()
             }

--- a/Purchases/Networking/Operations/PostOfferForSigningOperation.swift
+++ b/Purchases/Networking/Operations/PostOfferForSigningOperation.swift
@@ -43,18 +43,19 @@ class PostOfferForSigningOperation: NetworkOperation {
     }
 
     private func post(completion: @escaping () -> Void) {
-        let requestBody: [String: Any] = ["app_user_id": self.configuration.appUserID,
-                                          "fetch_token": self.postOfferData.receiptData.asFetchToken,
-                                          "generate_offers": [
-                                            ["offer_id": self.postOfferData.offerIdentifier,
-                                             "product_id": self.postOfferData.productIdentifier,
-                                             "subscription_group": self.postOfferData.subscriptionGroup
-                                            ]
-                                          ]]
+        let request = HTTPRequest(
+            method: .post(body: ["app_user_id": self.configuration.appUserID,
+                                 "fetch_token": self.postOfferData.receiptData.asFetchToken,
+                                 "generate_offers": [
+                                    ["offer_id": self.postOfferData.offerIdentifier,
+                                     "product_id": self.postOfferData.productIdentifier,
+                                     "subscription_group": self.postOfferData.subscriptionGroup
+                                    ]
+                                 ]]),
+            path: .postOfferForSigning
+        )
 
-        self.httpClient.performPOSTRequest(path: "/offers",
-                                           requestBody: requestBody,
-                                           headers: authHeaders) { statusCode, response, error in
+        self.httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
             let result: (String?, String?, UUID?, Int?, Error?) = {
                 if let error = error {
                     return (nil, nil, nil, nil, ErrorUtils.networkError(withUnderlyingError: error))

--- a/Purchases/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Purchases/Networking/Operations/PostReceiptDataOperation.swift
@@ -90,9 +90,9 @@ class PostReceiptDataOperation: CacheableNetworkOperation {
             body["presented_offering_identifier"] = offeringIdentifier
         }
 
-        httpClient.performPOSTRequest(path: "/receipts",
-                                      requestBody: body,
-                                      headers: self.authHeaders) { statusCode, response, error in
+        let request = HTTPRequest(method: .post(body: body), path: .postReceiptData)
+
+        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
             self.customerInfoCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callbackObject in
                 self.customerInfoResponseHandler.handle(customerInfoResponse: response,
                                                         statusCode: statusCode,

--- a/Purchases/Networking/Operations/PostSubscriberAttributesOperation.swift
+++ b/Purchases/Networking/Operations/PostSubscriberAttributesOperation.swift
@@ -55,13 +55,12 @@ class PostSubscriberAttributesOperation: NetworkOperation {
             return
         }
 
-        let path = "/subscribers/\(appUserID)/attributes"
-
         let attributesInBackendFormat = self.subscriberAttributesMarshaller
             .map(subscriberAttributes: self.subscriberAttributes)
-        httpClient.performPOSTRequest(path: path,
-                                      requestBody: ["attributes": attributesInBackendFormat],
-                                      headers: self.authHeaders) { statusCode, response, error in
+        let request = HTTPRequest(method: .post(body: ["attributes": attributesInBackendFormat]),
+                                  path: .postSubscriberAttributes(appUserID: appUserID))
+
+        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
             defer {
                 completion()
             }

--- a/Purchases/Networking/SubscribersAPI.swift
+++ b/Purchases/Networking/SubscribersAPI.swift
@@ -46,7 +46,7 @@ class SubscribersAPI {
         operationQueue.addCacheableOperation(operation, cacheStatus: cacheStatus)
     }
 
-    func getSubscriberData(appUserID: String, completion: @escaping BackendCustomerInfoResponseHandler) {
+    func getCustomerInfo(appUserID: String, completion: @escaping BackendCustomerInfoResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.httpClient,
                                                                 authHeaders: self.authHeaders,
                                                                 appUserID: appUserID)

--- a/PurchasesTests/Mocks/MockBackend.swift
+++ b/PurchasesTests/Mocks/MockBackend.swift
@@ -77,7 +77,7 @@ class MockBackend: Backend {
     var stubbedGetSubscriberDataCustomerInfo: CustomerInfo?
     var stubbedGetSubscriberDataError: Error?
 
-    override func getSubscriberData(appUserID: String, completion: @escaping BackendCustomerInfoResponseHandler) {
+    override func getCustomerInfo(appUserID: String, completion: @escaping BackendCustomerInfoResponseHandler) {
         invokedGetSubscriberData = true
         invokedGetSubscriberDataCount += 1
         invokedGetSubscriberDataParameters = (appUserID, completion)

--- a/PurchasesTests/Mocks/MockHTTPClient.swift
+++ b/PurchasesTests/Mocks/MockHTTPClient.swift
@@ -3,9 +3,7 @@
 class MockHTTPClient: HTTPClient {
 
     struct InvokedPerformRequestParameters {
-        let httpMethod: String
-        let path: String
-        let requestBody: [String: Any]?
+        let request: HTTPRequest
         let headers: [String: String]?
         let completionHandler: ((Int, [String: Any]?, Error?) -> Void)?
     }
@@ -21,41 +19,14 @@ class MockHTTPClient: HTTPClient {
     var invokedPerformRequestParameters: InvokedPerformRequestParameters?
     var invokedPerformRequestParametersList = [InvokedPerformRequestParameters]()
 
-    override func performGETRequest(path: String,
-                                    headers authHeaders: [String: String],
-                                    completionHandler: ((Int, [String: Any]?, Error?) -> Void)?) {
-        performRequest("GET",
-                       path: path,
-                       requestBody: nil,
-                       headers: authHeaders,
-                       completionHandler: completionHandler)
-    }
-
-    override func performPOSTRequest(path: String,
-                                     requestBody: [String: Any],
-                                     headers authHeaders: [String: String],
-                                     completionHandler: ((Int, [String: Any]?, Error?) -> Void)?) {
-        performRequest("POST",
-                       path: path,
-                       requestBody: requestBody,
-                       headers: authHeaders,
-                       completionHandler: completionHandler)
-    }
-}
-
-private extension MockHTTPClient {
-    func performRequest(_ httpMethod: String,
-                        path: String,
-                        requestBody: [String: Any]?,
-                        headers: [String: String]?,
-                        completionHandler: ((Int, [String: Any]?, Error?) -> Void)?) {
+    override func perform(_ request: HTTPRequest,
+                          authHeaders: [String: String],
+                          completionHandler: ((Int, [String: Any]?, Error?) -> Void)?) {
         invokedPerformRequest = true
         invokedPerformRequestCount += 1
         let parameters = InvokedPerformRequestParameters(
-            httpMethod: httpMethod,
-            path: path,
-            requestBody: requestBody,
-            headers: headers,
+            request: request,
+            headers: authHeaders,
             completionHandler: completionHandler
         )
         invokedPerformRequestParameters = parameters

--- a/PurchasesTests/Networking/HTTPRequestTests.swift
+++ b/PurchasesTests/Networking/HTTPRequestTests.swift
@@ -1,0 +1,50 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  HTTPRequestTests.swift
+//
+//  Created by Nacho Soto on 3/4/22.
+
+import Foundation
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+class HTTPRequestTests: XCTestCase {
+
+    // MARK: - Paths
+
+    private static let userID = "the_user"
+
+    private static let paths: [HTTPRequest.Path] = [
+        .getCustomerInfo(appUserID: userID),
+        .getOfferings(appUserID: userID),
+        .getIntroEligibility(appUserID: userID),
+        .logIn,
+        .createAlias(appUserID: userID),
+        .postAttributionData(appUserID: userID),
+        .postOfferForSigning,
+        .postReceiptData,
+        .postSubscriberAttributes(appUserID: userID)
+    ]
+
+    func testPathsDontHaveLeadingSlash() {
+        for path in Self.paths {
+            expect(path.description).toNot(beginWith("/"))
+        }
+    }
+
+    func testPathsHaveValidURLs() {
+        for path in Self.paths {
+            expect(path.url).toNot(beNil())
+        }
+    }
+
+}

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -102,7 +102,7 @@ class PurchasesTests: XCTestCase {
                 "other_purchases": [:]
             ]])
 
-        override func getSubscriberData(appUserID: String, completion: @escaping BackendCustomerInfoResponseHandler) {
+        override func getCustomerInfo(appUserID: String, completion: @escaping BackendCustomerInfoResponseHandler) {
             getSubscriberCallCount += 1
             userID = appUserID
 

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -237,6 +237,7 @@
 		57C381DC27961547009E3940 /* SK2StoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381DB27961547009E3940 /* SK2StoreProductDiscount.swift */; };
 		57C381E2279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */; };
 		57C381E3279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */; };
+		57DC9F4627CC2E4900DA6AF9 /* HTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DC9F4527CC2E4900DA6AF9 /* HTTPRequest.swift */; };
 		57E0473B277260DE0082FE91 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 57E0473A277260DE0082FE91 /* SnapshotTesting */; };
 		57E2230727500BB1002DB06E /* AtomicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E2230627500BB1002DB06E /* AtomicTests.swift */; };
 		57EAE527274324C60060EB74 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE526274324C60060EB74 /* Lock.swift */; };
@@ -633,6 +634,7 @@
 		57C381D92796153D009E3940 /* SK1StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1StoreProductDiscount.swift; sourceTree = "<group>"; };
 		57C381DB27961547009E3940 /* SK2StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreProductDiscount.swift; sourceTree = "<group>"; };
 		57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreProductDiscount.swift; sourceTree = "<group>"; };
+		57DC9F4527CC2E4900DA6AF9 /* HTTPRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequest.swift; sourceTree = "<group>"; };
 		57E0474B27729A1E0082FE91 /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		57E2230627500BB1002DB06E /* AtomicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicTests.swift; sourceTree = "<group>"; };
 		57EAE526274324C60060EB74 /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
@@ -1293,6 +1295,7 @@
 				35F6FD61267426D600ABCB53 /* ETagAndResponseWrapper.swift */,
 				35D832CC262A5B7500E60AC5 /* ETagManager.swift */,
 				35F82BB326A9A74D0051DF03 /* HTTPClient.swift */,
+				57DC9F4527CC2E4900DA6AF9 /* HTTPRequest.swift */,
 				35D832F3262E606500E60AC5 /* HTTPResponse.swift */,
 				35D832D1262E56DB00E60AC5 /* HTTPStatusCodes.swift */,
 				B3766F1D26BDA95100141450 /* IntroEligibilityResponse.swift */,
@@ -1976,6 +1979,7 @@
 				9A65E0A52591A23500DE00B0 /* PurchaseStrings.swift in Sources */,
 				57EAE52B274332830060EB74 /* Obsoletions.swift in Sources */,
 				2C0B98CD2797070B00C5874F /* PromotionalOffer.swift in Sources */,
+				57DC9F4627CC2E4900DA6AF9 /* HTTPRequest.swift in Sources */,
 				2DC5623024EC63730031F69B /* OperationDispatcher.swift in Sources */,
 				57A0FBF22749CF66009E2FC3 /* SynchronizedUserDefaults.swift in Sources */,
 				F5714EE526DC2F1D00635477 /* CodableStrings.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 		575A17AB2773A59300AA6F22 /* CurrentTestCaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */; };
 		576C8A8B27CFCB150058FA6E /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A8A27CFCB150058FA6E /* AnyEncodable.swift */; };
 		576C8A8F27CFCD110058FA6E /* AnyEncodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A8E27CFCD110058FA6E /* AnyEncodableTests.swift */; };
+		576C8AD927D2BCB90058FA6E /* HTTPRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8AD827D2BCB90058FA6E /* HTTPRequestTests.swift */; };
 		578FB10E27ADDA8000F70709 /* AvailabilityChecks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE0263275942D500915B4C /* AvailabilityChecks.swift */; };
 		5791A1AA2767E42B00C972AA /* SKProduct+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791A1A92767E42A00C972AA /* SKProduct+Extensions.swift */; };
 		5791A1C82767FC9400C972AA /* ManageSubscriptionsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791A1C72767FC9400C972AA /* ManageSubscriptionsHelperTests.swift */; };
@@ -619,6 +620,7 @@
 		575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentTestCaseTracker.swift; sourceTree = "<group>"; };
 		576C8A8A27CFCB150058FA6E /* AnyEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
 		576C8A8E27CFCD110058FA6E /* AnyEncodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodableTests.swift; sourceTree = "<group>"; };
+		576C8AD827D2BCB90058FA6E /* HTTPRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestTests.swift; sourceTree = "<group>"; };
 		576C8A9027D180540058FA6E /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		5791A1A92767E42A00C972AA /* SKProduct+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SKProduct+Extensions.swift"; sourceTree = "<group>"; };
 		5791A1C72767FC9400C972AA /* ManageSubscriptionsHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionsHelperTests.swift; sourceTree = "<group>"; };
@@ -1312,6 +1314,7 @@
 				37E353CBE9CF2572A72A347F /* HTTPClientTests.swift */,
 				35D832FF262FAD8000E60AC5 /* ETagManagerTests.swift */,
 				B380D69A27726AB500984578 /* DNSCheckerTests.swift */,
+				576C8AD827D2BCB90058FA6E /* HTTPRequestTests.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -2177,6 +2180,7 @@
 				351B516A26D44CB300BD2BD7 /* ISOPeriodFormatterTests.swift in Sources */,
 				2DDF41DE24F6F527005BC22D /* MockAppleReceiptBuilder.swift in Sources */,
 				2DDF41E324F6F527005BC22D /* MockASN1ContainerBuilder.swift in Sources */,
+				576C8AD927D2BCB90058FA6E /* HTTPRequestTests.swift in Sources */,
 				2DDF41DA24F6F4DB005BC22D /* ReceiptParserTests.swift in Sources */,
 				2D1015E2275A67E40086173F /* SubscriptionPeriodTests.swift in Sources */,
 				351B519F26D4508A00BD2BD7 /* DeviceCacheTests.swift in Sources */,


### PR DESCRIPTION
For [CF-195] and #695.

## Overview

- Moved `HTTPClient.Method` into `HTTPRequest` (now `HTTPRequest.Method`).
- `HTTPClient.Request` now has an `HTTPRequest`, to encapsulate the `method` and `path`.
- `HTTPClient` now has a single `perform` method, since the method is encapsulated in the request.
- Abstracted creation of “relative” path that includes `/v1` to avoid hardcoding that everywhere.
- Represented all paths into `HTTPRequest.Path` to avoid hardcoding paths everywhere.

## Other changes

- Renamed `Backend.getSubscriberData` to `getCustomerInfo`.
- Simplified `MockHTTPClient` by using new `HTTPRequest` type.
- Simplified `BackendTests.MockHTTPClient` by using new `HTTPRequest` and `HTTPRequest.Path` types.
- Simplified `BackendTest`s by comparing `HTTPRequest`s.
- Refactored many tests using `Nimble` and `XCTUnwrap`.
- Added `isPath` overload that uses `HTTPRequest.Path` to easily mock paths.
- Removed duplication in tests creating requests with invalid bodies.
- Abstracted all usages of `requestNumber` keys in all tests.

## Notes

- Something that’s unchanged is that request bodys weren’t checked in a lot of tests because `[String: Any]` isn’t `Equatable`. However, the snapshot tests introduced in #1110 already verify the bodies for every request automatically.

[CF-195]: https://revenuecats.atlassian.net/browse/CF-195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ