### PR TITLE
`BackendTests`: fixed `MockHTTPClient` thread safety and `SnapshotTesting` usage

### DIFF
--- a/Purchases/Networking/Operations/NetworkOperation.swift
+++ b/Purchases/Networking/Operations/NetworkOperation.swift
@@ -89,6 +89,7 @@ class NetworkOperation: Operation {
         self.isExecuting = true
 
         self.log("Started")
+
         self.begin {
             self.finish()
         }
@@ -103,6 +104,7 @@ class NetworkOperation: Operation {
     }
 
     /// Overriden by subclasses to define the body of the operation
+    /// - Important: this method may be called from any thread so it must be thread-safe.
     /// - Parameter completion: must be called when the operation has finished.
     func begin(completion: @escaping () -> Void) {
         fatalError("Subclasses must override this method")

--- a/PurchasesTests/Networking/BackendTests.swift
+++ b/PurchasesTests/Networking/BackendTests.swift
@@ -40,27 +40,25 @@ class BackendTests: XCTestCase {
         override func perform(_ request: HTTPRequest,
                               authHeaders: [String: String],
                               completionHandler: Completion?) {
-            assert(mocks[request.path] != nil, "Path '\(request.path.relativePath)' not mocked")
-            let response = mocks[request.path]!
+            DispatchQueue.main.async {
+                assert(self.mocks[request.path] != nil, "Path '\(request.path.relativePath)' not mocked")
+                let response = self.mocks[request.path]!
 
-            if let body = request.requestBody {
-                assertSnapshot(matching: body, as: .json,
-                               file: #file, testName: CurrentTestCaseTracker.sanitizedTestName)
-            }
+                if let body = request.requestBody {
+                    assertSnapshot(matching: body, as: .json,
+                                   file: #file, testName: CurrentTestCaseTracker.sanitizedTestName)
+                }
 
-            calls.append(RequestCall(request: request, headers: authHeaders))
+                self.calls.append(RequestCall(request: request, headers: authHeaders))
 
-            if shouldFinish {
-                DispatchQueue.main.async {
-                    if completionHandler != nil {
-                        completionHandler!(response.statusCode, response.response, response.error)
-                    }
+                if self.shouldFinish, let completionHandler = completionHandler {
+                    completionHandler(response.statusCode, response.response, response.error)
                 }
             }
         }
 
         func mock(requestPath: HTTPRequest.Path, response: HTTPResponse) {
-            mocks[requestPath] = response
+            self.mocks[requestPath] = response
         }
     }
 


### PR DESCRIPTION
This was a regression that came with the move to `Operation` subclasses. Prior to that, `HTTPClient` was only used from the main thread.

This meant that if the snapshot tests failed, the test runner would crash because `XCTest` doesn't allow adding attachments from outside the main thread.
Additionally, `MockHTTPClient` wasn't thread safe, so without this, it could have lead to race conditions.