### PR TITLE
`HTTPClient`: removed `JSONSerialization.ReadingOptions.mutableContainers`

### DIFF
--- a/Purchases/Networking/HTTPClient.swift
+++ b/Purchases/Networking/HTTPClient.swift
@@ -160,7 +160,6 @@ private extension HTTPClient {
         self.start(request: request)
     }
 
-    // swiftlint:disable:next function_body_length
     func handle(urlResponse: URLResponse?,
                 request: Request,
                 urlRequest: URLRequest,
@@ -182,8 +181,7 @@ private extension HTTPClient {
                     jsonObject = [:]
                 } else if let data = data {
                     do {
-                        jsonObject = try JSONSerialization.jsonObject(with: data,
-                                                                      options: .mutableContainers) as? [String: Any]
+                        jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any]
                     } catch let jsonError {
                         Logger.error(Strings.network.parsing_json_error(error: jsonError))
 


### PR DESCRIPTION
This wasn't used anywhere, so it makes the code safer by making sure response bodies aren't mutable references.
Note that this will only be short-lived however, since all response deserialization will be done using `Decodable`.