### PR TITLE
`BackendIntegrationTests`: added test for failed purchase

### DIFF
--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -45,6 +45,18 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
         expect(entitlements?[Self.entitlementIdentifier]?.isActive) == true
     }
 
+    func testPurchaseFailuresAreReportedCorrectly() async throws {
+        self.testSession.failTransactionsEnabled = true
+        self.testSession.failureError = .invalidSignature
+
+        do {
+            try await self.purchaseMonthlyOffering()
+            fail("Expected error")
+        } catch {
+            expect(error).to(matchError(ErrorCode.invalidPromotionalOfferError))
+        }
+    }
+
     func testPurchaseMadeBeforeLogInIsRetainedAfter() async throws {
         let customerInfo = try await self.purchaseMonthlyOffering().customerInfo
         expect(customerInfo.entitlements.all.count) == 1


### PR DESCRIPTION
I was trying to add an automated test to cover #1445, but unfortunately `SKTestSession.failureError` only forwards a limited set of errors.
At least this test verifies that purchase errors are reported correctly.