### PR TITLE
Fix: local receipt parsing for StoreKitTest - part 1

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		2D11F5E1250FF886005A70E8 /* AttributionStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D11F5E0250FF886005A70E8 /* AttributionStrings.swift */; };
 		2D1C3F3926B9D8B800112626 /* MockBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1C3F3826B9D8B800112626 /* MockBundle.swift */; };
 		2D1E789926FE216800760949 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1E788926FE215500760949 /* SceneDelegate.swift */; };
+		2D222BAB27FB7008003D5F37 /* LocalReceiptParserStoreKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D222BAA27FB7008003D5F37 /* LocalReceiptParserStoreKitTests.swift */; };
 		2D22BF6526F3CB31001AE2F9 /* FatalErrorUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D22BF6426F3CB31001AE2F9 /* FatalErrorUtil.swift */; };
 		2D22BF6826F3CC6D001AE2F9 /* XCTestCase+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D22BF6626F3CBFB001AE2F9 /* XCTestCase+Extensions.swift */; };
 		2D294E5C26DECFD500B8FE4F /* StoreKit2TransactionListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D294E5B26DECFD500B8FE4F /* StoreKit2TransactionListener.swift */; };
@@ -458,6 +459,7 @@
 		2D11F5E0250FF886005A70E8 /* AttributionStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributionStrings.swift; sourceTree = "<group>"; };
 		2D1C3F3826B9D8B800112626 /* MockBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBundle.swift; sourceTree = "<group>"; };
 		2D1E788926FE215500760949 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		2D222BAA27FB7008003D5F37 /* LocalReceiptParserStoreKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalReceiptParserStoreKitTests.swift; sourceTree = "<group>"; };
 		2D22BF6426F3CB31001AE2F9 /* FatalErrorUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FatalErrorUtil.swift; sourceTree = "<group>"; };
 		2D22BF6626F3CBFB001AE2F9 /* XCTestCase+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Extensions.swift"; sourceTree = "<group>"; };
 		2D294E5B26DECFD500B8FE4F /* StoreKit2TransactionListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2TransactionListener.swift; sourceTree = "<group>"; };
@@ -998,6 +1000,7 @@
 				57C381B62791E593009E3940 /* StoreKit2TransactionListenerTests.swift */,
 				2D43017726EBFD7100BAB891 /* UnitTestsConfiguration.storekit */,
 				F5FCD3FB27DA2034003BDC04 /* PriceFormatterProviderTests.swift */,
+				2D222BAA27FB7008003D5F37 /* LocalReceiptParserStoreKitTests.swift */,
 			);
 			path = StoreKitUnitTests;
 			sourceTree = "<group>";
@@ -2024,6 +2027,7 @@
 				2D90F8C126FD20F2009B9142 /* MockHTTPClient.swift in Sources */,
 				F5847431278D00C1001B1CE6 /* MockDNSChecker.swift in Sources */,
 				F55FFA632763F60700995146 /* TransactionsManagerSK1Tests.swift in Sources */,
+				2D222BAB27FB7008003D5F37 /* LocalReceiptParserStoreKitTests.swift in Sources */,
 				571E7AD4279F2D0C003B3606 /* StoreKitTestHelpers.swift in Sources */,
 				2DFF6C56270CA28800ECAFAB /* MockRequestFetcher.swift in Sources */,
 				5738F489278CC2500096D623 /* MockTransaction.swift in Sources */,

