### PR TITLE
SK2 Purchases: handle `Product.PurchaseError` in `ErrorUtils.purchasesError`

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesErrorCodeAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesErrorCodeAPI.m
@@ -56,6 +56,7 @@
         case RCProductRequestTimedOut:
         case RCBeginRefundRequestError:
         case RCAPIEndpointBlocked:
+        case RCInvalidPromotionalOfferError:
             NSLog(@"%ld", (long)errCode);
     }
 }

--- a/APITesters/SwiftAPITester/SwiftAPITester/ErrorCodesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/ErrorCodesAPI.swift
@@ -50,7 +50,8 @@ func checkPurchasesErrorCodeEnums() {
          .systemInfoError,
          .beginRefundRequestError,
          .productRequestTimedOut,
-         .apiEndpointBlockedError:
+         .apiEndpointBlockedError,
+         .invalidPromotionalOfferError:
         print(errCode!)
     @unknown default:
         fatalError()

--- a/Purchases/Error Handling/ErrorCode.swift
+++ b/Purchases/Error Handling/ErrorCode.swift
@@ -153,7 +153,10 @@ extension ErrorCode: DescribableError {
         case .apiEndpointBlockedError:
             return "Requests to RevenueCat are being blocked. See: https://rev.cat/dnsBlocking for more info."
         case .invalidPromotionalOfferError:
-            return "The information associated with this PromotionalOffer is not valid. See TODO for more info."
+            return """
+                   The information associated with this PromotionalOffer is not valid.
+                   See https://rev.cat/ios-subscription-offers for more info.
+                   """
         @unknown default:
             return "Something went wrong."
         }

--- a/Purchases/Error Handling/ErrorCode.swift
+++ b/Purchases/Error Handling/ErrorCode.swift
@@ -56,6 +56,7 @@ import Foundation
     @objc(RCBeginRefundRequestError)case beginRefundRequestError = 31
     @objc(RCProductRequestTimedOut) case productRequestTimedOut = 32
     @objc(RCAPIEndpointBlocked) case apiEndpointBlockedError = 33
+    @objc(RCInvalidPromotionalOfferError) case invalidPromotionalOfferError = 34
 
     // swiftlint:enable missing_docs
 }
@@ -151,6 +152,8 @@ extension ErrorCode: DescribableError {
             return "SKProductsRequest took too long to complete."
         case .apiEndpointBlockedError:
             return "Requests to RevenueCat are being blocked. See: https://rev.cat/dnsBlocking for more info."
+        case .invalidPromotionalOfferError:
+            return "The information associated with this PromotionalOffer is not valid. See TODO for more info."
         @unknown default:
             return "Something went wrong."
         }
@@ -245,6 +248,8 @@ extension ErrorCode {
             return "PRODUCT_REQUEST_TIMED_OUT_ERROR"
         case .apiEndpointBlockedError:
             return "API_ENDPOINT_BLOCKED_ERROR"
+        case .invalidPromotionalOfferError:
+            return "INVALID_PROMOTIONAL_OFFER_ERROR"
         @unknown default:
             return "UNRECOGNIZED_ERROR"
         }

--- a/Purchases/Error Handling/StoreKitError+Extensions.swift
+++ b/Purchases/Error Handling/StoreKitError+Extensions.swift
@@ -48,3 +48,34 @@ extension StoreKitError {
     }
 
 }
+
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+extension Product.PurchaseError {
+
+    func toPurchasesError() -> Error {
+        switch self {
+        case .invalidQuantity:
+            return ErrorUtils.storeProblemError(error: self)
+
+        case .productUnavailable:
+            return ErrorUtils.productNotAvailableForPurchaseError(error: self)
+
+        case .purchaseNotAllowed:
+            return ErrorUtils.purchaseNotAllowedError(error: self)
+
+        case .ineligibleForOffer:
+            return ErrorUtils.ineligibleError(error: self)
+
+        case
+                .invalidOfferIdentifier,
+                .invalidOfferPrice,
+                .invalidOfferSignature,
+                .missingOfferParameters:
+            return ErrorUtils.invalidPromotionalOfferError(error: self)
+
+        @unknown default:
+            return ErrorUtils.unknownError(error: self)
+        }
+    }
+
+}

--- a/PurchasesTests/Purchasing/ErrorCodeTests.swift
+++ b/PurchasesTests/Purchasing/ErrorCodeTests.swift
@@ -162,8 +162,13 @@ class ErrorCodeTests: XCTestCase {
                                               expectedRawValue: 33)
     }
 
+    func testInvalidPromotionalOffer() {
+        ensureEnumCaseMatchesExpectedRawValue(errorCode: .invalidPromotionalOfferError,
+                                              expectedRawValue: 34)
+    }
+
     func testErrorCodeEnumCasesAreCoveredInTests() {
-        expect(ErrorCode.allCases.count).to(equal(34))
+        expect(ErrorCode.allCases).to(haveCount(35))
     }
 
     func ensureEnumCaseMatchesExpectedRawValue(errorCode: ErrorCode, expectedRawValue: Int) {


### PR DESCRIPTION
Unfortunately Swift still doesn't have typed errors (sad face).
Turns out that `Product.purchase` may throw either a `Product.PurchaseError` or `StoreKitError`, but we were only handling the latter.

Additionally, the call to `.unknownError()` wasn't adding the error, so we were losing all the context of the underlying error.

There's already a Jira for adding test coverage here: [CF-323]

## TODO:
- [x] Add link for promotional offer errors

[CF-323]: https://revenuecats.atlassian.net/browse/CF-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