### PR TITLE
Extracted authorization header creation

### DIFF
--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -53,7 +53,7 @@ class Backend {
         self.apiKey = apiKey
         self.offeringsCallbacksCache = CallbackCache<OfferingsCallback>(callbackQueue: self.callbackQueue)
         self.logInCallbacksCache = CallbackCache<LogInCallback>(callbackQueue: self.callbackQueue)
-        self.authHeaders = ["Authorization": "Bearer \(apiKey)"]
+        self.authHeaders = HTTPClient.authorizationHeader(withAPIKey: apiKey)
 
         let aliasCallbackCache = CallbackCache<AliasCallback>(callbackQueue: callbackQueue)
         let customerInfoCallbackCache = CallbackCache<CustomerInfoCallback>(callbackQueue: callbackQueue)

--- a/Purchases/Networking/HTTPClient.swift
+++ b/Purchases/Networking/HTTPClient.swift
@@ -15,6 +15,8 @@ import Foundation
 
 class HTTPClient {
 
+    typealias RequestHeaders = [String: String]
+
     private let session: URLSession
     internal let systemInfo: SystemInfo
     private let state: Atomic<State> = .init(.initial)
@@ -48,6 +50,14 @@ class HTTPClient {
 
 }
 
+extension HTTPClient {
+
+    static func authorizationHeader(withAPIKey apiKey: String) -> RequestHeaders {
+        return ["Authorization": "Bearer \(apiKey)"]
+    }
+
+}
+
 private extension HTTPClient {
     struct State {
         var queuedRequests: [Request]
@@ -63,11 +73,10 @@ private extension HTTPClient {
     // swiftlint:disable nesting
     struct Request: CustomStringConvertible {
 
-        typealias Headers = [String: String]
         typealias Completion = ((_ statusCode: Int, _ response: [String: Any]?, _ error: Error?) -> Void)
 
         var httpRequest: HTTPRequest
-        var headers: Headers
+        var headers: HTTPClient.RequestHeaders
         var completionHandler: Completion?
         var retried: Bool = false
 
@@ -75,7 +84,7 @@ private extension HTTPClient {
         var path: String { self.httpRequest.path.description }
         var requestBody: HTTPRequest.Body? { self.httpRequest.requestBody }
 
-        func adding(defaultHeaders: Headers) -> Self {
+        func adding(defaultHeaders: HTTPClient.RequestHeaders) -> Self {
             var copy = self
             copy.headers = defaultHeaders.merging(self.headers)
 

--- a/PurchasesTests/Networking/ETagManagerTests.swift
+++ b/PurchasesTests/Networking/ETagManagerTests.swift
@@ -192,16 +192,18 @@ class ETagManagerTests: XCTestCase {
     }
 
     private func getHeaders(eTag: String) -> [String: String] {
-        ["Content-Type": "application/json",
-         "X-Platform": "android",
-         "X-Platform-Flavor": "native",
-         "X-Platform-Version": "29",
-         "X-Version": "4.1.0",
-         "X-Client-Locale": "en-US",
-         "X-Client-Version": "1.0",
-         "X-Observer-Mode-Enabled": "false",
-         "Authorization": "Bearer apiKey",
-         ETagManager.eTagHeaderName: eTag]
+        return [
+            "Content-Type": "application/json",
+            "X-Platform": "android",
+            "X-Platform-Flavor": "native",
+            "X-Platform-Version": "29",
+            "X-Version": "4.1.0",
+            "X-Client-Locale": "en-US",
+            "X-Client-Version": "1.0",
+            "X-Observer-Mode-Enabled": "false",
+            ETagManager.eTagHeaderName: eTag
+        ]
+            .merging(HTTPClient.authorizationHeader(withAPIKey: "apikey"))
     }
 
     private func mockStoredETagAndResponse(for url: URL,

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -10,9 +10,10 @@ import XCTest
 
 class BackendSubscriberAttributesTests: XCTestCase {
 
-    let appUserID = "abc123"
-    let now = Date()
-    let receiptData = "an awesome receipt".data(using: String.Encoding.utf8)!
+    private let appUserID = "abc123"
+    private let now = Date()
+    private let receiptData = "an awesome receipt".data(using: String.Encoding.utf8)!
+    private static let apiKey = "the api key"
 
     var dateProvider: MockDateProvider!
     var subscriberAttribute1: SubscriberAttribute!
@@ -40,7 +41,7 @@ class BackendSubscriberAttributesTests: XCTestCase {
     override func setUp() {
         mockETagManager = MockETagManager(userDefaults: MockUserDefaults())
         mockHTTPClient = MockHTTPClient(systemInfo: systemInfo, eTagManager: mockETagManager)
-        self.backend = Backend(httpClient: mockHTTPClient, apiKey: "key")
+        self.backend = Backend(httpClient: mockHTTPClient, apiKey: Self.apiKey)
         dateProvider = MockDateProvider(stubbedNow: now)
         subscriberAttribute1 = SubscriberAttribute(withKey: "a key",
                                                    value: "a value",
@@ -85,7 +86,7 @@ class BackendSubscriberAttributesTests: XCTestCase {
         // This is implicitly checking that the request was .post
         expect(body) == expectedBody
         expect(receivedParameters.request.path) == .postSubscriberAttributes(appUserID: self.appUserID)
-        expect(receivedParameters.headers) == ["Authorization": "Bearer key"]
+        expect(receivedParameters.headers) == HTTPClient.authorizationHeader(withAPIKey: Self.apiKey)
     }
 
     func testPostSubscriberAttributesCallsCompletionInSuccessCase() {


### PR DESCRIPTION
For [CF-195] and #695.

This was duplicated all over the place, now only defined in one place.

[CF-195]: https://revenuecats.atlassian.net/browse/CF-195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