### PR TITLE
Added `StoreKit2Setting` to replace `useStoreKit2IfAvailable`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -260,6 +260,7 @@
 		57C381E3279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */; };
 		57CFB96C27FE0E79002A6730 /* MockCurrentUserProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CFB96B27FE0E79002A6730 /* MockCurrentUserProvider.swift */; };
 		57CFB96D27FE0E79002A6730 /* MockCurrentUserProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CFB96B27FE0E79002A6730 /* MockCurrentUserProvider.swift */; };
+		57CFB98427FE2258002A6730 /* StoreKit2Setting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CFB98327FE2258002A6730 /* StoreKit2Setting.swift */; };
 		57D04BB827D947C6006DAC06 /* HTTPResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D04BB727D947C6006DAC06 /* HTTPResponseTests.swift */; };
 		57DC9F4627CC2E4900DA6AF9 /* HTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DC9F4527CC2E4900DA6AF9 /* HTTPRequest.swift */; };
 		57DC9F4A27CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DC9F4927CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift */; };
@@ -683,6 +684,7 @@
 		57C381DB27961547009E3940 /* SK2StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreProductDiscount.swift; sourceTree = "<group>"; };
 		57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreProductDiscount.swift; sourceTree = "<group>"; };
 		57CFB96B27FE0E79002A6730 /* MockCurrentUserProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCurrentUserProvider.swift; sourceTree = "<group>"; };
+		57CFB98327FE2258002A6730 /* StoreKit2Setting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2Setting.swift; sourceTree = "<group>"; };
 		57D04BB727D947C6006DAC06 /* HTTPResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponseTests.swift; sourceTree = "<group>"; };
 		57DC9F4527CC2E4900DA6AF9 /* HTTPRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequest.swift; sourceTree = "<group>"; };
 		57DC9F4927CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCodeTests.swift; sourceTree = "<group>"; };
@@ -1094,6 +1096,7 @@
 				57EAE52C274468900060EB74 /* RawDataContainer.swift */,
 				57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */,
 				B3AA6237268B926F00894871 /* SystemInfo.swift */,
+				57CFB98327FE2258002A6730 /* StoreKit2Setting.swift */,
 			);
 			path = Misc;
 			sourceTree = "<group>";
@@ -2073,6 +2076,7 @@
 				B3B5FBBC269D121B00104A0C /* Offerings.swift in Sources */,
 				9A65E03B25918B0900DE00B0 /* CustomerInfoStrings.swift in Sources */,
 				B34605BB279A6E380031CA74 /* AliasCallback.swift in Sources */,
+				57CFB98427FE2258002A6730 /* StoreKit2Setting.swift in Sources */,
 				B3B5FBB6269CED6400104A0C /* ErrorDetails.swift in Sources */,
 				2D991ACA268BA56900085481 /* StoreKitRequestFetcher.swift in Sources */,
 				B3B5FBB4269CED4B00104A0C /* BackendErrorCode.swift in Sources */,

--- a/Sources/Misc/StoreKit2Setting.swift
+++ b/Sources/Misc/StoreKit2Setting.swift
@@ -17,11 +17,12 @@ enum StoreKit2Setting {
     /// Never use SK2
     case disabled
 
-    /// Use SK2 if available for certain APIs that provide a better implementation
+    /// Use SK2 (if available in the current device) only for certain APIs that provide a better implementation
+    /// For example: intro eligibility, determining if a receipt has purchases, managing subscriptions.
     case enabledOnlyForOptimizations
 
-    /// Enable SK2 in all APIs if available
-    case enabledIfAvailable
+    /// Enable SK2 in all APIs if available in the current device
+    case enabledForCompatibleDevices
 
 }
 
@@ -29,10 +30,22 @@ extension StoreKit2Setting {
 
     init(useStoreKit2IfAvailable: Bool) {
         self = useStoreKit2IfAvailable
-            ? .enabledIfAvailable
+            ? .enabledForCompatibleDevices
             : .enabledOnlyForOptimizations
     }
 
     static let `default`: Self = .enabledOnlyForOptimizations
+
+}
+
+extension StoreKit2Setting: CustomDebugStringConvertible {
+
+    var debugDescription: String {
+        switch self {
+        case .disabled: return "disabled"
+        case .enabledOnlyForOptimizations: return "optimizations-only"
+        case .enabledForCompatibleDevices: return "enabled"
+        }
+    }
 
 }

