### PR TITLE
fix: invalid exclude in Package.swift

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,6 +5,7 @@ excluded:
   - Tests/TestingApps
   - vendor
   - scan_derived_data
+  - .git
 
 opt_in_rules:
   - sorted_imports

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ func resolveTargets() -> [Target] {
                     "Gemfile.lock",
                     "LatestTagDocs",
                     "LICENSE",
-                    "Purchases/Info.plist",
+                    "Sources/Info.plist",
                     "README.md",
                     "RevenueCat.podspec",
                     "scripts",


### PR DESCRIPTION
There was an outdated exclusion in Package.swift, left over from [this PR](https://github.com/RevenueCat/purchases-ios/pull/1416)