### PR TITLE
Simplified `HTTPClient.Completion` and refactored response handling implementation

### DIFF
--- a/Sources/FoundationExtensions/JSONDecoder+Extensions.swift
+++ b/Sources/FoundationExtensions/JSONDecoder+Extensions.swift
@@ -129,3 +129,17 @@ extension Encodable {
     }
 
 }
+
+let defaultJsonEncoder: JSONEncoder = {
+    let encoder = JSONEncoder()
+    encoder.keyEncodingStrategy = .convertToSnakeCase
+
+    return encoder
+}()
+
+let defaultJsonDecoder: JSONDecoder = {
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+    return decoder
+}()

--- a/Sources/FoundationExtensions/JSONDecoder+Extensions.swift
+++ b/Sources/FoundationExtensions/JSONDecoder+Extensions.swift
@@ -130,16 +130,24 @@ extension Encodable {
 
 }
 
-let defaultJsonEncoder: JSONEncoder = {
-    let encoder = JSONEncoder()
-    encoder.keyEncodingStrategy = .convertToSnakeCase
+extension JSONEncoder {
 
-    return encoder
-}()
+    static let `default`: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
 
-let defaultJsonDecoder: JSONDecoder = {
-    let decoder = JSONDecoder()
-    decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return encoder
+    }()
 
-    return decoder
-}()
+}
+
+extension JSONDecoder {
+
+    static let `default`: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        return decoder
+    }()
+
+}

--- a/Sources/Networking/ETagManager.swift
+++ b/Sources/Networking/ETagManager.swift
@@ -39,13 +39,12 @@ class ETagManager {
     }
 
     func httpResultFromCacheOrBackend(with response: HTTPURLResponse,
-                                      jsonObject: [String: Any]?,
-                                      error: Error?,
+                                      jsonObject: [String: Any],
                                       request: URLRequest,
                                       retried: Bool) -> HTTPResponse? {
         let statusCode: HTTPStatusCode = .init(rawValue: response.statusCode)
         let resultFromBackend = HTTPResponse(statusCode: statusCode, jsonObject: jsonObject)
-        guard error == nil else { return resultFromBackend }
+
         let headersInResponse = response.allHeaderFields
 
         let eTagInResponse: String? = headersInResponse[ETagManager.eTagHeaderName] as? String ??

--- a/Sources/Networking/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient.swift
@@ -210,6 +210,8 @@ private extension HTTPClient {
 
                 return result
             } else {
+                // No data if the body was empty, or if status is `.notModified`
+                // since the body will be fetched from the eTag.
                 return [:]
             }
         }

