### PR TITLE
`NetworkError.errorResponse`: added status code to `userInfo`

### DIFF
--- a/Sources/Error Handling/ErrorDetails.swift
+++ b/Sources/Error Handling/ErrorDetails.swift
@@ -14,7 +14,11 @@
 
 import Foundation
 
-class ErrorDetails: NSObject {
+enum ErrorDetails {
+
+    static let attributeErrorsKey: NSError.UserInfoKey = "attribute_errors"
+    static let attributeErrorsResponseKey: NSError.UserInfoKey = "attributes_error_response"
+    static let statusCodeErrorKey: NSError.UserInfoKey = "rc_response_status_code"
 
     static let readableErrorCodeKey: NSError.UserInfoKey = "readable_error_code"
     static let extraContextKey: NSError.UserInfoKey = "extra_context"

--- a/Sources/Error Handling/ErrorDetails.swift
+++ b/Sources/Error Handling/ErrorDetails.swift
@@ -14,15 +14,28 @@
 
 import Foundation
 
+extension NSError.UserInfoKey {
+
+    static let attributeErrors: NSError.UserInfoKey = "attribute_errors"
+    static let attributeErrorsResponse: NSError.UserInfoKey = "attributes_error_response"
+    static let statusCodeError: NSError.UserInfoKey = "rc_response_status_code"
+
+    static let readableErrorCode: NSError.UserInfoKey = "readable_error_code"
+    static let extraContext: NSError.UserInfoKey = "extra_context"
+    static let file: NSError.UserInfoKey = "source_file"
+    static let function: NSError.UserInfoKey = "source_function"
+
+}
+
 enum ErrorDetails {
 
-    static let attributeErrorsKey: NSError.UserInfoKey = "attribute_errors"
-    static let attributeErrorsResponseKey: NSError.UserInfoKey = "attributes_error_response"
-    static let statusCodeErrorKey: NSError.UserInfoKey = "rc_response_status_code"
+    static let attributeErrorsKey = NSError.UserInfoKey.attributeErrors as String
+    static let attributeErrorsResponseKey = NSError.UserInfoKey.attributeErrorsResponse as String
+    static let statusCodeErrorKey = NSError.UserInfoKey.statusCodeError as String
 
-    static let readableErrorCodeKey: NSError.UserInfoKey = "readable_error_code"
-    static let extraContextKey: NSError.UserInfoKey = "extra_context"
-    static let fileKey: NSError.UserInfoKey = "source_file"
-    static let functionKey: NSError.UserInfoKey = "source_function"
+    static let readableErrorCodeKey = NSError.UserInfoKey.readableErrorCode as String
+    static let extraContextKey = NSError.UserInfoKey.extraContext as String
+    static let fileKey = NSError.UserInfoKey.file as String
+    static let functionKey = NSError.UserInfoKey.function as String
 
 }

--- a/Sources/Error Handling/ErrorDetails.swift
+++ b/Sources/Error Handling/ErrorDetails.swift
@@ -18,7 +18,7 @@ extension NSError.UserInfoKey {
 
     static let attributeErrors: NSError.UserInfoKey = "attribute_errors"
     static let attributeErrorsResponse: NSError.UserInfoKey = "attributes_error_response"
-    static let statusCodeError: NSError.UserInfoKey = "rc_response_status_code"
+    static let statusCode: NSError.UserInfoKey = "rc_response_status_code"
 
     static let readableErrorCode: NSError.UserInfoKey = "readable_error_code"
     static let extraContext: NSError.UserInfoKey = "extra_context"
@@ -31,7 +31,7 @@ enum ErrorDetails {
 
     static let attributeErrorsKey = NSError.UserInfoKey.attributeErrors as String
     static let attributeErrorsResponseKey = NSError.UserInfoKey.attributeErrorsResponse as String
-    static let statusCodeErrorKey = NSError.UserInfoKey.statusCodeError as String
+    static let statusCodeKey = NSError.UserInfoKey.statusCode as String
 
     static let readableErrorCodeKey = NSError.UserInfoKey.readableErrorCode as String
     static let extraContextKey = NSError.UserInfoKey.extraContext as String

--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -468,9 +468,9 @@ private extension ErrorUtils {
         if let underlyingError = underlyingError {
             userInfo[NSUnderlyingErrorKey as NSError.UserInfoKey] = underlyingError
         }
-        userInfo[ErrorDetails.readableErrorCodeKey] = code.codeName
-        userInfo[ErrorDetails.fileKey] = "\(fileName):\(line)"
-        userInfo[ErrorDetails.functionKey] = functionName
+        userInfo[.readableErrorCode] = code.codeName
+        userInfo[.file] = "\(fileName):\(line)"
+        userInfo[.function] = functionName
 
         Self.logErrorIfNeeded(code,
                               fileName: fileName, functionName: functionName, line: line)
@@ -492,10 +492,10 @@ private extension ErrorUtils {
         let errorDescription = describableSubError?.description ?? ErrorCode.unexpectedBackendResponseError.description
         userInfo[NSLocalizedDescriptionKey as NSError.UserInfoKey] = errorDescription
         userInfo[NSUnderlyingErrorKey as NSError.UserInfoKey] = subError
-        userInfo[ErrorDetails.readableErrorCodeKey] = ErrorCode.unexpectedBackendResponseError.codeName
-        userInfo[ErrorDetails.extraContextKey] = extraContext
-        userInfo[ErrorDetails.fileKey] = "\(fileName):\(line)"
-        userInfo[ErrorDetails.functionKey] = functionName
+        userInfo[.readableErrorCode] = ErrorCode.unexpectedBackendResponseError.codeName
+        userInfo[.extraContext] = extraContext
+        userInfo[.file] = "\(fileName):\(line)"
+        userInfo[.function] = functionName
 
         let nsError = ErrorCode.unexpectedBackendResponseError as NSError
         let nsErrorWithUserInfo = NSError(domain: nsError.domain,

--- a/Sources/FoundationExtensions/Error+Extensions.swift
+++ b/Sources/FoundationExtensions/Error+Extensions.swift
@@ -29,7 +29,7 @@ extension Error {
         let asNSError = self as NSError
         var userInfo = asNSError.userInfo as [NSError.UserInfoKey: Any]
         userInfo[NSUnderlyingErrorKey as NSString] = underlyingNSError
-        userInfo[ErrorDetails.extraContextKey] = extraContext ?? underlyingNSError.localizedDescription
+        userInfo[.extraContext] = extraContext ?? underlyingNSError.localizedDescription
         let nsErrorWithUserInfo = NSError(domain: asNSError.domain,
                                           code: asNSError.code,
                                           userInfo: userInfo as [String: Any])
@@ -41,7 +41,7 @@ extension Error {
 extension NSError {
 
     var subscriberAttributesErrors: [String: String]? {
-        return self.userInfo[ErrorDetails.attributeErrorsKey as String] as? [String: String]
+        return self.userInfo[ErrorDetails.attributeErrorsKey] as? [String: String]
     }
 
 }

--- a/Sources/FoundationExtensions/Error+Extensions.swift
+++ b/Sources/FoundationExtensions/Error+Extensions.swift
@@ -41,7 +41,7 @@ extension Error {
 extension NSError {
 
     var subscriberAttributesErrors: [String: String]? {
-        return userInfo[Backend.RCAttributeErrorsKey as String] as? [String: String]
+        return self.userInfo[ErrorDetails.attributeErrorsKey as String] as? [String: String]
     }
 
 }

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -26,6 +26,7 @@ class Backend {
 
     static let RCAttributeErrorsKey = "attribute_errors"
     static let RCAttributeErrorsResponseKey = "attributes_error_response"
+    static let RCStatusCodeErrorKey = "rc_response_status_code"
 
     private let apiKey: String
     private let authHeaders: [String: String]

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -24,10 +24,6 @@ class Backend {
     typealias SimpleResponseHandler = (BackendError?) -> Void
     typealias LogInResponseHandler = (Result<(info: CustomerInfo, created: Bool), BackendError>) -> Void
 
-    static let RCAttributeErrorsKey = "attribute_errors"
-    static let RCAttributeErrorsResponseKey = "attributes_error_response"
-    static let RCStatusCodeErrorKey = "rc_response_status_code"
-
     private let apiKey: String
     private let authHeaders: [String: String]
     private let httpClient: HTTPClient

--- a/Sources/Networking/HTTPResponse.swift
+++ b/Sources/Networking/HTTPResponse.swift
@@ -77,11 +77,11 @@ extension ErrorResponse {
         line: UInt = #line
     ) -> Error {
         var userInfo: [NSError.UserInfoKey: Any] = [
-            Backend.RCStatusCodeErrorKey as NSError.UserInfoKey: statusCode.rawValue
+            ErrorDetails.statusCodeErrorKey: statusCode.rawValue
         ]
 
         if !self.attributeErrors.isEmpty {
-            userInfo[Backend.RCAttributeErrorsKey as NSError.UserInfoKey] = self.attributeErrors
+            userInfo[ErrorDetails.attributeErrorsKey] = self.attributeErrors
         }
 
         return ErrorUtils.backendError(

--- a/Sources/Networking/HTTPResponse.swift
+++ b/Sources/Networking/HTTPResponse.swift
@@ -77,7 +77,7 @@ extension ErrorResponse {
         line: UInt = #line
     ) -> Error {
         var userInfo: [NSError.UserInfoKey: Any] = [
-            .statusCodeError: statusCode.rawValue
+            .statusCode: statusCode.rawValue
         ]
 
         if !self.attributeErrors.isEmpty {

--- a/Sources/Networking/HTTPResponse.swift
+++ b/Sources/Networking/HTTPResponse.swift
@@ -76,7 +76,9 @@ extension ErrorResponse {
         function: String = #function,
         line: UInt = #line
     ) -> Error {
-        var userInfo: [NSError.UserInfoKey: Any] = [:]
+        var userInfo: [NSError.UserInfoKey: Any] = [
+            Backend.RCStatusCodeErrorKey as NSError.UserInfoKey: statusCode.rawValue
+        ]
 
         if !self.attributeErrors.isEmpty {
             userInfo[Backend.RCAttributeErrorsKey as NSError.UserInfoKey] = self.attributeErrors

--- a/Sources/Networking/HTTPResponse.swift
+++ b/Sources/Networking/HTTPResponse.swift
@@ -77,11 +77,11 @@ extension ErrorResponse {
         line: UInt = #line
     ) -> Error {
         var userInfo: [NSError.UserInfoKey: Any] = [
-            ErrorDetails.statusCodeErrorKey: statusCode.rawValue
+            .statusCodeError: statusCode.rawValue
         ]
 
         if !self.attributeErrors.isEmpty {
-            userInfo[ErrorDetails.attributeErrorsKey] = self.attributeErrors
+            userInfo[.attributeErrors] = self.attributeErrors
         }
 
         return ErrorUtils.backendError(

--- a/Tests/UnitTests/FoundationExtensions/NSError+RCExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/NSError+RCExtensionsTests.swift
@@ -27,7 +27,7 @@ class NSErrorRCExtensionsTests: XCTestCase {
         let error = NSError(
             domain: RCPurchasesErrorCodeDomain,
             code: errorCode,
-            userInfo: [ErrorDetails.attributeErrorsKey as String: attributeErrors]
+            userInfo: [ErrorDetails.attributeErrorsKey: attributeErrors]
         )
         expect(error.subscriberAttributesErrors).toNot(beNil())
         expect(error.subscriberAttributesErrors) == attributeErrors

--- a/Tests/UnitTests/FoundationExtensions/NSError+RCExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/NSError+RCExtensionsTests.swift
@@ -27,7 +27,7 @@ class NSErrorRCExtensionsTests: XCTestCase {
         let error = NSError(
             domain: RCPurchasesErrorCodeDomain,
             code: errorCode,
-            userInfo: [Backend.RCAttributeErrorsKey as String: attributeErrors]
+            userInfo: [ErrorDetails.attributeErrorsKey as String: attributeErrors]
         )
         expect(error.subscriberAttributesErrors).toNot(beNil())
         expect(error.subscriberAttributesErrors) == attributeErrors

--- a/Tests/UnitTests/Networking/BaseErrorTests.swift
+++ b/Tests/UnitTests/Networking/BaseErrorTests.swift
@@ -25,7 +25,7 @@ class BaseErrorTests: XCTestCase {
         _ error: ErrorCodeConvertible,
         expectedCode: ErrorCode,
         underlyingError: Error? = nil,
-        userInfoKeys: [String]? = nil,
+        userInfoKeys: [NSError.UserInfoKey]? = nil,
         file: FileString = #file, line: UInt = #line
     ) {
         let nsError = error.asPurchasesError as NSError
@@ -53,7 +53,7 @@ class BaseErrorTests: XCTestCase {
         }
 
         if let userInfoKeys = userInfoKeys {
-            expect(nsError.userInfo.keys).to(contain(userInfoKeys))
+            expect(nsError.userInfo.keys).to(contain(userInfoKeys as [String]))
         }
     }
 

--- a/Tests/UnitTests/Networking/HTTPResponseTests.swift
+++ b/Tests/UnitTests/Networking/HTTPResponseTests.swift
@@ -31,7 +31,7 @@ class ErrorResponseTests: XCTestCase {
 
         expect(error.domain) == ErrorCode.errorDomain
         expect(error.code) == ErrorCode.invalidCredentialsError.rawValue
-        expect(error.userInfo[ErrorDetails.attributeErrorsKey as String]).to(beNil())
+        expect(error.userInfo[ErrorDetails.attributeErrorsKey]).to(beNil())
 
         let underlyingError = try XCTUnwrap(error.userInfo[NSUnderlyingErrorKey] as? NSError)
 
@@ -70,7 +70,7 @@ class ErrorResponseTests: XCTestCase {
 
         expect(error.domain) == ErrorCode.errorDomain
         expect(error.code) == ErrorCode.unknownBackendError.rawValue
-        expect(error.userInfo[ErrorDetails.attributeErrorsKey as String]).to(beNil())
+        expect(error.userInfo[ErrorDetails.attributeErrorsKey]).to(beNil())
 
         let underlyingError = try XCTUnwrap(error.userInfo[NSUnderlyingErrorKey] as? NSError)
 
@@ -84,7 +84,7 @@ class ErrorResponseTests: XCTestCase {
 
         expect(error.domain) == ErrorCode.errorDomain
         expect(error.code) == ErrorCode.unknownBackendError.rawValue
-        expect(error.userInfo[ErrorDetails.attributeErrorsKey as String]).to(beNil())
+        expect(error.userInfo[ErrorDetails.attributeErrorsKey]).to(beNil())
 
         let underlyingError = try XCTUnwrap(error.userInfo[NSUnderlyingErrorKey] as? NSError)
 
@@ -98,7 +98,7 @@ class ErrorResponseTests: XCTestCase {
 
         expect(error.domain) == ErrorCode.errorDomain
         expect(error.code) == ErrorCode.invalidSubscriberAttributesError.rawValue
-        expect(error.userInfo[ErrorDetails.attributeErrorsKey as String] as? [String: String]) == [
+        expect(error.userInfo[ErrorDetails.attributeErrorsKey] as? [String: String]) == [
             "$email": "Email address is not a valid email."
         ]
 
@@ -114,7 +114,7 @@ class ErrorResponseTests: XCTestCase {
 
         expect(error.domain) == ErrorCode.errorDomain
         expect(error.code) == ErrorCode.invalidSubscriberAttributesError.rawValue
-        expect(error.userInfo[ErrorDetails.attributeErrorsKey as String] as? [String: String]) == [
+        expect(error.userInfo[ErrorDetails.attributeErrorsKey] as? [String: String]) == [
             "$email": "Email address is not a valid email."
         ]
 
@@ -135,7 +135,7 @@ class ErrorResponseTests: XCTestCase {
 
         expect(error.domain) == ErrorCode.errorDomain
         expect(error.code) == ErrorCode.unknownBackendError.rawValue
-        expect(error.userInfo[ErrorDetails.attributeErrorsKey as String]).to(beNil())
+        expect(error.userInfo[ErrorDetails.attributeErrorsKey]).to(beNil())
 
         let underlyingError = try XCTUnwrap(error.userInfo[NSUnderlyingErrorKey] as? NSError)
 

--- a/Tests/UnitTests/Networking/HTTPResponseTests.swift
+++ b/Tests/UnitTests/Networking/HTTPResponseTests.swift
@@ -31,7 +31,7 @@ class ErrorResponseTests: XCTestCase {
 
         expect(error.domain) == ErrorCode.errorDomain
         expect(error.code) == ErrorCode.invalidCredentialsError.rawValue
-        expect(error.userInfo[Backend.RCAttributeErrorsKey]).to(beNil())
+        expect(error.userInfo[ErrorDetails.attributeErrorsKey as String]).to(beNil())
 
         let underlyingError = try XCTUnwrap(error.userInfo[NSUnderlyingErrorKey] as? NSError)
 
@@ -70,7 +70,7 @@ class ErrorResponseTests: XCTestCase {
 
         expect(error.domain) == ErrorCode.errorDomain
         expect(error.code) == ErrorCode.unknownBackendError.rawValue
-        expect(error.userInfo[Backend.RCAttributeErrorsKey]).to(beNil())
+        expect(error.userInfo[ErrorDetails.attributeErrorsKey as String]).to(beNil())
 
         let underlyingError = try XCTUnwrap(error.userInfo[NSUnderlyingErrorKey] as? NSError)
 
@@ -84,7 +84,7 @@ class ErrorResponseTests: XCTestCase {
 
         expect(error.domain) == ErrorCode.errorDomain
         expect(error.code) == ErrorCode.unknownBackendError.rawValue
-        expect(error.userInfo[Backend.RCAttributeErrorsKey]).to(beNil())
+        expect(error.userInfo[ErrorDetails.attributeErrorsKey as String]).to(beNil())
 
         let underlyingError = try XCTUnwrap(error.userInfo[NSUnderlyingErrorKey] as? NSError)
 
@@ -98,7 +98,7 @@ class ErrorResponseTests: XCTestCase {
 
         expect(error.domain) == ErrorCode.errorDomain
         expect(error.code) == ErrorCode.invalidSubscriberAttributesError.rawValue
-        expect(error.userInfo[Backend.RCAttributeErrorsKey] as? [String: String]) == [
+        expect(error.userInfo[ErrorDetails.attributeErrorsKey as String] as? [String: String]) == [
             "$email": "Email address is not a valid email."
         ]
 
@@ -114,7 +114,7 @@ class ErrorResponseTests: XCTestCase {
 
         expect(error.domain) == ErrorCode.errorDomain
         expect(error.code) == ErrorCode.invalidSubscriberAttributesError.rawValue
-        expect(error.userInfo[Backend.RCAttributeErrorsKey] as? [String: String]) == [
+        expect(error.userInfo[ErrorDetails.attributeErrorsKey as String] as? [String: String]) == [
             "$email": "Email address is not a valid email."
         ]
 
@@ -135,7 +135,7 @@ class ErrorResponseTests: XCTestCase {
 
         expect(error.domain) == ErrorCode.errorDomain
         expect(error.code) == ErrorCode.unknownBackendError.rawValue
-        expect(error.userInfo[Backend.RCAttributeErrorsKey]).to(beNil())
+        expect(error.userInfo[ErrorDetails.attributeErrorsKey as String]).to(beNil())
 
         let underlyingError = try XCTUnwrap(error.userInfo[NSUnderlyingErrorKey] as? NSError)
 

--- a/Tests/UnitTests/Networking/NetworkErrorTests.swift
+++ b/Tests/UnitTests/Networking/NetworkErrorTests.swift
@@ -78,8 +78,8 @@ class NetworkErrorAsPurchasesErrorTests: BaseErrorTests {
         verifyPurchasesError(error,
                              expectedCode: .invalidCredentialsError,
                              underlyingError: underlyingError,
-                             userInfoKeys: [ErrorDetails.attributeErrorsKey,
-                                            ErrorDetails.statusCodeErrorKey])
+                             userInfoKeys: [.attributeErrors,
+                                            .statusCodeError])
 
         expect((error.asPurchasesError as NSError).subscriberAttributesErrors) == errorResponse.attributeErrors
     }

--- a/Tests/UnitTests/Networking/NetworkErrorTests.swift
+++ b/Tests/UnitTests/Networking/NetworkErrorTests.swift
@@ -78,8 +78,8 @@ class NetworkErrorAsPurchasesErrorTests: BaseErrorTests {
         verifyPurchasesError(error,
                              expectedCode: .invalidCredentialsError,
                              underlyingError: underlyingError,
-                             userInfoKeys: [Backend.RCAttributeErrorsKey,
-                                            Backend.RCStatusCodeErrorKey])
+                             userInfoKeys: [ErrorDetails.attributeErrorsKey,
+                                            ErrorDetails.statusCodeErrorKey])
 
         expect((error.asPurchasesError as NSError).subscriberAttributesErrors) == errorResponse.attributeErrors
     }

--- a/Tests/UnitTests/Networking/NetworkErrorTests.swift
+++ b/Tests/UnitTests/Networking/NetworkErrorTests.swift
@@ -78,7 +78,8 @@ class NetworkErrorAsPurchasesErrorTests: BaseErrorTests {
         verifyPurchasesError(error,
                              expectedCode: .invalidCredentialsError,
                              underlyingError: underlyingError,
-                             userInfoKeys: [Backend.RCAttributeErrorsKey])
+                             userInfoKeys: [Backend.RCAttributeErrorsKey,
+                                            Backend.RCStatusCodeErrorKey])
 
         expect((error.asPurchasesError as NSError).subscriberAttributesErrors) == errorResponse.attributeErrors
     }

--- a/Tests/UnitTests/Networking/NetworkErrorTests.swift
+++ b/Tests/UnitTests/Networking/NetworkErrorTests.swift
@@ -79,7 +79,7 @@ class NetworkErrorAsPurchasesErrorTests: BaseErrorTests {
                              expectedCode: .invalidCredentialsError,
                              underlyingError: underlyingError,
                              userInfoKeys: [.attributeErrors,
-                                            .statusCodeError])
+                                            .statusCode])
 
         expect((error.asPurchasesError as NSError).subscriberAttributesErrors) == errorResponse.attributeErrors
     }

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTestBase.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTestBase.swift
@@ -167,7 +167,7 @@ class BackendSubscriberAttributesTestBase: XCTestCase {
             requestPath: .postReceiptData,
             response: .init(
                 statusCode: .success,
-                response: validSubscriberResponse + [ErrorDetails.attributeErrorsResponseKey as String: attributeErrors]
+                response: validSubscriberResponse + [ErrorDetails.attributeErrorsResponseKey: attributeErrors]
             )
         )
 
@@ -255,7 +255,7 @@ class BackendSubscriberAttributesTestBase: XCTestCase {
 
         let error: NetworkError = .errorResponse(
             ErrorResponse.from([
-                ErrorDetails.attributeErrorsKey as String: [
+                ErrorDetails.attributeErrorsKey: [
                     [
                         "key_name": "$some_attribute",
                         "message": "wasn't valid"

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTestBase.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTestBase.swift
@@ -155,7 +155,7 @@ class BackendSubscriberAttributesTestBase: XCTestCase {
 
     func testPostReceiptWithSubscriberAttributesPassesErrorsToCallbackIfStatusCodeIsSuccess() throws {
         let attributeErrors = [
-            Backend.RCAttributeErrorsKey: [
+            ErrorDetails.attributeErrorsKey: [
                 [
                     "key_name": "$email",
                     "message": "email is not in valid format"
@@ -165,8 +165,10 @@ class BackendSubscriberAttributesTestBase: XCTestCase {
 
         self.mockHTTPClient.mock(
             requestPath: .postReceiptData,
-            response: .init(statusCode: .success,
-                            response: validSubscriberResponse + [Backend.RCAttributeErrorsResponseKey: attributeErrors])
+            response: .init(
+                statusCode: .success,
+                response: validSubscriberResponse + [ErrorDetails.attributeErrorsResponseKey as String: attributeErrors]
+            )
         )
 
         let subscriberAttributesByKey: [String: SubscriberAttribute] = [
@@ -253,7 +255,7 @@ class BackendSubscriberAttributesTestBase: XCTestCase {
 
         let error: NetworkError = .errorResponse(
             ErrorResponse.from([
-                Backend.RCAttributeErrorsKey: [
+                ErrorDetails.attributeErrorsKey as String: [
                     [
                         "key_name": "$some_attribute",
                         "message": "wasn't valid"


### PR DESCRIPTION
This could help debug these errors.

Thanks to the error refactor this only had to be put in one place.