### PR TITLE
`BackendErrorTests`: added explicit test for subscriber not found errors

### DIFF
--- a/Tests/UnitTests/Networking/BackendErrorTests.swift
+++ b/Tests/UnitTests/Networking/BackendErrorTests.swift
@@ -51,4 +51,20 @@ class BackendErrorTests: BaseErrorTests {
                              underlyingError: underlyingError as NSError)
     }
 
+    func testSubscriptionNotFoundErrorsArentSuccessfullySynced() {
+        // See https://github.com/RevenueCat/purchases-ios/pull/1479
+        // This test ensures that if that race condition does happen
+        // at least the attributes won't be marked as synced
+
+        let response = ErrorResponse(
+            code: .subscriptionNotFoundForCustomer,
+            message: "Subscription not found for subscriber",
+            attributeErrors: [:]
+        )
+
+        let error: BackendError = .networkError(.errorResponse(response, .notFoundError))
+
+        expect(error.successfullySynced) == false
+    }
+
 }


### PR DESCRIPTION
The race condition fixed #1479 is luckily not a big deal because posting the attributes would have been retried.
This test ensures that behavior in a concise way.