### PR TITLE
`SKError`, `StoreKitError`, and `Product.PurchaseError` conform to `ErrorCodeConvertible` + tests

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -218,6 +218,9 @@
 		5733B1AA27FFBCF900EC2045 /* BaseErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5733B1A927FFBCF900EC2045 /* BaseErrorTests.swift */; };
 		5738F46E278CAC520096D623 /* StoreTransactionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5738F46D278CAC520096D623 /* StoreTransactionTests.swift */; };
 		5738F489278CC2500096D623 /* MockTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = F591492726B9956C00D32E58 /* MockTransaction.swift */; };
+		573A10D52800A7C800F976E5 /* SKErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573A10D42800A7C800F976E5 /* SKErrorTests.swift */; };
+		573A10D92800ADCD00F976E5 /* StoreKitErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573A10D82800ADCD00F976E5 /* StoreKitErrorTests.swift */; };
+		573A10DB2800AF4700F976E5 /* PurchaseErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573A10DA2800AF4700F976E5 /* PurchaseErrorTests.swift */; };
 		5746508C27586B2E0053AB09 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5746508B27586B2E0053AB09 /* Result+Extensions.swift */; };
 		5746508E275949F20053AB09 /* DispatchTimeInterval+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5746508D275949F20053AB09 /* DispatchTimeInterval+Extensions.swift */; };
 		5751379527F4C4D80064AB2C /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5751379427F4C4D80064AB2C /* Optional+Extensions.swift */; };
@@ -649,6 +652,9 @@
 		5733B1A727FFBCC800EC2045 /* BackendErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendErrorTests.swift; sourceTree = "<group>"; };
 		5733B1A927FFBCF900EC2045 /* BaseErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseErrorTests.swift; sourceTree = "<group>"; };
 		5738F46D278CAC520096D623 /* StoreTransactionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreTransactionTests.swift; sourceTree = "<group>"; };
+		573A10D42800A7C800F976E5 /* SKErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKErrorTests.swift; sourceTree = "<group>"; };
+		573A10D82800ADCD00F976E5 /* StoreKitErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitErrorTests.swift; sourceTree = "<group>"; };
+		573A10DA2800AF4700F976E5 /* PurchaseErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseErrorTests.swift; sourceTree = "<group>"; };
 		5746508B27586B2E0053AB09 /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
 		5746508D275949F20053AB09 /* DispatchTimeInterval+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchTimeInterval+Extensions.swift"; sourceTree = "<group>"; };
 		5751379427F4C4D80064AB2C /* Optional+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
@@ -1670,6 +1676,9 @@
 			isa = PBXGroup;
 			children = (
 				F591492526B994B400D32E58 /* SKPaymentTransactionExtensionsTests.swift */,
+				573A10D42800A7C800F976E5 /* SKErrorTests.swift */,
+				573A10D82800ADCD00F976E5 /* StoreKitErrorTests.swift */,
+				573A10DA2800AF4700F976E5 /* PurchaseErrorTests.swift */,
 			);
 			path = StoreKitExtensions;
 			sourceTree = "<group>";
@@ -2298,6 +2307,7 @@
 				2DDF41CC24F6F4C3005BC22D /* AppleReceiptBuilderTests.swift in Sources */,
 				351B51C026D450E800BD2BD7 /* PurchasesTests.swift in Sources */,
 				2DDF41CD24F6F4C3005BC22D /* ASN1ContainerBuilderTests.swift in Sources */,
+				573A10D52800A7C800F976E5 /* SKErrorTests.swift in Sources */,
 				351B513D26D4491E00BD2BD7 /* MockDeviceCache.swift in Sources */,
 				351B515C26D44B7900BD2BD7 /* MockIntroEligibilityCalculator.swift in Sources */,
 				35D83312262FBD4200E60AC5 /* MockETagManager.swift in Sources */,
