### PR TITLE
Fixed build phases order in target

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -1764,8 +1764,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2DC5622724EC63430031F69B /* Build configuration list for PBXNativeTarget "RevenueCat" */;
 			buildPhases = (
-				2DC5621124EC63420031F69B /* Headers */,
 				2DC5621224EC63420031F69B /* Sources */,
+				2DC5621124EC63420031F69B /* Headers */,
 				2DC5621324EC63420031F69B /* Frameworks */,
 				2DC5621424EC63420031F69B /* Resources */,
 				B3C302D926D8066F002B72D1 /* SwiftLint */,


### PR DESCRIPTION
See [Xcode 10's known issues](https://developer.apple.com/documentation/xcode-release-notes/build-system-release-notes-for-xcode-10) in the release notes:

> Targets with Copy Headers build phases ordered after Compile Sources build phases may fail to build and emit a diagnostic regarding build cycles. (39880168)
>*Workaround*: Arrange any Copy Headers build phases before Compile Sources build phases.

This has been an issue for nearly 4 years, and now with Xcode 13.3 it leads to `XCBBuildService` to crash consistently.