### PR TITLE
`ProductRequestData`: changed tests from manual dictionary comparisons to snapshot testing

### DIFF
--- a/PurchasesTests/Purchasing/ProductRequestDataExtensions.swift
+++ b/PurchasesTests/Purchasing/ProductRequestDataExtensions.swift
@@ -7,6 +7,7 @@ import Foundation
 @testable import RevenueCat
 
 extension ProductRequestData {
+
     static func createMockProductData(productIdentifier: String = "product_id",
                                       paymentMode: StoreProductDiscount.PaymentMode? = nil,
                                       currencyCode: String = "UYU",
@@ -28,4 +29,5 @@ extension ProductRequestData {
                            subscriptionGroup: subscriptionGroup,
                            discounts: discounts.map { $0.map(StoreProductDiscount.from) })
     }
+
 }

--- a/PurchasesTests/Purchasing/ProductRequestDataTests.swift
+++ b/PurchasesTests/Purchasing/ProductRequestDataTests.swift
@@ -5,88 +5,93 @@ import XCTest
 @testable import RevenueCat
 
 class ProductRequestDataTests: XCTestCase {
+
     func testAsDictionaryConvertsProductIdentifierCorrectly() throws {
         let productIdentifier = "cool_product"
         let productData: ProductRequestData = .createMockProductData(productIdentifier: productIdentifier)
-        expect(try productData.asDictionary()["product_id"] as? String) == productIdentifier
+
+        assertSnapshot(matching: productData, as: .formattedJson)
     }
 
     func testAsDictionaryConvertsPaymentModeCorrectly() throws {
         var paymentMode: StoreProductDiscount.PaymentMode?
         var productData: ProductRequestData = .createMockProductData(paymentMode: paymentMode)
-        expect(try productData.asDictionary()["payment_mode"]).to(beNil())
+
+        assertSnapshot(matching: productData, as: .formattedJson)
 
         paymentMode = .payAsYouGo
         productData = .createMockProductData(paymentMode: paymentMode)
 
-        var receivedPaymentMode = (try productData.asDictionary()["payment_mode"] as? NSNumber)?.intValue
-        expect(receivedPaymentMode) == paymentMode?.rawValue
+        assertSnapshot(matching: productData, as: .formattedJson)
 
         paymentMode = .freeTrial
         productData = .createMockProductData(paymentMode: paymentMode)
 
-        receivedPaymentMode = (try productData.asDictionary()["payment_mode"] as? NSNumber)?.intValue
-        expect(receivedPaymentMode) == paymentMode?.rawValue
+        assertSnapshot(matching: productData, as: .formattedJson)
 
         paymentMode = .payUpFront
         productData = .createMockProductData(paymentMode: paymentMode)
 
-        receivedPaymentMode = (try productData.asDictionary()["payment_mode"] as? NSNumber)?.intValue
-        expect(receivedPaymentMode) == paymentMode?.rawValue
+        assertSnapshot(matching: productData, as: .formattedJson)
     }
 
     func testAsDictionaryConvertsCurrencyCodeCorrectly() throws {
         let currencyCode = "USD"
         let productData: ProductRequestData = .createMockProductData(currencyCode: currencyCode)
-        expect(try productData.asDictionary()["currency"] as? String) == currencyCode
+
+        assertSnapshot(matching: productData, as: .formattedJson)
     }
 
     func testAsDictionaryConvertsPriceCorrectly() throws {
         let price: NSDecimalNumber = 9.99
         let productData: ProductRequestData = .createMockProductData(price: price as Decimal)
-        expect(try productData.asDictionary()["price"] as? String) == price.description
+
+        assertSnapshot(matching: productData, as: .formattedJson)
     }
 
     func testAsDictionaryConvertsNormalDurationCorrectly() throws {
         let normalDuration = "P3Y"
         let productData: ProductRequestData = .createMockProductData(normalDuration: normalDuration)
-        expect(try productData.asDictionary()["normal_duration"] as? String) == normalDuration
+
+        assertSnapshot(matching: productData, as: .formattedJson)
     }
 
     func testAsDictionaryConvertsIntroDurationCorrectlyForFreeTrial() throws {
         let trialDuration = "P3M"
         let productData: ProductRequestData = .createMockProductData(introDuration: trialDuration,
                                                                      introDurationType: .freeTrial)
-        expect(try productData.asDictionary()["trial_duration"] as? String) == trialDuration
-        expect(try productData.asDictionary()["intro_duration"]).to(beNil())
+
+        assertSnapshot(matching: productData, as: .formattedJson)
     }
 
     func testAsDictionaryConvertsIntroDurationCorrectlyForIntroPrice() throws {
         let introDuration = "P3M"
         let productData: ProductRequestData = .createMockProductData(introDuration: introDuration,
                                                                      introDurationType: .payUpFront)
-        expect(try productData.asDictionary()["intro_duration"] as? String) == introDuration
-        expect(try productData.asDictionary()["trial_duration"]).to(beNil())
+
+        assertSnapshot(matching: productData, as: .formattedJson)
     }
 
     func testAsDictionaryDoesntAddIntroDurationIfDurationTypeUnknown() throws {
         let introDuration = "P3M"
         let productData: ProductRequestData = .createMockProductData(introDuration: introDuration,
                                                                      introDurationType: nil)
-        expect(try productData.asDictionary()["trial_duration"]).to(beNil())
-        expect(try productData.asDictionary()["intro_duration"]).to(beNil())
+
+        assertSnapshot(matching: productData, as: .formattedJson)
     }
 
     func testAsDictionaryConvertsIntroPriceCorrectly() throws {
         let introPrice: NSDecimalNumber = 6.99
         let productData: ProductRequestData = .createMockProductData(introPrice: introPrice as Decimal)
-        expect(try productData.asDictionary()["introductory_price"] as? String) == introPrice.description
+
+        assertSnapshot(matching: productData, as: .formattedJson)
     }
 
     func testAsDictionaryConvertsSubscriptionGroupCorrectly() {
         let subscriptionGroup = "cool_group"
         let productData: ProductRequestData = .createMockProductData(subscriptionGroup: subscriptionGroup)
-        expect(try productData.asDictionary()["subscription_group_id"] as? String) == subscriptionGroup
+
+        assertSnapshot(matching: productData, as: .formattedJson)
     }
 
     func testAsDictionaryConvertsDiscountsCorrectly() throws {
@@ -116,20 +121,7 @@ class ProductRequestDataTests: XCTestCase {
 
         let productData: ProductRequestData = .createMockProductData(discounts: [discount1, discount2, discount3])
 
-        let dictionary = try productData.asDictionary()
-        let receivedOffers = try XCTUnwrap(dictionary["offers"] as? [[String: NSObject]])
-
-        expect(receivedOffers[0]["offer_identifier"] as? String) == discount1.offerIdentifier
-        expect(receivedOffers[0]["price"] as? String) == discount1.price.description
-        expect((receivedOffers[0]["payment_mode"] as? NSNumber)?.intValue) == discount1.paymentMode.rawValue
-
-        expect(receivedOffers[1]["offer_identifier"] as? String) == discount2.offerIdentifier
-        expect(receivedOffers[1]["price"] as? String) == discount2.price.description
-        expect((receivedOffers[1]["payment_mode"] as? NSNumber)?.intValue) == discount2.paymentMode.rawValue
-
-        expect(receivedOffers[2]["offer_identifier"] as? String) == discount3.offerIdentifier
-        expect(receivedOffers[2]["price"] as? String) == discount3.price.description
-        expect((receivedOffers[2]["payment_mode"] as? NSNumber)?.intValue) == discount3.paymentMode.rawValue
+        assertSnapshot(matching: productData, as: .formattedJson)
     }
 
     func testEncoding() throws {
@@ -168,7 +160,7 @@ class ProductRequestDataTests: XCTestCase {
                                                                      subscriptionGroup: "cool_group",
                                                                      discounts: [discount1, discount2, discount3])
 
-        try assertSnapshot(matching: productData.asDictionary(), as: .json)
+        assertSnapshot(matching: productData, as: .formattedJson)
     }
 
     func testCacheKey() {
@@ -210,22 +202,5 @@ class ProductRequestDataTests: XCTestCase {
                                                                      discounts: [discount1, discount2, discount3])
         expect(productData.cacheKey) == "cool_product-49.99-UYU-1-0-cool_group-P3Y-P3W-2-offerid1-offerid2-offerid3"
     }
-}
 
-// Remove once https://github.com/pointfreeco/swift-snapshot-testing/pull/552 is available in a release.
-extension Snapshotting where Value == Any, Format == String {
-    static var json: Snapshotting {
-        let options: JSONSerialization.WritingOptions = [
-            .prettyPrinted,
-            .sortedKeys
-        ]
-
-        var snapshotting = SimplySnapshotting.lines.pullback { (data: Value) in
-            // swiftlint:disable:next force_try
-            try! String(decoding: JSONSerialization.data(withJSONObject: data,
-                                                         options: options), as: UTF8.self)
-        }
-        snapshotting.pathExtension = "json"
-        return snapshotting
-    }
 }

--- a/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsCurrencyCodeCorrectly.1.json
+++ b/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsCurrencyCodeCorrectly.1.json
@@ -1,0 +1,5 @@
+{
+  "currency" : "USD",
+  "price" : "15.99",
+  "product_id" : "product_id"
+}

--- a/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsDiscountsCorrectly.1.json
+++ b/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsDiscountsCorrectly.1.json
@@ -1,0 +1,22 @@
+{
+  "currency" : "UYU",
+  "offers" : [
+    {
+      "offer_identifier" : "offerid1",
+      "payment_mode" : 0,
+      "price" : "11.1"
+    },
+    {
+      "offer_identifier" : "offerid2",
+      "payment_mode" : 1,
+      "price" : "12.2"
+    },
+    {
+      "offer_identifier" : "offerid3",
+      "payment_mode" : 2,
+      "price" : "13.3"
+    }
+  ],
+  "price" : "15.99",
+  "product_id" : "product_id"
+}

--- a/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsIntroDurationCorrectlyForFreeTrial.1.json
+++ b/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsIntroDurationCorrectlyForFreeTrial.1.json
@@ -1,0 +1,6 @@
+{
+  "currency" : "UYU",
+  "price" : "15.99",
+  "product_id" : "product_id",
+  "trial_duration" : "P3M"
+}

--- a/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsIntroDurationCorrectlyForIntroPrice.1.json
+++ b/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsIntroDurationCorrectlyForIntroPrice.1.json
@@ -1,0 +1,6 @@
+{
+  "currency" : "UYU",
+  "intro_duration" : "P3M",
+  "price" : "15.99",
+  "product_id" : "product_id"
+}

--- a/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsIntroPriceCorrectly.1.json
+++ b/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsIntroPriceCorrectly.1.json
@@ -1,0 +1,6 @@
+{
+  "currency" : "UYU",
+  "introductory_price" : "6.99",
+  "price" : "15.99",
+  "product_id" : "product_id"
+}

--- a/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsNormalDurationCorrectly.1.json
+++ b/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsNormalDurationCorrectly.1.json
@@ -1,0 +1,6 @@
+{
+  "currency" : "UYU",
+  "normal_duration" : "P3Y",
+  "price" : "15.99",
+  "product_id" : "product_id"
+}

--- a/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsPaymentModeCorrectly.1.json
+++ b/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsPaymentModeCorrectly.1.json
@@ -1,0 +1,5 @@
+{
+  "currency" : "UYU",
+  "price" : "15.99",
+  "product_id" : "product_id"
+}

--- a/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsPaymentModeCorrectly.2.json
+++ b/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsPaymentModeCorrectly.2.json
@@ -1,0 +1,6 @@
+{
+  "currency" : "UYU",
+  "payment_mode" : 0,
+  "price" : "15.99",
+  "product_id" : "product_id"
+}

--- a/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsPaymentModeCorrectly.3.json
+++ b/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsPaymentModeCorrectly.3.json
@@ -1,0 +1,6 @@
+{
+  "currency" : "UYU",
+  "payment_mode" : 2,
+  "price" : "15.99",
+  "product_id" : "product_id"
+}

--- a/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsPaymentModeCorrectly.4.json
+++ b/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsPaymentModeCorrectly.4.json
@@ -1,0 +1,6 @@
+{
+  "currency" : "UYU",
+  "payment_mode" : 1,
+  "price" : "15.99",
+  "product_id" : "product_id"
+}

--- a/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsPriceCorrectly.1.json
+++ b/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsPriceCorrectly.1.json
@@ -1,0 +1,5 @@
+{
+  "currency" : "UYU",
+  "price" : "9.99",
+  "product_id" : "product_id"
+}

--- a/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsProductIdentifierCorrectly.1.json
+++ b/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsProductIdentifierCorrectly.1.json
@@ -1,0 +1,5 @@
+{
+  "currency" : "UYU",
+  "price" : "15.99",
+  "product_id" : "cool_product"
+}

--- a/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsSubscriptionGroupCorrectly.1.json
+++ b/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryConvertsSubscriptionGroupCorrectly.1.json
@@ -1,0 +1,6 @@
+{
+  "currency" : "UYU",
+  "price" : "15.99",
+  "product_id" : "product_id",
+  "subscription_group_id" : "cool_group"
+}

--- a/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryDoesntAddIntroDurationIfDurationTypeUnknown.1.json
+++ b/PurchasesTests/Purchasing/__Snapshots__/ProductRequestDataTests/testAsDictionaryDoesntAddIntroDurationIfDurationTypeUnknown.1.json
@@ -1,0 +1,5 @@
+{
+  "currency" : "UYU",
+  "price" : "15.99",
+  "product_id" : "product_id"
+}

--- a/PurchasesTests/TestHelpers/SnapshotTesting+Extensions.swift
+++ b/PurchasesTests/TestHelpers/SnapshotTesting+Extensions.swift
@@ -1,0 +1,66 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SnapshotTesting+Extensions.swift
+//
+//  Created by Nacho Soto on 3/4/22.
+
+import Foundation
+import SnapshotTesting
+
+@testable import RevenueCat
+
+// Remove once https://github.com/pointfreeco/swift-snapshot-testing/pull/552 is available in a release.
+extension Snapshotting where Value == Any, Format == String {
+
+    static var json: Snapshotting {
+        let options: JSONSerialization.WritingOptions = [
+            .prettyPrinted,
+            .sortedKeys
+        ]
+
+        var snapshotting = SimplySnapshotting.lines.pullback { (data: Value) in
+            // swiftlint:disable:next force_try
+            try! String(decoding: JSONSerialization.data(withJSONObject: data,
+                                                         options: options), as: UTF8.self)
+        }
+        snapshotting.pathExtension = "json"
+        return snapshotting
+    }
+
+}
+
+extension Snapshotting where Value == Encodable, Format == String {
+
+    /// Equivalent to .json, but with `JSONEncoder.KeyEncodingStrategy.convertToSnakeCase`
+    static var formattedJson: Snapshotting {
+        var snapshotting = SimplySnapshotting.lines.pullback { (data: Value) in
+            // swiftlint:disable:next force_try
+            return String(decoding: try! data.asFormattedData(), as: UTF8.self)
+        }
+        snapshotting.pathExtension = "json"
+        return snapshotting
+    }
+
+}
+
+private extension Encodable {
+
+    func asFormattedData() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        encoder.outputFormatting = [
+            .prettyPrinted,
+            .sortedKeys
+        ]
+
+        return try encoder.encode(self)
+    }
+
+}

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 		576C8A8B27CFCB150058FA6E /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A8A27CFCB150058FA6E /* AnyEncodable.swift */; };
 		576C8A8F27CFCD110058FA6E /* AnyEncodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A8E27CFCD110058FA6E /* AnyEncodableTests.swift */; };
 		576C8AD927D2BCB90058FA6E /* HTTPRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8AD827D2BCB90058FA6E /* HTTPRequestTests.swift */; };
