### PR TITLE
`BackendSubscriberAttributesTests`: replaced manual request body checking with snapshot testing

### DIFF
--- a/PurchasesTests/Networking/HTTPRequestTests.swift
+++ b/PurchasesTests/Networking/HTTPRequestTests.swift
@@ -48,3 +48,20 @@ class HTTPRequestTests: XCTestCase {
     }
 
 }
+
+extension HTTPRequest {
+
+    enum MethodType {
+        case get
+        case post
+    }
+
+    /// For testing purposes only
+    var methodType: MethodType {
+        switch self.method {
+        case .get: return .get
+        case .post: return .post
+        }
+    }
+
+}

--- a/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostReceiptWithSubscriberAttributesPassesErrorsToCallbackIfStatusCodeIsError.1.json
+++ b/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostReceiptWithSubscriberAttributesPassesErrorsToCallbackIfStatusCodeIsError.1.json
@@ -1,0 +1,16 @@
+{
+  "app_user_id" : "abc123",
+  "attributes" : {
+    "a key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "a value"
+    },
+    "another key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "another value"
+    }
+  },
+  "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+  "is_restore" : false,
+  "observer_mode" : false
+}

--- a/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostReceiptWithSubscriberAttributesPassesErrorsToCallbackIfStatusCodeIsSuccess.1.json
+++ b/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostReceiptWithSubscriberAttributesPassesErrorsToCallbackIfStatusCodeIsSuccess.1.json
@@ -1,0 +1,16 @@
+{
+  "app_user_id" : "abc123",
+  "attributes" : {
+    "a key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "a value"
+    },
+    "another key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "another value"
+    }
+  },
+  "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+  "is_restore" : false,
+  "observer_mode" : false
+}

--- a/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -1,0 +1,16 @@
+{
+  "app_user_id" : "abc123",
+  "attributes" : {
+    "a key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "a value"
+    },
+    "another key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "another value"
+    }
+  },
+  "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+  "is_restore" : false,
+  "observer_mode" : false
+}

--- a/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -1,0 +1,16 @@
+{
+  "app_user_id" : "abc123",
+  "attributes" : {
+    "a key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "a value"
+    },
+    "another key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "another value"
+    }
+  },
+  "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+  "is_restore" : false,
+  "observer_mode" : false
+}

--- a/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -1,0 +1,6 @@
+{
+  "app_user_id" : "abc123",
+  "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+  "is_restore" : false,
+  "observer_mode" : false
+}

--- a/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -1,0 +1,12 @@
+{
+  "attributes" : {
+    "a key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "a value"
+    },
+    "another key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "another value"
+    }
+  }
+}

--- a/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -1,0 +1,12 @@
+{
+  "attributes" : {
+    "a key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "a value"
+    },
+    "another key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "another value"
+    }
+  }
+}

--- a/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostSubscriberAttributesCallsCompletionWithErrorInBackendErrorCase.1.json
+++ b/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostSubscriberAttributesCallsCompletionWithErrorInBackendErrorCase.1.json
@@ -1,0 +1,12 @@
+{
+  "attributes" : {
+    "a key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "a value"
+    },
+    "another key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "another value"
+    }
+  }
+}

--- a/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -1,0 +1,12 @@
+{
+  "attributes" : {
+    "a key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "a value"
+    },
+    "another key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "another value"
+    }
+  }
+}

--- a/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostSubscriberAttributesCallsCompletionWithErrorInNotFoundCase.1.json
+++ b/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostSubscriberAttributesCallsCompletionWithErrorInNotFoundCase.1.json
@@ -1,0 +1,12 @@
+{
+  "attributes" : {
+    "a key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "a value"
+    },
+    "another key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "another value"
+    }
+  }
+}

--- a/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -1,0 +1,12 @@
+{
+  "attributes" : {
+    "a key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "a value"
+    },
+    "another key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "another value"
+    }
+  }
+}

--- a/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/PurchasesTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/testPostSubscriberAttributesSendsRightParameters.1.json
@@ -1,0 +1,12 @@
+{
+  "attributes" : {
+    "a key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "a value"
+    },
+    "another key" : {
+      "updated_at_ms" : 1678307200000,
+      "value" : "another value"
+    }
+  }
+}

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -223,6 +223,9 @@
 		576C8A8F27CFCD110058FA6E /* AnyEncodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A8E27CFCD110058FA6E /* AnyEncodableTests.swift */; };
 		576C8AD927D2BCB90058FA6E /* HTTPRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8AD827D2BCB90058FA6E /* HTTPRequestTests.swift */; };
 		576C8A9227D27DDD0058FA6E /* SnapshotTesting+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A9127D27DDD0058FA6E /* SnapshotTesting+Extensions.swift */; };
