### PR TITLE
Extracted `CurrentUserProvider` protocol to simplify dependency injection

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -258,6 +258,8 @@
 		57C381DC27961547009E3940 /* SK2StoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381DB27961547009E3940 /* SK2StoreProductDiscount.swift */; };
 		57C381E2279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */; };
 		57C381E3279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */; };
+		57CFB96C27FE0E79002A6730 /* MockCurrentUserProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CFB96B27FE0E79002A6730 /* MockCurrentUserProvider.swift */; };
+		57CFB96D27FE0E79002A6730 /* MockCurrentUserProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CFB96B27FE0E79002A6730 /* MockCurrentUserProvider.swift */; };
 		57D04BB827D947C6006DAC06 /* HTTPResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D04BB727D947C6006DAC06 /* HTTPResponseTests.swift */; };
 		57DC9F4627CC2E4900DA6AF9 /* HTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DC9F4527CC2E4900DA6AF9 /* HTTPRequest.swift */; };
 		57DC9F4A27CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DC9F4927CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift */; };
@@ -680,6 +682,7 @@
 		57C381D92796153D009E3940 /* SK1StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1StoreProductDiscount.swift; sourceTree = "<group>"; };
 		57C381DB27961547009E3940 /* SK2StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreProductDiscount.swift; sourceTree = "<group>"; };
 		57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreProductDiscount.swift; sourceTree = "<group>"; };
+		57CFB96B27FE0E79002A6730 /* MockCurrentUserProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCurrentUserProvider.swift; sourceTree = "<group>"; };
 		57D04BB727D947C6006DAC06 /* HTTPResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponseTests.swift; sourceTree = "<group>"; };
 		57DC9F4527CC2E4900DA6AF9 /* HTTPRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequest.swift; sourceTree = "<group>"; };
 		57DC9F4927CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCodeTests.swift; sourceTree = "<group>"; };
@@ -1203,6 +1206,7 @@
 				F55FFA5927634C3F00995146 /* MockTransactionsManager.swift */,
 				F584742F278D00C0001B1CE6 /* MockDNSChecker.swift */,
 				57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */,
+				57CFB96B27FE0E79002A6730 /* MockCurrentUserProvider.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -2032,6 +2036,7 @@
 				2DFF6C56270CA28800ECAFAB /* MockRequestFetcher.swift in Sources */,
 				5738F489278CC2500096D623 /* MockTransaction.swift in Sources */,
 				576C8ABC27D2997C0058FA6E /* SnapshotTesting+Extensions.swift in Sources */,
+				57CFB96D27FE0E79002A6730 /* MockCurrentUserProvider.swift in Sources */,
 				2D90F8C826FD2225009B9142 /* MockAppleReceiptBuilder.swift in Sources */,
 				F55FFA672763FAC300995146 /* TransactionsManagerSK2Tests.swift in Sources */,
 				57C381B72791E593009E3940 /* StoreKit2TransactionListenerTests.swift in Sources */,
@@ -2309,6 +2314,7 @@
 				351B51BE26D450E800BD2BD7 /* CustomerInfoTests.swift in Sources */,
 				35272E1B26D0029300F22C3B /* DeviceCacheSubscriberAttributesTests.swift in Sources */,
 				5796A39627D6BDAB00653165 /* BackendPostOfferForSigningTests.swift in Sources */,
+				57CFB96C27FE0E79002A6730 /* MockCurrentUserProvider.swift in Sources */,
 				351B516126D44BEB00BD2BD7 /* IdentityManagerTests.swift in Sources */,
 				351B51C126D450E800BD2BD7 /* OfferingsManagerTests.swift in Sources */,
 				5796A39927D6C1E000653165 /* BackendPostSubscriberAttributesTests.swift in Sources */,

