### PR TITLE
Adds new method for checking intro eligibility for a single `StoreProduct`

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -147,6 +147,7 @@ BOOL isAnonymous;
     [p restorePurchasesWithCompletion:^(RCCustomerInfo *i, NSError *e) {}];
     [p syncPurchasesWithCompletion:^(RCCustomerInfo *i, NSError *e) {}];
     
+    [p checkTrialOrIntroDiscountEligibilityForProduct:storeProduct completion:^(RCIntroEligibilityStatus status) { }];
     [p checkTrialOrIntroDiscountEligibility:@[@""] completion:^(NSDictionary<NSString *,RCIntroEligibility *> *d) { }];
     [p getPromotionalOfferForProductDiscount:stpd
                                  withProduct:storeProduct

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -111,7 +111,7 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.purchase(package: pack) { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
     purchases.syncPurchases { (_: CustomerInfo?, _: Error?) in }
 
-    purchases.checkTrialOrIntroDiscountEligibility(storeProduct) { (_: IntroEligibilityStatus) in }
+    purchases.checkTrialOrIntroDiscountEligibility(product: storeProduct) { (_: IntroEligibilityStatus) in }
     purchases.checkTrialOrIntroDiscountEligibility([String]()) { (_: [String: IntroEligibility]) in }
     purchases.getPromotionalOffer(
         forProductDiscount: discount,
@@ -176,7 +176,7 @@ private func checkAsyncMethods(purchases: Purchases) async {
 
     do {
         let _: (CustomerInfo, Bool) = try await purchases.logIn("")
-        let _: IntroEligibilityStatus = await purchases.checkTrialOrIntroDiscountEligibility(stp)
+        let _: IntroEligibilityStatus = await purchases.checkTrialOrIntroDiscountEligibility(product: stp)
         let _: [String: IntroEligibility] = await purchases.checkTrialOrIntroDiscountEligibility([])
         let _: PromotionalOffer = try await purchases.getPromotionalOffer(
             forProductDiscount: discount,

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -111,6 +111,7 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.purchase(package: pack) { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) in }
     purchases.syncPurchases { (_: CustomerInfo?, _: Error?) in }
 
+    purchases.checkTrialOrIntroDiscountEligibility(storeProduct) { (_: IntroEligibilityStatus) in }
     purchases.checkTrialOrIntroDiscountEligibility([String]()) { (_: [String: IntroEligibility]) in }
     purchases.getPromotionalOffer(
         forProductDiscount: discount,

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -176,6 +176,7 @@ private func checkAsyncMethods(purchases: Purchases) async {
 
     do {
         let _: (CustomerInfo, Bool) = try await purchases.logIn("")
+        let _: IntroEligibilityStatus = await purchases.checkTrialOrIntroDiscountEligibility(stp)
         let _: [String: IntroEligibility] = await purchases.checkTrialOrIntroDiscountEligibility([])
         let _: PromotionalOffer = try await purchases.getPromotionalOffer(
             forProductDiscount: discount,

--- a/Documentation.docc/Purchases.md
+++ b/Documentation.docc/Purchases.md
@@ -44,6 +44,8 @@ Most features require configuring the SDK before using it.
 ### Making Purchases with Subscription Offers
 - ``Purchases/checkTrialOrIntroDiscountEligibility(_:)``
 - ``Purchases/checkTrialOrIntroDiscountEligibility(_:completion:)``
+- ``Purchases/checkTrialOrIntroDiscountEligibility(product:)``
+- ``Purchases/checkTrialOrIntroDiscountEligibility(product:completion:)``
 - ``Purchases/getPromotionalOffer(forProductDiscount:product:)``
 - ``Purchases/getPromotionalOffer(forProductDiscount:product:completion:)``
 - ``Purchases/purchase(package:promotionalOffer:)``

--- a/Documentation.docc/RevenueCat.md
+++ b/Documentation.docc/RevenueCat.md
@@ -86,6 +86,8 @@ Or browse our iOS sample apps:
 
 - ``Purchases/checkTrialOrIntroDiscountEligibility(_:)``
 - ``Purchases/checkTrialOrIntroDiscountEligibility(_:completion:)``
+- ``Purchases/checkTrialOrIntroDiscountEligibility(product:)``
+- ``Purchases/checkTrialOrIntroDiscountEligibility(product:completion:)``
 - ``Purchases/getPromotionalOffer(forProductDiscount:product:)``
 - ``Purchases/getPromotionalOffer(forProductDiscount:product:completion:)``
 - ``Purchases/purchase(package:promotionalOffer:)``

--- a/Purchases/Misc/Purchases+async.swift
+++ b/Purchases/Misc/Purchases+async.swift
@@ -190,6 +190,16 @@ extension Purchases {
             }
         }
     }
+    
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func checkTrialOrIntroductoryDiscountEligibilityAsync(_ product: StoreProduct) async
+    -> IntroEligibilityStatus {
+        return await withCheckedContinuation { continuation in
+            checkTrialOrIntroDiscountEligibility(product) { status in
+                continuation.resume(returning: status)
+            }
+        }
+    }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func checkTrialOrIntroductoryDiscountEligibilityAsync(_ productIdentifiers: [String]) async

--- a/Purchases/Misc/Purchases+async.swift
+++ b/Purchases/Misc/Purchases+async.swift
@@ -195,7 +195,7 @@ extension Purchases {
     func checkTrialOrIntroductoryDiscountEligibilityAsync(_ product: StoreProduct) async
     -> IntroEligibilityStatus {
         return await withCheckedContinuation { continuation in
-            checkTrialOrIntroDiscountEligibility(product) { status in
+            checkTrialOrIntroDiscountEligibility(product: product) { status in
                 continuation.resume(returning: status)
             }
         }

--- a/Purchases/Misc/Purchases+async.swift
+++ b/Purchases/Misc/Purchases+async.swift
@@ -190,7 +190,7 @@ extension Purchases {
             }
         }
     }
-    
+
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func checkTrialOrIntroductoryDiscountEligibilityAsync(_ product: StoreProduct) async
     -> IntroEligibilityStatus {

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -1299,7 +1299,7 @@ public extension Purchases {
     func checkTrialOrIntroDiscountEligibility(_ productIdentifiers: [String]) async -> [String: IntroEligibility] {
         return await checkTrialOrIntroductoryDiscountEligibilityAsync(productIdentifiers)
     }
-    
+
     /**
      * Computes whether or not a user is eligible for the introductory pricing period of a given product.
      * You should use this method to determine whether or not you show the user the normal product price or
@@ -1324,7 +1324,7 @@ public extension Purchases {
                                               completion: @escaping (IntroEligibilityStatus) -> Void) {
         trialOrIntroPriceEligibilityChecker.checkEligibility(product: product, completion: completion)
     }
-    
+
     /**
      * Computes whether or not a user is eligible for the introductory pricing period of a given product.
      * You should use this method to determine whether or not you show the user the normal product price or

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -1272,7 +1272,7 @@ public extension Purchases {
      * - Parameter completion: A block that receives a dictionary of `product_id` -> ``IntroEligibility``.
      *
      * ### Related symbols
-     * - ``checkTrialOrIntroDiscountEligibility(_:)``
+     * - ``checkTrialOrIntroDiscountEligibility(product:)``
      */
     @objc(checkTrialOrIntroDiscountEligibility:completion:)
     func checkTrialOrIntroDiscountEligibility(_ productIdentifiers: [String],
@@ -1299,7 +1299,7 @@ public extension Purchases {
      * - Parameter productIdentifiers: Array of product identifiers for which you want to compute eligibility
      *
      * ### Related symbols
-     * - ``checkTrialOrIntroDiscountEligibility(_:)``
+     * - ``checkTrialOrIntroDiscountEligibility(product:)``
      */
     @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
     func checkTrialOrIntroDiscountEligibility(_ productIdentifiers: [String]) async -> [String: IntroEligibility] {
@@ -1326,7 +1326,7 @@ public extension Purchases {
      * - Parameter completion: A block that receives an ``IntroEligibilityStatus``.
      */
     @objc(checkTrialOrIntroDiscountEligibilityForProduct:completion:)
-    func checkTrialOrIntroDiscountEligibility(_ product: StoreProduct,
+    func checkTrialOrIntroDiscountEligibility(product: StoreProduct,
                                               completion: @escaping (IntroEligibilityStatus) -> Void) {
         trialOrIntroPriceEligibilityChecker.checkEligibility(product: product, completion: completion)
     }
@@ -1351,7 +1351,7 @@ public extension Purchases {
      * - Parameter completion: A block that receives an ``IntroEligibilityStatus``.
      */
     @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
-    func checkTrialOrIntroDiscountEligibility(_ product: StoreProduct) async -> IntroEligibilityStatus {
+    func checkTrialOrIntroDiscountEligibility(product: StoreProduct) async -> IntroEligibilityStatus {
         return await checkTrialOrIntroductoryDiscountEligibilityAsync(product)
     }
 

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -1324,6 +1324,9 @@ public extension Purchases {
      *
      * - Parameter product: The ``StoreProduct``  for which you want to compute eligibility.
      * - Parameter completion: A block that receives an ``IntroEligibilityStatus``.
+     *
+     * ### Related symbols
+     * - ``checkTrialOrIntroDiscountEligibility(_:completion:)``
      */
     @objc(checkTrialOrIntroDiscountEligibilityForProduct:completion:)
     func checkTrialOrIntroDiscountEligibility(product: StoreProduct,
@@ -1349,6 +1352,9 @@ public extension Purchases {
      *
      * - Parameter product: The ``StoreProduct``  for which you want to compute eligibility.
      * - Parameter completion: A block that receives an ``IntroEligibilityStatus``.
+     *
+     * ### Related symbols
+     * - ``checkTrialOrIntroDiscountEligibility(_:)``
      */
     @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
     func checkTrialOrIntroDiscountEligibility(product: StoreProduct) async -> IntroEligibilityStatus {

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -1258,6 +1258,9 @@ public extension Purchases {
      * the introductory price. This also applies to trials (trials are considered a type of introductory pricing).
      * [iOS Introductory  Offers](https://docs.revenuecat.com/docs/ios-subscription-offers).
      *
+     * - Note: If you're looking to just check the eligibility status of a single ``StoreProduct``,
+     * use ``Purchases/checkTrialOrIntroDiscountEligibility(_:)``.
+     *
      * - Note: If you're looking to use Promotional Offers instead,
      * use ``Purchases/getPromotionalOffer(forProductDiscount:product:completion:)``.
      *
@@ -1283,6 +1286,9 @@ public extension Purchases {
      * You should use this method to determine whether or not you show the user the normal product price or
      * the introductory price. This also applies to trials (trials are considered a type of introductory pricing).
      * [iOS Introductory  Offers](https://docs.revenuecat.com/docs/ios-subscription-offers).
+     *
+     * - Note: If you're looking to just check the eligibility status of a single ``StoreProduct``,
+     * use ``Purchases/checkTrialOrIntroDiscountEligibility(_:)``.
      *
      * - Note: If you're looking to use Promotional Offers instead,
      * use ``Purchases/getPromotionalOffer(forProductDiscount:product:completion:)``.

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -1299,6 +1299,55 @@ public extension Purchases {
     func checkTrialOrIntroDiscountEligibility(_ productIdentifiers: [String]) async -> [String: IntroEligibility] {
         return await checkTrialOrIntroductoryDiscountEligibilityAsync(productIdentifiers)
     }
+    
+    /**
+     * Computes whether or not a user is eligible for the introductory pricing period of a given product.
+     * You should use this method to determine whether or not you show the user the normal product price or
+     * the introductory price. This also applies to trials (trials are considered a type of introductory pricing).
+     * [iOS Introductory  Offers](https://docs.revenuecat.com/docs/ios-subscription-offers).
+     *
+     * - Note: If you're looking to use Promotional Offers instead,
+     * use ``Purchases/getPromotionalOffer(forProductDiscount:product:completion:)``.
+     *
+     * - Note: Subscription groups are automatically collected for determining eligibility. If RevenueCat can't
+     * definitively compute the eligibility, most likely because of missing group information, it will return
+     * ``IntroEligibilityStatus/unknown``. The best course of action on unknown status is to display the non-intro
+     * pricing, to not create a misleading situation. To avoid this, make sure you are testing with the latest
+     * version of iOS so that the subscription group can be collected by the SDK.
+     *
+     *
+     * - Parameter product: The ``StoreProduct``  for which you want to compute eligibility.
+     * - Parameter completion: A block that receives an ``IntroEligibilityStatus``.
+     */
+    @objc(checkTrialOrIntroDiscountEligibilityForProduct:completion:)
+    func checkTrialOrIntroDiscountEligibility(_ product: StoreProduct,
+                                              completion: @escaping (IntroEligibilityStatus) -> Void) {
+        trialOrIntroPriceEligibilityChecker.checkEligibility(product: product, completion: completion)
+    }
+    
+    /**
+     * Computes whether or not a user is eligible for the introductory pricing period of a given product.
+     * You should use this method to determine whether or not you show the user the normal product price or
+     * the introductory price. This also applies to trials (trials are considered a type of introductory pricing).
+     * [iOS Introductory  Offers](https://docs.revenuecat.com/docs/ios-subscription-offers).
+     *
+     * - Note: If you're looking to use Promotional Offers instead,
+     * use ``Purchases/getPromotionalOffer(forProductDiscount:product:completion:)``.
+     *
+     * - Note: Subscription groups are automatically collected for determining eligibility. If RevenueCat can't
+     * definitively compute the eligibility, most likely because of missing group information, it will return
+     * ``IntroEligibilityStatus/unknown``. The best course of action on unknown status is to display the non-intro
+     * pricing, to not create a misleading situation. To avoid this, make sure you are testing with the latest
+     * version of iOS so that the subscription group can be collected by the SDK.
+     *
+     *
+     * - Parameter product: The ``StoreProduct``  for which you want to compute eligibility.
+     * - Parameter completion: A block that receives an ``IntroEligibilityStatus``.
+     */
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
+    func checkTrialOrIntroDiscountEligibility(_ product: StoreProduct) async -> IntroEligibilityStatus {
+        return await checkTrialOrIntroductoryDiscountEligibilityAsync(product)
+    }
 
     /**
      * Invalidates the cache for customer information.

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -1258,9 +1258,6 @@ public extension Purchases {
      * the introductory price. This also applies to trials (trials are considered a type of introductory pricing).
      * [iOS Introductory  Offers](https://docs.revenuecat.com/docs/ios-subscription-offers).
      *
-     * - Note: If you're looking to just check the eligibility status of a single ``StoreProduct``,
-     * use ``Purchases/checkTrialOrIntroDiscountEligibility(_:)``.
-     *
      * - Note: If you're looking to use Promotional Offers instead,
      * use ``Purchases/getPromotionalOffer(forProductDiscount:product:completion:)``.
      *
@@ -1273,6 +1270,9 @@ public extension Purchases {
      *
      * - Parameter productIdentifiers: Array of product identifiers for which you want to compute eligibility
      * - Parameter completion: A block that receives a dictionary of `product_id` -> ``IntroEligibility``.
+     *
+     * ### Related symbols
+     * - ``checkTrialOrIntroDiscountEligibility(_:)``
      */
     @objc(checkTrialOrIntroDiscountEligibility:completion:)
     func checkTrialOrIntroDiscountEligibility(_ productIdentifiers: [String],
@@ -1287,9 +1287,6 @@ public extension Purchases {
      * the introductory price. This also applies to trials (trials are considered a type of introductory pricing).
      * [iOS Introductory  Offers](https://docs.revenuecat.com/docs/ios-subscription-offers).
      *
-     * - Note: If you're looking to just check the eligibility status of a single ``StoreProduct``,
-     * use ``Purchases/checkTrialOrIntroDiscountEligibility(_:)``.
-     *
      * - Note: If you're looking to use Promotional Offers instead,
      * use ``Purchases/getPromotionalOffer(forProductDiscount:product:completion:)``.
      *
@@ -1300,6 +1297,9 @@ public extension Purchases {
      * version of iOS so that the subscription group can be collected by the SDK.
      *
      * - Parameter productIdentifiers: Array of product identifiers for which you want to compute eligibility
+     *
+     * ### Related symbols
+     * - ``checkTrialOrIntroDiscountEligibility(_:)``
      */
     @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
     func checkTrialOrIntroDiscountEligibility(_ productIdentifiers: [String]) async -> [String: IntroEligibility] {

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -1272,7 +1272,7 @@ public extension Purchases {
      * - Parameter completion: A block that receives a dictionary of `product_id` -> ``IntroEligibility``.
      *
      * ### Related symbols
-     * - ``checkTrialOrIntroDiscountEligibility(product:)``
+     * - ``checkTrialOrIntroDiscountEligibility(product:completion:)``
      */
     @objc(checkTrialOrIntroDiscountEligibility:completion:)
     func checkTrialOrIntroDiscountEligibility(_ productIdentifiers: [String],

--- a/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -17,7 +17,6 @@ import StoreKit
 class TrialOrIntroPriceEligibilityChecker {
 
     typealias ReceiveIntroEligibilityBlock = ([String: IntroEligibility]) -> Void
-    typealias ReceiveIntroEligibilityStatusBlock = (IntroEligibilityStatus) -> Void
 
     private var appUserID: String { identityManager.currentAppUserID }
     private let receiptFetcher: ReceiptFetcher
@@ -68,7 +67,7 @@ class TrialOrIntroPriceEligibilityChecker {
     }
 
     func checkEligibility(product: StoreProduct,
-                          completion: @escaping ReceiveIntroEligibilityStatusBlock) {
+                          completion: @escaping (IntroEligibilityStatus) -> Void) {
         checkEligibility(productIdentifiers: [product.productIdentifier]) { eligibility in
             completion(eligibility[product.productIdentifier]?.status ?? .unknown)
         }

--- a/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -17,6 +17,7 @@ import StoreKit
 class TrialOrIntroPriceEligibilityChecker {
 
     typealias ReceiveIntroEligibilityBlock = ([String: IntroEligibility]) -> Void
+    typealias ReceiveIntroEligibilityStatusBlock = (IntroEligibilityStatus) -> Void
 
     private var appUserID: String { identityManager.currentAppUserID }
     private let receiptFetcher: ReceiptFetcher
@@ -63,6 +64,13 @@ class TrialOrIntroPriceEligibilityChecker {
             }
         } else {
             sk1CheckEligibility(productIdentifiers, completion: completion)
+        }
+    }
+    
+    func checkEligibility(product: StoreProduct,
+                          completion: @escaping ReceiveIntroEligibilityStatusBlock) {
+        checkEligibility(productIdentifiers: [product.productIdentifier]) { eligibility in
+            completion(eligibility[product.productIdentifier]?.status ?? .unknown)
         }
     }
 

--- a/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Purchases/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -66,7 +66,7 @@ class TrialOrIntroPriceEligibilityChecker {
             sk1CheckEligibility(productIdentifiers, completion: completion)
         }
     }
-    
+
     func checkEligibility(product: StoreProduct,
                           completion: @escaping ReceiveIntroEligibilityStatusBlock) {
         checkEligibility(productIdentifiers: [product.productIdentifier]) { eligibility in

--- a/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
+++ b/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
@@ -19,6 +19,8 @@ import XCTest
 // swiftlint:disable:next type_name
 class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
+    typealias ContinuationStatusResult = CheckedContinuation<IntroEligibilityStatus, Error>
+
     var receiptFetcher: MockReceiptFetcher!
     var trialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityChecker!
     var mockIntroEligibilityCalculator: MockIntroEligibilityCalculator!
@@ -146,7 +148,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
         var completionCalled = false
 
-        let eligibilityStatus = try await withCheckedThrowingContinuation({ (continuation: CheckedContinuation<IntroEligibilityStatus, Error>) in
+        let status = try await withCheckedThrowingContinuation({ (continuation: ContinuationStatusResult) in
             self.trialOrIntroPriceEligibilityChecker!.checkEligibility(product: storeProduct) { status in
                 completionCalled = true
                 continuation.resume(returning: status)
@@ -154,7 +156,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
         })
 
         expect(completionCalled) == true
-        expect(eligibilityStatus) == .eligible
+        expect(status) == .eligible
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -171,7 +173,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
         var completionCalled = false
 
-        let eligibilityStatus = try await withCheckedThrowingContinuation({ (continuation: CheckedContinuation<IntroEligibilityStatus, Error>) in
+        let status = try await withCheckedThrowingContinuation({ (continuation: ContinuationStatusResult) in
             self.trialOrIntroPriceEligibilityChecker!.checkEligibility(product: storeProduct) { status in
                 completionCalled = true
                 continuation.resume(returning: status)
@@ -179,7 +181,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
         })
 
         expect(completionCalled) == true
-        expect(eligibilityStatus) == .noIntroOfferExists
+        expect(status) == .noIntroOfferExists
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -196,7 +198,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
         var completionCalled = false
 
-        let prePurchaseEligibility = try await withCheckedThrowingContinuation({ (continuation: CheckedContinuation<IntroEligibilityStatus, Error>) in
+        let prePurchaseStatus = try await withCheckedThrowingContinuation({ (continuation: ContinuationStatusResult) in
             self.trialOrIntroPriceEligibilityChecker!.checkEligibility(product: storeProduct) { status in
                 completionCalled = true
                 continuation.resume(returning: status)
@@ -204,14 +206,14 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
         })
 
         expect(completionCalled) == true
-        expect(prePurchaseEligibility) == .eligible
+        expect(prePurchaseStatus) == .eligible
 
         let purchasableSK2Product = try XCTUnwrap(storeProduct.sk2Product)
         _ = try await purchasableSK2Product.purchase()
 
         completionCalled = false
 
-        let postPurchaseEligibility = try await withCheckedThrowingContinuation({ (continuation: CheckedContinuation<IntroEligibilityStatus, Error>) in
+        let postPurchaseStatus = try await withCheckedThrowingContinuation({ (continuation: ContinuationStatusResult) in
             self.trialOrIntroPriceEligibilityChecker!.checkEligibility(product: storeProduct) { status in
                 completionCalled = true
                 continuation.resume(returning: status)
@@ -219,7 +221,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
         })
 
         expect(completionCalled) == true
-        expect(postPurchaseEligibility) == .ineligible
+        expect(postPurchaseStatus) == .ineligible
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -239,7 +241,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
         // We can't fetch an invalid StoreProduct to pass into the
         // eligibility checker so this just fakes an unknown response,
         // regardless of the real status from the checker
-        let fakeEligibilityStatus = try await withCheckedThrowingContinuation({ (continuation: CheckedContinuation<IntroEligibilityStatus, Error>) in
+        let fakeStatus = try await withCheckedThrowingContinuation({ (continuation: ContinuationStatusResult) in
             self.trialOrIntroPriceEligibilityChecker!.checkEligibility(product: storeProduct) { _ in
                 completionCalled = true
                 continuation.resume(returning: .unknown)
@@ -247,6 +249,6 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
         })
 
         expect(completionCalled) == true
-        expect(fakeEligibilityStatus) == .unknown
+        expect(fakeStatus) == .unknown
     }
 }

--- a/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
+++ b/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
@@ -135,19 +135,18 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testCheckEligibilityForProductIsEligible() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-        
+
         let productIdentifiers = Set([
             "com.revenuecat.monthly_4.99.1_week_intro"
         ])
-        
+
         let sk2Product = try await ProductsFetcherSK2().products(identifiers: productIdentifiers).first
         let receivedProduct = try XCTUnwrap(sk2Product)
         let storeProduct = StoreProduct.from(product: receivedProduct)
-        
+
         var completionCalled = false
-        
-        let eligibilityStatus = try await withCheckedThrowingContinuation({
-            (continuation: CheckedContinuation<IntroEligibilityStatus, Error>) in
+
+        let eligibilityStatus = try await withCheckedThrowingContinuation({ (continuation: CheckedContinuation<IntroEligibilityStatus, Error>) in
             self.trialOrIntroPriceEligibilityChecker!.checkEligibility(product: storeProduct) { status in
                 completionCalled = true
                 continuation.resume(returning: status)
@@ -161,25 +160,24 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testCheckEligibilityForLifetimeProductIsNoIntroOfferExists() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-        
+
         let productIdentifiers = Set([
             "lifetime"
         ])
-        
+
         let sk2Product = try await ProductsFetcherSK2().products(identifiers: productIdentifiers).first
         let receivedProduct = try XCTUnwrap(sk2Product)
         let storeProduct = StoreProduct.from(product: receivedProduct)
-        
+
         var completionCalled = false
-        
-        let eligibilityStatus = try await withCheckedThrowingContinuation({
-            (continuation: CheckedContinuation<IntroEligibilityStatus, Error>) in
+
+        let eligibilityStatus = try await withCheckedThrowingContinuation({ (continuation: CheckedContinuation<IntroEligibilityStatus, Error>) in
             self.trialOrIntroPriceEligibilityChecker!.checkEligibility(product: storeProduct) { status in
                 completionCalled = true
                 continuation.resume(returning: status)
             }
         })
-        
+
         expect(completionCalled) == true
         expect(eligibilityStatus) == .noIntroOfferExists
     }
@@ -187,41 +185,39 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testCheckEligibilityForProductIsIneligibleAfterPurchasing() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-        
+
         let productIdentifiers = Set([
             "com.revenuecat.monthly_4.99.1_week_intro"
         ])
-        
+
         let sk2Product = try await ProductsFetcherSK2().products(identifiers: productIdentifiers).first
         let receivedProduct = try XCTUnwrap(sk2Product)
         let storeProduct = StoreProduct.from(product: receivedProduct)
-        
+
         var completionCalled = false
-        
-        let prePurchaseEligibility = try await withCheckedThrowingContinuation({
-            (continuation: CheckedContinuation<IntroEligibilityStatus, Error>) in
+
+        let prePurchaseEligibility = try await withCheckedThrowingContinuation({ (continuation: CheckedContinuation<IntroEligibilityStatus, Error>) in
             self.trialOrIntroPriceEligibilityChecker!.checkEligibility(product: storeProduct) { status in
                 completionCalled = true
                 continuation.resume(returning: status)
             }
         })
-        
+
         expect(completionCalled) == true
         expect(prePurchaseEligibility) == .eligible
 
         let purchasableSK2Product = try XCTUnwrap(storeProduct.sk2Product)
         _ = try await purchasableSK2Product.purchase()
-        
+
         completionCalled = false
-        
-        let postPurchaseEligibility = try await withCheckedThrowingContinuation({
-            (continuation: CheckedContinuation<IntroEligibilityStatus, Error>) in
+
+        let postPurchaseEligibility = try await withCheckedThrowingContinuation({ (continuation: CheckedContinuation<IntroEligibilityStatus, Error>) in
             self.trialOrIntroPriceEligibilityChecker!.checkEligibility(product: storeProduct) { status in
                 completionCalled = true
                 continuation.resume(returning: status)
             }
         })
-        
+
         expect(completionCalled) == true
         expect(postPurchaseEligibility) == .ineligible
     }
@@ -229,28 +225,27 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testCheckEligibilityForProductIsUnknown() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-        
+
         let productIdentifiers = Set([
             "com.revenuecat.monthly_4.99.1_week_intro"
         ])
-        
+
         let sk2Product = try await ProductsFetcherSK2().products(identifiers: productIdentifiers).first
         let receivedProduct = try XCTUnwrap(sk2Product)
         let storeProduct = StoreProduct.from(product: receivedProduct)
-        
+
         var completionCalled = false
-        
+
         // We can't fetch an invalid StoreProduct to pass into the
         // eligibility checker so this just fakes an unknown response,
         // regardless of the real status from the checker
-        let fakeEligibilityStatus = try await withCheckedThrowingContinuation({
-            (continuation: CheckedContinuation<IntroEligibilityStatus, Error>) in
-            self.trialOrIntroPriceEligibilityChecker!.checkEligibility(product: storeProduct) { status in
+        let fakeEligibilityStatus = try await withCheckedThrowingContinuation({ (continuation: CheckedContinuation<IntroEligibilityStatus, Error>) in
+            self.trialOrIntroPriceEligibilityChecker!.checkEligibility(product: storeProduct) { _ in
                 completionCalled = true
                 continuation.resume(returning: .unknown)
             }
         })
-        
+
         expect(completionCalled) == true
         expect(fakeEligibilityStatus) == .unknown
     }

--- a/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
+++ b/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
@@ -19,8 +19,6 @@ import XCTest
 // swiftlint:disable:next type_name
 class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
-    typealias ContinuationStatusResult = CheckedContinuation<IntroEligibilityStatus, Error>
-
     var receiptFetcher: MockReceiptFetcher!
     var trialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityChecker!
     var mockIntroEligibilityCalculator: MockIntroEligibilityCalculator!
@@ -87,7 +85,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
         var completionCalled = false
         var eligibilities: [String: IntroEligibility]?
-        trialOrIntroPriceEligibilityChecker!.checkEligibility(productIdentifiers: products) { receivedEligibilities in
+        trialOrIntroPriceEligibilityChecker.checkEligibility(productIdentifiers: products) { receivedEligibilities in
             completionCalled = true
             eligibilities = receivedEligibilities
         }
@@ -119,7 +117,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
         var completionCalled = false
         var eligibilities: [String: IntroEligibility]?
-        trialOrIntroPriceEligibilityChecker!.checkEligibility(productIdentifiers: products) { receivedEligibilities in
+        trialOrIntroPriceEligibilityChecker.checkEligibility(productIdentifiers: products) { receivedEligibilities in
             completionCalled = true
             eligibilities = receivedEligibilities
         }
@@ -135,7 +133,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-    func testCheckEligibilityForProductIsEligible() async throws {
+    func testCheckEligibilityForProductIsEligibleForEligibleSubscription() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         let productIdentifiers = Set([
@@ -148,8 +146,8 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
         var completionCalled = false
 
-        let status = try await withCheckedThrowingContinuation({ (continuation: ContinuationStatusResult) in
-            self.trialOrIntroPriceEligibilityChecker!.checkEligibility(product: storeProduct) { status in
+        let status: IntroEligibilityStatus = try await withCheckedThrowingContinuation({ continuation in
+            self.trialOrIntroPriceEligibilityChecker.checkEligibility(product: storeProduct) { status in
                 completionCalled = true
                 continuation.resume(returning: status)
             }
@@ -173,8 +171,8 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
         var completionCalled = false
 
-        let status = try await withCheckedThrowingContinuation({ (continuation: ContinuationStatusResult) in
-            self.trialOrIntroPriceEligibilityChecker!.checkEligibility(product: storeProduct) { status in
+        let status: IntroEligibilityStatus = try await withCheckedThrowingContinuation({ continuation in
+            self.trialOrIntroPriceEligibilityChecker.checkEligibility(product: storeProduct) { status in
                 completionCalled = true
                 continuation.resume(returning: status)
             }
@@ -198,8 +196,8 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
         var completionCalled = false
 
-        let prePurchaseStatus = try await withCheckedThrowingContinuation({ (continuation: ContinuationStatusResult) in
-            self.trialOrIntroPriceEligibilityChecker!.checkEligibility(product: storeProduct) { status in
+        let prePurchaseStatus: IntroEligibilityStatus = try await withCheckedThrowingContinuation({ continuation in
+            self.trialOrIntroPriceEligibilityChecker.checkEligibility(product: storeProduct) { status in
                 completionCalled = true
                 continuation.resume(returning: status)
             }
@@ -213,8 +211,8 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
         completionCalled = false
 
-        let postPurchaseStatus = try await withCheckedThrowingContinuation({ (continuation: ContinuationStatusResult) in
-            self.trialOrIntroPriceEligibilityChecker!.checkEligibility(product: storeProduct) { status in
+        let postPurchaseStatus: IntroEligibilityStatus = try await withCheckedThrowingContinuation({ continuation in
+            self.trialOrIntroPriceEligibilityChecker.checkEligibility(product: storeProduct) { status in
                 completionCalled = true
                 continuation.resume(returning: status)
             }
@@ -225,7 +223,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-    func testCheckEligibilityForProductIsUnknown() async throws {
+    func testCheckEligibilityForInvalidProductIsUnknown() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         let productIdentifiers = Set([
@@ -241,8 +239,8 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
         // We can't fetch an invalid StoreProduct to pass into the
         // eligibility checker so this just fakes an unknown response,
         // regardless of the real status from the checker
-        let fakeStatus = try await withCheckedThrowingContinuation({ (continuation: ContinuationStatusResult) in
-            self.trialOrIntroPriceEligibilityChecker!.checkEligibility(product: storeProduct) { _ in
+        let fakeStatus: IntroEligibilityStatus = try await withCheckedThrowingContinuation({ continuation in
+            self.trialOrIntroPriceEligibilityChecker.checkEligibility(product: storeProduct) { _ in
                 completionCalled = true
                 continuation.resume(returning: .unknown)
             }

--- a/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
+++ b/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
@@ -131,4 +131,127 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
             expect(receivedEligibility.status) == expected[product]
         }
     }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func testCheckEligibilityForProductIsEligible() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        
+        let productIdentifiers = Set([
+            "com.revenuecat.monthly_4.99.1_week_intro"
+        ])
+        
+        let sk2Product = try await ProductsFetcherSK2().products(identifiers: productIdentifiers).first
+        let receivedProduct = try XCTUnwrap(sk2Product)
+        let storeProduct = StoreProduct.from(product: receivedProduct)
+        
+        var completionCalled = false
+        
+        let eligibilityStatus = try await withCheckedThrowingContinuation({
+            (continuation: CheckedContinuation<IntroEligibilityStatus, Error>) in
+            self.trialOrIntroPriceEligibilityChecker!.checkEligibility(product: storeProduct) { status in
+                completionCalled = true
+                continuation.resume(returning: status)
+            }
+        })
+
+        expect(completionCalled) == true
+        expect(eligibilityStatus) == .eligible
+    }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func testCheckEligibilityForLifetimeProductIsNoIntroOfferExists() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        
+        let productIdentifiers = Set([
+            "lifetime"
+        ])
+        
+        let sk2Product = try await ProductsFetcherSK2().products(identifiers: productIdentifiers).first
+        let receivedProduct = try XCTUnwrap(sk2Product)
+        let storeProduct = StoreProduct.from(product: receivedProduct)
+        
+        var completionCalled = false
+        
+        let eligibilityStatus = try await withCheckedThrowingContinuation({
+            (continuation: CheckedContinuation<IntroEligibilityStatus, Error>) in
+            self.trialOrIntroPriceEligibilityChecker!.checkEligibility(product: storeProduct) { status in
+                completionCalled = true
+                continuation.resume(returning: status)
+            }
+        })
+        
+        expect(completionCalled) == true
+        expect(eligibilityStatus) == .noIntroOfferExists
+    }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func testCheckEligibilityForProductIsIneligibleAfterPurchasing() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        
+        let productIdentifiers = Set([
+            "com.revenuecat.monthly_4.99.1_week_intro"
+        ])
+        
+        let sk2Product = try await ProductsFetcherSK2().products(identifiers: productIdentifiers).first
+        let receivedProduct = try XCTUnwrap(sk2Product)
+        let storeProduct = StoreProduct.from(product: receivedProduct)
+        
+        var completionCalled = false
+        
+        let prePurchaseEligibility = try await withCheckedThrowingContinuation({
+            (continuation: CheckedContinuation<IntroEligibilityStatus, Error>) in
+            self.trialOrIntroPriceEligibilityChecker!.checkEligibility(product: storeProduct) { status in
+                completionCalled = true
+                continuation.resume(returning: status)
+            }
+        })
+        
+        expect(completionCalled) == true
+        expect(prePurchaseEligibility) == .eligible
+
+        let purchasableSK2Product = try XCTUnwrap(storeProduct.sk2Product)
+        _ = try await purchasableSK2Product.purchase()
+        
+        completionCalled = false
+        
+        let postPurchaseEligibility = try await withCheckedThrowingContinuation({
+            (continuation: CheckedContinuation<IntroEligibilityStatus, Error>) in
+            self.trialOrIntroPriceEligibilityChecker!.checkEligibility(product: storeProduct) { status in
+                completionCalled = true
+                continuation.resume(returning: status)
+            }
+        })
+        
+        expect(completionCalled) == true
+        expect(postPurchaseEligibility) == .ineligible
+    }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func testCheckEligibilityForProductIsUnknown() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+        
+        let productIdentifiers = Set([
+            "com.revenuecat.monthly_4.99.1_week_intro"
+        ])
+        
+        let sk2Product = try await ProductsFetcherSK2().products(identifiers: productIdentifiers).first
+        let receivedProduct = try XCTUnwrap(sk2Product)
+        let storeProduct = StoreProduct.from(product: receivedProduct)
+        
+        var completionCalled = false
+        
+        // We can't fetch an invalid StoreProduct to pass into the
+        // eligibility checker so this just fakes an unknown response,
+        // regardless of the real status from the checker
+        let fakeEligibilityStatus = try await withCheckedThrowingContinuation({
+            (continuation: CheckedContinuation<IntroEligibilityStatus, Error>) in
+            self.trialOrIntroPriceEligibilityChecker!.checkEligibility(product: storeProduct) { status in
+                completionCalled = true
+                continuation.resume(returning: .unknown)
+            }
+        })
+        
+        expect(completionCalled) == true
+        expect(fakeEligibilityStatus) == .unknown
+    }
 }


### PR DESCRIPTION
For [CF-160](https://revenuecats.atlassian.net/browse/CF-160)

### Motivation
Checking intro eligibility for a single product is a little awkward, since you need to provide an array of `productIdentifiers` and we return a dict with product identifiers and statuses.

### Description
Adds a new method (+async) for checking the eligibility of a single `StoreProduct` that returns a single `IntroEligibilityStatus`, using our abstractions to avoid product ID strings and dictionaries.
