### PR TITLE
`HTTPClient.perform`: changed response to `Result<[String: Any], Error>`

### DIFF
--- a/Purchases/Error Handling/UnexpectedBackendResponseSubErrorCode.swift
+++ b/Purchases/Error Handling/UnexpectedBackendResponseSubErrorCode.swift
@@ -15,17 +15,11 @@ import Foundation
 
 enum UnexpectedBackendResponseSubErrorCode: Int, Error {
 
-    /// Login call returned with no response.
-    case loginMissingResponse = 0
-
     /// Login call failed due to a problem with the response.
-    case loginResponseDecoding
-
-    /// Received an empty response after posting an offer.
-    case postOfferEmptyResponse
+    case loginResponseDecoding = 1
 
     /// Received a bad response after posting an offer- "offers" couldn't be read from response.
-    case postOfferIdBadResponse
+    case postOfferIdBadResponse = 3
 
     /// Received a bad response after posting an offer- "offers" was totally missing.
     case postOfferIdMissingOffersInResponse
@@ -48,12 +42,8 @@ extension UnexpectedBackendResponseSubErrorCode: DescribableError {
 
     var description: String {
         switch self {
-        case .loginMissingResponse:
-            return "Login returned with a missing response."
         case .loginResponseDecoding:
             return "Unable to decode response returned from login."
-        case .postOfferEmptyResponse:
-            return "posting offer for signing failed, received an empty response."
         case .postOfferIdBadResponse:
             return "Unable to decode response returned from posting offer for signing."
         case .postOfferIdMissingOffersInResponse:

--- a/Purchases/Identity/CustomerInfoManager.swift
+++ b/Purchases/Identity/CustomerInfoManager.swift
@@ -34,21 +34,23 @@ class CustomerInfoManager {
 
     func fetchAndCacheCustomerInfo(appUserID: String,
                                    isAppBackgrounded: Bool,
-                                   completion: ((CustomerInfo?, Error?) -> Void)?) {
+                                   completion: ((Result<CustomerInfo, Error>) -> Void)?) {
         deviceCache.setCacheTimestampToNowToPreventConcurrentCustomerInfoUpdates(appUserID: appUserID)
         operationDispatcher.dispatchOnWorkerThread(withRandomDelay: isAppBackgrounded) {
-            self.backend.getCustomerInfo(appUserID: appUserID) { customerInfo, error in
-                if let error = error {
+            self.backend.getCustomerInfo(appUserID: appUserID) { result in
+                switch result {
+                case let .failure(error):
                     self.deviceCache.clearCustomerInfoCacheTimestamp(appUserID: appUserID)
                     Logger.warn(Strings.customerInfo.customerinfo_updated_from_network_error(error: error))
-                } else if let info = customerInfo {
+
+                case let .success(info):
                     self.cache(customerInfo: info, appUserID: appUserID)
                     Logger.rcSuccess(Strings.customerInfo.customerinfo_updated_from_network)
                 }
 
                 if let completion = completion {
                     self.operationDispatcher.dispatchOnMainThread {
-                        completion(customerInfo, error)
+                        completion(result)
                     }
                 }
 
@@ -58,23 +60,24 @@ class CustomerInfoManager {
 
     func fetchAndCacheCustomerInfoIfStale(appUserID: String,
                                           isAppBackgrounded: Bool,
-                                          completion: ((CustomerInfo?, Error?) -> Void)?) {
+                                          completion: ((Result<CustomerInfo, Error>) -> Void)?) {
         let cachedCustomerInfo = cachedCustomerInfo(appUserID: appUserID)
         let isCacheStale = deviceCache.isCustomerInfoCacheStale(appUserID: appUserID,
                                                                 isAppBackgrounded: isAppBackgrounded)
-        let needsToRefresh = isCacheStale || cachedCustomerInfo == nil
-        if needsToRefresh {
+
+        guard !isCacheStale, let customerInfo = cachedCustomerInfo else {
             Logger.debug(isAppBackgrounded
                             ? Strings.customerInfo.customerinfo_stale_updating_in_background
                             : Strings.customerInfo.customerinfo_stale_updating_in_foreground)
             fetchAndCacheCustomerInfo(appUserID: appUserID,
                                       isAppBackgrounded: isAppBackgrounded,
                                       completion: completion)
-        } else {
-            if let completion = completion {
-                operationDispatcher.dispatchOnMainThread {
-                    completion(cachedCustomerInfo, nil)
-                }
+            return
+        }
+
+        if let completion = completion {
+            operationDispatcher.dispatchOnMainThread {
+                completion(.success(customerInfo))
             }
         }
     }
@@ -87,7 +90,7 @@ class CustomerInfoManager {
         sendUpdateIfChanged(customerInfo: info)
     }
 
-    func customerInfo(appUserID: String, completion: ((CustomerInfo?, Error?) -> Void)?) {
+    func customerInfo(appUserID: String, completion: ((Result<CustomerInfo, Error>) -> Void)?) {
         let infoFromCache = cachedCustomerInfo(appUserID: appUserID)
         var completionCalled = false
 
@@ -96,7 +99,7 @@ class CustomerInfoManager {
             if let completion = completion {
                 completionCalled = true
                 operationDispatcher.dispatchOnMainThread {
-                    completion(infoFromCache, nil)
+                    completion(.success(infoFromCache))
                 }
             }
         }
@@ -222,6 +225,17 @@ class CustomerInfoManager {
                     closure(customerInfo)
                 }
             }
+        }
+    }
+
+}
+
+extension CustomerInfoManager {
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func customerInfo(appUserID: String) async throws -> CustomerInfo {
+        return try await withCheckedThrowingContinuation { continuation in
+            return self.customerInfo(appUserID: appUserID, completion: continuation.resume)
         }
     }
 

--- a/Purchases/Identity/IdentityManager.swift
+++ b/Purchases/Identity/IdentityManager.swift
@@ -81,7 +81,7 @@ class IdentityManager {
         }
 
         backend.logIn(currentAppUserID: currentAppUserID, newAppUserID: newAppUserID) { result in
-            if let customerInfo = result.value?.info {
+            if case let .success((customerInfo, _)) = result {
                 self.deviceCache.clearCaches(oldAppUserID: self.currentAppUserID, andSaveWithNewUserID: newAppUserID)
                 self.customerInfoManager.cache(customerInfo: customerInfo, appUserID: newAppUserID)
             }

--- a/Purchases/Logging/Strings/BackendErrorStrings.swift
+++ b/Purchases/Logging/Strings/BackendErrorStrings.swift
@@ -34,9 +34,6 @@ enum BackendErrorStrings {
     // Posting offerIdForSigning failed due to a signature problem.
     case signature_error(signatureDataString: Any?)
 
-    // getOfferings failed and we're not totally sure why.
-    case unknown_get_offerings_error(statusCode: HTTPStatusCode, responseString: String?)
-
 }
 
 extension BackendErrorStrings: CustomStringConvertible {
@@ -59,12 +56,6 @@ extension BackendErrorStrings: CustomStringConvertible {
             return "No offerings found in response:\n\(String(describing: response["offers"]))"
         case .signature_error(let signatureDataString):
             return "Missing 'signatureData' or its structure changed:\n\(String(describing: signatureDataString))"
-        case let .unknown_get_offerings_error(statusCode, responseString):
-            var message = "Encountered an error getting offerings, status code:\(statusCode.rawValue)"
-            if let responseString = responseString {
-                message += "\nresponse: \(responseString)"
-            }
-            return message
         }
     }
 

--- a/Purchases/Logging/Strings/ManageSubscriptionsStrings.swift
+++ b/Purchases/Logging/Strings/ManageSubscriptionsStrings.swift
@@ -22,7 +22,6 @@ extension ManageSubscriptionsHelper {
         case cant_form_apple_subscriptions_url
         case error_from_appstore_show_manage_subscription(error: Error)
         case failed_to_get_management_url_error_unknown(error: Error)
-        case failed_to_get_management_url_nil_customer_info
         case failed_to_get_window_scene
         case management_url_nil_opening_default
         case show_manage_subscriptions_called_in_unsupported_platform
@@ -42,8 +41,6 @@ extension ManageSubscriptionsHelper.Strings: CustomStringConvertible {
             return "Error when trying to show manage subscription: \(error.localizedDescription)"
         case .failed_to_get_management_url_error_unknown(let error):
             return "Failed to get managementURL from CustomerInfo. Details: \(error.localizedDescription)"
-        case .failed_to_get_management_url_nil_customer_info:
-            return "Failed to get managementURL from CustomerInfo. Details: customerInfo is nil."
         case .failed_to_get_window_scene:
             return "Failed to get UIWindowScene"
         case .management_url_nil_opening_default:

--- a/Purchases/Logging/Strings/PurchaseStrings.swift
+++ b/Purchases/Logging/Strings/PurchaseStrings.swift
@@ -52,7 +52,6 @@ enum PurchaseStrings {
     case transaction_unverified(productID: String, errorMessage: String)
     case unknown_purchase_result(result: String)
     case begin_refund_request_unsupported
-    case begin_refund_for_entitlement_nil_customer_info(entitlementID: String?)
     case begin_refund_no_entitlement_found(entitlementID: String?)
     case begin_refund_no_active_entitlement
     case begin_refund_multiple_active_entitlements
@@ -189,9 +188,6 @@ extension PurchaseStrings: CustomStringConvertible {
             return "Received unknown purchase result: \(result)"
         case .begin_refund_request_unsupported:
             return "Tried to call beginRefundRequest in a platform that doesn't support it!"
-        case .begin_refund_for_entitlement_nil_customer_info(let entitlementID):
-            return "Failed to get \(entitlementID.flatMap { "entitlement with ID " + $0 } ?? "active entitlement")" +
-                " for refund. CustomerInfo is nil."
         case .begin_refund_no_entitlement_found(let entitlementID):
             return "Could not find  \(entitlementID.flatMap { "entitlement with ID " + $0 } ?? "active entitlement")" +
                 " for refund."

--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -14,12 +14,12 @@
 import Foundation
 
 typealias SubscriberAttributeDict = [String: SubscriberAttribute]
-typealias BackendCustomerInfoResponseHandler = (CustomerInfo?, Error?) -> Void
+typealias BackendCustomerInfoResponseHandler = (Result<CustomerInfo, Error>) -> Void
 typealias IntroEligibilityResponseHandler = ([String: IntroEligibility], Error?) -> Void
-typealias OfferingsResponseHandler = ([String: Any]?, Error?) -> Void
-typealias OfferSigningResponseHandler = (String?, String?, UUID?, Int?, Error?) -> Void
+typealias OfferingsResponseHandler = (Result<[String: Any], Error>) -> Void
+typealias OfferSigningResponseHandler = (Result<PostOfferForSigningOperation.SigningData, Error>) -> Void
 typealias SimpleResponseHandler = (Error?) -> Void
-typealias LogInResponseHandler = (CustomerInfo?, Bool, Error?) -> Void
+typealias LogInResponseHandler = (Result<(info: CustomerInfo, created: Bool), Error>) -> Void
 
 class Backend {
 

--- a/Purchases/Networking/Caching/CustomerInfoCallback.swift
+++ b/Purchases/Networking/Caching/CustomerInfoCallback.swift
@@ -15,7 +15,7 @@ import Foundation
 
 struct CustomerInfoCallback: CacheKeyProviding {
 
-    typealias Completion = (CustomerInfo?, Error?) -> Void
+    typealias Completion = (Result<CustomerInfo, Error>) -> Void
 
     let cacheKey: String
     let source: NetworkOperation.Type

--- a/Purchases/Networking/Caching/LogInCallback.swift
+++ b/Purchases/Networking/Caching/LogInCallback.swift
@@ -16,6 +16,6 @@ import Foundation
 struct LogInCallback: CacheKeyProviding {
 
     let cacheKey: String
-    let completion: (CustomerInfo?, Bool, Error?) -> Void
+    let completion: (Result<(info: CustomerInfo, created: Bool), Error>) -> Void
 
 }

--- a/Purchases/Networking/Caching/OfferingsCallback.swift
+++ b/Purchases/Networking/Caching/OfferingsCallback.swift
@@ -16,6 +16,6 @@ import Foundation
 struct OfferingsCallback: CacheKeyProviding {
 
     let cacheKey: String
-    let completion: ([String: Any]?, Error?) -> Void
+    let completion: (Result<[String: Any], Error>) -> Void
 
 }

--- a/Purchases/Networking/HTTPClient.swift
+++ b/Purchases/Networking/HTTPClient.swift
@@ -16,7 +16,7 @@ import Foundation
 class HTTPClient {
 
     typealias RequestHeaders = [String: String]
-    typealias Completion = ((_ statusCode: HTTPStatusCode, _ response: [String: Any]?, _ error: Error?) -> Void)
+    typealias Completion = ((_ statusCode: HTTPStatusCode, _ result: Result<[String: Any], Error>) -> Void)
 
     private let session: URLSession
     internal let systemInfo: SystemInfo
@@ -215,7 +215,7 @@ private extension HTTPClient {
         if let httpResponse = httpResponse,
            let completionHandler = request.completionHandler {
             let error = receivedJSONError ?? networkError
-            completionHandler(httpResponse.statusCode, httpResponse.jsonObject, error)
+            completionHandler(httpResponse.statusCode, Result(jsonObject, error))
         }
 
         self.beginNextRequest()
@@ -243,9 +243,10 @@ private extension HTTPClient {
         guard let urlRequest = urlRequest else {
             Logger.error("Could not create request to \(request.path)")
 
-            request.completionHandler?(.invalidRequest,
-                                       nil,
-                                       ErrorUtils.networkError(withUnderlyingError: ErrorUtils.unknownError()))
+            request.completionHandler?(
+                .invalidRequest,
+                .failure(ErrorUtils.networkError(withUnderlyingError: ErrorUtils.unknownError()))
+            )
             return
         }
 

--- a/Purchases/Networking/IntroEligibilityResponse.swift
+++ b/Purchases/Networking/IntroEligibilityResponse.swift
@@ -16,9 +16,8 @@ import Foundation
 // All parameters that are required to process the reponse from a GetIntroEligibility API call.
 struct IntroEligibilityResponse {
 
-    let response: [String: Any]?
+    let result: Result<[String: Any], Error>
     let statusCode: HTTPStatusCode
-    let error: Error?
     let productIdentifiers: [String]
     let unknownEligibilityClosure: () -> [String: IntroEligibility]
     let completion: IntroEligibilityResponseHandler

--- a/Purchases/Networking/Operations/CreateAliasOperation.swift
+++ b/Purchases/Networking/Operations/CreateAliasOperation.swift
@@ -54,16 +54,15 @@ private extension CreateAliasOperation {
         let request = HTTPRequest(method: .post(Body(newAppUserID: newAppUserID)),
                                   path: .createAlias(appUserID: appUserID))
 
-        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
+        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, result in
             self.aliasCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { aliasCallback in
 
                 guard let completion = aliasCallback.completion else {
                     return
                 }
 
-                self.createAliasResponseHandler.handle(response: response,
-                                                       statusCode: statusCode,
-                                                       error: error,
+                self.createAliasResponseHandler.handle(statusCode: statusCode,
+                                                       result: result,
                                                        completion: completion)
             }
 

--- a/Purchases/Networking/Operations/GetCustomerInfoOperation.swift
+++ b/Purchases/Networking/Operations/GetCustomerInfoOperation.swift
@@ -51,7 +51,7 @@ private extension GetCustomerInfoOperation {
     func getCustomerInfo(completion: @escaping () -> Void) {
         guard let appUserID = try? configuration.appUserID.escapedOrError() else {
             self.customerInfoCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
-                callback.completion(nil, ErrorUtils.missingAppUserIDError())
+                callback.completion(.failure(ErrorUtils.missingAppUserIDError()))
             }
             completion()
 
@@ -60,11 +60,10 @@ private extension GetCustomerInfoOperation {
 
         let request = HTTPRequest(method: .get, path: .getCustomerInfo(appUserID: appUserID))
 
-        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
+        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, result in
             self.customerInfoCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
-                self.customerInfoResponseHandler.handle(customerInfoResponse: response,
+                self.customerInfoResponseHandler.handle(customerInfoResponse: result,
                                                         statusCode: statusCode,
-                                                        error: error,
                                                         completion: callback.completion)
             }
 

--- a/Purchases/Networking/Operations/GetIntroEligibilityOperation.swift
+++ b/Purchases/Networking/Operations/GetIntroEligibilityOperation.swift
@@ -86,10 +86,9 @@ private extension GetIntroEligibilityOperation {
                                                      fetchToken: self.receiptData.asFetchToken)),
                                   path: .getIntroEligibility(appUserID: appUserID))
 
-        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
-            let eligibilityResponse = IntroEligibilityResponse(response: response,
+        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, result in
+            let eligibilityResponse = IntroEligibilityResponse(result: result,
                                                                statusCode: statusCode,
-                                                               error: error,
                                                                productIdentifiers: self.productIdentifiers,
                                                                unknownEligibilityClosure: unknownEligibilityClosure,
                                                                completion: self.responseHandler)
@@ -100,8 +99,9 @@ private extension GetIntroEligibilityOperation {
 
     func handleIntroEligibility(response: IntroEligibilityResponse) {
         let result: [String: IntroEligibility] = {
-            var eligibilitiesByProductIdentifier = response.response
-            if !response.statusCode.isSuccessfulResponse || response.error != nil {
+            var eligibilitiesByProductIdentifier = response.result.value
+
+            if !response.statusCode.isSuccessfulResponse || response.result.error != nil {
                 eligibilitiesByProductIdentifier = [:]
             }
 

--- a/Purchases/Networking/Operations/GetOfferingsOperation.swift
+++ b/Purchases/Networking/Operations/GetOfferingsOperation.swift
@@ -54,14 +54,12 @@ private extension GetOfferingsOperation {
             let parsedResponse: Result<[String: Any], Error> = result
                 .mapError { ErrorUtils.networkError(withUnderlyingError: $0) }
                 .flatMap { response in
-                    if statusCode.isSuccessfulResponse {
-                        return .success(response)
-                    } else {
-                        return .failure(
-                            ErrorUtils.backendError(withBackendCode: BackendErrorCode(code: response["code"]),
-                                                    backendMessage: response["message"] as? String)
-                        )
-                    }
+                    return statusCode.isSuccessfulResponse
+                    ? .success(response)
+                    : .failure(
+                        ErrorUtils.backendError(withBackendCode: BackendErrorCode(code: response["code"]),
+                                                backendMessage: response["message"] as? String)
+                    )
                 }
 
             self.offeringsCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callbackObject in

--- a/Purchases/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
+++ b/Purchases/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
@@ -22,71 +22,73 @@ class CustomerInfoResponseHandler {
     }
 
     // swiftlint:disable:next function_body_length
-    func handle(customerInfoResponse response: [String: Any]?,
+    func handle(customerInfoResponse response: Result<[String: Any], Error>,
                 statusCode: HTTPStatusCode,
-                error: Error?,
                 file: String = #fileID,
                 function: String = #function,
                 line: UInt = #line,
                 completion: BackendCustomerInfoResponseHandler) {
-        if let error = error {
-            completion(nil, ErrorUtils.networkError(withUnderlyingError: error,
-                                                    fileName: file, functionName: function, line: line))
-            return
-        }
-        let isErrorStatusCode = !statusCode.isSuccessfulResponse
+        switch response {
+        case let .failure(error):
+            completion(.failure(
+                ErrorUtils.networkError(withUnderlyingError: error,
+                                        fileName: file, functionName: function, line: line)
+            ))
 
-        let customerInfoError: Error?
-        let customerInfo: CustomerInfo?
+        case let .success(response):
+            let isErrorStatusCode = !statusCode.isSuccessfulResponse
 
-        if !isErrorStatusCode {
-            // Only attempt to parse a response if we don't have an error status code from the backend.
-            do {
-                customerInfo = try CustomerInfo.from(json: response)
-                customerInfoError = nil
-            } catch let error {
-                customerInfo = nil
-                customerInfoError = error
+            var result: Result<CustomerInfo, Error> = {
+                // Only attempt to parse a response if we don't have an error status code from the backend.
+                if !isErrorStatusCode {
+                    return Result { try CustomerInfo.from(json: response) }
+                } else {
+                    let finishable = !statusCode.isServerError
+                    let backendErrorCode = BackendErrorCode(code: response["code"])
+                    let message = response["message"] as? String
+
+                    return .failure(
+                        ErrorUtils.backendError(withBackendCode: backendErrorCode,
+                                                backendMessage: message,
+                                                extraUserInfo: [
+                                                    ErrorDetails.finishableKey: finishable
+                                                ])
+                    )
+                }
+            }()
+
+            let subscriberAttributesErrorInfo = self.userInfoAttributeParser
+                .attributesUserInfoFromResponse(response: response, statusCode: statusCode)
+
+            let hasError = (isErrorStatusCode
+                            || subscriberAttributesErrorInfo[Backend.RCAttributeErrorsKey] != nil
+                            || result.error != nil)
+
+            if hasError {
+                result = .failure({
+                    let finishable = !statusCode.isServerError
+                    let extraUserInfo: [String: Any] = subscriberAttributesErrorInfo + [
+                        ErrorDetails.finishableKey as String: finishable
+                    ]
+                    let backendErrorCode = BackendErrorCode(code: response["code"])
+                    let message = response["message"] as? String
+                    let responseError = ErrorUtils.backendError(
+                        withBackendCode: backendErrorCode,
+                        backendMessage: message,
+                        extraUserInfo: extraUserInfo as [NSError.UserInfoKey: Any]
+                    )
+
+                    if !isErrorStatusCode {
+                        return responseError
+                            .addingUnderlyingError(result.error, extraContext: response.stringRepresentation)
+                    } else {
+                        return responseError
+                    }
+                }())
             }
-        } else {
-            customerInfoError = nil
-            customerInfo = nil
+
+            completion(result)
         }
-
-        if !isErrorStatusCode && customerInfo == nil {
-            let extraContext = "statusCode: \(statusCode), json:\(response.debugDescription)"
-            completion(nil, ErrorUtils.unexpectedBackendResponse(withSubError: customerInfoError,
-                                                                 extraContext: extraContext,
-                                                                 fileName: file, functionName: function, line: line))
-            return
-        }
-
-        let subscriberAttributesErrorInfo = self.userInfoAttributeParser
-            .attributesUserInfoFromResponse(response: response ?? [:], statusCode: statusCode)
-
-        let hasError = (isErrorStatusCode
-                        || subscriberAttributesErrorInfo[Backend.RCAttributeErrorsKey] != nil
-                        || customerInfoError != nil)
-
-        guard !hasError else {
-            let finishable = !statusCode.isServerError
-            var extraUserInfo = [ErrorDetails.finishableKey: finishable] as [String: Any]
-            extraUserInfo.merge(subscriberAttributesErrorInfo) { _, new in new }
-            let backendErrorCode = BackendErrorCode(code: response?["code"])
-            let message = response?["message"] as? String
-            var responseError = ErrorUtils.backendError(withBackendCode: backendErrorCode,
-                                                        backendMessage: message,
-                                                        extraUserInfo: extraUserInfo as [NSError.UserInfoKey: Any])
-            if let customerInfoError = customerInfoError {
-                responseError = customerInfoError
-                    .addingUnderlyingError(responseError, extraContext: response?.stringRepresentation)
-            }
-
-            completion(customerInfo, responseError)
-            return
-        }
-
-        completion(customerInfo, nil)
     }
 
 }

--- a/Purchases/Networking/Operations/Handling/SubscriberAttributeHandler.swift
+++ b/Purchases/Networking/Operations/Handling/SubscriberAttributeHandler.swift
@@ -22,28 +22,28 @@ class SubscriberAttributeHandler {
     }
 
     func handleSubscriberAttributesResult(statusCode: HTTPStatusCode,
-                                          response: [String: Any]?,
-                                          error: Error?,
+                                          response: Result<[String: Any], Error>,
                                           completion: SimpleResponseHandler) {
-        if let error = error {
-            completion(ErrorUtils.networkError(withUnderlyingError: error))
-            return
-        }
+        let result: Result<[String: Any], Error> = response
+            .mapError {
+                ErrorUtils.networkError(withUnderlyingError: $0)
+            }
+            .flatMap { response in
+                if !statusCode.isSuccessfulResponse {
+                    let extraUserInfo = self.userInfoAttributeParser
+                        .attributesUserInfoFromResponse(response: response, statusCode: statusCode)
+                    let backendErrorCode = BackendErrorCode(code: response["code"])
+                    return .failure(
+                        ErrorUtils.backendError(withBackendCode: backendErrorCode,
+                                                backendMessage: response["message"] as? String,
+                                                extraUserInfo: extraUserInfo as [NSError.UserInfoKey: Any])
+                    )
+                } else {
+                    return .success(response)
+                }
+            }
 
-        let responseError: Error?
-
-        if let response = response, !statusCode.isSuccessfulResponse {
-            let extraUserInfo = self.userInfoAttributeParser
-                .attributesUserInfoFromResponse(response: response, statusCode: statusCode)
-            let backendErrorCode = BackendErrorCode(code: response["code"])
-            responseError = ErrorUtils.backendError(withBackendCode: backendErrorCode,
-                                                    backendMessage: response["message"] as? String,
-                                                    extraUserInfo: extraUserInfo as [NSError.UserInfoKey: Any])
-        } else {
-            responseError = nil
-        }
-
-        completion(responseError)
+        completion(result.error)
     }
 
 }

--- a/Purchases/Networking/Operations/LogInOperation.swift
+++ b/Purchases/Networking/Operations/LogInOperation.swift
@@ -40,7 +40,7 @@ private extension LogInOperation {
     func logIn(completion: @escaping () -> Void) {
         guard let newAppUserID = try? self.newAppUserID.trimmedOrError() else {
             self.loginCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
-                callback.completion(nil, false, ErrorUtils.missingAppUserIDError())
+                callback.completion(.failure(ErrorUtils.missingAppUserIDError()))
             }
             completion()
 
@@ -51,11 +51,10 @@ private extension LogInOperation {
                                                      newAppUserID: newAppUserID)),
                                   path: .logIn)
 
-        self.httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
+        self.httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, result in
             self.loginCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callbackObject in
-                self.handleLogin(response: response,
+                self.handleLogin(result: result,
                                  statusCode: statusCode,
-                                 error: error,
                                  completion: callbackObject.completion)
             }
 
@@ -63,46 +62,43 @@ private extension LogInOperation {
         }
     }
 
-    func handleLogin(response: [String: Any]?,
+    func handleLogin(result: Result<[String: Any], Error>,
                      statusCode: HTTPStatusCode,
-                     error: Error?,
                      completion: LogInResponseHandler) {
-        let result: (info: CustomerInfo?, cancelled: Bool, error: Error?) = {
-            if let error = error {
-                return (nil, false, ErrorUtils.networkError(withUnderlyingError: error))
+        let result: Result<(info: CustomerInfo, created: Bool), Error> = result
+            .mapError { ErrorUtils.networkError(withUnderlyingError: $0) }
+            .flatMap { response in
+                if !statusCode.isSuccessfulResponse {
+                    let backendCode = BackendErrorCode(code: response["code"])
+                    let backendMessage = response["message"] as? String
+                    let responsError = ErrorUtils.backendError(withBackendCode: backendCode,
+                                                               backendMessage: backendMessage)
+                    return .failure(ErrorUtils.networkError(withUnderlyingError: responsError))
+                }
+
+                do {
+                    let customerInfo = try CustomerInfo.from(json: response)
+                    let created = statusCode == .createdSuccess
+
+                    return .success((customerInfo, created))
+                } catch let customerInfoError {
+                    Logger.error(Strings.backendError.customer_info_instantiation_error(response: response))
+
+                    let extraContext = "statusCode: \(statusCode)"
+                    let subErrorCode = UnexpectedBackendResponseSubErrorCode
+                        .loginResponseDecoding
+                        .addingUnderlyingError(customerInfoError)
+                    let responseError = ErrorUtils.unexpectedBackendResponse(withSubError: subErrorCode,
+                                                                             extraContext: extraContext)
+                    return .failure(responseError)
+                }
             }
 
-            guard let response = response else {
-                let subErrorCode = UnexpectedBackendResponseSubErrorCode.loginMissingResponse
-                let responseError = ErrorUtils.unexpectedBackendResponse(withSubError: subErrorCode)
-                return (nil, false, responseError)
-            }
+        if case .success = result {
+            Logger.user(Strings.identity.login_success)
+        }
 
-            if !statusCode.isSuccessfulResponse {
-                let backendCode = BackendErrorCode(code: response["code"])
-                let backendMessage = response["message"] as? String
-                let responsError = ErrorUtils.backendError(withBackendCode: backendCode, backendMessage: backendMessage)
-                return (nil, false, ErrorUtils.networkError(withUnderlyingError: responsError))
-            }
-
-            do {
-                let customerInfo = try CustomerInfo.from(json: response)
-                let created = statusCode == .createdSuccess
-                Logger.user(Strings.identity.login_success)
-                return (customerInfo, created, nil)
-            } catch let customerInfoError {
-                Logger.error(Strings.backendError.customer_info_instantiation_error(response: response))
-                let extraContext = "statusCode: \(statusCode)"
-                let subErrorCode = UnexpectedBackendResponseSubErrorCode
-                    .loginResponseDecoding
-                    .addingUnderlyingError(customerInfoError)
-                let responseError = ErrorUtils.unexpectedBackendResponse(withSubError: subErrorCode,
-                                                                         extraContext: extraContext)
-                return (nil, false, responseError)
-            }
-        }()
-
-        completion(result.info, result.cancelled, result.error)
+        completion(result)
     }
 }
 

--- a/Purchases/Networking/Operations/LogInOperation.swift
+++ b/Purchases/Networking/Operations/LogInOperation.swift
@@ -71,9 +71,9 @@ private extension LogInOperation {
                 if !statusCode.isSuccessfulResponse {
                     let backendCode = BackendErrorCode(code: response["code"])
                     let backendMessage = response["message"] as? String
-                    let responsError = ErrorUtils.backendError(withBackendCode: backendCode,
-                                                               backendMessage: backendMessage)
-                    return .failure(ErrorUtils.networkError(withUnderlyingError: responsError))
+                    let responseError = ErrorUtils.backendError(withBackendCode: backendCode,
+                                                                backendMessage: backendMessage)
+                    return .failure(ErrorUtils.networkError(withUnderlyingError: responseError))
                 }
 
                 do {

--- a/Purchases/Networking/Operations/PostAttributionDataOperation.swift
+++ b/Purchases/Networking/Operations/PostAttributionDataOperation.swift
@@ -50,7 +50,7 @@ class PostAttributionDataOperation: NetworkOperation {
         let request = HTTPRequest(method: .post(Body(network: self.network, attributionData: self.attributionData)),
                                   path: .postAttributionData(appUserID: appUserID))
 
-        self.httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
+        self.httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, result in
             defer {
                 completion()
             }
@@ -59,9 +59,8 @@ class PostAttributionDataOperation: NetworkOperation {
                 return
             }
 
-            self.postAttributionDataResponseHandler.handle(response: response,
-                                                           statusCode: statusCode,
-                                                           error: error,
+            self.postAttributionDataResponseHandler.handle(statusCode: statusCode,
+                                                           result: result,
                                                            completion: responseHandler)
         }
     }

--- a/Purchases/Networking/Operations/PostOfferForSigningOperation.swift
+++ b/Purchases/Networking/Operations/PostOfferForSigningOperation.swift
@@ -15,6 +15,8 @@ import Foundation
 
 class PostOfferForSigningOperation: NetworkOperation {
 
+    typealias SigningData = (signature: String, keyIdentifier: String, nonce: UUID, timestamp: Int)
+
     struct PostOfferForSigningData {
 
         let offerIdentifier: String
@@ -48,70 +50,66 @@ class PostOfferForSigningOperation: NetworkOperation {
             path: .postOfferForSigning
         )
 
-        self.httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
-            let result: (String?, String?, UUID?, Int?, Error?) = {
-                if let error = error {
-                    return (nil, nil, nil, nil, ErrorUtils.networkError(withUnderlyingError: error))
+        self.httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, result in
+            let result: Result<PostOfferForSigningOperation.SigningData, Error> = result
+                .mapError { ErrorUtils.networkError(withUnderlyingError: $0) }
+                .flatMap { response in
+                    guard statusCode.isSuccessfulResponse else {
+                        let backendCode = BackendErrorCode(code: response["code"])
+                        let backendMessage = response["message"] as? String
+
+                        return .failure(
+                            ErrorUtils.backendError(withBackendCode: backendCode, backendMessage: backendMessage)
+                        )
+                    }
+
+                    guard let offers = response["offers"] as? [[String: Any]] else {
+                        let subErrorCode = UnexpectedBackendResponseSubErrorCode.postOfferIdBadResponse
+                        let error = ErrorUtils.unexpectedBackendResponse(withSubError: subErrorCode,
+                                                                         extraContext: response.stringRepresentation)
+                        Logger.debug(Strings.backendError.offerings_response_json_error(response: response))
+
+                        return .failure(error)
+                    }
+
+                    guard offers.count > 0 else {
+                        let subErrorCode = UnexpectedBackendResponseSubErrorCode.postOfferIdMissingOffersInResponse
+                        let error = ErrorUtils.unexpectedBackendResponse(withSubError: subErrorCode)
+                        Logger.debug(Strings.backendError.no_offerings_response_json(response: response))
+
+                        return .failure(error)
+                    }
+
+                    return Self.handleOffer(offers[0])
                 }
 
-                guard statusCode.isSuccessfulResponse else {
-                    let backendCode = BackendErrorCode(code: response?["code"])
-                    let backendMessage = response?["message"] as? String
-                    let error = ErrorUtils.backendError(withBackendCode: backendCode, backendMessage: backendMessage)
-                    return (nil, nil, nil, nil, error)
-                }
-
-                guard let response = response else {
-                    let subErrorCode = UnexpectedBackendResponseSubErrorCode.postOfferEmptyResponse
-                    let error = ErrorUtils.unexpectedBackendResponse(withSubError: subErrorCode)
-                    Logger.debug(Strings.backendError.offerings_empty_response)
-                    return (nil, nil, nil, nil, error)
-                }
-
-                guard let offers = response["offers"] as? [[String: Any]] else {
-                    let subErrorCode = UnexpectedBackendResponseSubErrorCode.postOfferIdBadResponse
-                    let error = ErrorUtils.unexpectedBackendResponse(withSubError: subErrorCode,
-                                                                     extraContext: response.stringRepresentation)
-                    Logger.debug(Strings.backendError.offerings_response_json_error(response: response))
-                    return (nil, nil, nil, nil, error)
-                }
-
-                guard offers.count > 0 else {
-                    let subErrorCode = UnexpectedBackendResponseSubErrorCode.postOfferIdMissingOffersInResponse
-                    let error = ErrorUtils.unexpectedBackendResponse(withSubError: subErrorCode)
-                    Logger.debug(Strings.backendError.no_offerings_response_json(response: response))
-                    return (nil, nil, nil, nil, error)
-                }
-
-                return Self.handleOffer(offers[0])
-            }()
-
-            self.responseHandler(result.0, result.1, result.2, result.3, result.4)
+            self.responseHandler(result)
             completion()
         }
     }
 
-    // swiftlint:disable:next large_tuple
-    private static func handleOffer(_ offer: [String: Any]) -> (String?, String?, UUID?, Int?, Error?) {
+    private static func handleOffer(_ offer: [String: Any]) -> Result<PostOfferForSigningOperation.SigningData, Error> {
         if let signatureError = offer["signature_error"] as? [String: Any] {
             let backendCode = BackendErrorCode(code: signatureError["code"])
             let backendMessage = signatureError["message"] as? String
             let error = ErrorUtils.backendError(withBackendCode: backendCode, backendMessage: backendMessage)
-            return (nil, nil, nil, nil, error)
 
-        } else if let signatureData = offer["signature_data"] as? [String: Any] {
-            let signature = signatureData["signature"] as? String
-            let keyIdentifier = offer["key_id"] as? String
-            let nonceString = signatureData["nonce"] as? String
-            let nonce = nonceString.flatMap { UUID(uuidString: $0) }
-            let timestamp = signatureData["timestamp"] as? Int
-
-            return (signature, keyIdentifier, nonce, timestamp, nil)
+            return .failure(error)
+        } else if let signatureData = offer["signature_data"] as? [String: Any],
+                  let signature = signatureData["signature"] as? String,
+                  let keyIdentifier = offer["key_id"] as? String,
+                  let nonce = (signatureData["nonce"] as? String).flatMap({ UUID(uuidString: $0) }),
+                  let timestamp = signatureData["timestamp"] as? Int {
+            return .success((signature, keyIdentifier, nonce, timestamp))
         } else {
             Logger.error(Strings.backendError.signature_error(signatureDataString: offer["signature_data"]))
             let subErrorCode = UnexpectedBackendResponseSubErrorCode.postOfferIdSignature
-            let signatureError = ErrorUtils.unexpectedBackendResponse(withSubError: subErrorCode)
-            return (nil, nil, nil, nil, signatureError)
+            let signatureError = ErrorUtils.unexpectedBackendResponseError(extraUserInfo: [
+                "response": offer
+            ])
+                .addingUnderlyingError(subErrorCode)
+
+            return .failure(signatureError)
         }
     }
 

--- a/Purchases/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Purchases/Networking/Operations/PostReceiptDataOperation.swift
@@ -60,11 +60,10 @@ class PostReceiptDataOperation: CacheableNetworkOperation {
         let request = HTTPRequest(method: .post(self.postData),
                                   path: .postReceiptData)
 
-        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
+        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, result in
             self.customerInfoCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callbackObject in
-                self.customerInfoResponseHandler.handle(customerInfoResponse: response,
+                self.customerInfoResponseHandler.handle(customerInfoResponse: result,
                                                         statusCode: statusCode,
-                                                        error: error,
                                                         completion: callbackObject.completion)
             }
 

--- a/Purchases/Networking/Operations/PostSubscriberAttributesOperation.swift
+++ b/Purchases/Networking/Operations/PostSubscriberAttributesOperation.swift
@@ -55,7 +55,7 @@ class PostSubscriberAttributesOperation: NetworkOperation {
         let request = HTTPRequest(method: .post(Body(self.subscriberAttributes)),
                                   path: .postSubscriberAttributes(appUserID: appUserID))
 
-        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, response, error in
+        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, result in
             defer {
                 completion()
             }
@@ -65,8 +65,7 @@ class PostSubscriberAttributesOperation: NetworkOperation {
             }
 
             self.subscriberAttributeHandler.handleSubscriberAttributesResult(statusCode: statusCode,
-                                                                             response: response,
-                                                                             error: error,
+                                                                             response: result,
                                                                              completion: responseHandler)
         }
     }

--- a/Purchases/Purchasing/OfferingsManager.swift
+++ b/Purchases/Purchasing/OfferingsManager.swift
@@ -71,14 +71,14 @@ class OfferingsManager {
     func updateOfferingsCache(appUserID: String, isAppBackgrounded: Bool, completion: ((Offerings?, Error?) -> Void)?) {
         deviceCache.setOfferingsCacheTimestampToNow()
         operationDispatcher.dispatchOnWorkerThread(withRandomDelay: isAppBackgrounded) {
-            self.backend.getOfferings(appUserID: appUserID) { data, error in
-                if let data = data {
+            self.backend.getOfferings(appUserID: appUserID) { result in
+                switch result {
+                case let .success(data):
                     self.handleOfferingsBackendResult(with: data, completion: completion)
-                    return
-                }
 
-                let error = error ?? ErrorUtils.unexpectedBackendResponseError()
-                self.handleOfferingsUpdateError(error, completion: completion)
+                case let .failure(error):
+                    self.handleOfferingsUpdateError(error, completion: completion)
+                }
             }
         }
     }

--- a/Purchases/Purchasing/PurchasesOrchestrator.swift
+++ b/Purchases/Purchasing/PurchasesOrchestrator.swift
@@ -630,8 +630,7 @@ private extension PurchasesOrchestrator {
         let currentAppUserID = appUserID
         let unsyncedAttributes = unsyncedAttributes
         // Refresh the receipt and post to backend, this will allow the transactions to be transferred.
-        // swiftlint:disable:next line_length
-        // https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/StoreKitGuide/Chapters/Restoring.html
+        // https://rev.cat/apple-restoring-purchased-products
         receiptFetcher.receiptData(refreshPolicy: receiptRefreshPolicy) { receiptData in
             guard let receiptData = receiptData,
                   !receiptData.isEmpty else {

--- a/PurchasesTests/Mocks/MockCustomerInfoManager.swift
+++ b/PurchasesTests/Mocks/MockCustomerInfoManager.swift
@@ -14,14 +14,14 @@ class MockCustomerInfoManager: CustomerInfoManager {
 
     var invokedFetchAndCacheCustomerInfo = false
     var invokedFetchAndCacheCustomerInfoCount = 0
-    var invokedFetchAndCacheCustomerInfoParameters: (appUserID: String, isAppBackgrounded: Bool, completion: ((CustomerInfo?, Error?) -> Void)?)?
+    var invokedFetchAndCacheCustomerInfoParameters: (appUserID: String, isAppBackgrounded: Bool, completion: ((Result<CustomerInfo, Error>) -> Void)?)?
     var invokedFetchAndCacheCustomerInfoParametersList = [(appUserID: String,
                                                            isAppBackgrounded: Bool,
-                                                           completion: ((CustomerInfo?, Error?) -> Void)?)]()
+                                                           completion: ((Result<CustomerInfo, Error>) -> Void)?)]()
 
     override func fetchAndCacheCustomerInfo(appUserID: String,
                                             isAppBackgrounded: Bool,
-                                            completion: ((CustomerInfo?, Error?) -> Void)?) {
+                                            completion: ((Result<CustomerInfo, Error>) -> Void)?) {
         invokedFetchAndCacheCustomerInfo = true
         invokedFetchAndCacheCustomerInfoCount += 1
         invokedFetchAndCacheCustomerInfoParameters = (appUserID, isAppBackgrounded, completion)
@@ -30,14 +30,14 @@ class MockCustomerInfoManager: CustomerInfoManager {
 
     var invokedFetchAndCacheCustomerInfoIfStale = false
     var invokedFetchAndCacheCustomerInfoIfStaleCount = 0
-    var invokedFetchAndCacheCustomerInfoIfStaleParameters: (appUserID: String, isAppBackgrounded: Bool, completion: ((CustomerInfo?, Error?) -> Void)?)?
+    var invokedFetchAndCacheCustomerInfoIfStaleParameters: (appUserID: String, isAppBackgrounded: Bool, completion: ((Result<CustomerInfo, Error>) -> Void)?)?
     var invokedFetchAndCacheCustomerInfoIfStaleParametersList = [(appUserID: String,
                                                                   isAppBackgrounded: Bool,
-                                                                  completion: ((CustomerInfo?, Error?) -> Void)?)]()
+                                                                  completion: ((Result<CustomerInfo, Error>) -> Void)?)]()
 
     override func fetchAndCacheCustomerInfoIfStale(appUserID: String,
                                                    isAppBackgrounded: Bool,
-                                                   completion: ((CustomerInfo?, Error?) -> Void)?) {
+                                                   completion: ((Result<CustomerInfo, Error>) -> Void)?) {
         invokedFetchAndCacheCustomerInfoIfStale = true
         invokedFetchAndCacheCustomerInfoIfStaleCount += 1
         invokedFetchAndCacheCustomerInfoIfStaleParameters = (appUserID, isAppBackgrounded, completion)
@@ -58,19 +58,18 @@ class MockCustomerInfoManager: CustomerInfoManager {
 
     var invokedCustomerInfo = false
     var invokedCustomerInfoCount = 0
-    var invokedCustomerInfoParameters: (appUserID: String, completion: ((CustomerInfo?, Error?) -> Void)?)?
-    var invokedCustomerInfoParametersList = [(appUserID: String, completion: ((CustomerInfo?, Error?) -> Void)?)]()
+    var invokedCustomerInfoParameters: (appUserID: String, completion: ((Result<CustomerInfo, Error>) -> Void)?)?
+    var invokedCustomerInfoParametersList = [(appUserID: String, completion: ((Result<CustomerInfo, Error>) -> Void)?)]()
 
-    var stubbedCustomerInfo: CustomerInfo?
-    var stubbedError: Error?
+    var stubbedCustomerInfoResult: Result<CustomerInfo, Error> = .failure(ErrorCode.unknownError)
 
     override func customerInfo(appUserID: String,
-                               completion: ((CustomerInfo?, Error?) -> Void)?) {
+                               completion: ((Result<CustomerInfo, Error>) -> Void)?) {
         invokedCustomerInfo = true
         invokedCustomerInfoCount += 1
         invokedCustomerInfoParameters = (appUserID, completion)
         invokedCustomerInfoParametersList.append((appUserID, completion))
-        completion?(stubbedCustomerInfo, stubbedError)
+        completion?(self.stubbedCustomerInfoResult)
     }
 
     var invokedCachedCustomerInfo = false

--- a/PurchasesTests/Mocks/MockHTTPClient.swift
+++ b/PurchasesTests/Mocks/MockHTTPClient.swift
@@ -16,13 +16,21 @@ class MockHTTPClient: HTTPClient {
     struct Response {
 
         let statusCode: HTTPStatusCode
-        let response: [String: Any]?
-        let error: Error?
+        let response: Result<[String: Any], Error>
 
-        init(statusCode: HTTPStatusCode, response: [String: Any]?, error: Error? = nil) {
+        init(statusCode: HTTPStatusCode, response: Result<[String: Any], Error>) {
             self.statusCode = statusCode
             self.response = response
-            self.error = error
+        }
+
+        init(statusCode: HTTPStatusCode, response: [String: Any] = [:]) {
+            self.init(statusCode: statusCode,
+                      response: .success(response))
+        }
+
+        init(statusCode: HTTPStatusCode, error: Error) {
+            self.init(statusCode: statusCode,
+                      response: .failure(error))
         }
 
     }
@@ -61,8 +69,7 @@ class MockHTTPClient: HTTPClient {
             let response = self.mocks[request.path]
 
             completionHandler?(response?.statusCode ?? .success,
-                               response?.response ?? [:],
-                               response?.error)
+                               response?.response ?? .success([:]))
         }
     }
 

--- a/PurchasesTests/Networking/Backend/BackendCreateAliasTests.swift
+++ b/PurchasesTests/Networking/Backend/BackendCreateAliasTests.swift
@@ -27,7 +27,7 @@ class BackendCreateAliasTests: BaseBackendTests {
         var completionCalled = false
 
         let path: HTTPRequest.Path = .createAlias(appUserID: Self.userID)
-        let response = MockHTTPClient.Response(statusCode: .success, response: nil)
+        let response = MockHTTPClient.Response(statusCode: .success)
 
         self.httpClient.mock(requestPath: path, response: response)
 
@@ -42,7 +42,7 @@ class BackendCreateAliasTests: BaseBackendTests {
     func testCreateAliasCachesForSameUserIDs() {
         self.httpClient.mock(
             requestPath: .createAlias(appUserID: Self.userID),
-            response: .init(statusCode: .success, response: nil)
+            response: .init(statusCode: .success)
         )
 
         backend.createAlias(appUserID: Self.userID, newAppUserID: "new_alias") { _ in }
@@ -54,7 +54,7 @@ class BackendCreateAliasTests: BaseBackendTests {
     func testCreateAliasDoesntCacheForDifferentNewUserID() {
         self.httpClient.mock(
             requestPath: .createAlias(appUserID: Self.userID),
-            response: .init(statusCode: .success, response: nil)
+            response: .init(statusCode: .success)
         )
 
         backend.createAlias(appUserID: Self.userID, newAppUserID: "new_alias") { _ in }
@@ -66,7 +66,7 @@ class BackendCreateAliasTests: BaseBackendTests {
     func testCreateAliasCachesWhenCallbackNil() {
         self.httpClient.mock(
             requestPath: .createAlias(appUserID: Self.userID),
-            response: .init(statusCode: .success, response: nil)
+            response: .init(statusCode: .success)
         )
 
         backend.createAlias(appUserID: Self.userID, newAppUserID: "new_alias") { _ in }
@@ -78,7 +78,7 @@ class BackendCreateAliasTests: BaseBackendTests {
     func testCreateAliasCallsAllCompletionBlocksInCache() {
         self.httpClient.mock(
             requestPath: .createAlias(appUserID: Self.userID),
-            response: .init(statusCode: .success, response: nil)
+            response: .init(statusCode: .success)
         )
 
         var completion1Called = false
@@ -102,7 +102,7 @@ class BackendCreateAliasTests: BaseBackendTests {
         let currentAppUserID1 = Self.userID
         let currentAppUserID2 = Self.userID + "2"
 
-        let response = MockHTTPClient.Response(statusCode: .success, response: nil)
+        let response = MockHTTPClient.Response(statusCode: .success)
 
         httpClient.mock(requestPath: .createAlias(appUserID: currentAppUserID1), response: response)
         backend.createAlias(appUserID: currentAppUserID1, newAppUserID: newAppUserID) { _ in }
@@ -117,8 +117,7 @@ class BackendCreateAliasTests: BaseBackendTests {
         self.httpClient.mock(
             requestPath: .createAlias(appUserID: Self.userID),
             response: .init(statusCode: .success,
-                            response: nil,
-                            error: NSError(domain: NSURLErrorDomain, code: -1009))
+                            response: .failure(NSError(domain: NSURLErrorDomain, code: -1009)))
         )
 
         var receivedError: NSError?

--- a/PurchasesTests/Networking/Backend/BackendGetCustomerInfoTests.swift
+++ b/PurchasesTests/Networking/Backend/BackendGetCustomerInfoTests.swift
@@ -29,8 +29,8 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
             response: .init(statusCode: .success, response: Self.validCustomerResponse)
         )
 
-        backend.getCustomerInfo(appUserID: Self.userID) { _, _ in }
-        backend.getCustomerInfo(appUserID: Self.userID) { _, _ in }
+        backend.getCustomerInfo(appUserID: Self.userID) { _ in }
+        backend.getCustomerInfo(appUserID: Self.userID) { _ in }
 
         expect(self.httpClient.calls).toEventually(haveCount(1))
     }
@@ -41,8 +41,8 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         httpClient.mock(requestPath: .getCustomerInfo(appUserID: Self.userID), response: response)
         httpClient.mock(requestPath: .getCustomerInfo(appUserID: userID2), response: response)
 
-        backend.getCustomerInfo(appUserID: Self.userID) { _, _ in }
-        backend.getCustomerInfo(appUserID: userID2) { _, _ in }
+        backend.getCustomerInfo(appUserID: Self.userID) { _ in }
+        backend.getCustomerInfo(appUserID: userID2) { _ in }
 
         expect(self.httpClient.calls).toEventually(haveCount(2))
     }
@@ -53,7 +53,7 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
 
         self.httpClient.mock(requestPath: path, response: response)
 
-        backend.getCustomerInfo(appUserID: Self.userID) { _, _ in }
+        backend.getCustomerInfo(appUserID: Self.userID) { _ in }
         expect(self.httpClient.calls).toEventually(haveCount(1))
     }
 
@@ -63,13 +63,14 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
             response: .init(statusCode: .success, response: Self.validCustomerResponse)
         )
 
-        var customerInfo: CustomerInfo?
+        var customerInfo: Result<CustomerInfo, Error>?
 
-        backend.getCustomerInfo(appUserID: Self.userID) { (info, _) in
-            customerInfo = info
+        backend.getCustomerInfo(appUserID: Self.userID) { result in
+            customerInfo = result
         }
 
         expect(customerInfo).toEventuallyNot(beNil())
+        expect(customerInfo?.value).toNot(beNil())
     }
 
     func testEncodesCustomerUserID() {
@@ -79,35 +80,39 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
 
         httpClient.mock(requestPath: .getCustomerInfo(appUserID: encodedUserID), response: response)
         httpClient.mock(requestPath: .getCustomerInfo(appUserID: encodeableUserID),
-                        response: .init(statusCode: .notFoundError, response: nil))
+                        response: .init(statusCode: .notFoundError,
+                                        error: ErrorUtils.networkError(withUnderlyingError: ErrorUtils.unknownError())))
 
-        var customerInfo: CustomerInfo?
+        var customerInfo: Result<CustomerInfo, Error>?
 
-        backend.getCustomerInfo(appUserID: encodeableUserID) { (info, _) in
-            customerInfo = info
+        backend.getCustomerInfo(appUserID: encodeableUserID) { result in
+            customerInfo = result
         }
 
         expect(customerInfo).toEventuallyNot(beNil())
+        expect(customerInfo?.value).toNot(beNil())
     }
 
-    func testHandlesGetCustomerInfoErrors() {
+    func testHandlesGetCustomerInfoErrors() throws {
         self.httpClient.mock(
             requestPath: .getCustomerInfo(appUserID: Self.userID),
-            response: .init(statusCode: .notFoundError, response: nil)
+            response: .init(statusCode: .notFoundError, response: [:])
         )
 
-        var error: NSError?
+        var result: Result<CustomerInfo, NSError>?
 
-        backend.getCustomerInfo(appUserID: Self.userID) { (_, newError) in
-            error = newError as NSError?
+        backend.getCustomerInfo(appUserID: Self.userID) {
+            result = $0.mapError { $0 as NSError }
         }
 
-        expect(error).toEventuallyNot(beNil())
-        expect(error?.domain).to(equal(RCPurchasesErrorCodeDomain))
-        let underlyingError = (error?.userInfo[NSUnderlyingErrorKey]) as? NSError
-        expect(underlyingError).toEventuallyNot(beNil())
-        expect(underlyingError?.domain).to(equal("RevenueCat.BackendErrorCode"))
-        expect(error?.userInfo["finishable"] as? Bool) == true
+        expect(result).toEventuallyNot(beNil())
+
+        let error = try XCTUnwrap(result?.error)
+        expect(error.domain) == RCPurchasesErrorCodeDomain
+        expect(error.userInfo["finishable"] as? Bool) == true
+
+        let underlyingError = try XCTUnwrap(error.userInfo[NSUnderlyingErrorKey] as? NSError)
+        expect(underlyingError.domain) == "RevenueCat.BackendErrorCode"
     }
 
     func testHandlesInvalidJSON() {
@@ -116,15 +121,15 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
             response: .init(statusCode: .success, response: ["sjkaljdklsjadkjs": ""])
         )
 
-        var error: NSError?
+        var result: Result<CustomerInfo, NSError>?
 
-        backend.getCustomerInfo(appUserID: Self.userID) { (_, newError) in
-            error = newError as NSError?
+        backend.getCustomerInfo(appUserID: Self.userID) {
+            result = $0.mapError { $0 as NSError }
         }
 
-        expect(error).toEventuallyNot(beNil())
-        expect(error?.domain).to(equal(RCPurchasesErrorCodeDomain))
-        expect(error?.code).to(equal(ErrorCode.unexpectedBackendResponseError.rawValue))
+        expect(result).toEventuallyNot(beNil())
+        expect(result?.error?.domain) == RCPurchasesErrorCodeDomain
+        expect(result?.error?.code) == ErrorCode.unknownBackendError.rawValue
     }
 
     func testGetCustomerInfoDoesNotMakeTwoRequests() {
@@ -140,19 +145,20 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         let customerInfoResponse = MockHTTPClient.Response(statusCode: .success, response: customerResponse)
         httpClient.mock(requestPath: path, response: customerInfoResponse)
 
-        var firstCustomerInfo: CustomerInfo?
-        var secondCustomerInfo: CustomerInfo?
+        var firstResult: Result<CustomerInfo, Error>?
+        var secondResult: Result<CustomerInfo, Error>?
 
-        backend.getCustomerInfo(appUserID: Self.userID, completion: { (customerInfo, _) in
-            firstCustomerInfo = customerInfo
-        })
+        backend.getCustomerInfo(appUserID: Self.userID) {
+            firstResult = $0
+        }
 
-        backend.getCustomerInfo(appUserID: Self.userID, completion: { (customerInfo, _) in
-            secondCustomerInfo = customerInfo
-        })
+        backend.getCustomerInfo(appUserID: Self.userID) {
+            secondResult = $0
+        }
 
-        expect(firstCustomerInfo).toEventuallyNot(beNil())
-        expect(secondCustomerInfo) == firstCustomerInfo
+        expect(firstResult).toEventuallyNot(beNil())
+        expect(firstResult?.value).toNot(beNil())
+        expect(secondResult?.value) == firstResult?.value
 
         expect(self.httpClient.calls.map { $0.request.path }) == [path]
     }

--- a/PurchasesTests/Networking/Backend/BackendGetIntroEligibilityTests.swift
+++ b/PurchasesTests/Networking/Backend/BackendGetIntroEligibilityTests.swift
@@ -91,7 +91,8 @@ class BackendGetIntroEligibilityTests: BaseBackendTests {
         // Set us up for a 404 because if the input sanitizing code fails, it will execute and we'd get a 404.
         self.httpClient.mock(
             requestPath: .getIntroEligibility(appUserID: ""),
-            response: .init(statusCode: .notFoundError, response: nil)
+            response: .init(statusCode: .notFoundError,
+                            error: ErrorUtils.networkError(withUnderlyingError: ErrorUtils.unknownError()))
         )
 
         var eligibility: [String: IntroEligibility]?
@@ -138,7 +139,7 @@ class BackendGetIntroEligibilityTests: BaseBackendTests {
         let error = NSError(domain: "myhouse", code: 12, userInfo: nil) as Error
         self.httpClient.mock(
             requestPath: .getIntroEligibility(appUserID: Self.userID),
-            response: .init(statusCode: .success, response: Self.serverErrorResponse, error: error)
+            response: .init(statusCode: .success, response: .failure(error))
         )
 
         var eligibility: [String: IntroEligibility]?

--- a/PurchasesTests/Networking/Backend/BackendLoginTests.swift
+++ b/PurchasesTests/Networking/Backend/BackendLoginTests.swift
@@ -30,7 +30,7 @@ class BackendLoginTests: BaseBackendTests {
         var completionCalled = false
 
         backend.logIn(currentAppUserID: currentAppUserID,
-                      newAppUserID: newAppUserID) { _, _, _ in
+                      newAppUserID: newAppUserID) { _ in
             completionCalled = true
         }
 
@@ -43,27 +43,19 @@ class BackendLoginTests: BaseBackendTests {
         let errorCode = 123465
         let stubbedError = NSError(domain: RCPurchasesErrorCodeDomain, code: errorCode, userInfo: [:])
         let currentAppUserID = "old id"
-        _ = mockLoginRequest(appUserID: currentAppUserID, error: stubbedError)
+        _ = mockLoginRequest(appUserID: currentAppUserID, response: .failure(stubbedError))
 
-        var completionCalled = false
-        var receivedError: Error?
-        var receivedCustomerInfo: CustomerInfo?
-        var receivedCreated: Bool?
+        var receivedResult: Result<(info: CustomerInfo, created: Bool), Error>?
 
         backend.logIn(currentAppUserID: currentAppUserID,
-                      newAppUserID: newAppUserID) { customerInfo, created, error in
-            completionCalled = true
-            receivedError = error
-            receivedCustomerInfo = customerInfo
-            receivedCreated = created
+                      newAppUserID: newAppUserID) { result in
+            receivedResult = result
         }
 
-        expect(completionCalled).toEventually(beTrue())
-        expect(receivedCreated) == false
-        expect(receivedCustomerInfo).to(beNil())
+        expect(receivedResult).toEventuallyNot(beNil())
+        expect(receivedResult?.value).to(beNil())
 
-        expect(receivedError).toNot(beNil())
-        let receivedNSError = receivedError! as NSError
+        let receivedNSError = try XCTUnwrap(receivedResult?.error as NSError?)
         expect(receivedNSError.code) == ErrorCode.networkError.rawValue
         let expectedUserInfoError = try XCTUnwrap(receivedNSError.userInfo[NSUnderlyingErrorKey] as? NSError)
         expect(expectedUserInfoError) == stubbedError
@@ -77,60 +69,44 @@ class BackendLoginTests: BaseBackendTests {
                                    code: errorCode,
                                    userInfo: [:])
         let currentAppUserID = "old id"
-        _ = self.mockLoginRequest(appUserID: currentAppUserID, error: stubbedError)
+        _ = self.mockLoginRequest(appUserID: currentAppUserID, response: .failure(stubbedError))
 
-        var completionCalled = false
-        var receivedError: Error?
-        var receivedCustomerInfo: CustomerInfo?
-        var receivedCreated: Bool?
+        var receivedResult: Result<(info: CustomerInfo, created: Bool), Error>?
 
         backend.logIn(currentAppUserID: currentAppUserID,
-                      newAppUserID: newAppUserID) { customerInfo, created, error in
-            completionCalled = true
-            receivedError = error
-            receivedCustomerInfo = customerInfo
-            receivedCreated = created
+                      newAppUserID: newAppUserID) { result in
+            receivedResult = result
         }
 
-        expect(completionCalled).toEventually(beTrue())
-        expect(receivedCreated) == false
-        expect(receivedCustomerInfo).to(beNil())
+        expect(receivedResult).toEventuallyNot(beNil())
+        expect(receivedResult?.value).to(beNil())
 
-        expect(receivedError).toNot(beNil())
-        let receivedNSError = receivedError! as NSError
+        let receivedNSError = try XCTUnwrap(receivedResult?.error as NSError?)
         expect(receivedNSError.code) == ErrorCode.networkError.rawValue
         let expectedUserInfoError = try XCTUnwrap(receivedNSError.userInfo[NSUnderlyingErrorKey] as? NSError)
         expect(expectedUserInfoError) == stubbedError
     }
 
-    func testLoginConsidersErrorStatusCodesAsErrors() {
+    func testLoginConsidersErrorStatusCodesAsErrors() throws {
         let newAppUserID = "new id"
         let currentAppUserID = "old id"
         let underlyingErrorMessage = "header fields too large"
         let underlyingErrorCode = BackendErrorCode.cannotTransferPurchase.rawValue
         _ = self.mockLoginRequest(appUserID: currentAppUserID,
                                   statusCode: 431,
-                                  response: ["code": underlyingErrorCode, "message": underlyingErrorMessage])
+                                  response: .success(["code": underlyingErrorCode, "message": underlyingErrorMessage]))
 
-        var completionCalled = false
-        var receivedError: Error?
-        var receivedCustomerInfo: CustomerInfo?
-        var receivedCreated: Bool?
+        var receivedResult: Result<(info: CustomerInfo, created: Bool), Error>?
 
         backend.logIn(currentAppUserID: currentAppUserID,
-                      newAppUserID: newAppUserID) { customerInfo, created, error in
-            completionCalled = true
-            receivedError = error
-            receivedCustomerInfo = customerInfo
-            receivedCreated = created
+                      newAppUserID: newAppUserID) { result in
+            receivedResult = result
         }
 
-        expect(completionCalled).toEventually(beTrue())
-        expect(receivedCreated) == false
-        expect(receivedCustomerInfo).to(beNil())
+        expect(receivedResult).toEventuallyNot(beNil())
+        expect(receivedResult?.value).to(beNil())
 
-        expect(receivedError).toNot(beNil())
-        let receivedNSError = receivedError! as NSError
+        let receivedNSError = try XCTUnwrap(receivedResult?.error as NSError?)
         expect(receivedNSError.code) == ErrorCode.networkError.rawValue
 
         // custom errors get wrapped in a backendError
@@ -141,87 +117,65 @@ class BackendLoginTests: BaseBackendTests {
         expect(underlyingError?.localizedDescription) == underlyingErrorMessage
     }
 
-    func testLoginCallsCompletionWithErrorIfCustomerInfoNil() {
+    func testLoginCallsCompletionWithErrorIfCustomerInfoNil() throws {
         let newAppUserID = "new id"
 
         let currentAppUserID = "old id"
-        _ = self.mockLoginRequest(appUserID: currentAppUserID, statusCode: .createdSuccess, response: [:])
+        _ = self.mockLoginRequest(appUserID: currentAppUserID, statusCode: .createdSuccess)
 
-        var completionCalled = false
-        var receivedError: Error?
-        var receivedCustomerInfo: CustomerInfo?
-        var receivedCreated: Bool?
+        var receivedResult: Result<(info: CustomerInfo, created: Bool), Error>?
 
         backend.logIn(currentAppUserID: currentAppUserID,
-                      newAppUserID: newAppUserID) { customerInfo, created, error in
-            completionCalled = true
-            receivedError = error
-            receivedCustomerInfo = customerInfo
-            receivedCreated = created
+                      newAppUserID: newAppUserID) { result in
+            receivedResult = result
         }
 
-        expect(completionCalled).toEventually(beTrue())
-        expect(receivedCreated) == false
-        expect(receivedCustomerInfo).to(beNil())
+        expect(receivedResult).toEventuallyNot(beNil())
+        expect(receivedResult?.value).to(beNil())
 
-        expect(receivedError).toNot(beNil())
-        let receivedNSError = receivedError! as NSError
+        let receivedNSError = try XCTUnwrap(receivedResult?.error as NSError?)
         expect(receivedNSError.code) == ErrorCode.unexpectedBackendResponseError.rawValue
     }
 
-    func testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201() {
+    func testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201() throws {
         let newAppUserID = "new id"
 
         let currentAppUserID = "old id"
         _ = self.mockLoginRequest(appUserID: currentAppUserID,
                                   statusCode: .createdSuccess,
-                                  response: Self.mockCustomerInfoData)
+                                  response: .success(Self.mockCustomerInfoData))
 
-        var completionCalled = false
-        var receivedError: Error?
-        var receivedCustomerInfo: CustomerInfo?
-        var receivedCreated: Bool?
+        var receivedResult: Result<(info: CustomerInfo, created: Bool), Error>?
 
         backend.logIn(currentAppUserID: currentAppUserID,
-                      newAppUserID: newAppUserID) { customerInfo, created, error in
-            completionCalled = true
-            receivedError = error
-            receivedCustomerInfo = customerInfo
-            receivedCreated = created
+                      newAppUserID: newAppUserID) { result in
+            receivedResult = result
         }
 
-        expect(completionCalled).toEventually(beTrue())
-        expect(receivedCreated) == true
-        expect(receivedCustomerInfo) == CustomerInfo(testData: Self.mockCustomerInfoData)
-        expect(receivedError).to(beNil())
+        expect(receivedResult).toEventuallyNot(beNil())
+        expect(receivedResult?.value?.created) == true
+        expect(receivedResult?.value?.info) == CustomerInfo(testData: Self.mockCustomerInfoData)
     }
 
-    func testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200() {
+    func testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200() throws {
         let newAppUserID = "new id"
 
         let currentAppUserID = "old id"
         _ = self.mockLoginRequest(appUserID: currentAppUserID,
                                   statusCode: .success,
-                                  response: Self.mockCustomerInfoData)
+                                  response: .success(Self.mockCustomerInfoData))
 
-        var completionCalled = false
-        var receivedError: Error?
-        var receivedCustomerInfo: CustomerInfo?
-        var receivedCreated: Bool?
+        var receivedResult: Result<(info: CustomerInfo, created: Bool), Error>?
 
         backend.logIn(currentAppUserID: currentAppUserID,
-                      newAppUserID: newAppUserID) { customerInfo, created, error in
-            completionCalled = true
-            receivedError = error
-            receivedCustomerInfo = customerInfo
-            receivedCreated = created
+                      newAppUserID: newAppUserID) { result in
+            receivedResult = result
         }
 
-        expect(completionCalled).toEventually(beTrue())
+        expect(receivedResult).toEventuallyNot(beNil())
 
-        expect(receivedCreated) == false
-        expect(receivedCustomerInfo) == CustomerInfo(testData: Self.mockCustomerInfoData)
-        expect(receivedError).to(beNil())
+        expect(receivedResult?.value?.created) == false
+        expect(receivedResult?.value?.info) == CustomerInfo(testData: Self.mockCustomerInfoData)
     }
 
     func testLoginCachesForSameUserIDs() {
@@ -230,12 +184,12 @@ class BackendLoginTests: BaseBackendTests {
         let currentAppUserID = "old id"
         _ = self.mockLoginRequest(appUserID: currentAppUserID,
                                   statusCode: .createdSuccess,
-                                  response: Self.mockCustomerInfoData)
+                                  response: .success(Self.mockCustomerInfoData))
 
         backend.logIn(currentAppUserID: currentAppUserID,
-                      newAppUserID: newAppUserID) { _, _, _  in }
+                      newAppUserID: newAppUserID) { _  in }
         backend.logIn(currentAppUserID: currentAppUserID,
-                      newAppUserID: newAppUserID) { _, _, _  in }
+                      newAppUserID: newAppUserID) { _  in }
 
         expect(self.httpClient.calls).toEventually(haveCount(1))
     }
@@ -247,12 +201,12 @@ class BackendLoginTests: BaseBackendTests {
         let currentAppUserID = "old id"
         _ = self.mockLoginRequest(appUserID: currentAppUserID,
                                   statusCode: .createdSuccess,
-                                  response: Self.mockCustomerInfoData)
+                                  response: .success(Self.mockCustomerInfoData))
 
         backend.logIn(currentAppUserID: currentAppUserID,
-                      newAppUserID: newAppUserID) { _, _, _  in }
+                      newAppUserID: newAppUserID) { _ in }
         backend.logIn(currentAppUserID: currentAppUserID,
-                      newAppUserID: secondNewAppUserID) { _, _, _  in }
+                      newAppUserID: secondNewAppUserID) { _ in }
 
         expect(self.httpClient.calls).toEventually(haveCount(2))
     }
@@ -264,12 +218,12 @@ class BackendLoginTests: BaseBackendTests {
         let currentAppUserID2 = "old id 2"
         _ = self.mockLoginRequest(appUserID: currentAppUserID,
                                   statusCode: .createdSuccess,
-                                  response: Self.mockCustomerInfoData)
+                                  response: .success(Self.mockCustomerInfoData))
 
         backend.logIn(currentAppUserID: currentAppUserID,
-                      newAppUserID: newAppUserID) { _, _, _  in }
+                      newAppUserID: newAppUserID) { _ in }
         backend.logIn(currentAppUserID: currentAppUserID2,
-                      newAppUserID: newAppUserID) { _, _, _  in }
+                      newAppUserID: newAppUserID) { _ in }
 
         expect(self.httpClient.calls).toEventually(haveCount(2))
     }
@@ -280,17 +234,17 @@ class BackendLoginTests: BaseBackendTests {
         let currentAppUserID = "old id"
         _ = self.mockLoginRequest(appUserID: currentAppUserID,
                                   statusCode: .createdSuccess,
-                                  response: Self.mockCustomerInfoData)
+                                  response: .success(Self.mockCustomerInfoData))
 
         var completion1Called = false
         var completion2Called = false
 
         backend.logIn(currentAppUserID: currentAppUserID,
-                      newAppUserID: newAppUserID) { _, _, _  in
+                      newAppUserID: newAppUserID) { _ in
             completion1Called = true
         }
         backend.logIn(currentAppUserID: currentAppUserID,
-                      newAppUserID: newAppUserID) { _, _, _  in
+                      newAppUserID: newAppUserID) { _ in
             completion2Called = true
         }
 
@@ -305,10 +259,9 @@ private extension BackendLoginTests {
 
     func mockLoginRequest(appUserID: String,
                           statusCode: HTTPStatusCode = .success,
-                          response: [String: Any]? = [:],
-                          error: Error? = nil) -> HTTPRequest.Path {
+                          response: Result<[String: Any], Error> = .success([:])) -> HTTPRequest.Path {
         let path: HTTPRequest.Path = .logIn
-        let response = MockHTTPClient.Response(statusCode: statusCode, response: response, error: error)
+        let response = MockHTTPClient.Response(statusCode: statusCode, response: response)
 
         self.httpClient.mock(requestPath: path, response: response)
 

--- a/PurchasesTests/Networking/Backend/BackendPostAttributionDataTests.swift
+++ b/PurchasesTests/Networking/Backend/BackendPostAttributionDataTests.swift
@@ -26,7 +26,7 @@ class BackendPostAttributionDataTests: BaseBackendTests {
     func testPostAttributesPutsDataInDataKey() throws {
         self.httpClient.mock(
             requestPath: .postAttributionData(appUserID: Self.userID),
-            response: .init(statusCode: .success, response: nil)
+            response: .init(statusCode: .success)
         )
 
         let data: [String: AnyObject] = ["a": "b" as NSString, "c": "d" as NSString]

--- a/PurchasesTests/Networking/HTTPClientTests.swift
+++ b/PurchasesTests/Networking/HTTPClientTests.swift
@@ -171,7 +171,7 @@ class HTTPClientTests: XCTestCase {
             return .emptySuccessResponse
         }
 
-        self.client.perform(request, authHeaders: [:]) { (_, _, _) in
+        self.client.perform(request, authHeaders: [:]) { _, _ in
             completionCalled.value = true
         }
 
@@ -189,10 +189,9 @@ class HTTPClientTests: XCTestCase {
             response.error = error
             return response
         }
-        self.client.perform(request, authHeaders: [:]) { (status, data, responseError) in
-            if let responseNSError = responseError as NSError? {
+        self.client.perform(request, authHeaders: [:]) { (status, result) in
+            if let responseNSError = result.error as NSError? {
                 successFailed.value = (status.isServerError
-                                       && data == nil
                                        && error.domain == responseNSError.domain
                                        && error.code == responseNSError.code)
             } else {
@@ -219,11 +218,10 @@ class HTTPClientTests: XCTestCase {
             )
         }
 
-        self.client.perform(request, authHeaders: [:]) { (status, data, error) in
-            correctResponse.value = (status.rawValue == errorCode) && (data != nil) && (error == nil)
-            if data != nil {
-                message.value = data?["message"] as? String
-            }
+        self.client.perform(request, authHeaders: [:]) { (status, result) in
+            correctResponse.value = (status.rawValue == errorCode) && (result.value != nil)
+
+            message.value = result.value?["message"] as? String
         }
 
         expect(message.value).toEventually(equal("something is broken up in the cloud"), timeout: .seconds(1))
@@ -246,11 +244,9 @@ class HTTPClientTests: XCTestCase {
             )
         }
 
-        self.client.perform(request, authHeaders: [:]) { (status, data, error) in
-            correctResponse.value = (status.rawValue == errorCode) && (data != nil) && (error == nil)
-            if data != nil {
-                message.value = data?["message"] as? String
-            }
+        self.client.perform(request, authHeaders: [:]) { (status, result) in
+            correctResponse.value = (status.rawValue == errorCode) && (result.value != nil)
+            message.value = result.value?["message"] as? String
         }
 
         expect(message.value).toEventually(equal("something is broken up in the cloud"), timeout: .seconds(1))
@@ -272,8 +268,8 @@ class HTTPClientTests: XCTestCase {
             )
         }
 
-        self.client.perform(request, authHeaders: [:]) { (status, data, error) in
-            correctResponse.value = (status.rawValue == errorCode) && (data == nil) && (error != nil)
+        self.client.perform(request, authHeaders: [:]) { (status, result) in
+            correctResponse.value = (status.rawValue == errorCode) && (result.error != nil)
         }
 
         expect(correctResponse.value).toEventually(beTrue(), timeout: .seconds(1))
@@ -292,11 +288,9 @@ class HTTPClientTests: XCTestCase {
                                      headers: nil)
         }
 
-        self.client.perform(request, authHeaders: [:]) { (status, data, error) in
-            successIsTrue.value = (status == .success) && (error == nil)
-            if data != nil {
-                message.value = data?["message"] as? String
-            }
+        self.client.perform(request, authHeaders: [:]) { (status, result) in
+            successIsTrue.value = (status == .success) && (result.error == nil)
+            message.value = result.value?["message"] as? String
         }
 
         expect(message.value).toEventually(equal("something is great up in the cloud"), timeout: .seconds(1))
@@ -491,7 +485,7 @@ class HTTPClientTests: XCTestCase {
         let serialRequests = 10
         for requestNumber in 0..<serialRequests {
             client.perform(.init(method: .requestNumber(requestNumber), path: path),
-                           authHeaders: [:]) { (_, _, _) in
+                           authHeaders: [:]) { (_, _) in
                 completionCallCount.value += 1
             }
         }
@@ -519,12 +513,12 @@ class HTTPClientTests: XCTestCase {
         }
 
         self.client.perform(.init(method: .requestNumber(1), path: path),
-                            authHeaders: [:]) { (_, _, _) in
+                            authHeaders: [:]) { (_, _) in
             firstRequestFinished.value = true
         }
 
         self.client.perform(.init(method: .requestNumber(2), path: path),
-                            authHeaders: [:]) { (_, _, _) in
+                            authHeaders: [:]) { (_, _) in
             secondRequestFinished.value = true
         }
 
@@ -563,17 +557,17 @@ class HTTPClientTests: XCTestCase {
         }
 
         self.client.perform(.init(method: .requestNumber(1), path: path),
-                            authHeaders: [:]) { (_, _, _) in
+                            authHeaders: [:]) { (_, _) in
             firstRequestFinished.value = true
         }
 
         self.client.perform(.init(method: .requestNumber(2), path: path),
-                            authHeaders: [:]) { (_, _, _) in
+                            authHeaders: [:]) { (_, _) in
             secondRequestFinished.value = true
         }
 
         self.client.perform(.init(method: .requestNumber(3), path: path),
-                            authHeaders: [:]) { (_, _, _) in
+                            authHeaders: [:]) { (_, _) in
             thirdRequestFinished.value = true
         }
 
@@ -582,24 +576,20 @@ class HTTPClientTests: XCTestCase {
         expect(thirdRequestFinished.value).toEventually(beTrue(), timeout: .seconds(3))
     }
 
-    func testPerformRequestExitsWithErrorIfBodyCouldntBeParsedIntoJSON() {
-        var completionCalled = false
-        var receivedError: Error?
+    func testPerformRequestExitsWithErrorIfBodyCouldntBeParsedIntoJSON() throws {
         var receivedStatus: HTTPStatusCode?
-        var receivedData: [String: Any]?
+        var receivedResult: Result<[String: Any], Error>?
+
         self.client.perform(.init(method: .invalidBody(), path: .mockPath),
-                            authHeaders: [:]) { (status, data, error) in
-            completionCalled = true
-            receivedError = error
+                            authHeaders: [:]) { (status, result) in
             receivedStatus = status
-            receivedData = data
+            receivedResult = result
         }
 
-        expect(completionCalled).toEventually(beTrue())
-        expect(receivedError).toNot(beNil())
-        let receivedNSError = receivedError! as NSError
+        expect(receivedResult).toEventuallyNot(beNil())
+
+        let receivedNSError = try XCTUnwrap(receivedResult?.error as NSError?)
         expect(receivedNSError.code) == ErrorCode.networkError.rawValue
-        expect(receivedData).to(beNil())
         expect(receivedStatus) == .invalidRequest
     }
 
@@ -615,7 +605,7 @@ class HTTPClientTests: XCTestCase {
         }
 
         self.client.perform(.init(method: .invalidBody(), path: path),
-                            authHeaders: [:]) { (_, _, _) in
+                            authHeaders: [:]) { (_, _) in
             completionCalled = true
         }
 
@@ -639,7 +629,7 @@ class HTTPClientTests: XCTestCase {
 
         self.eTagManager.shouldReturnResultFromBackend = false
         self.eTagManager.stubbedHTTPResultFromCacheOrBackendResult = nil
-        self.client.perform(.init(method: .get, path: path), authHeaders: [:]) { (_, _, _) in
+        self.client.perform(.init(method: .get, path: path), authHeaders: [:]) { (_, _) in
             completionCalled.value = true
         }
 
@@ -752,8 +742,8 @@ class HTTPClientTests: XCTestCase {
         }
 
         let obtainedError: Atomic<DNSError?> = .init(nil)
-        self.client.perform(.init(method: .get, path: path), authHeaders: [:] ) { _, _, error in
-            obtainedError.value = error as? DNSError
+        self.client.perform(.init(method: .get, path: path), authHeaders: [:] ) { _, result in
+            obtainedError.value = result.error as? DNSError
         }
 
         expect(MockDNSChecker.invokedIsBlockedAPIError.value).toEventually(equal(true))

--- a/PurchasesTests/Purchasing/EntitlementInfosTests.swift
+++ b/PurchasesTests/Purchasing/EntitlementInfosTests.swift
@@ -86,7 +86,7 @@ class EntitlementInfosTests: XCTestCase {
             ]
         )
 
-        let subscriberInfo = try XCTUnwrap(CustomerInfo(testData: response))
+        let subscriberInfo = try CustomerInfo(data: response)
         expect(subscriberInfo.entitlements.all.count).to(equal(2))
         // The default is "pro_cat"
         try verifySubscriberInfo()
@@ -133,7 +133,7 @@ class EntitlementInfosTests: XCTestCase {
             ]
         )
 
-        let subscriberInfo = try XCTUnwrap(CustomerInfo(testData: response))
+        let subscriberInfo = try CustomerInfo(data: response)
 
         expect(subscriberInfo.entitlements["pro_cat"]).toNot(beNil())
         expect(subscriberInfo.entitlements.active["pro_cat"]).toNot(beNil())
@@ -193,7 +193,7 @@ class EntitlementInfosTests: XCTestCase {
 
     func testGetsEmptySubscriberInfo() throws {
         stubResponse()
-        let subscriberInfo = try XCTUnwrap(CustomerInfo(testData: response))
+        let subscriberInfo = try CustomerInfo(data: response)
 
         expect(subscriberInfo.originalAppUserId) == "cesarsandbox1"
         expect(subscriberInfo.entitlements.all).to(beEmpty())
@@ -472,7 +472,7 @@ class EntitlementInfosTests: XCTestCase {
         stubResponse(entitlements: mockEntitlements,
                      subscriptions: mockSubscriptions(ownershipType: "PURCHASED"))
 
-        var subscriberInfo = try XCTUnwrap(CustomerInfo(testData: response))
+        var subscriberInfo = try CustomerInfo(data: response)
         var entitlement = try XCTUnwrap(subscriberInfo.entitlements.active["pro_cat"])
 
         expect(entitlement.ownershipType) == .purchased
@@ -480,7 +480,7 @@ class EntitlementInfosTests: XCTestCase {
         stubResponse(entitlements: mockEntitlements,
                      subscriptions: mockSubscriptions(ownershipType: "FAMILY_SHARED"))
 
-        subscriberInfo = try XCTUnwrap(CustomerInfo(testData: response))
+        subscriberInfo = try CustomerInfo(data: response)
         entitlement = try XCTUnwrap(subscriberInfo.entitlements.active["pro_cat"])
 
         expect(entitlement.ownershipType) == .familyShared
@@ -488,7 +488,7 @@ class EntitlementInfosTests: XCTestCase {
         stubResponse(entitlements: mockEntitlements,
                      subscriptions: mockSubscriptions(ownershipType: "BOATY_MCBOATFACE"))
 
-        subscriberInfo = try XCTUnwrap(CustomerInfo(testData: response))
+        subscriberInfo = try CustomerInfo(data: response)
         entitlement = try XCTUnwrap(subscriberInfo.entitlements.active["pro_cat"])
 
         expect(entitlement.ownershipType) == .unknown
@@ -505,7 +505,7 @@ class EntitlementInfosTests: XCTestCase {
         stubResponse(entitlements: mockEntitlements,
                      subscriptions: mockSubscriptions(ownershipType: nil))
 
-        let subscriberInfo = try XCTUnwrap(CustomerInfo(testData: response))
+        let subscriberInfo = try CustomerInfo(data: response)
         let entitlement = try XCTUnwrap(subscriberInfo.entitlements.active["pro_cat"])
 
         expect(entitlement.ownershipType) == .purchased
@@ -1020,7 +1020,7 @@ class EntitlementInfosTests: XCTestCase {
     }
 
     func verifySubscriberInfo() throws {
-        let subscriberInfo = try XCTUnwrap(CustomerInfo(testData: response))
+        let subscriberInfo = try CustomerInfo(data: response)
 
         expect(subscriberInfo).toNot(beNil())
         expect(subscriberInfo.firstSeen).to(equal(formatter.date(from: "2019-07-26T23:29:50Z")))
@@ -1028,7 +1028,7 @@ class EntitlementInfosTests: XCTestCase {
     }
 
     func verifyEntitlementActive(_ expectedEntitlementActive: Bool = true, entitlement: String = "pro_cat") throws {
-        let subscriberInfo = try XCTUnwrap(CustomerInfo(testData: response))
+        let subscriberInfo = try CustomerInfo(data: response)
         let proCat = try XCTUnwrap(subscriberInfo.entitlements[entitlement])
 
         expect(proCat.identifier) == entitlement
@@ -1041,7 +1041,7 @@ class EntitlementInfosTests: XCTestCase {
                        expectedUnsubscribeDetectedAt: Date? = nil,
                        expectedBillingIssueDetectedAt: Date? = nil,
                        entitlement: String = "pro_cat") throws {
-        let subscriberInfo = try XCTUnwrap(CustomerInfo(testData: response))
+        let subscriberInfo = try CustomerInfo(data: response)
         let proCat = try XCTUnwrap(subscriberInfo.entitlements[entitlement])
 
         expect(proCat.willRenew) == expectedWillRenew
@@ -1063,21 +1063,21 @@ class EntitlementInfosTests: XCTestCase {
         _ expectedPeriodType: PeriodType = PeriodType.normal,
         expectedEntitlement: String = "pro_cat"
     ) throws {
-        let subscriberInfo = try XCTUnwrap(CustomerInfo(testData: response))
+        let subscriberInfo = try CustomerInfo(data: response)
         let proCat = try XCTUnwrap(subscriberInfo.entitlements[expectedEntitlement])
 
         expect(proCat.periodType) == expectedPeriodType
     }
 
     func verifyStore(_ expectedStore: Store = Store.appStore, expectedEntitlement: String = "pro_cat") throws {
-        let subscriberInfo = try XCTUnwrap(CustomerInfo(testData: response))
+        let subscriberInfo = try CustomerInfo(data: response)
         let proCat = try XCTUnwrap(subscriberInfo.entitlements[expectedEntitlement])
 
         expect(proCat.store) == expectedStore
     }
 
     func verifySandbox(_ expectedIsSandbox: Bool = false, expectedEntitlement: String = "pro_cat") throws {
-        let subscriberInfo = try XCTUnwrap(CustomerInfo(testData: response))
+        let subscriberInfo = try CustomerInfo(data: response)
         let proCat = try XCTUnwrap(subscriberInfo.entitlements[expectedEntitlement])
 
         expect(proCat.isSandbox) == expectedIsSandbox
@@ -1098,7 +1098,7 @@ class EntitlementInfosTests: XCTestCase {
                        expectedOriginalPurchaseDate: Date?,
                        expectedExpirationDate: Date?,
                        expectedEntitlement: String = "pro_cat") throws {
-        let subscriberInfo = try XCTUnwrap(CustomerInfo(testData: response))
+        let subscriberInfo = try CustomerInfo(data: response)
         let proCat = try XCTUnwrap(subscriberInfo.entitlements[expectedEntitlement])
 
         if expectedLatestPurchaseDate != nil {

--- a/PurchasesTests/Purchasing/OfferingsManagerTests.swift
+++ b/PurchasesTests/Purchasing/OfferingsManagerTests.swift
@@ -48,7 +48,7 @@ extension OfferingsManagerTests {
     func testOfferingsForAppUserIDReturnsNilIfMissingStoreProduct() throws {
         // given
         mockOfferingsFactory.emptyOfferings = true
-        mockBackend.stubbedGetOfferingsCompletionResult = (MockData.anyBackendOfferingsData, nil)
+        mockBackend.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsData)
 
         // when
         var obtainedOfferings: Offerings?
@@ -66,7 +66,7 @@ extension OfferingsManagerTests {
 
     func testOfferingsForAppUserIDReturnsOfferingsIfSuccessBackendRequest() throws {
         // given
-        mockBackend.stubbedGetOfferingsCompletionResult = (MockData.anyBackendOfferingsData, nil)
+        mockBackend.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsData)
 
         // when
         var obtainedOfferings: Offerings?
@@ -86,7 +86,7 @@ extension OfferingsManagerTests {
 
     func testOfferingsForAppUserIDReturnsNilIfFailBackendRequest() {
         // given
-        mockBackend.stubbedGetOfferingsCompletionResult = (nil, MockData.unexpectedBackendResponseError)
+        mockBackend.stubbedGetOfferingsCompletionResult = .failure(MockData.unexpectedBackendResponseError)
         mockOfferingsFactory.emptyOfferings = true
 
         // when
@@ -104,7 +104,7 @@ extension OfferingsManagerTests {
 
     func testOfferingsForAppUserIDReturnsConfigurationErrorIfBackendReturnsEmpty() throws {
         // given
-        mockBackend.stubbedGetOfferingsCompletionResult = ([:], nil)
+        mockBackend.stubbedGetOfferingsCompletionResult = .success([:])
         mockOfferingsFactory.emptyOfferings = true
 
         // when
@@ -126,7 +126,7 @@ extension OfferingsManagerTests {
 
     func testOfferingsForAppUserIDReturnsConfigurationErrorIfProductsRequestsReturnsEmpty() throws {
         // given
-        mockBackend.stubbedGetOfferingsCompletionResult = (MockData.anyBackendOfferingsData, nil)
+        mockBackend.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsData)
         mockProductsManager.stubbedProductsCompletionResult = Set()
 
         // when
@@ -148,7 +148,7 @@ extension OfferingsManagerTests {
 
     func testOfferingsForAppUserIDReturnsUnexpectedBackendResponseIfOfferingsFactoryCantCreateOfferings() throws {
         // given
-        mockBackend.stubbedGetOfferingsCompletionResult = (MockData.anyBackendOfferingsData, nil)
+        mockBackend.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsData)
         mockOfferingsFactory.nilOfferings = true
 
         // when
@@ -168,31 +168,9 @@ extension OfferingsManagerTests {
         expect((error as NSError).code) == ErrorCode.unexpectedBackendResponseError.rawValue
     }
 
-    func testOfferingsForAppUserIDReturnsNilUnexpectedBackendResponseIfBackendReturnsNilDataAndNilOfferings() throws {
-        // given
-        mockBackend.stubbedGetOfferingsCompletionResult = (nil, nil)
-        mockOfferingsFactory.emptyOfferings = true
-
-        // when
-        var obtainedOfferings: Offerings?
-        var completionCalled = false
-        var obtainedError: Error?
-        offeringsManager.offerings(appUserID: MockData.anyAppUserID) { offerings, error in
-            obtainedOfferings = offerings
-            completionCalled = true
-            obtainedError = error
-        }
-
-        // then
-        expect(completionCalled).toEventually(beTrue())
-        expect(obtainedOfferings).to(beNil())
-        let unwrappedError = try XCTUnwrap(obtainedError)
-        expect((unwrappedError as NSError).code) == ErrorCode.unexpectedBackendResponseError.rawValue
-    }
-
     func testOfferingsForAppUserIDReturnsUnexpectedBackendErrorIfBadBackendRequest() throws {
         // given
-        mockBackend.stubbedGetOfferingsCompletionResult = (nil, MockData.unexpectedBackendResponseError)
+        mockBackend.stubbedGetOfferingsCompletionResult = .failure(MockData.unexpectedBackendResponseError)
         mockOfferingsFactory.nilOfferings = true
 
         // when
@@ -212,7 +190,7 @@ extension OfferingsManagerTests {
 
     func testFailBackendDeviceCacheClearsOfferingsCache() {
         // given
-        mockBackend.stubbedGetOfferingsCompletionResult = (nil, MockData.unexpectedBackendResponseError)
+        mockBackend.stubbedGetOfferingsCompletionResult = .failure(MockData.unexpectedBackendResponseError)
         mockOfferingsFactory.emptyOfferings = true
         let expectedCallCount = 1
 
@@ -227,7 +205,7 @@ extension OfferingsManagerTests {
 
     func testUpdateOfferingsCacheOK() {
         // given
-        mockBackend.stubbedGetOfferingsCompletionResult = (MockData.anyBackendOfferingsData, nil)
+        mockBackend.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsData)
         let expectedCallCount = 1
 
         // when

--- a/PurchasesTests/Purchasing/PurchasesTests.swift
+++ b/PurchasesTests/Purchasing/PurchasesTests.swift
@@ -92,24 +92,25 @@ class PurchasesTests: XCTestCase {
         var originalPurchaseDate: Date?
         var timeout = false
         var getSubscriberCallCount = 0
-        var overrideCustomerInfoError: Error?
-        var overrideCustomerInfo = CustomerInfo(testData: [
-            "request_date": "2019-08-16T10:30:42Z",
-            "subscriber": [
-                "first_seen": "2019-07-17T00:05:54Z",
-                "original_app_user_id": "app_user_id",
-                "subscriptions": [:],
-                "other_purchases": [:]
-            ]])
+        var overrideCustomerInfoResult: Result<CustomerInfo, Error> = .success(
+            CustomerInfo(testData: [
+                "request_date": "2019-08-16T10:30:42Z",
+                "subscriber": [
+                    "first_seen": "2019-07-17T00:05:54Z",
+                    "original_app_user_id": "app_user_id",
+                    "subscriptions": [:],
+                    "other_purchases": [:]
+                ]])!
+        )
 
         override func getCustomerInfo(appUserID: String, completion: @escaping BackendCustomerInfoResponseHandler) {
             getSubscriberCallCount += 1
             userID = appUserID
 
             if !timeout {
-                let info = self.overrideCustomerInfo
+                let result = self.overrideCustomerInfoResult
                 DispatchQueue.main.async {
-                    completion(info, self.overrideCustomerInfoError)
+                    completion(result)
                 }
             }
         }
@@ -127,8 +128,7 @@ class PurchasesTests: XCTestCase {
         var postedOfferingIdentifier: String?
         var postedObserverMode: Bool?
 
-        var postReceiptCustomerInfo: CustomerInfo?
-        var postReceiptError: Error?
+        var postReceiptResult: Result<CustomerInfo, Error>?
         var aliasError: Error?
         var aliasCalled = false
 
@@ -158,7 +158,7 @@ class PurchasesTests: XCTestCase {
 
             postedOfferingIdentifier = presentedOfferingIdentifier
             postedObserverMode = observerMode
-            completion(postReceiptCustomerInfo, postReceiptError)
+            completion(postReceiptResult ?? .failure(ErrorCode.unknownError))
         }
 
         var postedProductIdentifiers: [String]?
@@ -185,11 +185,11 @@ class PurchasesTests: XCTestCase {
             gotOfferings += 1
             if failOfferings {
                 let subError = UnexpectedBackendResponseSubErrorCode.getOfferUnexpectedResponse
-                completion(nil, ErrorUtils.unexpectedBackendResponse(withSubError: subError))
+                completion(.failure(ErrorUtils.unexpectedBackendResponse(withSubError: subError)))
                 return
             }
             if badOfferingsResponse {
-                completion([:], nil)
+                completion(.success([:]))
                 return
             }
 
@@ -207,7 +207,7 @@ class PurchasesTests: XCTestCase {
                 "current_offering_id": "base"
             ] as [String: Any]
 
-            completion(offeringsData, nil)
+            completion(.success(offeringsData))
         }
 
         override func createAlias(appUserID: String, newAppUserID: String, completion: ((Error?) -> Void)?) {
@@ -247,8 +247,7 @@ class PurchasesTests: XCTestCase {
         }
 
         var postOfferForSigningCalled = false
-        var postOfferForSigningPaymentDiscountResponse: [String: Any] = [:]
-        var postOfferForSigningError: Error?
+        var postOfferForSigningPaymentDiscountResponse: Result<[String: Any], Error> = .success([:])
 
         override func post(offerIdForSigning offerIdentifier: String,
                            productIdentifier: String,
@@ -257,11 +256,15 @@ class PurchasesTests: XCTestCase {
                            appUserID: String,
                            completion: @escaping OfferSigningResponseHandler) {
             postOfferForSigningCalled = true
-            completion(postOfferForSigningPaymentDiscountResponse["signature"] as? String,
-                       postOfferForSigningPaymentDiscountResponse["keyIdentifier"] as? String,
-                       postOfferForSigningPaymentDiscountResponse["nonce"] as? UUID,
-                       postOfferForSigningPaymentDiscountResponse["timestamp"] as? Int,
-                       postOfferForSigningError)
+
+            completion(
+                postOfferForSigningPaymentDiscountResponse.map {
+                    (
+                        // swiftlint:disable:next force_cast line_length
+                        $0["signature"] as! String, $0["keyIdentifier"] as! String, $0["nonce"] as! UUID, $0["timestamp"] as! Int
+                    )
+                }
+            )
         }
     }
 
@@ -454,16 +457,16 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.getSubscriberCallCount).toEventually(equal(1))
     }
 
-    func testDelegateIsCalledForRandomPurchaseSuccess() {
+    func testDelegateIsCalledForRandomPurchaseSuccess() throws {
         setupPurchases()
 
-        let customerInfo = CustomerInfo(testData: emptyCustomerInfoData)
-        self.backend.postReceiptCustomerInfo = customerInfo
+        let customerInfo = try CustomerInfo(data: emptyCustomerInfoData)
+        self.backend.postReceiptResult = .success(customerInfo)
 
         let product = MockSK1Product(mockProductIdentifier: "product")
         let payment = SKPayment(product: product)
 
-        let customerInfoBeforePurchase = CustomerInfo(testData: [
+        let customerInfoBeforePurchase = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -471,7 +474,7 @@ class PurchasesTests: XCTestCase {
                 "subscriptions": [:],
                 "non_subscriptions": [:]
             ]])
-        let customerInfoAfterPurchase = CustomerInfo(testData: [
+        let customerInfoAfterPurchase = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -479,8 +482,8 @@ class PurchasesTests: XCTestCase {
                 "subscriptions": [:],
                 "non_subscriptions": [product.mockProductIdentifier: []]
             ]])
-        self.backend.overrideCustomerInfo = customerInfoBeforePurchase
-        self.backend.postReceiptCustomerInfo = customerInfoAfterPurchase
+        self.backend.overrideCustomerInfoResult = .success(customerInfoBeforePurchase)
+        self.backend.postReceiptResult = .success(customerInfoAfterPurchase)
 
         let transaction = MockTransaction()
 
@@ -496,10 +499,10 @@ class PurchasesTests: XCTestCase {
         expect(self.purchasesDelegate.customerInfoReceivedCount).toEventually(equal(2))
     }
 
-    func testDelegateIsOnlyCalledOnceIfCustomerInfoTheSame() {
+    func testDelegateIsOnlyCalledOnceIfCustomerInfoTheSame() throws {
         setupPurchases()
 
-        let customerInfo1 = CustomerInfo(testData: [
+        let customerInfo1 = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -522,11 +525,11 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        self.backend.postReceiptCustomerInfo = customerInfo1
+        self.backend.postReceiptResult = .success(customerInfo1)
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        self.backend.postReceiptCustomerInfo = customerInfo2
+        self.backend.postReceiptResult = .success(customerInfo2)
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
@@ -534,10 +537,10 @@ class PurchasesTests: XCTestCase {
         expect(self.purchasesDelegate.customerInfoReceivedCount).toEventually(equal(2))
     }
 
-    func testDelegateIsCalledTwiceIfCustomerInfoTheDifferent() {
+    func testDelegateIsCalledTwiceIfCustomerInfoTheDifferent() throws {
         setupPurchases()
 
-        let customerInfo1 = CustomerInfo(testData: [
+        let customerInfo1 = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -548,7 +551,7 @@ class PurchasesTests: XCTestCase {
             ]
         ])
 
-        let customerInfo2 = CustomerInfo(testData: [
+        let customerInfo2 = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -569,11 +572,11 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        self.backend.postReceiptCustomerInfo = customerInfo1
+        self.backend.postReceiptResult = .success(customerInfo1)
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        self.backend.postReceiptCustomerInfo = customerInfo2
+        self.backend.postReceiptResult = .success(customerInfo2)
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
@@ -753,7 +756,7 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.postedIsRestore).to(beTrue())
     }
 
-    func testFinishesTransactionsIfSentToBackendCorrectly() {
+    func testFinishesTransactionsIfSentToBackendCorrectly() throws {
         setupPurchases()
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases.purchase(product: product) { (_, _, _, _) in
@@ -766,7 +769,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: emptyCustomerInfoData)
+        self.backend.postReceiptResult = .success(try CustomerInfo(data: emptyCustomerInfoData))
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -775,7 +778,7 @@ class PurchasesTests: XCTestCase {
         expect(self.storeKitWrapper.finishCalled).toEventually(beTrue())
     }
 
-    func testDoesntFinishTransactionsIfFinishingDisabled() {
+    func testDoesntFinishTransactionsIfFinishingDisabled() throws {
         setupPurchases()
         self.purchases?.finishTransactions = false
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
@@ -789,7 +792,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
+        self.backend.postReceiptResult = .success(try CustomerInfo(data: self.emptyCustomerInfoData))
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -798,7 +801,7 @@ class PurchasesTests: XCTestCase {
         expect(self.storeKitWrapper.finishCalled).toEventually(beFalse())
     }
 
-    func testSendsProductDataIfProductIsCached() {
+    func testSendsProductDataIfProductIsCached() throws {
         setupPurchases()
         let productIdentifiers = ["com.product.id1", "com.product.id2"]
         purchases!.getProducts(productIdentifiers) { (newProducts) in
@@ -813,7 +816,7 @@ class PurchasesTests: XCTestCase {
             transaction.mockState = SKPaymentTransactionState.purchasing
             self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-            self.backend.postReceiptCustomerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
+            self.backend.postReceiptResult = .success(CustomerInfo(testData: self.emptyCustomerInfoData)!)
 
             transaction.mockState = SKPaymentTransactionState.purchased
             self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -851,7 +854,7 @@ class PurchasesTests: XCTestCase {
         }
     }
 
-    func testFetchesProductDataIfNotCached() {
+    func testFetchesProductDataIfNotCached() throws {
         systemInfo.stubbedIsApplicationBackgrounded = true
         setupPurchases()
         let sk1Product = MockSK1Product(mockProductIdentifier: "com.product.id1")
@@ -864,7 +867,7 @@ class PurchasesTests: XCTestCase {
 
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: emptyCustomerInfoData)
+        self.backend.postReceiptResult = .success(try CustomerInfo(data: emptyCustomerInfoData))
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -892,9 +895,11 @@ class PurchasesTests: XCTestCase {
 
         let transaction = MockTransaction()
         transaction.mockPayment = self.storeKitWrapper.payment!
-        self.backend.postReceiptError = ErrorUtils.backendError(withBackendCode: .invalidAPIKey,
-                                                                backendMessage: "Invalid credentials",
-                                                                finishable: false)
+        self.backend.postReceiptResult = .failure(
+            ErrorUtils.backendError(withBackendCode: .invalidAPIKey,
+                                    backendMessage: "Invalid credentials",
+                                    finishable: false)
+        )
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -913,9 +918,11 @@ class PurchasesTests: XCTestCase {
         let transaction = MockTransaction()
         transaction.mockPayment = self.storeKitWrapper.payment!
 
-        self.backend.postReceiptError = ErrorUtils.backendError(withBackendCode: .invalidAPIKey,
-                                                                backendMessage: "Invalid credentials",
-                                                                finishable: true)
+        self.backend.postReceiptResult = .failure(
+            ErrorUtils.backendError(withBackendCode: .invalidAPIKey,
+                                    backendMessage: "Invalid credentials",
+                                    finishable: true)
+        )
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -935,9 +942,11 @@ class PurchasesTests: XCTestCase {
         transaction.mockPayment = self.storeKitWrapper.payment!
 
         let backendErrorCode = BackendErrorCode(code: ErrorCode.invalidCredentialsError.rawValue)
-        self.backend.postReceiptError = ErrorUtils.backendError(withBackendCode: backendErrorCode,
-                                                                backendMessage: "Invalid credentials",
-                                                                finishable: false)
+        self.backend.postReceiptResult = .failure(
+            ErrorUtils.backendError(withBackendCode: backendErrorCode,
+                                    backendMessage: "Invalid credentials",
+                                    finishable: false)
+        )
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -958,7 +967,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockError = NSError.init(domain: SKErrorDomain, code: 2, userInfo: nil)
         transaction.mockPayment = self.storeKitWrapper.payment!
 
-        self.backend.postReceiptError = BackendError.unknown
+        self.backend.postReceiptResult = .failure(BackendError.unknown)
 
         transaction.mockState = SKPaymentTransactionState.failed
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -968,7 +977,7 @@ class PurchasesTests: XCTestCase {
         expect(receivedError).toEventuallyNot(beNil())
     }
 
-    func testCallsDelegateAfterBackendResponse() {
+    func testCallsDelegateAfterBackendResponse() throws {
         setupPurchases()
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
 
@@ -976,7 +985,7 @@ class PurchasesTests: XCTestCase {
         var receivedError: Error?
         var receivedUserCancelled: Bool?
 
-        let customerInfoBeforePurchase = CustomerInfo(testData: [
+        let customerInfoBeforePurchase = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -984,7 +993,7 @@ class PurchasesTests: XCTestCase {
                 "subscriptions": [:],
                 "non_subscriptions": [:]
             ]])
-        let customerInfoAfterPurchase = CustomerInfo(testData: [
+        let customerInfoAfterPurchase = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -992,8 +1001,8 @@ class PurchasesTests: XCTestCase {
                 "subscriptions": [:],
                 "non_subscriptions": [product.productIdentifier: []]
             ]])
-        self.backend.overrideCustomerInfo = customerInfoBeforePurchase
-        self.backend.postReceiptCustomerInfo = customerInfoAfterPurchase
+        self.backend.overrideCustomerInfoResult = .success(customerInfoBeforePurchase)
+        self.backend.postReceiptResult = .success(customerInfoAfterPurchase)
 
         self.purchases.purchase(product: product) { (_, info, error, userCancelled) in
             customerInfo = info
@@ -1007,13 +1016,13 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        expect(customerInfo).toEventually(be(self.backend.postReceiptCustomerInfo))
+        expect(customerInfo).toEventually(equal(customerInfoAfterPurchase))
         expect(receivedError).toEventually(beNil())
         expect(self.purchasesDelegate.customerInfoReceivedCount).to(equal(2))
         expect(receivedUserCancelled).toEventually(beFalse())
     }
 
-    func testCompletionBlockOnlyCalledOnce() {
+    func testCompletionBlockOnlyCalledOnce() throws {
         setupPurchases()
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
 
@@ -1026,7 +1035,7 @@ class PurchasesTests: XCTestCase {
         let transaction = MockTransaction()
         transaction.mockPayment = self.storeKitWrapper.payment!
 
-        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: emptyCustomerInfoData)
+        self.backend.postReceiptResult = .success(try CustomerInfo(data: emptyCustomerInfoData))
 
         transaction.mockState = SKPaymentTransactionState.purchased
 
@@ -1036,7 +1045,7 @@ class PurchasesTests: XCTestCase {
         expect(callCount).toEventually(equal(1))
     }
 
-    func testCompletionBlockNotCalledForDifferentProducts() {
+    func testCompletionBlockNotCalledForDifferentProducts() throws {
         setupPurchases()
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         let otherProduct = MockSK1Product(mockProductIdentifier: "com.product.id2")
@@ -1050,7 +1059,7 @@ class PurchasesTests: XCTestCase {
         let transaction = MockTransaction()
         transaction.mockPayment = SKPayment.init(product: otherProduct)
 
-        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
+        self.backend.postReceiptResult = .success(try CustomerInfo(data: self.emptyCustomerInfoData))
 
         transaction.mockState = SKPaymentTransactionState.purchased
 
@@ -1257,11 +1266,11 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.postedIsRestore!).to(beTrue())
     }
 
-    func testRestoringPurchasesCallsSuccessDelegateMethod() {
+    func testRestoringPurchasesCallsSuccessDelegateMethod() throws {
         setupPurchases()
 
-        let customerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
-        self.backend.postReceiptCustomerInfo = customerInfo
+        let customerInfo = try CustomerInfo(data: self.emptyCustomerInfoData)
+        self.backend.postReceiptResult = .success(customerInfo)
 
         var receivedCustomerInfo: CustomerInfo?
 
@@ -1279,7 +1288,7 @@ class PurchasesTests: XCTestCase {
                                             backendMessage: "Invalid credentials",
                                             finishable: true)
 
-        self.backend.postReceiptError = error
+        self.backend.postReceiptResult = .failure(error)
         self.purchasesDelegate.customerInfo = nil
 
         var receivedError: Error?
@@ -1419,11 +1428,11 @@ class PurchasesTests: XCTestCase {
         expect(self.backend.postedIsRestore!) == true
     }
 
-    func testSyncPurchasesCallsSuccessDelegateMethod() {
+    func testSyncPurchasesCallsSuccessDelegateMethod() throws {
         setupPurchases()
 
-        let customerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
-        self.backend.postReceiptCustomerInfo = customerInfo
+        let customerInfo = try CustomerInfo(data: self.emptyCustomerInfoData)
+        self.backend.postReceiptResult = .success(customerInfo)
 
         var receivedCustomerInfo: CustomerInfo?
 
@@ -1441,7 +1450,7 @@ class PurchasesTests: XCTestCase {
                                             backendMessage: "Invalid credentials",
                                             finishable: true)
 
-        self.backend.postReceiptError = error
+        self.backend.postReceiptResult = .failure(error)
         self.purchasesDelegate.customerInfo = nil
 
         var receivedError: Error?
@@ -1560,10 +1569,10 @@ class PurchasesTests: XCTestCase {
             .to(beTrue())
     }
 
-    func testFetchVersionSendsAReceiptIfNoVersion() {
+    func testFetchVersionSendsAReceiptIfNoVersion() throws {
         setupPurchases()
 
-        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: [
+        self.backend.postReceiptResult = .success(try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -1573,7 +1582,7 @@ class PurchasesTests: XCTestCase {
                 "original_application_version": "1.0",
                 "original_purchase_date": "2018-10-26T23:17:53Z"
             ]
-        ])
+        ]))
 
         var receivedCustomerInfo: CustomerInfo?
 
@@ -1605,19 +1614,19 @@ class PurchasesTests: XCTestCase {
         }
     }
 
-    func testCachesCustomerInfoOnPurchase() {
+    func testCachesCustomerInfoOnPurchase() throws {
         setupPurchases()
 
         expect(self.deviceCache.cachedCustomerInfo.count).toEventually(equal(1))
 
-        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: [
+        self.backend.postReceiptResult = .success(try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "app_user_id",
                 "subscriptions": [:],
                 "other_purchases": [:]
-            ]])
+            ]]))
 
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases.purchase(product: product) { (_, _, _, _) in
@@ -1839,7 +1848,7 @@ class PurchasesTests: XCTestCase {
             transaction.mockState = SKPaymentTransactionState.purchasing
             self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-            self.backend.postReceiptCustomerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
+            self.backend.postReceiptResult = .success(CustomerInfo(testData: self.emptyCustomerInfoData)!)
 
             transaction.mockState = SKPaymentTransactionState.purchased
             self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -2193,7 +2202,7 @@ class PurchasesTests: XCTestCase {
         expect(self.subscriberAttributesManager.invokedConvertAttributionDataAndSetParametersList.count) == 1
     }
 
-    func testObserverModeSetToFalseSetFinishTransactions() {
+    func testObserverModeSetToFalseSetFinishTransactions() throws {
         setupPurchases()
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases.purchase(product: product) { (_, _, _, _) in
@@ -2206,7 +2215,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
+        self.backend.postReceiptResult = .success(try CustomerInfo(data: self.emptyCustomerInfoData))
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -2228,7 +2237,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
+        self.backend.postReceiptResult = .success(try CustomerInfo(data: self.emptyCustomerInfoData))
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -2255,7 +2264,7 @@ class PurchasesTests: XCTestCase {
         self.storeKitWrapper.delegate?.storeKitWrapper(
             self.storeKitWrapper, updatedTransaction: transaction)
 
-        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
+        self.backend.postReceiptResult = .success(try CustomerInfo(data: self.emptyCustomerInfoData))
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -2281,7 +2290,7 @@ class PurchasesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
+        self.backend.postReceiptResult = .success(try CustomerInfo(data: self.emptyCustomerInfoData))
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -2363,7 +2372,7 @@ class PurchasesTests: XCTestCase {
             transaction.mockState = SKPaymentTransactionState.purchasing
             self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
 
-            self.backend.postReceiptCustomerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
+            self.backend.postReceiptResult = .success(CustomerInfo(testData: self.emptyCustomerInfoData)!)
 
             transaction.mockState = SKPaymentTransactionState.purchased
             self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
@@ -2406,7 +2415,7 @@ class PurchasesTests: XCTestCase {
 
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
-        self.backend.postReceiptCustomerInfo = CustomerInfo(testData: self.emptyCustomerInfoData)
+        self.backend.postReceiptResult = .success(CustomerInfo(testData: self.emptyCustomerInfoData)!)
         transaction.mockState = SKPaymentTransactionState.purchased
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
     }
@@ -2432,12 +2441,12 @@ class PurchasesTests: XCTestCase {
         expect(self.purchases.isAnonymous).to(beFalse())
     }
 
-    func testProductIsRemovedButPresentInTheQueuedTransaction() {
+    func testProductIsRemovedButPresentInTheQueuedTransaction() throws {
         self.mockProductsManager.stubbedProductsCompletionResult = Set()
         setupPurchases()
         let product = MockSK1Product(mockProductIdentifier: "product")
 
-        let customerInfoBeforePurchase = CustomerInfo(testData: [
+        let customerInfoBeforePurchase = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -2445,7 +2454,7 @@ class PurchasesTests: XCTestCase {
                 "subscriptions": [:],
                 "non_subscriptions": [:]
             ]])
-        let customerInfoAfterPurchase = CustomerInfo(testData: [
+        let customerInfoAfterPurchase = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -2453,8 +2462,8 @@ class PurchasesTests: XCTestCase {
                 "subscriptions": [:],
                 "non_subscriptions": [product.mockProductIdentifier: []]
             ]])
-        self.backend.overrideCustomerInfo = customerInfoBeforePurchase
-        self.backend.postReceiptCustomerInfo = customerInfoAfterPurchase
+        self.backend.overrideCustomerInfoResult = .success(customerInfoBeforePurchase)
+        self.backend.postReceiptResult = .success(customerInfoAfterPurchase)
 
         let payment = SKPayment(product: product)
 
@@ -2525,14 +2534,14 @@ class PurchasesTests: XCTestCase {
         expect(self.deviceCache.invokedClearCustomerInfoCacheCount) == 1
     }
 
-    func testGetCustomerInfoAfterInvalidatingDoesntReturnCachedVersion() {
+    func testGetCustomerInfoAfterInvalidatingDoesntReturnCachedVersion() throws {
         setupPurchases()
         guard let nonOptionalPurchases = purchases else { fatalError("failed when setting up purchases for testing") }
 
         let appUserID = identityManager.currentAppUserID
         let oldAppUserInfo = Data()
         self.deviceCache.cache(customerInfo: oldAppUserInfo, appUserID: appUserID)
-        let overrideCustomerInfo = CustomerInfo(testData: [
+        let overrideCustomerInfo = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
@@ -2540,7 +2549,7 @@ class PurchasesTests: XCTestCase {
                 "subscriptions": [:],
                 "other_purchases": [:]
             ]])
-        self.backend.overrideCustomerInfo = overrideCustomerInfo
+        self.backend.overrideCustomerInfoResult = .success(overrideCustomerInfo)
 
         var receivedCustomerInfo: CustomerInfo?
         var completionCallCount = 0
@@ -2563,8 +2572,7 @@ class PurchasesTests: XCTestCase {
         let backendError = ErrorUtils.backendError(withBackendCode: .invalidAPIKey,
                                                    backendMessage: "Invalid credentials",
                                                    finishable: true)
-        self.backend.overrideCustomerInfoError = backendError
-        self.backend.overrideCustomerInfo = nil
+        self.backend.overrideCustomerInfoResult = .failure(backendError)
 
         setupPurchases()
         guard let nonOptionalPurchases = purchases else { fatalError("failed when setting up purchases for testing") }

--- a/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/PurchasesTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -211,17 +211,19 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
     }
 
     func testSubscriberAttributesSyncIsPerformedAfterCustomerInfoSync() {
-        mockBackend.stubbedGetSubscriberDataCustomerInfo = CustomerInfo(testData: [
-            "request_date": "2019-08-16T10:30:42Z",
-            "subscriber": [
-                "first_seen": "2019-07-17T00:05:54Z",
-                "original_app_user_id": "app_user_id",
-                "subscriptions": [:],
-                "other_purchases": [:],
-                "original_application_version": "1.0",
-                "original_purchase_date": "2018-10-26T23:17:53Z"
-            ]
-        ])
+        mockBackend.stubbedGetCustomerInfoResult = .success(
+            CustomerInfo(testData: [
+                "request_date": "2019-08-16T10:30:42Z",
+                "subscriber": [
+                    "first_seen": "2019-07-17T00:05:54Z",
+                    "original_app_user_id": "app_user_id",
+                    "subscriptions": [:],
+                    "other_purchases": [:],
+                    "original_application_version": "1.0",
+                    "original_purchase_date": "2018-10-26T23:17:53Z"
+                ]
+            ])!
+        )
 
         setupPurchases()
 
@@ -605,7 +607,7 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
         transaction.mockState = SKPaymentTransactionState.purchasing
         self.mockStoreKitWrapper.delegate?.storeKitWrapper(self.mockStoreKitWrapper, updatedTransaction: transaction)
 
-        self.mockBackend.stubbedPostReceiptCustomerInfo = CustomerInfo(testData: emptyCustomerInfoData)
+        self.mockBackend.stubbedPostReceiptResult = .success(CustomerInfo(testData: emptyCustomerInfoData)!)
 
         transaction.mockState = SKPaymentTransactionState.purchased
         self.mockStoreKitWrapper.delegate?.storeKitWrapper(self.mockStoreKitWrapper, updatedTransaction: transaction)
@@ -632,10 +634,12 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
         self.mockStoreKitWrapper.delegate?.storeKitWrapper(self.mockStoreKitWrapper, updatedTransaction: transaction)
 
         let extraUserInfo = [Backend.RCSuccessfullySyncedKey: true]
-        self.mockBackend.stubbedPostReceiptPurchaserError = ErrorUtils.backendError(
-            withBackendCode: .invalidAPIKey,
-            backendMessage: "Invalid credentials",
-            extraUserInfo: extraUserInfo
+        self.mockBackend.stubbedPostReceiptResult = .failure(
+            ErrorUtils.backendError(
+                withBackendCode: .invalidAPIKey,
+                backendMessage: "Invalid credentials",
+                extraUserInfo: extraUserInfo
+            )
         )
 
         transaction.mockState = SKPaymentTransactionState.purchased
@@ -662,10 +666,12 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
         self.mockStoreKitWrapper.delegate?.storeKitWrapper(self.mockStoreKitWrapper, updatedTransaction: transaction)
 
         let extraUserInfo = [Backend.RCSuccessfullySyncedKey as NSError.UserInfoKey: false]
-        self.mockBackend.stubbedPostReceiptPurchaserError = ErrorUtils.backendError(
-            withBackendCode: .invalidAPIKey,
-            backendMessage: "Invalid credentials",
-            extraUserInfo: extraUserInfo
+        self.mockBackend.stubbedPostReceiptResult = .failure(
+            ErrorUtils.backendError(
+                withBackendCode: .invalidAPIKey,
+                backendMessage: "Invalid credentials",
+                extraUserInfo: extraUserInfo
+            )
         )
 
         transaction.mockState = SKPaymentTransactionState.purchased
@@ -674,4 +680,5 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
         expect(self.mockBackend.invokedPostReceiptData).to(beTrue())
         expect(self.mockSubscriberAttributesManager.invokedMarkAttributes) == false
     }
+
 }

--- a/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
+++ b/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
@@ -237,7 +237,7 @@ class BeginRefundRequestHelperTests: XCTestCase {
     func testBeginRefundForEntitlementFailsOnCustomerInfoFetchFail() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        customerInfoManager.stubbedError = ErrorUtils.customerInfoError(withMessage: "")
+        customerInfoManager.stubbedCustomerInfoResult = .failure(ErrorUtils.customerInfoError(withMessage: ""))
 
         let expectedError = ErrorUtils.beginRefundRequestError(
             withMessage: Strings.purchase.begin_refund_customer_info_error(
@@ -256,7 +256,7 @@ class BeginRefundRequestHelperTests: XCTestCase {
     func testBeginRefundForActiveEntitlementFailsOnCustomerInfoFetchFail() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        customerInfoManager.stubbedError = ErrorUtils.customerInfoError(withMessage: "")
+        customerInfoManager.stubbedCustomerInfoResult = .failure(ErrorUtils.customerInfoError(withMessage: ""))
 
         let expectedError = ErrorUtils.beginRefundRequestError(
             withMessage: Strings.purchase.begin_refund_customer_info_error(entitlementID: nil).description)
@@ -271,48 +271,12 @@ class BeginRefundRequestHelperTests: XCTestCase {
     }
 
     @available(iOS 15.0, macCatalyst 15.0, *)
-    func testBeginRefundForEntitlementFailsIfCustomerInfoNil() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-
-        customerInfoManager.stubbedCustomerInfo = nil
-
-        let expectedError = ErrorUtils.beginRefundRequestError(
-            withMessage: Strings.purchase.begin_refund_for_entitlement_nil_customer_info(
-                entitlementID: mockEntitlementID).description)
-
-        do {
-            _ = try await helper.beginRefundRequest(forEntitlement: mockEntitlementID)
-            XCTFail("beginRefundRequestForEntitlement should have thrown error")
-        } catch {
-            expect(error.localizedDescription) == expectedError.localizedDescription
-            expect(error).to(matchError(expectedError))
-        }
-    }
-
-    @available(iOS 15.0, macCatalyst 15.0, *)
-    func testBeginRefundForActiveEntitlementFailsIfCustomerInfoNil() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-
-        customerInfoManager.stubbedCustomerInfo = nil
-
-        let expectedError = ErrorUtils.beginRefundRequestError(
-            withMessage: Strings.purchase.begin_refund_for_entitlement_nil_customer_info(
-                entitlementID: nil).description)
-
-        do {
-            _ = try await helper.beginRefundRequestForActiveEntitlement()
-            XCTFail("beginRefundRequestForActiveEntitlement should have thrown error")
-        } catch {
-            expect(error).to(matchError(expectedError))
-            expect(error.localizedDescription) == expectedError.localizedDescription
-        }
-    }
-
-    @available(iOS 15.0, macCatalyst 15.0, *)
     func testBeginRefundForEntitlementFailsIfEntitlementNotInCustomerInfo() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        customerInfoManager.stubbedCustomerInfo = try CustomerInfo(data: mockCustomerInfoResponseWithoutMockEntitlement)
+        customerInfoManager.stubbedCustomerInfoResult = .success(
+            try CustomerInfo(data: mockCustomerInfoResponseWithoutMockEntitlement)
+        )
 
         let expectedMessage =
             Strings.purchase.begin_refund_no_entitlement_found(entitlementID: mockEntitlementID).description
@@ -331,8 +295,9 @@ class BeginRefundRequestHelperTests: XCTestCase {
     func testBeginRefundForActiveEntitlementFailsIfNoActiveEntitlement() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        customerInfoManager.stubbedCustomerInfo =
+        customerInfoManager.stubbedCustomerInfoResult = .success(
             try CustomerInfo(data: mockCustomerInfoResponseWithNoActiveEntitlement)
+        )
 
         let expectedMessage = Strings.purchase.begin_refund_no_active_entitlement.description
         let expectedError = ErrorUtils.beginRefundRequestError(withMessage: expectedMessage)
@@ -350,8 +315,9 @@ class BeginRefundRequestHelperTests: XCTestCase {
     func testBeginRefundForActiveEntitlementFailsIfMultipleActiveEntitlements() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        customerInfoManager.stubbedCustomerInfo =
+        customerInfoManager.stubbedCustomerInfoResult = .success(
             try CustomerInfo(data: mockCustomerInfoResponseWithMockEntitlementActiveMultiple)
+        )
 
         let expectedMessage = Strings.purchase.begin_refund_multiple_active_entitlements.description
         let expectedError = ErrorUtils.beginRefundRequestError(withMessage: expectedMessage)

--- a/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
+++ b/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
@@ -54,7 +54,7 @@ class ManageSubscriptionsHelperTests: XCTestCase {
         guard #available(iOS 15.0, *) else { throw XCTSkip("Required API is not available for this test.") }
         // given
         var callbackCalled = false
-        customerInfoManager.stubbedCustomerInfo = try CustomerInfo(data: mockCustomerInfoData)
+        customerInfoManager.stubbedCustomerInfoResult = .success(try CustomerInfo(data: mockCustomerInfoData))
 
         // when
         helper.showManageSubscriptions { _ in
@@ -77,7 +77,7 @@ class ManageSubscriptionsHelperTests: XCTestCase {
         // given
         var callbackCalled = false
         var receivedResult: Result<Void, Error>?
-        customerInfoManager.stubbedCustomerInfo = try CustomerInfo(data: mockCustomerInfoData)
+        customerInfoManager.stubbedCustomerInfoResult = .success(try CustomerInfo(data: mockCustomerInfoData))
 
         // when
         helper.showManageSubscriptions { result in
@@ -99,7 +99,7 @@ class ManageSubscriptionsHelperTests: XCTestCase {
         // given
         var callbackCalled = false
         var receivedResult: Result<Void, Error>?
-        customerInfoManager.stubbedCustomerInfo = try CustomerInfo(data: mockCustomerInfoData)
+        customerInfoManager.stubbedCustomerInfoResult = .success(try CustomerInfo(data: mockCustomerInfoData))
 
         // when
         helper.showManageSubscriptions { result in
@@ -114,10 +114,12 @@ class ManageSubscriptionsHelperTests: XCTestCase {
     }
 
     func testShowManageSubscriptionsFailsIfCouldntGetCustomerInfo() throws {
+let error = NSError(domain: RCPurchasesErrorCodeDomain, code: 123, userInfo: nil)
+
         // given
         var callbackCalled = false
         var receivedResult: Result<Void, Error>?
-        customerInfoManager.stubbedError = NSError(domain: RCPurchasesErrorCodeDomain, code: 123, userInfo: nil)
+        customerInfoManager.stubbedCustomerInfoResult = .failure(error)
 
         // when
         helper.showManageSubscriptions { result in
@@ -131,7 +133,7 @@ class ManageSubscriptionsHelperTests: XCTestCase {
         let expectedErrorMessage = "Failed to get managementURL from CustomerInfo. " +
         "Details: The operation couldn’t be completed"
         let expectedError = ErrorUtils.customerInfoError(withMessage: expectedErrorMessage,
-                                                         error: customerInfoManager.stubbedError)
+                                                         error: error)
         expect(nonNilReceivedResult).to(beFailure { error in
             expect(error).to(matchError(expectedError))
         })

--- a/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -109,7 +109,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
     func testPurchaseSK1PackageSendsReceiptToBackendIfSuccessful() async throws {
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
-        backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
+        backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
         let product = try await fetchSk1Product()
         let storeProduct = try await fetchSk1StoreProduct()
@@ -133,8 +133,8 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
     func testPurchaseSK1PromotionalOffer() async throws {
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
-        backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
-        backend.stubbedPostOfferCompetionResult = ("signature", "identifier", UUID(), 12345, nil)
+        backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
+        backend.stubbedPostOfferCompletionResult = .success(("signature", "identifier", UUID(), 12345))
 
         let product = try await fetchSk1Product()
 
@@ -146,10 +146,10 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                                                             subscriptionPeriod: .init(value: 1, unit: .month),
                                                             type: .promotional)
 
-        _ = await withCheckedContinuation { continuation in
+        _ = try await withCheckedThrowingContinuation { continuation in
             orchestrator.promotionalOffer(forProductDiscount: storeProductDiscount,
-                                          product: StoreProduct(sk1Product: product)) { paymentDiscount, error in
-                continuation.resume(returning: (paymentDiscount, error))
+                                          product: StoreProduct(sk1Product: product)) { result in
+                continuation.resume(with: result)
             }
         }
 
@@ -159,8 +159,8 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
     func testPurchaseSK1PackageWithDiscountSendsReceiptToBackendIfSuccessful() async throws {
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
-        backend.stubbedPostOfferCompetionResult = ("signature", "identifier", UUID(), 12345, nil)
-        backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
+        backend.stubbedPostOfferCompletionResult = .success(("signature", "identifier", UUID(), 12345))
+        backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
         let product = try await fetchSk1Product()
         let storeProduct = StoreProduct(sk1Product: product)
@@ -201,7 +201,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         let mockTransaction = try await createTransactionWithPurchase()
 
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
-        backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
+        backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
         mockStoreKit2TransactionListener?.mockTransaction = .init(mockTransaction)
 
         let product = try await self.fetchSk2Product()
@@ -228,7 +228,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
-        backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
+        backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
         let storeProduct = StoreProduct.from(product: try await fetchSk2StoreProduct())
         let package = Package(identifier: "package",
@@ -252,7 +252,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
-        backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
+        backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
         let product = try await fetchSk2Product()
 
@@ -267,7 +267,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         testSession.failTransactionsEnabled = true
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
-        backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
+        backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
         let product = try await fetchSk2Product()
         let storeProduct = StoreProduct(sk2Product: product)
@@ -347,8 +347,8 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
-        backend.stubbedPostReceiptCustomerInfo = mockCustomerInfo
-        backend.stubbedPostOfferCompetionResult = ("signature", "identifier", UUID(), 12345, nil)
+        backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
+        backend.stubbedPostOfferCompletionResult = .success(("signature", "identifier", UUID(), 12345))
 
         let storeProduct = try await self.fetchSk2StoreProduct()
 


### PR DESCRIPTION
Currently pretty much all closures in the codebase use `(Value?, Error?)`, which is a leftover from Objective-C days. These can represent 4 different cases:
- **Value / no-error**
- **No-value / error**
- _Value / error_
- _No-value / no-error_

Out of those 4, only 2 are really valid, which meant that a lot of code was spent handling the other 2, either creating errors (like `UnexpectedBackendResponseSubErrorCode.loginMissingResponse`) that weren't possible, or hard to follow code because both a value and an error were possible.

In tests, too, the mocks were initially set up to produce no value and no error, which were in many cases triggering code paths that weren't legal with real code.

This change removes this possibility all together by ensuring **at compile time**, that one of the two is always present.

This is step 1 in a series of refactors.
- Step 2 will move _a lot of duplicated code_ that handles status codes != 20x, error handling, parsing error responses, etc. up to `HTTPClient` and out of the operations, making the operations a lot simpler.
- Step 3 will change `HTTPClient` to return a `Response: Decodable` instead of `[String: Any]`, moving more of the response serialization logic to `HTTPClient`, and leaving the operations to only focus on the "happy path".