### PR TITLE
StoreKit 2 purchases: removed double request to `syncPurchases`

### DIFF
--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
@@ -102,10 +102,13 @@ private extension StoreKit2TransactionListener {
         }
     }
 
+    /// - Returns `nil` only if the delegate isn't set.
     func finish(transaction: StoreKit.Transaction) async throws -> CustomerInfo? {
         await transaction.finish()
 
-        return try await delegate?.transactionsUpdated()
+        guard let delegate = self.delegate else { return nil }
+
+        return try await delegate.transactionsUpdated()
     }
 
 }

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -326,25 +326,30 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
+        backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
-        orchestrator.transactionsUpdated()
+        let customerInfo = try await orchestrator.transactionsUpdated()
 
         expect(self.backend.invokedPostReceiptData).to(beTrue())
         expect(self.backend.invokedPostReceiptDataParameters?.isRestore).to(beFalse())
+        expect(customerInfo) == mockCustomerInfo
     }
 
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testStoreKit2TransactionListenerDelegateWithObserverMode() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         try setUpSystemInfo(finishTransactions: false)
         setUpOrchestrator()
 
+        backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
 
-        orchestrator.transactionsUpdated()
+        let customerInfo = try await orchestrator.transactionsUpdated()
 
         expect(self.backend.invokedPostReceiptData).to(beTrue())
         expect(self.backend.invokedPostReceiptDataParameters?.isRestore).to(beTrue())
+        expect(customerInfo) == mockCustomerInfo
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)

--- a/Tests/StoreKitUnitTests/StoreKit2TransactionListenerTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2TransactionListenerTests.swift
@@ -51,18 +51,20 @@ class StoreKit2TransactionListenerTests: StoreKitConfigTestCase {
 
         let fakeTransaction = try await createTransactionWithPurchase()
 
-        let (isCancelled, transaction) = try await self.listener.handle(
+        let (isCancelled, customerInfo, transaction) = try await self.listener.handle(
             purchaseResult: .success(.verified(fakeTransaction))
         )
         expect(isCancelled) == false
+        expect(customerInfo).to(beNil())
         expect(transaction) == fakeTransaction
     }
 
     func testIsCancelledIsTrueWhenPurchaseIsCancelled() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        let (isCancelled, transaction) = try await self.listener.handle(purchaseResult: .userCancelled)
+        let (isCancelled, customerInfo, transaction) = try await self.listener.handle(purchaseResult: .userCancelled)
         expect(isCancelled) == true
+        expect(customerInfo).to(beNil())
         expect(transaction).to(beNil())
     }
 

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionListener.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionListener.swift
@@ -65,13 +65,13 @@ class MockStoreKit2TransactionListener: StoreKit2TransactionListener {
 
     override func handle(
         purchaseResult: StoreKit.Product.PurchaseResult
-    ) async throws -> (userCancelled: Bool, transaction: SK2Transaction?) {
+    ) async throws -> ResultData {
         invokedHandle = true
         invokedHandleCount += 1
         invokedHandleParameters = (.init(purchaseResult), ())
         invokedHandleParametersList.append((.init(purchaseResult), ()))
 
-        return (false, mockTransaction.value)
+        return (false, nil, mockTransaction.value)
     }
 }
 


### PR DESCRIPTION
`StoreKit2TransactionListener` was triggering an asynchronous call to `syncPurchases` during transaction verification, and at the end of every purchase, another `syncPurchases` call was being made.
This refactor combines both calls into one by making `finish(transaction:)` wait for that call to finish.