### PR TITLE
Handle new `StoreKitError.notEntitled`

### DIFF
--- a/Purchases/Error Handling/StoreKitError+Extensions.swift
+++ b/Purchases/Error Handling/StoreKitError+Extensions.swift
@@ -31,6 +31,11 @@ extension StoreKitError {
         case .notAvailableInStorefront:
             return ErrorUtils.productNotAvailableForPurchaseError(error: self)
 
+#if swift(>=5.6)
+        case .notEntitled:
+            return ErrorUtils.storeProblemError(error: self)
+#endif
+
         case .unknown:
             /// See also https://github.com/RevenueCat/purchases-ios/issues/392
             /// `StoreKitError` doesn't conform to `CustomNSError` as of `iOS 15.2`


### PR DESCRIPTION
Fixes [CF-321]

[CF-321]: https://revenuecats.atlassian.net/browse/CF-321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