### PR TITLE
Fix: ASN1 length calculation for indefinite-length

### DIFF
--- a/Sources/LocalReceiptParsing/BasicTypes/ASN1Container.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/ASN1Container.swift
@@ -64,6 +64,14 @@ struct ASN1Length: Equatable {
 
     let value: Int
     let bytesUsedForLength: Int
+    let definition: LengthDefinition
+
+    enum LengthDefinition: Int {
+
+        case definite
+        case indefinite
+
+    }
 
 }
 

--- a/Sources/LocalReceiptParsing/Builders/ASN1ContainerBuilder.swift
+++ b/Sources/LocalReceiptParsing/Builders/ASN1ContainerBuilder.swift
@@ -24,8 +24,9 @@ class ASN1ContainerBuilder {
         let containerClass = try extractClass(byte: firstByte)
         let encodingType = try extractEncodingType(byte: firstByte)
         let containerIdentifier = try extractIdentifier(byte: firstByte)
+        let isConstructed = encodingType == .constructed
         let (length, internalContainers) = try extractLengthAndInternalContainers(data: payload.dropFirst(),
-                                                                                  isConstructed: encodingType == .constructed)
+                                                                                  isConstructed: isConstructed)
         let bytesUsedForIdentifier = 1
         let bytesUsedForMetadata = bytesUsedForIdentifier + length.bytesUsedForLength
 

