### PR TITLE
Rename async promotional offer methods

### DIFF
--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -186,7 +186,7 @@ private func checkAsyncMethods(purchases: Purchases) async {
         )
         // Deprecated
         let _: [String: IntroEligibility] = await purchases.checkTrialOrIntroDiscountEligibility([String]())
-        let _: PromotionalOffer = try await purchases.getPromotionalOffer(
+        let _: PromotionalOffer = try await purchases.promotionalOffer(
             forProductDiscount: discount,
             product: stp
         )
@@ -212,7 +212,7 @@ private func checkAsyncMethods(purchases: Purchases) async {
         let _: RefundRequestStatus = try await purchases.beginRefundRequest(forEntitlement: "")
         let _: RefundRequestStatus = try await purchases.beginRefundRequestForActiveEntitlement()
 
-        let _: [PromotionalOffer] = await purchases.getEligiblePromotionalOffers(forProduct: stp)
+        let _: [PromotionalOffer] = await purchases.eligiblePromotionalOffers(forProduct: stp)
         #endif
     } catch {}
 }

--- a/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -186,6 +186,11 @@ private func checkAsyncMethods(purchases: Purchases) async {
         )
         // Deprecated
         let _: [String: IntroEligibility] = await purchases.checkTrialOrIntroDiscountEligibility([String]())
