### PR TITLE
Using `HTTPStatusCode` for status codes everywhere

### DIFF
--- a/Purchases/Logging/Strings/BackendErrorStrings.swift
+++ b/Purchases/Logging/Strings/BackendErrorStrings.swift
@@ -35,7 +35,7 @@ enum BackendErrorStrings {
     case signature_error(signatureDataString: Any?)
 
     // getOfferings failed and we're not totally sure why.
-    case unknown_get_offerings_error(statusCode: Int, responseString: String?)
+    case unknown_get_offerings_error(statusCode: HTTPStatusCode, responseString: String?)
 
 }
 
@@ -59,8 +59,8 @@ extension BackendErrorStrings: CustomStringConvertible {
             return "No offerings found in response:\n\(String(describing: response["offers"]))"
         case .signature_error(let signatureDataString):
             return "Missing 'signatureData' or its structure changed:\n\(String(describing: signatureDataString))"
-        case .unknown_get_offerings_error(let statusCode, let responseString):
-            var message = "Encountered an error getting offerings, status code:\(statusCode)"
+        case let .unknown_get_offerings_error(statusCode, responseString):
+            var message = "Encountered an error getting offerings, status code:\(statusCode.rawValue)"
             if let responseString = responseString {
                 message += "\nresponse: \(responseString)"
             }

--- a/Purchases/Logging/Strings/NetworkStrings.swift
+++ b/Purchases/Logging/Strings/NetworkStrings.swift
@@ -17,7 +17,7 @@ import Foundation
 // swiftlint:disable identifier_name
 enum NetworkStrings {
 
-    case api_request_completed(httpMethod: String, path: String, httpCode: Int)
+    case api_request_completed(httpMethod: String, path: String, httpCode: HTTPStatusCode)
     case api_request_started(httpMethod: String?, path: String?)
     case creating_json_error(requestBody: [String: Any], error: String)
     case creating_json_error_invalid(requestBody: [String: Any])
@@ -40,7 +40,7 @@ extension NetworkStrings: CustomStringConvertible {
         switch self {
 
         case let .api_request_completed(httpMethod, path, httpCode):
-            return "API request completed with status: \(httpMethod) \(path) \(httpCode)"
+            return "API request completed with status: \(httpMethod) \(path) \(httpCode.rawValue)"
 
         case let .api_request_started(httpMethod, path):
             return "API request started: \(httpMethod ?? "") \(path ?? "")"

--- a/Purchases/Networking/ETagAndResponseWrapper.swift
+++ b/Purchases/Networking/ETagAndResponseWrapper.swift
@@ -21,13 +21,13 @@ struct ETagAndResponseWrapper {
     private static let jsonObjectKey = "responseObject"
 
     let eTag: String
-    let statusCode: Int
+    let statusCode: HTTPStatusCode
     let jsonObject: [String: Any]
 
     func asDictionary() -> [String: Any] {
         [
             ETagAndResponseWrapper.eTagKey: eTag,
-            ETagAndResponseWrapper.statusCodeKey: statusCode,
+            ETagAndResponseWrapper.statusCodeKey: statusCode.rawValue,
             ETagAndResponseWrapper.jsonObjectKey: jsonObject
         ]
     }
@@ -59,7 +59,7 @@ extension ETagAndResponseWrapper {
             Logger.error("Could not initialize ETagAndResponseWrapper Object from dictionary")
             return nil
         }
-        self.init(eTag: eTag, statusCode: statusCode, jsonObject: jsonObject)
+        self.init(eTag: eTag, statusCode: .init(rawValue: statusCode), jsonObject: jsonObject)
     }
 
 }

--- a/Purchases/Networking/ETagManager.swift
+++ b/Purchases/Networking/ETagManager.swift
@@ -43,7 +43,7 @@ class ETagManager {
                                       error: Error?,
                                       request: URLRequest,
                                       retried: Bool) -> HTTPResponse? {
-        let statusCode = response.statusCode
+        let statusCode: HTTPStatusCode = .init(rawValue: response.statusCode)
         let resultFromBackend = HTTPResponse(statusCode: statusCode, jsonObject: jsonObject)
         guard error == nil else { return resultFromBackend }
         let headersInResponse = response.allHeaderFields
@@ -84,8 +84,8 @@ class ETagManager {
 
 private extension ETagManager {
 
-    func shouldUseCachedVersion(responseCode: Int) -> Bool {
-        responseCode == HTTPStatusCode.notModifiedResponseCode.rawValue
+    func shouldUseCachedVersion(responseCode: HTTPStatusCode) -> Bool {
+        responseCode == .notModifiedResponseCode
     }
 
     func storedETagAndResponse(for request: URLRequest) -> ETagAndResponseWrapper? {
@@ -104,18 +104,18 @@ private extension ETagManager {
         if let storedETagAndResponse = storedETagAndResponse(for: request) {
             return HTTPResponse(
                     statusCode: storedETagAndResponse.statusCode,
-                    jsonObject: storedETagAndResponse.jsonObject)
+                    jsonObject: storedETagAndResponse.jsonObject
+            )
         }
 
         return nil
     }
 
     func storeStatusCodeAndResponseIfNoError(for request: URLRequest,
-                                             statusCode: Int,
+                                             statusCode: HTTPStatusCode,
                                              responseObject: [String: Any]?,
                                              eTag: String) {
-        if statusCode != HTTPStatusCode.notModifiedResponseCode.rawValue &&
-            statusCode < HTTPStatusCode.internalServerError.rawValue,
+        if statusCode != .notModifiedResponseCode && !statusCode.isInternalServerError,
            let responseObject = responseObject,
            let cacheKey = eTagDefaultCacheKey(for: request) {
             let eTagAndResponse = ETagAndResponseWrapper(eTag: eTag, statusCode: statusCode, jsonObject: responseObject)

--- a/Purchases/Networking/ETagManager.swift
+++ b/Purchases/Networking/ETagManager.swift
@@ -85,7 +85,7 @@ class ETagManager {
 private extension ETagManager {
 
     func shouldUseCachedVersion(responseCode: HTTPStatusCode) -> Bool {
-        responseCode == .notModifiedResponseCode
+        responseCode == .notModified
     }
 
     func storedETagAndResponse(for request: URLRequest) -> ETagAndResponseWrapper? {
@@ -115,7 +115,7 @@ private extension ETagManager {
                                              statusCode: HTTPStatusCode,
                                              responseObject: [String: Any]?,
                                              eTag: String) {
-        if statusCode != .notModifiedResponseCode && !statusCode.isInternalServerError,
+        if statusCode != .notModified && !statusCode.isServerError,
            let responseObject = responseObject,
            let cacheKey = eTagDefaultCacheKey(for: request) {
             let eTagAndResponse = ETagAndResponseWrapper(eTag: eTag, statusCode: statusCode, jsonObject: responseObject)

--- a/Purchases/Networking/HTTPClient.swift
+++ b/Purchases/Networking/HTTPClient.swift
@@ -179,7 +179,7 @@ private extension HTTPClient {
                                                                    path: request.path,
                                                                    httpCode: statusCode))
 
-                if statusCode == .notModifiedResponseCode || data == nil {
+                if statusCode == .notModified || data == nil {
                     jsonObject = [:]
                 } else if let data = data {
                     do {

--- a/Purchases/Networking/HTTPResponse.swift
+++ b/Purchases/Networking/HTTPResponse.swift
@@ -14,13 +14,17 @@
 
 import Foundation
 
-struct HTTPResponse: CustomStringConvertible {
+struct HTTPResponse {
 
-    let statusCode: Int
+    let statusCode: HTTPStatusCode
     let jsonObject: [String: Any]?
 
+}
+
+extension HTTPResponse: CustomStringConvertible {
+
     var description: String {
-        "HTTPResponse(statusCode: \(statusCode), jsonObject: \(jsonObject?.description ?? ""))"
+        "HTTPResponse(statusCode: \(self.statusCode.rawValue), jsonObject: \(self.jsonObject?.description ?? ""))"
     }
 
 }

--- a/Purchases/Networking/HTTPStatusCode.swift
+++ b/Purchases/Networking/HTTPStatusCode.swift
@@ -14,14 +14,61 @@
 
 import Foundation
 
-enum HTTPStatusCode: Int {
+enum HTTPStatusCode: RawRepresentable {
 
-    case success = 200,
-         createdSuccess = 201,
-         redirect = 300,
-         notModifiedResponseCode = 304,
-         internalServerError = 500,
-         notFoundError = 404,
-         networkConnectTimeoutError = 599
+    init(rawValue: Int) {
+        self = Self.statusByCode[rawValue] ?? .other(rawValue)
+    }
+
+    case success
+    case createdSuccess
+    case redirect
+    case notModifiedResponseCode
+    case invalidRequest
+    case notFoundError
+    case internalServerError
+    case networkConnectTimeoutError
+
+    case other(Int)
+
+    var rawValue: Int {
+        switch self {
+        case .success: return 200
+        case .createdSuccess: return 201
+        case .redirect: return 300
+        case .notModifiedResponseCode: return 304
+        case .invalidRequest: return 400
+        case .notFoundError: return 404
+        case .internalServerError: return 500
+        case .networkConnectTimeoutError: return 599
+
+        case let .other(code): return code
+        }
+    }
+
+    private static let knownStatus: Set<HTTPStatusCode> = [
+        .success,
+        .createdSuccess,
+        .redirect,
+        .notModifiedResponseCode,
+        .invalidRequest,
+        .notFoundError,
+        .internalServerError,
+        .networkConnectTimeoutError
+    ]
+    private static let statusByCode: [Int: HTTPStatusCode] = Self.knownStatus.dictionaryWithKeys { $0.rawValue }
+}
+
+extension HTTPStatusCode: Hashable {}
+
+extension HTTPStatusCode {
+
+    var isValidResponse: Bool {
+        return self.rawValue < HTTPStatusCode.redirect.rawValue
+    }
+
+    var isInternalServerError: Bool {
+        return self.rawValue >= HTTPStatusCode.internalServerError.rawValue
+    }
 
 }

--- a/Purchases/Networking/HTTPStatusCode.swift
+++ b/Purchases/Networking/HTTPStatusCode.swift
@@ -76,11 +76,11 @@ extension HTTPStatusCode: Hashable {}
 extension HTTPStatusCode {
 
     var isSuccessfulResponse: Bool {
-        return self.rawValue < HTTPStatusCode.redirect.rawValue
+        return 200...299 ~= self.rawValue
     }
 
     var isServerError: Bool {
-        return self.rawValue >= HTTPStatusCode.internalServerError.rawValue
+        return 500...599 ~= self.rawValue
     }
 
 }

--- a/Purchases/Networking/HTTPStatusCode.swift
+++ b/Purchases/Networking/HTTPStatusCode.swift
@@ -14,11 +14,7 @@
 
 import Foundation
 
-enum HTTPStatusCode: RawRepresentable {
-
-    init(rawValue: Int) {
-        self = Self.statusByCode[rawValue] ?? .other(rawValue)
-    }
+enum HTTPStatusCode {
 
     case success
     case createdSuccess
@@ -30,6 +26,25 @@ enum HTTPStatusCode: RawRepresentable {
     case networkConnectTimeoutError
 
     case other(Int)
+
+    private static let knownStatus: Set<HTTPStatusCode> = [
+        .success,
+        .createdSuccess,
+        .redirect,
+        .notModified,
+        .invalidRequest,
+        .notFoundError,
+        .internalServerError,
+        .networkConnectTimeoutError
+    ]
+    private static let statusByCode: [Int: HTTPStatusCode] = Self.knownStatus.dictionaryWithKeys { $0.rawValue }
+}
+
+extension HTTPStatusCode: RawRepresentable {
+
+    init(rawValue: Int) {
+        self = Self.statusByCode[rawValue] ?? .other(rawValue)
+    }
 
     var rawValue: Int {
         switch self {
@@ -46,17 +61,14 @@ enum HTTPStatusCode: RawRepresentable {
         }
     }
 
-    private static let knownStatus: Set<HTTPStatusCode> = [
-        .success,
-        .createdSuccess,
-        .redirect,
-        .notModified,
-        .invalidRequest,
-        .notFoundError,
-        .internalServerError,
-        .networkConnectTimeoutError
-    ]
-    private static let statusByCode: [Int: HTTPStatusCode] = Self.knownStatus.dictionaryWithKeys { $0.rawValue }
+}
+
+extension HTTPStatusCode: ExpressibleByIntegerLiteral {
+
+    init(integerLiteral value: IntegerLiteralType) {
+        self.init(rawValue: value)
+    }
+
 }
 
 extension HTTPStatusCode: Hashable {}

--- a/Purchases/Networking/HTTPStatusCode.swift
+++ b/Purchases/Networking/HTTPStatusCode.swift
@@ -23,7 +23,7 @@ enum HTTPStatusCode: RawRepresentable {
     case success
     case createdSuccess
     case redirect
-    case notModifiedResponseCode
+    case notModified
     case invalidRequest
     case notFoundError
     case internalServerError
@@ -36,7 +36,7 @@ enum HTTPStatusCode: RawRepresentable {
         case .success: return 200
         case .createdSuccess: return 201
         case .redirect: return 300
-        case .notModifiedResponseCode: return 304
+        case .notModified: return 304
         case .invalidRequest: return 400
         case .notFoundError: return 404
         case .internalServerError: return 500
@@ -50,7 +50,7 @@ enum HTTPStatusCode: RawRepresentable {
         .success,
         .createdSuccess,
         .redirect,
-        .notModifiedResponseCode,
+        .notModified,
         .invalidRequest,
         .notFoundError,
         .internalServerError,
@@ -67,7 +67,7 @@ extension HTTPStatusCode {
         return self.rawValue < HTTPStatusCode.redirect.rawValue
     }
 
-    var isInternalServerError: Bool {
+    var isServerError: Bool {
         return self.rawValue >= HTTPStatusCode.internalServerError.rawValue
     }
 

--- a/Purchases/Networking/HTTPStatusCode.swift
+++ b/Purchases/Networking/HTTPStatusCode.swift
@@ -63,7 +63,7 @@ extension HTTPStatusCode: Hashable {}
 
 extension HTTPStatusCode {
 
-    var isValidResponse: Bool {
+    var isSuccessfulResponse: Bool {
         return self.rawValue < HTTPStatusCode.redirect.rawValue
     }
 

--- a/Purchases/Networking/IntroEligibilityResponse.swift
+++ b/Purchases/Networking/IntroEligibilityResponse.swift
@@ -17,7 +17,7 @@ import Foundation
 struct IntroEligibilityResponse {
 
     let response: [String: Any]?
-    let statusCode: Int
+    let statusCode: HTTPStatusCode
     let error: Error?
     let productIdentifiers: [String]
     let unknownEligibilityClosure: () -> [String: IntroEligibility]

--- a/Purchases/Networking/Operations/GetIntroEligibilityOperation.swift
+++ b/Purchases/Networking/Operations/GetIntroEligibilityOperation.swift
@@ -101,7 +101,7 @@ private extension GetIntroEligibilityOperation {
     func handleIntroEligibility(response: IntroEligibilityResponse) {
         let result: [String: IntroEligibility] = {
             var eligibilitiesByProductIdentifier = response.response
-            if response.statusCode >= HTTPStatusCode.redirect.rawValue || response.error != nil {
+            if !response.statusCode.isValidResponse || response.error != nil {
                 eligibilitiesByProductIdentifier = [:]
             }
 

--- a/Purchases/Networking/Operations/GetIntroEligibilityOperation.swift
+++ b/Purchases/Networking/Operations/GetIntroEligibilityOperation.swift
@@ -101,7 +101,7 @@ private extension GetIntroEligibilityOperation {
     func handleIntroEligibility(response: IntroEligibilityResponse) {
         let result: [String: IntroEligibility] = {
             var eligibilitiesByProductIdentifier = response.response
-            if !response.statusCode.isValidResponse || response.error != nil {
+            if !response.statusCode.isSuccessfulResponse || response.error != nil {
                 eligibilitiesByProductIdentifier = [:]
             }
 

--- a/Purchases/Networking/Operations/GetOfferingsOperation.swift
+++ b/Purchases/Networking/Operations/GetOfferingsOperation.swift
@@ -51,7 +51,7 @@ private extension GetOfferingsOperation {
                 completion()
             }
 
-            if error == nil && statusCode < HTTPStatusCode.redirect.rawValue {
+            if error == nil && statusCode.isValidResponse {
                 self.offeringsCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callbackObject in
                     callbackObject.completion(response, nil)
                 }
@@ -61,7 +61,7 @@ private extension GetOfferingsOperation {
             let errorForCallbacks: Error
             if let error = error {
                 errorForCallbacks = ErrorUtils.networkError(withUnderlyingError: error)
-            } else if statusCode >= HTTPStatusCode.redirect.rawValue {
+            } else if !statusCode.isValidResponse {
                 let backendCode = BackendErrorCode(code: response?["code"])
                 let backendMessage = response?["message"] as? String
                 errorForCallbacks = ErrorUtils.backendError(withBackendCode: backendCode,

--- a/Purchases/Networking/Operations/GetOfferingsOperation.swift
+++ b/Purchases/Networking/Operations/GetOfferingsOperation.swift
@@ -51,7 +51,7 @@ private extension GetOfferingsOperation {
                 completion()
             }
 
-            if error == nil && statusCode.isValidResponse {
+            if error == nil && statusCode.isSuccessfulResponse {
                 self.offeringsCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callbackObject in
                     callbackObject.completion(response, nil)
                 }
@@ -61,7 +61,7 @@ private extension GetOfferingsOperation {
             let errorForCallbacks: Error
             if let error = error {
                 errorForCallbacks = ErrorUtils.networkError(withUnderlyingError: error)
-            } else if !statusCode.isValidResponse {
+            } else if !statusCode.isSuccessfulResponse {
                 let backendCode = BackendErrorCode(code: response?["code"])
                 let backendMessage = response?["message"] as? String
                 errorForCallbacks = ErrorUtils.backendError(withBackendCode: backendCode,

--- a/Purchases/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
+++ b/Purchases/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
@@ -23,7 +23,7 @@ class CustomerInfoResponseHandler {
 
     // swiftlint:disable:next function_body_length
     func handle(customerInfoResponse response: [String: Any]?,
-                statusCode: Int,
+                statusCode: HTTPStatusCode,
                 error: Error?,
                 file: String = #fileID,
                 function: String = #function,
@@ -34,7 +34,7 @@ class CustomerInfoResponseHandler {
                                                     fileName: file, functionName: function, line: line))
             return
         }
-        let isErrorStatusCode = statusCode >= HTTPStatusCode.redirect.rawValue
+        let isErrorStatusCode = !statusCode.isValidResponse
 
         let customerInfoError: Error?
         let customerInfo: CustomerInfo?
@@ -69,7 +69,7 @@ class CustomerInfoResponseHandler {
                         || customerInfoError != nil)
 
         guard !hasError else {
-            let finishable = statusCode < HTTPStatusCode.internalServerError.rawValue
+            let finishable = !statusCode.isInternalServerError
             var extraUserInfo = [ErrorDetails.finishableKey: finishable] as [String: Any]
             extraUserInfo.merge(subscriberAttributesErrorInfo) { _, new in new }
             let backendErrorCode = BackendErrorCode(code: response?["code"])

--- a/Purchases/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
+++ b/Purchases/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
@@ -69,7 +69,7 @@ class CustomerInfoResponseHandler {
                         || customerInfoError != nil)
 
         guard !hasError else {
-            let finishable = !statusCode.isInternalServerError
+            let finishable = !statusCode.isServerError
             var extraUserInfo = [ErrorDetails.finishableKey: finishable] as [String: Any]
             extraUserInfo.merge(subscriberAttributesErrorInfo) { _, new in new }
             let backendErrorCode = BackendErrorCode(code: response?["code"])

--- a/Purchases/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
+++ b/Purchases/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
@@ -34,7 +34,7 @@ class CustomerInfoResponseHandler {
                                                     fileName: file, functionName: function, line: line))
             return
         }
-        let isErrorStatusCode = !statusCode.isValidResponse
+        let isErrorStatusCode = !statusCode.isSuccessfulResponse
 
         let customerInfoError: Error?
         let customerInfo: CustomerInfo?

--- a/Purchases/Networking/Operations/Handling/NoContentResponseHandler.swift
+++ b/Purchases/Networking/Operations/Handling/NoContentResponseHandler.swift
@@ -16,7 +16,7 @@ import Foundation
 class NoContentResponseHandler {
 
     func handle(response: [String: Any]?,
-                statusCode: Int,
+                statusCode: HTTPStatusCode,
                 error: Error?,
                 completion: SimpleResponseHandler) {
         if let error = error {
@@ -24,7 +24,7 @@ class NoContentResponseHandler {
             return
         }
 
-        guard statusCode <= HTTPStatusCode.redirect.rawValue else {
+        guard statusCode.isValidResponse else {
             let backendErrorCode = BackendErrorCode(code: response?["code"])
             let message = response?["message"] as? String
             let responseError = ErrorUtils.backendError(withBackendCode: backendErrorCode, backendMessage: message)

--- a/Purchases/Networking/Operations/Handling/NoContentResponseHandler.swift
+++ b/Purchases/Networking/Operations/Handling/NoContentResponseHandler.swift
@@ -24,7 +24,7 @@ class NoContentResponseHandler {
             return
         }
 
-        guard statusCode.isValidResponse else {
+        guard statusCode.isSuccessfulResponse else {
             let backendErrorCode = BackendErrorCode(code: response?["code"])
             let message = response?["message"] as? String
             let responseError = ErrorUtils.backendError(withBackendCode: backendErrorCode, backendMessage: message)

--- a/Purchases/Networking/Operations/Handling/SubscriberAttributeHandler.swift
+++ b/Purchases/Networking/Operations/Handling/SubscriberAttributeHandler.swift
@@ -21,7 +21,7 @@ class SubscriberAttributeHandler {
         self.userInfoAttributeParser = userInfoAttributeParser
     }
 
-    func handleSubscriberAttributesResult(statusCode: Int,
+    func handleSubscriberAttributesResult(statusCode: HTTPStatusCode,
                                           response: [String: Any]?,
                                           error: Error?,
                                           completion: SimpleResponseHandler) {
@@ -32,7 +32,7 @@ class SubscriberAttributeHandler {
 
         let responseError: Error?
 
-        if let response = response, statusCode > HTTPStatusCode.redirect.rawValue {
+        if let response = response, !statusCode.isValidResponse {
             let extraUserInfo = self.userInfoAttributeParser
                 .attributesUserInfoFromResponse(response: response, statusCode: statusCode)
             let backendErrorCode = BackendErrorCode(code: response["code"])

--- a/Purchases/Networking/Operations/Handling/SubscriberAttributeHandler.swift
+++ b/Purchases/Networking/Operations/Handling/SubscriberAttributeHandler.swift
@@ -32,7 +32,7 @@ class SubscriberAttributeHandler {
 
         let responseError: Error?
 
-        if let response = response, !statusCode.isValidResponse {
+        if let response = response, !statusCode.isSuccessfulResponse {
             let extraUserInfo = self.userInfoAttributeParser
                 .attributesUserInfoFromResponse(response: response, statusCode: statusCode)
             let backendErrorCode = BackendErrorCode(code: response["code"])

--- a/Purchases/Networking/Operations/Handling/UserInfoAttributeParser.swift
+++ b/Purchases/Networking/Operations/Handling/UserInfoAttributeParser.swift
@@ -15,10 +15,10 @@ import Foundation
 
 class UserInfoAttributeParser {
 
-    func attributesUserInfoFromResponse(response: [String: Any], statusCode: Int) -> [String: Any] {
+    func attributesUserInfoFromResponse(response: [String: Any], statusCode: HTTPStatusCode) -> [String: Any] {
         var resultDict: [String: Any] = [:]
-        let isInternalServerError = statusCode >= HTTPStatusCode.internalServerError.rawValue
-        let isNotFoundError = statusCode == HTTPStatusCode.notFoundError.rawValue
+        let isInternalServerError = statusCode.isInternalServerError
+        let isNotFoundError = statusCode == .notFoundError
 
         let successfullySynced = !(isInternalServerError || isNotFoundError)
         resultDict[Backend.RCSuccessfullySyncedKey as String] = successfullySynced

--- a/Purchases/Networking/Operations/Handling/UserInfoAttributeParser.swift
+++ b/Purchases/Networking/Operations/Handling/UserInfoAttributeParser.swift
@@ -17,10 +17,10 @@ class UserInfoAttributeParser {
 
     func attributesUserInfoFromResponse(response: [String: Any], statusCode: HTTPStatusCode) -> [String: Any] {
         var resultDict: [String: Any] = [:]
-        let isInternalServerError = statusCode.isInternalServerError
+        let isServerError = statusCode.isServerError
         let isNotFoundError = statusCode == .notFoundError
 
-        let successfullySynced = !(isInternalServerError || isNotFoundError)
+        let successfullySynced = !(isServerError || isNotFoundError)
         resultDict[Backend.RCSuccessfullySyncedKey as String] = successfullySynced
 
         let hasAttributesResponseContainerKey = (response[Backend.RCAttributeErrorsResponseKey] != nil)

--- a/Purchases/Networking/Operations/LogInOperation.swift
+++ b/Purchases/Networking/Operations/LogInOperation.swift
@@ -64,7 +64,7 @@ private extension LogInOperation {
     }
 
     func handleLogin(response: [String: Any]?,
-                     statusCode: Int,
+                     statusCode: HTTPStatusCode,
                      error: Error?,
                      completion: LogInResponseHandler) {
         let result: (info: CustomerInfo?, cancelled: Bool, error: Error?) = {
@@ -78,7 +78,7 @@ private extension LogInOperation {
                 return (nil, false, responseError)
             }
 
-            if statusCode > HTTPStatusCode.redirect.rawValue {
+            if !statusCode.isValidResponse {
                 let backendCode = BackendErrorCode(code: response["code"])
                 let backendMessage = response["message"] as? String
                 let responsError = ErrorUtils.backendError(withBackendCode: backendCode, backendMessage: backendMessage)
@@ -87,7 +87,7 @@ private extension LogInOperation {
 
             do {
                 let customerInfo = try CustomerInfo.from(json: response)
-                let created = statusCode == HTTPStatusCode.createdSuccess.rawValue
+                let created = statusCode == .createdSuccess
                 Logger.user(Strings.identity.login_success)
                 return (customerInfo, created, nil)
             } catch let customerInfoError {

--- a/Purchases/Networking/Operations/LogInOperation.swift
+++ b/Purchases/Networking/Operations/LogInOperation.swift
@@ -78,7 +78,7 @@ private extension LogInOperation {
                 return (nil, false, responseError)
             }
 
-            if !statusCode.isValidResponse {
+            if !statusCode.isSuccessfulResponse {
                 let backendCode = BackendErrorCode(code: response["code"])
                 let backendMessage = response["message"] as? String
                 let responsError = ErrorUtils.backendError(withBackendCode: backendCode, backendMessage: backendMessage)

--- a/Purchases/Networking/Operations/PostOfferForSigningOperation.swift
+++ b/Purchases/Networking/Operations/PostOfferForSigningOperation.swift
@@ -61,7 +61,7 @@ class PostOfferForSigningOperation: NetworkOperation {
                     return (nil, nil, nil, nil, ErrorUtils.networkError(withUnderlyingError: error))
                 }
 
-                guard statusCode < HTTPStatusCode.redirect.rawValue else {
+                guard statusCode.isValidResponse else {
                     let backendCode = BackendErrorCode(code: response?["code"])
                     let backendMessage = response?["message"] as? String
                     let error = ErrorUtils.backendError(withBackendCode: backendCode, backendMessage: backendMessage)

--- a/Purchases/Networking/Operations/PostOfferForSigningOperation.swift
+++ b/Purchases/Networking/Operations/PostOfferForSigningOperation.swift
@@ -61,7 +61,7 @@ class PostOfferForSigningOperation: NetworkOperation {
                     return (nil, nil, nil, nil, ErrorUtils.networkError(withUnderlyingError: error))
                 }
 
-                guard statusCode.isValidResponse else {
+                guard statusCode.isSuccessfulResponse else {
                     let backendCode = BackendErrorCode(code: response?["code"])
                     let backendMessage = response?["message"] as? String
                     let error = ErrorUtils.backendError(withBackendCode: backendCode, backendMessage: backendMessage)

--- a/PurchasesTests/Mocks/MockETagManager.swift
+++ b/PurchasesTests/Mocks/MockETagManager.swift
@@ -62,7 +62,7 @@ class MockETagManager: ETagManager {
             invokedHTTPResultFromCacheOrBackendParameters = params
             invokedHTTPResultFromCacheOrBackendParametersList.append(params)
             if shouldReturnResultFromBackend {
-                return HTTPResponse(statusCode: response.statusCode, jsonObject: jsonObject)
+                return HTTPResponse(statusCode: .init(rawValue: response.statusCode), jsonObject: jsonObject)
             }
             return stubbedHTTPResultFromCacheOrBackendResult
         }

--- a/PurchasesTests/Mocks/MockHTTPClient.swift
+++ b/PurchasesTests/Mocks/MockHTTPClient.swift
@@ -5,14 +5,14 @@ class MockHTTPClient: HTTPClient {
     struct InvokedPerformRequestParameters {
         let request: HTTPRequest
         let headers: [String: String]?
-        let completionHandler: ((Int, [String: Any]?, Error?) -> Void)?
+        let completionHandler: HTTPClient.Completion?
     }
 
     var invokedPerformRequest = false
     var invokedPerformRequestCount = 0
     var shouldInvokeCompletion = true
 
-    var stubbedCompletionStatusCode = 200
+    var stubbedCompletionStatusCode: HTTPStatusCode = .success
     var stubbedCompletionResponse: [String: Any]? = [:]
     var stubbedCompletionError: Error?
 
@@ -21,7 +21,7 @@ class MockHTTPClient: HTTPClient {
 
     override func perform(_ request: HTTPRequest,
                           authHeaders: [String: String],
-                          completionHandler: ((Int, [String: Any]?, Error?) -> Void)?) {
+                          completionHandler: Completion?) {
         invokedPerformRequest = true
         invokedPerformRequestCount += 1
         let parameters = InvokedPerformRequestParameters(

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -20,10 +20,10 @@ class BackendTests: XCTestCase {
     }
 
     struct HTTPResponse {
-        let statusCode: Int
+        let statusCode: HTTPStatusCode
         let response: [String: Any]?
         let error: Error?
-        init(statusCode: Int, response: [String: Any]?, error: Error? = nil) {
+        init(statusCode: HTTPStatusCode, response: [String: Any]?, error: Error? = nil) {
             self.statusCode = statusCode
             self.response = response
             self.error = error
@@ -39,7 +39,7 @@ class BackendTests: XCTestCase {
 
         override func perform(_ request: HTTPRequest,
                               authHeaders: [String: String],
-                              completionHandler: ((Int, [String: Any]?, Error?) -> Void)?) {
+                              completionHandler: Completion?) {
             assert(mocks[request.path] != nil, "Path '\(request.path.relativePath)' not mocked")
             let response = mocks[request.path]!
 
@@ -138,7 +138,7 @@ class BackendTests: XCTestCase {
     func testPostsReceiptDataCorrectly() {
         let path: HTTPRequest.Path = .postReceiptData
 
-        let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSubscriberResponse, error: nil)
         httpClient.mock(requestPath: path, response: response)
 
         var completionCalled = false
@@ -175,7 +175,7 @@ class BackendTests: XCTestCase {
     }
 
     func testCachesRequestsForSameReceipt() {
-        let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSubscriberResponse, error: nil)
         httpClient.mock(requestPath: .postReceiptData, response: response)
 
         var completionCalled = 0
@@ -210,7 +210,7 @@ class BackendTests: XCTestCase {
     }
 
     func testDoesntCacheForDifferentRestore() {
-        let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSubscriberResponse, error: nil)
         httpClient.mock(requestPath: .postReceiptData, response: response)
 
         var completionCalled = 0
@@ -245,7 +245,7 @@ class BackendTests: XCTestCase {
     }
 
     func testDoesntCacheForDifferentReceipts() {
-        let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSubscriberResponse, error: nil)
         httpClient.mock(requestPath: .postReceiptData, response: response)
 
         var completionCalled = 0
@@ -280,7 +280,7 @@ class BackendTests: XCTestCase {
     }
 
     func testDoesntCacheForDifferentCurrency() {
-        let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSubscriberResponse, error: nil)
         httpClient.mock(requestPath: .postReceiptData, response: response)
 
         var completionCalled = 0
@@ -316,7 +316,7 @@ class BackendTests: XCTestCase {
     }
 
     func testDoesntCacheForDifferentOffering() {
-        let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSubscriberResponse, error: nil)
         httpClient.mock(requestPath: .postReceiptData, response: response)
 
         var completionCalled = 0
@@ -351,7 +351,7 @@ class BackendTests: XCTestCase {
     }
 
     func testCachesSubscriberGetsForSameSubscriber() {
-        let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSubscriberResponse, error: nil)
         httpClient.mock(requestPath: .getCustomerInfo(appUserID: userID), response: response)
 
         backend.getCustomerInfo(appUserID: userID) { _, _ in }
@@ -361,7 +361,7 @@ class BackendTests: XCTestCase {
     }
 
     func testDoesntCacheSubscriberGetsForSameSubscriber() {
-        let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSubscriberResponse, error: nil)
         let userID2 = "user_id_2"
         httpClient.mock(requestPath: .getCustomerInfo(appUserID: userID), response: response)
         httpClient.mock(requestPath: .getCustomerInfo(appUserID: userID2), response: response)
@@ -373,7 +373,7 @@ class BackendTests: XCTestCase {
     }
 
     func testPostsReceiptDataWithProductRequestDataCorrectly() {
-        let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSubscriberResponse, error: nil)
         httpClient.mock(requestPath: .postReceiptData, response: response)
 
         let productIdentifier = "a_great_product"
@@ -428,7 +428,7 @@ class BackendTests: XCTestCase {
     }
 
     func testIndividualParamsCanBeNil() {
-        let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSubscriberResponse, error: nil)
         httpClient.mock(requestPath: .postReceiptData, response: response)
 
         var completionCalled = false
@@ -479,28 +479,28 @@ class BackendTests: XCTestCase {
     }
 
     func testPayAsYouGoPostsCorrectly() throws {
-        let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSubscriberResponse, error: nil)
         httpClient.mock(requestPath: .postReceiptData, response: response)
         postPaymentMode(paymentMode: .payAsYouGo)
         try checkCall(expectedValue: 0)
     }
 
     func testPayUpFrontPostsCorrectly() throws {
-        let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSubscriberResponse, error: nil)
         httpClient.mock(requestPath: .postReceiptData, response: response)
         postPaymentMode(paymentMode: .payUpFront)
         try checkCall(expectedValue: 1)
     }
 
     func testFreeTrialPostsCorrectly() throws {
-        let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSubscriberResponse, error: nil)
         httpClient.mock(requestPath: .postReceiptData, response: response)
         postPaymentMode(paymentMode: .freeTrial)
         try checkCall(expectedValue: 2)
     }
 
     func testForwards500ErrorsCorrectlyForCustomerInfoCalls() {
-        let response = HTTPResponse(statusCode: 501, response: serverErrorResponse, error: nil)
+        let response = HTTPResponse(statusCode: .internalServerError, response: serverErrorResponse, error: nil)
         httpClient.mock(requestPath: .postReceiptData, response: response)
 
         var error: NSError?
@@ -526,7 +526,7 @@ class BackendTests: XCTestCase {
     }
 
     func testForwards400ErrorsCorrectly() {
-        let response = HTTPResponse(statusCode: 400, response: serverErrorResponse, error: nil)
+        let response = HTTPResponse(statusCode: .invalidRequest, response: serverErrorResponse, error: nil)
         httpClient.mock(requestPath: .postReceiptData, response: response)
 
         var error: Error?
@@ -553,7 +553,7 @@ class BackendTests: XCTestCase {
     }
 
     func testPostingReceiptCreatesASubscriberInfoObject() {
-        let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSubscriberResponse, error: nil)
         httpClient.mock(requestPath: .postReceiptData, response: response)
 
         var customerInfo: CustomerInfo?
@@ -579,7 +579,7 @@ class BackendTests: XCTestCase {
     func testGetSubscriberCallsBackendProperly() {
         let path: HTTPRequest.Path = .getCustomerInfo(appUserID: userID)
 
-        let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSubscriberResponse, error: nil)
         httpClient.mock(requestPath: path, response: response)
 
         backend.getCustomerInfo(appUserID: userID) { _, _ in }
@@ -597,7 +597,7 @@ class BackendTests: XCTestCase {
     }
 
     func testGetsSubscriberInfo() {
-        let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSubscriberResponse, error: nil)
         httpClient.mock(requestPath: .getCustomerInfo(appUserID: userID), response: response)
 
         var subscriberInfo: CustomerInfo?
@@ -612,10 +612,10 @@ class BackendTests: XCTestCase {
     func testEncodesSubscriberUserID() {
         let encodeableUserID = "userid with spaces"
         let encodedUserID = "userid%20with%20spaces"
-        let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSubscriberResponse, error: nil)
         httpClient.mock(requestPath: .getCustomerInfo(appUserID: encodedUserID), response: response)
         httpClient.mock(requestPath: .getCustomerInfo(appUserID: encodeableUserID),
-                        response: HTTPResponse(statusCode: 404, response: nil, error: nil))
+                        response: HTTPResponse(statusCode: .notFoundError, response: nil, error: nil))
 
         var subscriberInfo: CustomerInfo?
 
@@ -627,7 +627,7 @@ class BackendTests: XCTestCase {
     }
 
     func testHandlesGetSubscriberInfoErrors() {
-        let response = HTTPResponse(statusCode: 404, response: nil, error: nil)
+        let response = HTTPResponse(statusCode: .notFoundError, response: nil, error: nil)
         httpClient.mock(requestPath: .getCustomerInfo(appUserID: userID), response: response)
 
         var error: NSError?
@@ -645,7 +645,7 @@ class BackendTests: XCTestCase {
     }
 
     func testHandlesInvalidJSON() {
-        let response = HTTPResponse(statusCode: 200, response: ["sjkaljdklsjadkjs": ""], error: nil)
+        let response = HTTPResponse(statusCode: .success, response: ["sjkaljdklsjadkjs": ""], error: nil)
         httpClient.mock(requestPath: .getCustomerInfo(appUserID: userID), response: response)
 
         var error: NSError?
@@ -671,7 +671,7 @@ class BackendTests: XCTestCase {
     }
 
     func testPostsProductIdentifiers() {
-        let response = HTTPResponse(statusCode: 200,
+        let response = HTTPResponse(statusCode: .success,
                                     response: ["producta": true, "productb": false, "productd": NSNull()],
                                     error: nil)
         httpClient.mock(requestPath: .getIntroEligibility(appUserID: userID), response: response)
@@ -714,7 +714,7 @@ class BackendTests: XCTestCase {
     }
 
     func testEligibilityUnknownIfError() {
-        let response = HTTPResponse(statusCode: 499, response: serverErrorResponse, error: nil)
+        let response = HTTPResponse(statusCode: .invalidRequest, response: serverErrorResponse, error: nil)
         httpClient.mock(requestPath: .getIntroEligibility(appUserID: userID), response: response)
 
         var eligibility: [String: IntroEligibility]?
@@ -736,7 +736,7 @@ class BackendTests: XCTestCase {
 
     func testEligibilityUnknownIfMissingAppUserID() {
         // Set us up for a 404 because if the input sanitizing code fails, it will execute and we'd get a 404.
-        let response = HTTPResponse(statusCode: 404, response: nil, error: nil)
+        let response = HTTPResponse(statusCode: .notFoundError, response: nil, error: nil)
         httpClient.mock(requestPath: .getIntroEligibility(appUserID: ""), response: response)
 
         var eligibility: [String: IntroEligibility]?
@@ -790,7 +790,7 @@ class BackendTests: XCTestCase {
 
     func testEligibilityUnknownIfUnknownError() {
         let error = NSError(domain: "myhouse", code: 12, userInfo: nil) as Error
-        let response = HTTPResponse(statusCode: 200, response: serverErrorResponse, error: error)
+        let response = HTTPResponse(statusCode: .success, response: serverErrorResponse, error: error)
         httpClient.mock(requestPath: .getIntroEligibility(appUserID: userID), response: response)
 
         var eligibility: [String: IntroEligibility]?
@@ -811,7 +811,7 @@ class BackendTests: XCTestCase {
     }
 
     func testGetOfferingsCallsHTTPMethod() {
-        let response = HTTPResponse(statusCode: 200, response: noOfferingsResponse as [String: Any], error: nil)
+        let response = HTTPResponse(statusCode: .success, response: noOfferingsResponse as [String: Any], error: nil)
         httpClient.mock(requestPath: .getOfferings(appUserID: userID), response: response)
 
         var offeringsData: [String: Any]?
@@ -825,7 +825,7 @@ class BackendTests: XCTestCase {
     }
 
     func testGetOfferingsCachesForSameUserID() {
-        let response = HTTPResponse(statusCode: 200, response: noOfferingsResponse as [String: Any], error: nil)
+        let response = HTTPResponse(statusCode: .success, response: noOfferingsResponse as [String: Any], error: nil)
         httpClient.mock(requestPath: .getOfferings(appUserID: userID), response: response)
         backend.getOfferings(appUserID: userID) { (_, _) in }
         backend.getOfferings(appUserID: userID) { (_, _) in }
@@ -834,7 +834,7 @@ class BackendTests: XCTestCase {
     }
 
     func testGetEntitlementsDoesntCacheForMultipleUserID() {
-        let response = HTTPResponse(statusCode: 200, response: noOfferingsResponse as [String: Any], error: nil)
+        let response = HTTPResponse(statusCode: .success, response: noOfferingsResponse as [String: Any], error: nil)
         let userID2 = "user_id_2"
         httpClient.mock(requestPath: .getOfferings(appUserID: userID), response: response)
         httpClient.mock(requestPath: .getOfferings(appUserID: userID2), response: response)
@@ -846,7 +846,7 @@ class BackendTests: XCTestCase {
     }
 
     func testGetOfferingsOneOffering() {
-        let response = HTTPResponse(statusCode: 200, response: oneOfferingResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: oneOfferingResponse, error: nil)
         httpClient.mock(requestPath: .getOfferings(appUserID: userID), response: response)
         var responseReceived: [String: Any]?
         var offerings: [[String: Any]]?
@@ -873,7 +873,7 @@ class BackendTests: XCTestCase {
     }
 
     func testGetOfferingsFailSendsNil() {
-        let response = HTTPResponse(statusCode: 500, response: oneOfferingResponse, error: nil)
+        let response = HTTPResponse(statusCode: .internalServerError, response: oneOfferingResponse, error: nil)
         httpClient.mock(requestPath: .getOfferings(appUserID: userID), response: response)
 
         var offerings: [String: Any]?
@@ -886,7 +886,7 @@ class BackendTests: XCTestCase {
     }
 
     func testPostAttributesPutsDataInDataKey() throws {
-        let response = HTTPResponse(statusCode: 200, response: nil, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: nil, error: nil)
         httpClient.mock(requestPath: .postAttributionData(appUserID: userID), response: response)
 
         let data: [String: AnyObject] = ["a": "b" as NSString, "c": "d" as NSString]
@@ -912,7 +912,7 @@ class BackendTests: XCTestCase {
 
         let path: HTTPRequest.Path = .createAlias(appUserID: userID)
 
-        let response = HTTPResponse(statusCode: 200, response: nil, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: nil, error: nil)
         httpClient.mock(requestPath: path, response: response)
 
         backend.createAlias(appUserID: userID, newAppUserID: "new_alias", completion: { (_) in
@@ -935,7 +935,7 @@ class BackendTests: XCTestCase {
     }
 
     func testCreateAliasCachesForSameUserIDs() {
-        let response = HTTPResponse(statusCode: 200, response: nil, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: nil, error: nil)
         httpClient.mock(requestPath: .createAlias(appUserID: userID), response: response)
 
         backend.createAlias(appUserID: userID, newAppUserID: "new_alias") { _ in }
@@ -945,7 +945,7 @@ class BackendTests: XCTestCase {
     }
 
     func testCreateAliasDoesntCacheForDifferentNewUserID() {
-        let response = HTTPResponse(statusCode: 200, response: nil, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: nil, error: nil)
         httpClient.mock(requestPath: .createAlias(appUserID: userID), response: response)
 
         backend.createAlias(appUserID: userID, newAppUserID: "new_alias") { _ in }
@@ -955,7 +955,7 @@ class BackendTests: XCTestCase {
     }
 
     func testCreateAliasCachesWhenCallbackNil() {
-        let response = HTTPResponse(statusCode: 200, response: nil, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: nil, error: nil)
         httpClient.mock(requestPath: .createAlias(appUserID: userID), response: response)
 
         backend.createAlias(appUserID: userID, newAppUserID: "new_alias") { _ in }
@@ -965,7 +965,7 @@ class BackendTests: XCTestCase {
     }
 
     func testCreateAliasCallsAllCompletionBlocksInCache() {
-        let response = HTTPResponse(statusCode: 200, response: nil, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: nil, error: nil)
         httpClient.mock(requestPath: .createAlias(appUserID: userID), response: response)
 
         var completion1Called = false
@@ -989,7 +989,7 @@ class BackendTests: XCTestCase {
         let currentAppUserID1 = userID
         let currentAppUserID2 = userID + "2"
 
-        let response = HTTPResponse(statusCode: 200, response: nil, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: nil, error: nil)
 
         httpClient.mock(requestPath: .createAlias(appUserID: currentAppUserID1), response: response)
         backend.createAlias(appUserID: currentAppUserID1, newAppUserID: newAppUserID) { _ in }
@@ -1001,7 +1001,7 @@ class BackendTests: XCTestCase {
     }
 
     func testNetworkErrorIsForwardedForCustomerInfoCalls() {
-        let response = HTTPResponse(statusCode: 200,
+        let response = HTTPResponse(statusCode: .success,
                                     response: nil,
                                     error: NSError(domain: NSURLErrorDomain, code: -1009))
         httpClient.mock(requestPath: .postReceiptData, response: response)
@@ -1028,7 +1028,7 @@ class BackendTests: XCTestCase {
     }
 
     func testNetworkErrorIsForwarded() {
-        let response = HTTPResponse(statusCode: 200,
+        let response = HTTPResponse(statusCode: .success,
                                     response: nil,
                                     error: NSError(domain: NSURLErrorDomain, code: -1009))
         httpClient.mock(requestPath: .createAlias(appUserID: userID), response: response)
@@ -1048,7 +1048,7 @@ class BackendTests: XCTestCase {
     }
 
     func testForwards500ErrorsCorrectly() {
-        let response = HTTPResponse(statusCode: 501, response: serverErrorResponse, error: nil)
+        let response = HTTPResponse(statusCode: .internalServerError, response: serverErrorResponse, error: nil)
         httpClient.mock(requestPath: .createAlias(appUserID: userID), response: response)
 
         var receivedError: NSError?
@@ -1085,7 +1085,7 @@ class BackendTests: XCTestCase {
     }
 
     func testGetOfferingsNetworkErrorSendsNilAndError() {
-        let response = HTTPResponse(statusCode: 200,
+        let response = HTTPResponse(statusCode: .success,
                                     response: nil,
                                     error: NSError(domain: NSURLErrorDomain, code: -1009))
         httpClient.mock(requestPath: .getOfferings(appUserID: userID), response: response)
@@ -1106,7 +1106,7 @@ class BackendTests: XCTestCase {
     }
 
     func test500GetOfferingsUnexpectedResponse() {
-        let response = HTTPResponse(statusCode: 501, response: serverErrorResponse, error: nil)
+        let response = HTTPResponse(statusCode: .internalServerError, response: serverErrorResponse, error: nil)
         httpClient.mock(requestPath: .getOfferings(appUserID: userID), response: response)
 
         var receivedError: NSError?
@@ -1149,7 +1149,7 @@ class BackendTests: XCTestCase {
 
     @available(iOS 11.2, *)
     func testDoesntCacheForDifferentDiscounts() {
-        let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSubscriberResponse, error: nil)
         httpClient.mock(requestPath: .postReceiptData, response: response)
 
         var completionCalled = 0
@@ -1194,7 +1194,7 @@ class BackendTests: XCTestCase {
     func testPostsReceiptDataWithDiscountInfoCorrectly() {
         let path: HTTPRequest.Path = .postReceiptData
 
-        let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSubscriberResponse, error: nil)
         httpClient.mock(requestPath: path, response: response)
 
         let productIdentifier = "a_great_product"
@@ -1284,7 +1284,7 @@ class BackendTests: XCTestCase {
         ]
 
         let path: HTTPRequest.Path = .postOfferForSigning
-        let response = HTTPResponse(statusCode: 200, response: validSigningResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSigningResponse, error: nil)
         httpClient.mock(requestPath: path, response: response)
 
         let productIdentifier = "a_great_product"
@@ -1325,7 +1325,7 @@ class BackendTests: XCTestCase {
     }
 
     func testOfferForSigningNetworkError() {
-        let response = HTTPResponse(statusCode: 200,
+        let response = HTTPResponse(statusCode: .success,
                                     response: nil,
                                     error: NSError(domain: NSURLErrorDomain, code: -1009))
         httpClient.mock(requestPath: .postOfferForSigning, response: response)
@@ -1359,7 +1359,7 @@ class BackendTests: XCTestCase {
             "offers": []
         ]
 
-        let response = HTTPResponse(statusCode: 200, response: validSigningResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSigningResponse, error: nil)
         httpClient.mock(requestPath: .postOfferForSigning, response: response)
 
         let productIdentifier = "a_great_product"
@@ -1403,7 +1403,7 @@ class BackendTests: XCTestCase {
             ]
         ]
 
-        let response = HTTPResponse(statusCode: 200, response: validSigningResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSigningResponse, error: nil)
         httpClient.mock(requestPath: .postOfferForSigning, response: response)
 
         let productIdentifier = "a_great_product"
@@ -1446,7 +1446,7 @@ class BackendTests: XCTestCase {
             ]
         ]
 
-        let response = HTTPResponse(statusCode: 200, response: validSigningResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSigningResponse, error: nil)
         httpClient.mock(requestPath: .postOfferForSigning, response: response)
 
         let productIdentifier = "a_great_product"
@@ -1476,7 +1476,7 @@ class BackendTests: XCTestCase {
     }
 
     func testOfferForSigning501Response() {
-        let response = HTTPResponse(statusCode: 501, response: serverErrorResponse, error: nil)
+        let response = HTTPResponse(statusCode: .other(501), response: serverErrorResponse, error: nil)
         httpClient.mock(requestPath: .postOfferForSigning, response: response)
         let productIdentifier = "a_great_product"
         let group = "sub_group"
@@ -1502,7 +1502,7 @@ class BackendTests: XCTestCase {
     }
 
     func testDoesntCacheForDifferentOfferings() {
-        let response = HTTPResponse(statusCode: 200, response: validSubscriberResponse, error: nil)
+        let response = HTTPResponse(statusCode: .success, response: validSubscriberResponse, error: nil)
         httpClient.mock(requestPath: .postReceiptData, response: response)
 
         var completionCalled = 0
@@ -1628,7 +1628,7 @@ class BackendTests: XCTestCase {
         let underlyingErrorMessage = "header fields too large"
         let underlyingErrorCode = BackendErrorCode.cannotTransferPurchase.rawValue
         _ = self.mockLoginRequest(appUserID: currentAppUserID,
-                                  statusCode: 431,
+                                  statusCode: .other(431),
                                   response: ["code": underlyingErrorCode, "message": underlyingErrorMessage])
 
         var completionCalled = false
@@ -1664,7 +1664,7 @@ class BackendTests: XCTestCase {
         let newAppUserID = "new id"
 
         let currentAppUserID = "old id"
-        _ = self.mockLoginRequest(appUserID: currentAppUserID, statusCode: 201, response: [:])
+        _ = self.mockLoginRequest(appUserID: currentAppUserID, statusCode: .createdSuccess, response: [:])
 
         var completionCalled = false
         var receivedError: Error?
@@ -1692,7 +1692,9 @@ class BackendTests: XCTestCase {
         let newAppUserID = "new id"
 
         let currentAppUserID = "old id"
-        _ = self.mockLoginRequest(appUserID: currentAppUserID, statusCode: 201, response: mockCustomerInfoDict)
+        _ = self.mockLoginRequest(appUserID: currentAppUserID,
+                                  statusCode: .createdSuccess,
+                                  response: mockCustomerInfoDict)
 
         var completionCalled = false
         var receivedError: Error?
@@ -1718,7 +1720,7 @@ class BackendTests: XCTestCase {
 
         let currentAppUserID = "old id"
         _ = self.mockLoginRequest(appUserID: currentAppUserID,
-                                  statusCode: 200,
+                                  statusCode: .success,
                                   response: mockCustomerInfoDict)
 
         var completionCalled = false
@@ -1745,7 +1747,9 @@ class BackendTests: XCTestCase {
         let newAppUserID = "new id"
 
         let currentAppUserID = "old id"
-        _ = self.mockLoginRequest(appUserID: currentAppUserID, statusCode: 201, response: mockCustomerInfoDict)
+        _ = self.mockLoginRequest(appUserID: currentAppUserID,
+                                  statusCode: .createdSuccess,
+                                  response: mockCustomerInfoDict)
 
         backend.logIn(currentAppUserID: currentAppUserID,
                       newAppUserID: newAppUserID) { _, _, _  in }
@@ -1760,7 +1764,9 @@ class BackendTests: XCTestCase {
         let secondNewAppUserID = "new id 2"
 
         let currentAppUserID = "old id"
-        _ = self.mockLoginRequest(appUserID: currentAppUserID, statusCode: 201, response: mockCustomerInfoDict)
+        _ = self.mockLoginRequest(appUserID: currentAppUserID,
+                                  statusCode: .createdSuccess,
+                                  response: mockCustomerInfoDict)
 
         backend.logIn(currentAppUserID: currentAppUserID,
                       newAppUserID: newAppUserID) { _, _, _  in }
@@ -1775,7 +1781,9 @@ class BackendTests: XCTestCase {
 
         let currentAppUserID = "old id"
         let currentAppUserID2 = "old id 2"
-        _ = self.mockLoginRequest(appUserID: currentAppUserID, statusCode: 201, response: mockCustomerInfoDict)
+        _ = self.mockLoginRequest(appUserID: currentAppUserID,
+                                  statusCode: .createdSuccess,
+                                  response: mockCustomerInfoDict)
 
         backend.logIn(currentAppUserID: currentAppUserID,
                       newAppUserID: newAppUserID) { _, _, _  in }
@@ -1789,7 +1797,9 @@ class BackendTests: XCTestCase {
         let newAppUserID = "new id"
 
         let currentAppUserID = "old id"
-        _ = self.mockLoginRequest(appUserID: currentAppUserID, statusCode: 201, response: mockCustomerInfoDict)
+        _ = self.mockLoginRequest(appUserID: currentAppUserID,
+                                  statusCode: .createdSuccess,
+                                  response: mockCustomerInfoDict)
 
         var completion1Called = false
         var completion2Called = false
@@ -1818,7 +1828,7 @@ class BackendTests: XCTestCase {
             ]
         ]
         let path: HTTPRequest.Path = .getCustomerInfo(appUserID: userID)
-        let customerInfoResponse = HTTPResponse(statusCode: 200, response: subscriberResponse)
+        let customerInfoResponse = HTTPResponse(statusCode: .success, response: subscriberResponse)
         httpClient.mock(requestPath: path, response: customerInfoResponse)
 
         var firstCustomerInfo: CustomerInfo?
@@ -1874,9 +1884,9 @@ class BackendTests: XCTestCase {
                 ]
             ]
         ]
-        let initialCustomerInfoResponse = HTTPResponse(statusCode: 200, response: validSubscriberResponse)
-        let updatedCustomerInfoResponse = HTTPResponse(statusCode: 200, response: validUpdatedSubscriberResponse)
-        let postResponse = HTTPResponse(statusCode: 200, response: validUpdatedSubscriberResponse)
+        let initialCustomerInfoResponse = HTTPResponse(statusCode: .success, response: validSubscriberResponse)
+        let updatedCustomerInfoResponse = HTTPResponse(statusCode: .success, response: validUpdatedSubscriberResponse)
+        let postResponse = HTTPResponse(statusCode: .success, response: validUpdatedSubscriberResponse)
         httpClient.mock(requestPath: .postReceiptData, response: postResponse)
         httpClient.mock(requestPath: getCustomerInfoPath, response: initialCustomerInfoResponse)
 
@@ -1931,7 +1941,7 @@ class BackendTests: XCTestCase {
 private extension BackendTests {
 
     func mockLoginRequest(appUserID: String,
-                          statusCode: Int = 200,
+                          statusCode: HTTPStatusCode = .success,
                           response: [String: Any]? = [:],
                           error: Error? = nil) -> HTTPRequest.Path {
         let path: HTTPRequest.Path = .logIn

--- a/PurchasesTests/Networking/ETagManagerTests.swift
+++ b/PurchasesTests/Networking/ETagManagerTests.swift
@@ -46,7 +46,7 @@ class ETagManagerTests: XCTestCase {
         let eTag = "an_etag"
         let url = urlForTest()
         let request = URLRequest(url: url)
-        let cachedResponse = mockStoredETagAndResponse(for: url, statusCode: HTTPStatusCode.success, eTag: eTag)
+        let cachedResponse = mockStoredETagAndResponse(for: url, statusCode: .success, eTag: eTag)
 
         guard let httpURLResponse = HTTPURLResponse(url: url,
                                                     statusCode: HTTPStatusCode.notModifiedResponseCode.rawValue,
@@ -60,7 +60,7 @@ class ETagManagerTests: XCTestCase {
                                                                 request: request,
                                                                 retried: false)
         expect(response).toNot(beNil())
-        expect(response?.statusCode) == HTTPStatusCode.success.rawValue
+        expect(response?.statusCode) == .success
         expect(response?.jsonObject as? [String: String]).to(equal(cachedResponse))
     }
 
@@ -68,13 +68,13 @@ class ETagManagerTests: XCTestCase {
         let eTag = "an_etag"
         let url = urlForTest()
         let request = URLRequest(url: url)
-        _ = mockStoredETagAndResponse(for: url, statusCode: HTTPStatusCode.success, eTag: eTag)
+        _ = mockStoredETagAndResponse(for: url, statusCode: .success, eTag: eTag)
         let responseObject = ["a": "response"]
-        let httpURLResponse = httpURLResponseForTest(url: url, eTag: eTag, statusCode: HTTPStatusCode.success.rawValue)
+        let httpURLResponse = httpURLResponseForTest(url: url, eTag: eTag, statusCode: .success)
         let response = eTagManager.httpResultFromCacheOrBackend(
             with: httpURLResponse, jsonObject: responseObject, error: nil, request: request, retried: false)
         expect(response).toNot(beNil())
-        expect(response?.statusCode) == HTTPStatusCode.success.rawValue
+        expect(response?.statusCode) == .success
         expect(response?.jsonObject as? [String: String]).to(equal(responseObject))
     }
 
@@ -82,17 +82,18 @@ class ETagManagerTests: XCTestCase {
         let eTag = "an_etag"
         let url = urlForTest()
         let request = URLRequest(url: url)
-        _ = mockStoredETagAndResponse(for: url, statusCode: HTTPStatusCode.success, eTag: eTag)
+        _ = mockStoredETagAndResponse(for: url, statusCode: .success, eTag: eTag)
         let responseObject = ["a": "response"]
         let error = NSError(domain: NSCocoaErrorDomain, code: 123, userInfo: [:])
         let httpURLResponse = httpURLResponseForTest(
             url: url,
             eTag: eTag,
-            statusCode: HTTPStatusCode.notModifiedResponseCode.rawValue)
+            statusCode: .notModifiedResponseCode
+        )
         let response = eTagManager.httpResultFromCacheOrBackend(
             with: httpURLResponse, jsonObject: responseObject, error: error, request: request, retried: false)
         expect(response).toNot(beNil())
-        expect(response?.statusCode) == HTTPStatusCode.notModifiedResponseCode.rawValue
+        expect(response?.statusCode) == .notModifiedResponseCode
         expect(response?.jsonObject as? [String: String]).to(equal(responseObject))
     }
 
@@ -104,11 +105,12 @@ class ETagManagerTests: XCTestCase {
         let httpURLResponse = httpURLResponseForTest(
             url: url,
             eTag: eTag,
-            statusCode: HTTPStatusCode.notModifiedResponseCode.rawValue)
+            statusCode: .notModifiedResponseCode
+        )
         let response = eTagManager.httpResultFromCacheOrBackend(
             with: httpURLResponse, jsonObject: responseObject, error: nil, request: request, retried: true)
         expect(response).toNot(beNil())
-        expect(response?.statusCode) == HTTPStatusCode.notModifiedResponseCode.rawValue
+        expect(response?.statusCode) == .notModifiedResponseCode
         expect(response?.jsonObject as? [String: String]).to(equal(responseObject))
     }
 
@@ -120,7 +122,8 @@ class ETagManagerTests: XCTestCase {
         let httpURLResponse = httpURLResponseForTest(
             url: url,
             eTag: eTag,
-            statusCode: HTTPStatusCode.notModifiedResponseCode.rawValue)
+            statusCode: .notModifiedResponseCode
+        )
         let response = eTagManager.httpResultFromCacheOrBackend(
             with: httpURLResponse, jsonObject: responseObject, error: nil, request: request, retried: false)
         expect(response).to(beNil())
@@ -134,7 +137,8 @@ class ETagManagerTests: XCTestCase {
         let httpURLResponse = httpURLResponseForTest(
             url: url,
             eTag: eTag,
-            statusCode: HTTPStatusCode.success.rawValue)
+            statusCode: .success
+        )
         let response = eTagManager.httpResultFromCacheOrBackend(
             with: httpURLResponse, jsonObject: responseObject, error: nil, request: request, retried: false)
 
@@ -164,12 +168,13 @@ class ETagManagerTests: XCTestCase {
         let httpURLResponse = httpURLResponseForTest(
             url: url,
             eTag: eTag,
-            statusCode: HTTPStatusCode.internalServerError.rawValue)
+            statusCode: .internalServerError
+        )
         let response = eTagManager.httpResultFromCacheOrBackend(
             with: httpURLResponse, jsonObject: responseObject, error: nil, request: request, retried: false)
 
         expect(response).toNot(beNil())
-        expect(response?.statusCode) == HTTPStatusCode.internalServerError.rawValue
+        expect(response?.statusCode) == .internalServerError
         expect(response?.jsonObject as? [String: String]).to(equal(responseObject))
 
         expect(self.mockUserDefaults.setObjectForKeyCallCount) == 0
@@ -181,7 +186,7 @@ class ETagManagerTests: XCTestCase {
     func testClearCachesWorks() {
         let eTag = "an_etag"
         let url = urlForTest()
-        _ = mockStoredETagAndResponse(for: url, statusCode: HTTPStatusCode.success, eTag: eTag)
+        _ = mockStoredETagAndResponse(for: url, statusCode: .success, eTag: eTag)
 
         let cacheKey = url.absoluteString
         expect(self.mockUserDefaults.mockValues[cacheKey]).toNot(beNil())
@@ -207,12 +212,12 @@ class ETagManagerTests: XCTestCase {
     }
 
     private func mockStoredETagAndResponse(for url: URL,
-                                           statusCode: HTTPStatusCode = HTTPStatusCode.success,
+                                           statusCode: HTTPStatusCode = .success,
                                            eTag: String = "an_etag") -> [String: String] {
         let jsonObject = ["arg": "value"]
         let etagAndResponse = ETagAndResponseWrapper(
             eTag: eTag,
-            statusCode: statusCode.rawValue,
+            statusCode: statusCode,
             jsonObject: jsonObject)
         let cacheKey = url.absoluteString
         self.mockUserDefaults.mockValues[cacheKey] = etagAndResponse.asData()
@@ -226,10 +231,10 @@ class ETagManagerTests: XCTestCase {
         return url
     }
 
-    private func httpURLResponseForTest(url: URL, eTag: String, statusCode: Int) -> HTTPURLResponse {
+    private func httpURLResponseForTest(url: URL, eTag: String, statusCode: HTTPStatusCode) -> HTTPURLResponse {
         guard let httpURLResponse = HTTPURLResponse(
             url: url,
-            statusCode: statusCode,
+            statusCode: statusCode.rawValue,
             httpVersion: "HTTP/1.1",
             headerFields: getHeaders(eTag: eTag)
         ) else {

--- a/PurchasesTests/Networking/ETagManagerTests.swift
+++ b/PurchasesTests/Networking/ETagManagerTests.swift
@@ -49,7 +49,7 @@ class ETagManagerTests: XCTestCase {
         let cachedResponse = mockStoredETagAndResponse(for: url, statusCode: .success, eTag: eTag)
 
         guard let httpURLResponse = HTTPURLResponse(url: url,
-                                                    statusCode: HTTPStatusCode.notModifiedResponseCode.rawValue,
+                                                    statusCode: HTTPStatusCode.notModified.rawValue,
                                                     httpVersion: "HTTP/1.1",
                                                     headerFields: getHeaders(eTag: eTag)) else {
             fatalError("Error initializing HTTPURLResponse")
@@ -88,12 +88,12 @@ class ETagManagerTests: XCTestCase {
         let httpURLResponse = httpURLResponseForTest(
             url: url,
             eTag: eTag,
-            statusCode: .notModifiedResponseCode
+            statusCode: .notModified
         )
         let response = eTagManager.httpResultFromCacheOrBackend(
             with: httpURLResponse, jsonObject: responseObject, error: error, request: request, retried: false)
         expect(response).toNot(beNil())
-        expect(response?.statusCode) == .notModifiedResponseCode
+        expect(response?.statusCode) == .notModified
         expect(response?.jsonObject as? [String: String]).to(equal(responseObject))
     }
 
@@ -105,12 +105,12 @@ class ETagManagerTests: XCTestCase {
         let httpURLResponse = httpURLResponseForTest(
             url: url,
             eTag: eTag,
-            statusCode: .notModifiedResponseCode
+            statusCode: .notModified
         )
         let response = eTagManager.httpResultFromCacheOrBackend(
             with: httpURLResponse, jsonObject: responseObject, error: nil, request: request, retried: true)
         expect(response).toNot(beNil())
-        expect(response?.statusCode) == .notModifiedResponseCode
+        expect(response?.statusCode) == .notModified
         expect(response?.jsonObject as? [String: String]).to(equal(responseObject))
     }
 
@@ -122,7 +122,7 @@ class ETagManagerTests: XCTestCase {
         let httpURLResponse = httpURLResponseForTest(
             url: url,
             eTag: eTag,
-            statusCode: .notModifiedResponseCode
+            statusCode: .notModified
         )
         let response = eTagManager.httpResultFromCacheOrBackend(
             with: httpURLResponse, jsonObject: responseObject, error: nil, request: request, retried: false)

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -45,7 +45,7 @@ class HTTPClientTests: XCTestCase {
         let host = try XCTUnwrap(SystemInfo.serverHostURL.host)
         stub(condition: isHost(host)) { _ in
             hostCorrect.value = true
-            return .emptyValidResponse
+            return .emptySuccessResponse
         }
 
         let request = HTTPRequest(method: .get, path: .mockPath)
@@ -59,7 +59,7 @@ class HTTPClientTests: XCTestCase {
 
         stub(condition: hasHeaderNamed("test_header")) { _ in
             headerPresent.value = true
-            return .emptyValidResponse
+            return .emptySuccessResponse
         }
 
         let request = HTTPRequest(method: .post(body: [:]), path: .mockPath)
@@ -75,7 +75,7 @@ class HTTPClientTests: XCTestCase {
 
         stub(condition: hasHeaderNamed("content-type", value: "application/json")) { _ in
             headerPresent.value = true
-            return .emptyValidResponse
+            return .emptySuccessResponse
         }
 
         let request = HTTPRequest(method: .post(body: [:]), path: .mockPath)
@@ -90,7 +90,7 @@ class HTTPClientTests: XCTestCase {
 
         stub(condition: hasHeaderNamed("X-Platform", value: SystemInfo.platformHeader)) { _ in
             headerPresent.value = true
-            return .emptyValidResponse
+            return .emptySuccessResponse
         }
 
         let request = HTTPRequest(method: .post(body: [:]), path: .mockPath)
@@ -105,7 +105,7 @@ class HTTPClientTests: XCTestCase {
 
         stub(condition: hasHeaderNamed("X-Version", value: Purchases.frameworkVersion)) { _ in
             headerPresent.value = true
-            return .emptyValidResponse
+            return .emptySuccessResponse
         }
 
         let request = HTTPRequest(method: .post(body: [:]), path: .mockPath)
@@ -120,7 +120,7 @@ class HTTPClientTests: XCTestCase {
 
         stub(condition: hasHeaderNamed("X-Platform-Version", value: ProcessInfo().operatingSystemVersionString)) { _ in
             headerPresent.value = true
-            return .emptyValidResponse
+            return .emptySuccessResponse
         }
 
         let request = HTTPRequest(method: .post(body: [:]), path: .mockPath)
@@ -137,7 +137,7 @@ class HTTPClientTests: XCTestCase {
 
         stub(condition: isPath(request.path)) { _ in
             pathHit.value = true
-            return .emptyValidResponse
+            return .emptySuccessResponse
         }
 
         self.client.perform(request, authHeaders: [:], completionHandler: nil)
@@ -153,7 +153,7 @@ class HTTPClientTests: XCTestCase {
 
         stub(condition: hasBody(bodyData)) { _ in
             pathHit.value = true
-            return .emptyValidResponse
+            return .emptySuccessResponse
         }
         let request = HTTPRequest(method: .post(body: body), path: .mockPath)
 
@@ -168,7 +168,7 @@ class HTTPClientTests: XCTestCase {
         let completionCalled: Atomic<Bool> = .init(false)
 
         stub(condition: isPath(request.path)) { _ in
-            return .emptyValidResponse
+            return .emptySuccessResponse
         }
 
         self.client.perform(request, authHeaders: [:]) { (_, _, _) in
@@ -185,7 +185,7 @@ class HTTPClientTests: XCTestCase {
         let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: nil)
 
         stub(condition: isPath(request.path)) { _ in
-            let response = HTTPStubsResponse.emptyValidResponse
+            let response = HTTPStubsResponse.emptySuccessResponse
             response.error = error
             return response
         }
@@ -312,7 +312,7 @@ class HTTPClientTests: XCTestCase {
 
         stub(condition: hasHeaderNamed("X-Client-Version", value: version )) { _ in
             headerPresent.value = true
-            return .emptyValidResponse
+            return .emptySuccessResponse
         }
 
         self.client.perform(request, authHeaders: ["test_header": "value"], completionHandler: nil)
@@ -329,7 +329,7 @@ class HTTPClientTests: XCTestCase {
 
         stub(condition: hasHeaderNamed("X-Client-Build-Version", value: version )) { _ in
             headerPresent.value = true
-            return .emptyValidResponse
+            return .emptySuccessResponse
         }
 
         self.client.perform(request, authHeaders: ["test_header": "value"], completionHandler: nil)
@@ -348,7 +348,7 @@ class HTTPClientTests: XCTestCase {
 
         stub(condition: hasHeaderNamed("X-Apple-Device-Identifier", value: idfv )) { _ in
             headerPresent.value = true
-            return .emptyValidResponse
+            return .emptySuccessResponse
         }
 
         self.client.perform(request, authHeaders: ["test_header": "value"], completionHandler: nil)
@@ -376,7 +376,7 @@ class HTTPClientTests: XCTestCase {
 
         stub(condition: hasHeaderNamed("X-Apple-Device-Identifier", value: idfv )) { _ in
             headerPresent.value = true
-            return .emptyValidResponse
+            return .emptySuccessResponse
         }
 
         self.client.perform(request, authHeaders: ["test_header": "value"], completionHandler: nil)
@@ -392,7 +392,7 @@ class HTTPClientTests: XCTestCase {
 
         stub(condition: hasHeaderNamed("X-Platform-Flavor", value: "native")) { _ in
             headerPresent.value = true
-            return .emptyValidResponse
+            return .emptySuccessResponse
         }
 
         self.client.perform(request, authHeaders: ["test_header": "value"], completionHandler: nil)
@@ -407,7 +407,7 @@ class HTTPClientTests: XCTestCase {
 
         stub(condition: hasHeaderNamed("X-Platform-Flavor", value: "react-native")) { _ in
             headerPresent.value = true
-            return .emptyValidResponse
+            return .emptySuccessResponse
         }
         let platformInfo = Purchases.PlatformInfo(flavor: "react-native", version: "3.2.1")
         let systemInfo = try SystemInfo(platformInfo: platformInfo,
@@ -426,7 +426,7 @@ class HTTPClientTests: XCTestCase {
 
         stub(condition: hasHeaderNamed("X-Platform-Flavor-Version", value: "1.2.3")) { _ in
             headerPresent.value = true
-            return .emptyValidResponse
+            return .emptySuccessResponse
         }
         let platformInfo = Purchases.PlatformInfo(flavor: "react-native", version: "1.2.3")
         let systemInfo = try SystemInfo(platformInfo: platformInfo,
@@ -445,7 +445,7 @@ class HTTPClientTests: XCTestCase {
 
         stub(condition: hasHeaderNamed("X-Observer-Mode-Enabled", value: "false")) { _ in
             headerPresent.value = true
-            return .emptyValidResponse
+            return .emptySuccessResponse
         }
         let systemInfo = try SystemInfo(platformInfo: nil, finishTransactions: true)
         let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
@@ -462,7 +462,7 @@ class HTTPClientTests: XCTestCase {
 
         stub(condition: hasHeaderNamed("X-Observer-Mode-Enabled", value: "true")) { _ in
             headerPresent.value = true
-            return .emptyValidResponse
+            return .emptySuccessResponse
         }
         let systemInfo = try SystemInfo(platformInfo: nil, finishTransactions: false)
         let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
@@ -611,7 +611,7 @@ class HTTPClientTests: XCTestCase {
 
         stub(condition: isPath(path)) { _ in
             httpCallMade.value = true
-            return .emptyValidResponse
+            return .emptySuccessResponse
         }
 
         self.client.perform(.init(method: .invalidBody(), path: path),
@@ -634,7 +634,7 @@ class HTTPClientTests: XCTestCase {
                 self.eTagManager.shouldReturnResultFromBackend = true
             }
             firstTimeCalled.value = true
-            return .emptyValidResponse
+            return .emptySuccessResponse
         }
 
         self.eTagManager.shouldReturnResultFromBackend = false
@@ -653,7 +653,7 @@ class HTTPClientTests: XCTestCase {
         MockDNSChecker.stubbedIsBlockedAPIErrorResult.value = false
 
         stub(condition: isPath(path)) { _ in
-            let response = HTTPStubsResponse.emptyValidResponse
+            let response = HTTPStubsResponse.emptySuccessResponse
             response.error = error
             return response
         }
@@ -671,7 +671,7 @@ class HTTPClientTests: XCTestCase {
         MockDNSChecker.stubbedIsBlockedAPIErrorResult.value = false
 
         stub(condition: isPath(path)) { _ in
-            let response = HTTPStubsResponse.emptyValidResponse
+            let response = HTTPStubsResponse.emptySuccessResponse
             response.error = error
             return response
         }
@@ -693,7 +693,7 @@ class HTTPClientTests: XCTestCase {
         MockDNSChecker.stubbedIsBlockedAPIErrorResult.value = true
 
         stub(condition: isPath(path)) { _ in
-            let response = HTTPStubsResponse.emptyValidResponse
+            let response = HTTPStubsResponse.emptySuccessResponse
             response.error = nsErrorWithUserInfo
             return response
         }
@@ -715,7 +715,7 @@ class HTTPClientTests: XCTestCase {
         MockDNSChecker.stubbedIsBlockedAPIErrorResult.value = true
 
         stub(condition: isPath(path)) { _ in
-            let response = HTTPStubsResponse.emptyValidResponse
+            let response = HTTPStubsResponse.emptySuccessResponse
             response.error = nsErrorWithUserInfo
             return response
         }
@@ -746,7 +746,7 @@ class HTTPClientTests: XCTestCase {
         defer { Logger.logHandler = originalLogHandler }
 
         stub(condition: isPath(path)) { _ in
-            let response = HTTPStubsResponse.emptyValidResponse
+            let response = HTTPStubsResponse.emptySuccessResponse
             response.error = error
             return response
         }
@@ -779,7 +779,7 @@ class HTTPClientTests: XCTestCase {
         }
 
         stub(condition: isPath(path)) { _ in
-            let response = HTTPStubsResponse.emptyValidResponse
+            let response = HTTPStubsResponse.emptySuccessResponse
             response.error = error
             return response
         }
@@ -842,9 +842,9 @@ private func isPath(_ path: HTTPRequest.Path) -> HTTPStubsTestBlock {
 
 private extension HTTPStubsResponse {
 
-    static let emptyValidResponse: HTTPStubsResponse = .init(data: Data(),
-                                                             statusCode: .success,
-                                                             headers: nil)
+    static let emptySuccessResponse: HTTPStubsResponse = .init(data: Data(),
+                                                               statusCode: .success,
+                                                               headers: nil)
 
     convenience init(data: Data, statusCode: HTTPStatusCode, headers: HTTPClient.RequestHeaders?) {
         self.init(data: data, statusCode: Int32(statusCode.rawValue), headers: headers)

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -191,7 +191,7 @@ class HTTPClientTests: XCTestCase {
         }
         self.client.perform(request, authHeaders: [:]) { (status, data, responseError) in
             if let responseNSError = responseError as NSError? {
-                successFailed.value = (status.isInternalServerError
+                successFailed.value = (status.isServerError
                                        && data == nil
                                        && error.domain == responseNSError.domain
                                        && error.code == responseNSError.code)

--- a/PurchasesTests/Networking/HTTPStatusCodeTests.swift
+++ b/PurchasesTests/Networking/HTTPStatusCodeTests.swift
@@ -1,0 +1,38 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  HTTPStatusCodeTests.swift
+//
+//  Created by Nacho Soto on 2/28/22.
+
+import Foundation
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+class HTTPStatusCodeTests: XCTestCase {
+
+    func testCreatingAnUnknownCode() {
+        let code = 205
+        let status = HTTPStatusCode(rawValue: code)
+
+        expect(status) == .other(code)
+        expect(status.rawValue) == code
+    }
+
+    func testKnownCodeIsDetected() {
+        let code = 404
+        let status = HTTPStatusCode(rawValue: code)
+
+        expect(status) == .notFoundError
+        expect(status.rawValue) == code
+    }
+
+}

--- a/PurchasesTests/Networking/HTTPStatusCodeTests.swift
+++ b/PurchasesTests/Networking/HTTPStatusCodeTests.swift
@@ -38,7 +38,7 @@ class HTTPStatusCodeTests: XCTestCase {
     func testIsValidResponse() {
         expect(HTTPStatusCode.success.isValidResponse) == true
         expect(HTTPStatusCode.createdSuccess.isValidResponse) == true
-        expect(status(100).isServerError) == false
+        expect(status(100).isValidResponse) == true
         expect(status(202).isValidResponse) == true
         expect(status(226).isValidResponse) == true
         expect(status(299).isValidResponse) == true

--- a/PurchasesTests/Networking/HTTPStatusCodeTests.swift
+++ b/PurchasesTests/Networking/HTTPStatusCodeTests.swift
@@ -35,4 +35,45 @@ class HTTPStatusCodeTests: XCTestCase {
         expect(status.rawValue) == code
     }
 
+    func testIsValidResponse() {
+        expect(HTTPStatusCode.success.isValidResponse) == true
+        expect(HTTPStatusCode.createdSuccess.isValidResponse) == true
+        expect(status(100).isServerError) == false
+        expect(status(202).isValidResponse) == true
+        expect(status(226).isValidResponse) == true
+        expect(status(299).isValidResponse) == true
+    }
+
+    func testIsNotValidResponse() {
+        expect(HTTPStatusCode.redirect.isValidResponse) == false
+        expect(HTTPStatusCode.notModified.isValidResponse) == false
+        expect(HTTPStatusCode.invalidRequest.isValidResponse) == false
+        expect(HTTPStatusCode.notFoundError.isValidResponse) == false
+        expect(HTTPStatusCode.internalServerError.isValidResponse) == false
+        expect(HTTPStatusCode.networkConnectTimeoutError.isValidResponse) == false
+        expect(status(418).isValidResponse) == false
+    }
+
+    func testIsServerError() {
+        expect(HTTPStatusCode.internalServerError.isServerError) == true
+        expect(HTTPStatusCode.networkConnectTimeoutError.isServerError) == true
+    }
+
+    func testIsNotServerError() {
+        expect(HTTPStatusCode.success.isServerError) == false
+        expect(HTTPStatusCode.createdSuccess.isServerError) == false
+        expect(HTTPStatusCode.redirect.isServerError) == false
+        expect(HTTPStatusCode.notModified.isServerError) == false
+        expect(HTTPStatusCode.invalidRequest.isServerError) == false
+        expect(HTTPStatusCode.notFoundError.isServerError) == false
+        expect(status(100).isServerError) == false
+        expect(status(202).isServerError) == false
+        expect(status(226).isServerError) == false
+        expect(status(299).isServerError) == false
+    }
+
+}
+
+private func status(_ code: Int) -> HTTPStatusCode {
+    return .init(rawValue: code)
 }

--- a/PurchasesTests/Networking/HTTPStatusCodeTests.swift
+++ b/PurchasesTests/Networking/HTTPStatusCodeTests.swift
@@ -35,23 +35,23 @@ class HTTPStatusCodeTests: XCTestCase {
         expect(status.rawValue) == code
     }
 
-    func testIsValidResponse() {
-        expect(HTTPStatusCode.success.isValidResponse) == true
-        expect(HTTPStatusCode.createdSuccess.isValidResponse) == true
-        expect(status(100).isValidResponse) == true
-        expect(status(202).isValidResponse) == true
-        expect(status(226).isValidResponse) == true
-        expect(status(299).isValidResponse) == true
+    func testIsSuccessfulResponse() {
+        expect(HTTPStatusCode.success.isSuccessfulResponse) == true
+        expect(HTTPStatusCode.createdSuccess.isSuccessfulResponse) == true
+        expect(status(100).isSuccessfulResponse) == true
+        expect(status(202).isSuccessfulResponse) == true
+        expect(status(226).isSuccessfulResponse) == true
+        expect(status(299).isSuccessfulResponse) == true
     }
 
     func testIsNotValidResponse() {
-        expect(HTTPStatusCode.redirect.isValidResponse) == false
-        expect(HTTPStatusCode.notModified.isValidResponse) == false
-        expect(HTTPStatusCode.invalidRequest.isValidResponse) == false
-        expect(HTTPStatusCode.notFoundError.isValidResponse) == false
-        expect(HTTPStatusCode.internalServerError.isValidResponse) == false
-        expect(HTTPStatusCode.networkConnectTimeoutError.isValidResponse) == false
-        expect(status(418).isValidResponse) == false
+        expect(HTTPStatusCode.redirect.isSuccessfulResponse) == false
+        expect(HTTPStatusCode.notModified.isSuccessfulResponse) == false
+        expect(HTTPStatusCode.invalidRequest.isSuccessfulResponse) == false
+        expect(HTTPStatusCode.notFoundError.isSuccessfulResponse) == false
+        expect(HTTPStatusCode.internalServerError.isSuccessfulResponse) == false
+        expect(HTTPStatusCode.networkConnectTimeoutError.isSuccessfulResponse) == false
+        expect(status(418).isSuccessfulResponse) == false
     }
 
     func testIsServerError() {

--- a/PurchasesTests/Networking/HTTPStatusCodeTests.swift
+++ b/PurchasesTests/Networking/HTTPStatusCodeTests.swift
@@ -19,6 +19,14 @@ import XCTest
 
 class HTTPStatusCodeTests: XCTestCase {
 
+    func testInitializeFromInteger() {
+        func method(_ status: HTTPStatusCode) {
+            expect(status) == .internalServerError
+        }
+
+        method(500)
+    }
+
     func testCreatingAnUnknownCode() {
         let code = 205
         let status = HTTPStatusCode(rawValue: code)

--- a/PurchasesTests/Networking/HTTPStatusCodeTests.swift
+++ b/PurchasesTests/Networking/HTTPStatusCodeTests.swift
@@ -46,7 +46,6 @@ class HTTPStatusCodeTests: XCTestCase {
     func testIsSuccessfulResponse() {
         expect(HTTPStatusCode.success.isSuccessfulResponse) == true
         expect(HTTPStatusCode.createdSuccess.isSuccessfulResponse) == true
-        expect(status(100).isSuccessfulResponse) == true
         expect(status(202).isSuccessfulResponse) == true
         expect(status(226).isSuccessfulResponse) == true
         expect(status(299).isSuccessfulResponse) == true
@@ -59,6 +58,7 @@ class HTTPStatusCodeTests: XCTestCase {
         expect(HTTPStatusCode.notFoundError.isSuccessfulResponse) == false
         expect(HTTPStatusCode.internalServerError.isSuccessfulResponse) == false
         expect(HTTPStatusCode.networkConnectTimeoutError.isSuccessfulResponse) == false
+        expect(status(100).isSuccessfulResponse) == false
         expect(status(418).isSuccessfulResponse) == false
     }
 
@@ -78,6 +78,7 @@ class HTTPStatusCodeTests: XCTestCase {
         expect(status(202).isServerError) == false
         expect(status(226).isServerError) == false
         expect(status(299).isServerError) == false
+        expect(status(600).isServerError) == false
     }
 
 }

--- a/PurchasesTests/SubscriberAttributes/AttributionDataMigratorTests.swift
+++ b/PurchasesTests/SubscriberAttributes/AttributionDataMigratorTests.swift
@@ -665,7 +665,7 @@ private extension AttributionDataMigratorTests {
                        ip: KeyPresence = .defaultValue) -> [String: Any] {
         var data: [String: Any] = [
             "adset_id": "23847301359550211",
-            "campaign_id": "23847301359200211",
+            "campaign_id": "23847301359.success211",
             "click_time": "2021-05-04 18:08:51.000",
             "iscache": false,
             "adgroup_id": "238473013556789090",

--- a/PurchasesTests/SubscriberAttributes/AttributionDataMigratorTests.swift
+++ b/PurchasesTests/SubscriberAttributes/AttributionDataMigratorTests.swift
@@ -665,7 +665,7 @@ private extension AttributionDataMigratorTests {
                        ip: KeyPresence = .defaultValue) -> [String: Any] {
         var data: [String: Any] = [
             "adset_id": "23847301359550211",
-            "campaign_id": "23847301359.success211",
+            "campaign_id": "23847301359200211",
             "click_time": "2021-05-04 18:08:51.000",
             "iscache": false,
             "adgroup_id": "238473013556789090",

--- a/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -137,7 +137,7 @@ class BackendSubscriberAttributesTests: XCTestCase {
     func testPostSubscriberAttributesCallsCompletionWithErrorInBackendErrorCase() throws {
         var completionCallCount = 0
         mockHTTPClient.shouldInvokeCompletion = true
-        mockHTTPClient.stubbedCompletionStatusCode = 503
+        mockHTTPClient.stubbedCompletionStatusCode = .other(503)
         mockHTTPClient.stubbedCompletionError = nil
 
         var receivedError: Error?
@@ -168,7 +168,7 @@ class BackendSubscriberAttributesTests: XCTestCase {
     func testPostSubscriberAttributesSendsAttributesErrorsIfAny() {
         var completionCallCount = 0
         mockHTTPClient.shouldInvokeCompletion = true
-        mockHTTPClient.stubbedCompletionStatusCode = 503
+        mockHTTPClient.stubbedCompletionStatusCode = .other(503)
         mockHTTPClient.stubbedCompletionError = nil
         let attributeErrors = [Backend.RCAttributeErrorsKey: ["some_attribute": "wasn't valid"]]
         mockHTTPClient.stubbedCompletionResponse = attributeErrors
@@ -204,7 +204,7 @@ class BackendSubscriberAttributesTests: XCTestCase {
     func testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase() throws {
         var completionCallCount = 0
         mockHTTPClient.shouldInvokeCompletion = true
-        mockHTTPClient.stubbedCompletionStatusCode = 400
+        mockHTTPClient.stubbedCompletionStatusCode = .invalidRequest
         mockHTTPClient.stubbedCompletionError = nil
 
         var receivedError: Error?
@@ -248,7 +248,7 @@ class BackendSubscriberAttributesTests: XCTestCase {
     func testPostSubscriberAttributesCallsCompletionWithErrorInNotFoundCase() throws {
         var completionCallCount = 0
         mockHTTPClient.shouldInvokeCompletion = true
-        mockHTTPClient.stubbedCompletionStatusCode = 404
+        mockHTTPClient.stubbedCompletionStatusCode = .notFoundError
         mockHTTPClient.stubbedCompletionError = nil
 
         var receivedError: Error?
@@ -392,7 +392,7 @@ class BackendSubscriberAttributesTests: XCTestCase {
     func testPostReceiptWithSubscriberAttributesPassesErrorsToCallbackIfStatusCodeIsError() {
         var completionCallCount = 0
 
-        self.mockHTTPClient.stubbedCompletionStatusCode = 400
+        self.mockHTTPClient.stubbedCompletionStatusCode = .invalidRequest
         let attributeErrors = [
             Backend.RCAttributeErrorsKey: ["$email": "email is not in valid format"]
         ]
@@ -438,7 +438,7 @@ class BackendSubscriberAttributesTests: XCTestCase {
     func testPostReceiptWithSubscriberAttributesPassesErrorsToCallbackIfStatusCodeIsSuccess() {
         var completionCallCount = 0
 
-        self.mockHTTPClient.stubbedCompletionStatusCode = 200
+        self.mockHTTPClient.stubbedCompletionStatusCode = .success
         let attributeErrors = [
             Backend.RCAttributeErrorsKey: ["$email": "email is not in valid format"]
         ]

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -239,6 +239,7 @@
 		57C381E2279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */; };
 		57C381E3279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */; };
 		57DC9F4627CC2E4900DA6AF9 /* HTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DC9F4527CC2E4900DA6AF9 /* HTTPRequest.swift */; };
+		57DC9F4A27CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DC9F4927CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift */; };
 		57E0473B277260DE0082FE91 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 57E0473A277260DE0082FE91 /* SnapshotTesting */; };
 		57E2230727500BB1002DB06E /* AtomicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E2230627500BB1002DB06E /* AtomicTests.swift */; };
 		57EAE527274324C60060EB74 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE526274324C60060EB74 /* Lock.swift */; };
@@ -637,6 +638,7 @@
 		57C381DB27961547009E3940 /* SK2StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreProductDiscount.swift; sourceTree = "<group>"; };
 		57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreProductDiscount.swift; sourceTree = "<group>"; };
 		57DC9F4527CC2E4900DA6AF9 /* HTTPRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequest.swift; sourceTree = "<group>"; };
+		57DC9F4927CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCodeTests.swift; sourceTree = "<group>"; };
 		57E0474B27729A1E0082FE91 /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		57E2230627500BB1002DB06E /* AtomicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicTests.swift; sourceTree = "<group>"; };
 		57EAE526274324C60060EB74 /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
@@ -1315,6 +1317,7 @@
 				35D832FF262FAD8000E60AC5 /* ETagManagerTests.swift */,
 				B380D69A27726AB500984578 /* DNSCheckerTests.swift */,
 				576C8AD827D2BCB90058FA6E /* HTTPRequestTests.swift */,
+				57DC9F4927CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -2178,6 +2181,7 @@
 				35E840CE2710E2EB00899AE2 /* MockManageSubscriptionsHelper.swift in Sources */,
 				F591492826B9956C00D32E58 /* MockTransaction.swift in Sources */,
 				351B516A26D44CB300BD2BD7 /* ISOPeriodFormatterTests.swift in Sources */,
+				57DC9F4A27CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift in Sources */,
 				2DDF41DE24F6F527005BC22D /* MockAppleReceiptBuilder.swift in Sources */,
 				2DDF41E324F6F527005BC22D /* MockASN1ContainerBuilder.swift in Sources */,
 				576C8AD927D2BCB90058FA6E /* HTTPRequestTests.swift in Sources */,


### PR DESCRIPTION
For [CF-195] and #695.

## Changes
- Abstracted duplicated logic for checking status codes into tested `HTTPSTatusCode` properties
- Reuse `HTTPClient.Completion` typealias
- Using `XCTUnwrap` in a few more tests

[CF-195]: https://revenuecats.atlassian.net/browse/CF-195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