### PR TITLE
Preventing logging if ownershipType key is missing

### DIFF
--- a/Purchases/CodableExtensions/EntitlementProductData+Extensions.swift
+++ b/Purchases/CodableExtensions/EntitlementProductData+Extensions.swift
@@ -32,7 +32,8 @@ extension EntitlementInfo.ProductData {
         self.store = container.decode(Store.self, forKey: .store, defaultValue: .unknownStore)
         self.ownershipType = container.decode(PurchaseOwnershipType.self,
                                               forKey: .ownershipType,
-                                              defaultValue: .purchased)
+                                              defaultValue: .purchased,
+                                              logDecodingError: false)
     }
 
 }

--- a/Purchases/CodableExtensions/EntitlementProductData+Extensions.swift
+++ b/Purchases/CodableExtensions/EntitlementProductData+Extensions.swift
@@ -32,8 +32,7 @@ extension EntitlementInfo.ProductData {
         self.store = container.decode(Store.self, forKey: .store, defaultValue: .unknownStore)
         self.ownershipType = container.decode(PurchaseOwnershipType.self,
                                               forKey: .ownershipType,
-                                              defaultValue: .purchased,
-                                              logDecodingError: false)
+                                              defaultValue: .purchased)
     }
 
 }

--- a/Purchases/FoundationExtensions/JSONDecoder+Extensions.swift
+++ b/Purchases/FoundationExtensions/JSONDecoder+Extensions.swift
@@ -79,11 +79,16 @@ extension KeyedDecodingContainer {
     ///   - defaultValue: The default value returned if decoding fails.
     /// - Returns: A value of the requested type, or the given default value
     /// if decoding fails.
-    func decode<T: Decodable>(_ type: T.Type, forKey key: Self.Key, defaultValue: T) -> T {
+    func decode<T: Decodable>(_ type: T.Type,
+                              forKey key: Self.Key,
+                              defaultValue: T,
+                              logDecodingError: Bool = true) -> T {
         do {
             return try decode(type, forKey: key)
         } catch {
-            ErrorUtils.logDecodingError(error)
+            if logDecodingError {
+                ErrorUtils.logDecodingError(error)
+            }
             return defaultValue
         }
     }

--- a/Purchases/FoundationExtensions/JSONDecoder+Extensions.swift
+++ b/Purchases/FoundationExtensions/JSONDecoder+Extensions.swift
@@ -79,16 +79,10 @@ extension KeyedDecodingContainer {
     ///   - defaultValue: The default value returned if decoding fails.
     /// - Returns: A value of the requested type, or the given default value
     /// if decoding fails.
-    func decode<T: Decodable>(_ type: T.Type,
-                              forKey key: Self.Key,
-                              defaultValue: T,
-                              logDecodingError: Bool = true) -> T {
+    func decode<T: Decodable>(_ type: T.Type, forKey key: Self.Key, defaultValue: T) -> T {
         do {
             return try decode(type, forKey: key)
         } catch {
-            if logDecodingError {
-                ErrorUtils.logDecodingError(error)
-            }
             return defaultValue
         }
     }


### PR DESCRIPTION
Fixes https://github.com/RevenueCat/purchases-ios/issues/1392

I am not sure about the fix, so open to suggestions. For now I made the logging optional, but maybe we want to not log anytime there's a `defaultValue`.

[CF-366]

[CF-366]: https://revenuecats.atlassian.net/browse/CF-366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