### PR TITLE
Logging: removed duplicate log and cleared some warning noise

### DIFF
--- a/Sources/Purchasing/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/PurchasesOrchestrator.swift
@@ -626,7 +626,6 @@ private extension PurchasesOrchestrator {
                         self.storeKitWrapper.finishTransaction(transaction)
                     }
                 } else {
-                    Logger.error(error)
                     completion?(storeTransaction, nil, purchasesError, false)
                 }
             }

--- a/Tests/StoreKitUnitTests/StoreTransactionTests.swift
+++ b/Tests/StoreKitUnitTests/StoreTransactionTests.swift
@@ -56,6 +56,7 @@ class StoreTransactionTests: StoreKitConfigTestCase {
 
     func testSk1TransactionDateBecomesAnInvalidDateIfNoDate() {
         let sk1Transaction = MockTransaction()
+        sk1Transaction.mockTransactionDate = nil
         sk1Transaction.mockPayment = SKPayment(product: MockSK1Product(mockProductIdentifier: ""))
 
         let transaction = StoreTransaction(sk1Transaction: sk1Transaction)
@@ -67,6 +68,7 @@ class StoreTransactionTests: StoreKitConfigTestCase {
         let payment = SKPayment(product: product)
 
         let sk1Transaction = MockTransaction()
+        sk1Transaction.mockTransactionIdentifier = nil
         sk1Transaction.mockPayment = payment
 
         let transaction = StoreTransaction(sk1Transaction: sk1Transaction)

--- a/Tests/UnitTests/Mocks/MockTransaction.swift
+++ b/Tests/UnitTests/Mocks/MockTransaction.swift
@@ -22,12 +22,12 @@ class MockTransaction: SKPaymentTransaction {
         mockError
     }
 
-    var mockTransactionDate: Date?
+    var mockTransactionDate: Date? = Date()
     override var transactionDate: Date? {
         mockTransactionDate
     }
 
-    var mockTransactionIdentifier: String?
+    var mockTransactionIdentifier: String? = UUID().uuidString
     override var transactionIdentifier: String? {
         mockTransactionIdentifier
     }


### PR DESCRIPTION
Clears a bunch of these errors:
> 2022-04-14 15:57:25.051397+0200 xctest[86968:5767146] [Purchases] - WARN: 🍎‼️ There is a problem with the SKPaymentTransaction missing a transaction date - this is an issue with the App Store.
> 2022-04-14 15:57:25.051530+0200 xctest[86968:5767146] [Purchases] - WARN: 🍎‼️ There is a problem with the SKPaymentTransaction missing a transaction identifier - this is an issue with the App Store.
