### PR TITLE
`HTTPClient`: improved debug logs by making them consistent

### DIFF
--- a/Purchases/Logging/Strings/NetworkStrings.swift
+++ b/Purchases/Logging/Strings/NetworkStrings.swift
@@ -17,8 +17,8 @@ import Foundation
 // swiftlint:disable identifier_name
 enum NetworkStrings {
 
-    case api_request_completed(httpMethod: String, path: String, httpCode: HTTPStatusCode)
-    case api_request_started(httpMethod: String?, path: String?)
+    case api_request_completed(httpMethod: String, path: HTTPRequest.Path, httpCode: HTTPStatusCode)
+    case api_request_started(httpMethod: String, path: HTTPRequest.Path)
     case creating_json_error(error: String)
     case json_data_received(dataString: String)
     case parsing_json_error(error: Error)
@@ -39,10 +39,10 @@ extension NetworkStrings: CustomStringConvertible {
         switch self {
 
         case let .api_request_completed(httpMethod, path, httpCode):
-            return "API request completed with status: \(httpMethod) \(path) \(httpCode.rawValue)"
+            return "API request completed: \(httpMethod) \(path.url?.path ?? "") \(httpCode.rawValue)"
 
         case let .api_request_started(httpMethod, path):
-            return "API request started: \(httpMethod ?? "") \(path ?? "")"
+            return "API request started: \(httpMethod) \(path.url?.path ?? "")"
 
         case let .creating_json_error(error):
             return "Error creating request with body: \(error)"

--- a/Purchases/Logging/Strings/NetworkStrings.swift
+++ b/Purchases/Logging/Strings/NetworkStrings.swift
@@ -17,8 +17,8 @@ import Foundation
 // swiftlint:disable identifier_name
 enum NetworkStrings {
 
-    case api_request_completed(httpMethod: String, path: HTTPRequest.Path, httpCode: HTTPStatusCode)
-    case api_request_started(httpMethod: String, path: HTTPRequest.Path)
+    case api_request_completed(_ request: HTTPRequest, httpCode: HTTPStatusCode)
+    case api_request_started(HTTPRequest)
     case creating_json_error(error: String)
     case json_data_received(dataString: String)
     case parsing_json_error(error: Error)
@@ -38,11 +38,12 @@ extension NetworkStrings: CustomStringConvertible {
     var description: String {
         switch self {
 
-        case let .api_request_completed(httpMethod, path, httpCode):
-            return "API request completed: \(httpMethod) \(path.url?.path ?? "") \(httpCode.rawValue)"
+        case let .api_request_completed(request, httpCode):
+            return "API request completed: \(request.method.httpMethod) \(request.path.url?.path ?? "")" +
+            "\(httpCode.rawValue)"
 
-        case let .api_request_started(httpMethod, path):
-            return "API request started: \(httpMethod) \(path.url?.path ?? "")"
+        case let .api_request_started(request):
+            return "API request started: \(request.method.httpMethod) \(request.path.url?.path ?? "")"
 
         case let .creating_json_error(error):
             return "Error creating request with body: \(error)"

--- a/Purchases/Networking/HTTPClient.swift
+++ b/Purchases/Networking/HTTPClient.swift
@@ -173,9 +173,7 @@ private extension HTTPClient {
         if networkError == nil {
             if let httpURLResponse = urlResponse as? HTTPURLResponse {
                 statusCode = .init(rawValue: httpURLResponse.statusCode)
-                Logger.debug(Strings.network.api_request_completed(httpMethod: request.method.httpMethod,
-                                                                   path: request.httpRequest.path,
-                                                                   httpCode: statusCode))
+                Logger.debug(Strings.network.api_request_completed(request.httpRequest, httpCode: statusCode))
 
                 if statusCode == .notModified || data == nil {
                     jsonObject = [:]
@@ -251,8 +249,7 @@ private extension HTTPClient {
             return
         }
 
-        Logger.debug(Strings.network.api_request_started(httpMethod: request.method.httpMethod,
-                                                         path: request.httpRequest.path))
+        Logger.debug(Strings.network.api_request_started(request.httpRequest))
 
         let task = session.dataTask(with: urlRequest) { (data, urlResponse, error) -> Void in
             self.handle(urlResponse: urlResponse,

--- a/Purchases/Networking/HTTPClient.swift
+++ b/Purchases/Networking/HTTPClient.swift
@@ -174,7 +174,7 @@ private extension HTTPClient {
             if let httpURLResponse = urlResponse as? HTTPURLResponse {
                 statusCode = .init(rawValue: httpURLResponse.statusCode)
                 Logger.debug(Strings.network.api_request_completed(httpMethod: request.method.httpMethod,
-                                                                   path: request.path,
+                                                                   path: request.httpRequest.path,
                                                                    httpCode: statusCode))
 
                 if statusCode == .notModified || data == nil {
@@ -251,8 +251,8 @@ private extension HTTPClient {
             return
         }
 
-        Logger.debug(Strings.network.api_request_started(httpMethod: urlRequest.httpMethod,
-                                                         path: urlRequest.url?.path))
+        Logger.debug(Strings.network.api_request_started(httpMethod: request.method.httpMethod,
+                                                         path: request.httpRequest.path))
 
         let task = session.dataTask(with: urlRequest) { (data, urlResponse, error) -> Void in
             self.handle(urlResponse: urlResponse,


### PR DESCRIPTION
I was looking at these while debugging and getting confused because of the message "completed with status", followed by something that wasn't a status.

The new format is consistent across "started" and "completed" messages, and it's easier to read:
> 2022-03-08 09:51:04.633994-0800 BackendIntegrationTestsHostApp[74639:8672511] [Purchases] - DEBUG: ℹ️ API request started: POST /v1/receipts
> 2022-03-08 09:51:05.037849-0800 BackendIntegrationTestsHostApp[74639:8672508] [Purchases] - DEBUG: ℹ️ API request completed: POST /v1/receipts 200