+        // Deprecated
+        let _: PromotionalOffer = try await purchases.getPromotionalOffer(
+            forProductDiscount: discount,
+            product: stp
+        )
         let _: PromotionalOffer = try await purchases.promotionalOffer(
             forProductDiscount: discount,
             product: stp
@@ -212,6 +217,8 @@ private func checkAsyncMethods(purchases: Purchases) async {
         let _: RefundRequestStatus = try await purchases.beginRefundRequest(forEntitlement: "")
         let _: RefundRequestStatus = try await purchases.beginRefundRequestForActiveEntitlement()
 
+        // Deprecated
+        let _: [PromotionalOffer] = await purchases.getEligiblePromotionalOffers(forProduct: stp)
         let _: [PromotionalOffer] = await purchases.eligiblePromotionalOffers(forProduct: stp)
         #endif
     } catch {}

--- a/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
@@ -89,5 +89,7 @@ func checkProductType(_ type: StoreProduct.ProductType) {
 }
 
 func checkStoreProductAsyncAPI() async {
+    // Deprecated
+    let _: [PromotionalOffer] = await product.getEligiblePromotionalOffers()
     let _: [PromotionalOffer] = await product.eligiblePromotionalOffers()
 }

--- a/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
+++ b/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
@@ -89,5 +89,5 @@ func checkProductType(_ type: StoreProduct.ProductType) {
 }
 
 func checkStoreProductAsyncAPI() async {
-    let _: [PromotionalOffer] = await product.getEligiblePromotionalOffers()
+    let _: [PromotionalOffer] = await product.eligiblePromotionalOffers()
 }

--- a/Documentation.docc/Purchases.md
+++ b/Documentation.docc/Purchases.md
@@ -46,7 +46,7 @@ Most features require configuring the SDK before using it.
 - ``Purchases/checkTrialOrIntroDiscountEligibility(productIdentifiers:completion:)``
 - ``Purchases/checkTrialOrIntroDiscountEligibility(product:)``
 - ``Purchases/checkTrialOrIntroDiscountEligibility(product:completion:)``
-- ``Purchases/getPromotionalOffer(forProductDiscount:product:)``
+- ``Purchases/promotionalOffer(forProductDiscount:product:)``
 - ``Purchases/getPromotionalOffer(forProductDiscount:product:completion:)``
 - ``Purchases/purchase(package:promotionalOffer:)``
 - ``Purchases/purchase(package:promotionalOffer:completion:)``

--- a/Documentation.docc/RevenueCat.md
+++ b/Documentation.docc/RevenueCat.md
@@ -88,7 +88,7 @@ Or browse our iOS sample apps:
 - ``Purchases/checkTrialOrIntroDiscountEligibility(productIdentifiers:completion:)``
 - ``Purchases/checkTrialOrIntroDiscountEligibility(product:)``
 - ``Purchases/checkTrialOrIntroDiscountEligibility(product:completion:)``
-- ``Purchases/getPromotionalOffer(forProductDiscount:product:)``
+- ``Purchases/promotionalOffer(forProductDiscount:product:)``
 - ``Purchases/getPromotionalOffer(forProductDiscount:product:completion:)``
 - ``Purchases/purchase(package:promotionalOffer:)``
 - ``Purchases/purchase(package:promotionalOffer:completion:)``

--- a/Documentation.docc/V4_API_Migration_guide.md
+++ b/Documentation.docc/V4_API_Migration_guide.md
@@ -243,7 +243,7 @@ These types replace native StoreKit types in all public API methods that used th
 | purchasePackage(_ package:, _ completion:) | ``Purchases/purchase(package:completion:)`` |
 | restoreTransactions(_ completion:) | ``Purchases/restorePurchases(completion:)`` |
 | syncPurchases(_ completion:) | ``Purchases/syncPurchases(completion:)`` |
-| paymentDiscount(for:product:completion:) | REMOVED - Get eligibility for a discount using ``Purchases/getPromotionalOffer(forProductDiscount:product:)``, then pass the offer directly to ``Purchases/purchase(package:promotionalOffer:)`` or ``Purchases/purchase(product:promotionalOffer:)`` |
+| paymentDiscount(for:product:completion:) | REMOVED - Get eligibility for a discount using ``Purchases/promotionalOffer(forProductDiscount:product:)``, then pass the offer directly to ``Purchases/purchase(package:promotionalOffer:)`` or ``Purchases/purchase(product:promotionalOffer:)`` |
 | purchaseProduct(_:discount:_) | ``Purchases/purchase(product:promotionalOffer:completion:)`` |
 | purchasePackage(_:discount:_) | ``Purchases/purchase(package:promotionalOffer:completion:)`` |
 

--- a/Purchases/Misc/Deprecations.swift
+++ b/Purchases/Misc/Deprecations.swift
@@ -37,4 +37,34 @@ public extension Purchases {
         return await self.checkTrialOrIntroDiscountEligibility(productIdentifiers: productIdentifiers)
     }
 
+    @available(iOS, introduced: 13.0, deprecated, renamed: "promotionalOffer(forProductDiscount:product:)")
+    @available(tvOS, introduced: 13.0, deprecated, renamed: "promotionalOffer(forProductDiscount:product:)")
+    @available(watchOS, introduced: 6.2, deprecated, renamed: "promotionalOffer(forProductDiscount:product:)")
+    @available(macOS, introduced: 10.15, deprecated, renamed: "promotionalOffer(forProductDiscount:product:)")
+    @available(macCatalyst, introduced: 13.0, deprecated, renamed: "promotionalOffer(forProductDiscount:product:)")
+    func getPromotionalOffer(forProductDiscount discount: StoreProductDiscount,
+                             product: StoreProduct) async throws -> PromotionalOffer {
+        return try await self.promotionalOffer(forProductDiscount: discount, product: product)
+    }
+
+    @available(iOS, introduced: 13.0, deprecated, renamed: "eligiblePromotionalOffers(forProduct:)")
+    @available(tvOS, introduced: 13.0, deprecated, renamed: "eligiblePromotionalOffers(forProduct:)")
+    @available(watchOS, introduced: 6.2, deprecated, renamed: "eligiblePromotionalOffers(forProduct:)")
+    @available(macOS, introduced: 10.15, deprecated, renamed: "eligiblePromotionalOffers(forProduct:)")
+    @available(macCatalyst, introduced: 13.0, deprecated, renamed: "eligiblePromotionalOffers(forProduct:)")
+    func getEligiblePromotionalOffers(forProduct product: StoreProduct) async -> [PromotionalOffer] {
+        return await eligiblePromotionalOffers(forProduct: product)
+    }
+
+}
+
+public extension StoreProduct {
+    @available(iOS, introduced: 13.0, deprecated, renamed: "eligiblePromotionalOffers()")
+    @available(tvOS, introduced: 13.0, deprecated, renamed: "eligiblePromotionalOffers()")
+    @available(watchOS, introduced: 6.2, deprecated, renamed: "eligiblePromotionalOffers()")
+    @available(macOS, introduced: 10.15, deprecated, renamed: "eligiblePromotionalOffers()")
+    @available(macCatalyst, introduced: 13.0, deprecated, renamed: "eligiblePromotionalOffers()")
+    func getEligiblePromotionalOffers() async -> [PromotionalOffer] {
+        return await self.eligiblePromotionalOffers()
+    }
 }

