### PR TITLE
Added workaround for StoreKit 1 incorrectly reporting purchase cancellations

### DIFF
--- a/Sources/Error Handling/SKError+Extensions.swift
+++ b/Sources/Error Handling/SKError+Extensions.swift
@@ -49,10 +49,14 @@ extension SKError {
             return ErrorUtils.invalidPromotionalOfferError(error: self)
         case .unknown:
             if let error = self.userInfo[NSUnderlyingErrorKey] as? NSError {
-                switch (error.domain, error.code) {
-                case ("ASDServerErrorDomain", 3532): // "You’re currently subscribed to this"
-                    // See https://github.com/RevenueCat/purchases-ios/issues/392
-                    return ErrorUtils.productAlreadyPurchasedError(error: self)
+                switch error.domain {
+                case ASDServerError.domain:
+                    switch ASDServerError.Code(rawValue: error.code) {
+                    case .currentlySubscribed:
+                        return ErrorUtils.productAlreadyPurchasedError(error: self)
+
+                    default: break
+                    }
 
                 default: break
                 }
@@ -61,13 +65,19 @@ extension SKError {
             return ErrorUtils.storeProblemError(error: self)
 
         @unknown default:
-            switch self.code.rawValue {
-            case 907: // "Unhandled exception"
+            switch SKError.UndocumentedCode(rawValue: self.code.rawValue) {
+            case .unhandledException:
                 if let error = self.userInfo[NSUnderlyingErrorKey] as? NSError {
-                    switch (error.domain, error.code) {
-                    case ("AMSErrorDomain", 6): // "Payment Sheet Failed"
-                        // See https://github.com/RevenueCat/purchases-ios/issues/1445
-                        return .purchaseCancelledError
+                    switch error.domain {
+                    case AMSError.domain:
+                        switch AMSError.Code(rawValue: error.code) {
+                            // See https://github.com/RevenueCat/purchases-ios/issues/1445
+                            // Cancellations sometimes show up as undocumented errors instead of regular cancellations
+                        case .paymentSheetFailed:
+                            return ErrorUtils.purchaseCancelledError(error: self)
+
+                        default: break
+                        }
 
                     default: break
                     }
@@ -78,6 +88,43 @@ extension SKError {
 
             return ErrorUtils.unknownError(error: self)
         }
+    }
+
+}
+
+private extension SKError {
+
+    enum UndocumentedCode: Int {
+
+        // See https://github.com/RevenueCat/purchases-ios/issues/1445
+        case unhandledException = 907
+
+    }
+
+}
+
+private enum ASDServerError {
+
+    static let domain = "ASDServerErrorDomain"
+
+    enum Code: Int {
+
+        // See https://github.com/RevenueCat/purchases-ios/issues/392
+        case currentlySubscribed = 3532
+
+    }
+
+}
+
+private enum AMSError {
+
+    static let domain = "AMSErrorDomain"
+
+    enum Code: Int {
+
+        // See https://github.com/RevenueCat/purchases-ios/issues/1445
+        case paymentSheetFailed = 6
+
     }
 
 }

--- a/Sources/Error Handling/SKError+Extensions.swift
+++ b/Sources/Error Handling/SKError+Extensions.swift
@@ -16,7 +16,7 @@ import StoreKit
 
 extension SKError {
 
-    // swiftlint:disable:next cyclomatic_complexity
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
     func toPurchasesError() -> Error {
         switch self.code {
         case .cloudServiceNetworkConnectionFailed,
@@ -61,6 +61,21 @@ extension SKError {
             return ErrorUtils.storeProblemError(error: self)
 
         @unknown default:
+            switch self.code.rawValue {
+            case 907: // "Unhandled exception"
+                if let error = self.userInfo[NSUnderlyingErrorKey] as? NSError {
+                    switch (error.domain, error.code) {
+                    case ("AMSErrorDomain", 6): // "Payment Sheet Failed"
+                        // See https://github.com/RevenueCat/purchases-ios/issues/1445
+                        return .purchaseCancelledError
+
+                    default: break
+                    }
+                }
+
+            default: break
+            }
+
             return ErrorUtils.unknownError(error: self)
         }
     }

--- a/Sources/Purchasing/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/PurchasesOrchestrator.swift
@@ -465,13 +465,12 @@ private extension PurchasesOrchestrator {
     func handleFailedTransaction(_ transaction: SKPaymentTransaction) {
         if let error = transaction.error,
            let completion = getAndRemovePurchaseCompletedCallback(forTransaction: transaction) {
-            let nsError = error as NSError
-            let userCancelled = nsError.domain == SKErrorDomain && nsError.code == SKError.paymentCancelled.rawValue
+            let purchasesError = ErrorUtils.purchasesError(withSKError: error)
             operationDispatcher.dispatchOnMainThread {
                 completion(StoreTransaction(sk1Transaction: transaction),
                            nil,
-                           ErrorUtils.purchasesError(withSKError: error),
-                           userCancelled)
+                           purchasesError,
+                           purchasesError.isCancelledError)
             }
         }
 
@@ -708,6 +707,14 @@ private extension PurchasesOrchestrator {
                  payment: payment,
                  package: package,
                  completion: completion)
+    }
+
+}
+
+private extension Error {
+
+    var isCancelledError: Bool {
+        return (self as? ErrorCode) == .purchaseCancelledError
     }
 
 }


### PR DESCRIPTION
Fixes #1445.
Similar solution to #965, this attempts to introspect the unknown `SKError` to detect if it actually corresponds to a failed purchase.