--- a/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
@@ -40,7 +40,7 @@ struct AppleReceipt: Equatable {
 
     let bundleId: String
     let applicationVersion: String
-    let originalApplicationVersion: String
+    let originalApplicationVersion: String?
     let opaqueValue: Data
     let sha1Hash: Data
     let creationDate: Date
@@ -58,7 +58,7 @@ struct AppleReceipt: Equatable {
         return [
             "bundleId": bundleId,
             "applicationVersion": applicationVersion,
-            "originalApplicationVersion": originalApplicationVersion,
+            "originalApplicationVersion": originalApplicationVersion ?? "<unknown>",
             "opaqueValue": opaqueValue,
             "sha1Hash": sha1Hash,
             "creationDate": creationDate,

--- a/Sources/LocalReceiptParsing/Builders/ASN1ContainerBuilder.swift
+++ b/Sources/LocalReceiptParsing/Builders/ASN1ContainerBuilder.swift
@@ -106,8 +106,11 @@ private extension ASN1ContainerBuilder {
             lengthValue = lengthBytes.toInt()
         }
         // StoreKitTest receipts report a length of zero for Constructed elements.
-        // When length == 0, the element's size is the entire container
-        // minus the bytesUsedForLength, minus the header (which isn't passed to this method)
+        // This is called indefinite-length in ASN1 containers.
+        // When length == 0, the element's contents end when there are two subsequent 0x00 octets.
+        // This (naive) implementation just assumes that the end of content octets are at the end of the
+        // sequence, which is incorrect but works in practice.
+        // This code should be refactored to find the end of content octets, though. 
         if lengthValue == 0 {
             lengthValue = data.count - bytesUsedForLength
         }

--- a/Sources/LocalReceiptParsing/Builders/ASN1ContainerBuilder.swift
+++ b/Sources/LocalReceiptParsing/Builders/ASN1ContainerBuilder.swift
@@ -32,7 +32,8 @@ class ASN1ContainerBuilder {
             throw ReceiptReadingError.asn1ParsingError(description: "payload is shorter than length value")
         }
 
-        let internalPayload = payload.dropFirst(bytesUsedForMetadata).prefix(length.value)
+        let internalPayload = length.value == 0 ? payload.dropFirst(bytesUsedForMetadata)
+                                                : payload.dropFirst(bytesUsedForMetadata).prefix(length.value)
         var internalContainers: [ASN1Container] = []
         if encodingType == .constructed {
             internalContainers = try buildInternalContainers(payload: internalPayload)

--- a/Sources/LocalReceiptParsing/Builders/AppleReceiptBuilder.swift
+++ b/Sources/LocalReceiptParsing/Builders/AppleReceiptBuilder.swift
@@ -45,7 +45,8 @@ class AppleReceiptBuilder {
             throw ReceiptReadingError.receiptParsingError
         }
         let receiptContainer = try containerBuilder.build(fromPayload: internalContainer.internalPayload)
-        for receiptAttribute in receiptContainer.internalContainers {
+        let internalReceiptContainer = try containerBuilder.build(fromPayload: receiptContainer.internalPayload)
+        for receiptAttribute in internalReceiptContainer.internalContainers {
             guard receiptAttribute.internalContainers.count == expectedInternalContainersCount else {
                 throw ReceiptReadingError.receiptParsingError
             }
@@ -85,7 +86,6 @@ class AppleReceiptBuilder {
 
         guard let nonOptionalBundleId = bundleId,
             let nonOptionalApplicationVersion = applicationVersion,
-            let nonOptionalOriginalApplicationVersion = originalApplicationVersion,
             let nonOptionalOpaqueValue = opaqueValue,
             let nonOptionalSha1Hash = sha1Hash,
             let nonOptionalCreationDate = creationDate else {
@@ -94,7 +94,7 @@ class AppleReceiptBuilder {
 
         let receipt = AppleReceipt(bundleId: nonOptionalBundleId,
                                    applicationVersion: nonOptionalApplicationVersion,
-                                   originalApplicationVersion: nonOptionalOriginalApplicationVersion,
+                                   originalApplicationVersion: originalApplicationVersion,
                                    opaqueValue: nonOptionalOpaqueValue,
                                    sha1Hash: nonOptionalSha1Hash,
                                    creationDate: nonOptionalCreationDate,

--- a/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
@@ -51,7 +51,7 @@ class LocalReceiptParserStoreKitTests: StoreKitConfigTestCase {
 
         expect(completionCalled).toEventually(beTrue())
         let receipt = try XCTUnwrap(maybeReceipt)
-        expect(receipt.applicationVersion) == "version"
+        expect(receipt.applicationVersion) == "1"
     }
 
 }

--- a/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
@@ -12,8 +12,8 @@
 //  Created by Andrés Boedo on 4/4/22.
 
 import Foundation
-@testable import RevenueCat
 import Nimble
+@testable import RevenueCat
 import XCTest
 
 class LocalReceiptParserStoreKitTests: StoreKitConfigTestCase {

--- a/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
@@ -1,0 +1,57 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  LocalReceiptParserStoreKitTests.swift
+//
+//  Created by Andrés Boedo on 4/4/22.
+
+import Foundation
+@testable import RevenueCat
+import Nimble
+import XCTest
+
+class LocalReceiptParserStoreKitTests: StoreKitConfigTestCase {
+
+    func testReceiptParserParsesEmptyReceipt() throws {
+
+        let operationDispatcher: OperationDispatcher = .default
+        let receiptRefreshRequestFactory = ReceiptRefreshRequestFactory()
+        let fetcher = StoreKitRequestFetcher(requestFactory: receiptRefreshRequestFactory,
+                                             operationDispatcher: operationDispatcher)
+        let systemInfo: SystemInfo
+        do {
+            systemInfo = try SystemInfo(platformInfo: Purchases.platformInfo,
+                                        finishTransactions: true,
+                                        operationDispatcher: operationDispatcher,
+                                        useStoreKit2IfAvailable: false)
+        } catch {
+            fatalError(error.localizedDescription)
+        }
+
+        let receiptFetcher = ReceiptFetcher(requestFetcher: fetcher, systemInfo: systemInfo)
+        let parser = ReceiptParser()
+        var maybeReceipt: AppleReceipt?
+        var completionCalled = false
+        receiptFetcher.receiptData(refreshPolicy: .always) { data in
+            guard let data = data else { return }
+            do {
+                maybeReceipt = try parser.parse(from: data)
+                completionCalled = true
+            } catch {
+                print("failed to parse. Error: \(error)")
+                completionCalled = true
+            }
+        }
+
+        expect(completionCalled).toEventually(beTrue())
+        let receipt = try XCTUnwrap(maybeReceipt)
+        expect(receipt.applicationVersion) == "version"
+    }
+
+}

--- a/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
@@ -24,15 +24,10 @@ class LocalReceiptParserStoreKitTests: StoreKitConfigTestCase {
         let receiptRefreshRequestFactory = ReceiptRefreshRequestFactory()
         let fetcher = StoreKitRequestFetcher(requestFactory: receiptRefreshRequestFactory,
                                              operationDispatcher: operationDispatcher)
-        let systemInfo: SystemInfo
-        do {
-            systemInfo = try SystemInfo(platformInfo: Purchases.platformInfo,
+        let systemInfo = try SystemInfo(platformInfo: Purchases.platformInfo,
                                         finishTransactions: true,
                                         operationDispatcher: operationDispatcher,
                                         useStoreKit2IfAvailable: false)
-        } catch {
-            fatalError(error.localizedDescription)
-        }
 
         let receiptFetcher = ReceiptFetcher(requestFetcher: fetcher, systemInfo: systemInfo)
         let parser = ReceiptParser()
@@ -42,11 +37,10 @@ class LocalReceiptParserStoreKitTests: StoreKitConfigTestCase {
             guard let data = data else { return }
             do {
                 maybeReceipt = try parser.parse(from: data)
-                completionCalled = true
             } catch {
                 print("failed to parse. Error: \(error)")
-                completionCalled = true
             }
+            completionCalled = true
         }
 
         expect(completionCalled).toEventually(beTrue())

--- a/Tests/UnitTests/LocalReceiptParsing/Builders/AppleReceiptBuilderTests.swift
+++ b/Tests/UnitTests/LocalReceiptParsing/Builders/AppleReceiptBuilderTests.swift
@@ -127,7 +127,7 @@ class AppleReceiptBuilderTests: XCTestCase {
         expect { try self.appleReceiptBuilder.build(fromContainer: receiptContainer) }.to(throwError())
     }
 
-    func testBuildThrowsIfOriginalAppVersionIsMissing() {
+    func testBuildDoesntThrowIfOriginalAppVersionIsMissing() {
         let receiptContainer = containerFactory.receiptContainerFromContainers(containers: [
             bundleIdContainer(),
             appVersionContainer(),
@@ -135,7 +135,7 @@ class AppleReceiptBuilderTests: XCTestCase {
             sha1HashContainer(),
             creationDateContainer()
         ])
-        expect { try self.appleReceiptBuilder.build(fromContainer: receiptContainer) }.to(throwError())
+        expect { try self.appleReceiptBuilder.build(fromContainer: receiptContainer) }.notTo(throwError())
     }
 
     func testBuildThrowsIfOpaqueValueIsMissing() {


### PR DESCRIPTION
This PR fixes local receipt parsing for StoreKitTest receipts. 

So far this only includes a single test, next PR is going to add more tests for different StoreKitTest receipts, and will also clean up the test code to make it a lot nicer. 

So this is part 1, but it does the main thing, which is to make it actually compatible. 

Main changes: 

### StoreKitTest receipts reported length value: 
These receipts use indefinite-length containers, so our calculation for the container length would break, because it would be understood to be zero. 
This first (naive) implementation assumes the indefinite-length containers to be as big as the entire payload, which is incorrect, but works in practice, so it's a decent temporary patch. 

### StoreKitTest receipts missing originalAppVersion
The [`originalAppVersion`](https://developer.apple.com/library/archive/releasenotes/General/ValidateAppStoreReceipt/Chapters/ReceiptFields.html) is non-optional for production and sandbox receipts, but the value is missing for StoreKitTest receipts, so this PR makes it optional. 

### StoreKitTest receipt structure
The data in StoreKItTest receipts is structured slightly differently to regular: 

Regular receipts: 
- Sequence
    - Main object (data object identifier)
    - Data
        - Sequence with single element
            - octet string
                - **Actual receipt data**

StoreKitTest receipts: 

- Sequence
    - Main object (data object identifier)
    - Data
        - Sequence with single element
            - octet string
                - **another octet string**
                    - **Actual receipt data**


I could of course not find any documentation for any of the changes above, this is just reverse-engineering. 

Follow-up PRs will: 
- Clean up tests code and make it a ton simpler (this is just a terrible and hacky copy-paste)
- Add more tests
- Fix the indefinite-length value calculation logic, to get the correct value instead of the naively-assumed value of "the entire payload"
