### PR TITLE
`ErrorUtils`: fixed duplicate error logs and logging underlying errors

### DIFF
--- a/Sources/Error Handling/BackendError.swift
+++ b/Sources/Error Handling/BackendError.swift
@@ -104,7 +104,26 @@ extension BackendError: ErrorCodeConvertible {
 
 }
 
-extension BackendError: DescribableError { }
+extension BackendError: DescribableError {
+
+    var description: String {
+        switch self {
+        case let .networkError(error):
+            return error.description
+        case .missingAppUserID:
+            return ErrorCode.invalidAppUserIdError.description
+        case .emptySubscriberAttributes:
+            return ErrorCode.emptySubscriberAttributes.description
+        case .missingReceiptFile:
+            return ErrorCode.missingReceiptFileError.description
+        case .missingTransactionProductIdentifier:
+            return Strings.purchase.skpayment_missing_product_identifier.description
+        case let .unexpectedBackendResponse(error, _, _):
+            return error.description
+        }
+    }
+
+}
 
 extension BackendError {
 

--- a/Sources/Error Handling/ErrorCode.swift
+++ b/Sources/Error Handling/ErrorCode.swift
@@ -277,11 +277,3 @@ protocol ErrorCodeConvertible: Swift.Error {
     var asPurchasesError: Error { get }
 
 }
-
-extension ErrorCodeConvertible {
-
-    var description: String {
-        return self.asPurchasesError.localizedDescription
-    }
-
-}

--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -484,6 +484,7 @@ private extension ErrorUtils {
 
         Self.logErrorIfNeeded(
             code,
+            underlyingError: underlyingError,
             fileName: fileName, functionName: functionName, line: line
         )
 
@@ -526,9 +527,10 @@ private extension ErrorUtils {
 
     // swiftlint:disable:next function_body_length
     private static func logErrorIfNeeded(_ code: ErrorCode,
-                                         fileName: String = #fileID,
-                                         functionName: String = #function,
-                                         line: UInt = #line) {
+                                         underlyingError: Error?,
+                                         fileName: String,
+                                         functionName: String,
+                                         line: UInt) {
         switch code {
         case .networkError,
                 .unknownError,
@@ -583,6 +585,16 @@ private extension ErrorUtils {
         @unknown default:
             Logger.error(
                 code.description,
+                fileName: fileName,
+                functionName: functionName,
+                line: line
+            )
+        }
+
+        // Also print underylying error if present
+        if let description = underlyingError?.localizedDescription, !description.isEmpty {
+            Logger.error(
+                description,
                 fileName: fileName,
                 functionName: functionName,
                 line: line

--- a/Sources/Networking/NetworkError.swift
+++ b/Sources/Networking/NetworkError.swift
@@ -155,7 +155,28 @@ extension NetworkError: ErrorCodeConvertible {
 
 }
 
-extension NetworkError: DescribableError {}
+extension NetworkError: DescribableError {
+
+    var description: String {
+        switch self {
+        case let .decoding(error, _):
+            return error.localizedDescription
+        case .offlineConnection:
+            return ErrorCode.offlineConnectionError.description
+        case let .networkError(error, _):
+            return error.localizedDescription
+        case let .dnsError(failedURL, resolvedHost, _):
+            return NetworkStrings.blocked_network(url: failedURL, newHost: resolvedHost).description
+        case .unableToCreateRequest:
+            return ErrorCode.networkError.description
+        case .unexpectedResponse:
+            return ErrorCode.unexpectedBackendResponseError.description
+        case let .errorResponse(response, _, _):
+            return response.code.toPurchasesErrorCode().description
+        }
+    }
+
+}
 
 extension NetworkError {
 


### PR DESCRIPTION
## Changes:
- Removed default conformance of `ErrorCodeConvertible` to `DescribableError`. This implementation called `asPurchasesError`, which created the error through `ErrorUtils`, leading to calling `logErrorIfNeeded` more than once.
- `logErrorIfNeeded` now logs the underlying error if it's present.

Example:
> 2022-04-14 16:05:15.557712+0200 xctest[88464:5783875] [Purchases] - ERROR: 🍎‼️ The product is not available for purchase.
> 2022-04-14 16:05:15.558381+0200 xctest[88464:5783875] [Purchases] - ERROR: 😿‼️ The operation couldn’t be completed. (SKErrorDomain error 5.)