### PR TITLE
Fix non-attribution integrations from trying to collect attribution data

### DIFF
--- a/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -76,15 +76,15 @@ class SubscriberAttributesManager {
     }
 
     func setOnesignalID(_ onesignalID: String?, appUserID: String) {
-        setAttributionID(onesignalID, forNetworkID: .oneSignalID, appUserID: appUserID)
+        setReservedAttribute(.oneSignalID, value: onesignalID, appUserID: appUserID)
     }
 
     func setAirshipChannelID(_ airshipChannelID: String?, appUserID: String) {
-        setAttributionID(airshipChannelID, forNetworkID: .airshipChannelID, appUserID: appUserID)
+        setReservedAttribute(.airshipChannelID, value: airshipChannelID, appUserID: appUserID)
     }
 
     func setCleverTapID(_ cleverTapID: String?, appUserID: String) {
-        setAttributionID(cleverTapID, forNetworkID: .cleverTapID, appUserID: appUserID)
+        setReservedAttribute(.cleverTapID, value: cleverTapID, appUserID: appUserID)
     }
 
     func setMixpanelDistinctID(_ mixpanelDistinctID: String?, appUserID: String) {

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -371,6 +371,26 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
             .to(equal((nil, purchases.appUserID)))
     }
 
+    func testSetAndClearCleverTapID() {
+        setupPurchases()
+        purchases.setCleverTapID("clever")
+        purchases.setCleverTapID(nil)
+        expect(self.mockSubscriberAttributesManager.invokedSetCleverTapIDParametersList[0])
+            .to(equal(("clever", purchases.appUserID)))
+        expect(self.mockSubscriberAttributesManager.invokedSetCleverTapIDParametersList[1])
+            .to(equal((nil, purchases.appUserID)))
+    }
+
+    func testSetAndClearMixpanelDistinctID() {
+        setupPurchases()
+        purchases.setMixpanelDistinctID("mixp")
+        purchases.setMixpanelDistinctID(nil)
+        expect(self.mockSubscriberAttributesManager.invokedSetMixpanelDistinctIDParametersList[0])
+            .to(equal(("mixp", purchases.appUserID)))
+        expect(self.mockSubscriberAttributesManager.invokedSetMixpanelDistinctIDParametersList[1])
+            .to(equal((nil, purchases.appUserID)))
+    }
+
     func testSetAndClearMediaSource() {
         setupPurchases()
         purchases.setMediaSource("media")

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -849,7 +849,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
     func testSetOnesignalID() {
         let onesignalID = "onesignalID"
         self.subscriberAttributesManager.setOnesignalID(onesignalID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -865,7 +865,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
 
         self.subscriberAttributesManager.setOnesignalID(nil, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 8
+        expect(self.mockDeviceCache.invokedStoreCount) == 2
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -883,7 +883,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
 
         self.subscriberAttributesManager.setOnesignalID(onesignalID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 3
+        expect(self.mockDeviceCache.invokedStoreCount) == 0
     }
 
     func testSetOnesignalIDOverwritesIfNewValue() {
@@ -897,7 +897,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
 
         self.subscriberAttributesManager.setOnesignalID(onesignalID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
         guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
             fatalError("no attributes received")
         }
@@ -908,14 +908,14 @@ class SubscriberAttributesManagerTests: XCTestCase {
         expect(receivedAttribute.setTime) > oldSyncTime
     }
 
-    func testSetOnesignalIDSetsDeviceIdentifiers() {
+    func testSetOnesignalIDDoesNotSetDeviceIdentifiers() {
         let onesignalID = "onesignalID"
         self.subscriberAttributesManager.setOnesignalID(onesignalID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
 
-        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 4
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 1
 
-        checkDeviceIdentifiersAreSet()
+        checkDeviceIdentifiersAreNotSet()
     }
     // endregion
     // region AirshipChannelID
@@ -923,7 +923,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
         let airshipChannelID = "airshipChannelID"
 
         self.subscriberAttributesManager.setAirshipChannelID(airshipChannelID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
 
         let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
         let receivedAttribute = invokedParams.attribute
@@ -939,7 +939,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
         self.subscriberAttributesManager.setAirshipChannelID(airshipChannelID, appUserID: "kratos")
         self.subscriberAttributesManager.setAirshipChannelID(nil, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 8
+        expect(self.mockDeviceCache.invokedStoreCount) == 2
 
         let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
         let receivedAttribute = invokedParams.attribute
@@ -956,7 +956,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
                                                                                     value: airshipChannelID)
         self.subscriberAttributesManager.setAirshipChannelID(airshipChannelID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 3
+        expect(self.mockDeviceCache.invokedStoreCount) == 0
     }
 
     func testSetAirshipChannelIDOverwritesIfNewValue() throws {
@@ -970,7 +970,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
 
         self.subscriberAttributesManager.setAirshipChannelID(airshipChannelID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
 
         let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
         let receivedAttribute = invokedParams.attribute
@@ -981,14 +981,14 @@ class SubscriberAttributesManagerTests: XCTestCase {
         expect(receivedAttribute.setTime) > oldSyncTime
     }
 
-    func testSetAirshipChannelIDSetsDeviceIdentifiers() {
+    func testSetAirshipChannelIDDoesNotSetDeviceIdentifiers() {
         let airshipChannelID = "airshipChannelID"
         self.subscriberAttributesManager.setAirshipChannelID(airshipChannelID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
 
-        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 4
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 1
 
-        checkDeviceIdentifiersAreSet()
+        checkDeviceIdentifiersAreNotSet()
     }
     // endregion
     // region CleverTapID
@@ -996,7 +996,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
         let cleverTapID = "cleverTapID"
 
         self.subscriberAttributesManager.setCleverTapID(cleverTapID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
 
         let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
         let receivedAttribute = invokedParams.attribute
@@ -1012,7 +1012,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
         self.subscriberAttributesManager.setCleverTapID(cleverTapID, appUserID: "kratos")
         self.subscriberAttributesManager.setCleverTapID(nil, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 8
+        expect(self.mockDeviceCache.invokedStoreCount) == 2
 
         let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
         let receivedAttribute = invokedParams.attribute
@@ -1029,7 +1029,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
                                                                                     value: cleverTapID)
         self.subscriberAttributesManager.setCleverTapID(cleverTapID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 3
+        expect(self.mockDeviceCache.invokedStoreCount) == 0
     }
 
     func testSetCleverTapIDOverwritesIfNewValue() throws {
@@ -1043,7 +1043,7 @@ class SubscriberAttributesManagerTests: XCTestCase {
 
         self.subscriberAttributesManager.setCleverTapID(cleverTapID, appUserID: "kratos")
 
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
 
         let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
         let receivedAttribute = invokedParams.attribute
@@ -1054,14 +1054,14 @@ class SubscriberAttributesManagerTests: XCTestCase {
         expect(receivedAttribute.setTime) > oldSyncTime
     }
 
-    func testSetCleverTapIDSetsDeviceIdentifiers() {
+    func testSetCleverTapIDDoesNotSetDeviceIdentifiers() {
         let cleverTapID = "cleverTapID"
         self.subscriberAttributesManager.setCleverTapID(cleverTapID, appUserID: "kratos")
-        expect(self.mockDeviceCache.invokedStoreCount) == 4
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
 
-        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 4
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 1
 
-        checkDeviceIdentifiersAreSet()
+        checkDeviceIdentifiersAreNotSet()
     }
     // endregion
     // region MixpanelDistinctID
@@ -1125,6 +1125,16 @@ class SubscriberAttributesManagerTests: XCTestCase {
         expect(receivedAttribute.value) == mixpanelDistinctID
         expect(receivedAttribute.isSynced) == false
         expect(receivedAttribute.setTime) > oldSyncTime
+    }
+
+    func testSetMixpanelDistinctIDDoesNotSetDeviceIdentifiers() {
+        let mixpanelDistinctID = "mixpanelDistinctID"
+        self.subscriberAttributesManager.setMixpanelDistinctID(mixpanelDistinctID, appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 1
+
+        checkDeviceIdentifiersAreNotSet()
     }
     // endregion
     // region Media source
@@ -1598,6 +1608,19 @@ private extension SubscriberAttributesManagerTests {
 
         expect(ipReceived.value) == "true"
         expect(ipReceived.isSynced) == false
+    }
+
+    func checkDeviceIdentifiersAreNotSet() {
+        let invokedParams = self.mockDeviceCache.invokedStoreParametersList
+
+        let idfvNilAttribute = invokedParams.first(where: { $0.attribute.key == "$idfv" })
+        expect(idfvNilAttribute) == nil
+
+        let idfvaNilAttribute = invokedParams.first(where: { $0.attribute.key == "$idfa" })
+        expect(idfvaNilAttribute) == nil
+
+        let ipNilAttribute = invokedParams.first(where: { $0.attribute.key == "$ip" })
+        expect(ipNilAttribute) == nil
     }
 
 }


### PR DESCRIPTION
For [CF-449](https://revenuecats.atlassian.net/browse/CF-449)

### Motivation
[OneSignal](https://docs.revenuecat.com/docs/onesignal), [Airship](https://docs.revenuecat.com/docs/airship), and [CleverTap](https://docs.revenuecat.com/docs/clevertap) are not attribution providers and the convenience setters should only be setting single subscriber attributes, and not additional device identifiers required for attribution providers.

### Description
Each of the integrations now only set their single specific subscriber attribute, and attempt to collect no other identifiers.
