### PR TITLE
`CircleCI`: increased `make-release`'s `no_output_timeout` to 30 minutes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,6 +329,7 @@ jobs:
       - run:
           name: Deploy new version
           command: bundle exec fastlane release
+          no_output_timeout: 30m
 
   prepare-next-version:
     <<: *base-job


### PR DESCRIPTION
See [documentation](https://support.circleci.com/hc/en-us/articles/360007188574-Build-has-hit-timeout-limit). The default value is 10 minutes.
Fixes [CF-528].

[CF-528]: https://revenuecats.atlassian.net/browse/CF-528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