### PR TITLE
New `Result` initializer to simplify conversions from old completion blocks

### DIFF
--- a/Purchases/FoundationExtensions/Result+Extensions.swift
+++ b/Purchases/FoundationExtensions/Result+Extensions.swift
@@ -12,6 +12,19 @@
 //  Created by Nacho Soto on 12/1/21.
 
 extension Result {
+
+    /// Creates a `Result` from either a value or an error.
+    /// This is useful for converting from old Objective-C closures to new APIs.
+    init( _ value: Success?, _ error: Failure?, file: StaticString = #fileID, line: UInt = #line) {
+        if let value = value {
+            self = .success(value)
+        } else if let error = error {
+            self = .failure(error)
+        } else {
+            fatalError("Unexpected nil value and nil error", file: file, line: line)
+        }
+    }
+
     var value: Success? {
         switch self {
         case let .success(value): return value
@@ -25,4 +38,5 @@ extension Result {
         case let .failure(error): return error
         }
     }
+
 }

--- a/Purchases/Misc/Purchases+async.swift
+++ b/Purchases/Misc/Purchases+async.swift
@@ -20,14 +20,8 @@ extension Purchases {
     func logInAsync(_ appUserID: String) async throws -> (customerInfo: CustomerInfo, created: Bool) {
         return try await withCheckedThrowingContinuation { continuation in
             logIn(appUserID) { customerInfo, created, error in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let customerInfo = customerInfo else {
-                    fatalError("Expected non-nil result 'customerInfo' for nil error")
-                }
-                continuation.resume(returning: (customerInfo, created))
+                continuation.resume(with: Result(customerInfo, error)
+                                        .map { ($0, created) })
             }
         }
     }
@@ -36,14 +30,7 @@ extension Purchases {
     func logOutAsync() async throws -> CustomerInfo {
         return try await withCheckedThrowingContinuation { continuation in
             logOut { customerInfo, error in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let customerInfo = customerInfo else {
-                    fatalError("Expected non-nil result 'customerInfo' for nil error")
-                }
-                continuation.resume(returning: customerInfo)
+                continuation.resume(with: Result(customerInfo, error))
             }
         }
     }
@@ -52,14 +39,7 @@ extension Purchases {
     func offeringsAsync() async throws -> Offerings {
         return try await withCheckedThrowingContinuation { continuation in
             getOfferings { offerings, error in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let offerings = offerings else {
-                    fatalError("Expected non-nil result 'result' for nil error")
-                }
-                continuation.resume(returning: offerings)
+                continuation.resume(with: Result(offerings, error))
             }
         }
     }
@@ -68,14 +48,7 @@ extension Purchases {
     func customerInfoAsync() async throws -> CustomerInfo {
         return try await withCheckedThrowingContinuation { continuation in
             getCustomerInfo { customerInfo, error in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let customerInfo = customerInfo else {
-                    fatalError("Expected non-nil result 'customerInfo' for nil error")
-                }
-                continuation.resume(returning: customerInfo)
+                continuation.resume(with: Result(customerInfo, error))
             }
         }
     }
@@ -93,15 +66,8 @@ extension Purchases {
     func purchaseAsync(product: StoreProduct) async throws -> PurchaseResultData {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(product: product) { transaction, customerInfo, error, userCancelled in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let customerInfo = customerInfo else {
-                    fatalError("Expected non-nil result 'customerInfo' for nil error")
-                }
-
-                continuation.resume(returning: (transaction, customerInfo, userCancelled))
+                continuation.resume(with: Result(customerInfo, error)
+                                        .map { PurchaseResultData(transaction, $0, userCancelled) })
             }
         }
     }
@@ -110,15 +76,8 @@ extension Purchases {
     func purchaseAsync(package: Package) async throws -> PurchaseResultData {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(package: package) { transaction, customerInfo, error, userCancelled in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let customerInfo = customerInfo else {
-                    fatalError("Expected non-nil result 'customerInfo' for nil error")
-                }
-
-                continuation.resume(returning: (transaction, customerInfo, userCancelled))
+                continuation.resume(with: Result(customerInfo, error)
+                                        .map { PurchaseResultData(transaction, $0, userCancelled) })
             }
         }
     }
@@ -128,15 +87,8 @@ extension Purchases {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(product: product,
                      promotionalOffer: promotionalOffer) { transaction, customerInfo, error, userCancelled in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let customerInfo = customerInfo else {
-                    fatalError("Expected non-nil result 'customerInfo' for nil error")
-                }
-
-                continuation.resume(returning: (transaction, customerInfo, userCancelled))
+                continuation.resume(with: Result(customerInfo, error)
+                                        .map { PurchaseResultData(transaction, $0, userCancelled) })
             }
         }
     }
@@ -146,15 +98,8 @@ extension Purchases {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(package: package,
                      promotionalOffer: promotionalOffer) { transaction, customerInfo, error, userCancelled in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let customerInfo = customerInfo else {
-                    fatalError("Expected non-nil result 'customerInfo' for nil error")
-                }
-
-                continuation.resume(returning: (transaction, customerInfo, userCancelled))
+                continuation.resume(with: Result(customerInfo, error)
+                                        .map { PurchaseResultData(transaction, $0, userCancelled) })
             }
         }
     }
@@ -163,14 +108,7 @@ extension Purchases {
     func syncPurchasesAsync() async throws -> CustomerInfo {
         return try await withCheckedThrowingContinuation { continuation in
             syncPurchases { customerInfo, error in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let customerInfo = customerInfo else {
-                    fatalError("Expected non-nil result 'customerInfo' for nil error")
-                }
-                continuation.resume(returning: customerInfo)
+                continuation.resume(with: Result(customerInfo, error))
             }
         }
     }
@@ -179,14 +117,7 @@ extension Purchases {
     func restorePurchasesAsync() async throws -> CustomerInfo {
         return try await withCheckedThrowingContinuation { continuation in
             restorePurchases { customerInfo, error in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let customerInfo = customerInfo else {
-                    fatalError("Expected non-nil result 'customerInfo' for nil error")
-                }
-                continuation.resume(returning: customerInfo)
+                continuation.resume(with: Result(customerInfo, error))
             }
         }
     }
@@ -216,14 +147,7 @@ extension Purchases {
                                   product: StoreProduct) async throws -> PromotionalOffer {
         return try await withCheckedThrowingContinuation { continuation in
             getPromotionalOffer(forProductDiscount: discount, product: product) { offer, error in
-                 if let error = error {
-                     continuation.resume(throwing: error)
-                     return
-                 } else if let offer = offer {
-                     continuation.resume(returning: offer)
-                 } else {
-                     fatalError("Unexpected non-nil result for nil error")
-                 }
+                continuation.resume(with: Result(offer, error))
              }
          }
      }
@@ -274,9 +198,9 @@ extension Purchases {
             showManageSubscriptions { error in
                 if let error = error {
                     continuation.resume(throwing: error)
-                    return
+                } else {
+                    continuation.resume(returning: ())
                 }
-                continuation.resume(returning: ())
             }
         }
     }

--- a/PurchasesTests/FoundationExtensions/ResultExtensionsTests.swift
+++ b/PurchasesTests/FoundationExtensions/ResultExtensionsTests.swift
@@ -1,0 +1,61 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ResultExtensionsTests.swift
+//
+//  Created by Nacho Soto on 3/8/22.
+
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+class ResultExtensionsTests: XCTestCase {
+
+    func testValue() {
+        expect(Data.success("test").value) == "test"
+        expect(Data.failure(.error1).value).to(beNil())
+    }
+
+    func testError() {
+        expect(Data.success("test").error).to(beNil())
+        expect(Data.failure(.error1).error) == .error1
+    }
+
+    func testInitWithValueAndNoError() {
+        expect(Data("1", nil)) == .success("1")
+    }
+
+    func testInitWithValueAndErrorBecomesSuccess() {
+        expect(Data("1", .error1)) == .success("1")
+    }
+
+    func testInitWithError() {
+        expect(Data(nil, .error1)) == .failure(.error1)
+    }
+
+    func testInitWithNoValueOrError() {
+        expectFatalError(expectedMessage: "Unexpected nil value and nil error") {
+            _ = Data(nil, nil)
+        }
+    }
+
+}
+
+private extension ResultExtensionsTests {
+
+    enum Error: Swift.Error {
+
+        case error1
+
+    }
+
+    typealias Data = Result<String, Error>
+
+}

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -239,6 +239,7 @@
 		5796A39627D6BDAB00653165 /* BackendPostOfferForSigningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A39527D6BDAB00653165 /* BackendPostOfferForSigningTests.swift */; };
 		5796A39927D6C1E000653165 /* BackendPostSubscriberAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A39827D6C1E000653165 /* BackendPostSubscriberAttributesTests.swift */; };
 		5796A39B27D6C20A00653165 /* BackendPostAttributionDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A39A27D6C20A00653165 /* BackendPostAttributionDataTests.swift */; };
+		5796A3C027D7D64500653165 /* ResultExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A3BF27D7D64500653165 /* ResultExtensionsTests.swift */; };
 		5796A3A927D7C43500653165 /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A3A827D7C43500653165 /* Deprecations.swift */; };
 		57A0FBF02749C0C2009E2FC3 /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */; };
 		57A0FBF22749CF66009E2FC3 /* SynchronizedUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */; };
