### PR TITLE
Static DocC docs part 1: lanes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ Pods/
 IntegrationTests/CarthageInstallation/Cartfile.resolved
 scan_derived_data/
 generated_docs/
-RevenueCat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+**/Package.resolved
 
 # fastlane
 fastlane/.env

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,6 +6,7 @@ excluded:
   - vendor
   - scan_derived_data
   - .git
+  - .build
 
 opt_in_rules:
   - sorted_imports

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,6 @@ func resolveTargets() -> [Target] {
     return baseTargets
 }
 
-
 // Only add DocC Plugin when building docs, so that clients of this library won't
 // unnecessarily also get the DocC Plugin
 let environmentVariables = ProcessInfo.processInfo.environment

--- a/Package.swift
+++ b/Package.swift
@@ -45,6 +45,8 @@ let package = Package(
         .library(name: "RevenueCat",
                  targets: ["RevenueCat"])
     ],
-    dependencies: [],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+    ],
     targets: resolveTargets()
 )

--- a/Package.swift
+++ b/Package.swift
@@ -33,6 +33,17 @@ func resolveTargets() -> [Target] {
     return baseTargets
 }
 
+
+// Only add DocC Plugin when building docs, so that clients of this library won't
+// unnecessarily also get the DocC Plugin
+let environmentVariables = ProcessInfo.processInfo.environment
+let shouldIncludeDocCPlugin = environmentVariables["INCLUDE_DOCC_PLUGIN"] == "true"
+
+var dependencies: [Package.Dependency] = []
+if shouldIncludeDocCPlugin {
+    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
+}
+
 let package = Package(
     name: "RevenueCat",
     platforms: [
@@ -45,8 +56,6 @@ let package = Package(
         .library(name: "RevenueCat",
                  targets: ["RevenueCat"])
     ],
-    dependencies: [
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-    ],
+    dependencies: dependencies,
     targets: resolveTargets()
 )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -425,6 +425,41 @@ platform :ios do
     }
   end
 
+  desc "Preview docs"
+  lane :preview_docs do
+    Dir.chdir("..") do
+      sh("swift",
+         "package",
+         "--disable-sandbox",
+         "preview-documentation",
+         "--target",
+         "RevenueCat",
+         "--transform-for-static-hosting")
+    end
+  end
+
+  desc "Generate docs"
+  lane :generate_docs do
+    Dir.chdir("..") do
+      hosting_base_path = "purchases-ios"
+      docs_folder = "docs"
+      sh("swift",
+         "package",
+         "--disable-sandbox",
+         "--allow-writing-to-directory",
+         docs_folder,
+         "generate-documentation",
+         "--target",
+         "RevenueCat",
+         "--disable-indexing",
+         "--output-path",
+         docs_folder,
+         "--hosting-base-path",
+         "#{hosting_base_path}",
+         "--transform-for-static-hosting")
+    end
+  end
+
   desc "Create or delete sandbox testers"
   lane :sandbox_testers do
     Spaceship::ConnectAPI.login(use_portal: false)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -427,6 +427,7 @@ platform :ios do
 
   desc "Preview docs"
   lane :preview_docs do
+    ENV["INCLUDE_DOCC_PLUGIN"] = "true"
     Dir.chdir("..") do
       sh("swift",
          "package",
@@ -440,6 +441,7 @@ platform :ios do
 
   desc "Generate docs"
   lane :generate_docs do
+    ENV["INCLUDE_DOCC_PLUGIN"] = "true"
     Dir.chdir("..") do
       hosting_base_path = "purchases-ios"
       docs_folder = "docs"

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -144,7 +144,7 @@ build ObjC API tester
 [bundle exec] fastlane ios replace_api_key_integration_tests
 ```
 
-replace API KEY for integration tests
+replace API KEY for installation and integration tests
 
 ### ios release
 
@@ -209,6 +209,22 @@ Run BackendIntegrationTests
 ```
 
 Update swift package commit
+
+### ios preview_docs
+
+```sh
+[bundle exec] fastlane ios preview_docs
+```
+
+Preview docs
+
+### ios generate_docs
+
+```sh
+[bundle exec] fastlane ios generate_docs
+```
+
+Generate docs
 
 ### ios sandbox_testers
 


### PR DESCRIPTION
Part 1 of a series of PRs to break #1368 into actually manageable pieces. 

This adds two lanes, one to preview the docs, and another one to compile them into files, both as a static site. 

We already have lanes in place for DocC docs, but for a dynamic website, so the difference here is that using the new setup we'll have more flexibility when deploying, for example, to github pages. 

I didn't remove the old lanes yet because we'll still need them until a few more cleanups are done w/regards to file structure (PRs incoming). 