### PR TITLE
`HTTPClient`: correctly return cached data for 304 responses

### DIFF
--- a/Purchases/Networking/HTTPClient.swift
+++ b/Purchases/Networking/HTTPClient.swift
@@ -215,7 +215,7 @@ private extension HTTPClient {
         if let httpResponse = httpResponse,
            let completionHandler = request.completionHandler {
             let error = receivedJSONError ?? networkError
-            completionHandler(httpResponse.statusCode, Result(jsonObject, error))
+            completionHandler(httpResponse.statusCode, Result(httpResponse.jsonObject, error))
         }
 
         self.beginNextRequest()

--- a/Purchases/Networking/HTTPResponse.swift
+++ b/Purchases/Networking/HTTPResponse.swift
@@ -16,8 +16,10 @@ import Foundation
 
 struct HTTPResponse {
 
+    typealias Body = [String: Any]
+
     let statusCode: HTTPStatusCode
-    let jsonObject: [String: Any]?
+    let jsonObject: Body?
 
 }
 


### PR DESCRIPTION
Fixes https://community.revenuecat.com/sdks-51/error-fetching-offerings-but-only-from-second-run-onwards-1405