@@ -651,6 +652,7 @@
 		5796A39727D6C07D00653165 /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		5796A39827D6C1E000653165 /* BackendPostSubscriberAttributesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendPostSubscriberAttributesTests.swift; sourceTree = "<group>"; };
 		5796A39A27D6C20A00653165 /* BackendPostAttributionDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendPostAttributionDataTests.swift; sourceTree = "<group>"; };
+		5796A3BF27D7D64500653165 /* ResultExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultExtensionsTests.swift; sourceTree = "<group>"; };
 		5796A3A827D7C43500653165 /* Deprecations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deprecations.swift; sourceTree = "<group>"; };
 		57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 		57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedUserDefaults.swift; sourceTree = "<group>"; };
@@ -1368,6 +1370,7 @@
 				57A1772A276A726C0052D3A8 /* SetExtensionsTests.swift */,
 				37E35FDA0A44EA03EA12DAA2 /* DateFormatter+ExtensionsTests.swift */,
 				572247F627BF1ADF00C524A7 /* ArrayExtensionsTests.swift */,
+				5796A3BF27D7D64500653165 /* ResultExtensionsTests.swift */,
 			);
 			path = FoundationExtensions;
 			sourceTree = "<group>";
@@ -2246,6 +2249,7 @@
 				351B519F26D4508A00BD2BD7 /* DeviceCacheTests.swift in Sources */,
 				2D22BF6826F3CC6D001AE2F9 /* XCTestCase+Extensions.swift in Sources */,
 				351B51B626D450E800BD2BD7 /* ReceiptFetcherTests.swift in Sources */,
+				5796A3C027D7D64500653165 /* ResultExtensionsTests.swift in Sources */,
 				351B51A726D450D400BD2BD7 /* SystemInfoTests.swift in Sources */,
 				351B515626D44B2300BD2BD7 /* MockNotificationCenter.swift in Sources */,
 				351B515226D44AF000BD2BD7 /* MockReceiptFetcher.swift in Sources */,


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests