### PR TITLE
Updates log message for unconfigured offerings

### DIFF
--- a/Purchases/Logging/Strings/OfferingStrings.swift
+++ b/Purchases/Logging/Strings/OfferingStrings.swift
@@ -111,8 +111,9 @@ extension OfferingStrings: CustomStringConvertible {
             "if one is being used). \nMore information: https://rev.cat/why-are-offerings-empty"
 
         case .configuration_error_no_products_for_offering:
-            return "There's a problem with your configuration. There are no products registered in the RevenueCat " +
-            "dashboard for your offerings. To configure products, follow the instructions in " +
+            return "There are no products registered in the RevenueCat dashboard for your offerings. " +
+            "If you don't want to use the offerings system, you can safely ignore this message. " +
+            "To configure offerings and their products, follow the instructions in " +
             "https://rev.cat/how-to-configure-offerings. \nMore information: https://rev.cat/why-are-offerings-empty"
 
         case .offering_empty(let offeringIdentifier):


### PR DESCRIPTION
This issue was opened https://github.com/RevenueCat/purchases-ios/issues/1395 with valid feedback.

Offerings is optional and the log message makes it sound like there's an error in the configuration. I figured the easiest would be to update the log so it's less alarming but still provides information for whoever is actually having issues.

