### PR TITLE
Fixed lint warnings

### DIFF
--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -206,7 +206,7 @@ class HTTPClientTests: XCTestCase {
     func testServerSide400s() {
         let request = HTTPRequest(method: .get, path: .mockPath)
 
-        let errorCode = HTTPStatusCode.invalidRequest.rawValue + Int(arc4random() % 50)
+        let errorCode = HTTPStatusCode.invalidRequest.rawValue + Int.random(in: 0..<50)
         let isResponseCorrect: Atomic<Bool> = .init(false)
         let message: Atomic<String?> = .init(nil)
 
@@ -232,7 +232,7 @@ class HTTPClientTests: XCTestCase {
     func testServerSide500s() {
         let request = HTTPRequest(method: .get, path: .mockPath)
 
-        let errorCode = Int32(500 + arc4random() % 50)
+        let errorCode = Int32(500 + Int.random(in: 0..<50))
         let isResponseCorrect: Atomic<Bool> = .init(false)
         let message: Atomic<String?> = .init(nil)
 
@@ -257,7 +257,7 @@ class HTTPClientTests: XCTestCase {
     func testParseError() {
         let request = HTTPRequest(method: .get, path: .mockPath)
 
-        let errorCode = HTTPStatusCode.success.rawValue + Int(arc4random() % 300)
+        let errorCode = HTTPStatusCode.success.rawValue + Int.random(in: 0..<300)
         let correctResponse: Atomic<Bool> = .init(false)
 
         stub(condition: isPath(request.path)) { _ in

--- a/Tests/UnitTests/Purchasing/StoreKitWrapperTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKitWrapperTests.swift
@@ -115,7 +115,7 @@ class StoreKitWrapperTests: XCTestCase, StoreKitWrapperDelegate {
         let product = SK1Product()
         let payment = SKPayment.init(product: product)
 
-        shouldAddPromo = (arc4random() % 2 == 0) as Bool
+        shouldAddPromo = Bool.random()
 
         let result = wrapper?.paymentQueue(paymentQueue, shouldAddStorePayment: payment, for: product)
 


### PR DESCRIPTION
Looks like `SwiftLint` v0.47.0 added this new rule.
Fixes https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/5838/workflows/65f92776-8d3e-4344-bd4f-f90c1a646a25/jobs/20591