### PR TITLE
`CircleCI`: install iOS 13 simulator to fix iOS 13 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,6 +224,11 @@ jobs:
     steps:
       - checkout
       - install-dependencies
+      - install-and-create-sim:
+          install-name: iOS 13.7 Simulator
+          sim-device-type: iPhone-8
+          sim-device-runtime: iOS-13-7
+          sim-name: iPhone 8 (13.7)
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios


### PR DESCRIPTION
Follow up to #1503.

Fixes the following error:
> [12:36:18]: No simulators found that are equal to the version of specifier (13.7) and greater than or equal to the version of deployment target (0)
> [12:36:18]: Ignoring 'iPhone 8 (13.7)', couldn’t find matching simulator
> [12:36:18]: Couldn't find any matching simulators for '["iPhone 8 (13.7)"]' - falling back to default simulator
> [12:36:18]: Found simulator "iPhone 8 (14.5)"

The tests weren't actually running on iOS 13.x.