### PR TITLE
`TransactionsManager`: added note about using SK2 implementation

### DIFF
--- a/Purchases/Purchasing/TransactionsManager.swift
+++ b/Purchases/Purchasing/TransactionsManager.swift
@@ -22,6 +22,8 @@ class TransactionsManager {
     }
 
     func customerHasTransactions(receiptData: Data, completion: @escaping (Bool) -> Void) {
+        // Note: this uses SK2 regardless of the value of `SystemInfo.useStoreKit2IfAvailable`
+        // because its implementation is more accurate.
         if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
             _ = Task<Void, Never> {
                 completion(await sk2CheckCustomerHasTransactions())


### PR DESCRIPTION
This was currently using SK2 without it being enabled.