### PR TITLE
Renamed `PurchasesDelegate.purchases(_:shouldPurchasePromoProduct:defermentBlock:)`

### DIFF
--- a/Sources/Misc/Obsoletions.swift
+++ b/Sources/Misc/Obsoletions.swift
@@ -17,7 +17,7 @@ import StoreKit
 // and therefore the `fatalError`s are unreachable.
 // See also: Development/Deprecations.md
 
-// swiftlint:disable file_length missing_docs
+// swiftlint:disable file_length missing_docs line_length
 
 public extension Purchases {
 
@@ -467,6 +467,16 @@ public extension Purchases {
                message: "Check eligibility for a discount using getPromotionalOffer:")
     func paymentDiscount(for discount: SKProductDiscount,
                          product: SKProduct) async throws -> SKPaymentDiscount {
+        fatalError()
+    }
+
+    @available(iOS, obsoleted: 1, message: "Use PurchasesDelegate.purchases(_:isReadyForPromotedProduct:purchase:)")
+    @available(tvOS, obsoleted: 1, message: "Use PurchasesDelegate.purchases(_:isReadyForPromotedProduct:purchase:)")
+    @available(watchOS, obsoleted: 1, message: "Use PurchasesDelegate.purchases(_:isReadyForPromotedProduct:purchase:)")
+    @available(macOS, obsoleted: 1, message: "Use PurchasesDelegate.purchases(_:isReadyForPromotedProduct:purchase:)")
+    @available(macCatalyst, obsoleted: 1, message: "Use PurchasesDelegate.purchases(_:isReadyForPromotedProduct:purchase:)")
+    @objc func shouldPurchasePromoProduct(_ product: StoreProduct,
+                                          defermentBlock: @escaping DeferredPromotionalPurchaseBlock) {
         fatalError()
     }
 

--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -32,7 +32,7 @@ public typealias PurchaseResultData = (transaction: StoreTransaction?,
 public typealias PurchaseCompletedBlock = (StoreTransaction?, CustomerInfo?, Error?, Bool) -> Void
 
 /**
- Deferred block for ``Purchases/shouldPurchasePromoProduct(_:defermentBlock:)``
+ Deferred block for ``PurchasesDelegate/purchases(_:isReadyForPromotedProduct:purchase:)``
  */
 public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
@@ -1776,24 +1776,24 @@ extension Purchases: PurchasesOrchestratorDelegate {
     /**
      * Called when a user initiates a promotional in-app purchase from the App Store.
      *
-     * If your app is able to handle a purchase at the current time, run the deferment block in this method.
+     * If your app is able to handle a purchase at the current time, run the `startPurchase` block.
      *
-     * If the app is not in a state to make a purchase: cache the defermentBlock, then call the defermentBlock
+     * If the app is not in a state to make a purchase: cache the `startPurchase` block, then call it
      * when the app is ready to make the promotional purchase.
      *
-     * If the purchase should never be made, you don't need to ever call the defermentBlock and ``Purchases``
-     * will not proceed with promotional purchases.
+     * If the purchase should never be made, you don't need to ever call the `starrtPurchase` block
+     * and ``Purchases`` will not proceed with promotional purchases.
      *
      * - Parameter product: ``StoreProduct`` the product that was selected from the app store.
+     * - Parameter startPurchase: Method that begins the purchase flow for the promoted purchase.
+     * If the app is ready to start the purchase flow when this delegate method is called, then this method
+     * should be called right away. Otherwise, the method should be stored as a property in memory, and then called
+     * once the app is ready to start the purchase flow. 
      */
     @objc
-    public func shouldPurchasePromoProduct(_ product: StoreProduct,
-                                           defermentBlock: @escaping DeferredPromotionalPurchaseBlock) {
-        guard let delegate = delegate else {
-            return
-        }
-
-        delegate.purchases?(self, shouldPurchasePromoProduct: product, defermentBlock: defermentBlock)
+    internal func promotedPurchaseReadyToStart(for product: StoreProduct,
+                                               startPurchase: @escaping DeferredPromotionalPurchaseBlock) {
+        self.delegate?.purchases?(self, isReadyForPromotedProduct: product, purchase: startPurchase)
     }
 
 }

--- a/Sources/Purchasing/PurchasesDelegate.swift
+++ b/Sources/Purchasing/PurchasesDelegate.swift
@@ -47,13 +47,24 @@ import Foundation
     /**
      * Called when a user initiates a promotional in-app purchase from the App Store.
      * If your app is able to handle a purchase at the current time, run the deferment block in this method.
-     * If the app is not in a state to make a purchase: cache the defermentBlock,
-     * then call the defermentBlock when the app is ready to make the promotional purchase.
-     * If the purchase should never be made, you don't need to ever call the defermentBlock and
-     * ``Purchases`` will not proceed with promotional purchases.
-
+     * If the app is not in a state to make a purchase: cache the `startPurchase` block,
+     * then call the `startPurchase` block when the app is ready to make the promotional purchase.
+     *
+     * If the purchase should never be made, you don't need to ever call the block and
+     * ``Purchases`` will not proceed with the promotional purchase.
+     *
      * - Parameter product: `StoreProduct` the product that was selected from the app store
      */
+    @objc optional func purchases(_ purchases: Purchases,
+                                  isReadyForPromotedProduct product: StoreProduct,
+                                  purchase startPurchase: @escaping DeferredPromotionalPurchaseBlock)
+
+    @available(iOS, obsoleted: 1, renamed: "purchases(_:isReadyForPromotedProduct:purchase:)")
+    @available(tvOS, obsoleted: 1, renamed: "purchases(_:isReadyForPromotedProduct:purchase:)")
+    @available(watchOS, obsoleted: 1, renamed: "purchases(_:isReadyForPromotedProduct:purchase:)")
+    @available(macOS, obsoleted: 1, renamed: "purchases(_:isReadyForPromotedProduct:purchase:)")
+    @available(macCatalyst, obsoleted: 1, renamed: "purchases(_:isReadyForPromotedProduct:purchase:)")
+    // swiftlint:disable:next missing_docs
     @objc optional func purchases(_ purchases: Purchases,
                                   shouldPurchasePromoProduct product: StoreProduct,
                                   defermentBlock makeDeferredPurchase: @escaping DeferredPromotionalPurchaseBlock)

--- a/Sources/Purchasing/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/PurchasesOrchestrator.swift
@@ -16,8 +16,8 @@ import StoreKit
 
 @objc protocol PurchasesOrchestratorDelegate {
 
-    func shouldPurchasePromoProduct(_ product: StoreProduct,
-                                    defermentBlock: @escaping DeferredPromotionalPurchaseBlock)
+    func promotedPurchaseReadyToStart(for product: StoreProduct,
+                                      startPurchase: @escaping DeferredPromotionalPurchaseBlock)
 
 }
 
@@ -428,7 +428,7 @@ extension PurchasesOrchestrator: StoreKitWrapperDelegate {
 
         let storeProduct = StoreProduct(sk1Product: product)
         lock.lock()
-        delegate.shouldPurchasePromoProduct(storeProduct) { completion in
+        delegate.promotedPurchaseReadyToStart(for: storeProduct) { completion in
             self.purchaseCompleteCallbacksByProductID[product.productIdentifier] = completion
             storeKitWrapper.add(payment)
         }

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -163,11 +163,13 @@ BOOL isAnonymous;
 
     [p.delegate purchases:p receivedUpdatedCustomerInfo:pi];
     [p.delegate purchases:p
-shouldPurchasePromoProduct:storeProduct
-           defermentBlock:^(void (^ _Nonnull completion)(RCStoreTransaction * _Nullable transaction,
+isReadyForPromotedProduct:storeProduct
+                 purchase:^(void (^ _Nonnull completion)(RCStoreTransaction * _Nullable transaction,
                                                          RCCustomerInfo * _Nullable info,
                                                          NSError * _Nullable error,
-                                                         BOOL cancelled)) {}];
+                                                         BOOL cancelled)) {
+
+    }];
 
 #if (TARGET_OS_IPHONE || TARGET_OS_MACCATALYST) && !TARGET_OS_TV
     [p beginRefundRequestForProduct:@"1234" completion:^(RCRefundRequestStatus s, NSError * _Nullable e) { }];

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -136,7 +136,7 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.delegate?.purchases?(purchases, receivedUpdated: customerInfo!)
 
     let defermentBlock = { (_: (StoreTransaction?, CustomerInfo?, Error?, Bool) -> Void) in }
-    purchases.delegate?.purchases?(purchases, shouldPurchasePromoProduct: storeProduct, defermentBlock: defermentBlock)
+    purchases.delegate?.purchases?(purchases, isReadyForPromotedProduct: storeProduct, purchase: defermentBlock)
 }
 
 private func checkIdentity(purchases: Purchases) {

--- a/Tests/UnitTests/Mocks/MockPurchasesDelegate.swift
+++ b/Tests/UnitTests/Mocks/MockPurchasesDelegate.swift
@@ -21,10 +21,10 @@ public class MockPurchasesDelegate: NSObject, PurchasesDelegate {
     var makeDeferredPurchase: DeferredPromotionalPurchaseBlock?
 
     public func purchases(_ purchases: Purchases,
-                          shouldPurchasePromoProduct product: StoreProduct,
-                          defermentBlock makeDeferredPurchase: @escaping (@escaping PurchaseCompletedBlock) -> Void) {
+                          isReadyForPromotedProduct product: StoreProduct,
+                          purchase startPurchase: @escaping DeferredPromotionalPurchaseBlock) {
         promoProduct = product
-        self.makeDeferredPurchase = makeDeferredPurchase
+        self.makeDeferredPurchase = startPurchase
     }
 
 }


### PR DESCRIPTION
Finishing #1439.
Fixes [CF-464].

The goal of this change is to make the behavior and usage of this API more clear.