### PR TITLE
Clean storekit receipt parsing tests

### DIFF
--- a/Sources/Purchasing/ReceiptFetcher.swift
+++ b/Sources/Purchasing/ReceiptFetcher.swift
@@ -42,6 +42,15 @@ class ReceiptFetcher {
         }
     }
 
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func receiptData(refreshPolicy: ReceiptRefreshPolicy) async -> Data? {
+        return await withCheckedContinuation { continuation in
+            receiptData(refreshPolicy: refreshPolicy) { result in
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
 }
 
 private extension ReceiptFetcher {


### PR DESCRIPTION
Yet another follow-up for storekit parsing in https://github.com/RevenueCat/purchases-ios/pull/1446

This one cleans up the test code. The final follow-up will include more tests for the actual receipt using this as a base.