### PR TITLE
Added new `ErrorCode.offlineConnectionError`

### DIFF
--- a/Sources/Error Handling/ErrorCode.swift
+++ b/Sources/Error Handling/ErrorCode.swift
@@ -57,6 +57,7 @@ import Foundation
     @objc(RCProductRequestTimedOut) case productRequestTimedOut = 32
     @objc(RCAPIEndpointBlocked) case apiEndpointBlockedError = 33
     @objc(RCInvalidPromotionalOfferError) case invalidPromotionalOfferError = 34
+    @objc(RCOfflineConnectionError) case offlineConnectionError = 35
 
     // swiftlint:enable missing_docs
 }
@@ -157,6 +158,9 @@ extension ErrorCode: DescribableError {
                    The information associated with this PromotionalOffer is not valid.
                    See https://rev.cat/ios-subscription-offers for more info.
                    """
+        case .offlineConnectionError:
+            return "Error performing request because the Internet Connection appears to be offline."
+
         @unknown default:
             return "Something went wrong."
         }
@@ -253,6 +257,8 @@ extension ErrorCode {
             return "API_ENDPOINT_BLOCKED_ERROR"
         case .invalidPromotionalOfferError:
             return "INVALID_PROMOTIONAL_OFFER_ERROR"
+        case .offlineConnectionError:
+            return "OFFLINE_CONNECTION_ERROR"
         @unknown default:
             return "UNRECOGNIZED_ERROR"
         }

--- a/Sources/Error Handling/ErrorCode.swift
+++ b/Sources/Error Handling/ErrorCode.swift
@@ -159,7 +159,7 @@ extension ErrorCode: DescribableError {
                    See https://rev.cat/ios-subscription-offers for more info.
                    """
         case .offlineConnectionError:
-            return "Error performing request because the Internet Connection appears to be offline."
+            return "Error performing request because the internet connection appears to be offline."
 
         @unknown default:
             return "Something went wrong."

--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -15,7 +15,7 @@
 import Foundation
 import StoreKit
 
-// swiftlint:disable file_length multiline_parameters
+// swiftlint:disable file_length multiline_parameters type_body_length
 
 enum ErrorUtils {
 
@@ -46,6 +46,16 @@ enum ErrorUtils {
                      message: message,
                      underlyingError: underlyingError,
                      extraUserInfo: extraUserInfo,
+                     fileName: fileName, functionName: functionName, line: line)
+    }
+
+    /**
+     * Constructs an NSError with the ``ErrorCode/offlineConnection`` code.
+     */
+    static func offlineConnectionError(
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> Error {
+        return error(with: .offlineConnectionError,
                      fileName: fileName, functionName: functionName, line: line)
     }
 
@@ -472,8 +482,10 @@ private extension ErrorUtils {
         userInfo[.file] = "\(fileName):\(line)"
         userInfo[.function] = functionName
 
-        Self.logErrorIfNeeded(code,
-                              fileName: fileName, functionName: functionName, line: line)
+        Self.logErrorIfNeeded(
+            code,
+            fileName: fileName, functionName: functionName, line: line
+        )
 
         let nsError = code as NSError
         let nsErrorWithUserInfo = NSError(domain: nsError.domain,
@@ -512,6 +524,7 @@ private extension ErrorUtils {
         return backendCode.addingUserInfo(userInfo)
     }
 
+    // swiftlint:disable:next function_body_length
     private static func logErrorIfNeeded(_ code: ErrorCode,
                                          fileName: String = #fileID,
                                          functionName: String = #function,
@@ -538,8 +551,14 @@ private extension ErrorUtils {
                 .systemInfoError,
                 .beginRefundRequestError,
                 .apiEndpointBlockedError,
-                .invalidPromotionalOfferError:
-            Logger.error(code.description)
+                .invalidPromotionalOfferError,
+                .offlineConnectionError:
+                Logger.error(
+                    code.description,
+                    fileName: fileName,
+                    functionName: functionName,
+                    line: line
+                )
 
         case .purchaseCancelledError,
                 .storeProblemError,
@@ -554,10 +573,20 @@ private extension ErrorUtils {
                 .insufficientPermissionsError,
                 .paymentPendingError,
                 .productRequestTimedOut:
-            Logger.appleError(code.description)
+                Logger.appleError(
+                    code.description,
+                    fileName: fileName,
+                    functionName: functionName,
+                    line: line
+                )
 
         @unknown default:
-            Logger.error(code.description)
+            Logger.error(
+                code.description,
+                fileName: fileName,
+                functionName: functionName,
+                line: line
+            )
         }
     }
 }

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesErrorCodeAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesErrorCodeAPI.m
@@ -57,6 +57,7 @@
         case RCBeginRefundRequestError:
         case RCAPIEndpointBlocked:
         case RCInvalidPromotionalOfferError:
+        case RCOfflineConnectionError:
             NSLog(@"%ld", (long)errCode);
     }
 }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/ErrorCodesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/ErrorCodesAPI.swift
@@ -51,7 +51,8 @@ func checkPurchasesErrorCodeEnums() {
          .beginRefundRequestError,
          .productRequestTimedOut,
          .apiEndpointBlockedError,
-         .invalidPromotionalOfferError:
+         .invalidPromotionalOfferError,
+         .offlineConnectionError:
         print(errCode!)
     @unknown default:
         fatalError()

--- a/Tests/UnitTests/Networking/NetworkErrorTests.swift
+++ b/Tests/UnitTests/Networking/NetworkErrorTests.swift
@@ -62,6 +62,13 @@ class NetworkErrorAsPurchasesErrorTests: BaseErrorTests {
                              userInfoKeys: ["response"])
     }
 
+    func testOfflineConnection() {
+        let error: NetworkError = .offlineConnection()
+
+        verifyPurchasesError(error,
+                             expectedCode: .offlineConnectionError)
+    }
+
     func testErrorResponse() throws {
         let errorResponse = ErrorResponse(code: .invalidAPIKey,
                                           message: "Invalid API key",
@@ -107,6 +114,7 @@ class NetworkErrorTests: XCTestCase {
     func testSuccessfullySyncedFalse() {
         let errors = [
             error(Self.decodingError),
+            error(Self.offlineError),
             error(Self.networkError),
             error(Self.dnsError),
             error(Self.unableToCreateRequestError),
@@ -144,6 +152,7 @@ class NetworkErrorTests: XCTestCase {
     func testFinishableFalse() {
         let errors = [
             error(Self.decodingError),
+            error(Self.offlineError),
             error(Self.networkError),
             error(Self.dnsError),
             error(Self.unableToCreateRequestError),
@@ -183,6 +192,7 @@ class NetworkErrorTests: XCTestCase {
         )
     }
 
+    private static let offlineError: NetworkError = .offlineConnection()
     private static let decodingError: NetworkError = .decoding(NSError(domain: "domain", code: 20), Data())
     private static let networkError: NetworkError = .networkError(NSError(domain: "domain", code: 30))
     private static let dnsError: NetworkError = .dnsError(failedURL: URL(string: "https://google.com")!,

--- a/Tests/UnitTests/Purchasing/ErrorCodeTests.swift
+++ b/Tests/UnitTests/Purchasing/ErrorCodeTests.swift
@@ -167,8 +167,13 @@ class ErrorCodeTests: XCTestCase {
                                               expectedRawValue: 34)
     }
 
+    func testOfflineConnectionError() {
+        ensureEnumCaseMatchesExpectedRawValue(errorCode: .offlineConnectionError,
+                                              expectedRawValue: 35)
+    }
+
     func testErrorCodeEnumCasesAreCoveredInTests() {
-        expect(ErrorCode.allCases).to(haveCount(35))
+        expect(ErrorCode.allCases).to(haveCount(36))
     }
 
     func ensureEnumCaseMatchesExpectedRawValue(errorCode: ErrorCode, expectedRawValue: Int) {


### PR DESCRIPTION
This is a special enough error that it's worth distinguishing from other `ErrorCode.networkError`s.

I see a couple benefits:
- When opening an app that has the SDK, this used to print lots of errors that just said "Error performing request". Now it's more clear what's happening
- Users can respond to failed calls to the SDK more appropriately, whereas before it might not be clear why a request failed.

Also fixed `logErrorIfNeeded` not passing the file/function/line parameters to the log functions.