@@ -2344,6 +2354,7 @@
 				5796A38127D6B78500653165 /* BaseBackendTest.swift in Sources */,
 				351B516226D44BEE00BD2BD7 /* CustomerInfoManagerTests.swift in Sources */,
 				351B51A326D450BC00BD2BD7 /* DictionaryExtensionsTests.swift in Sources */,
+				573A10D92800ADCD00F976E5 /* StoreKitErrorTests.swift in Sources */,
 				351B515826D44B3E00BD2BD7 /* MockOfferingsFactory.swift in Sources */,
 				351B51A526D450BC00BD2BD7 /* NSDate+RCExtensionsTests.swift in Sources */,
 				B390F5BA271DDC7400B64D65 /* PurchasesDeprecation.swift in Sources */,
@@ -2354,6 +2365,7 @@
 				351B517A26D44FF000BD2BD7 /* MockRequestFetcher.swift in Sources */,
 				351B514E26D44ACE00BD2BD7 /* SubscriberAttributesManagerTests.swift in Sources */,
 				2DDF41CE24F6F4C3005BC22D /* InAppPurchaseBuilderTests.swift in Sources */,
+				573A10DB2800AF4700F976E5 /* PurchaseErrorTests.swift in Sources */,
 				B300E4BF26D436F900B22262 /* LogIntent.swift in Sources */,
 				351B513F26D4496000BD2BD7 /* MockIdentityManager.swift in Sources */,
 				B319514926C19856002CA9AC /* NSData+RCExtensionsTests.swift in Sources */,

