### PR TITLE
`OfferingsManager`/`OfferingsFactory`: using `OfferingsResponse`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -269,6 +269,7 @@
 		57CFB98427FE2258002A6730 /* StoreKit2Setting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CFB98327FE2258002A6730 /* StoreKit2Setting.swift */; };
 		57D04BB827D947C6006DAC06 /* HTTPResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D04BB727D947C6006DAC06 /* HTTPResponseTests.swift */; };
 		57D5414227F656D9004CC35C /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D5414127F656D9004CC35C /* NetworkError.swift */; };
+		57D5412E27F6311C004CC35C /* OfferingsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D5412D27F6311C004CC35C /* OfferingsResponse.swift */; };
 		57DC9F4627CC2E4900DA6AF9 /* HTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DC9F4527CC2E4900DA6AF9 /* HTTPRequest.swift */; };
 		57DC9F4A27CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DC9F4927CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift */; };
 		57DE806D28074976008D6C6F /* Storefront.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DE806C28074976008D6C6F /* Storefront.swift */; };
@@ -704,6 +705,7 @@
 		57CFB98327FE2258002A6730 /* StoreKit2Setting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2Setting.swift; sourceTree = "<group>"; };
 		57D04BB727D947C6006DAC06 /* HTTPResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponseTests.swift; sourceTree = "<group>"; };
 		57D5414127F656D9004CC35C /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		57D5412D27F6311C004CC35C /* OfferingsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferingsResponse.swift; sourceTree = "<group>"; };
 		57DC9F4527CC2E4900DA6AF9 /* HTTPRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequest.swift; sourceTree = "<group>"; };
 		57DC9F4927CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCodeTests.swift; sourceTree = "<group>"; };
 		57DE806C28074976008D6C6F /* Storefront.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storefront.swift; sourceTree = "<group>"; };
@@ -1410,6 +1412,7 @@
 		35D832CB262A5B3400E60AC5 /* Networking */ = {
 			isa = PBXGroup;
 			children = (
+				57D5412C27F63108004CC35C /* Responses */,
 				B34605A1279A6E380031CA74 /* Caching */,
 				B34605AA279A6E380031CA74 /* Operations */,
 				B3C4AAD426B8911300E1B3C8 /* Backend.swift */,
@@ -1576,6 +1579,14 @@
 			);
 			name = "Test Plans";
 			path = ..;
+			sourceTree = "<group>";
+		};
+		57D5412C27F63108004CC35C /* Responses */ = {
+			isa = PBXGroup;
+			children = (
+				57D5412D27F6311C004CC35C /* OfferingsResponse.swift */,
+			);
+			path = Responses;
 			sourceTree = "<group>";
 		};
 		B324DC482720C15300103EE9 /* Error Handling */ = {
@@ -2114,6 +2125,7 @@
 				2DDF41B624F6F387005BC22D /* ASN1ObjectIdentifierBuilder.swift in Sources */,
 				35D832D2262E56DB00E60AC5 /* HTTPStatusCode.swift in Sources */,
 				572247D127BEC28E00C524A7 /* Array+Extensions.swift in Sources */,
+				57D5412E27F6311C004CC35C /* OfferingsResponse.swift in Sources */,
 				57AC4C1C2770F56200DDE30F /* SK1StoreProduct.swift in Sources */,
 				B34605C3279A6E380031CA74 /* PostOfferForSigningOperation.swift in Sources */,
 				B34605C7279A6E380031CA74 /* SubscriberAttributesMarshaller.swift in Sources */,

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -19,7 +19,7 @@ class Backend {
 
     typealias CustomerInfoResponseHandler = (Result<CustomerInfo, BackendError>) -> Void
     typealias IntroEligibilityResponseHandler = ([String: IntroEligibility], BackendError?) -> Void
-    typealias OfferingsResponseHandler = (Result<[String: Any], BackendError>) -> Void
+    typealias OfferingsResponseHandler = (Result<OfferingsResponse, BackendError>) -> Void
     typealias OfferSigningResponseHandler = (Result<PostOfferForSigningOperation.SigningData, BackendError>) -> Void
     typealias SimpleResponseHandler = (BackendError?) -> Void
     typealias LogInResponseHandler = (Result<(info: CustomerInfo, created: Bool), BackendError>) -> Void

--- a/Sources/Networking/Caching/OfferingsCallback.swift
+++ b/Sources/Networking/Caching/OfferingsCallback.swift
@@ -16,6 +16,6 @@ import Foundation
 struct OfferingsCallback: CacheKeyProviding {
 
     let cacheKey: String
-    let completion: (Result<[String: Any], BackendError>) -> Void
+    let completion: (Result<OfferingsResponse, BackendError>) -> Void
 
 }

--- a/Sources/Networking/Operations/GetOfferingsOperation.swift
+++ b/Sources/Networking/Operations/GetOfferingsOperation.swift
@@ -46,7 +46,8 @@ private extension GetOfferingsOperation {
 
         let request = HTTPRequest(method: .get, path: .getOfferings(appUserID: appUserID))
 
-        httpClient.perform(request, authHeaders: self.authHeaders) { (response: HTTPResponse<[String: Any]>.Result) in
+        httpClient.perform(request,
+                           authHeaders: self.authHeaders) { (response: HTTPResponse<OfferingsResponse>.Result) in
             defer {
                 completion()
             }

--- a/Sources/Networking/Responses/OfferingsResponse.swift
+++ b/Sources/Networking/Responses/OfferingsResponse.swift
@@ -1,0 +1,57 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  OfferingsResponse.swift
+//
+//  Created by Nacho Soto on 3/31/22.
+
+import Foundation
+
+// swiftlint:disable nesting
+
+struct OfferingsResponse {
+
+    struct Offering {
+
+        struct Package {
+
+            let identifier: String
+            let platformProductIdentifier: String
+
+        }
+
+        let identifier: String
+        let description: String
+        let packages: [Package]
+
+    }
+
+    let currentOfferingId: String?
+    let offerings: [Offering]
+
+}
+
+extension OfferingsResponse {
+
+    var productIdentifiers: Set<String> {
+        return Set(
+            self.offerings
+                .lazy
+                .flatMap { $0.packages }
+                .map { $0.platformProductIdentifier }
+        )
+    }
+
+}
+
+extension OfferingsResponse.Offering.Package: Decodable {}
+extension OfferingsResponse.Offering: Decodable {}
+extension OfferingsResponse: Decodable {}
+
+extension OfferingsResponse: HTTPResponseBody {}

--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -871,8 +871,8 @@ public extension Purchases {
      * -  [Displaying Products](https://docs.revenuecat.com/docs/displaying-products)
      */
     @objc func getOfferings(completion: @escaping (Offerings?, Error?) -> Void) {
-        offeringsManager.offerings(appUserID: appUserID) { offerings, error in
-            completion(offerings, error?.asPurchasesError)
+        offeringsManager.offerings(appUserID: appUserID) { result in
+            completion(result.value, result.error?.asPurchasesError)
         }
     }
 

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -110,7 +110,7 @@ class MockBackend: Backend {
     var invokedGetOfferingsForAppUserIDCount = 0
     var invokedGetOfferingsForAppUserIDParameters: (appUserID: String?, completion: OfferingsResponseHandler?)?
     var invokedGetOfferingsForAppUserIDParametersList = [(appUserID: String?, completion: OfferingsResponseHandler?)]()
-    var stubbedGetOfferingsCompletionResult: Result<[String: Any], BackendError>?
+    var stubbedGetOfferingsCompletionResult: Result<OfferingsResponse, BackendError>?
 
     override func getOfferings(appUserID: String, completion: @escaping OfferingsResponseHandler) {
         invokedGetOfferingsForAppUserID = true

--- a/Tests/UnitTests/Mocks/MockOfferingsFactory.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsFactory.swift
@@ -10,7 +10,10 @@ class MockOfferingsFactory: OfferingsFactory {
     var emptyOfferings = false
     var nilOfferings = false
 
-    override func createOfferings(from storeProductsByID: [String: StoreProduct], data: [String: Any]) -> Offerings? {
+    override func createOfferings(
+        from storeProductsByID: [String: StoreProduct],
+        data: OfferingsResponse
+    ) -> Offerings? {
         if emptyOfferings {
             return Offerings(offerings: [:], currentOfferingID: "base")
         }

--- a/Tests/UnitTests/Mocks/MockOfferingsManager.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsManager.swift
@@ -18,35 +18,35 @@ class MockOfferingsManager: OfferingsManager {
 
     var invokedOfferings = false
     var invokedOfferingsCount = 0
-    var invokedOfferingsParameters: (appUserID: String, completion: ((Offerings?, Error?) -> Void)?)?
-    var invokedOfferingsParametersList = [(appUserID: String, completion: ((Offerings?, Error?) -> Void)?)]()
-    var stubbedOfferingsCompletionResult: (offerings: Offerings?, error: Error?)?
+    var invokedOfferingsParameters: (appUserID: String, completion: ((Result<Offerings, Error>) -> Void)?)?
+    var invokedOfferingsParametersList = [(appUserID: String, completion: ((Result<Offerings, Error>) -> Void)?)]()
+    var stubbedOfferingsCompletionResult: Result<Offerings, Error>?
 
-    override func offerings(appUserID: String, completion: ((Offerings?, Error?) -> Void)?) {
+    override func offerings(appUserID: String, completion: ((Result<Offerings, Error>) -> Void)?) {
         invokedOfferings = true
         invokedOfferingsCount += 1
         invokedOfferingsParameters = (appUserID, completion)
         invokedOfferingsParametersList.append((appUserID, completion))
 
-        completion?(stubbedOfferingsCompletionResult?.offerings, stubbedOfferingsCompletionResult?.error)
+        completion?(stubbedOfferingsCompletionResult!)
     }
 
     struct InvokedUpdateOfferingsCacheParameters {
         let appUserID: String
         let isAppBackgrounded: Bool
-        let completion: ((Offerings?, Error?) -> Void)?
+        let completion: ((Result<Offerings, Error>) -> Void)?
     }
 
     var invokedUpdateOfferingsCache = false
     var invokedUpdateOfferingsCacheCount = 0
     var invokedUpdateOfferingsCacheParameters: InvokedUpdateOfferingsCacheParameters?
     var invokedUpdateOfferingsCachesParametersList = [InvokedUpdateOfferingsCacheParameters]()
-    var stubbedUpdateOfferingsCompletionResult: (offerings: Offerings?, error: Error?)?
+    var stubbedUpdateOfferingsCompletionResult: Result<Offerings, Error>?
 
     override func updateOfferingsCache(
         appUserID: String,
         isAppBackgrounded: Bool,
-        completion: ((Offerings?, Error?) -> Void)?
+        completion: ((Result<Offerings, Error>) -> Void)?
     ) {
         invokedUpdateOfferingsCache = true
         invokedUpdateOfferingsCacheCount += 1
@@ -60,7 +60,7 @@ class MockOfferingsManager: OfferingsManager {
         invokedUpdateOfferingsCacheParameters = parameters
         invokedUpdateOfferingsCachesParametersList.append(parameters)
 
-        completion?(stubbedUpdateOfferingsCompletionResult?.offerings, stubbedUpdateOfferingsCompletionResult?.error)
+        completion?(stubbedUpdateOfferingsCompletionResult!)
     }
 
 }

--- a/Tests/UnitTests/Purchasing/PurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/PurchasesTests.swift
@@ -193,25 +193,11 @@ class PurchasesTests: XCTestCase {
                 return
             }
             if badOfferingsResponse {
-                completion(.success([:]))
+                completion(.failure(.networkError(.decoding(CodableError.invalidJSONObject(value: [:]), Data()))))
                 return
             }
 
-            let offeringsData = [
-                "offerings": [
-                    [
-                        "identifier": "base",
-                        "description": "This is the base offering",
-                        "packages": [
-                            ["identifier": "$rc_monthly",
-                             "platform_product_identifier": "monthly_freetrial"]
-                        ]
-                    ]
-                ],
-                "current_offering_id": "base"
-            ] as [String: Any]
-
-            completion(.success(offeringsData))
+            completion(.success(.mockResponse))
         }
 
         override func createAlias(appUserID: String, newAppUserID: String, completion: ((BackendError?) -> Void)?) {
@@ -1831,10 +1817,11 @@ class PurchasesTests: XCTestCase {
         expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount).toEventually(equal(0))
     }
 
-    func testProductDataIsCachedForOfferings() {
+    func testProductDataIsCachedForOfferings() throws {
         setupPurchases()
-        mockOfferingsManager.stubbedOfferingsCompletionResult =
-        (offeringsFactory.createOfferings(from: [:], data: [:]), nil)
+        mockOfferingsManager.stubbedOfferingsCompletionResult = .success(
+            try XCTUnwrap(self.offeringsFactory.createOfferings(from: [:], data: .mockResponse))
+        )
         self.purchases?.getOfferings { (newOfferings, _) in
             let storeProduct = newOfferings!["base"]!.monthly!.storeProduct
             let product = storeProduct.sk1Product!
@@ -2395,10 +2382,12 @@ class PurchasesTests: XCTestCase {
         self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
     }
 
-    func testPostsOfferingIfPurchasingPackage() {
+    func testPostsOfferingIfPurchasingPackage() throws {
         setupPurchases()
-        mockOfferingsManager.stubbedOfferingsCompletionResult =
-        (offeringsFactory.createOfferings(from: [:], data: [:]), nil)
+        mockOfferingsManager.stubbedOfferingsCompletionResult = .success(
+            try XCTUnwrap(self.offeringsFactory.createOfferings(from: [:], data: .mockResponse))
+        )
+
         self.purchases!.getOfferings { (newOfferings, _) in
             let package = newOfferings!["base"]!.monthly!
             self.purchases!.purchase(package: package) { (_, _, _, _) in
@@ -2426,12 +2415,14 @@ class PurchasesTests: XCTestCase {
         }
     }
 
-    func testPurchasingPackageDoesntThrowPurchaseAlreadyInProgressIfCallbackMakesANewPurchase() {
+    func testPurchasingPackageDoesntThrowPurchaseAlreadyInProgressIfCallbackMakesANewPurchase() throws {
         setupPurchases()
         var receivedError: NSError?
         var secondCompletionCalled = false
-        mockOfferingsManager.stubbedOfferingsCompletionResult =
-        (offeringsFactory.createOfferings(from: [:], data: [:]), nil)
+        mockOfferingsManager.stubbedOfferingsCompletionResult = .success(
+            try XCTUnwrap(self.offeringsFactory.createOfferings(from: [:], data: .mockResponse))
+        )
+
         self.purchases!.getOfferings { (newOfferings, _) in
             let package = newOfferings!["base"]!.monthly!
             self.purchases!.purchase(package: package) { _, _, _, _  in
@@ -2715,5 +2706,20 @@ class PurchasesTests: XCTestCase {
         expect(self.deviceCache.setCustomerInfoCacheTimestampToNowCount).toEventually(equal(expectedCallCount))
         expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount).toEventually(equal(expectedCallCount))
     }
+
+}
+
+private extension OfferingsResponse {
+
+    static let mockResponse: Self = .init(
+        currentOfferingId: "base",
+        offerings: [
+            .init(identifier: "base",
+                  description: "This is the base offering",
+                  packages: [
+                    .init(identifier: "$rc_monthly", platformProductIdentifier: "monthly_freetrial")
+                  ])
+        ]
+    )
 
 }


### PR DESCRIPTION
Depends on #1437.
This takes full advantage of `Decodable` when decoding and creating `Offerings`.