--- a/Sources/Networking/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient.swift
@@ -355,7 +355,7 @@ extension HTTPRequest.Path {
 private extension Encodable {
 
     func asData() throws -> Data {
-        return try defaultJsonEncoder.encode(self)
+        return try JSONEncoder.default.encode(self)
     }
 
 }

--- a/Sources/Networking/HTTPResponse.swift
+++ b/Sources/Networking/HTTPResponse.swift
@@ -19,14 +19,14 @@ struct HTTPResponse {
     typealias Body = [String: Any]
 
     let statusCode: HTTPStatusCode
-    let jsonObject: Body?
+    let jsonObject: Body
 
 }
 
 extension HTTPResponse: CustomStringConvertible {
 
     var description: String {
-        "HTTPResponse(statusCode: \(self.statusCode.rawValue), jsonObject: \(self.jsonObject?.description ?? ""))"
+        "HTTPResponse(statusCode: \(self.statusCode.rawValue), jsonObject: \(self.jsonObject.description))"
     }
 
 }

--- a/Sources/Networking/IntroEligibilityResponse.swift
+++ b/Sources/Networking/IntroEligibilityResponse.swift
@@ -16,8 +16,7 @@ import Foundation
 // All parameters that are required to process the reponse from a GetIntroEligibility API call.
 struct IntroEligibilityResponse {
 
-    let result: Result<[String: Any], Error>
-    let statusCode: HTTPStatusCode
+    let result: Result<HTTPResponse, Error>
     let productIdentifiers: [String]
     let unknownEligibilityClosure: () -> [String: IntroEligibility]
     let completion: IntroEligibilityResponseHandler

--- a/Sources/Networking/Operations/CreateAliasOperation.swift
+++ b/Sources/Networking/Operations/CreateAliasOperation.swift
@@ -54,16 +54,14 @@ private extension CreateAliasOperation {
         let request = HTTPRequest(method: .post(Body(newAppUserID: newAppUserID)),
                                   path: .createAlias(appUserID: appUserID))
 
-        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, result in
+        httpClient.perform(request, authHeaders: self.authHeaders) { response in
             self.aliasCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { aliasCallback in
 
                 guard let completion = aliasCallback.completion else {
                     return
                 }
 
-                self.createAliasResponseHandler.handle(statusCode: statusCode,
-                                                       result: result,
-                                                       completion: completion)
+                self.createAliasResponseHandler.handle(response, completion: completion)
             }
 
             completion()

--- a/Sources/Networking/Operations/GetCustomerInfoOperation.swift
+++ b/Sources/Networking/Operations/GetCustomerInfoOperation.swift
@@ -60,10 +60,9 @@ private extension GetCustomerInfoOperation {
 
         let request = HTTPRequest(method: .get, path: .getCustomerInfo(appUserID: appUserID))
 
-        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, result in
+        httpClient.perform(request, authHeaders: self.authHeaders) { response in
             self.customerInfoCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
-                self.customerInfoResponseHandler.handle(customerInfoResponse: result,
-                                                        statusCode: statusCode,
+                self.customerInfoResponseHandler.handle(customerInfoResponse: response,
                                                         completion: callback.completion)
             }
 

--- a/Sources/Networking/Operations/GetIntroEligibilityOperation.swift
+++ b/Sources/Networking/Operations/GetIntroEligibilityOperation.swift
@@ -86,9 +86,8 @@ private extension GetIntroEligibilityOperation {
                                                      fetchToken: self.receiptData.asFetchToken)),
                                   path: .getIntroEligibility(appUserID: appUserID))
 
-        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, result in
-            let eligibilityResponse = IntroEligibilityResponse(result: result,
-                                                               statusCode: statusCode,
+        httpClient.perform(request, authHeaders: self.authHeaders) { response in
+            let eligibilityResponse = IntroEligibilityResponse(result: response,
                                                                productIdentifiers: self.productIdentifiers,
                                                                unknownEligibilityClosure: unknownEligibilityClosure,
                                                                completion: self.responseHandler)
@@ -99,9 +98,9 @@ private extension GetIntroEligibilityOperation {
 
     func handleIntroEligibility(response: IntroEligibilityResponse) {
         let result: [String: IntroEligibility] = {
-            var eligibilitiesByProductIdentifier = response.result.value
+            var eligibilitiesByProductIdentifier = response.result.value?.jsonObject
 
-            if !response.statusCode.isSuccessfulResponse || response.result.error != nil {
+            if response.result.value?.statusCode.isSuccessfulResponse != true {
                 eligibilitiesByProductIdentifier = [:]
             }
 

--- a/Sources/Networking/Operations/GetOfferingsOperation.swift
+++ b/Sources/Networking/Operations/GetOfferingsOperation.swift
@@ -46,14 +46,16 @@ private extension GetOfferingsOperation {
 
         let request = HTTPRequest(method: .get, path: .getOfferings(appUserID: appUserID))
 
-        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, result in
+        httpClient.perform(request, authHeaders: self.authHeaders) { response in
             defer {
                 completion()
             }
 
-            let parsedResponse: Result<[String: Any], Error> = result
+            let parsedResponse: Result<[String: Any], Error> = response
                 .mapError { ErrorUtils.networkError(withUnderlyingError: $0) }
                 .flatMap { response in
+                    let (statusCode, response) = (response.statusCode, response.jsonObject)
+
                     return statusCode.isSuccessfulResponse
                     ? .success(response)
                     : .failure(

--- a/Sources/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
+++ b/Sources/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
@@ -15,15 +15,10 @@ import Foundation
 
 class CustomerInfoResponseHandler {
 
-    let userInfoAttributeParser: UserInfoAttributeParser
-
-    init(userInfoAttributeParser: UserInfoAttributeParser = UserInfoAttributeParser()) {
-        self.userInfoAttributeParser = userInfoAttributeParser
-    }
+    init() { }
 
     // swiftlint:disable:next function_body_length
-    func handle(customerInfoResponse response: Result<[String: Any], Error>,
-                statusCode: HTTPStatusCode,
+    func handle(customerInfoResponse response: Result<HTTPResponse, Error>,
                 file: String = #fileID,
                 function: String = #function,
                 line: UInt = #line,
@@ -36,6 +31,7 @@ class CustomerInfoResponseHandler {
             ))
 
         case let .success(response):
+            let (statusCode, response) = (response.statusCode, response.jsonObject)
             let isErrorStatusCode = !statusCode.isSuccessfulResponse
 
             var result: Result<CustomerInfo, Error> = {
@@ -57,7 +53,7 @@ class CustomerInfoResponseHandler {
                 }
             }()
 
-            let subscriberAttributesErrorInfo = self.userInfoAttributeParser
+            let subscriberAttributesErrorInfo = UserInfoAttributeParser
                 .attributesUserInfoFromResponse(response: response, statusCode: statusCode)
 
             let hasError = (isErrorStatusCode

--- a/Sources/Networking/Operations/Handling/NoContentResponseHandler.swift
+++ b/Sources/Networking/Operations/Handling/NoContentResponseHandler.swift
@@ -15,14 +15,13 @@ import Foundation
 
 class NoContentResponseHandler {
 
-    func handle(statusCode: HTTPStatusCode,
-                result: Result<[String: Any], Error>,
+    func handle(_ response: Result<HTTPResponse, Error>,
                 completion: SimpleResponseHandler) {
-        switch result {
+        switch response {
         case let .success(response):
-            guard statusCode.isSuccessfulResponse else {
-                let backendErrorCode = BackendErrorCode(code: response["code"])
-                let message = response["message"] as? String
+            guard response.statusCode.isSuccessfulResponse else {
+                let backendErrorCode = BackendErrorCode(code: response.jsonObject["code"])
+                let message = response.jsonObject["message"] as? String
                 let responseError = ErrorUtils.backendError(withBackendCode: backendErrorCode, backendMessage: message)
                 completion(responseError)
 

--- a/Sources/Networking/Operations/Handling/SubscriberAttributeHandler.swift
+++ b/Sources/Networking/Operations/Handling/SubscriberAttributeHandler.swift
@@ -15,22 +15,19 @@ import Foundation
 
 class SubscriberAttributeHandler {
 
-    let userInfoAttributeParser: UserInfoAttributeParser
+    init() { }
 
-    init(userInfoAttributeParser: UserInfoAttributeParser = UserInfoAttributeParser()) {
-        self.userInfoAttributeParser = userInfoAttributeParser
-    }
-
-    func handleSubscriberAttributesResult(statusCode: HTTPStatusCode,
-                                          response: Result<[String: Any], Error>,
+    func handleSubscriberAttributesResult(_ response: Result<HTTPResponse, Error>,
                                           completion: SimpleResponseHandler) {
         let result: Result<[String: Any], Error> = response
             .mapError {
                 ErrorUtils.networkError(withUnderlyingError: $0)
             }
             .flatMap { response in
+                let (statusCode, response) = (response.statusCode, response.jsonObject)
+
                 if !statusCode.isSuccessfulResponse {
-                    let extraUserInfo = self.userInfoAttributeParser
+                    let extraUserInfo = UserInfoAttributeParser
                         .attributesUserInfoFromResponse(response: response, statusCode: statusCode)
                     let backendErrorCode = BackendErrorCode(code: response["code"])
                     return .failure(

--- a/Sources/Networking/Operations/Handling/UserInfoAttributeParser.swift
+++ b/Sources/Networking/Operations/Handling/UserInfoAttributeParser.swift
@@ -13,9 +13,9 @@
 
 import Foundation
 
-class UserInfoAttributeParser {
+enum UserInfoAttributeParser {
 
-    func attributesUserInfoFromResponse(response: [String: Any], statusCode: HTTPStatusCode) -> [String: Any] {
+    static func attributesUserInfoFromResponse(response: [String: Any], statusCode: HTTPStatusCode) -> [String: Any] {
         var resultDict: [String: Any] = [:]
         let isServerError = statusCode.isServerError
         let isNotFoundError = statusCode == .notFoundError

--- a/Sources/Networking/Operations/PostAttributionDataOperation.swift
+++ b/Sources/Networking/Operations/PostAttributionDataOperation.swift
@@ -50,7 +50,7 @@ class PostAttributionDataOperation: NetworkOperation {
         let request = HTTPRequest(method: .post(Body(network: self.network, attributionData: self.attributionData)),
                                   path: .postAttributionData(appUserID: appUserID))
 
-        self.httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, result in
+        self.httpClient.perform(request, authHeaders: self.authHeaders) { response in
             defer {
                 completion()
             }
@@ -59,9 +59,7 @@ class PostAttributionDataOperation: NetworkOperation {
                 return
             }
 
-            self.postAttributionDataResponseHandler.handle(statusCode: statusCode,
-                                                           result: result,
-                                                           completion: responseHandler)
+            self.postAttributionDataResponseHandler.handle(response, completion: responseHandler)
         }
     }
 

--- a/Sources/Networking/Operations/PostOfferForSigningOperation.swift
+++ b/Sources/Networking/Operations/PostOfferForSigningOperation.swift
@@ -50,10 +50,12 @@ class PostOfferForSigningOperation: NetworkOperation {
             path: .postOfferForSigning
         )
 
-        self.httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, result in
-            let result: Result<PostOfferForSigningOperation.SigningData, Error> = result
+        self.httpClient.perform(request, authHeaders: self.authHeaders) { response in
+            let result: Result<PostOfferForSigningOperation.SigningData, Error> = response
                 .mapError { ErrorUtils.networkError(withUnderlyingError: $0) }
                 .flatMap { response in
+                    let (statusCode, response) = (response.statusCode, response.jsonObject)
+
                     guard statusCode.isSuccessfulResponse else {
                         let backendCode = BackendErrorCode(code: response["code"])
                         let backendMessage = response["message"] as? String

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -60,10 +60,9 @@ class PostReceiptDataOperation: CacheableNetworkOperation {
         let request = HTTPRequest(method: .post(self.postData),
                                   path: .postReceiptData)
 
-        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, result in
+        httpClient.perform(request, authHeaders: self.authHeaders) { response in
             self.customerInfoCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callbackObject in
-                self.customerInfoResponseHandler.handle(customerInfoResponse: result,
-                                                        statusCode: statusCode,
+                self.customerInfoResponseHandler.handle(customerInfoResponse: response,
                                                         completion: callbackObject.completion)
             }
 

--- a/Sources/Networking/Operations/PostSubscriberAttributesOperation.swift
+++ b/Sources/Networking/Operations/PostSubscriberAttributesOperation.swift
@@ -55,7 +55,7 @@ class PostSubscriberAttributesOperation: NetworkOperation {
         let request = HTTPRequest(method: .post(Body(self.subscriberAttributes)),
                                   path: .postSubscriberAttributes(appUserID: appUserID))
 
-        httpClient.perform(request, authHeaders: self.authHeaders) { statusCode, result in
+        httpClient.perform(request, authHeaders: self.authHeaders) { response in
             defer {
                 completion()
             }
@@ -64,8 +64,7 @@ class PostSubscriberAttributesOperation: NetworkOperation {
                 return
             }
 
-            self.subscriberAttributeHandler.handleSubscriberAttributesResult(statusCode: statusCode,
-                                                                             response: result,
+            self.subscriberAttributeHandler.handleSubscriberAttributesResult(response,
                                                                              completion: responseHandler)
         }
     }

--- a/Tests/UnitTests/Mocks/MockETagManager.swift
+++ b/Tests/UnitTests/Mocks/MockETagManager.swift
@@ -31,8 +31,7 @@ class MockETagManager: ETagManager {
 
     private struct InvokedHTTPResultFromCacheOrBackendParams {
         let response: HTTPURLResponse
-        let responseObject: [String: Any]?
-        let error: Error?
+        let responseObject: [String: Any]
         let request: URLRequest
         let retried: Bool
     }
@@ -45,8 +44,7 @@ class MockETagManager: ETagManager {
     var shouldReturnResultFromBackend = true
 
     override func httpResultFromCacheOrBackend(with response: HTTPURLResponse,
-                                               jsonObject: [String: Any]?,
-                                               error: Error?,
+                                               jsonObject: [String: Any],
                                                request: URLRequest,
                                                retried: Bool) -> HTTPResponse? {
         return lock.perform {
@@ -55,7 +53,6 @@ class MockETagManager: ETagManager {
             let params = InvokedHTTPResultFromCacheOrBackendParams(
                 response: response,
                 responseObject: jsonObject,
-                error: error,
                 request: request,
                 retried: retried
             )

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -15,22 +15,18 @@ class MockHTTPClient: HTTPClient {
 
     struct Response {
 
-        let statusCode: HTTPStatusCode
-        let response: Result<[String: Any], Error>
+        let response: Result<HTTPResponse, Error>
 
-        init(statusCode: HTTPStatusCode, response: Result<[String: Any], Error>) {
-            self.statusCode = statusCode
+        private init(response: Result<HTTPResponse, Error>) {
             self.response = response
         }
 
         init(statusCode: HTTPStatusCode, response: [String: Any] = [:]) {
-            self.init(statusCode: statusCode,
-                      response: .success(response))
+            self.init(response: .success(.init(statusCode: statusCode, jsonObject: response)))
         }
 
-        init(statusCode: HTTPStatusCode, error: Error) {
-            self.init(statusCode: statusCode,
-                      response: .failure(error))
+        init(error: Error) {
+            self.init(response: .failure(error))
         }
 
     }
@@ -68,8 +64,7 @@ class MockHTTPClient: HTTPClient {
 
             let response = self.mocks[request.path]
 
-            completionHandler?(response?.statusCode ?? .success,
-                               response?.response ?? .success([:]))
+            completionHandler?(response?.response ?? .success(.init(statusCode: .success, jsonObject: [:])))
         }
     }
 

--- a/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
@@ -80,8 +80,7 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
 
         httpClient.mock(requestPath: .getCustomerInfo(appUserID: encodedUserID), response: response)
         httpClient.mock(requestPath: .getCustomerInfo(appUserID: encodeableUserID),
-                        response: .init(statusCode: .notFoundError,
-                                        error: ErrorUtils.networkError(withUnderlyingError: ErrorUtils.unknownError())))
+                        response: .init(error: ErrorUtils.networkError(withUnderlyingError: ErrorUtils.unknownError())))
 
         var customerInfo: Result<CustomerInfo, Error>?
 

--- a/Tests/UnitTests/Networking/Backend/BackendGetIntroEligibilityTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetIntroEligibilityTests.swift
@@ -91,8 +91,7 @@ class BackendGetIntroEligibilityTests: BaseBackendTests {
         // Set us up for a 404 because if the input sanitizing code fails, it will execute and we'd get a 404.
         self.httpClient.mock(
             requestPath: .getIntroEligibility(appUserID: ""),
-            response: .init(statusCode: .notFoundError,
-                            error: ErrorUtils.networkError(withUnderlyingError: ErrorUtils.unknownError()))
+            response: .init(error: ErrorUtils.networkError(withUnderlyingError: ErrorUtils.unknownError()))
         )
 
         var eligibility: [String: IntroEligibility]?
@@ -139,7 +138,7 @@ class BackendGetIntroEligibilityTests: BaseBackendTests {
         let error = NSError(domain: "myhouse", code: 12, userInfo: nil) as Error
         self.httpClient.mock(
             requestPath: .getIntroEligibility(appUserID: Self.userID),
-            response: .init(statusCode: .success, response: .failure(error))
+            response: .init(error: error)
         )
 
         var eligibility: [String: IntroEligibility]?

--- a/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
@@ -111,8 +111,7 @@ class BackendGetOfferingsTests: BaseBackendTests {
     func testGetOfferingsNetworkErrorSendsNilAndError() {
         self.httpClient.mock(
             requestPath: .getOfferings(appUserID: Self.userID),
-            response: .init(statusCode: .success,
-                            response: .failure(NSError(domain: NSURLErrorDomain, code: -1009)))
+            response: .init(error: NSError(domain: NSURLErrorDomain, code: -1009))
         )
 
         var receivedError: NSError?

--- a/Tests/UnitTests/Networking/Backend/BackendLoginTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendLoginTests.swift
@@ -43,7 +43,7 @@ class BackendLoginTests: BaseBackendTests {
         let errorCode = 123465
         let stubbedError = NSError(domain: RCPurchasesErrorCodeDomain, code: errorCode, userInfo: [:])
         let currentAppUserID = "old id"
-        _ = mockLoginRequest(appUserID: currentAppUserID, response: .failure(stubbedError))
+        _ = mockLoginRequest(appUserID: currentAppUserID, error: stubbedError)
 
         var receivedResult: Result<(info: CustomerInfo, created: Bool), Error>?
 
@@ -69,7 +69,7 @@ class BackendLoginTests: BaseBackendTests {
                                    code: errorCode,
                                    userInfo: [:])
         let currentAppUserID = "old id"
-        _ = self.mockLoginRequest(appUserID: currentAppUserID, response: .failure(stubbedError))
+        _ = self.mockLoginRequest(appUserID: currentAppUserID, error: stubbedError)
 
         var receivedResult: Result<(info: CustomerInfo, created: Bool), Error>?
 
@@ -94,7 +94,7 @@ class BackendLoginTests: BaseBackendTests {
         let underlyingErrorCode = BackendErrorCode.cannotTransferPurchase.rawValue
         _ = self.mockLoginRequest(appUserID: currentAppUserID,
                                   statusCode: 431,
-                                  response: .success(["code": underlyingErrorCode, "message": underlyingErrorMessage]))
+                                  response: ["code": underlyingErrorCode, "message": underlyingErrorMessage])
 
         var receivedResult: Result<(info: CustomerInfo, created: Bool), Error>?
 
@@ -143,7 +143,7 @@ class BackendLoginTests: BaseBackendTests {
         let currentAppUserID = "old id"
         _ = self.mockLoginRequest(appUserID: currentAppUserID,
                                   statusCode: .createdSuccess,
-                                  response: .success(Self.mockCustomerInfoData))
+                                  response: Self.mockCustomerInfoData)
 
         var receivedResult: Result<(info: CustomerInfo, created: Bool), Error>?
 
@@ -163,7 +163,7 @@ class BackendLoginTests: BaseBackendTests {
         let currentAppUserID = "old id"
         _ = self.mockLoginRequest(appUserID: currentAppUserID,
                                   statusCode: .success,
-                                  response: .success(Self.mockCustomerInfoData))
+                                  response: Self.mockCustomerInfoData)
 
         var receivedResult: Result<(info: CustomerInfo, created: Bool), Error>?
 
@@ -184,7 +184,7 @@ class BackendLoginTests: BaseBackendTests {
         let currentAppUserID = "old id"
         _ = self.mockLoginRequest(appUserID: currentAppUserID,
                                   statusCode: .createdSuccess,
-                                  response: .success(Self.mockCustomerInfoData))
+                                  response: Self.mockCustomerInfoData)
 
         backend.logIn(currentAppUserID: currentAppUserID,
                       newAppUserID: newAppUserID) { _  in }
@@ -201,7 +201,7 @@ class BackendLoginTests: BaseBackendTests {
         let currentAppUserID = "old id"
         _ = self.mockLoginRequest(appUserID: currentAppUserID,
                                   statusCode: .createdSuccess,
-                                  response: .success(Self.mockCustomerInfoData))
+                                  response: Self.mockCustomerInfoData)
 
         backend.logIn(currentAppUserID: currentAppUserID,
                       newAppUserID: newAppUserID) { _ in }
@@ -218,7 +218,7 @@ class BackendLoginTests: BaseBackendTests {
         let currentAppUserID2 = "old id 2"
         _ = self.mockLoginRequest(appUserID: currentAppUserID,
                                   statusCode: .createdSuccess,
-                                  response: .success(Self.mockCustomerInfoData))
+                                  response: Self.mockCustomerInfoData)
 
         backend.logIn(currentAppUserID: currentAppUserID,
                       newAppUserID: newAppUserID) { _ in }
@@ -234,7 +234,7 @@ class BackendLoginTests: BaseBackendTests {
         let currentAppUserID = "old id"
         _ = self.mockLoginRequest(appUserID: currentAppUserID,
                                   statusCode: .createdSuccess,
-                                  response: .success(Self.mockCustomerInfoData))
+                                  response: Self.mockCustomerInfoData)
 
         var completion1Called = false
         var completion2Called = false
@@ -259,9 +259,19 @@ private extension BackendLoginTests {
 
     func mockLoginRequest(appUserID: String,
                           statusCode: HTTPStatusCode = .success,
-                          response: Result<[String: Any], Error> = .success([:])) -> HTTPRequest.Path {
+                          response: [String: Any] = [:]) -> HTTPRequest.Path {
         let path: HTTPRequest.Path = .logIn
-        let response = MockHTTPClient.Response(statusCode: statusCode, response: response)
+        let response =  MockHTTPClient.Response(statusCode: statusCode, response: response)
+
+        self.httpClient.mock(requestPath: path, response: response)
+
+        return path
+    }
+
+    func mockLoginRequest(appUserID: String,
+                          error: Error) -> HTTPRequest.Path {
+        let path: HTTPRequest.Path = .logIn
+        let response =  MockHTTPClient.Response(error: error)
 
         self.httpClient.mock(requestPath: path, response: response)
 

--- a/Tests/UnitTests/Networking/Backend/BackendPostOfferForSigningTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostOfferForSigningTests.swift
@@ -66,8 +66,7 @@ class BackendPostOfferForSigningTests: BaseBackendTests {
     func testOfferForSigningNetworkError() {
         self.httpClient.mock(
             requestPath: .postOfferForSigning,
-            response: .init(statusCode: .success,
-                            response: .failure(NSError(domain: NSURLErrorDomain, code: -1009)))
+            response: .init(error: NSError(domain: NSURLErrorDomain, code: -1009))
         )
 
         let productIdentifier = "a_great_product"

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTestBase.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTestBase.swift
@@ -497,8 +497,7 @@ class BackendPostReceiptDataTestBase: BaseBackendTests {
 
         self.httpClient.mock(
             requestPath: .postReceiptData,
-            response: .init(statusCode: .networkConnectTimeoutError,
-                            response: .failure(error))
+            response: .init(error: error)
         )
 
         var receivedError: NSError?

--- a/Tests/UnitTests/Networking/ETagManagerTests.swift
+++ b/Tests/UnitTests/Networking/ETagManagerTests.swift
@@ -8,7 +8,7 @@ class ETagManagerTests: XCTestCase {
 
     private var mockUserDefaults: MockUserDefaults! = nil
     private var eTagManager: ETagManager!
-    private var baseURL: URL = URL(string: "https://api.revenuecat.com")!
+    private let baseURL = URL(string: "https://api.revenuecat.com")!
 
     override func setUp() {
         super.setUp()
@@ -56,7 +56,6 @@ class ETagManagerTests: XCTestCase {
         }
         let response = eTagManager.httpResultFromCacheOrBackend(with: httpURLResponse,
                                                                 jsonObject: [:],
-                                                                error: nil,
                                                                 request: request,
                                                                 retried: false)
         expect(response).toNot(beNil())
@@ -72,28 +71,9 @@ class ETagManagerTests: XCTestCase {
         let responseObject = ["a": "response"]
         let httpURLResponse = httpURLResponseForTest(url: url, eTag: eTag, statusCode: .success)
         let response = eTagManager.httpResultFromCacheOrBackend(
-            with: httpURLResponse, jsonObject: responseObject, error: nil, request: request, retried: false)
+            with: httpURLResponse, jsonObject: responseObject, request: request, retried: false)
         expect(response).toNot(beNil())
         expect(response?.statusCode) == .success
-        expect(response?.jsonObject as? [String: String]).to(equal(responseObject))
-    }
-
-    func testBackendResponseIsReturnedIfThereIsAnError() {
-        let eTag = "an_etag"
-        let url = urlForTest()
-        let request = URLRequest(url: url)
-        _ = mockStoredETagAndResponse(for: url, statusCode: .success, eTag: eTag)
-        let responseObject = ["a": "response"]
-        let error = NSError(domain: NSCocoaErrorDomain, code: 123, userInfo: [:])
-        let httpURLResponse = httpURLResponseForTest(
-            url: url,
-            eTag: eTag,
-            statusCode: .notModified
-        )
-        let response = eTagManager.httpResultFromCacheOrBackend(
-            with: httpURLResponse, jsonObject: responseObject, error: error, request: request, retried: false)
-        expect(response).toNot(beNil())
-        expect(response?.statusCode) == .notModified
         expect(response?.jsonObject as? [String: String]).to(equal(responseObject))
     }
 
@@ -108,7 +88,7 @@ class ETagManagerTests: XCTestCase {
             statusCode: .notModified
         )
         let response = eTagManager.httpResultFromCacheOrBackend(
-            with: httpURLResponse, jsonObject: responseObject, error: nil, request: request, retried: true)
+            with: httpURLResponse, jsonObject: responseObject, request: request, retried: true)
         expect(response).toNot(beNil())
         expect(response?.statusCode) == .notModified
         expect(response?.jsonObject as? [String: String]).to(equal(responseObject))
@@ -125,7 +105,7 @@ class ETagManagerTests: XCTestCase {
             statusCode: .notModified
         )
         let response = eTagManager.httpResultFromCacheOrBackend(
-            with: httpURLResponse, jsonObject: responseObject, error: nil, request: request, retried: false)
+            with: httpURLResponse, jsonObject: responseObject, request: request, retried: false)
         expect(response).to(beNil())
     }
 
@@ -140,7 +120,7 @@ class ETagManagerTests: XCTestCase {
             statusCode: .success
         )
         let response = eTagManager.httpResultFromCacheOrBackend(
-            with: httpURLResponse, jsonObject: responseObject, error: nil, request: request, retried: false)
+            with: httpURLResponse, jsonObject: responseObject, request: request, retried: false)
 
         expect(response).toNot(beNil())
         expect(self.mockUserDefaults.setObjectForKeyCallCount) == 1
@@ -171,7 +151,7 @@ class ETagManagerTests: XCTestCase {
             statusCode: .internalServerError
         )
         let response = eTagManager.httpResultFromCacheOrBackend(
-            with: httpURLResponse, jsonObject: responseObject, error: nil, request: request, retried: false)
+            with: httpURLResponse, jsonObject: responseObject, request: request, retried: false)
 
         expect(response).toNot(beNil())
         expect(response?.statusCode) == .internalServerError
@@ -195,8 +175,11 @@ class ETagManagerTests: XCTestCase {
 
         expect(self.mockUserDefaults.mockValues.count) == 0
     }
+}
 
-    private func getHeaders(eTag: String) -> [String: String] {
+private extension ETagManagerTests {
+
+    func getHeaders(eTag: String) -> [String: String] {
         return [
             "Content-Type": "application/json",
             "X-Platform": "android",
@@ -211,9 +194,9 @@ class ETagManagerTests: XCTestCase {
             .merging(HTTPClient.authorizationHeader(withAPIKey: "apikey"))
     }
 
-    private func mockStoredETagAndResponse(for url: URL,
-                                           statusCode: HTTPStatusCode = .success,
-                                           eTag: String = "an_etag") -> [String: String] {
+    func mockStoredETagAndResponse(for url: URL,
+                                   statusCode: HTTPStatusCode = .success,
+                                   eTag: String = "an_etag") -> [String: String] {
         let jsonObject = ["arg": "value"]
         let etagAndResponse = ETagAndResponseWrapper(
             eTag: eTag,
@@ -224,14 +207,14 @@ class ETagManagerTests: XCTestCase {
         return jsonObject
     }
 
-    private func urlForTest() -> URL {
+    func urlForTest() -> URL {
         guard let url: URL = URL(string: "/v1/subscribers/appUserID", relativeTo: baseURL) else {
             fatalError("Error initializing URL")
         }
         return url
     }
 
-    private func httpURLResponseForTest(url: URL, eTag: String, statusCode: HTTPStatusCode) -> HTTPURLResponse {
+    func httpURLResponseForTest(url: URL, eTag: String, statusCode: HTTPStatusCode) -> HTTPURLResponse {
         guard let httpURLResponse = HTTPURLResponse(
             url: url,
             statusCode: statusCode.rawValue,

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTestBase.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTestBase.swift
@@ -267,8 +267,7 @@ class BackendSubscriberAttributesTestBase: XCTestCase {
 
         self.mockHTTPClient.mock(
             requestPath: .postSubscriberAttributes(appUserID: appUserID),
-            response: .init(statusCode: .invalidRequest,
-                            response: .failure(ErrorUtils.networkError(withUnderlyingError: underlyingError)))
+            response: .init(error: ErrorUtils.networkError(withUnderlyingError: underlyingError))
         )
 
         var receivedError: Error?


### PR DESCRIPTION
For #695.

The biggest change is that this code at the beginning of `HTTPClient.handle` is now gone:
```swift
var statusCode: HTTPStatusCode = .networkConnectTimeoutError
var jsonObject: [String: Any]?
var httpResponse: HTTPResponse? = HTTPResponse(statusCode: statusCode, jsonObject: jsonObject)
var receivedJSONError: Error?
```

It was hard to trace which paths modified these default values. The new implementation has a mostly linear path (part of it abstracted in smaller methods now) and doesn’t have mutable values.

This is the new `handle` implementation:
```swift
func handle(urlResponse: URLResponse?,
            request: Request,
            urlRequest: URLRequest,
            data: Data?,
            error networkError: Error?) {
    let (response, shouldRetry) = self.parse(
        urlResponse: urlResponse,
        request: request,
        urlRequest: urlRequest,
        data: data,
        error: networkError
    )

    if shouldRetry {
        Logger.debug(Strings.network.retrying_request(httpMethod: request.method.httpMethod,
                                                      path: request.path))

        self.state.modify {
            $0.queuedRequests.insert(request.retriedRequest(), at: 0)
        }
    } else {
        request.completionHandler?(response)
    }

    self.beginNextRequest()
}
```

## All Changes:

- `HTTPClient.perform` no longer has a bunch of mutable variables with forking paths that make it hard to follow. Most of the response handling is now in a new `parse` method. This will simplify the task of continuing to refactor response deserialization.
- `HTTPClient`’s completion abstracts response into `HTTPResponse`
- `UserInfoAttributeParser` is now an `enum`
- `ETagManager` no longer takes an `Error`. The only thing it did with it is to return the default response.
- `HTTPResponse.jsonObject` is no longer `Optional`
- Moved `defaultJsonEncoder` / `defaultJsonDecoder` to `JSONDecoder+Extensions`. They used by `HTTPClient` and others soon.