--- a/Sources/LocalReceiptParsing/Builders/ASN1ContainerBuilder.swift
+++ b/Sources/LocalReceiptParsing/Builders/ASN1ContainerBuilder.swift
@@ -24,7 +24,7 @@ class ASN1ContainerBuilder {
         let containerClass = try extractClass(byte: firstByte)
         let encodingType = try extractEncodingType(byte: firstByte)
         let containerIdentifier = try extractIdentifier(byte: firstByte)
-        let length = try extractLength(data: payload.dropFirst())
+        let length = try extractLength(data: payload.dropFirst(), isConstructed: encodingType == .constructed)
         let bytesUsedForIdentifier = 1
         let bytesUsedForMetadata = bytesUsedForIdentifier + length.bytesUsedForLength
 
@@ -55,6 +55,9 @@ private extension ASN1ContainerBuilder {
         while currentPayload.count > 0 {
             let internalContainer = try build(fromPayload: currentPayload)
             internalContainers.append(internalContainer)
+            if internalContainer.containerIdentifier == .endOfContent {
+                break
+            }
             currentPayload = currentPayload.dropFirst(internalContainer.totalBytesUsed)
         }
         return internalContainers
@@ -84,7 +87,7 @@ private extension ASN1ContainerBuilder {
         return asn1Identifier
     }
 
-    func extractLength(data: ArraySlice<UInt8>) throws -> ASN1Length {
+    func extractLength(data: ArraySlice<UInt8>, isConstructed: Bool) throws -> ASN1Length {
         guard let firstByte = data.first else {
             throw ReceiptReadingError.asn1ParsingError(description: "length needs to be at least one byte")
         }
@@ -107,14 +110,17 @@ private extension ASN1ContainerBuilder {
         }
         // StoreKitTest receipts report a length of zero for Constructed elements.
         // This is called indefinite-length in ASN1 containers.
-        // When length == 0, the element's contents end when there are two subsequent 0x00 octets.
-        // This (naive) implementation just assumes that the end of content octets are at the end of the
-        // sequence, which is incorrect but works in practice.
-        // This code should be refactored to find the end of content octets, though. 
-        if lengthValue == 0 {
-            lengthValue = data.count - bytesUsedForLength
+        // When length == 0, the element's contents end when there's a container with .endOfContent identifier
+        // To get the length, we build the internal containers until we run into .endOfContent
+        let lengthDefinition: ASN1Length.LengthDefinition = (isConstructed && lengthValue == 0)
+                                                            ? .indefinite : .definite
+
+        if lengthDefinition == .indefinite {
+            let innerContainers = try buildInternalContainers(payload: data.dropFirst(bytesUsedForLength))
+            let innerContainersOverallLength = innerContainers.map { $0.totalBytesUsed }.reduce(0, +)
+            lengthValue = innerContainersOverallLength
         }
-        return ASN1Length(value: lengthValue, bytesUsedForLength: bytesUsedForLength)
+        return ASN1Length(value: lengthValue, bytesUsedForLength: bytesUsedForLength, definition: lengthDefinition)
     }
 
 }

--- a/Sources/LocalReceiptParsing/ReceiptParser.swift
+++ b/Sources/LocalReceiptParsing/ReceiptParser.swift
@@ -39,7 +39,6 @@ class ReceiptParser {
     }
 
     func parse(from receiptData: Data) throws -> AppleReceipt {
-        guard !receiptData.isEmpty else { throw ReceiptReadingError.dataObjectIdentifierMissing }
         let intData = [UInt8](receiptData)
 
         let asn1Container = try containerBuilder.build(fromPayload: ArraySlice(intData))

--- a/Sources/LocalReceiptParsing/ReceiptParser.swift
+++ b/Sources/LocalReceiptParsing/ReceiptParser.swift
@@ -39,6 +39,7 @@ class ReceiptParser {
     }
 
     func parse(from receiptData: Data) throws -> AppleReceipt {
+        guard !receiptData.isEmpty else { throw ReceiptReadingError.dataObjectIdentifierMissing }
         let intData = [UInt8](receiptData)
 
         let asn1Container = try containerBuilder.build(fromPayload: ArraySlice(intData))

--- a/Tests/UnitTests/TestHelpers/ContainerFactory.swift
+++ b/Tests/UnitTests/TestHelpers/ContainerFactory.swift
@@ -14,7 +14,7 @@ class ContainerFactory {
         return ASN1Container(containerClass: .application,
                              containerIdentifier: .octetString,
                              encodingType: .primitive,
-                             length: ASN1Length(value: length, bytesUsedForLength: 1),
+                             length: ASN1Length(value: length, bytesUsedForLength: 1, definition: .definite),
                              internalPayload: ArraySlice(Array(repeating: UInt8(0b1), count: length)),
                              internalContainers: [])
     }
@@ -25,7 +25,9 @@ class ContainerFactory {
         return ASN1Container(containerClass: .application,
                              containerIdentifier: .octetString,
                              encodingType: .primitive,
-                             length: ASN1Length(value: stringAsBytes.count, bytesUsedForLength: 1),
+                             length: ASN1Length(value: stringAsBytes.count,
+                                                bytesUsedForLength: 1,
+                                                definition: .definite),
                              internalPayload: ArraySlice(Array(stringAsBytes)),
                              internalContainers: [])
     }
@@ -42,7 +44,9 @@ class ContainerFactory {
         return ASN1Container(containerClass: .application,
                              containerIdentifier: .octetString,
                              encodingType: .primitive,
-                             length: ASN1Length(value: stringAsBytes.count, bytesUsedForLength: 1),
+                             length: ASN1Length(value: stringAsBytes.count,
+                                                bytesUsedForLength: 1,
+                                                definition: .definite),
                              internalPayload: ArraySlice(stringAsBytes),
                              internalContainers: [])
     }
@@ -51,7 +55,7 @@ class ContainerFactory {
         return ASN1Container(containerClass: .application,
                              containerIdentifier: .octetString,
                              encodingType: .primitive,
-                             length: ASN1Length(value: 1, bytesUsedForLength: 1),
+                             length: ASN1Length(value: 1, bytesUsedForLength: 1, definition: .definite),
                              internalPayload: ArraySlice([UInt8(booleanLiteral: bool)]),
                              internalContainers: [])
     }
@@ -63,7 +67,9 @@ class ContainerFactory {
         return ASN1Container(containerClass: .application,
                              containerIdentifier: .octetString,
                              encodingType: .primitive,
-                             length: ASN1Length(value: intAsBytes.count, bytesUsedForLength: bytesUsedForLength),
+                             length: ASN1Length(value: intAsBytes.count,
+                                                bytesUsedForLength: bytesUsedForLength,
+                                                definition: .definite),
                              internalPayload: ArraySlice(intAsBytes),
                              internalContainers: [])
     }
@@ -75,7 +81,9 @@ class ContainerFactory {
         return ASN1Container(containerClass: .application,
                              containerIdentifier: .octetString,
                              encodingType: .primitive,
-                             length: ASN1Length(value: intAsBytes.count, bytesUsedForLength: bytesUsedForLength),
+                             length: ASN1Length(value: intAsBytes.count,
+                                                bytesUsedForLength: bytesUsedForLength,
+                                                definition: .definite),
                              internalPayload: ArraySlice(intAsBytes),
                              internalContainers: [])
     }
@@ -87,7 +95,9 @@ class ContainerFactory {
         return ASN1Container(containerClass: .application,
                              containerIdentifier: .octetString,
                              encodingType: encodingType,
-                             length: ASN1Length(value: payload.count, bytesUsedForLength: bytesUsedForLength),
+                             length: ASN1Length(value: payload.count,
+                                                bytesUsedForLength: bytesUsedForLength,
+                                                definition: .definite),
                              internalPayload: ArraySlice(payload),
                              internalContainers: containers)
     }
@@ -162,7 +172,9 @@ class ContainerFactory {
         return ASN1Container(containerClass: .application,
                              containerIdentifier: .objectIdentifier,
                              encodingType: .primitive,
-                             length: ASN1Length(value: payload.count, bytesUsedForLength: bytesUsedForLength),
+                             length: ASN1Length(value: payload.count,
+                                                bytesUsedForLength: bytesUsedForLength,
+                                                definition: .definite),
                              internalPayload: payload,
                              internalContainers: [])
     }


### PR DESCRIPTION
Follow-up to #1446. 

This one fixes the length calculation logic for indefinite-length receipts. 
In this type of receipt, the length bytes are set to a value of zero, and you find the actual length by finding a container with `objectIdentifier` = `endOfContent` (two bytes of 0x00 value). 

So the new logic for indefinite-length containers parses the inner containers until an endOfContent container is found, then sums up the length of all of them and uses that value. 

Definite-length receipts don't actually have `endOfContent` bytes, which makes the parsing logic slightly more complex, sadly. 