--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -238,7 +238,7 @@ enum ErrorUtils {
     ) -> Error {
         switch error {
         case let skError as SKError:
-            return skError.toPurchasesError()
+            return skError.asPurchasesError
 
         default:
             return ErrorUtils.unknownError(
@@ -261,9 +261,9 @@ enum ErrorUtils {
     ) -> Error {
         switch error {
         case let storeKitError as StoreKitError:
-            return storeKitError.toPurchasesError()
+            return storeKitError.asPurchasesError
         case let purchasesError as Product.PurchaseError:
-            return purchasesError.toPurchasesError()
+            return purchasesError.asPurchasesError
         default:
             return ErrorUtils.unknownError(
                 error: error,

--- a/Sources/Error Handling/SKError+Extensions.swift
+++ b/Sources/Error Handling/SKError+Extensions.swift
@@ -14,10 +14,9 @@
 import Foundation
 import StoreKit
 
-extension SKError {
+extension SKError: ErrorCodeConvertible {
 
-    // swiftlint:disable:next cyclomatic_complexity function_body_length
-    func toPurchasesError() -> Error {
+    var asPurchasesError: Error {
         switch self.code {
         case .cloudServiceNetworkConnectionFailed,
              .cloudServiceRevoked,

--- a/Sources/Error Handling/StoreKitError+Extensions.swift
+++ b/Sources/Error Handling/StoreKitError+Extensions.swift
@@ -15,9 +15,9 @@ import StoreKit
 
 /// - SeeAlso: SKError+Extensions
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-extension StoreKitError {
+extension StoreKitError: ErrorCodeConvertible {
 
-    func toPurchasesError() -> Error {
+    var asPurchasesError: Error {
         switch self {
         case .userCancelled:
             return ErrorUtils.purchaseCancelledError(error: self)
@@ -50,9 +50,9 @@ extension StoreKitError {
 }
 
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-extension Product.PurchaseError {
+extension Product.PurchaseError: ErrorCodeConvertible {
 
-    func toPurchasesError() -> Error {
+    var asPurchasesError: Error {
         switch self {
         case .invalidQuantity:
             return ErrorUtils.storeProblemError(error: self)

--- a/Tests/UnitTests/StoreKitExtensions/PurchaseErrorTests.swift
+++ b/Tests/UnitTests/StoreKitExtensions/PurchaseErrorTests.swift
@@ -1,0 +1,68 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchaseErrorTests.swift
+//
+//  Created by Nacho Soto on 4/8/22.
+
+import Nimble
+@testable import RevenueCat
+import StoreKit
+import XCTest
+
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+class PurchaseErrorTests: BaseErrorTests {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+    }
+
+    func testInvalidQuantityError() {
+        let error: Product.PurchaseError = .invalidQuantity
+
+        verifyPurchasesError(error,
+                             expectedCode: .storeProblemError,
+                             underlyingError: error)
+    }
+
+    func testProductUnavailableError() {
+        let error: Product.PurchaseError = .productUnavailable
+
+        verifyPurchasesError(error,
+                             expectedCode: .productNotAvailableForPurchaseError,
+                             underlyingError: error)
+    }
+
+    func testPurchaseNotAllowedError() {
+        let error: Product.PurchaseError = .purchaseNotAllowed
+
+        verifyPurchasesError(error,
+                             expectedCode: .purchaseNotAllowedError,
+                             underlyingError: error)
+    }
+
+    func testIneligibleForOfferError() {
+        let error: Product.PurchaseError = .ineligibleForOffer
+
+        verifyPurchasesError(error,
+                             expectedCode: .ineligibleError,
+                             underlyingError: error)
+    }
+
+    func testInvalidOfferError() {
+        let error: Product.PurchaseError = .missingOfferParameters
+
+        verifyPurchasesError(error,
+                             expectedCode: .invalidPromotionalOfferError,
+                             underlyingError: error)
+    }
+
+}

--- a/Tests/UnitTests/StoreKitExtensions/SKErrorTests.swift
+++ b/Tests/UnitTests/StoreKitExtensions/SKErrorTests.swift
@@ -1,0 +1,148 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SKErrorTests.swift
+//
+//  Created by Nacho Soto on 4/8/22.
+
+import Nimble
+@testable import RevenueCat
+import StoreKit
+import XCTest
+
+class SKErrorTests: BaseErrorTests {
+
+    func testStoreProblemError() {
+        let error: SKError = .init(.cloudServiceNetworkConnectionFailed)
+
+        verifyPurchasesError(error,
+                             expectedCode: .storeProblemError,
+                             underlyingError: error)
+    }
+
+    func testPurchaseNotAllowedError() {
+        let error: SKError = .init(.paymentNotAllowed)
+
+        verifyPurchasesError(error,
+                             expectedCode: .purchaseNotAllowedError,
+                             underlyingError: error)
+    }
+
+    func testPaymentCancelled() {
+        let error: SKError = .init(.paymentCancelled)
+
+        verifyPurchasesError(error,
+                             expectedCode: .purchaseCancelledError,
+                             underlyingError: error)
+    }
+
+    func testPaymentInvalid() {
+        let error: SKError = .init(.paymentInvalid)
+
+        verifyPurchasesError(error,
+                             expectedCode: .purchaseInvalidError,
+                             underlyingError: error)
+    }
+
+    func testProductNotAvailableError() {
+        let error: SKError = .init(.storeProductNotAvailable)
+
+        verifyPurchasesError(error,
+                             expectedCode: .productNotAvailableForPurchaseError,
+                             underlyingError: error)
+    }
+
+    @available(iOS 14.0, macOS 11.0, watchOS 6.2, *)
+    @available(tvOS, unavailable)
+    func testUnsupportedPlatformError() throws {
+        try AvailabilityChecks.iOS14APIAvailableOrSkipTest()
+
+        let error: SKError = .init(.unsupportedPlatform)
+
+        verifyPurchasesError(error,
+                             expectedCode: .purchaseNotAllowedError,
+                             underlyingError: error)
+    }
+
+    @available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 6.2, *)
+    func testIneligibleForOfferError() throws {
+        try AvailabilityChecks.iOS14APIAvailableOrSkipTest()
+
+        let error: SKError = .init(.ineligibleForOffer)
+
+        verifyPurchasesError(error,
+                             expectedCode: .ineligibleError,
+                             underlyingError: error)
+    }
+
+    @available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 6.2, *)
+    func testInvalidOfferError() throws {
+        try AvailabilityChecks.iOS14APIAvailableOrSkipTest()
+
+        let error: SKError = .init(.invalidOfferIdentifier)
+
+        verifyPurchasesError(error,
+                             expectedCode: .invalidPromotionalOfferError,
+                             underlyingError: error)
+    }
+
+    func testCurrentlySubscribedError() throws {
+        let error = try XCTUnwrap(
+            NSError(
+                domain: SKErrorDomain,
+                code: SKError.unknown.rawValue,
+                userInfo: [
+                    NSUnderlyingErrorKey: NSError(
+                        domain: "ASDServerErrorDomain",
+                        code: 3532,
+                        userInfo: [:]
+                    )
+                ]
+            ) as? SKError
+        )
+
+        verifyPurchasesError(error,
+                             expectedCode: .productAlreadyPurchasedError,
+                             underlyingError: error)
+    }
+
+    func testPaymentSheetCancelledError() throws {
+        let error = try XCTUnwrap(
+            NSError(
+                domain: SKErrorDomain,
+                code: 907,
+                userInfo: [
+                    NSUnderlyingErrorKey: NSError(
+                        domain: "AMSErrorDomain",
+                        code: 6,
+                        userInfo: [:]
+                    )
+                ]
+            ) as? SKError
+        )
+
+        verifyPurchasesError(error,
+                             expectedCode: .purchaseCancelledError,
+                             underlyingError: error)
+    }
+
+    func testUnknownError() throws {
+        let error = try XCTUnwrap(
+            NSError(
+                domain: SKErrorDomain,
+                code: 100000
+            ) as? SKError
+        )
+
+        verifyPurchasesError(error,
+                             expectedCode: .unknownError,
+                             underlyingError: error)
+    }
+
+}

--- a/Tests/UnitTests/StoreKitExtensions/StoreKitErrorTests.swift
+++ b/Tests/UnitTests/StoreKitExtensions/StoreKitErrorTests.swift
@@ -1,0 +1,84 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  StoreKitErrorTests.swift
+//
+//  Created by Nacho Soto on 4/8/22.
+
+import Nimble
+@testable import RevenueCat
+import StoreKit
+import XCTest
+
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+class StoreKitErrorTests: BaseErrorTests {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+    }
+
+    func testUserCancelledError() {
+        let error: StoreKitError = .userCancelled
+
+        verifyPurchasesError(error,
+                             expectedCode: .purchaseCancelledError,
+                             underlyingError: error)
+    }
+
+    func testNetworkError() {
+        let underlyingError: URLError = .init(.badServerResponse)
+        let error: StoreKitError = .networkError(underlyingError)
+
+        verifyPurchasesError(error,
+                             expectedCode: .networkError,
+                             underlyingError: underlyingError)
+    }
+
+    func testSystemError() {
+        let underlyingError: URLError = .init(.cannotCreateFile)
+        let error: StoreKitError = .systemError(underlyingError)
+
+        verifyPurchasesError(error,
+                             expectedCode: .storeProblemError,
+                             underlyingError: underlyingError)
+    }
+
+    func testNotAvailableInStorefrontError() {
+        let error: StoreKitError = .notAvailableInStorefront
+
+        verifyPurchasesError(error,
+                             expectedCode: .productNotAvailableForPurchaseError,
+                             underlyingError: error)
+    }
+
+    #if swift(>=5.6)
+    func testNotEntitledError() throws {
+        guard #available(iOS 15.4, tvOS 15.4, *) else {
+            throw XCTSkip("Required API is not available for this test.")
+        }
+
+        let error: StoreKitError = .notEntitled
+
+        verifyPurchasesError(error,
+                             expectedCode: .storeProblemError,
+                             underlyingError: error)
+    }
+    #endif
+
+    func testUnknownError() {
+        let error: StoreKitError = .unknown
+
+        verifyPurchasesError(error,
+                             expectedCode: .storeProblemError,
+                             underlyingError: error)
+    }
+
+}


### PR DESCRIPTION
Follow up to #1437.
Fixes [CF-323]


[CF-323]: https://revenuecats.atlassian.net/browse/CF-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