### PR TITLE
Adds new convenience method for setting Mixpanel Distinct ID attribute

### DIFF
--- a/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -125,6 +125,8 @@ BOOL isAnonymous;
     [p setOnesignalID: @""];
     [p setCleverTapID: nil];
     [p setCleverTapID: @""];
+    [p setMixpanelDistinctID: nil];
+    [p setMixpanelDistinctID: @""];
     [p setMediaSource: nil];
     [p setMediaSource: @""];
     [p setCampaign: nil];

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -162,6 +162,7 @@ private func checkPurchasesSubscriberAttributesAPI(purchases: Purchases) {
     purchases.setMparticleID("")
     purchases.setOnesignalID("")
     purchases.setCleverTapID("")
+    purchases.setMixpanelDistinctID("")
     purchases.setMediaSource("")
     purchases.setCampaign("")
     purchases.setAdGroup("")

--- a/Documentation.docc/Purchases.md
+++ b/Documentation.docc/Purchases.md
@@ -100,6 +100,7 @@ Most features require configuring the SDK before using it.
 - ``Purchases/setMparticleID(_:)``
 - ``Purchases/setOnesignalID(_:)``
 - ``Purchases/setFBAnonymousID(_:)``
+- ``Purchases/setMixpanelDistinctID(_:)``
 
 ### Advanced Configuration
 - ``Purchases/finishTransactions``

--- a/Documentation.docc/RevenueCat.md
+++ b/Documentation.docc/RevenueCat.md
@@ -144,3 +144,4 @@ Or browse our iOS sample apps:
 - ``Purchases/setMparticleID(_:)``
 - ``Purchases/setOnesignalID(_:)``
 - ``Purchases/setFBAnonymousID(_:)``
+- ``Purchases/setMixpanelDistinctID(_:)``

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -614,6 +614,19 @@ extension Purchases {
     }
 
     /**
+     * Subscriber attribute associated with the Mixpanel Distinct ID for the user.
+     * Optional for the RevenueCat Mixpanel integration.
+     *
+     * #### Related Articles
+     * - [Mixpanel RevenueCat Integration](https://docs.revenuecat.com/docs/mixpanel)
+     *
+     *- Parameter mixpanelDistinctID: Empty String or `nil` will delete the subscriber attribute.
+     */
+    @objc public func setMixpanelDistinctID(_ mixpanelDistinctID: String?) {
+        subscriberAttributesManager.setMixpanelDistinctID(mixpanelDistinctID, appUserID: appUserID)
+    }
+
+    /**
      * Subscriber attribute associated with the install media source for the user.
      *
      * #### Related Articles

--- a/Purchases/SubscriberAttributes/ReservedSubscriberAttributes.swift
+++ b/Purchases/SubscriberAttributes/ReservedSubscriberAttributes.swift
@@ -37,6 +37,7 @@ enum ReservedSubscriberAttribute: String {
     case oneSignalID = "$onesignalId"
     case airshipChannelID = "$airshipChannelId"
     case cleverTapID = "$clevertapId"
+    case mixpanelDistinctID = "$mixpanelDistinctId"
 
     case mediaSource = "$mediaSource"
     case campaign = "$campaign"

--- a/Purchases/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Purchases/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -87,6 +87,10 @@ class SubscriberAttributesManager {
         setAttributionID(cleverTapID, forNetworkID: .cleverTapID, appUserID: appUserID)
     }
 
+    func setMixpanelDistinctID(_ mixpanelDistinctID: String?, appUserID: String) {
+        setReservedAttribute(.mixpanelDistinctID, value: mixpanelDistinctID, appUserID: appUserID)
+    }
+
     func setMediaSource(_ mediaSource: String?, appUserID: String) {
         setReservedAttribute(.mediaSource, value: mediaSource, appUserID: appUserID)
     }

--- a/PurchasesTests/Mocks/MockSubscriberAttributesManager.swift
+++ b/PurchasesTests/Mocks/MockSubscriberAttributesManager.swift
@@ -166,6 +166,18 @@ class MockSubscriberAttributesManager: SubscriberAttributesManager {
         invokedSetCleverTapIDParametersList.append((cleverTapID, appUserID))
     }
 
+    var invokedSetMixpanelDistinctID = false
+    var invokedSetMixpanelDistinctIDCount = 0
+    var invokedSetMixpanelDistinctIDParameters: (mixpanelDistinctID: String?, appUserID: String?)?
+    var invokedSetMixpanelDistinctIDParametersList = [(mixpanelDistinctID: String?, appUserID: String?)]()
+
+    override func setMixpanelDistinctID(_ mixpanelDistinctID: String?, appUserID: String) {
+        invokedSetMixpanelDistinctID = true
+        invokedSetMixpanelDistinctIDCount += 1
+        invokedSetMixpanelDistinctIDParameters = (mixpanelDistinctID, appUserID)
+        invokedSetMixpanelDistinctIDParametersList.append((mixpanelDistinctID, appUserID))
+    }
+
     var invokedSetMediaSource = false
     var invokedSetMediaSourceCount = 0
     var invokedSetMediaSourceParameters: (mediaSource: String?, appUserID: String?)?

--- a/PurchasesTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/PurchasesTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -1064,6 +1064,69 @@ class SubscriberAttributesManagerTests: XCTestCase {
         checkDeviceIdentifiersAreSet()
     }
     // endregion
+    // region MixpanelDistinctID
+    func testSetMixpanelDistinctID() throws {
+        let mixpanelDistinctID = "mixpanelDistinctID"
+
+        self.subscriberAttributesManager.setMixpanelDistinctID(mixpanelDistinctID, appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$mixpanelDistinctId"
+        expect(receivedAttribute.value) == mixpanelDistinctID
+        expect(receivedAttribute.isSynced) == false
+    }
+
+    func testSetMixpanelDistinctIDSetsEmptyIfNil() throws {
+        let mixpanelDistinctID = "mixpanelDistinctID"
+
+        self.subscriberAttributesManager.setMixpanelDistinctID(mixpanelDistinctID, appUserID: "kratos")
+        self.subscriberAttributesManager.setMixpanelDistinctID(nil, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 2
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$mixpanelDistinctId"
+        expect(receivedAttribute.value) == ""
+        expect(receivedAttribute.isSynced) == false
+    }
+
+    func testSetMixpanelDistinctIDSkipsIfSameValue() {
+        let mixpanelDistinctID = "mixpanelDistinctID"
+
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$mixpanelDistinctId",
+                                                                                    value: mixpanelDistinctID)
+        self.subscriberAttributesManager.setMixpanelDistinctID(mixpanelDistinctID, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 0
+    }
+
+    func testSetMixpanelDistinctIDOverwritesIfNewValue() throws {
+        let oldSyncTime = Date()
+        let mixpanelDistinctID = "mixpanelDistinctID"
+
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$mixpanelDistinctId",
+                                                                                    value: "old_id",
+                                                                                    isSynced: true,
+                                                                                    setTime: oldSyncTime)
+
+        self.subscriberAttributesManager.setMixpanelDistinctID(mixpanelDistinctID, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$mixpanelDistinctId"
+        expect(receivedAttribute.value) == mixpanelDistinctID
+        expect(receivedAttribute.isSynced) == false
+        expect(receivedAttribute.setTime) > oldSyncTime
+    }
+    // endregion
     // region Media source
     func testSetMediaSource() {
         let mediaSource = "mediaSource"


### PR DESCRIPTION
[CF-346](https://revenuecats.atlassian.net/browse/CF-346)

### Motivation
We now support setting the `$mixpanelDistinctId` subscriber attribute for the RevenueCat Mixpanel integration to use for an event's identity instead of the last seen alias: https://docs.revenuecat.com/docs/mixpanel 

### Description
Adds a new convenience method for setting the Mixpanel reserved attribute: `$mixpanelDistinctId`
