### PR TITLE
test: fix flakiness in CI

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		2DE20B8626409EB8004C597D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2DE20B8526409EB8004C597D /* Assets.xcassets */; };
 		2DE20B8926409EB8004C597D /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2DE20B8826409EB8004C597D /* Preview Assets.xcassets */; };
 		2DE20B9226409ECF004C597D /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2DE20B9126409ECF004C597D /* StoreKit.framework */; };
+		2DE21DE928046EAA002297A4 /* StoreKitConfigTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D90F8CB26FD2BA1009B9142 /* StoreKitConfigTestCase.swift */; };
 		2DE61A84264190830021CEA0 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE61A83264190830021CEA0 /* Constants.swift */; };
 		2DEAC2DD26EFE46E006914ED /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DEAC2DC26EFE46E006914ED /* AppDelegate.swift */; };
 		2DEAC2E126EFE46E006914ED /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DEAC2E026EFE46E006914ED /* ViewController.swift */; };
@@ -2406,6 +2407,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2DE21DE928046EAA002297A4 /* StoreKitConfigTestCase.swift in Sources */,
 				2DA85A8B26DEA7DD00F1136D /* MockProductsRequestFactory.swift in Sources */,
 				2D3BFAD326DEA47100370B11 /* MockSKProductDiscount.swift in Sources */,
 				57DE80BE28077010008D6C6F /* XCTestCase+Extensions.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -119,6 +119,8 @@
 		2DE20B8926409EB8004C597D /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2DE20B8826409EB8004C597D /* Preview Assets.xcassets */; };
 		2DE20B9226409ECF004C597D /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2DE20B9126409ECF004C597D /* StoreKit.framework */; };
 		2DE21DE928046EAA002297A4 /* StoreKitConfigTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D90F8CB26FD2BA1009B9142 /* StoreKitConfigTestCase.swift */; };
+		2DE21DEC280470B0002297A4 /* UnitTestsConfiguration.storekit in Resources */ = {isa = PBXBuildFile; fileRef = 2D43017726EBFD7100BAB891 /* UnitTestsConfiguration.storekit */; };
+		2DE21DED280470B0002297A4 /* UnitTestsConfiguration.storekit in Resources */ = {isa = PBXBuildFile; fileRef = 2D43017726EBFD7100BAB891 /* UnitTestsConfiguration.storekit */; };
 		2DE61A84264190830021CEA0 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE61A83264190830021CEA0 /* Constants.swift */; };
 		2DEAC2DD26EFE46E006914ED /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DEAC2DC26EFE46E006914ED /* AppDelegate.swift */; };
 		2DEAC2E126EFE46E006914ED /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DEAC2E026EFE46E006914ED /* ViewController.swift */; };
@@ -1987,6 +1989,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2CD2C544278CE0E0005D1CC2 /* RevenueCat_IntegrationPurchaseTesterConfiguration.storekit in Resources */,
+				2DE21DED280470B0002297A4 /* UnitTestsConfiguration.storekit in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1994,6 +1997,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2DE21DEC280470B0002297A4 /* UnitTestsConfiguration.storekit in Resources */,
 				2DE20B8926409EB8004C597D /* Preview Assets.xcassets in Resources */,
 				2DE20B8626409EB8004C597D /* Assets.xcassets in Resources */,
 			);

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -26,9 +26,8 @@ final class TestPurchaseDelegate: NSObject, PurchasesDelegate {
 
 }
 
-class BaseBackendIntegrationTests: XCTestCase {
+class BaseBackendIntegrationTests: StoreKitConfigTestCase {
 
-    private var userDefaults: UserDefaults!
     // swiftlint:disable:next weak_delegate
     private(set) var purchasesDelegate: TestPurchaseDelegate!
 

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -21,9 +21,8 @@ class StoreKit2IntegrationTests: StoreKit1IntegrationTests {
 
 class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
 
-    private var testSession: SKTestSession!
-
     private static let timeout: DispatchTimeInterval = .seconds(10)
+    override var storeKitConfigFileName: String { Constants.storeKitConfigFileName }
 
     override func setUp() async throws {
         try await super.setUp()

--- a/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -21,6 +21,7 @@ import XCTest
 class StoreKitConfigTestCase: XCTestCase {
 
     static var requestTimeout: DispatchTimeInterval = .seconds(60)
+    var storeKitConfigFileName: String { "UnitTestsConfiguration" }
 
     private static var hasWaited = false
     private static let waitLock = Lock()
@@ -33,7 +34,7 @@ class StoreKitConfigTestCase: XCTestCase {
     var userDefaults: UserDefaults!
 
     override func setUpWithError() throws {
-        testSession = try SKTestSession(configurationFileNamed: "UnitTestsConfiguration")
+        testSession = try SKTestSession(configurationFileNamed: storeKitConfigFileName)
         testSession.resetToDefaultState()
         testSession.disableDialogs = true
         testSession.clearTransactions()


### PR DESCRIPTION
`BackendIntegrationTests` are flaky right now in CI, but they're fine locally. We get failures from different tests on each run. 

I think this may be happening because `BackendIntegrationTests` started using SKTest, and SKTest needs time to initialize, but we didn't add that to `BackendIntegrationTests`. 

We do have an artificial delay for `StoreKitConfigTestCase`. 

So this ugly PR just makes `BaseBackendIntegrationTests` a subclass of `StoreKitConfigTestCase` so that it gets this artificial delay. 

