### PR TITLE
Route the AttributionFetcher and DateProvider to the SubscriptionAPI

### DIFF
--- a/Purchases/Networking/Backend.swift
+++ b/Purchases/Networking/Backend.swift
@@ -39,12 +39,20 @@ class Backend {
 
     convenience init(apiKey: String,
                      systemInfo: SystemInfo,
-                     eTagManager: ETagManager) {
+                     eTagManager: ETagManager,
+                     attributionFetcher: AttributionFetcher,
+                     dateProvider: DateProvider = DateProvider()) {
         let httpClient = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
-        self.init(httpClient: httpClient, apiKey: apiKey)
+        self.init(httpClient: httpClient,
+                  apiKey: apiKey,
+                  attributionFetcher: attributionFetcher,
+                  dateProvider: dateProvider)
     }
 
-    required init(httpClient: HTTPClient, apiKey: String) {
+    required init(httpClient: HTTPClient,
+                  apiKey: String,
+                  attributionFetcher: AttributionFetcher,
+                  dateProvider: DateProvider = DateProvider()) {
         self.operationQueue = OperationQueue()
         self.operationQueue.name = "Backend Queue"
         self.operationQueue.maxConcurrentOperationCount = 1
@@ -58,10 +66,12 @@ class Backend {
         let aliasCallbackCache = CallbackCache<AliasCallback>(callbackQueue: callbackQueue)
         let customerInfoCallbackCache = CallbackCache<CustomerInfoCallback>(callbackQueue: callbackQueue)
         self.subscribersAPI = SubscribersAPI(httpClient: httpClient,
+                                             attributionFetcher: attributionFetcher,
                                              authHeaders: self.authHeaders,
                                              operationQueue: self.operationQueue,
                                              aliasCallbackCache: aliasCallbackCache,
-                                             customerInfoCallbackCache: customerInfoCallbackCache)
+                                             customerInfoCallbackCache: customerInfoCallbackCache,
+                                             dateProvider: dateProvider)
     }
 
     func createAlias(appUserID: String, newAppUserID: String, completion: SimpleResponseHandler?) {

--- a/Purchases/Networking/SubscribersAPI.swift
+++ b/Purchases/Networking/SubscribersAPI.swift
@@ -20,17 +20,23 @@ class SubscribersAPI {
     private let authHeaders: [String: String]
     private let aliasCallbackCache: CallbackCache<AliasCallback>
     private let customerInfoCallbackCache: CallbackCache<CustomerInfoCallback>
+    private let attributionFetcher: AttributionFetcher
+    private let dateProvider: DateProvider
 
     init(httpClient: HTTPClient,
+         attributionFetcher: AttributionFetcher,
          authHeaders: [String: String],
          operationQueue: OperationQueue,
          aliasCallbackCache: CallbackCache<AliasCallback>,
-         customerInfoCallbackCache: CallbackCache<CustomerInfoCallback>) {
+         customerInfoCallbackCache: CallbackCache<CustomerInfoCallback>,
+         dateProvider: DateProvider) {
         self.httpClient = httpClient
+        self.attributionFetcher = attributionFetcher
         self.authHeaders = authHeaders
         self.operationQueue = operationQueue
         self.aliasCallbackCache = aliasCallbackCache
         self.customerInfoCallbackCache = customerInfoCallbackCache
+        self.dateProvider = dateProvider
     }
 
     func createAlias(appUserID: String, newAppUserID: String, completion: SimpleResponseHandler?) {
@@ -83,6 +89,7 @@ class SubscribersAPI {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.httpClient,
                                                                 authHeaders: self.authHeaders,
                                                                 appUserID: appUserID)
+
         let postData = PostReceiptDataOperation.PostData(appUserID: appUserID,
                                                          receiptData: receiptData,
                                                          isRestore: isRestore,

--- a/Purchases/Purchasing/Purchases.swift
+++ b/Purchases/Purchasing/Purchases.swift
@@ -261,9 +261,12 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
 
         let receiptFetcher = ReceiptFetcher(requestFetcher: fetcher, systemInfo: systemInfo)
         let eTagManager = ETagManager()
+        let attributionTypeFactory = AttributionTypeFactory()
+        let attributionFetcher = AttributionFetcher(attributionFactory: attributionTypeFactory, systemInfo: systemInfo)
         let backend = Backend(apiKey: apiKey,
                               systemInfo: systemInfo,
-                              eTagManager: eTagManager)
+                              eTagManager: eTagManager,
+                              attributionFetcher: attributionFetcher)
         let storeKitWrapper = StoreKitWrapper()
         let offeringsFactory = OfferingsFactory()
         let userDefaults = userDefaults ?? UserDefaults.standard
@@ -278,8 +281,6 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
                                               backend: backend,
                                               customerInfoManager: customerInfoManager,
                                               appUserID: appUserID)
-        let attributionTypeFactory = AttributionTypeFactory()
-        let attributionFetcher = AttributionFetcher(attributionFactory: attributionTypeFactory, systemInfo: systemInfo)
         let attributionDataMigrator = AttributionDataMigrator()
         let subscriberAttributesManager = SubscriberAttributesManager(backend: backend,
                                                                       deviceCache: deviceCache,

--- a/Purchases/SubscriberAttributes/ReservedSubscriberAttributes.swift
+++ b/Purchases/SubscriberAttributes/ReservedSubscriberAttributes.swift
@@ -27,6 +27,7 @@ enum ReservedSubscriberAttribute: String {
     case idfa = "$idfa"
     case idfv = "$idfv"
     case gpsAdId = "$gpsAdId"
+    case consentStatus = "$attConsentStatus"
 
     case ip = "$ip"
 

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -321,6 +321,7 @@
 		B34D2AA626976FC700D88C3A /* ErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B34D2AA526976FC700D88C3A /* ErrorCode.swift */; };
 		B35042C426CDB79A00905B95 /* Purchases.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35042C326CDB79A00905B95 /* Purchases.swift */; };
 		B35042C626CDD3B100905B95 /* PurchasesDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35042C526CDD3B100905B95 /* PurchasesDelegate.swift */; };
+		B359DDF027EAA2B4003ABA54 /* MockDateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351B516F26D44E8D00BD2BD7 /* MockDateProvider.swift */; };
 		B35F9E0926B4BEED00095C3F /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35F9E0826B4BEED00095C3F /* String+Extensions.swift */; };
 		B3645F3D26E042B9002C490E /* RevenueCat.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DC5621824EC63430031F69B /* RevenueCat.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B36824BE268FBC5B00957E4C /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B36824BD268FBC5B00957E4C /* XCTest.framework */; };
