### PR TITLE
`ETagManager`: added test to verify that reading cached data in old format fails gracefully

### DIFF
--- a/Sources/Networking/ETagManager.swift
+++ b/Sources/Networking/ETagManager.swift
@@ -124,8 +124,6 @@ private extension ETagManager {
         return request.url?.absoluteString
     }
 
-    // TODO: delete old data since this isn't backwards compatible
-
     static let suiteNameBase: String  = "revenuecat.etags"
     static var suiteName: String {
         guard let bundleID = Bundle.main.bundleIdentifier else {


### PR DESCRIPTION
Follow up to #1425.