+		576C8A9227D27DDD0058FA6E /* SnapshotTesting+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A9127D27DDD0058FA6E /* SnapshotTesting+Extensions.swift */; };
 		578FB10E27ADDA8000F70709 /* AvailabilityChecks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE0263275942D500915B4C /* AvailabilityChecks.swift */; };
 		5791A1AA2767E42B00C972AA /* SKProduct+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791A1A92767E42A00C972AA /* SKProduct+Extensions.swift */; };
 		5791A1C82767FC9400C972AA /* ManageSubscriptionsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791A1C72767FC9400C972AA /* ManageSubscriptionsHelperTests.swift */; };
@@ -623,6 +624,7 @@
 		576C8A8E27CFCD110058FA6E /* AnyEncodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodableTests.swift; sourceTree = "<group>"; };
 		576C8AD827D2BCB90058FA6E /* HTTPRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestTests.swift; sourceTree = "<group>"; };
 		576C8A9027D180540058FA6E /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
+		576C8A9127D27DDD0058FA6E /* SnapshotTesting+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SnapshotTesting+Extensions.swift"; sourceTree = "<group>"; };
 		5791A1A92767E42A00C972AA /* SKProduct+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SKProduct+Extensions.swift"; sourceTree = "<group>"; };
 		5791A1C72767FC9400C972AA /* ManageSubscriptionsHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionsHelperTests.swift; sourceTree = "<group>"; };
 		5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = base64encoded_sandboxReceipt.txt; sourceTree = "<group>"; };
@@ -1371,6 +1373,7 @@
 				37E35C4A4B241A545D1D06BD /* ASN1ObjectIdentifierEncoder.swift */,
 				37E35092F0E41512E0D610BA /* ContainerFactory.swift */,
 				575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */,
+				576C8A9127D27DDD0058FA6E /* SnapshotTesting+Extensions.swift */,
 			);
 			path = TestHelpers;
 			sourceTree = "<group>";
@@ -2129,6 +2132,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				576C8A9227D27DDD0058FA6E /* SnapshotTesting+Extensions.swift in Sources */,
 				57C381E2279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */,
 				2DDF41E824F6F61B005BC22D /* MockSKProductDiscount.swift in Sources */,
 				35272E2226D0048D00F22C3B /* HTTPClientTests.swift in Sources */,


### PR DESCRIPTION
Future refactor is removing manual JSON encoding, and this is easier to maintain without needing to hardcode key names.