### PR TITLE
Unit Tests: localized test IAP to avoid warnings

### DIFF
--- a/Tests/StoreKitUnitTests/UnitTestsConfiguration.storekit
+++ b/Tests/StoreKitUnitTests/UnitTestsConfiguration.storekit
@@ -25,7 +25,7 @@
       "localizations" : [
         {
           "description" : "",
-          "displayName" : "",
+          "displayName" : "Lifetime subscription",
           "locale" : "en_US"
         }
       ],
@@ -40,7 +40,7 @@
       "localizations" : [
         {
           "description" : "",
-          "displayName" : "",
+          "displayName" : "Consumable IAP",
           "locale" : "en_US"
         }
       ],
@@ -117,8 +117,8 @@
           },
           "localizations" : [
             {
-              "description" : "",
-              "displayName" : "",
+              "description" : "Annual Subscription with 2 weeks Free Trial",
+              "displayName" : "Annual Subscription",
               "locale" : "en_US"
             }
           ],

--- a/Tests/UnitTests/Mocks/MockSK1Product.swift
+++ b/Tests/UnitTests/Mocks/MockSK1Product.swift
@@ -8,10 +8,13 @@ import StoreKit
 // swiftlint:disable line_length
 class MockSK1Product: SK1Product {
     var mockProductIdentifier: String
+    var mockLocalizedTitle: String
 
     init(mockProductIdentifier: String, mockSubscriptionGroupIdentifier: String? = nil) {
         self.mockProductIdentifier = mockProductIdentifier
         self.mockSubscriptionGroupIdentifier = mockSubscriptionGroupIdentifier
+        self.mockLocalizedTitle = mockProductIdentifier
+
         super.init()
     }
 
@@ -32,6 +35,10 @@ class MockSK1Product: SK1Product {
     var mockPrice: Decimal?
     override var price: NSDecimalNumber {
         return (mockPrice ?? 2.99) as NSDecimalNumber
+    }
+
+    override var localizedTitle: String {
+        return self.mockLocalizedTitle
     }
 
     @available(iOS 11.2, macCatalyst 13.0, tvOS 11.2, macOS 10.13.2, *)


### PR DESCRIPTION
Same as #1494 but for Unit Tests.
This makes the logs during tests a lot less noisy.