--- a/Purchases/Misc/Obsoletions.swift
+++ b/Purchases/Misc/Obsoletions.swift
@@ -396,6 +396,43 @@ public extension Purchases {
     }
 
     /**
+     * Use this method to find eligibility for this user for
+     * [iOS Promotional Offers](https://docs.revenuecat.com/docs/ios-subscription-offers#promotional-offers).
+     * - Note: If you're looking to use free trials or Introductory Offers instead,
+     * use ``Purchases/checkTrialOrIntroDiscountEligibility(productIdentifiers:completion:)``.
+     *
+     * - Parameter discount: The ``StoreProductDiscount`` to apply to the product.
+     * - Parameter product: The ``StoreProduct`` the user intends to purchase.
+     */
+    @available(iOS, introduced: 13.0, unavailable, renamed: "promotionalOffer(forProductDiscount:product:)")
+    @available(tvOS, introduced: 13.0, unavailable, renamed: "promotionalOffer(forProductDiscount:product:)")
+    @available(watchOS, introduced: 6.2, unavailable, renamed: "promotionalOffer(forProductDiscount:product:)")
+    @available(macOS, introduced: 10.15, unavailable, renamed: "promotionalOffer(forProductDiscount:product:)")
+    @available(macCatalyst, introduced: 13.0, unavailable, renamed: "promotionalOffer(forProductDiscount:product:)")
+    func getPromotionalOffer(forProductDiscount discount: StoreProductDiscount,
+                             product: StoreProduct) async throws -> PromotionalOffer {
+        fatalError()
+    }
+
+    /// Finds the subset of ``StoreProduct/discounts`` that's eligible for the current user.
+    ///
+    /// - Parameter product: the product to filter discounts from.
+    /// - Note: if checking for eligibility for a `StoreProductDiscount` fails (for example, if network is down),
+    ///   that discount will fail silently and be considered not eligible.
+    /// #### Related Symbols
+    /// - ``getPromotionalOffer(forProductDiscount:product:)``
+    /// - ``StoreProduct/getEligiblePromotionalOffers()``
+    /// - ``StoreProduct/discounts``
+    @available(iOS, introduced: 13.0, unavailable, renamed: "eligiblePromotionalOffers(forProduct:)")
+    @available(tvOS, introduced: 13.0, unavailable, renamed: "eligiblePromotionalOffers(forProduct:)")
+    @available(watchOS, introduced: 6.2, unavailable, renamed: "eligiblePromotionalOffers(forProduct:)")
+    @available(macOS, introduced: 10.15, unavailable, renamed: "eligiblePromotionalOffers(forProduct:)")
+    @available(macCatalyst, introduced: 13.0, unavailable, renamed: "eligiblePromotionalOffers(forProduct:)")
+    func getEligiblePromotionalOffers(forProduct product: StoreProduct) async -> [PromotionalOffer] {
+        fatalError()
+    }
+
+    /**
      * Computes whether or not a user is eligible for the introductory pricing period of a given product.
      * You should use this method to determine whether or not you show the user the normal product price or
      * the introductory price. This also applies to trials (trials are considered a type of introductory pricing).
@@ -556,6 +593,23 @@ public extension Package {
     @available(macOS, obsoleted: 1, renamed: "storeProduct", message: "Use StoreProduct instead")
     @available(macCatalyst, obsoleted: 1, renamed: "storeProduct", message: "Use StoreProduct instead")
     @objc var product: SKProduct { fatalError() }
+}
+
+public extension StoreProduct {
+    /// Finds the subset of ``discounts`` that's eligible for the current user.
+    /// - Note: if checking for eligibility for a `StoreProductDiscount` fails (for example, if network is down),
+    ///   that discount will fail silently and be considered not eligible.
+    /// - Warning: this method implicitly relies on ``Purchases`` already being initialized.
+    /// #### Related Symbols
+    /// - ``discounts``
+    @available(iOS, introduced: 13.0, unavailable, renamed: "eligiblePromotionalOffers()")
+    @available(tvOS, introduced: 13.0, unavailable, renamed: "eligiblePromotionalOffers()")
+    @available(watchOS, introduced: 6.2, unavailable, renamed: "eligiblePromotionalOffers()")
+    @available(macOS, introduced: 10.15, unavailable, renamed: "eligiblePromotionalOffers()")
+    @available(macCatalyst, introduced: 13.0, unavailable, renamed: "eligiblePromotionalOffers()")
+    func getEligiblePromotionalOffers() async -> [PromotionalOffer] {
+        fatalError()
+    }
 }
 
 public extension StoreProductDiscount.PaymentMode {

--- a/Purchases/Misc/Obsoletions.swift
+++ b/Purchases/Misc/Obsoletions.swift
@@ -396,43 +396,6 @@ public extension Purchases {
     }
 
     /**
-     * Use this method to find eligibility for this user for
-     * [iOS Promotional Offers](https://docs.revenuecat.com/docs/ios-subscription-offers#promotional-offers).
-     * - Note: If you're looking to use free trials or Introductory Offers instead,
-     * use ``Purchases/checkTrialOrIntroDiscountEligibility(productIdentifiers:completion:)``.
-     *
-     * - Parameter discount: The ``StoreProductDiscount`` to apply to the product.
-     * - Parameter product: The ``StoreProduct`` the user intends to purchase.
-     */
-    @available(iOS, introduced: 13.0, unavailable, renamed: "promotionalOffer(forProductDiscount:product:)")
-    @available(tvOS, introduced: 13.0, unavailable, renamed: "promotionalOffer(forProductDiscount:product:)")
-    @available(watchOS, introduced: 6.2, unavailable, renamed: "promotionalOffer(forProductDiscount:product:)")
-    @available(macOS, introduced: 10.15, unavailable, renamed: "promotionalOffer(forProductDiscount:product:)")
-    @available(macCatalyst, introduced: 13.0, unavailable, renamed: "promotionalOffer(forProductDiscount:product:)")
-    func getPromotionalOffer(forProductDiscount discount: StoreProductDiscount,
-                             product: StoreProduct) async throws -> PromotionalOffer {
-        fatalError()
-    }
-
-    /// Finds the subset of ``StoreProduct/discounts`` that's eligible for the current user.
-    ///
-    /// - Parameter product: the product to filter discounts from.
-    /// - Note: if checking for eligibility for a `StoreProductDiscount` fails (for example, if network is down),
-    ///   that discount will fail silently and be considered not eligible.
-    /// #### Related Symbols
-    /// - ``getPromotionalOffer(forProductDiscount:product:)``
-    /// - ``StoreProduct/getEligiblePromotionalOffers()``
-    /// - ``StoreProduct/discounts``
-    @available(iOS, introduced: 13.0, unavailable, renamed: "eligiblePromotionalOffers(forProduct:)")
-    @available(tvOS, introduced: 13.0, unavailable, renamed: "eligiblePromotionalOffers(forProduct:)")
-    @available(watchOS, introduced: 6.2, unavailable, renamed: "eligiblePromotionalOffers(forProduct:)")
-    @available(macOS, introduced: 10.15, unavailable, renamed: "eligiblePromotionalOffers(forProduct:)")
-    @available(macCatalyst, introduced: 13.0, unavailable, renamed: "eligiblePromotionalOffers(forProduct:)")
-    func getEligiblePromotionalOffers(forProduct product: StoreProduct) async -> [PromotionalOffer] {
-        fatalError()
-    }
-
-    /**
      * Computes whether or not a user is eligible for the introductory pricing period of a given product.
      * You should use this method to determine whether or not you show the user the normal product price or
      * the introductory price. This also applies to trials (trials are considered a type of introductory pricing).
@@ -593,23 +556,6 @@ public extension Package {
     @available(macOS, obsoleted: 1, renamed: "storeProduct", message: "Use StoreProduct instead")
     @available(macCatalyst, obsoleted: 1, renamed: "storeProduct", message: "Use StoreProduct instead")
     @objc var product: SKProduct { fatalError() }
-}
-
-public extension StoreProduct {
-    /// Finds the subset of ``discounts`` that's eligible for the current user.
-    /// - Note: if checking for eligibility for a `StoreProductDiscount` fails (for example, if network is down),
-    ///   that discount will fail silently and be considered not eligible.
-    /// - Warning: this method implicitly relies on ``Purchases`` already being initialized.
-    /// #### Related Symbols
-    /// - ``discounts``
-    @available(iOS, introduced: 13.0, unavailable, renamed: "eligiblePromotionalOffers()")
-    @available(tvOS, introduced: 13.0, unavailable, renamed: "eligiblePromotionalOffers()")
-    @available(watchOS, introduced: 6.2, unavailable, renamed: "eligiblePromotionalOffers()")
-    @available(macOS, introduced: 10.15, unavailable, renamed: "eligiblePromotionalOffers()")
-    @available(macCatalyst, introduced: 13.0, unavailable, renamed: "eligiblePromotionalOffers()")
-    func getEligiblePromotionalOffers() async -> [PromotionalOffer] {
-        fatalError()
-    }
 }
 
 public extension StoreProductDiscount.PaymentMode {

--- a/Purchases/Misc/Purchases+async.swift
+++ b/Purchases/Misc/Purchases+async.swift
@@ -143,7 +143,7 @@ extension Purchases {
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func getPromotionalOfferAsync(forProductDiscount discount: StoreProductDiscount,
+    func promotionalOfferAsync(forProductDiscount discount: StoreProductDiscount,
                                   product: StoreProduct) async throws -> PromotionalOffer {
         return try await withCheckedThrowingContinuation { continuation in
             getPromotionalOffer(forProductDiscount: discount, product: product) { offer, error in
@@ -153,14 +153,14 @@ extension Purchases {
      }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func getEligiblePromotionalOffersAsync(forProduct product: StoreProduct) async -> [PromotionalOffer] {
+    func eligiblePromotionalOffersAsync(forProduct product: StoreProduct) async -> [PromotionalOffer] {
         let discounts = product.discounts
 
         return await withTaskGroup(of: Optional<PromotionalOffer>.self) { group in
             for discount in discounts {
                 group.addTask {
                     do {
-                        return try await self.getPromotionalOffer(
+                        return try await self.promotionalOffer(
                             forProductDiscount: discount,
                             product: product
                         )

--- a/Purchases/Misc/Purchases+async.swift
+++ b/Purchases/Misc/Purchases+async.swift
@@ -144,7 +144,7 @@ extension Purchases {
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func promotionalOfferAsync(forProductDiscount discount: StoreProductDiscount,
-                                  product: StoreProduct) async throws -> PromotionalOffer {
+                               product: StoreProduct) async throws -> PromotionalOffer {
         return try await withCheckedThrowingContinuation { continuation in
             getPromotionalOffer(forProductDiscount: discount, product: product) { offer, error in
                 continuation.resume(with: Result(offer, error))

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -1115,8 +1115,8 @@ public extension Purchases {
      *
      * #### Related Symbols
      * - ``StoreProduct/discounts``
-     * - ``StoreProduct/getEligiblePromotionalOffers()``
-     * - ``getPromotionalOffer(forProductDiscount:product:)``
+     * - ``StoreProduct/eligiblePromotionalOffers()``
+     * - ``promotionalOffer(forProductDiscount:product:)``
      */
     @available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvOS 12.2, *)
     @objc(purchaseProduct:withPromotionalOffer:completion:)
