### PR TITLE
`PurchasesOrchestrator`: added logs for completed and failed purchases

### DIFF
--- a/Sources/Logging/Logger.swift
+++ b/Sources/Logging/Logger.swift
@@ -130,7 +130,7 @@ extension Logger {
                          fileName: String = #fileID,
                          functionName: String = #function,
                          line: UInt = #line) {
-        log(level: .debug, intent: .purchase, message: message.description,
+        log(level: .info, intent: .purchase, message: message.description,
             fileName: fileName, functionName: functionName, line: line)
     }
 

--- a/Sources/Logging/Logger.swift
+++ b/Sources/Logging/Logger.swift
@@ -142,6 +142,14 @@ extension Logger {
             fileName: fileName, functionName: functionName, line: line)
     }
 
+    static func rcPurchaseError(_ message: CustomStringConvertible,
+                                fileName: String = #fileID,
+                                functionName: String = #function,
+                                line: UInt = #line) {
+        log(level: .error, intent: .purchase, message: message.description,
+            fileName: fileName, functionName: functionName, line: line)
+    }
+
     static func rcSuccess(_ message: CustomStringConvertible,
                           fileName: String = #fileID,
                           functionName: String = #function,

--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -30,6 +30,8 @@ enum PurchaseStrings {
     case purchases_synced
     case purchasing_product_from_package(productIdentifier: String, offeringIdentifier: String)
     case purchasing_product(productIdentifier: String)
+    case purchased_product(productIdentifier: String)
+    case product_purchase_failed(productIdentifier: String, error: Error)
     case skpayment_missing_from_skpaymenttransaction
     case skpayment_missing_product_identifier
     case sktransaction_missing_transaction_date
@@ -117,10 +119,16 @@ extension PurchaseStrings: CustomStringConvertible {
             return "Purchases synced."
 
         case let .purchasing_product_from_package(productIdentifier, offeringIdentifier):
-            return "Purchasing product from package  - \(productIdentifier) in Offering \(offeringIdentifier)"
+            return "Purchasing product from package '\(productIdentifier)' in Offering '\(offeringIdentifier)'"
 
         case .purchasing_product(let productIdentifier):
-            return "Purchasing product - \(productIdentifier)"
+            return "Purchasing product '\(productIdentifier)'"
+
+        case let .purchased_product(productIdentifier):
+            return "Purchased product - '\(productIdentifier)'"
+
+        case let .product_purchase_failed(productIdentifier, error):
+            return "Product purchase for '\(productIdentifier)' failed with error: \(error)"
 
         case .skpayment_missing_from_skpaymenttransaction:
             return "There is a problem with the " +


### PR DESCRIPTION
Follow up to #1489

Examples:
> 2022-04-11 14:36:08.815265-0700 UnitTestsHostApp[58688:3901390] [Purchases] - INFO: 😻💰 Purchased product - 'com.revenuecat.monthly_4.99.1_week_intro'
> 2022-04-11 14:37:31.793204-0700 BackendIntegrationTestsHostApp[58835:3904176] [Purchases] - ERROR: 💰 Product purchase for 'com.revenuecat.monthly_4.99.1_week_intro' failed with error: Error Domain=RevenueCat.ErrorCode Code=34 "The information associated with this PromotionalOffer is not valid.