### PR TITLE
`StoreKitIntegrationTests`: removed incorrect `waitUntilCustomerInfoIsUpdated` and fixed race condition

### DIFF
--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -36,8 +36,8 @@ class BaseBackendIntegrationTests: XCTestCase {
         return .default
     }
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    override func setUp() async throws {
+        try await super.setUp()
 
         // Avoid continuing with potentially bad data after a failed assertion
         self.continueAfterFailure = false

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -78,8 +78,6 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
     }
 
     func testPurchaseMadeBeforeLogInWithExistingUserIsNotRetainedUnlessRestoreCalled() async throws {
-        self.testSession.timeRate = .realTime
-
         let existingUserID = "\(UUID().uuidString)"
 
         // log in to create the user, then log out

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -118,7 +118,7 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
         // `SKTestSession` ignores the override done by `Purchases.simulatesAskToBuyInSandbox = true`
         self.testSession.askToBuyEnabled = true
 
-        try await Purchases.shared.logIn(UUID().uuidString)
+        _ = try await Purchases.shared.logIn(UUID().uuidString)
 
         do {
             try await self.purchaseMonthlyOffering()


### PR DESCRIPTION
This is probably a leftover from before integration tests got changed to async.

`Purchases` initialization can fetch an updated `CustomerInfo`, so assuming this will be 1 is a race condition waiting to happen, because there are potentially multiple customer info requests happening.

Also, SDK initialization begins with an initial request to offerings, which results in a get-create of the initial anonymous user. To avoid race conditions with when this request finishes and make all tests deterministic, integration tests now wait for the initial get offerings to finish

## Changes:
- Removed `waitUntilCustomerInfoIsUpdated`
- `verifyEntitlementWentThrough` now calls `verifyEntitlementWentThrough` to verify the `CustomerInfo` has the correct entitlement
- No longer checking the `PurchasesDelegate.customerInfo` in all tests, which could lead to race conditions
- Added a single test that verifies the delegate is notified. This might still be flaky, but at least this issue should be isolated to that new test now.
- Fixed race condition