### PR TITLE
`HTTPRequest.Method.post`: replaced all request bodies manual encoding with `Encodable`

### DIFF
--- a/Purchases/Attribution/AttributionNetwork.swift
+++ b/Purchases/Attribution/AttributionNetwork.swift
@@ -55,3 +55,12 @@ import Foundation
     case mParticle
 
 }
+
+extension AttributionNetwork: Encodable {
+
+    // swiftlint:disable:next missing_docs
+    public func encode(to encoder: Encoder) throws {
+        try self.rawValue.encode(to: encoder)
+    }
+
+}

--- a/Purchases/Logging/Strings/NetworkStrings.swift
+++ b/Purchases/Logging/Strings/NetworkStrings.swift
@@ -19,8 +19,7 @@ enum NetworkStrings {
 
     case api_request_completed(httpMethod: String, path: String, httpCode: HTTPStatusCode)
     case api_request_started(httpMethod: String?, path: String?)
-    case creating_json_error(requestBody: [String: Any], error: String)
-    case creating_json_error_invalid(requestBody: [String: Any])
+    case creating_json_error(error: String)
     case json_data_received(dataString: String)
     case parsing_json_error(error: Error)
     case serial_request_done(httpMethod: String?, path: String?, queuedRequestsCount: Int)
@@ -45,11 +44,8 @@ extension NetworkStrings: CustomStringConvertible {
         case let .api_request_started(httpMethod, path):
             return "API request started: \(httpMethod ?? "") \(path ?? "")"
 
-        case let .creating_json_error(requestBody, error):
-            return "Error creating request with JSON body: \(requestBody) ; error: \(error)"
-
-        case .creating_json_error_invalid(let requestBody):
-            return "JSON body is invalid: \(requestBody)"
+        case let .creating_json_error(error):
+            return "Error creating request with body: \(error)"
 
         case .json_data_received(let dataString):
             return "Data received: \(dataString)"

--- a/Purchases/Networking/HTTPRequest.swift
+++ b/Purchases/Networking/HTTPRequest.swift
@@ -23,12 +23,10 @@ struct HTTPRequest {
 
 extension HTTPRequest {
 
-    typealias Body = [String: Any]
-
     enum Method {
 
         case get
-        case post(body: Body)
+        case post(Encodable)
 
     }
 
@@ -36,7 +34,7 @@ extension HTTPRequest {
 
 extension HTTPRequest {
 
-    var requestBody: Body? {
+    var requestBody: Encodable? {
         switch self.method {
         case let .post(body): return body
         case .get: return nil

--- a/Purchases/Networking/Operations/CreateAliasOperation.swift
+++ b/Purchases/Networking/Operations/CreateAliasOperation.swift
@@ -51,7 +51,7 @@ private extension CreateAliasOperation {
         }
         Logger.user(Strings.identity.creating_alias)
 
-        let request = HTTPRequest(method: .post(body: ["new_app_user_id": newAppUserID]),
+        let request = HTTPRequest(method: .post(Body(newAppUserID: newAppUserID)),
                                   path: .createAlias(appUserID: appUserID))
 
         httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
@@ -69,6 +69,16 @@ private extension CreateAliasOperation {
 
             completion()
         }
+    }
+
+}
+
+private extension CreateAliasOperation {
+
+    struct Body: Encodable {
+
+        let newAppUserID: String
+
     }
 
 }

--- a/Purchases/Networking/Operations/GetIntroEligibilityOperation.swift
+++ b/Purchases/Networking/Operations/GetIntroEligibilityOperation.swift
@@ -82,8 +82,8 @@ private extension GetIntroEligibilityOperation {
             return
         }
 
-        let request = HTTPRequest(method: .post(body: ["product_identifiers": self.productIdentifiers,
-                                                       "fetch_token": self.receiptData.asFetchToken]),
+        let request = HTTPRequest(method: .post(Body(productIdentifiers: self.productIdentifiers,
+                                                     fetchToken: self.receiptData.asFetchToken)),
                                   path: .getIntroEligibility(appUserID: appUserID))
 
         httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
@@ -121,6 +121,17 @@ private extension GetIntroEligibilityOperation {
         }()
 
         response.completion(result, nil)
+    }
+
+}
+
+private extension GetIntroEligibilityOperation {
+
+    struct Body: Encodable {
+
+        let productIdentifiers: [String]
+        let fetchToken: String
+
     }
 
 }

--- a/Purchases/Networking/Operations/Handling/SubscriberAttributesMarshaller.swift
+++ b/Purchases/Networking/Operations/Handling/SubscriberAttributesMarshaller.swift
@@ -13,9 +13,10 @@
 
 import Foundation
 
-class SubscriberAttributesMarshaller {
+enum SubscriberAttributesMarshaller {
 
-    func map(subscriberAttributes: SubscriberAttributeDict) -> [String: [String: Any]] {
+    // fixme: make `SubscriberAttributeDict` `Encodable` instead
+    static func map(subscriberAttributes: SubscriberAttributeDict) -> [String: [String: Any]] {
         var attributesByKey: [String: [String: Any]] = [:]
         for (key, value) in subscriberAttributes {
             attributesByKey[key] = value.asBackendDictionary()

--- a/Purchases/Networking/Operations/LogInOperation.swift
+++ b/Purchases/Networking/Operations/LogInOperation.swift
@@ -47,8 +47,8 @@ private extension LogInOperation {
             return
         }
 
-        let request = HTTPRequest(method: .post(body: ["app_user_id": self.configuration.appUserID,
-                                                       "new_app_user_id": newAppUserID]),
+        let request = HTTPRequest(method: .post(Body(appUserID: self.configuration.appUserID,
+                                                     newAppUserID: newAppUserID)),
                                   path: .logIn)
 
         self.httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
@@ -104,4 +104,15 @@ private extension LogInOperation {
 
         completion(result.info, result.cancelled, result.error)
     }
+}
+
+private extension LogInOperation {
+
+    struct Body: Encodable {
+
+        let appUserID: String
+        let newAppUserID: String
+
+    }
+
 }

--- a/Purchases/Networking/Operations/PostAttributionDataOperation.swift
+++ b/Purchases/Networking/Operations/PostAttributionDataOperation.swift
@@ -47,7 +47,7 @@ class PostAttributionDataOperation: NetworkOperation {
             return
         }
 
-        let request = HTTPRequest(method: .post(body: ["network": self.network.rawValue, "data": self.attributionData]),
+        let request = HTTPRequest(method: .post(Body(network: self.network, attributionData: self.attributionData)),
                                   path: .postAttributionData(appUserID: appUserID))
 
         self.httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
@@ -64,6 +64,22 @@ class PostAttributionDataOperation: NetworkOperation {
                                                            error: error,
                                                            completion: responseHandler)
         }
+    }
+
+}
+
+private extension PostAttributionDataOperation {
+
+    struct Body: Encodable {
+
+        let network: AttributionNetwork
+        let data: AnyEncodable
+
+        init(network: AttributionNetwork, attributionData: [String: Any]) {
+            self.network = network
+            self.data = AnyEncodable(attributionData)
+        }
+
     }
 
 }

--- a/Purchases/Networking/Operations/PostOfferForSigningOperation.swift
+++ b/Purchases/Networking/Operations/PostOfferForSigningOperation.swift
@@ -44,14 +44,7 @@ class PostOfferForSigningOperation: NetworkOperation {
 
     private func post(completion: @escaping () -> Void) {
         let request = HTTPRequest(
-            method: .post(body: ["app_user_id": self.configuration.appUserID,
-                                 "fetch_token": self.postOfferData.receiptData.asFetchToken,
-                                 "generate_offers": [
-                                    ["offer_id": self.postOfferData.offerIdentifier,
-                                     "product_id": self.postOfferData.productIdentifier,
-                                     "subscription_group": self.postOfferData.subscriptionGroup
-                                    ]
-                                 ]]),
+            method: .post(Body(appUserID: self.configuration.appUserID, data: self.postOfferData)),
             path: .postOfferForSigning
         )
 
@@ -120,6 +113,39 @@ class PostOfferForSigningOperation: NetworkOperation {
             let signatureError = ErrorUtils.unexpectedBackendResponse(withSubError: subErrorCode)
             return (nil, nil, nil, nil, signatureError)
         }
+    }
+
+}
+
+private extension PostOfferForSigningOperation {
+
+    struct Body: Encodable {
+
+        // swiftlint:disable:next nesting
+        struct Offer: Encodable {
+
+            let offerID: String
+            let productID: String
+            let subscriptionGroup: String
+
+        }
+
+        let appUserID: String
+        let fetchToken: String
+        let generateOffers: [Offer]
+
+        init(appUserID: String, data: PostOfferForSigningData) {
+            self.appUserID = appUserID
+            self.fetchToken = data.receiptData.asFetchToken
+            self.generateOffers = [
+                .init(
+                    offerID: data.offerIdentifier,
+                    productID: data.productIdentifier,
+                    subscriptionGroup: data.subscriptionGroup
+                )
+            ]
+        }
+
     }
 
 }

--- a/Purchases/Networking/Operations/PostSubscriberAttributesOperation.swift
+++ b/Purchases/Networking/Operations/PostSubscriberAttributesOperation.swift
@@ -15,7 +15,6 @@ import Foundation
 
 class PostSubscriberAttributesOperation: NetworkOperation {
 
-    private let subscriberAttributesMarshaller: SubscriberAttributesMarshaller
     private let subscriberAttributeHandler: SubscriberAttributeHandler
     private let configuration: UserSpecificConfiguration
     private let subscriberAttributes: SubscriberAttributeDict
@@ -24,12 +23,10 @@ class PostSubscriberAttributesOperation: NetworkOperation {
     init(configuration: UserSpecificConfiguration,
          subscriberAttributes: SubscriberAttributeDict,
          completion: SimpleResponseHandler?,
-         subscriberAttributesMarshaller: SubscriberAttributesMarshaller = SubscriberAttributesMarshaller(),
          subscriberAttributeHandler: SubscriberAttributeHandler = SubscriberAttributeHandler()) {
         self.configuration = configuration
         self.subscriberAttributes = subscriberAttributes
         self.responseHandler = completion
-        self.subscriberAttributesMarshaller = subscriberAttributesMarshaller
         self.subscriberAttributeHandler = subscriberAttributeHandler
 
         super.init(configuration: configuration)
@@ -55,9 +52,7 @@ class PostSubscriberAttributesOperation: NetworkOperation {
             return
         }
 
-        let attributesInBackendFormat = self.subscriberAttributesMarshaller
-            .map(subscriberAttributes: self.subscriberAttributes)
-        let request = HTTPRequest(method: .post(body: ["attributes": attributesInBackendFormat]),
+        let request = HTTPRequest(method: .post(Body(self.subscriberAttributes)),
                                   path: .postSubscriberAttributes(appUserID: appUserID))
 
         httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
@@ -74,6 +69,22 @@ class PostSubscriberAttributesOperation: NetworkOperation {
                                                                              error: error,
                                                                              completion: responseHandler)
         }
+    }
+
+}
+
+extension PostSubscriberAttributesOperation {
+
+    private struct Body: Encodable {
+
+        let attributes: AnyEncodable
+
+        init(_ attributes: SubscriberAttributeDict) {
+            self.attributes = AnyEncodable(
+                SubscriberAttributesMarshaller.map(subscriberAttributes: attributes)
+            )
+        }
+
     }
 
 }

--- a/Purchases/Networking/SubscribersAPI.swift
+++ b/Purchases/Networking/SubscribersAPI.swift
@@ -83,7 +83,8 @@ class SubscribersAPI {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.httpClient,
                                                                 authHeaders: self.authHeaders,
                                                                 appUserID: appUserID)
-        let postData = PostReceiptDataOperation.PostData(receiptData: receiptData,
+        let postData = PostReceiptDataOperation.PostData(appUserID: appUserID,
+                                                         receiptData: receiptData,
                                                          isRestore: isRestore,
                                                          productData: productData,
                                                          presentedOfferingIdentifier: offeringIdentifier,

--- a/PurchasesTests/Mocks/MockHTTPClient.swift
+++ b/PurchasesTests/Mocks/MockHTTPClient.swift
@@ -42,7 +42,7 @@ class MockHTTPClient: HTTPClient {
                           completionHandler: Completion?) {
         DispatchQueue.main.async { [self] in
             if let body = request.requestBody {
-                assertSnapshot(matching: body, as: .json,
+                assertSnapshot(matching: body, as: .formattedJson,
                                file: self.sourceTest,
                                testName: CurrentTestCaseTracker.sanitizedTestName)
             }

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -62,7 +62,7 @@ class HTTPClientTests: XCTestCase {
             return .emptySuccessResponse
         }
 
-        let request = HTTPRequest(method: .post(body: [:]), path: .mockPath)
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
         self.client.perform(request,
                             authHeaders: ["test_header": "value"],
                             completionHandler: nil)
@@ -78,7 +78,7 @@ class HTTPClientTests: XCTestCase {
             return .emptySuccessResponse
         }
 
-        let request = HTTPRequest(method: .post(body: [:]), path: .mockPath)
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
         self.client.perform(request, authHeaders: ["test_header": "value"], completionHandler: nil)
 
@@ -93,7 +93,7 @@ class HTTPClientTests: XCTestCase {
             return .emptySuccessResponse
         }
 
-        let request = HTTPRequest(method: .post(body: [:]), path: .mockPath)
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
         self.client.perform(request, authHeaders: ["test_header": "value"], completionHandler: nil)
 
@@ -108,7 +108,7 @@ class HTTPClientTests: XCTestCase {
             return .emptySuccessResponse
         }
 
-        let request = HTTPRequest(method: .post(body: [:]), path: .mockPath)
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
         self.client.perform(request, authHeaders: ["test_header": "value"], completionHandler: nil)
 
@@ -123,7 +123,7 @@ class HTTPClientTests: XCTestCase {
             return .emptySuccessResponse
         }
 
-        let request = HTTPRequest(method: .post(body: [:]), path: .mockPath)
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
         self.client.perform(request, authHeaders: ["test_header": "value"], completionHandler: nil)
 
@@ -131,7 +131,7 @@ class HTTPClientTests: XCTestCase {
     }
 
     func testCallsTheGivenPath() {
-        let request = HTTPRequest(method: .post(body: [:]), path: .mockPath)
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
         let pathHit: Atomic<Bool> = .init(false)
 
@@ -155,7 +155,7 @@ class HTTPClientTests: XCTestCase {
             pathHit.value = true
             return .emptySuccessResponse
         }
-        let request = HTTPRequest(method: .post(body: body), path: .mockPath)
+        let request = HTTPRequest(method: .post(body), path: .mockPath)
 
         self.client.perform(request, authHeaders: [:], completionHandler: nil)
 
@@ -304,7 +304,7 @@ class HTTPClientTests: XCTestCase {
     }
 
     func testAlwaysPassesClientVersion() {
-        let request = HTTPRequest(method: .post(body: [:]), path: .mockPath)
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
         let headerPresent: Atomic<Bool> = .init(false)
 
@@ -321,7 +321,7 @@ class HTTPClientTests: XCTestCase {
     }
 
     func testAlwaysPassesClientBuildVersion() throws {
-        let request = HTTPRequest(method: .post(body: [:]), path: .mockPath)
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
         let headerPresent: Atomic<Bool> = .init(false)
 
@@ -368,7 +368,7 @@ class HTTPClientTests: XCTestCase {
 
     #if !os(macOS) && !targetEnvironment(macCatalyst)
     func testAlwaysPassesAppleDeviceIdentifier() {
-        let request = HTTPRequest(method: .post(body: [:]), path: .mockPath)
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
         let headerPresent: Atomic<Bool> = .init(false)
 
@@ -386,7 +386,7 @@ class HTTPClientTests: XCTestCase {
     #endif
 
     func testDefaultsPlatformFlavorToNative() {
-        let request = HTTPRequest(method: .post(body: [:]), path: .mockPath)
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
         let headerPresent: Atomic<Bool> = .init(false)
 
@@ -401,7 +401,7 @@ class HTTPClientTests: XCTestCase {
     }
 
     func testPassesPlatformFlavorHeader() throws {
-        let request = HTTPRequest(method: .post(body: [:]), path: .mockPath)
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
         let headerPresent: Atomic<Bool> = .init(false)
 
@@ -420,7 +420,7 @@ class HTTPClientTests: XCTestCase {
     }
 
     func testPassesPlatformFlavorVersionHeader() throws {
-        let request = HTTPRequest(method: .post(body: [:]), path: .mockPath)
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
         let headerPresent: Atomic<Bool> = .init(false)
 
@@ -439,7 +439,7 @@ class HTTPClientTests: XCTestCase {
     }
 
     func testPassesObserverModeHeaderCorrectlyWhenEnabled() throws {
-        let request = HTTPRequest(method: .post(body: [:]), path: .mockPath)
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
         let headerPresent: Atomic<Bool> = .init(false)
 
@@ -456,7 +456,7 @@ class HTTPClientTests: XCTestCase {
     }
 
     func testPassesObserverModeHeaderCorrectlyWhenDisabled() throws {
-        let request = HTTPRequest(method: .post(body: [:]), path: .mockPath)
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
         let headerPresent: Atomic<Bool> = .init(false)
 
@@ -676,7 +676,7 @@ class HTTPClientTests: XCTestCase {
             return response
         }
 
-        self.client.perform(.init(method: .post(body: [:]), path: path), authHeaders: [:], completionHandler: nil)
+        self.client.perform(.init(method: .post([:]), path: path), authHeaders: [:], completionHandler: nil)
 
         expect(MockDNSChecker.invokedIsBlockedAPIError.value).toEventually(equal(true))
         expect(MockDNSChecker.invokedErrorWithBlockedHostFromError.value).toEventually(equal(false))
@@ -698,7 +698,7 @@ class HTTPClientTests: XCTestCase {
             return response
         }
 
-        self.client.perform(.init(method: .post(body: [:]), path: path), authHeaders: [:], completionHandler: nil)
+        self.client.perform(.init(method: .post([:]), path: path), authHeaders: [:], completionHandler: nil)
 
         expect(MockDNSChecker.invokedIsBlockedAPIError.value).toEventually(equal(true))
         expect(MockDNSChecker.invokedErrorWithBlockedHostFromError.value).toEventually(equal(true))
@@ -803,19 +803,26 @@ private extension HTTPRequest.Path {
 
 }
 
-private extension HTTPRequest.Method {
+extension HTTPRequest.Method {
 
-    static func requestNumber(_ number: Int) -> Self {
-        return .post(body: [HTTPClientTests.requestNumberKeyName: number])
+    fileprivate static func requestNumber(_ number: Int) -> Self {
+        return .post([HTTPClientTests.requestNumberKeyName: number])
     }
 
-    static func invalidBody() -> Self {
+    fileprivate static func invalidBody() -> Self {
         // infinity can't be cast into JSON, so we use it to force a parsing exception. See:
         // https://developer.apple.com/documentation/foundation/nsjsonserialization?language=objc
         let nonJSONBody = ["something": Double.infinity]
 
-        return .post(body: nonJSONBody)
+        return .post(nonJSONBody)
     }
+
+    /// Creates a `HTTPRequest.Method.post` request with `[String: Any]`.
+    /// - Note: this is for testing only, real requests must use `Encodable`.
+    internal static func post(_ body: [String: Any]) -> Self {
+        return .post(AnyEncodable(body))
+    }
+
 }
 
 private extension HTTPClientTests {

--- a/PurchasesTests/TestHelpers/SnapshotTesting+Extensions.swift
+++ b/PurchasesTests/TestHelpers/SnapshotTesting+Extensions.swift
@@ -16,33 +16,13 @@ import SnapshotTesting
 
 @testable import RevenueCat
 
-// Remove once https://github.com/pointfreeco/swift-snapshot-testing/pull/552 is available in a release.
-extension Snapshotting where Value == Any, Format == String {
-
-    static var json: Snapshotting {
-        let options: JSONSerialization.WritingOptions = [
-            .prettyPrinted,
-            .sortedKeys
-        ]
-
-        var snapshotting = SimplySnapshotting.lines.pullback { (data: Value) in
-            // swiftlint:disable:next force_try
-            try! String(decoding: JSONSerialization.data(withJSONObject: data,
-                                                         options: options), as: UTF8.self)
-        }
-        snapshotting.pathExtension = "json"
-        return snapshotting
-    }
-
-}
-
 extension Snapshotting where Value == Encodable, Format == String {
 
     /// Equivalent to .json, but with `JSONEncoder.KeyEncodingStrategy.convertToSnakeCase`
     static var formattedJson: Snapshotting {
         var snapshotting = SimplySnapshotting.lines.pullback { (data: Value) in
             // swiftlint:disable:next force_try
-            return String(decoding: try! data.asFormattedData(), as: UTF8.self)
+            return try! data.asFormattedString()
         }
         snapshotting.pathExtension = "json"
         return snapshotting
@@ -51,6 +31,10 @@ extension Snapshotting where Value == Encodable, Format == String {
 }
 
 private extension Encodable {
+
+    func asFormattedString() throws -> String {
+        return String(decoding: try self.asFormattedData(), as: UTF8.self)
+    }
 
     func asFormattedData() throws -> Data {
         let encoder = JSONEncoder()

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1489,12 +1489,12 @@
 			isa = PBXGroup;
 			children = (
 				B34605AE279A6E380031CA74 /* Handling */,
+				B34605AB279A6E380031CA74 /* NetworkOperation.swift */,
 				B34605AC279A6E380031CA74 /* CreateAliasOperation.swift */,
 				B34605B5279A6E380031CA74 /* GetCustomerInfoOperation.swift */,
 				B34605B4279A6E380031CA74 /* GetIntroEligibilityOperation.swift */,
 				B34605BA279A6E380031CA74 /* GetOfferingsOperation.swift */,
 				B34605B7279A6E380031CA74 /* LogInOperation.swift */,
-				B34605AB279A6E380031CA74 /* NetworkOperation.swift */,
 				B34605B8279A6E380031CA74 /* PostAttributionDataOperation.swift */,
 				B34605AD279A6E380031CA74 /* PostOfferForSigningOperation.swift */,
 				B34605B6279A6E380031CA74 /* PostReceiptDataOperation.swift */,


### PR DESCRIPTION
Finishes [CF-195] and #695.

All the prior PRs have been building up to being able to do this, and with 100% confidence thanks to snapshot tests.

[CF-195]: https://revenuecats.atlassian.net/browse/CF-195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