### PR TITLE
Integration Tests: localized test IAP to avoid warnings

### DIFF
--- a/Tests/TestingApps/PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit
+++ b/Tests/TestingApps/PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit
@@ -134,8 +134,8 @@
           },
           "localizations" : [
             {
-              "description" : "",
-              "displayName" : "",
+              "description" : "Annual subscription with a 1 week free trial",
+              "displayName" : "Annual subscription",
               "locale" : "en_US"
             }
           ],


### PR DESCRIPTION
Fixes the noisy console warning:
> Empty Product titles are not supported. Found in product with identifier: com.revenuecat.annual_39.99.2_week_intro