--- a/Sources/Attribution/AttributionPoster.swift
+++ b/Sources/Attribution/AttributionPoster.swift
@@ -15,21 +15,21 @@ import Foundation
 
 class AttributionPoster {
 
-    let deviceCache: DeviceCache
-    let identityManager: IdentityManager
-    let backend: Backend
-    let attributionFetcher: AttributionFetcher
-    let subscriberAttributesManager: SubscriberAttributesManager
+    private let deviceCache: DeviceCache
+    private let currentUserProvider: CurrentUserProvider
+    private let backend: Backend
+    private let attributionFetcher: AttributionFetcher
+    private let subscriberAttributesManager: SubscriberAttributesManager
 
     private static var postponedAttributionData: [AttributionData]?
 
     init(deviceCache: DeviceCache,
-         identityManager: IdentityManager,
+         currentUserProvider: CurrentUserProvider,
          backend: Backend,
          attributionFetcher: AttributionFetcher,
          subscriberAttributesManager: SubscriberAttributesManager) {
         self.deviceCache = deviceCache
-        self.identityManager = identityManager
+        self.currentUserProvider = currentUserProvider
         self.backend = backend
         self.attributionFetcher = attributionFetcher
         self.subscriberAttributesManager = subscriberAttributesManager
@@ -53,7 +53,7 @@ class AttributionPoster {
             Logger.warn(Strings.attribution.missing_advertiser_identifiers)
         }
 
-        let currentAppUserID = identityManager.currentAppUserID
+        let currentAppUserID = self.currentUserProvider.currentAppUserID
         let networkKey = String(network.rawValue)
         let latestNetworkIdsAndAdvertisingIdsSentByNetwork =
             deviceCache.latestNetworkAndAdvertisingIdsSent(appUserID: currentAppUserID)
@@ -156,7 +156,9 @@ class AttributionPoster {
 
     private func latestNetworkIdAndAdvertisingIdentifierSent(network: AttributionNetwork) -> String? {
         let networkID = String(network.rawValue)
-        let cachedDict = deviceCache.latestNetworkAndAdvertisingIdsSent(appUserID: identityManager.currentAppUserID)
+        let cachedDict = deviceCache.latestNetworkAndAdvertisingIdsSent(
+            appUserID: self.currentUserProvider.currentAppUserID
+        )
         return cachedDict[networkID]
     }
 

--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -288,7 +288,7 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
                                                                       attributionFetcher: attributionFetcher,
                                                                       attributionDataMigrator: attributionDataMigrator)
         let attributionPoster = AttributionPoster(deviceCache: deviceCache,
-                                                  identityManager: identityManager,
+                                                  currentUserProvider: identityManager,
                                                   backend: backend,
                                                   attributionFetcher: attributionFetcher,
                                                   subscriberAttributesManager: subscriberAttributesManager)
@@ -303,10 +303,10 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
                                                 productsManager: productsManager)
         let manageSubsHelper = ManageSubscriptionsHelper(systemInfo: systemInfo,
                                                          customerInfoManager: customerInfoManager,
-                                                         identityManager: identityManager)
+                                                         currentUserProvider: identityManager)
         let beginRefundRequestHelper = BeginRefundRequestHelper(systemInfo: systemInfo,
                                                                 customerInfoManager: customerInfoManager,
-                                                                identityManager: identityManager)
+                                                                currentUserProvider: identityManager)
         let purchasesOrchestrator = PurchasesOrchestrator(productsManager: productsManager,
                                                           storeKitWrapper: storeKitWrapper,
                                                           systemInfo: systemInfo,
@@ -315,7 +315,7 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
                                                           receiptFetcher: receiptFetcher,
                                                           customerInfoManager: customerInfoManager,
                                                           backend: backend,
-                                                          identityManager: identityManager,
+                                                          currentUserProvider: identityManager,
                                                           transactionsManager: transactionsManager,
                                                           deviceCache: deviceCache,
                                                           manageSubscriptionsHelper: manageSubsHelper,
@@ -323,7 +323,7 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
         let trialOrIntroPriceChecker = TrialOrIntroPriceEligibilityChecker(receiptFetcher: receiptFetcher,
                                                                            introEligibilityCalculator: introCalculator,
                                                                            backend: backend,
-                                                                           identityManager: identityManager,
+                                                                           currentUserProvider: identityManager,
                                                                            operationDispatcher: operationDispatcher,
                                                                            productsManager: productsManager)
         self.init(appUserID: appUserID,

--- a/Sources/Purchasing/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/PurchasesOrchestrator.swift
@@ -27,7 +27,7 @@ class PurchasesOrchestrator {
     var finishTransactions: Bool { systemInfo.finishTransactions }
     var allowSharingAppStoreAccount: Bool {
         get {
-            return _allowSharingAppStoreAccount ?? identityManager.currentUserIsAnonymous
+            return _allowSharingAppStoreAccount ?? self.currentUserProvider.currentUserIsAnonymous
         }
         set {
             _allowSharingAppStoreAccount = newValue
@@ -40,7 +40,7 @@ class PurchasesOrchestrator {
     private var presentedOfferingIDsByProductID: [String: String] = [:]
     private var purchaseCompleteCallbacksByProductID: [String: PurchaseCompletedBlock] = [:]
 
-    private var appUserID: String { identityManager.currentAppUserID }
+    private var appUserID: String { self.currentUserProvider.currentAppUserID }
     private var unsyncedAttributes: SubscriberAttributeDict {
         subscriberAttributesManager.unsyncedAttributesByKey(appUserID: self.appUserID)
     }
@@ -53,7 +53,7 @@ class PurchasesOrchestrator {
     private let receiptFetcher: ReceiptFetcher
     private let customerInfoManager: CustomerInfoManager
     private let backend: Backend
-    private let identityManager: IdentityManager
+    private let currentUserProvider: CurrentUserProvider
     private let transactionsManager: TransactionsManager
     private let deviceCache: DeviceCache
     private let manageSubscriptionsHelper: ManageSubscriptionsHelper
@@ -71,7 +71,7 @@ class PurchasesOrchestrator {
          receiptFetcher: ReceiptFetcher,
          customerInfoManager: CustomerInfoManager,
          backend: Backend,
-         identityManager: IdentityManager,
+         currentUserProvider: CurrentUserProvider,
          transactionsManager: TransactionsManager,
          deviceCache: DeviceCache,
          manageSubscriptionsHelper: ManageSubscriptionsHelper,
@@ -84,7 +84,7 @@ class PurchasesOrchestrator {
         self.receiptFetcher = receiptFetcher
         self.customerInfoManager = customerInfoManager
         self.backend = backend
-        self.identityManager = identityManager
+        self.currentUserProvider = currentUserProvider
         self.transactionsManager = transactionsManager
         self.deviceCache = deviceCache
         self.manageSubscriptionsHelper = manageSubscriptionsHelper

--- a/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -18,24 +18,24 @@ class TrialOrIntroPriceEligibilityChecker {
 
     typealias ReceiveIntroEligibilityBlock = ([String: IntroEligibility]) -> Void
 
-    private var appUserID: String { identityManager.currentAppUserID }
+    private var appUserID: String { self.currentUserProvider.currentAppUserID }
     private let receiptFetcher: ReceiptFetcher
     private let introEligibilityCalculator: IntroEligibilityCalculator
     private let backend: Backend
-    private let identityManager: IdentityManager
+    private let currentUserProvider: CurrentUserProvider
     private let operationDispatcher: OperationDispatcher
     private let productsManager: ProductsManager
 
     init(receiptFetcher: ReceiptFetcher,
          introEligibilityCalculator: IntroEligibilityCalculator,
          backend: Backend,
-         identityManager: IdentityManager,
+         currentUserProvider: CurrentUserProvider,
          operationDispatcher: OperationDispatcher,
          productsManager: ProductsManager) {
         self.receiptFetcher = receiptFetcher
         self.introEligibilityCalculator = introEligibilityCalculator
         self.backend = backend
-        self.identityManager = identityManager
+        self.currentUserProvider = currentUserProvider
         self.operationDispatcher = operationDispatcher
         self.productsManager = productsManager
     }

--- a/Sources/Support/BeginRefundRequestHelper.swift
+++ b/Sources/Support/BeginRefundRequestHelper.swift
@@ -21,7 +21,7 @@ class BeginRefundRequestHelper {
 
     private let systemInfo: SystemInfo
     private let customerInfoManager: CustomerInfoManager
-    private let identityManager: IdentityManager
+    private let currentUserProvider: CurrentUserProvider
 
 #if os(iOS)
     @available(iOS 15.0, *)
@@ -31,10 +31,10 @@ class BeginRefundRequestHelper {
     lazy var sk2Helper = SK2BeginRefundRequestHelper()
 #endif
 
-    init(systemInfo: SystemInfo, customerInfoManager: CustomerInfoManager, identityManager: IdentityManager) {
+    init(systemInfo: SystemInfo, customerInfoManager: CustomerInfoManager, currentUserProvider: CurrentUserProvider) {
         self.systemInfo = systemInfo
         self.customerInfoManager = customerInfoManager
-        self.identityManager = identityManager
+        self.currentUserProvider = currentUserProvider
     }
 
 #if os(iOS)
@@ -93,7 +93,7 @@ private extension BeginRefundRequestHelper {
 
         do {
             customerInfo = try await self.customerInfoManager.customerInfo(
-                appUserID: self.identityManager.currentAppUserID
+                appUserID: self.currentUserProvider.currentAppUserID
             )
         } catch {
             let message = Strings.purchase.begin_refund_customer_info_error(entitlementID: entitlementID)

--- a/Sources/Support/ManageSubscriptionsHelper.swift
+++ b/Sources/Support/ManageSubscriptionsHelper.swift
@@ -17,14 +17,14 @@ class ManageSubscriptionsHelper {
 
     private let systemInfo: SystemInfo
     private let customerInfoManager: CustomerInfoManager
-    private let identityManager: IdentityManager
+    private let currentUserProvider: CurrentUserProvider
 
     init(systemInfo: SystemInfo,
          customerInfoManager: CustomerInfoManager,
-         identityManager: IdentityManager) {
+         currentUserProvider: CurrentUserProvider) {
         self.systemInfo = systemInfo
         self.customerInfoManager = customerInfoManager
-        self.identityManager = identityManager
+        self.currentUserProvider = currentUserProvider
     }
 
 #if os(iOS) || os(macOS)
@@ -32,7 +32,7 @@ class ManageSubscriptionsHelper {
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     func showManageSubscriptions(completion: @escaping (Result<Void, Error>) -> Void) {
-        let currentAppUserID = identityManager.currentAppUserID
+        let currentAppUserID = self.currentUserProvider.currentAppUserID
         customerInfoManager.customerInfo(appUserID: currentAppUserID) { result in
             let result: Result<URL, Error> = result
                 .mapError { error in

--- a/Tests/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
+++ b/Tests/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
@@ -22,7 +22,7 @@ class BeginRefundRequestHelperTests: XCTestCase {
 
     private var systemInfo: MockSystemInfo!
     private var customerInfoManager: MockCustomerInfoManager!
-    private var identityManager: MockIdentityManager!
+    private var currentUserProvider: MockCurrentUserProvider!
     private var helper: BeginRefundRequestHelper!
     private let mockProductID = "1234"
     private let mockEntitlementID = "1234"
@@ -41,10 +41,10 @@ class BeginRefundRequestHelperTests: XCTestCase {
                                                       deviceCache: MockDeviceCache(systemInfo: systemInfo),
                                                       backend: MockBackend(),
                                                       systemInfo: systemInfo)
-        identityManager = MockIdentityManager(mockAppUserID: "appUserID")
+        currentUserProvider = MockCurrentUserProvider(mockAppUserID: "appUserID")
         helper = BeginRefundRequestHelper(systemInfo: systemInfo,
                                           customerInfoManager: customerInfoManager,
-                                          identityManager: identityManager)
+                                          currentUserProvider: currentUserProvider)
 
         if #available(iOS 15.0, macCatalyst 15.0, *) {
             sk2Helper = MockSK2BeginRefundRequestHelper()

--- a/Tests/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
+++ b/Tests/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
@@ -23,7 +23,7 @@ class ManageSubscriptionsHelperTests: XCTestCase {
 
     private var systemInfo: MockSystemInfo!
     private var customerInfoManager: MockCustomerInfoManager!
-    private var identityManager: MockIdentityManager!
+    private var currentUserProvider: CurrentUserProvider!
     private var helper: ManageSubscriptionsHelper!
     private let mockCustomerInfoData: [String: Any] = [
         "request_date": "2018-12-21T02:40:36Z",
@@ -44,10 +44,10 @@ class ManageSubscriptionsHelperTests: XCTestCase {
                                                       deviceCache: MockDeviceCache(systemInfo: systemInfo),
                                                       backend: MockBackend(),
                                                       systemInfo: systemInfo)
-        identityManager = MockIdentityManager(mockAppUserID: "appUserID")
+        currentUserProvider = MockCurrentUserProvider(mockAppUserID: "appUserID")
         helper = ManageSubscriptionsHelper(systemInfo: systemInfo,
                                            customerInfoManager: customerInfoManager,
-                                           identityManager: identityManager)
+                                           currentUserProvider: currentUserProvider)
     }
 
     func testShowManageSubscriptionsMakesRightCalls() throws {

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -27,7 +27,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     var receiptFetcher: MockReceiptFetcher!
     var customerInfoManager: MockCustomerInfoManager!
     var backend: MockBackend!
-    var identityManager: MockIdentityManager!
+    var currentUserProvider: MockCurrentUserProvider!
     var transactionsManager: MockTransactionsManager!
     var deviceCache: MockDeviceCache!
     var mockManageSubsHelper: MockManageSubscriptionsHelper!
@@ -47,7 +47,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                                                       deviceCache: deviceCache,
                                                       backend: backend,
                                                       systemInfo: systemInfo)
-        identityManager = MockIdentityManager(mockAppUserID: "appUserID")
+        currentUserProvider = MockCurrentUserProvider(mockAppUserID: "appUserID")
         transactionsManager = MockTransactionsManager(receiptParser: MockReceiptParser())
         let attributionFetcher = MockAttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
                                                         systemInfo: systemInfo)
@@ -58,10 +58,10 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
             attributionDataMigrator: MockAttributionDataMigrator())
         mockManageSubsHelper = MockManageSubscriptionsHelper(systemInfo: systemInfo,
                                                              customerInfoManager: customerInfoManager,
-                                                             identityManager: identityManager)
+                                                             currentUserProvider: currentUserProvider)
         mockBeginRefundRequestHelper = MockBeginRefundRequestHelper(systemInfo: systemInfo,
                                                                     customerInfoManager: customerInfoManager,
-                                                                    identityManager: identityManager)
+                                                                    currentUserProvider: currentUserProvider)
         setupStoreKitWrapper()
         setUpOrchestrator()
         setUpStoreKit2Listener()
@@ -99,7 +99,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                                              receiptFetcher: receiptFetcher,
                                              customerInfoManager: customerInfoManager,
                                              backend: backend,
-                                             identityManager: identityManager,
+                                             currentUserProvider: currentUserProvider,
                                              transactionsManager: transactionsManager,
                                              deviceCache: deviceCache,
                                              manageSubscriptionsHelper: mockManageSubsHelper,

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
@@ -37,14 +37,15 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
                                                                         receiptParser: MockReceiptParser())
         mockBackend = MockBackend()
         let mockOperationDispatcher = MockOperationDispatcher()
-        let identityManager = MockIdentityManager(mockAppUserID: "app_user")
-        trialOrIntroPriceEligibilityChecker =
-        TrialOrIntroPriceEligibilityChecker(receiptFetcher: receiptFetcher,
-                                            introEligibilityCalculator: mockIntroEligibilityCalculator,
-                                            backend: mockBackend,
-                                            identityManager: identityManager,
-                                            operationDispatcher: mockOperationDispatcher,
-                                            productsManager: mockProductsManager)
+        let userProvider = MockCurrentUserProvider(mockAppUserID: "app_user")
+        trialOrIntroPriceEligibilityChecker = TrialOrIntroPriceEligibilityChecker(
+            receiptFetcher: receiptFetcher,
+            introEligibilityCalculator: mockIntroEligibilityCalculator,
+            backend: mockBackend,
+            currentUserProvider: userProvider,
+            operationDispatcher: mockOperationDispatcher,
+            productsManager: mockProductsManager
+        )
     }
 
     func testSK1CheckTrialOrIntroPriceEligibilityDoesntCrash() throws {

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
@@ -38,14 +38,16 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
                                                                         receiptParser: MockReceiptParser())
         mockBackend = MockBackend()
         let mockOperationDispatcher = MockOperationDispatcher()
-        let identityManager = MockIdentityManager(mockAppUserID: "app_user")
-        trialOrIntroPriceEligibilityChecker =
-        TrialOrIntroPriceEligibilityChecker(receiptFetcher: receiptFetcher,
-                                            introEligibilityCalculator: mockIntroEligibilityCalculator,
-                                            backend: mockBackend,
-                                            identityManager: identityManager,
-                                            operationDispatcher: mockOperationDispatcher,
-                                            productsManager: mockProductsManager)
+        let currentUserProvider = MockCurrentUserProvider(mockAppUserID: "app_user")
+
+        trialOrIntroPriceEligibilityChecker = TrialOrIntroPriceEligibilityChecker(
+            receiptFetcher: receiptFetcher,
+            introEligibilityCalculator: mockIntroEligibilityCalculator,
+            backend: mockBackend,
+            currentUserProvider: currentUserProvider,
+            operationDispatcher: mockOperationDispatcher,
+            productsManager: mockProductsManager
+        )
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)

--- a/Tests/UnitTests/Attribution/AttributionPosterTests.swift
+++ b/Tests/UnitTests/Attribution/AttributionPosterTests.swift
@@ -24,7 +24,7 @@ class AttributionPosterTests: XCTestCase {
     var attributionFetcher: AttributionFetcher!
     var attributionPoster: AttributionPoster!
     var deviceCache: MockDeviceCache!
-    var identityManager: MockIdentityManager!
+    var currentUserProvider: MockCurrentUserProvider!
     var backend: MockBackend!
     var subscriberAttributesManager: MockSubscriberAttributesManager!
     var attributionFactory: AttributionTypeFactory! = MockAttributionTypeFactory()
@@ -49,9 +49,9 @@ class AttributionPosterTests: XCTestCase {
             deviceCache: self.deviceCache,
             attributionFetcher: self.attributionFetcher,
             attributionDataMigrator: AttributionDataMigrator())
-        identityManager = MockIdentityManager(mockAppUserID: userID)
+        currentUserProvider = MockCurrentUserProvider(mockAppUserID: userID)
         attributionPoster = AttributionPoster(deviceCache: deviceCache,
-                                              identityManager: identityManager,
+                                              currentUserProvider: currentUserProvider,
                                               backend: backend,
                                               attributionFetcher: attributionFetcher,
                                               subscriberAttributesManager: subscriberAttributesManager)

--- a/Tests/UnitTests/Mocks/MockCurrentUserProvider.swift
+++ b/Tests/UnitTests/Mocks/MockCurrentUserProvider.swift
@@ -1,0 +1,37 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockCurrentUserProvider.swift
+//
+//  Created by Nacho Soto on 4/6/22.
+
+@testable import RevenueCat
+
+final class MockCurrentUserProvider: CurrentUserProvider {
+
+    var mockIsAnonymous = false
+    var mockAppUserID: String
+
+    init(mockAppUserID: String) {
+        self.mockAppUserID = mockAppUserID
+    }
+
+    var currentAppUserID: String {
+        return self.mockIsAnonymous
+            ? self.mockAnonymousID
+            : self.mockAppUserID
+    }
+
+    var currentUserIsAnonymous: Bool {
+        return self.mockIsAnonymous
+    }
+
+    private let mockAnonymousID = IdentityManager.generateRandomID()
+
+}

--- a/Tests/UnitTests/Mocks/MockIdentityManager.swift
+++ b/Tests/UnitTests/Mocks/MockIdentityManager.swift
@@ -45,4 +45,12 @@ class MockIdentityManager: IdentityManager {
         return mockIsAnonymous
     }
 
+    override func logIn(appUserID: String, completion: @escaping LogInResponseHandler) {
+        fatalError("Logging in not supported on mock")
+    }
+
+    override func logOut(completion: (Error?) -> Void) {
+        fatalError("Logging out not supported on mock")
+    }
+
 }

--- a/Tests/UnitTests/Mocks/MockTrialOrIntroPriceEligibilityChecker.swift
+++ b/Tests/UnitTests/Mocks/MockTrialOrIntroPriceEligibilityChecker.swift
@@ -26,7 +26,7 @@ class MockTrialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityCheck
                   introEligibilityCalculator: MockIntroEligibilityCalculator(productsManager: productsManager,
                                                                              receiptParser: MockReceiptParser()),
                   backend: MockBackend(),
-                  identityManager: MockIdentityManager(mockAppUserID: "app_user"),
+                  currentUserProvider: MockCurrentUserProvider(mockAppUserID: "app_user"),
                   operationDispatcher: MockOperationDispatcher(),
                   productsManager: MockProductsManager(systemInfo: systemInfo))
     }

--- a/Tests/UnitTests/Purchasing/PurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/PurchasesTests.swift
@@ -57,7 +57,7 @@ class PurchasesTests: XCTestCase {
                                         attributionFetcher: self.attributionFetcher,
                                         attributionDataMigrator: AttributionDataMigrator())
         attributionPoster = AttributionPoster(deviceCache: deviceCache,
-                                              identityManager: identityManager,
+                                              currentUserProvider: identityManager,
                                               backend: backend,
                                               attributionFetcher: attributionFetcher,
                                               subscriberAttributesManager: subscriberAttributesManager)
@@ -73,10 +73,10 @@ class PurchasesTests: XCTestCase {
                                                     productsManager: mockProductsManager)
         mockManageSubsHelper = MockManageSubscriptionsHelper(systemInfo: systemInfo,
                                                              customerInfoManager: customerInfoManager,
-                                                             identityManager: identityManager)
+                                                             currentUserProvider: identityManager)
         mockBeginRefundRequestHelper = MockBeginRefundRequestHelper(systemInfo: systemInfo,
                                                                     customerInfoManager: customerInfoManager,
-                                                                    identityManager: identityManager)
+                                                                    currentUserProvider: identityManager)
         mockTransactionsManager = MockTransactionsManager(receiptParser: mockReceiptParser)
     }
 
@@ -326,7 +326,7 @@ class PurchasesTests: XCTestCase {
                                                       receiptFetcher: receiptFetcher,
                                                       customerInfoManager: customerInfoManager,
                                                       backend: backend,
-                                                      identityManager: identityManager,
+                                                      currentUserProvider: identityManager,
                                                       transactionsManager: mockTransactionsManager,
                                                       deviceCache: deviceCache,
                                                       manageSubscriptionsHelper: mockManageSubsHelper,
@@ -335,7 +335,7 @@ class PurchasesTests: XCTestCase {
             receiptFetcher: receiptFetcher,
             introEligibilityCalculator: mockIntroEligibilityCalculator,
             backend: backend,
-            identityManager: identityManager,
+            currentUserProvider: identityManager,
             operationDispatcher: mockOperationDispatcher,
             productsManager: mockProductsManager
         )

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -91,7 +91,7 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
             attributionDataMigrator: AttributionDataMigrator())
         self.mockIdentityManager = MockIdentityManager(mockAppUserID: "app_user")
         self.mockAttributionPoster = AttributionPoster(deviceCache: mockDeviceCache,
-                                                       identityManager: mockIdentityManager,
+                                                       currentUserProvider: mockIdentityManager,
                                                        backend: mockBackend,
                                                        attributionFetcher: mockAttributionFetcher,
                                                        subscriberAttributesManager: mockSubscriberAttributesManager)
@@ -111,10 +111,10 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
         )
         self.mockManageSubsHelper = MockManageSubscriptionsHelper(systemInfo: systemInfo,
                                                                   customerInfoManager: customerInfoManager,
-                                                                  identityManager: mockIdentityManager)
+                                                                  currentUserProvider: mockIdentityManager)
         self.mockBeginRefundRequestHelper = MockBeginRefundRequestHelper(systemInfo: systemInfo,
                                                                          customerInfoManager: customerInfoManager,
-                                                                         identityManager: mockIdentityManager)
+                                                                         currentUserProvider: mockIdentityManager)
         self.mockTransactionsManager = MockTransactionsManager(receiptParser: mockReceiptParser)
     }
 
@@ -135,18 +135,19 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
                                                           receiptFetcher: mockReceiptFetcher,
                                                           customerInfoManager: customerInfoManager,
                                                           backend: mockBackend,
-                                                          identityManager: mockIdentityManager,
+                                                          currentUserProvider: mockIdentityManager,
                                                           transactionsManager: mockTransactionsManager,
                                                           deviceCache: mockDeviceCache,
                                                           manageSubscriptionsHelper: mockManageSubsHelper,
                                                           beginRefundRequestHelper: mockBeginRefundRequestHelper)
-        let trialOrIntroductoryPriceEligibilityChecker =
-        TrialOrIntroPriceEligibilityChecker(receiptFetcher: mockReceiptFetcher,
-                                            introEligibilityCalculator: mockIntroEligibilityCalculator,
-                                            backend: mockBackend,
-                                            identityManager: mockIdentityManager,
-                                            operationDispatcher: mockOperationDispatcher,
-                                            productsManager: mockProductsManager)
+        let trialOrIntroductoryPriceEligibilityChecker = TrialOrIntroPriceEligibilityChecker(
+            receiptFetcher: mockReceiptFetcher,
+            introEligibilityCalculator: mockIntroEligibilityCalculator,
+            backend: mockBackend,
+            currentUserProvider: mockIdentityManager,
+            operationDispatcher: mockOperationDispatcher,
+            productsManager: mockProductsManager
+        )
         purchases = Purchases(appUserID: mockIdentityManager.currentAppUserID,
                               requestFetcher: mockRequestFetcher,
                               receiptFetcher: mockReceiptFetcher,


### PR DESCRIPTION
A lot of our classes depended on the mutable `IdentityManager`, when in reality they only needed a read-only `currentAppUserID`.
This PR changes the requirement, with the following advantages:

- Ensure all these classes (`AttributionPoster`, `PurchasesOrchestrator`, `TrialOrIntroPriceEligibiltyChecker`, `BeginRefundRequestHelper`, `ManageSubscriptionsHelper`) cannot logIn / logOut, only read the current user
- Simplify tests by only requiring a smaller type
- Simplifying instantiation of these types outside the normal `Purchases` initialization.

I've also created `MockCurrentUserProvider`, but changed the existing `MockIdentityManager` so that calls to `logIn`/`logOut` just fail. These aren't mocked, and they wouldn't have an impact on the mocked readable values, so calling them is most likely unexpected and should make the test fail.