### PR TITLE
Add SK2 configure parameter to DocC

### DIFF
--- a/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
@@ -26,6 +26,7 @@ Most features require configuring the SDK before using it.
 - ``Purchases/configure(withAPIKey:appUserID:)``
 - ``Purchases/configure(withAPIKey:appUserID:observerMode:)``
 - ``Purchases/configure(withAPIKey:appUserID:observerMode:userDefaults:)``
+- ``Purchases/configure(withAPIKey:appUserID:observerMode:userDefaults:useStoreKit2IfAvailable:)``
 
 ### Displaying Products
 - ``Purchases/offerings()``

--- a/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md
@@ -58,6 +58,7 @@ Or browse our iOS sample apps:
 - ``Purchases/configure(withAPIKey:appUserID:)``
 - ``Purchases/configure(withAPIKey:appUserID:observerMode:)``
 - ``Purchases/configure(withAPIKey:appUserID:observerMode:userDefaults:)``
+- ``Purchases/configure(withAPIKey:appUserID:observerMode:userDefaults:useStoreKit2IfAvailable:)``
 
 ### Displaying Products
 - ``Offerings``


### PR DESCRIPTION
For [CF-476](https://revenuecats.atlassian.net/browse/CF-496)

### Motivation
We support using SK2 (beta, experimentally), so we should include it in our DocC docs.

### Description
Adds the `configure` option with `useStoreKit2IfAvailable` to DocC docs
