### PR TITLE
Fixed sporadic `BeginRefundRequestHelperTests` failures

### DIFF
--- a/Purchases/FoundationExtensions/UIApplication+RCExtensions.swift
+++ b/Purchases/FoundationExtensions/UIApplication+RCExtensions.swift
@@ -23,13 +23,31 @@ extension UIApplication {
     @available(watchOSApplicationExtension, unavailable)
     @available(tvOS, unavailable)
     var currentWindowScene: UIWindowScene? {
-        let windowScene = self
+        var scenes = self
             .connectedScenes
             .filter { $0.activationState == .foregroundActive }
-            .first
 
-        return windowScene as? UIWindowScene
+        #if DEBUG && targetEnvironment(simulator)
+        // Running StoreKitUnitTests might not always have an active scene
+        // Sporadically, the only scene will be `foregroundInactive` or `background`
+        if scenes.isEmpty, UIApplication.isRunningUnitTests {
+            scenes = self.connectedScenes
+        }
+        #endif
+
+        return scenes.first as? UIWindowScene
     }
 
 }
+
+#if DEBUG
+
+private extension UIApplication {
+    static var isRunningUnitTests: Bool {
+        return ProcessInfo.processInfo.environment.keys.contains("XCTestConfigurationFilePath")
+    }
+}
+
+#endif
+
 #endif

--- a/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
+++ b/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
@@ -28,99 +28,11 @@ class BeginRefundRequestHelperTests: XCTestCase {
     private let mockEntitlementID = "1234"
     private let mockEntitlementID2 = "2345"
 
-    var mockCustomerInfoResponseWithMockEntitlementActive: [String: Any] {
-        return [
-            "request_date": "2018-10-19T02:40:36Z",
-            "subscriber": [
-                "original_app_user_id": "app_user_id",
-                "original_application_version": "2083",
-                "first_seen": "2019-06-17T16:05:33Z",
-                "non_subscriptions": [],
-                "subscriptions": [
-                    "onemonth_freetrial": [:]
-                ],
-                "entitlements": [
-                    "\(mockEntitlementID)": [
-                        "expires_date": "2100-08-30T02:40:36Z",
-                        "product_identifier": "onemonth_freetrial",
-                        "purchase_date": "2018-10-26T23:17:53Z"
-                    ]
-                ]
-            ]
-        ]
-    }
-
-    var mockCustomerInfoResponseWithMockEntitlementActiveMultiple: [String: Any] {
-        return [
-            "request_date": "2018-10-19T02:40:36Z",
-            "subscriber": [
-                "original_app_user_id": "app_user_id",
-                "original_application_version": "2083",
-                "first_seen": "2019-06-17T16:05:33Z",
-                "non_subscriptions": [],
-                "subscriptions": [
-                    "onemonth_freetrial": [:],
-                    "onemonth_freetrial2": [:]
-                ],
-                "entitlements": [
-                    "\(mockEntitlementID)": [
-                        "expires_date": "2100-08-30T02:40:36Z",
-                        "product_identifier": "onemonth_freetrial",
-                        "purchase_date": "2018-10-26T23:17:53Z"
-                    ],
-                    "\(mockEntitlementID2)": [
-                        "expires_date": "2100-08-30T02:40:36Z",
-                        "product_identifier": "onemonth_freetrial2",
-                        "purchase_date": "2018-10-26T23:17:53Z"
-                    ]
-                ]
-            ]
-        ]
-    }
-
-    var mockCustomerInfoResponseWithNoActiveEntitlement: [String: Any] {
-        return [
-            "request_date": "2018-10-19T02:40:36Z",
-            "subscriber": [
-                "original_app_user_id": "app_user_id",
-                "original_application_version": "2083",
-                "first_seen": "2019-06-17T16:05:33Z",
-                "non_subscriptions": [],
-                "subscriptions": [],
-                "entitlements": [
-                    "\(mockEntitlementID)": [
-                        "expires_date": "2000-08-30T02:40:36Z",
-                        "product_identifier": "onemonth_freetrial",
-                        "purchase_date": "2018-10-26T23:17:53Z"
-                    ]
-                ]
-            ]
-        ]
-    }
-
-    let mockCustomerInfoResponseWithoutMockEntitlement: [String: Any] = [
-        "request_date": "2018-10-19T02:40:36Z",
-        "subscriber": [
-            "original_app_user_id": "app_user_id",
-            "original_application_version": "2083",
-            "first_seen": "2019-06-17T16:05:33Z",
-            "non_subscriptions": [],
-            "subscriptions": [],
-            "entitlements": [
-                "pro": [
-                    "expires_date": "2100-08-30T02:40:36Z",
-                    "product_identifier": "onemonth_freetrial",
-                    "purchase_date": "2018-10-26T23:17:53Z"
-                ]
-            ]
-        ]
-    ]
-
     @available(iOS 15.0, macCatalyst 15.0, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     @available(macOS, unavailable)
-    private lazy var sk2Helper = MockSK2BeginRefundRequestHelper()
+    private lazy var sk2Helper: MockSK2BeginRefundRequestHelper! = nil
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -135,9 +47,9 @@ class BeginRefundRequestHelperTests: XCTestCase {
                                           identityManager: identityManager)
 
         if #available(iOS 15.0, macCatalyst 15.0, *) {
+            sk2Helper = MockSK2BeginRefundRequestHelper()
             helper.sk2Helper = sk2Helper
         }
-
     }
 
     func testBeginRefundRequestForProductFatalErrorIfNotIosOrCatalyst() throws {
@@ -331,5 +243,99 @@ class BeginRefundRequestHelperTests: XCTestCase {
         }
     }
 #endif
