### PR TITLE
Changed `SystemInfo.isApplicationBackgrounded` to use `OperationDispatcher`

### DIFF
--- a/Sources/Misc/OperationDispatcher.swift
+++ b/Sources/Misc/OperationDispatcher.swift
@@ -20,6 +20,8 @@ class OperationDispatcher {
     private let workerQueue = DispatchQueue(label: "OperationDispatcherWorkerQueue")
     private let maxJitterInSeconds: Double = 5
 
+    static let `default`: OperationDispatcher = .init()
+
     func dispatchOnMainThread(_ block: @escaping () -> Void) {
         if Thread.isMainThread {
             block()

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -41,6 +41,7 @@ class SystemInfo {
 
     let useStoreKit2IfAvailable: Bool
     var finishTransactions: Bool
+    let operationDispatcher: OperationDispatcher
     let platformFlavor: String
     let platformFlavorVersion: String?
     let bundle: Bundle
@@ -113,6 +114,7 @@ class SystemInfo {
 
     init(platformInfo: Purchases.PlatformInfo?,
          finishTransactions: Bool,
+         operationDispatcher: OperationDispatcher = .default,
          bundle: Bundle = .main,
          useStoreKit2IfAvailable: Bool = false,
          dangerousSettings: DangerousSettings? = nil) throws {
@@ -121,12 +123,13 @@ class SystemInfo {
         self.bundle = bundle
 
         self.finishTransactions = finishTransactions
+        self.operationDispatcher = operationDispatcher
         self.useStoreKit2IfAvailable = useStoreKit2IfAvailable
         self.dangerousSettings = dangerousSettings ?? DangerousSettings()
     }
 
     func isApplicationBackgrounded(completion: @escaping (Bool) -> Void) {
-        DispatchQueue.main.async {
+        self.operationDispatcher.dispatchOnMainThread {
             completion(self.isApplicationBackgrounded)
         }
     }

--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -245,7 +245,7 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
                      platformInfo: PlatformInfo? = Purchases.platformInfo,
                      useStoreKit2IfAvailable: Bool = false,
                      dangerousSettings: DangerousSettings? = nil) {
-        let operationDispatcher = OperationDispatcher()
+        let operationDispatcher: OperationDispatcher = .default
         let receiptRefreshRequestFactory = ReceiptRefreshRequestFactory()
         let fetcher = StoreKitRequestFetcher(requestFactory: receiptRefreshRequestFactory,
                                              operationDispatcher: operationDispatcher)
@@ -253,6 +253,7 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
         do {
             systemInfo = try SystemInfo(platformInfo: platformInfo,
                                         finishTransactions: !observerMode,
+                                        operationDispatcher: operationDispatcher,
                                         useStoreKit2IfAvailable: useStoreKit2IfAvailable,
                                         dangerousSettings: dangerousSettings)
         } catch {


### PR DESCRIPTION
This solves a race condition that could cause operations to run out of order (discovered in #1441).

`Purchases.configure` triggers a `getCustomerInfo` call, which relies on `isApplicationBackgrounded`.
The previous implementation always had a runloop "jump", meaning that sometimes a subsequent request might happen out of order.
By using `OperationDispatcher.dispatchOnMainThread`, the jump is avoided if we're already in the main thread, meaning we run everything deterministically in order.