### PR TITLE
Integration Tests: added `number_of_retries` parameter to match iOS tests

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -373,6 +373,7 @@ platform :ios do
       scheme: "BackendIntegrationTests", 
       derived_data_path: "scan_derived_data",
       output_types: 'junit',
+      number_of_retries: 3,
       output_directory: "fastlane/test_output/xctest/ios"
     )
   end


### PR DESCRIPTION
Might help with flaky tests too.