### PR TITLE
`SKError.toPurchasesError`: fixed mapping to make it consistent with `StoreKitError.toPurchasesError`

### DIFF
--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -15,7 +15,7 @@
 import Foundation
 import StoreKit
 
-// swiftlint:disable file_length multiline_parameters
+// swiftlint:disable file_length multiline_parameters type_body_length
 
 enum ErrorUtils {
 
@@ -252,17 +252,24 @@ enum ErrorUtils {
     }
 
     /**
-     * Maps an `SKError` to a Error with a ``ErrorCode``. Adds a underlying error in the `NSError.userInfo` dictionary.
+     * Maps an `SKError` to a Error with an ``ErrorCode``. Adds a underlying error in the `NSError.userInfo` dictionary.
      *
      * - Parameter skError: The originating `SKError`.
      */
     static func purchasesError(
-        withSKError skError: Error,
+        withSKError error: Error,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
     ) -> Error {
-        let errorCode = (skError as? SKError)?.toPurchasesErrorCode() ?? .unknownError
-        return error(with: errorCode, message: errorCode.description, underlyingError: skError,
-                     fileName: fileName, functionName: functionName, line: line)
+        switch error {
+        case let skError as SKError:
+            return skError.toPurchasesError()
+
+        default:
+            return ErrorUtils.unknownError(
+                error: error,
+                fileName: fileName, functionName: functionName, line: line
+            )
+        }
     }
 
     /**
@@ -272,14 +279,20 @@ enum ErrorUtils {
      * - Parameter storeKitError: The originating `StoreKitError` or `Product.PurchaseError`.
      */
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    static func purchasesError(withStoreKitError error: Error) -> Error {
+    static func purchasesError(
+        withStoreKitError error: Error,
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
         switch error {
         case let storeKitError as StoreKitError:
             return storeKitError.toPurchasesError()
         case let purchasesError as Product.PurchaseError:
             return purchasesError.toPurchasesError()
         default:
-            return self.unknownError(error: error)
+            return ErrorUtils.unknownError(
+                error: error,
+                fileName: fileName, functionName: functionName, line: line
+            )
         }
     }
 
@@ -289,12 +302,13 @@ enum ErrorUtils {
      * - Note: This error is used when  a purchase is cancelled by the user.
      */
     static func purchaseCancelledError(
+        error: Error? = nil,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
     ) -> Error {
         let errorCode = ErrorCode.purchaseCancelledError
         return ErrorUtils.error(with: errorCode,
                                 message: errorCode.description,
-                                underlyingError: nil,
+                                underlyingError: error,
                                 fileName: fileName, functionName: functionName, line: line)
     }
 
@@ -313,6 +327,17 @@ enum ErrorUtils {
     }
 
     /**
+     * Constructs an Error with the ``ErrorCode/productAlreadyPurchasedError`` code.
+     */
+    static func productAlreadyPurchasedError(
+        error: Error? = nil,
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
+        return ErrorUtils.error(with: .productAlreadyPurchasedError,
+                                underlyingError: error)
+    }
+
+    /**
      * Constructs an Error with the ``ErrorCode/purchaseNotAllowedError`` code.
      */
     static func purchaseNotAllowedError(
@@ -320,6 +345,17 @@ enum ErrorUtils {
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
     ) -> Error {
         return ErrorUtils.error(with: .purchaseNotAllowedError,
+                                underlyingError: error)
+    }
+
+    /**
+     * Constructs an Error with the ``ErrorCode/purchaseInvalidError`` code.
+     */
+    static func purchaseInvalidError(
+        error: Error? = nil,
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
+        return ErrorUtils.error(with: .purchaseInvalidError,
                                 underlyingError: error)
     }
 

--- a/Sources/Error Handling/SKError+Extensions.swift
+++ b/Sources/Error Handling/SKError+Extensions.swift
@@ -17,49 +17,51 @@ import StoreKit
 extension SKError {
 
     // swiftlint:disable:next cyclomatic_complexity
-    func toPurchasesErrorCode() -> ErrorCode {
+    func toPurchasesError() -> Error {
         switch self.code {
         case .cloudServiceNetworkConnectionFailed,
              .cloudServiceRevoked,
              .overlayTimeout,
              .overlayPresentedInBackgroundScene:
-            return .storeProblemError
+            return ErrorUtils.storeProblemError(error: self)
         case .clientInvalid,
              .paymentNotAllowed,
              .cloudServicePermissionDenied,
              .privacyAcknowledgementRequired:
-            return .purchaseNotAllowedError
+            return ErrorUtils.purchaseNotAllowedError(error: self)
         case .paymentCancelled,
              .overlayCancelled:
-            return .purchaseCancelledError
+            return ErrorUtils.purchaseCancelledError(error: self)
         case .paymentInvalid,
-             .unauthorizedRequestData,
-             .missingOfferParams,
-             .invalidOfferPrice,
-             .invalidSignature,
-             .invalidOfferIdentifier:
-            return .purchaseInvalidError
+            .unauthorizedRequestData:
+            return ErrorUtils.purchaseInvalidError(error: self)
         case .storeProductNotAvailable:
-            return .productNotAvailableForPurchaseError
-        case .ineligibleForOffer,
-             .overlayInvalidConfiguration,
+            return ErrorUtils.productNotAvailableForPurchaseError(error: self)
+        case .overlayInvalidConfiguration,
              .unsupportedPlatform:
-            return .purchaseNotAllowedError
+            return ErrorUtils.purchaseNotAllowedError(error: self)
+        case .ineligibleForOffer:
+            return ErrorUtils.ineligibleError(error: self)
+        case .missingOfferParams,
+            .invalidOfferPrice,
+            .invalidSignature,
+            .invalidOfferIdentifier:
+            return ErrorUtils.invalidPromotionalOfferError(error: self)
         case .unknown:
             if let error = self.userInfo[NSUnderlyingErrorKey] as? NSError {
                 switch (error.domain, error.code) {
                 case ("ASDServerErrorDomain", 3532): // "You’re currently subscribed to this"
                     // See https://github.com/RevenueCat/purchases-ios/issues/392
-                    return .productAlreadyPurchasedError
+                    return ErrorUtils.productAlreadyPurchasedError(error: self)
 
                 default: break
                 }
             }
 
-            return .storeProblemError
+            return ErrorUtils.storeProblemError(error: self)
 
         @unknown default:
-            return .unknownError
+            return ErrorUtils.unknownError(error: self)
         }
     }
 

--- a/Sources/Error Handling/StoreKitError+Extensions.swift
+++ b/Sources/Error Handling/StoreKitError+Extensions.swift
@@ -20,7 +20,7 @@ extension StoreKitError {
     func toPurchasesError() -> Error {
         switch self {
         case .userCancelled:
-            return ErrorUtils.purchaseCancelledError()
+            return ErrorUtils.purchaseCancelledError(error: self)
 
         case let .networkError(error):
             return ErrorUtils.networkError(withUnderlyingError: error)


### PR DESCRIPTION
Our mapping between SK1/SK2 errors and `ErrorCode` was inconsistent, so that test was only passing for SK2.

This PR addresses that. It also makes use of `ErrorUtils` methods to ensure that the underlying error is added to the returned errors.