### PR TITLE
`NSError.successfullySynced`: check domain as well as code

### DIFF
--- a/Purchases/FoundationExtensions/Error+Extensions.swift
+++ b/Purchases/FoundationExtensions/Error+Extensions.swift
@@ -41,7 +41,7 @@ extension Error {
 extension NSError {
 
     var successfullySynced: Bool {
-        if code == ErrorCode.networkError.rawValue {
+        if self.domain == ErrorCode.errorDomain, self.code == ErrorCode.networkError.rawValue {
             return false
         }
 


### PR DESCRIPTION
Comparing `Error.code` without a domain can lead to incorrectly comparing against a completely different type of error that happens to have the same error code.