@@ -1444,9 +1444,9 @@ public extension Purchases {
      * - Parameter product: The ``StoreProduct`` the user intends to purchase.
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func getPromotionalOffer(forProductDiscount discount: StoreProductDiscount,
+    func promotionalOffer(forProductDiscount discount: StoreProductDiscount,
                              product: StoreProduct) async throws -> PromotionalOffer {
-        return try await getPromotionalOfferAsync(forProductDiscount: discount, product: product)
+        return try await promotionalOfferAsync(forProductDiscount: discount, product: product)
     }
 
     /// Finds the subset of ``StoreProduct/discounts`` that's eligible for the current user.
@@ -1455,12 +1455,12 @@ public extension Purchases {
     /// - Note: if checking for eligibility for a `StoreProductDiscount` fails (for example, if network is down),
     ///   that discount will fail silently and be considered not eligible.
     /// #### Related Symbols
-    /// - ``getPromotionalOffer(forProductDiscount:product:)``
-    /// - ``StoreProduct/getEligiblePromotionalOffers()``
+    /// - ``promotionalOffer(forProductDiscount:product:)``
+    /// - ``StoreProduct/eligiblePromotionalOffers()``
     /// - ``StoreProduct/discounts``
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func getEligiblePromotionalOffers(forProduct product: StoreProduct) async -> [PromotionalOffer] {
-        return await getEligiblePromotionalOffersAsync(forProduct: product)
+    func eligiblePromotionalOffers(forProduct product: StoreProduct) async -> [PromotionalOffer] {
+        return await eligiblePromotionalOffersAsync(forProduct: product)
     }
 
 #if os(iOS) || os(macOS)

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -1445,7 +1445,7 @@ public extension Purchases {
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func promotionalOffer(forProductDiscount discount: StoreProductDiscount,
-                             product: StoreProduct) async throws -> PromotionalOffer {
+                          product: StoreProduct) async throws -> PromotionalOffer {
         return try await promotionalOfferAsync(forProductDiscount: discount, product: product)
     }
 

--- a/Purchases/Purchasing/StoreKitAbstractions/PromotionalOffer.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/PromotionalOffer.swift
@@ -18,10 +18,10 @@ import StoreKit
 /// is ready to be used for a purchase.
 ///
 /// #### Related Symbols
-/// - ``Purchases/getPromotionalOffer(forProductDiscount:product:)``
+/// - ``Purchases/promotionalOffer(forProductDiscount:product:)``
 /// - ``Purchases/getPromotionalOffer(forProductDiscount:product:completion:)``
-/// - ``StoreProduct/getEligiblePromotionalOffers()``
-/// - ``Purchases/getEligiblePromotionalOffers(forProduct:)``
+/// - ``StoreProduct/eligiblePromotionalOffers()``
+/// - ``Purchases/eligiblePromotionalOffers(forProduct:)``
 /// - ``Purchases/purchase(package:promotionalOffer:)``
 /// - ``Purchases/purchase(package:promotionalOffer:completion:)``
 /// - ``Purchases/purchase(product:promotionalOffer:)``

--- a/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Purchases/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -181,10 +181,10 @@ internal protocol StoreProductType {
     /// An array of subscription offers available for the auto-renewable subscription.
     /// - Note: the current user may or may not be eligible for some of these.
     /// #### Related Symbols
-    /// - ``Purchases/getPromotionalOffer(forProductDiscount:product:)``
+    /// - ``Purchases/promotionalOffer(forProductDiscount:product:)``
     /// - ``Purchases/getPromotionalOffer(forProductDiscount:product:completion:)``
-    /// - ``Purchases/getEligiblePromotionalOffers(forProduct:)``
-    /// - ``StoreProduct/getEligiblePromotionalOffers()``
+    /// - ``Purchases/eligiblePromotionalOffers(forProduct:)``
+    /// - ``StoreProduct/eligiblePromotionalOffers()``
     @available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *)
     var discounts: [StoreProductDiscount] { get }
 
@@ -230,8 +230,8 @@ public extension StoreProduct {
     /// - Warning: this method implicitly relies on ``Purchases`` already being initialized.
     /// #### Related Symbols
     /// - ``discounts``
-    func getEligiblePromotionalOffers() async -> [PromotionalOffer] {
-        return await Purchases.shared.getEligiblePromotionalOffers(forProduct: self)
+    func eligiblePromotionalOffers() async -> [PromotionalOffer] {
+        return await Purchases.shared.eligiblePromotionalOffers(forProduct: self)
     }
 }
 


### PR DESCRIPTION
For [CF-337](https://revenuecats.atlassian.net/browse/CF-337)

### Motivation
Most async / await APIs omit the `get` that we have in the completion block counterparts, but for `getEligiblePromotionalOffers` and `getPromotionalOffer`, we kept the get part in the async / await version.

This goes against Apple’s recommendations for naming, which is to omit the `get` for async methods.

### Description
Renames the `getEligiblePromotionalOffers` methods to `eligiblePromotionalOffers` and renames `getPromotionalOffer` to `promotionalOffer`
