### PR TITLE
`SubscriberAttributesManager`: fixed potential race condition

### DIFF
--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -284,6 +284,7 @@ public typealias DeferredPromotionalPurchaseBlock = (@escaping PurchaseCompleted
         let attributionDataMigrator = AttributionDataMigrator()
         let subscriberAttributesManager = SubscriberAttributesManager(backend: backend,
                                                                       deviceCache: deviceCache,
+                                                                      operationDispatcher: operationDispatcher,
                                                                       attributionFetcher: attributionFetcher,
                                                                       attributionDataMigrator: attributionDataMigrator)
         let attributionPoster = AttributionPoster(deviceCache: deviceCache,

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -54,6 +54,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         subscriberAttributesManager = MockSubscriberAttributesManager(
             backend: backend,
             deviceCache: deviceCache,
+            operationDispatcher: MockOperationDispatcher(),
             attributionFetcher: attributionFetcher,
             attributionDataMigrator: MockAttributionDataMigrator())
         mockManageSubsHelper = MockManageSubscriptionsHelper(systemInfo: systemInfo,

--- a/Tests/UnitTests/Attribution/AttributionPosterTests.swift
+++ b/Tests/UnitTests/Attribution/AttributionPosterTests.swift
@@ -47,6 +47,7 @@ class AttributionPosterTests: XCTestCase {
         subscriberAttributesManager = MockSubscriberAttributesManager(
             backend: self.backend,
             deviceCache: self.deviceCache,
+            operationDispatcher: MockOperationDispatcher(),
             attributionFetcher: self.attributionFetcher,
             attributionDataMigrator: AttributionDataMigrator())
         identityManager = MockIdentityManager(mockAppUserID: userID)

--- a/Tests/UnitTests/Purchasing/PurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/PurchasesTests.swift
@@ -54,6 +54,7 @@ class PurchasesTests: XCTestCase {
         subscriberAttributesManager =
         MockSubscriberAttributesManager(backend: self.backend,
                                         deviceCache: self.deviceCache,
+                                        operationDispatcher: self.mockOperationDispatcher,
                                         attributionFetcher: self.attributionFetcher,
                                         attributionDataMigrator: AttributionDataMigrator())
         attributionPoster = AttributionPoster(deviceCache: deviceCache,

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -87,6 +87,7 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
         self.mockSubscriberAttributesManager = MockSubscriberAttributesManager(
             backend: self.mockBackend,
             deviceCache: self.mockDeviceCache,
+            operationDispatcher: self.mockOperationDispatcher,
             attributionFetcher: self.mockAttributionFetcher,
             attributionDataMigrator: AttributionDataMigrator())
         self.mockIdentityManager = MockIdentityManager(mockAppUserID: "app_user")

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -41,6 +41,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
         self.subscriberAttributesManager = SubscriberAttributesManager(
             backend: mockBackend,
             deviceCache: mockDeviceCache,
+            operationDispatcher: MockOperationDispatcher(),
             attributionFetcher: mockAttributionFetcher,
             attributionDataMigrator: mockAttributionDataMigrator
         )


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/6125/workflows/d418661d-752d-403e-84d5-e7fdc32dad88/jobs/22409/tests

The tests introduced in #1441 exposed a potential race condition in the SDK.
On SDK initialization, `Purchases` calls `updateAllCaches`, which in turn makes `CustomerInfoManager` and `OfferingsManager` update its internal caches. Specifically, `CustomerInfoManager` makes a `getCustomerInfo` request ensuring that the backend knows about the current `appUserID`.

These 2 calls are made in the `OperationDispatcher.workerQueue`, so they're ensured proper ordering.

However, `SubscriberAttributesManager` enqueues the requests to post new attributes synchronously and outside this worker thread. If this happens _before_ `CustomerInfoManager` has had a chance to enqueue the `Backend.getCustomerInfo` request, the backend will fail with `SUBSCRIPTION_NOT_FOUND` errors.