@@ -2003,6 +2004,7 @@
 				2D90F8B626FD2099009B9142 /* MockSubscriberAttributesManager.swift in Sources */,
 				2D90F8BF26FD20D6009B9142 /* MockAttributionFetcher.swift in Sources */,
 				2D90F8C526FD216A009B9142 /* MockSKProductDiscount.swift in Sources */,
+				B359DDF027EAA2B4003ABA54 /* MockDateProvider.swift in Sources */,
 				57C381E3279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */,
 				576C8AB927D2996C0058FA6E /* CurrentTestCaseTracker.swift in Sources */,
 				B3BE0264275942D500915B4C /* AvailabilityChecks.swift in Sources */,

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -31,11 +31,13 @@ class MockBackend: Backend {
         completion: BackendCustomerInfoResponseHandler?)]()
 
     public convenience init() {
-        self.init(httpClient: MockHTTPClient(systemInfo: try! MockSystemInfo(platformInfo: nil,
-                                                                             finishTransactions: false,
-                                                                             dangerousSettings: nil),
-                                             eTagManager: MockETagManager()),
-                  apiKey: "mockAPIKey")
+        let systemInfo = try! MockSystemInfo(platformInfo: nil, finishTransactions: false, dangerousSettings: nil)
+        let attributionFetcher = AttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
+                                                    systemInfo: systemInfo)
+        self.init(httpClient: MockHTTPClient(systemInfo: systemInfo, eTagManager: MockETagManager()),
+                  apiKey: "mockAPIKey",
+                  attributionFetcher: attributionFetcher,
+                  dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
     }
 
     override func post(receiptData: Data,
@@ -235,4 +237,7 @@ class MockBackend: Backend {
             completion(result)
         }
     }
+
+    static let referenceDate = Date(timeIntervalSinceReferenceDate: 700000000) // 2023-03-08 20:26:40
+
 }

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -32,7 +32,12 @@ class BaseBackendTests: XCTestCase {
 
         self.systemInfo = try SystemInfo(platformInfo: nil, finishTransactions: true)
         self.httpClient = self.createClient()
-        self.backend = Backend(httpClient: self.httpClient, apiKey: Self.apiKey)
+        let attributionFetcher = AttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
+                                                    systemInfo: self.systemInfo)
+        self.backend = Backend(httpClient: self.httpClient,
+                               apiKey: Self.apiKey,
+                               attributionFetcher: attributionFetcher,
+                               dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
     }
 
     override class func setUp() {

--- a/Tests/UnitTests/Purchasing/PurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/PurchasesTests.swift
@@ -49,7 +49,8 @@ class PurchasesTests: XCTestCase {
                                                     systemInfo: systemInfoAttribution)
         backend = MockBackend(httpClient: MockHTTPClient(systemInfo: systemInfo,
                                                          eTagManager: MockETagManager()),
-                              apiKey: "mockAPIKey")
+                              apiKey: "mockAPIKey",
+                              attributionFetcher: attributionFetcher)
         subscriberAttributesManager =
         MockSubscriberAttributesManager(backend: self.backend,
                                         deviceCache: self.deviceCache,

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -41,8 +41,15 @@ class BackendSubscriberAttributesTests: XCTestCase {
     override func setUp() {
         mockETagManager = MockETagManager(userDefaults: MockUserDefaults())
         mockHTTPClient = MockHTTPClient(systemInfo: systemInfo, eTagManager: mockETagManager)
-        self.backend = Backend(httpClient: mockHTTPClient, apiKey: Self.apiKey)
         dateProvider = MockDateProvider(stubbedNow: self.referenceDate)
+        let attributionFetcher = AttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
+                                                    systemInfo: self.systemInfo)
+
+        self.backend = Backend(httpClient: mockHTTPClient,
+                               apiKey: Self.apiKey,
+                               attributionFetcher: attributionFetcher,
+                               dateProvider: dateProvider)
+
         subscriberAttribute1 = SubscriberAttribute(withKey: "a key",
                                                    value: "a value",
                                                    dateProvider: dateProvider)


### PR DESCRIPTION
Part 2 of 3 
breaking apart my previous PR (https://github.com/RevenueCat/purchases-ios/pull/1400)
This is for [CF-281]

[CF-281]: https://revenuecats.atlassian.net/browse/CF-281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