--- a/Sources/Misc/StoreKit2Setting.swift
+++ b/Sources/Misc/StoreKit2Setting.swift
@@ -1,0 +1,38 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  StoreKit2Setting.swift
+//
+//  Created by Nacho Soto on 4/6/22.
+
+/// Defines when StoreKit 2 APIs may be used
+enum StoreKit2Setting {
+
+    /// Never use SK2
+    case disabled
+
+    /// Use SK2 if available for certain APIs that provide a better implementation
+    case enabledOnlyForOptimizations
+
+    /// Enable SK2 in all APIs if available
+    case enabledIfAvailable
+
+}
+
+extension StoreKit2Setting {
+
+    init(useStoreKit2IfAvailable: Bool) {
+        self = useStoreKit2IfAvailable
+            ? .enabledIfAvailable
+            : .enabledOnlyForOptimizations
+    }
+
+    static let `default`: Self = .enabledOnlyForOptimizations
+
+}

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -25,21 +25,9 @@ import AppKit
 
 class SystemInfo {
 
-    #if targetEnvironment(macCatalyst)
-    static let platformHeaderConstant = "uikitformac"
-    #elseif os(iOS)
-    static let platformHeaderConstant = "iOS"
-    #elseif os(watchOS)
-    static let platformHeaderConstant = "watchOS"
-    #elseif os(tvOS)
-    static let platformHeaderConstant = "tvOS"
-    #elseif os(macOS)
-    static let platformHeaderConstant = "macOS"
-    #endif
-
     let appleSubscriptionsURL = URL(string: "https://rev.cat/manage-apple-subscription")
 
-    let useStoreKit2IfAvailable: Bool
+    let storeKit2Setting: StoreKit2Setting
     var finishTransactions: Bool
     let operationDispatcher: OperationDispatcher
     let platformFlavor: String
@@ -116,7 +104,7 @@ class SystemInfo {
          finishTransactions: Bool,
          operationDispatcher: OperationDispatcher = .default,
          bundle: Bundle = .main,
-         useStoreKit2IfAvailable: Bool = false,
+         storeKit2Setting: StoreKit2Setting = .default,
          dangerousSettings: DangerousSettings? = nil) throws {
         self.platformFlavor = platformInfo?.flavor ?? "native"
         self.platformFlavorVersion = platformInfo?.version
@@ -124,7 +112,7 @@ class SystemInfo {
 
         self.finishTransactions = finishTransactions
         self.operationDispatcher = operationDispatcher
-        self.useStoreKit2IfAvailable = useStoreKit2IfAvailable
+        self.storeKit2Setting = storeKit2Setting
         self.dangerousSettings = dangerousSettings ?? DangerousSettings()
     }
 
@@ -148,6 +136,22 @@ class SystemInfo {
         guard let host = managementURL.host else { return false }
         return host.contains("apple.com")
     }
+
+}
+
+extension SystemInfo {
+
+    #if targetEnvironment(macCatalyst)
+    static let platformHeaderConstant = "uikitformac"
+    #elseif os(iOS)
+    static let platformHeaderConstant = "iOS"
+    #elseif os(watchOS)
+    static let platformHeaderConstant = "watchOS"
+    #elseif os(tvOS)
+    static let platformHeaderConstant = "tvOS"
+    #elseif os(macOS)
+    static let platformHeaderConstant = "macOS"
+    #endif
 
 }
 

--- a/Sources/Networking/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient.swift
@@ -124,7 +124,7 @@ private extension HTTPClient {
             "X-Platform-Flavor": systemInfo.platformFlavor,
             "X-Client-Version": SystemInfo.appVersion,
             "X-Client-Build-Version": SystemInfo.buildVersion,
-            "X-StoreKit2-Enabled": "\(self.systemInfo.storeKit2Setting == .enabledIfAvailable)",
+            "X-StoreKit2-Setting": "\(self.systemInfo.storeKit2Setting.debugDescription)",
             "X-Observer-Mode-Enabled": observerMode
         ]
 

--- a/Sources/Networking/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient.swift
@@ -124,7 +124,7 @@ private extension HTTPClient {
             "X-Platform-Flavor": systemInfo.platformFlavor,
             "X-Client-Version": SystemInfo.appVersion,
             "X-Client-Build-Version": SystemInfo.buildVersion,
-            "X-StoreKit2-Enabled": "\(self.systemInfo.useStoreKit2IfAvailable)",
+            "X-StoreKit2-Enabled": "\(self.systemInfo.storeKit2Setting == .enabledIfAvailable)",
             "X-Observer-Mode-Enabled": observerMode
         ]
 

--- a/Sources/Purchasing/ProductsManager.swift
+++ b/Sources/Purchasing/ProductsManager.swift
@@ -37,7 +37,7 @@ class ProductsManager: NSObject {
     func products(withIdentifiers identifiers: Set<String>,
                   completion: @escaping (Result<Set<StoreProduct>, Error>) -> Void) {
         if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *),
-           self.systemInfo.storeKit2Setting == .enabledIfAvailable {
+           self.systemInfo.storeKit2Setting == .enabledForCompatibleDevices {
             self.sk2Products(withIdentifiers: identifiers) { result in
                 completion(result.map { Set($0.map(StoreProduct.from(product:))) })
             }

--- a/Sources/Purchasing/ProductsManager.swift
+++ b/Sources/Purchasing/ProductsManager.swift
@@ -36,7 +36,8 @@ class ProductsManager: NSObject {
 
     func products(withIdentifiers identifiers: Set<String>,
                   completion: @escaping (Result<Set<StoreProduct>, Error>) -> Void) {
-        if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *), self.systemInfo.useStoreKit2IfAvailable {
+        if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *),
+           self.systemInfo.storeKit2Setting == .enabledIfAvailable {
             self.sk2Products(withIdentifiers: identifiers) { result in
                 completion(result.map { Set($0.map(StoreProduct.from(product:))) })
             }

--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -242,7 +242,7 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
                      userDefaults: UserDefaults? = nil,
                      observerMode: Bool = false,
                      platformInfo: PlatformInfo? = Purchases.platformInfo,
-                     useStoreKit2IfAvailable: Bool = false,
+                     storeKit2Setting: StoreKit2Setting = .default,
                      dangerousSettings: DangerousSettings? = nil) {
         let operationDispatcher: OperationDispatcher = .default
         let receiptRefreshRequestFactory = ReceiptRefreshRequestFactory()
@@ -253,7 +253,7 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
             systemInfo = try SystemInfo(platformInfo: platformInfo,
                                         finishTransactions: !observerMode,
                                         operationDispatcher: operationDispatcher,
-                                        useStoreKit2IfAvailable: useStoreKit2IfAvailable,
+                                        storeKit2Setting: storeKit2Setting,
                                         dangerousSettings: dangerousSettings)
         } catch {
             fatalError(error.localizedDescription)
@@ -272,7 +272,8 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
         let userDefaults = userDefaults ?? UserDefaults.standard
         let deviceCache = DeviceCache(systemInfo: systemInfo, userDefaults: userDefaults)
         let receiptParser = ReceiptParser()
-        let transactionsManager = TransactionsManager(receiptParser: receiptParser)
+        let transactionsManager = TransactionsManager(storeKit2Setting: systemInfo.storeKit2Setting,
+                                                      receiptParser: receiptParser)
         let customerInfoManager = CustomerInfoManager(operationDispatcher: operationDispatcher,
                                                       deviceCache: deviceCache,
                                                       backend: backend,
@@ -320,7 +321,8 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
                                                           deviceCache: deviceCache,
                                                           manageSubscriptionsHelper: manageSubsHelper,
                                                           beginRefundRequestHelper: beginRefundRequestHelper)
-        let trialOrIntroPriceChecker = TrialOrIntroPriceEligibilityChecker(receiptFetcher: receiptFetcher,
+        let trialOrIntroPriceChecker = TrialOrIntroPriceEligibilityChecker(systemInfo: systemInfo,
+                                                                           receiptFetcher: receiptFetcher,
                                                                            introEligibilityCalculator: introCalculator,
                                                                            backend: backend,
                                                                            currentUserProvider: identityManager,
@@ -369,7 +371,7 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
     ) {
 
         Logger.debug(Strings.configure.debug_enabled, fileName: nil)
-        if systemInfo.useStoreKit2IfAvailable {
+        if systemInfo.storeKit2Setting == .enabledIfAvailable {
             Logger.info(Strings.configure.store_kit_2_enabled, fileName: nil)
         }
         Logger.debug(Strings.configure.sdk_version(sdkVersion: Self.frameworkVersion), fileName: nil)
@@ -1754,16 +1756,34 @@ public extension Purchases {
                                              userDefaults: UserDefaults?,
                                              useStoreKit2IfAvailable: Bool,
                                              dangerousSettings: DangerousSettings?) -> Purchases {
+        return Self.configure(
+            withAPIKey: apiKey,
+            appUserID: appUserID,
+            observerMode: observerMode,
+            userDefaults: userDefaults,
+            storeKit2Setting: .init(useStoreKit2IfAvailable: useStoreKit2IfAvailable),
+            dangerousSettings: dangerousSettings
+        )
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    @discardableResult internal static func configure(withAPIKey apiKey: String,
+                                                      appUserID: String?,
+                                                      observerMode: Bool,
+                                                      userDefaults: UserDefaults?,
+                                                      storeKit2Setting: StoreKit2Setting,
+                                                      dangerousSettings: DangerousSettings?) -> Purchases {
         let purchases = Purchases(apiKey: apiKey,
                                   appUserID: appUserID,
                                   userDefaults: userDefaults,
                                   observerMode: observerMode,
                                   platformInfo: nil,
-                                  useStoreKit2IfAvailable: useStoreKit2IfAvailable,
+                                  storeKit2Setting: storeKit2Setting,
                                   dangerousSettings: dangerousSettings)
         setDefaultInstance(purchases)
         return purchases
     }
+
 }
 
 // MARK: Delegate implementation

--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -371,7 +371,7 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
     ) {
 
         Logger.debug(Strings.configure.debug_enabled, fileName: nil)
-        if systemInfo.storeKit2Setting == .enabledIfAvailable {
+        if systemInfo.storeKit2Setting == .enabledForCompatibleDevices {
             Logger.info(Strings.configure.store_kit_2_enabled, fileName: nil)
         }
         Logger.debug(Strings.configure.sdk_version(sdkVersion: Self.frameworkVersion), fileName: nil)

--- a/Sources/Purchasing/TransactionsManager.swift
+++ b/Sources/Purchasing/TransactionsManager.swift
@@ -15,16 +15,18 @@ import StoreKit
 
 class TransactionsManager {
 
+    private let storeKit2Setting: StoreKit2Setting
     private let receiptParser: ReceiptParser
 
-    init(receiptParser: ReceiptParser) {
+    init(storeKit2Setting: StoreKit2Setting,
+         receiptParser: ReceiptParser) {
+        self.storeKit2Setting = storeKit2Setting
         self.receiptParser = receiptParser
     }
 
     func customerHasTransactions(receiptData: Data, completion: @escaping (Bool) -> Void) {
-        // Note: this uses SK2 regardless of the value of `SystemInfo.useStoreKit2IfAvailable`
-        // because its implementation is more accurate.
-        if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
+        // Note: this uses SK2 (unless it's explicitly disabled) because its implementation is more accurate.
+        if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *), self.storeKit2Setting != .disabled {
             _ = Task<Void, Never> {
                 completion(await sk2CheckCustomerHasTransactions())
             }

--- a/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -19,6 +19,8 @@ class TrialOrIntroPriceEligibilityChecker {
     typealias ReceiveIntroEligibilityBlock = ([String: IntroEligibility]) -> Void
 
     private var appUserID: String { self.currentUserProvider.currentAppUserID }
+
+    private let systemInfo: SystemInfo
     private let receiptFetcher: ReceiptFetcher
     private let introEligibilityCalculator: IntroEligibilityCalculator
     private let backend: Backend
@@ -26,12 +28,16 @@ class TrialOrIntroPriceEligibilityChecker {
     private let operationDispatcher: OperationDispatcher
     private let productsManager: ProductsManager
 
-    init(receiptFetcher: ReceiptFetcher,
-         introEligibilityCalculator: IntroEligibilityCalculator,
-         backend: Backend,
-         currentUserProvider: CurrentUserProvider,
-         operationDispatcher: OperationDispatcher,
-         productsManager: ProductsManager) {
+    init(
+        systemInfo: SystemInfo,
+        receiptFetcher: ReceiptFetcher,
+        introEligibilityCalculator: IntroEligibilityCalculator,
+        backend: Backend,
+        currentUserProvider: CurrentUserProvider,
+        operationDispatcher: OperationDispatcher,
+        productsManager: ProductsManager
+    ) {
+        self.systemInfo = systemInfo
         self.receiptFetcher = receiptFetcher
         self.introEligibilityCalculator = introEligibilityCalculator
         self.backend = backend
@@ -48,7 +54,8 @@ class TrialOrIntroPriceEligibilityChecker {
             return
         }
 
-        if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
+        // Note: this uses SK2 (unless it's explicitly disabled) because its implementation is more accurate.
+        if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *), self.systemInfo.storeKit2Setting != .disabled {
             _ = Task<Void, Never> {
                 do {
                     completion(try await sk2CheckEligibility(productIdentifiers))

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -32,7 +32,9 @@ class BaseBackendIntegrationTests: XCTestCase {
     // swiftlint:disable:next weak_delegate
     private(set) var purchasesDelegate: TestPurchaseDelegate!
 
-    class var sk2Enabled: Bool { return false }
+    class var storeKit2Setting: StoreKit2Setting {
+        return .default
+    }
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -67,7 +69,8 @@ private extension BaseBackendIntegrationTests {
                             appUserID: nil,
                             observerMode: false,
                             userDefaults: userDefaults,
-                            useStoreKit2IfAvailable: Self.sk2Enabled)
+                            storeKit2Setting: Self.storeKit2Setting,
+                            dangerousSettings: nil)
         Purchases.logLevel = .debug
         Purchases.shared.delegate = purchasesDelegate
     }

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -13,7 +13,7 @@ import XCTest
 
 class StoreKit2IntegrationTests: StoreKit1IntegrationTests {
 
-    override class var storeKit2Setting: StoreKit2Setting { return .enabledIfAvailable }
+    override class var storeKit2Setting: StoreKit2Setting { return .enabledForCompatibleDevices }
 
 }
 
@@ -250,7 +250,8 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
     @available(iOS 15.2, tvOS 15.2, macOS 12.1, watchOS 8.3, *)
     func testPurchaseWithPromotionalOffer() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-        try XCTSkipIf(Self.storeKit2Setting == .enabledIfAvailable, "This test is not currently passing on SK2")
+        try XCTSkipIf(Self.storeKit2Setting == .enabledForCompatibleDevices,
+                      "This test is not currently passing on SK2")
 
         let user = UUID().uuidString
 

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -7,13 +7,13 @@
 //
 
 import Nimble
-import RevenueCat
+@testable import RevenueCat
 import StoreKitTest
 import XCTest
 
 class StoreKit2IntegrationTests: StoreKit1IntegrationTests {
 
-    override class var sk2Enabled: Bool { return true }
+    override class var storeKit2Setting: StoreKit2Setting { return .enabledIfAvailable }
 
 }
 
@@ -30,6 +30,10 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
         testSession.resetToDefaultState()
         testSession.disableDialogs = true
         testSession.clearTransactions()
+    }
+
+    override class var storeKit2Setting: StoreKit2Setting {
+        return .disabled
     }
 
     func testCanGetOfferings() async throws {
@@ -246,7 +250,7 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
     @available(iOS 15.2, tvOS 15.2, macOS 12.1, watchOS 8.3, *)
     func testPurchaseWithPromotionalOffer() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-        try XCTSkipIf(Self.sk2Enabled, "This test is not currently passing on SK2")
+        try XCTSkipIf(Self.storeKit2Setting == .enabledIfAvailable, "This test is not currently passing on SK2")
 
         let user = UUID().uuidString
 

--- a/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
@@ -34,7 +34,7 @@ class LocalReceiptParserStoreKitTests: StoreKitConfigTestCase {
         systemInfo = try SystemInfo(platformInfo: Purchases.platformInfo,
                                     finishTransactions: true,
                                     operationDispatcher: operationDispatcher,
-                                    useStoreKit2IfAvailable: false)
+                                    storeKit2Setting: .disabled)
         receiptFetcher = ReceiptFetcher(requestFetcher: requestFetcher, systemInfo: systemInfo)
         parser = ReceiptParser()
     }
@@ -54,7 +54,6 @@ class LocalReceiptParserStoreKitTests: StoreKitConfigTestCase {
         expect(receipt.expirationDate).toNot(beNil())
         expect(receipt.expirationDate).toNot(beCloseTo(Date(), within: 1))
         expect(receipt.inAppPurchases).to(beEmpty())
-
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -46,7 +46,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
             throw XCTSkip("Required API is not available for this test.")
         }
 
-        let manager = try createManager(storeKit2Setting: .enabledIfAvailable)
+        let manager = try createManager(storeKit2Setting: .enabledForCompatibleDevices)
 
         let identifier = "com.revenuecat.monthly_4.99.1_week_intro"
         var completionCalled = false

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -20,7 +20,7 @@ import XCTest
 class ProductsManagerTests: StoreKitConfigTestCase {
 
     func testFetchProductsWithIdentifiersSK1() throws {
-        let manager = try createManager(useStoreKit2IfAvailable: false)
+        let manager = try createManager(storeKit2Setting: .disabled)
 
         let identifier = "com.revenuecat.monthly_4.99.1_week_intro"
         var completionCalled = false
@@ -46,7 +46,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
             throw XCTSkip("Required API is not available for this test.")
         }
 
-        let manager = try createManager(useStoreKit2IfAvailable: true)
+        let manager = try createManager(storeKit2Setting: .enabledIfAvailable)
 
         let identifier = "com.revenuecat.monthly_4.99.1_week_intro"
         var completionCalled = false
@@ -67,13 +67,13 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         expect(product.productIdentifier) == identifier
     }
 
-    private func createManager(useStoreKit2IfAvailable: Bool) throws -> ProductsManager {
+    private func createManager(storeKit2Setting: StoreKit2Setting) throws -> ProductsManager {
         let platformInfo = Purchases.PlatformInfo(flavor: "xyz", version: "123")
         return ProductsManager(
             systemInfo: try MockSystemInfo(
                 platformInfo: platformInfo,
                 finishTransactions: true,
-                useStoreKit2IfAvailable: useStoreKit2IfAvailable
+                storeKit2Setting: storeKit2Setting
             ),
             requestTimeout: Self.requestTimeout
         )

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -48,7 +48,8 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                                                       backend: backend,
                                                       systemInfo: systemInfo)
         currentUserProvider = MockCurrentUserProvider(mockAppUserID: "appUserID")
-        transactionsManager = MockTransactionsManager(receiptParser: MockReceiptParser())
+        transactionsManager = MockTransactionsManager(storeKit2Setting: systemInfo.storeKit2Setting,
+                                                      receiptParser: MockReceiptParser())
         let attributionFetcher = MockAttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
                                                         systemInfo: systemInfo)
         subscriberAttributesManager = MockSubscriberAttributesManager(

--- a/Tests/StoreKitUnitTests/TransactionsManagerSK1Tests.swift
+++ b/Tests/StoreKitUnitTests/TransactionsManagerSK1Tests.swift
@@ -24,7 +24,8 @@ class TransactionsManagerSK1Tests: StoreKitConfigTestCase {
         try super.setUpWithError()
         mockReceiptParser = MockReceiptParser()
 
-        transactionsManager = TransactionsManager(receiptParser: mockReceiptParser)
+        transactionsManager = TransactionsManager(storeKit2Setting: .disabled,
+                                                  receiptParser: mockReceiptParser)
     }
 
     func testSK1CheckCustomerHasTransactionsParserIsCalled() {

--- a/Tests/StoreKitUnitTests/TransactionsManagerSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/TransactionsManagerSK2Tests.swift
@@ -25,7 +25,8 @@ class TransactionsManagerSK2Tests: StoreKitConfigTestCase {
         try super.setUpWithError()
 
         mockReceiptParser = MockReceiptParser()
-        transactionsManager = TransactionsManager(receiptParser: mockReceiptParser)
+        transactionsManager = TransactionsManager(storeKit2Setting: .enabledIfAvailable,
+                                                  receiptParser: mockReceiptParser)
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)

--- a/Tests/StoreKitUnitTests/TransactionsManagerSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/TransactionsManagerSK2Tests.swift
@@ -25,7 +25,7 @@ class TransactionsManagerSK2Tests: StoreKitConfigTestCase {
         try super.setUpWithError()
 
         mockReceiptParser = MockReceiptParser()
-        transactionsManager = TransactionsManager(storeKit2Setting: .enabledIfAvailable,
+        transactionsManager = TransactionsManager(storeKit2Setting: .enabledForCompatibleDevices,
                                                   receiptParser: mockReceiptParser)
     }
 

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
@@ -30,7 +30,8 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
         try super.setUpWithError()
         let platformInfo = Purchases.PlatformInfo(flavor: "xyz", version: "123")
         mockSystemInfo = try MockSystemInfo(platformInfo: platformInfo,
-                                            finishTransactions: true)
+                                            finishTransactions: true,
+                                            storeKit2Setting: .disabled)
         receiptFetcher = MockReceiptFetcher(requestFetcher: MockRequestFetcher(), systemInfo: mockSystemInfo)
         self.mockProductsManager = MockProductsManager(systemInfo: mockSystemInfo)
         mockIntroEligibilityCalculator = MockIntroEligibilityCalculator(productsManager: mockProductsManager,
@@ -39,6 +40,7 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
         let mockOperationDispatcher = MockOperationDispatcher()
         let userProvider = MockCurrentUserProvider(mockAppUserID: "app_user")
         trialOrIntroPriceEligibilityChecker = TrialOrIntroPriceEligibilityChecker(
+            systemInfo: mockSystemInfo,
             receiptFetcher: receiptFetcher,
             introEligibilityCalculator: mockIntroEligibilityCalculator,
             backend: mockBackend,

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
@@ -30,7 +30,8 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
         try super.setUpWithError()
         let platformInfo = Purchases.PlatformInfo(flavor: "xyz", version: "123")
         mockSystemInfo = try MockSystemInfo(platformInfo: platformInfo,
-                                            finishTransactions: true)
+                                            finishTransactions: true,
+                                            storeKit2Setting: .enabledIfAvailable)
 
         receiptFetcher = MockReceiptFetcher(requestFetcher: MockRequestFetcher(), systemInfo: mockSystemInfo)
         mockProductsManager = MockProductsManager(systemInfo: mockSystemInfo)
@@ -41,6 +42,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
         let currentUserProvider = MockCurrentUserProvider(mockAppUserID: "app_user")
 
         trialOrIntroPriceEligibilityChecker = TrialOrIntroPriceEligibilityChecker(
+            systemInfo: mockSystemInfo,
             receiptFetcher: receiptFetcher,
             introEligibilityCalculator: mockIntroEligibilityCalculator,
             backend: mockBackend,

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
@@ -31,7 +31,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
         let platformInfo = Purchases.PlatformInfo(flavor: "xyz", version: "123")
         mockSystemInfo = try MockSystemInfo(platformInfo: platformInfo,
                                             finishTransactions: true,
-                                            storeKit2Setting: .enabledIfAvailable)
+                                            storeKit2Setting: .enabledForCompatibleDevices)
 
         receiptFetcher = MockReceiptFetcher(requestFetcher: MockRequestFetcher(), systemInfo: mockSystemInfo)
         mockProductsManager = MockProductsManager(systemInfo: mockSystemInfo)

--- a/Tests/UnitTests/Misc/SystemInfoTests.swift
+++ b/Tests/UnitTests/Misc/SystemInfoTests.swift
@@ -4,6 +4,7 @@ import XCTest
 @testable import RevenueCat
 
 class SystemInfoTests: XCTestCase {
+
     func testproxyURL() {
         let defaultURL = URL(string: "https://api.revenuecat.com")
         expect(SystemInfo.serverHostURL) == defaultURL
@@ -66,20 +67,6 @@ class SystemInfoTests: XCTestCase {
         expect(try SystemInfo.withReceiptResult(.nilURL).isSandbox) == false
     }
 
-    func testUseStoreKit2IfAvailable() throws {
-        var useSK2 = false
-        var systemInfo = try SystemInfo(platformInfo: nil,
-                                        finishTransactions: true,
-                                        useStoreKit2IfAvailable: useSK2)
-        expect(systemInfo.useStoreKit2IfAvailable) == useSK2
-
-        useSK2 = true
-
-        systemInfo = try SystemInfo(platformInfo: nil,
-                                    finishTransactions: true,
-                                    useStoreKit2IfAvailable: useSK2)
-        expect(systemInfo.useStoreKit2IfAvailable) == useSK2
-    }
 }
 
 private extension SystemInfo {

--- a/Tests/UnitTests/Mocks/MockTrialOrIntroPriceEligibilityChecker.swift
+++ b/Tests/UnitTests/Mocks/MockTrialOrIntroPriceEligibilityChecker.swift
@@ -13,16 +13,15 @@
 
 @testable import RevenueCat
 
-// swiftlint:disable identifier_name
-// swiftlint:disable line_length
-// swiftlint:disable force_try
+// swiftlint:disable identifier_name line_length force_try
 class MockTrialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityChecker {
 
     convenience init() {
         let platformInfo = Purchases.PlatformInfo(flavor: "xyz", version: "123")
         let systemInfo = try! MockSystemInfo(platformInfo: platformInfo, finishTransactions: true)
         let productsManager = MockProductsManager(systemInfo: systemInfo)
-        self.init(receiptFetcher: MockReceiptFetcher(requestFetcher: MockRequestFetcher(), systemInfo: systemInfo),
+        self.init(systemInfo: systemInfo,
+                  receiptFetcher: MockReceiptFetcher(requestFetcher: MockRequestFetcher(), systemInfo: systemInfo),
                   introEligibilityCalculator: MockIntroEligibilityCalculator(productsManager: productsManager,
                                                                              receiptParser: MockReceiptParser()),
                   backend: MockBackend(),

--- a/Tests/UnitTests/Purchasing/PurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/PurchasesTests.swift
@@ -78,7 +78,8 @@ class PurchasesTests: XCTestCase {
         mockBeginRefundRequestHelper = MockBeginRefundRequestHelper(systemInfo: systemInfo,
                                                                     customerInfoManager: customerInfoManager,
                                                                     currentUserProvider: identityManager)
-        mockTransactionsManager = MockTransactionsManager(receiptParser: mockReceiptParser)
+        mockTransactionsManager = MockTransactionsManager(storeKit2Setting: systemInfo.storeKit2Setting,
+                                                          receiptParser: mockReceiptParser)
     }
 
     override func tearDown() {
@@ -333,6 +334,7 @@ class PurchasesTests: XCTestCase {
                                                       manageSubscriptionsHelper: mockManageSubsHelper,
                                                       beginRefundRequestHelper: mockBeginRefundRequestHelper)
         trialOrIntroPriceEligibilityChecker = MockTrialOrIntroPriceEligibilityChecker(
+            systemInfo: systemInfo,
             receiptFetcher: receiptFetcher,
             introEligibilityCalculator: mockIntroEligibilityCalculator,
             backend: backend,

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -116,7 +116,8 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
         self.mockBeginRefundRequestHelper = MockBeginRefundRequestHelper(systemInfo: systemInfo,
                                                                          customerInfoManager: customerInfoManager,
                                                                          currentUserProvider: mockIdentityManager)
-        self.mockTransactionsManager = MockTransactionsManager(receiptParser: mockReceiptParser)
+        self.mockTransactionsManager = MockTransactionsManager(storeKit2Setting: systemInfo.storeKit2Setting,
+                                                               receiptParser: mockReceiptParser)
     }
 
     override func tearDown() {
@@ -142,6 +143,7 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
                                                           manageSubscriptionsHelper: mockManageSubsHelper,
                                                           beginRefundRequestHelper: mockBeginRefundRequestHelper)
         let trialOrIntroductoryPriceEligibilityChecker = TrialOrIntroPriceEligibilityChecker(
+            systemInfo: systemInfo,
             receiptFetcher: mockReceiptFetcher,
             introEligibilityCalculator: mockIntroEligibilityCalculator,
             backend: mockBackend,


### PR DESCRIPTION
This adds a third case `disabled` that allows tests to explicitly disable StoreKit 2.
Some types, like `TrialOrIntroPriceEligibilityChecker` and `TransactionsManager` always used SK2 because the implementation was better. But this meant that tests couldn't explicitly disable it (other than calling the internal methods directly).

This allows #1464 to be a lot simpler but being able to use the public `Purchases` methods, but forcing the implementation to use SK1.

Note that this is purely an implementation detail. `StoreKit2Setting` is `internal`, and the public API still only exposes the same boolean.

This basically solves [CF-497] too, since those tests will now force `TrialOrIntroPriceEligibilityChecker` to run the SK1 implementation.

[CF-497]: https://revenuecats.atlassian.net/browse/CF-497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