+
+}
+
+private extension BeginRefundRequestHelperTests {
+
+    var mockCustomerInfoResponseWithMockEntitlementActive: [String: Any] {
+        return [
+            "request_date": "2018-10-19T02:40:36Z",
+            "subscriber": [
+                "original_app_user_id": "app_user_id",
+                "original_application_version": "2083",
+                "first_seen": "2019-06-17T16:05:33Z",
+                "non_subscriptions": [],
+                "subscriptions": [
+                    "onemonth_freetrial": [:]
+                ],
+                "entitlements": [
+                    "\(mockEntitlementID)": [
+                        "expires_date": "2100-08-30T02:40:36Z",
+                        "product_identifier": "onemonth_freetrial",
+                        "purchase_date": "2018-10-26T23:17:53Z"
+                    ]
+                ]
+            ]
+        ]
+    }
+
+    var mockCustomerInfoResponseWithMockEntitlementActiveMultiple: [String: Any] {
+        return [
+            "request_date": "2018-10-19T02:40:36Z",
+            "subscriber": [
+                "original_app_user_id": "app_user_id",
+                "original_application_version": "2083",
+                "first_seen": "2019-06-17T16:05:33Z",
+                "non_subscriptions": [],
+                "subscriptions": [
+                    "onemonth_freetrial": [:],
+                    "onemonth_freetrial2": [:]
+                ],
+                "entitlements": [
+                    "\(mockEntitlementID)": [
+                        "expires_date": "2100-08-30T02:40:36Z",
+                        "product_identifier": "onemonth_freetrial",
+                        "purchase_date": "2018-10-26T23:17:53Z"
+                    ],
+                    "\(mockEntitlementID2)": [
+                        "expires_date": "2100-08-30T02:40:36Z",
+                        "product_identifier": "onemonth_freetrial2",
+                        "purchase_date": "2018-10-26T23:17:53Z"
+                    ]
+                ]
+            ]
+        ]
+    }
+
+    var mockCustomerInfoResponseWithNoActiveEntitlement: [String: Any] {
+        return [
+            "request_date": "2018-10-19T02:40:36Z",
+            "subscriber": [
+                "original_app_user_id": "app_user_id",
+                "original_application_version": "2083",
+                "first_seen": "2019-06-17T16:05:33Z",
+                "non_subscriptions": [],
+                "subscriptions": [],
+                "entitlements": [
+                    "\(mockEntitlementID)": [
+                        "expires_date": "2000-08-30T02:40:36Z",
+                        "product_identifier": "onemonth_freetrial",
+                        "purchase_date": "2018-10-26T23:17:53Z"
+                    ]
+                ]
+            ]
+        ]
+    }
+
+    var mockCustomerInfoResponseWithoutMockEntitlement: [String: Any] {
+        return [
+            "request_date": "2018-10-19T02:40:36Z",
+            "subscriber": [
+                "original_app_user_id": "app_user_id",
+                "original_application_version": "2083",
+                "first_seen": "2019-06-17T16:05:33Z",
+                "non_subscriptions": [],
+                "subscriptions": [],
+                "entitlements": [
+                    "pro": [
+                        "expires_date": "2100-08-30T02:40:36Z",
+                        "product_identifier": "onemonth_freetrial",
+                        "purchase_date": "2018-10-26T23:17:53Z"
+                    ]
+                ]
+            ]
+        ]
+    }
 
 }


### PR DESCRIPTION
These have began failing on #1387, even though that doesn't change anything that should affect the `UIWindowScene` or anything related. This could have been a regression from Xcode 13.3.
When the test fails (which isn't always), the scene isn't yet `.foregroundActive` . To workaround that, this defaults to any scene, *though only when running tests, on debug, and on the simulator*. So nothing is changed in release or device builds.

This also has a small refactor on `BeginRefundRequestHelperTests` to move the test data below and make the tests more readable.
Additionally, the `MockSK2BeginRefundRequestHelper` is recreated for every test. I thought initially that this is what was making the test fail, as the mock expectations and state was being shared across tests. It's not, but now that should remove any potential issues with shared state.