### PR TITLE
`MockUserDefaults`: override `synchronize`

### DIFF
--- a/Tests/UnitTests/Mocks/MockUserDefaults.swift
+++ b/Tests/UnitTests/Mocks/MockUserDefaults.swift
@@ -57,6 +57,12 @@ class MockUserDefaults: UserDefaults {
 
     override func dictionaryRepresentation() -> [String: Any] { mockValues }
 
+    override func synchronize() -> Bool {
+        // Nothing to do
+
+        return false
+    }
+
     override func removePersistentDomain(forName domainName: String) {
         mockValues = [:]
     }


### PR DESCRIPTION
Right now the original `UserDefaults.synchronize` is being called which isn't great.