### PR TITLE
update all jobs to use Xcode 13.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -405,47 +405,47 @@ workflows:
   build-test:
     jobs:
       - lint:
-          xcode_version: '13.2.1'
+          xcode_version: '13.3.0'
       - run-test-ios-15:
-          xcode_version: '13.2.1'
+          xcode_version: '13.3.0'
       - run-test-tvos:
-          xcode_version: '13.2.1'
+          xcode_version: '13.3.0'
       - run-test-ios-14:
-          xcode_version: '13.2.1'
+          xcode_version: '13.3.0'
       - run-test-ios-12:
-          xcode_version: '13.2.1'
+          xcode_version: '13.3.0'
           <<: *release-branches-and-main
       - build-tv-watch-and-macos:
-          xcode_version: '13.2.1'
+          xcode_version: '13.3.0'
       - release-checks:
-          xcode_version: '13.2.1'
+          xcode_version: '13.3.0'
           <<: *release-branches
       - backend-integration-tests:
-          xcode_version: '13.2.1'
+          xcode_version: '13.3.0'
           filters:
               branches:
                 # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
                 ignore: /pull\/[0-9]+/
       - installation-tests-cocoapods:
-          xcode_version: '13.2.1'
+          xcode_version: '13.3.0'
           <<: *release-tags-and-branches
       - installation-tests-swift-package-manager:
-          xcode_version: '13.2.1'
+          xcode_version: '13.3.0'
           <<: *release-tags-and-branches
       - installation-tests-carthage:
-          xcode_version: '13.2.1'
+          xcode_version: '13.3.0'
           <<: *release-tags-and-branches
       - installation-tests-xcode-direct-integration:
-          xcode_version: '13.2.1'
+          xcode_version: '13.3.0'
           <<: *release-tags-and-branches
   deploy:
     jobs:
       - make-release:
-          xcode_version: '13.2.1'
+          xcode_version: '13.3.0'
           <<: *release-tags
       - prepare-next-version:
-          xcode_version: '13.2.1'
+          xcode_version: '13.3.0'
           <<: *release-tags
       - docs-deploy:
-          xcode_version: '13.2.1'
+          xcode_version: '13.3.0'
           <<: *release-tags


### PR DESCRIPTION
Updates all CircleCI jobs to use Xcode 13.3.0. 

This also fixes the `docs_deploy` job, which needs 13.3.0 for static page generation with DocC. 