### PR TITLE
Added explicit parameter name to `checkTrialOrIntroDiscountEligibility` for consistency

### DIFF
--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -112,7 +112,8 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.syncPurchases { (_: CustomerInfo?, _: Error?) in }
 
     purchases.checkTrialOrIntroDiscountEligibility(product: storeProduct) { (_: IntroEligibilityStatus) in }
-    purchases.checkTrialOrIntroDiscountEligibility([String]()) { (_: [String: IntroEligibility]) in }
+    purchases.checkTrialOrIntroDiscountEligibility(productIdentifiers: [String]()) { (_: [String: IntroEligibility]) in
+    }
     purchases.getPromotionalOffer(
         forProductDiscount: discount,
         product: storeProduct
@@ -177,7 +178,9 @@ private func checkAsyncMethods(purchases: Purchases) async {
     do {
         let _: (CustomerInfo, Bool) = try await purchases.logIn("")
         let _: IntroEligibilityStatus = await purchases.checkTrialOrIntroDiscountEligibility(product: stp)
-        let _: [String: IntroEligibility] = await purchases.checkTrialOrIntroDiscountEligibility([])
+        let _: [String: IntroEligibility] = await purchases.checkTrialOrIntroDiscountEligibility(
+            productIdentifiers: [String]()
+        )
         let _: PromotionalOffer = try await purchases.getPromotionalOffer(
             forProductDiscount: discount,
             product: stp

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -114,6 +114,8 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.checkTrialOrIntroDiscountEligibility(product: storeProduct) { (_: IntroEligibilityStatus) in }
     purchases.checkTrialOrIntroDiscountEligibility(productIdentifiers: [String]()) { (_: [String: IntroEligibility]) in
     }
+    // Deprecated
+    purchases.checkTrialOrIntroDiscountEligibility([String]()) { (_: [String: IntroEligibility]) in }
     purchases.getPromotionalOffer(
         forProductDiscount: discount,
         product: storeProduct
@@ -181,6 +183,8 @@ private func checkAsyncMethods(purchases: Purchases) async {
         let _: [String: IntroEligibility] = await purchases.checkTrialOrIntroDiscountEligibility(
             productIdentifiers: [String]()
         )
+        // Deprecated
+        let _: [String: IntroEligibility] = await purchases.checkTrialOrIntroDiscountEligibility([String]())
         let _: PromotionalOffer = try await purchases.getPromotionalOffer(
             forProductDiscount: discount,
             product: stp

--- a/BackendIntegrationTests/BackendIntegrationTests.swift
+++ b/BackendIntegrationTests/BackendIntegrationTests.swift
@@ -206,10 +206,10 @@ class BackendIntegrationSK1Tests: XCTestCase {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         let offerings = try await Purchases.shared.offerings()
-        let productID = try XCTUnwrap(offerings.current?.monthly?.storeProduct.productIdentifier)
+        let product = try XCTUnwrap(offerings.current?.monthly?.storeProduct)
 
-        var eligibility = await Purchases.shared.checkTrialOrIntroDiscountEligibility([productID])
-        expect(eligibility[productID]?.status) == .eligible
+        var eligibility = await Purchases.shared.checkTrialOrIntroDiscountEligibility(product: product)
+        expect(eligibility) == .eligible
 
         let customerInfo = try await self.purchaseMonthlyOffering().customerInfo
 
@@ -224,8 +224,8 @@ class BackendIntegrationSK1Tests: XCTestCase {
         expect(created) == true
         expect(identifiedCustomerInfo.entitlements["premium"]?.isActive) == true
 
-        eligibility = await Purchases.shared.checkTrialOrIntroDiscountEligibility([productID])
-        expect(eligibility[productID]?.status) == .ineligible
+        eligibility = await Purchases.shared.checkTrialOrIntroDiscountEligibility(product: product)
+        expect(eligibility) == .ineligible
     }
 
 }

--- a/Documentation.docc/Purchases.md
+++ b/Documentation.docc/Purchases.md
@@ -42,8 +42,8 @@ Most features require configuring the SDK before using it.
 - ``Purchases/canMakePayments()``
 
 ### Making Purchases with Subscription Offers
-- ``Purchases/checkTrialOrIntroDiscountEligibility(_:)``
-- ``Purchases/checkTrialOrIntroDiscountEligibility(_:completion:)``
+- ``Purchases/checkTrialOrIntroDiscountEligibility(productIdentifiers:)``
+- ``Purchases/checkTrialOrIntroDiscountEligibility(productIdentifiers:completion:)``
 - ``Purchases/checkTrialOrIntroDiscountEligibility(product:)``
 - ``Purchases/checkTrialOrIntroDiscountEligibility(product:completion:)``
 - ``Purchases/getPromotionalOffer(forProductDiscount:product:)``

--- a/Documentation.docc/RevenueCat.md
+++ b/Documentation.docc/RevenueCat.md
@@ -84,8 +84,8 @@ Or browse our iOS sample apps:
 - ``PromotionalOffer``
 - ``StoreProductDiscount``
 
-- ``Purchases/checkTrialOrIntroDiscountEligibility(_:)``
-- ``Purchases/checkTrialOrIntroDiscountEligibility(_:completion:)``
+- ``Purchases/checkTrialOrIntroDiscountEligibility(productIdentifiers:)``
+- ``Purchases/checkTrialOrIntroDiscountEligibility(productIdentifiers:completion:)``
 - ``Purchases/checkTrialOrIntroDiscountEligibility(product:)``
 - ``Purchases/checkTrialOrIntroDiscountEligibility(product:completion:)``
 - ``Purchases/getPromotionalOffer(forProductDiscount:product:)``

--- a/Purchases/Misc/Deprecations.swift
+++ b/Purchases/Misc/Deprecations.swift
@@ -1,0 +1,40 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Deprecations.swift
+//
+//  Created by Nacho Soto on 3/8/22.
+
+import Foundation
+import StoreKit
+
+// swiftlint:disable line_length missing_docs
+
+public extension Purchases {
+
+    @available(iOS, deprecated: 1, renamed: "checkTrialOrIntroDiscountEligibility(productIdentifiers:)")
+    @available(tvOS, deprecated: 1, renamed: "checkTrialOrIntroDiscountEligibility(productIdentifiers:)")
+    @available(watchOS, deprecated: 1, renamed: "checkTrialOrIntroDiscountEligibility(productIdentifiers:)")
+    @available(macOS, deprecated: 1, renamed: "checkTrialOrIntroDiscountEligibility(productIdentifiers:)")
+    @available(macCatalyst, deprecated: 1, renamed: "checkTrialOrIntroDiscountEligibility(productIdentifiers:)")
+    func checkTrialOrIntroDiscountEligibility(_ productIdentifiers: [String],
+                                              completion: @escaping ([String: IntroEligibility]) -> Void) {
+        self.checkTrialOrIntroDiscountEligibility(productIdentifiers: productIdentifiers, completion: completion)
+    }
+
+    @available(iOS, introduced: 13.0, deprecated: 1, renamed: "checkTrialOrIntroDiscountEligibility(productIdentifiers:)")
+    @available(tvOS, introduced: 13.0, deprecated: 1, renamed: "checkTrialOrIntroDiscountEligibility(productIdentifiers:)")
+    @available(watchOS, introduced: 6.2, deprecated: 1, renamed: "checkTrialOrIntroDiscountEligibility(productIdentifiers:)")
+    @available(macOS, introduced: 10.15, deprecated: 1, renamed: "checkTrialOrIntroDiscountEligibility(productIdentifiers:)")
+    @available(macCatalyst, introduced: 13.0, deprecated: 1, renamed: "checkTrialOrIntroDiscountEligibility(productIdentifiers:)")
+    func checkTrialOrIntroDiscountEligibility(_ productIdentifiers: [String]) async -> [String: IntroEligibility] {
+        return await self.checkTrialOrIntroDiscountEligibility(productIdentifiers: productIdentifiers)
+    }
+
+}

--- a/Purchases/Misc/Purchases+async.swift
+++ b/Purchases/Misc/Purchases+async.swift
@@ -205,7 +205,7 @@ extension Purchases {
     func checkTrialOrIntroductoryDiscountEligibilityAsync(_ productIdentifiers: [String]) async
     -> [String: IntroEligibility] {
         return await withCheckedContinuation { continuation in
-            checkTrialOrIntroDiscountEligibility(productIdentifiers) { result in
+            checkTrialOrIntroDiscountEligibility(productIdentifiers: productIdentifiers) { result in
                 continuation.resume(returning: result)
             }
         }

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -1275,7 +1275,7 @@ public extension Purchases {
      * - ``checkTrialOrIntroDiscountEligibility(product:completion:)``
      */
     @objc(checkTrialOrIntroDiscountEligibility:completion:)
-    func checkTrialOrIntroDiscountEligibility(_ productIdentifiers: [String],
+    func checkTrialOrIntroDiscountEligibility(productIdentifiers: [String],
                                               completion: @escaping ([String: IntroEligibility]) -> Void) {
             trialOrIntroPriceEligibilityChecker.checkEligibility(productIdentifiers: productIdentifiers,
                                                                  completion: completion)
@@ -1302,7 +1302,7 @@ public extension Purchases {
      * - ``checkTrialOrIntroDiscountEligibility(product:)``
      */
     @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
-    func checkTrialOrIntroDiscountEligibility(_ productIdentifiers: [String]) async -> [String: IntroEligibility] {
+    func checkTrialOrIntroDiscountEligibility(productIdentifiers: [String]) async -> [String: IntroEligibility] {
         return await checkTrialOrIntroductoryDiscountEligibilityAsync(productIdentifiers)
     }
 
@@ -1326,7 +1326,7 @@ public extension Purchases {
      * - Parameter completion: A block that receives an ``IntroEligibilityStatus``.
      *
      * ### Related symbols
-     * - ``checkTrialOrIntroDiscountEligibility(_:completion:)``
+     * - ``checkTrialOrIntroDiscountEligibility(productIdentifiers:completion:)``
      */
     @objc(checkTrialOrIntroDiscountEligibilityForProduct:completion:)
     func checkTrialOrIntroDiscountEligibility(product: StoreProduct,
@@ -1354,7 +1354,7 @@ public extension Purchases {
      * - Parameter completion: A block that receives an ``IntroEligibilityStatus``.
      *
      * ### Related symbols
-     * - ``checkTrialOrIntroDiscountEligibility(_:)``
+     * - ``checkTrialOrIntroDiscountEligibility(productIdentifiers:)``
      */
     @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
     func checkTrialOrIntroDiscountEligibility(product: StoreProduct) async -> IntroEligibilityStatus {
@@ -1395,7 +1395,7 @@ public extension Purchases {
      *  to use in ``purchase(package:promotionalOffer:)`` or ``purchase(product:promotionalOffer:)``.
      * [iOS Promotional Offers](https://docs.revenuecat.com/docs/ios-subscription-offers#promotional-offers).
      * - Note: If you're looking to use free trials or Introductory Offers instead,
-     * use ``Purchases/checkTrialOrIntroDiscountEligibility(_:completion:)``.
+     * use ``Purchases/checkTrialOrIntroDiscountEligibility(productIdentifiers:completion:)``.
      *
      * - Parameter discount: The ``StoreProductDiscount`` to apply to the product.
      * - Parameter product: The ``StoreProduct`` the user intends to purchase.
@@ -1417,7 +1417,7 @@ public extension Purchases {
      * Use this method to find eligibility for this user for
      * [iOS Promotional Offers](https://docs.revenuecat.com/docs/ios-subscription-offers#promotional-offers).
      * - Note: If you're looking to use free trials or Introductory Offers instead,
-     * use ``Purchases/checkTrialOrIntroDiscountEligibility(_:completion:)``.
+     * use ``Purchases/checkTrialOrIntroDiscountEligibility(productIdentifiers:completion:)``.
      *
      * - Parameter discount: The ``StoreProductDiscount`` to apply to the product.
      * - Parameter product: The ``StoreProduct`` the user intends to purchase.

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -174,7 +174,7 @@ internal protocol StoreProductType {
     /// Before displaying UI that offers the introductory price,
     /// you must first determine if the user is eligible to receive it.
     /// #### Related Symbols
-    /// - ``Purchases/checkTrialOrIntroDiscountEligibility(_:)`` to  determine eligibility.
+    /// - ``Purchases/checkTrialOrIntroDiscountEligibility(productIdentifiers:)`` to  determine eligibility.
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
     var introductoryDiscount: StoreProductDiscount? { get }
 

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -1553,7 +1553,7 @@ class PurchasesTests: XCTestCase {
 
     func testGetEligibility() {
         setupPurchases()
-        purchases.checkTrialOrIntroDiscountEligibility([]) { (_) in
+        purchases.checkTrialOrIntroDiscountEligibility(productIdentifiers: []) { (_) in
         }
 
         expect(self.trialOrIntroPriceEligibilityChecker.invokedCheckTrialOrIntroPriceEligibilityFromOptimalStore)

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -239,6 +239,7 @@
 		5796A39627D6BDAB00653165 /* BackendPostOfferForSigningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A39527D6BDAB00653165 /* BackendPostOfferForSigningTests.swift */; };
 		5796A39927D6C1E000653165 /* BackendPostSubscriberAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A39827D6C1E000653165 /* BackendPostSubscriberAttributesTests.swift */; };
 		5796A39B27D6C20A00653165 /* BackendPostAttributionDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A39A27D6C20A00653165 /* BackendPostAttributionDataTests.swift */; };
+		5796A3A927D7C43500653165 /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A3A827D7C43500653165 /* Deprecations.swift */; };
 		57A0FBF02749C0C2009E2FC3 /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */; };
 		57A0FBF22749CF66009E2FC3 /* SynchronizedUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */; };
 		57A17727276A721D0052D3A8 /* Set+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A17726276A721D0052D3A8 /* Set+Extensions.swift */; };
@@ -650,6 +651,7 @@
 		5796A39727D6C07D00653165 /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		5796A39827D6C1E000653165 /* BackendPostSubscriberAttributesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendPostSubscriberAttributesTests.swift; sourceTree = "<group>"; };
 		5796A39A27D6C20A00653165 /* BackendPostAttributionDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendPostAttributionDataTests.swift; sourceTree = "<group>"; };
+		5796A3A827D7C43500653165 /* Deprecations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deprecations.swift; sourceTree = "<group>"; };
 		57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 		57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedUserDefaults.swift; sourceTree = "<group>"; };
 		57A17726276A721D0052D3A8 /* Set+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Set+Extensions.swift"; sourceTree = "<group>"; };
@@ -1028,6 +1030,7 @@
 				B33CEA9F268CDCC9008A3144 /* ISOPeriodFormatter.swift */,
 				57EAE526274324C60060EB74 /* Lock.swift */,
 				F530E4FE275646EF001AF6BD /* MacDevice.swift */,
+				5796A3A827D7C43500653165 /* Deprecations.swift */,
 				57EAE52A274332830060EB74 /* Obsoletions.swift */,
 				2DDA3E4624DB0B5400EDFE5B /* OperationDispatcher.swift */,
 				2DD9F4BD274EADC20031AE2C /* Purchases+async.swift */,
@@ -2047,6 +2050,7 @@
 				2D11F5E1250FF886005A70E8 /* AttributionStrings.swift in Sources */,
 				2CD72944268A826F00BFC976 /* Date+Extensions.swift in Sources */,
 				B34605C5279A6E380031CA74 /* CustomerInfoResponseHandler.swift in Sources */,
+				5796A3A927D7C43500653165 /* Deprecations.swift in Sources */,
 				B3AA6238268B926F00894871 /* SystemInfo.swift in Sources */,
 				5746508E275949F20053AB09 /* DispatchTimeInterval+Extensions.swift in Sources */,
 				2D294E5C26DECFD500B8FE4F /* StoreKit2TransactionListener.swift in Sources */,

--- a/docs/Deprecations.md
+++ b/docs/Deprecations.md
@@ -7,7 +7,7 @@ As the framework evolves, some APIs change. For Version 4 there's a [general doc
 ### Deprecated ⚠️
 APIs marked as `deprecated` mean that a method or type can continue to be used, but it provides a warning to the developer letting them know that it will go away in a future version.
 
-Because they can still be called, the implementations need to remain valid, so they typically live in their existing files.
+Because they can still be called, the implementations need to remain valid. Some of these live in `Deprecations.swift`.
 
 ### Obsoleted ⛔️
 APIs marked as `obsoleted` result in a compile error, they can't be used.


### PR DESCRIPTION
Fixes [CF-287]
Now we have `checkTrialOrIntroDiscountEligibility(product:)` and `checkTrialOrIntroDiscountEligibility(productIdentifiers:)`

[CF-287]: https://revenuecats.atlassian.net/browse/CF-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