### PR TITLE
`CircleCI`: fixed iOS 15 simulator versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ jobs:
           name: Run tests
           command: bundle exec fastlane test_ios
           environment:
-            SCAN_DEVICE: iPhone 12 (15.2)
+            SCAN_DEVICE: iPhone 12 (15.4)
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:
@@ -277,7 +277,7 @@ jobs:
           name: Run backend_integration Tests
           command: bundle exec fastlane backend_integration_tests
           environment:
-            SCAN_DEVICE: iPhone 11 Pro (15.2)
+            SCAN_DEVICE: iPhone 11 Pro (15.4)
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:


### PR DESCRIPTION
This fixes the following error:
> [12:36:21]: No simulators found that are equal to the version of specifier (15.2) and greater than or equal to the version of deployment target (0)
> [12:36:21]: Ignoring 'iPhone 12 (15.2)', couldn’t find matching simulator
> [12:36:21]: Couldn't find any matching simulators for '["iPhone 12 (15.2)"]' - falling back to default simulator
> [12:36:21]: Found simulator "iPhone 8 (14.5)"

Neither iOS 15 nor Integration Tests were actually running on iOS 15, probably since we switched to Xcode 13.3.