+		576C8AB927D2996C0058FA6E /* CurrentTestCaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */; };
+		576C8ABC27D2997C0058FA6E /* SnapshotTesting+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A9127D27DDD0058FA6E /* SnapshotTesting+Extensions.swift */; };
+		576C8ABE27D299860058FA6E /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 576C8ABD27D299860058FA6E /* SnapshotTesting */; };
 		578FB10E27ADDA8000F70709 /* AvailabilityChecks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE0263275942D500915B4C /* AvailabilityChecks.swift */; };
 		5791A1AA2767E42B00C972AA /* SKProduct+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791A1A92767E42A00C972AA /* SKProduct+Extensions.swift */; };
 		5791A1C82767FC9400C972AA /* ManageSubscriptionsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791A1C72767FC9400C972AA /* ManageSubscriptionsHelperTests.swift */; };
@@ -625,6 +628,7 @@
 		576C8AD827D2BCB90058FA6E /* HTTPRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestTests.swift; sourceTree = "<group>"; };
 		576C8A9027D180540058FA6E /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		576C8A9127D27DDD0058FA6E /* SnapshotTesting+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SnapshotTesting+Extensions.swift"; sourceTree = "<group>"; };
+		576C8ABF27D29A020058FA6E /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		5791A1A92767E42A00C972AA /* SKProduct+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SKProduct+Extensions.swift"; sourceTree = "<group>"; };
 		5791A1C72767FC9400C972AA /* ManageSubscriptionsHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionsHelperTests.swift; sourceTree = "<group>"; };
 		5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = base64encoded_sandboxReceipt.txt; sourceTree = "<group>"; };
@@ -761,6 +765,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				576C8ABE27D299860058FA6E /* SnapshotTesting in Frameworks */,
 				2D803F6926F149E70069D717 /* RevenueCat.framework in Frameworks */,
 				2D9C5ED726F281750057FC45 /* OHHTTPStubsSwift in Frameworks */,
 				2D9C5ED526F281750057FC45 /* OHHTTPStubs in Frameworks */,
@@ -1513,6 +1518,7 @@
 		B36824BB268FBB9B00957E4C /* SubscriberAttributes */ = {
 			isa = PBXGroup;
 			children = (
+				576C8ABF27D29A020058FA6E /* __Snapshots__ */,
 				37E357F69438004E1F443C03 /* BackendSubscriberAttributesTests.swift */,
 				37E3567E972B9B04FE079ABA /* SubscriberAttributesManagerTests.swift */,
 				37E3508E52201122137D4B4A /* PurchasesSubscriberAttributesTests.swift */,
@@ -1627,6 +1633,7 @@
 				2D803F6726F144C40069D717 /* Nimble */,
 				2D9C5ED426F281750057FC45 /* OHHTTPStubs */,
 				2D9C5ED626F281750057FC45 /* OHHTTPStubsSwift */,
+				576C8ABD27D299860058FA6E /* SnapshotTesting */,
 			);
 			productName = StoreKitUnitTests;
 			productReference = 2DAC5F7226F13C9800C5258F /* StoreKitUnitTests.xctest */;
@@ -1935,6 +1942,7 @@
 				571E7AD4279F2D0C003B3606 /* StoreKitTestHelpers.swift in Sources */,
 				2DFF6C56270CA28800ECAFAB /* MockRequestFetcher.swift in Sources */,
 				5738F489278CC2500096D623 /* MockTransaction.swift in Sources */,
+				576C8ABC27D2997C0058FA6E /* SnapshotTesting+Extensions.swift in Sources */,
 				2D90F8C826FD2225009B9142 /* MockAppleReceiptBuilder.swift in Sources */,
 				F55FFA672763FAC300995146 /* TransactionsManagerSK2Tests.swift in Sources */,
 				57C381B72791E593009E3940 /* StoreKit2TransactionListenerTests.swift in Sources */,
@@ -1945,6 +1953,7 @@
 				2D90F8BF26FD20D6009B9142 /* MockAttributionFetcher.swift in Sources */,
 				2D90F8C526FD216A009B9142 /* MockSKProductDiscount.swift in Sources */,
 				57C381E3279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */,
+				576C8AB927D2996C0058FA6E /* CurrentTestCaseTracker.swift in Sources */,
 				B3BE0264275942D500915B4C /* AvailabilityChecks.swift in Sources */,
 				2D90F8B326FD2082009B9142 /* MockProductsManager.swift in Sources */,
 				2D90F8CA26FD257A009B9142 /* MockStoreKit2TransactionListener.swift in Sources */,
@@ -2939,6 +2948,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */;
 			productName = OHHTTPStubsSwift;
+		};
+		576C8ABD27D299860058FA6E /* SnapshotTesting */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 57E04739277260DE0082FE91 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
+			productName = SnapshotTesting;
 		};
 		57E0473A277260DE0082FE91 /* SnapshotTesting */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
For [CF-195](https://revenuecats.atlassian.net/browse/CF-195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ) and https://github.com/RevenueCat/purchases-ios/issues/695.

~~Depends on #1357.~~

A future PR is replacing `PostSubscriberAttributesOperation` manual encoding with `Encodable`, so this supports this.

### Changes
- Added `assertSnapshot` to `MockHTTPClient` like `BackendTests.MockHTTPClient`.
- No longer using `Date()` to make sure times don't change every time the test runs.
- Added `SnapshotTesting` to `StoreKitUnitTests` since `MockHTTPClient` is also used there.

### Notes
- I've made a mental note to combine both `MockHTTPClient`, since they've basically converged into the same implementation.