### PR TITLE
Renamed `HTTPStatusCodes` to `HTTPStatusCode`

### DIFF
--- a/Purchases/Networking/ETagManager.swift
+++ b/Purchases/Networking/ETagManager.swift
@@ -85,7 +85,7 @@ class ETagManager {
 private extension ETagManager {
 
     func shouldUseCachedVersion(responseCode: Int) -> Bool {
-        responseCode == HTTPStatusCodes.notModifiedResponseCode.rawValue
+        responseCode == HTTPStatusCode.notModifiedResponseCode.rawValue
     }
 
     func storedETagAndResponse(for request: URLRequest) -> ETagAndResponseWrapper? {
@@ -114,8 +114,8 @@ private extension ETagManager {
                                              statusCode: Int,
                                              responseObject: [String: Any]?,
                                              eTag: String) {
-        if statusCode != HTTPStatusCodes.notModifiedResponseCode.rawValue &&
-            statusCode < HTTPStatusCodes.internalServerError.rawValue,
+        if statusCode != HTTPStatusCode.notModifiedResponseCode.rawValue &&
+            statusCode < HTTPStatusCode.internalServerError.rawValue,
            let responseObject = responseObject,
            let cacheKey = eTagDefaultCacheKey(for: request) {
             let eTagAndResponse = ETagAndResponseWrapper(eTag: eTag, statusCode: statusCode, jsonObject: responseObject)

--- a/Purchases/Networking/HTTPClient.swift
+++ b/Purchases/Networking/HTTPClient.swift
@@ -169,7 +169,7 @@ private extension HTTPClient {
                 urlRequest: URLRequest,
                 data: Data?,
                 error networkError: Error?) {
-        var statusCode = HTTPStatusCodes.networkConnectTimeoutError.rawValue
+        var statusCode = HTTPStatusCode.networkConnectTimeoutError.rawValue
         var jsonObject: [String: Any]?
         var httpResponse: HTTPResponse? = HTTPResponse(statusCode: statusCode, jsonObject: jsonObject)
         var receivedJSONError: Error?
@@ -181,7 +181,7 @@ private extension HTTPClient {
                                                                    path: request.path,
                                                                    httpCode: statusCode))
 
-                if statusCode == HTTPStatusCodes.notModifiedResponseCode.rawValue || data == nil {
+                if statusCode == HTTPStatusCode.notModifiedResponseCode.rawValue || data == nil {
                     jsonObject = [:]
                 } else if let data = data {
                     do {

--- a/Purchases/Networking/HTTPStatusCode.swift
+++ b/Purchases/Networking/HTTPStatusCode.swift
@@ -7,14 +7,14 @@
 //
 //      https://opensource.org/licenses/MIT
 //
-//  HTTPStatusCodes.swift
+//  HTTPStatusCode.swift
 //
 //  Created by César de la Vega on 4/19/21.
 //
 
 import Foundation
 
-enum HTTPStatusCodes: Int {
+enum HTTPStatusCode: Int {
 
     case success = 200,
          createdSuccess = 201,

--- a/Purchases/Networking/Operations/GetIntroEligibilityOperation.swift
+++ b/Purchases/Networking/Operations/GetIntroEligibilityOperation.swift
@@ -101,7 +101,7 @@ private extension GetIntroEligibilityOperation {
     func handleIntroEligibility(response: IntroEligibilityResponse) {
         let result: [String: IntroEligibility] = {
             var eligibilitiesByProductIdentifier = response.response
-            if response.statusCode >= HTTPStatusCodes.redirect.rawValue || response.error != nil {
+            if response.statusCode >= HTTPStatusCode.redirect.rawValue || response.error != nil {
                 eligibilitiesByProductIdentifier = [:]
             }
 

--- a/Purchases/Networking/Operations/GetOfferingsOperation.swift
+++ b/Purchases/Networking/Operations/GetOfferingsOperation.swift
@@ -51,7 +51,7 @@ private extension GetOfferingsOperation {
                 completion()
             }
 
-            if error == nil && statusCode < HTTPStatusCodes.redirect.rawValue {
+            if error == nil && statusCode < HTTPStatusCode.redirect.rawValue {
                 self.offeringsCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callbackObject in
                     callbackObject.completion(response, nil)
                 }
@@ -61,7 +61,7 @@ private extension GetOfferingsOperation {
             let errorForCallbacks: Error
             if let error = error {
                 errorForCallbacks = ErrorUtils.networkError(withUnderlyingError: error)
-            } else if statusCode >= HTTPStatusCodes.redirect.rawValue {
+            } else if statusCode >= HTTPStatusCode.redirect.rawValue {
                 let backendCode = BackendErrorCode(code: response?["code"])
                 let backendMessage = response?["message"] as? String
                 errorForCallbacks = ErrorUtils.backendError(withBackendCode: backendCode,

--- a/Purchases/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
+++ b/Purchases/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
@@ -34,7 +34,7 @@ class CustomerInfoResponseHandler {
                                                     fileName: file, functionName: function, line: line))
             return
         }
-        let isErrorStatusCode = statusCode >= HTTPStatusCodes.redirect.rawValue
+        let isErrorStatusCode = statusCode >= HTTPStatusCode.redirect.rawValue
 
         let customerInfoError: Error?
         let customerInfo: CustomerInfo?
@@ -69,7 +69,7 @@ class CustomerInfoResponseHandler {
                         || customerInfoError != nil)
 
         guard !hasError else {
-            let finishable = statusCode < HTTPStatusCodes.internalServerError.rawValue
+            let finishable = statusCode < HTTPStatusCode.internalServerError.rawValue
             var extraUserInfo = [ErrorDetails.finishableKey: finishable] as [String: Any]
             extraUserInfo.merge(subscriberAttributesErrorInfo) { _, new in new }
             let backendErrorCode = BackendErrorCode(code: response?["code"])

--- a/Purchases/Networking/Operations/Handling/NoContentResponseHandler.swift
+++ b/Purchases/Networking/Operations/Handling/NoContentResponseHandler.swift
@@ -24,7 +24,7 @@ class NoContentResponseHandler {
             return
         }
 
-        guard statusCode <= HTTPStatusCodes.redirect.rawValue else {
+        guard statusCode <= HTTPStatusCode.redirect.rawValue else {
             let backendErrorCode = BackendErrorCode(code: response?["code"])
             let message = response?["message"] as? String
             let responseError = ErrorUtils.backendError(withBackendCode: backendErrorCode, backendMessage: message)

--- a/Purchases/Networking/Operations/Handling/SubscriberAttributeHandler.swift
+++ b/Purchases/Networking/Operations/Handling/SubscriberAttributeHandler.swift
@@ -32,7 +32,7 @@ class SubscriberAttributeHandler {
 
         let responseError: Error?
 
-        if let response = response, statusCode > HTTPStatusCodes.redirect.rawValue {
+        if let response = response, statusCode > HTTPStatusCode.redirect.rawValue {
             let extraUserInfo = self.userInfoAttributeParser
                 .attributesUserInfoFromResponse(response: response, statusCode: statusCode)
             let backendErrorCode = BackendErrorCode(code: response["code"])

--- a/Purchases/Networking/Operations/Handling/UserInfoAttributeParser.swift
+++ b/Purchases/Networking/Operations/Handling/UserInfoAttributeParser.swift
@@ -17,8 +17,8 @@ class UserInfoAttributeParser {
 
     func attributesUserInfoFromResponse(response: [String: Any], statusCode: Int) -> [String: Any] {
         var resultDict: [String: Any] = [:]
-        let isInternalServerError = statusCode >= HTTPStatusCodes.internalServerError.rawValue
-        let isNotFoundError = statusCode == HTTPStatusCodes.notFoundError.rawValue
+        let isInternalServerError = statusCode >= HTTPStatusCode.internalServerError.rawValue
+        let isNotFoundError = statusCode == HTTPStatusCode.notFoundError.rawValue
 
         let successfullySynced = !(isInternalServerError || isNotFoundError)
         resultDict[Backend.RCSuccessfullySyncedKey as String] = successfullySynced

--- a/Purchases/Networking/Operations/LogInOperation.swift
+++ b/Purchases/Networking/Operations/LogInOperation.swift
@@ -78,7 +78,7 @@ private extension LogInOperation {
                 return (nil, false, responseError)
             }
 
-            if statusCode > HTTPStatusCodes.redirect.rawValue {
+            if statusCode > HTTPStatusCode.redirect.rawValue {
                 let backendCode = BackendErrorCode(code: response["code"])
                 let backendMessage = response["message"] as? String
                 let responsError = ErrorUtils.backendError(withBackendCode: backendCode, backendMessage: backendMessage)
@@ -87,7 +87,7 @@ private extension LogInOperation {
 
             do {
                 let customerInfo = try CustomerInfo.from(json: response)
-                let created = statusCode == HTTPStatusCodes.createdSuccess.rawValue
+                let created = statusCode == HTTPStatusCode.createdSuccess.rawValue
                 Logger.user(Strings.identity.login_success)
                 return (customerInfo, created, nil)
             } catch let customerInfoError {

--- a/Purchases/Networking/Operations/PostOfferForSigningOperation.swift
+++ b/Purchases/Networking/Operations/PostOfferForSigningOperation.swift
@@ -61,7 +61,7 @@ class PostOfferForSigningOperation: NetworkOperation {
                     return (nil, nil, nil, nil, ErrorUtils.networkError(withUnderlyingError: error))
                 }
 
-                guard statusCode < HTTPStatusCodes.redirect.rawValue else {
+                guard statusCode < HTTPStatusCode.redirect.rawValue else {
                     let backendCode = BackendErrorCode(code: response?["code"])
                     let backendMessage = response?["message"] as? String
                     let error = ErrorUtils.backendError(withBackendCode: backendCode, backendMessage: backendMessage)

--- a/PurchasesTests/Networking/ETagManagerTests.swift
+++ b/PurchasesTests/Networking/ETagManagerTests.swift
@@ -46,10 +46,10 @@ class ETagManagerTests: XCTestCase {
         let eTag = "an_etag"
         let url = urlForTest()
         let request = URLRequest(url: url)
-        let cachedResponse = mockStoredETagAndResponse(for: url, statusCode: HTTPStatusCodes.success, eTag: eTag)
+        let cachedResponse = mockStoredETagAndResponse(for: url, statusCode: HTTPStatusCode.success, eTag: eTag)
 
         guard let httpURLResponse = HTTPURLResponse(url: url,
-                                                    statusCode: HTTPStatusCodes.notModifiedResponseCode.rawValue,
+                                                    statusCode: HTTPStatusCode.notModifiedResponseCode.rawValue,
                                                     httpVersion: "HTTP/1.1",
                                                     headerFields: getHeaders(eTag: eTag)) else {
             fatalError("Error initializing HTTPURLResponse")
@@ -60,7 +60,7 @@ class ETagManagerTests: XCTestCase {
                                                                 request: request,
                                                                 retried: false)
         expect(response).toNot(beNil())
-        expect(response?.statusCode) == HTTPStatusCodes.success.rawValue
+        expect(response?.statusCode) == HTTPStatusCode.success.rawValue
         expect(response?.jsonObject as? [String: String]).to(equal(cachedResponse))
     }
 
@@ -68,13 +68,13 @@ class ETagManagerTests: XCTestCase {
         let eTag = "an_etag"
         let url = urlForTest()
         let request = URLRequest(url: url)
-        _ = mockStoredETagAndResponse(for: url, statusCode: HTTPStatusCodes.success, eTag: eTag)
+        _ = mockStoredETagAndResponse(for: url, statusCode: HTTPStatusCode.success, eTag: eTag)
         let responseObject = ["a": "response"]
-        let httpURLResponse = httpURLResponseForTest(url: url, eTag: eTag, statusCode: HTTPStatusCodes.success.rawValue)
+        let httpURLResponse = httpURLResponseForTest(url: url, eTag: eTag, statusCode: HTTPStatusCode.success.rawValue)
         let response = eTagManager.httpResultFromCacheOrBackend(
             with: httpURLResponse, jsonObject: responseObject, error: nil, request: request, retried: false)
         expect(response).toNot(beNil())
-        expect(response?.statusCode) == HTTPStatusCodes.success.rawValue
+        expect(response?.statusCode) == HTTPStatusCode.success.rawValue
         expect(response?.jsonObject as? [String: String]).to(equal(responseObject))
     }
 
@@ -82,17 +82,17 @@ class ETagManagerTests: XCTestCase {
         let eTag = "an_etag"
         let url = urlForTest()
         let request = URLRequest(url: url)
-        _ = mockStoredETagAndResponse(for: url, statusCode: HTTPStatusCodes.success, eTag: eTag)
+        _ = mockStoredETagAndResponse(for: url, statusCode: HTTPStatusCode.success, eTag: eTag)
         let responseObject = ["a": "response"]
         let error = NSError(domain: NSCocoaErrorDomain, code: 123, userInfo: [:])
         let httpURLResponse = httpURLResponseForTest(
             url: url,
             eTag: eTag,
-            statusCode: HTTPStatusCodes.notModifiedResponseCode.rawValue)
+            statusCode: HTTPStatusCode.notModifiedResponseCode.rawValue)
         let response = eTagManager.httpResultFromCacheOrBackend(
             with: httpURLResponse, jsonObject: responseObject, error: error, request: request, retried: false)
         expect(response).toNot(beNil())
-        expect(response?.statusCode) == HTTPStatusCodes.notModifiedResponseCode.rawValue
+        expect(response?.statusCode) == HTTPStatusCode.notModifiedResponseCode.rawValue
         expect(response?.jsonObject as? [String: String]).to(equal(responseObject))
     }
 
@@ -104,11 +104,11 @@ class ETagManagerTests: XCTestCase {
         let httpURLResponse = httpURLResponseForTest(
             url: url,
             eTag: eTag,
-            statusCode: HTTPStatusCodes.notModifiedResponseCode.rawValue)
+            statusCode: HTTPStatusCode.notModifiedResponseCode.rawValue)
         let response = eTagManager.httpResultFromCacheOrBackend(
             with: httpURLResponse, jsonObject: responseObject, error: nil, request: request, retried: true)
         expect(response).toNot(beNil())
-        expect(response?.statusCode) == HTTPStatusCodes.notModifiedResponseCode.rawValue
+        expect(response?.statusCode) == HTTPStatusCode.notModifiedResponseCode.rawValue
         expect(response?.jsonObject as? [String: String]).to(equal(responseObject))
     }
 
@@ -120,7 +120,7 @@ class ETagManagerTests: XCTestCase {
         let httpURLResponse = httpURLResponseForTest(
             url: url,
             eTag: eTag,
-            statusCode: HTTPStatusCodes.notModifiedResponseCode.rawValue)
+            statusCode: HTTPStatusCode.notModifiedResponseCode.rawValue)
         let response = eTagManager.httpResultFromCacheOrBackend(
             with: httpURLResponse, jsonObject: responseObject, error: nil, request: request, retried: false)
         expect(response).to(beNil())
@@ -134,7 +134,7 @@ class ETagManagerTests: XCTestCase {
         let httpURLResponse = httpURLResponseForTest(
             url: url,
             eTag: eTag,
-            statusCode: HTTPStatusCodes.success.rawValue)
+            statusCode: HTTPStatusCode.success.rawValue)
         let response = eTagManager.httpResultFromCacheOrBackend(
             with: httpURLResponse, jsonObject: responseObject, error: nil, request: request, retried: false)
 
@@ -164,12 +164,12 @@ class ETagManagerTests: XCTestCase {
         let httpURLResponse = httpURLResponseForTest(
             url: url,
             eTag: eTag,
-            statusCode: HTTPStatusCodes.internalServerError.rawValue)
+            statusCode: HTTPStatusCode.internalServerError.rawValue)
         let response = eTagManager.httpResultFromCacheOrBackend(
             with: httpURLResponse, jsonObject: responseObject, error: nil, request: request, retried: false)
 
         expect(response).toNot(beNil())
-        expect(response?.statusCode) == HTTPStatusCodes.internalServerError.rawValue
+        expect(response?.statusCode) == HTTPStatusCode.internalServerError.rawValue
         expect(response?.jsonObject as? [String: String]).to(equal(responseObject))
 
         expect(self.mockUserDefaults.setObjectForKeyCallCount) == 0
@@ -181,7 +181,7 @@ class ETagManagerTests: XCTestCase {
     func testClearCachesWorks() {
         let eTag = "an_etag"
         let url = urlForTest()
-        _ = mockStoredETagAndResponse(for: url, statusCode: HTTPStatusCodes.success, eTag: eTag)
+        _ = mockStoredETagAndResponse(for: url, statusCode: HTTPStatusCode.success, eTag: eTag)
 
         let cacheKey = url.absoluteString
         expect(self.mockUserDefaults.mockValues[cacheKey]).toNot(beNil())
@@ -207,7 +207,7 @@ class ETagManagerTests: XCTestCase {
     }
 
     private func mockStoredETagAndResponse(for url: URL,
-                                           statusCode: HTTPStatusCodes = HTTPStatusCodes.success,
+                                           statusCode: HTTPStatusCode = HTTPStatusCode.success,
                                            eTag: String = "an_etag") -> [String: String] {
         let jsonObject = ["arg": "value"]
         let etagAndResponse = ETagAndResponseWrapper(

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -189,7 +189,7 @@
 		35B745A82711001A00458D46 /* MockManageSubscriptionsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E840CD2710E2EB00899AE2 /* MockManageSubscriptionsHelper.swift */; };
 		35D0E5D026A5886C0099EAD8 /* ErrorUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D0E5CF26A5886C0099EAD8 /* ErrorUtils.swift */; };
 		35D832CD262A5B7500E60AC5 /* ETagManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D832CC262A5B7500E60AC5 /* ETagManager.swift */; };
-		35D832D2262E56DB00E60AC5 /* HTTPStatusCodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D832D1262E56DB00E60AC5 /* HTTPStatusCodes.swift */; };
+		35D832D2262E56DB00E60AC5 /* HTTPStatusCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D832D1262E56DB00E60AC5 /* HTTPStatusCode.swift */; };
 		35D832F4262E606500E60AC5 /* HTTPResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D832F3262E606500E60AC5 /* HTTPResponse.swift */; };
 		35D83300262FAD8000E60AC5 /* ETagManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D832FF262FAD8000E60AC5 /* ETagManagerTests.swift */; };
 		35D8330A262FBA9A00E60AC5 /* MockUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E357D16038F07915D7825D /* MockUserDefaults.swift */; };
@@ -541,7 +541,7 @@
 		359E8E3E26DEBEEB00B869F9 /* TrialOrIntroPriceEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrialOrIntroPriceEligibilityChecker.swift; sourceTree = "<group>"; };
 		35D0E5CF26A5886C0099EAD8 /* ErrorUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorUtils.swift; sourceTree = "<group>"; };
 		35D832CC262A5B7500E60AC5 /* ETagManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ETagManager.swift; sourceTree = "<group>"; };
-		35D832D1262E56DB00E60AC5 /* HTTPStatusCodes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCodes.swift; sourceTree = "<group>"; };
+		35D832D1262E56DB00E60AC5 /* HTTPStatusCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCode.swift; sourceTree = "<group>"; };
 		35D832F3262E606500E60AC5 /* HTTPResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponse.swift; sourceTree = "<group>"; };
 		35D832FF262FAD8000E60AC5 /* ETagManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ETagManagerTests.swift; sourceTree = "<group>"; };
 		35D83311262FBD4200E60AC5 /* MockETagManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockETagManager.swift; sourceTree = "<group>"; };
@@ -1299,7 +1299,7 @@
 				35F82BB326A9A74D0051DF03 /* HTTPClient.swift */,
 				57DC9F4527CC2E4900DA6AF9 /* HTTPRequest.swift */,
 				35D832F3262E606500E60AC5 /* HTTPResponse.swift */,
-				35D832D1262E56DB00E60AC5 /* HTTPStatusCodes.swift */,
+				35D832D1262E56DB00E60AC5 /* HTTPStatusCode.swift */,
 				B3766F1D26BDA95100141450 /* IntroEligibilityResponse.swift */,
 				B34605D0279A6E600031CA74 /* SubscribersAPI.swift */,
 			);
@@ -1965,7 +1965,7 @@
 				2D991ACA268BA56900085481 /* StoreKitRequestFetcher.swift in Sources */,
 				B3B5FBB4269CED4B00104A0C /* BackendErrorCode.swift in Sources */,
 				2DDF41B624F6F387005BC22D /* ASN1ObjectIdentifierBuilder.swift in Sources */,
-				35D832D2262E56DB00E60AC5 /* HTTPStatusCodes.swift in Sources */,
+				35D832D2262E56DB00E60AC5 /* HTTPStatusCode.swift in Sources */,
 				572247D127BEC28E00C524A7 /* Array+Extensions.swift in Sources */,
 				57AC4C1C2770F56200DDE30F /* SK1StoreProduct.swift in Sources */,
 				B34605C3279A6E380031CA74 /* PostOfferForSigningOperation.swift in Sources */,


### PR DESCRIPTION
For [CF-195] and #695.

An `enum`eration should be singular, as each value represents just one code.
Just a preliminary change before a larger refactor.

[CF-195]: https://revenuecats.atlassian.net/browse/CF-195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