### PR TITLE
Expose `shouldShowPriceConsent` on PurchasesDelegate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,12 +179,17 @@ jobs:
     steps:
       - checkout
       - install-dependencies
+      - install-and-create-sim:
+          install-name: iOS 15.4 Simulator
+          sim-device-type: iPhone-13
+          sim-device-runtime: iOS-15-4
+          sim-name: iPhone 13 (15.4)
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios
           no_output_timeout: 30m
           environment:
-            SCAN_DEVICE: iPad mini (6th generation)
+            SCAN_DEVICE: iPhone 13 (15.4)
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
           command: bundle exec fastlane test_ios
           no_output_timeout: 30m
           environment:
-            SCAN_DEVICE: iPad Pro (12.9-inch) (4th generation) (15.4)
+            SCAN_DEVICE: iPad Pro (15.4)
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
           command: bundle exec fastlane test_ios
           no_output_timeout: 30m
           environment:
-            SCAN_DEVICE: iPhone 13 (15.2)
+            SCAN_DEVICE: iPhone 13 (15.4)
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,14 +182,14 @@ jobs:
       - install-and-create-sim:
           install-name: iOS 15.4 Simulator
           sim-device-type: iPhone-13
-          sim-device-runtime: iOS-15-4
-          sim-name: iPhone 13 (15.4)
+          sim-device-runtime: iOS-15-2
+          sim-name: iPhone 13 (15.2)
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios
           no_output_timeout: 30m
           environment:
-            SCAN_DEVICE: iPhone 13 (15.4)
+            SCAN_DEVICE: iPhone 13 (15.2)
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,12 +179,17 @@ jobs:
     steps:
       - checkout
       - install-dependencies
+      - install-and-create-sim:
+          install-name: iOS 15.2 Simulator
+          sim-device-type: iPhone-13
+          sim-device-runtime: iOS-15-2
+          sim-name: iPhone 13 (15.2)
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios
           no_output_timeout: 30m
           environment:
-            SCAN_DEVICE: iPad mini (6th generation)
+            SCAN_DEVICE: iPhone 13 (15.2)
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
           command: bundle exec fastlane test_ios
           no_output_timeout: 30m
           environment:
-            SCAN_DEVICE: iPad Pro (15.4)
+            SCAN_DEVICE: iPad mini (6th generation)
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
           command: bundle exec fastlane test_ios
           no_output_timeout: 30m
           environment:
-            SCAN_DEVICE: iPhone 13 (15.4)
+            SCAN_DEVICE: iPad mini (6th generation)
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -433,50 +433,50 @@ workflows:
   build-test:
     jobs:
       - lint:
-          xcode_version: '13.3.0'
+          xcode_version: '13.3.1'
       - run-test-ios-15:
-          xcode_version: '13.3.0'
+          xcode_version: '13.3.1'
       - run-test-tvos:
-          xcode_version: '13.3.0'
+          xcode_version: '13.3.1'
       - run-test-ios-14:
-          xcode_version: '13.3.0'
+          xcode_version: '13.3.1'
       - run-test-ios-13:
-          xcode_version: '13.3.0'
+          xcode_version: '13.3.1'
           <<: *release-branches-and-main
       - run-test-ios-12:
-          xcode_version: '13.3.0'
+          xcode_version: '13.3.1'
           <<: *release-branches-and-main
       - build-tv-watch-and-macos:
-          xcode_version: '13.3.0'
+          xcode_version: '13.3.1'
       - release-checks:
-          xcode_version: '13.3.0'
+          xcode_version: '13.3.1'
           <<: *release-branches
       - backend-integration-tests:
-          xcode_version: '13.3.0'
+          xcode_version: '13.3.1'
           filters:
               branches:
                 # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
                 ignore: /pull\/[0-9]+/
       - installation-tests-cocoapods:
-          xcode_version: '13.3.0'
+          xcode_version: '13.3.1'
           <<: *release-tags-and-branches
       - installation-tests-swift-package-manager:
-          xcode_version: '13.3.0'
+          xcode_version: '13.3.1'
           <<: *release-tags-and-branches
       - installation-tests-carthage:
-          xcode_version: '13.3.0'
+          xcode_version: '13.3.1'
           <<: *release-tags-and-branches
       - installation-tests-xcode-direct-integration:
-          xcode_version: '13.3.0'
+          xcode_version: '13.3.1'
           <<: *release-tags-and-branches
   deploy:
     jobs:
       - make-release:
-          xcode_version: '13.3.0'
+          xcode_version: '13.3.1'
           <<: *release-tags
       - prepare-next-version:
-          xcode_version: '13.3.0'
+          xcode_version: '13.3.1'
           <<: *release-tags
       - docs-deploy:
-          xcode_version: '13.3.0'
+          xcode_version: '13.3.1'
           <<: *release-tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,11 +179,6 @@ jobs:
     steps:
       - checkout
       - install-dependencies
-      - install-and-create-sim:
-          install-name: iOS 15.2 Simulator
-          sim-device-type: iPhone-13
-          sim-device-runtime: iOS-15-2
-          sim-name: iPhone 13 (15.2)
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ jobs:
           command: bundle exec fastlane test_ios
           no_output_timeout: 30m
           environment:
-            SCAN_DEVICE: iPhone 12 (15.4)
+            SCAN_DEVICE: iPad Pro (12.9-inch) (4th generation) (15.4)
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,7 @@ jobs:
       - checkout
       - install-dependencies
       - install-and-create-sim:
-          install-name: iOS 15.4 Simulator
+          install-name: iOS 15.2 Simulator
           sim-device-type: iPhone-13
           sim-device-runtime: iOS-15-2
           sim-name: iPhone 13 (15.2)

--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -1403,13 +1403,19 @@ public extension Purchases {
      * Displays price consent sheet if needed. You only need to call this manually if you implement
      * ``PurchasesDelegate/shouldShowPriceConsent()`` and return false at some point.
      *
+     * You may want to delay showing the sheet if it would interrupt your user’s interaction in your app. You can do
+     * this by implementing ``PurchasesDelegate/shouldShowPriceConsent()``.
+     *
      * In most cases, you don't _*typically*_ implement ``PurchasesDelegate/shouldShowPriceConsent()``, therefore,
      * you won't need to call this.
+     *
+     * ### Related Symbols
+     * - ``SKPaymentQueue/showPriceConsentIfNeeded``
+     *
+     * ### Related Articles
+     * - [Apple Documentation](https://rev.cat/testing-promoted-in-app-purchases)
      */
     @available(iOS 13.4, macCatalyst 13.4, *)
-    @available(macOS, unavailable)
-    @available(tvOS, unavailable)
-    @available(watchOS, unavailable)
     @objc func showPriceConsentIfNeeded() {
         self.storeKitWrapper.showPriceConsentIfNeeded()
     }
@@ -1849,9 +1855,6 @@ extension Purchases: PurchasesOrchestratorDelegate {
     #if os(iOS) || targetEnvironment(macCatalyst)
     @objc
     @available(iOS 13.4, macCatalyst 13.4, *)
-    @available(macOS, unavailable)
-    @available(tvOS, unavailable)
-    @available(watchOS, unavailable)
     internal func shouldShowPriceConsent() -> Bool {
         self.delegate?.shouldShowPriceConsent?() ?? true
     }

--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -1410,7 +1410,7 @@ public extension Purchases {
      * you won't need to call this.
      *
      * ### Related Symbols
-     * - ``SKPaymentQueue/showPriceConsentIfNeeded``
+     * - ``SKPaymentQueue/showPriceConsentIfNeeded()`
      *
      * ### Related Articles
      * - [Apple Documentation](https://rev.cat/testing-promoted-in-app-purchases)

--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -1846,16 +1846,14 @@ extension Purchases: PurchasesOrchestratorDelegate {
      * once the app is ready to start the purchase flow.
      * When the purchase completes, the result will be part of the callback parameters.
      */
-    @objc
-    internal func readyForPromotedProduct(_ product: StoreProduct,
-                                          purchase startPurchase: @escaping StartPurchaseBlock) {
+    func readyForPromotedProduct(_ product: StoreProduct,
+                                 purchase startPurchase: @escaping StartPurchaseBlock) {
         self.delegate?.purchases?(self, readyForPromotedProduct: product, purchase: startPurchase)
     }
 
     #if os(iOS) || targetEnvironment(macCatalyst)
-    @objc
     @available(iOS 13.4, macCatalyst 13.4, *)
-    internal func shouldShowPriceConsent() -> Bool {
+    func shouldShowPriceConsent() -> Bool {
         self.delegate?.shouldShowPriceConsent?() ?? true
     }
     #endif

--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -1398,6 +1398,23 @@ public extension Purchases {
         return await checkTrialOrIntroductoryDiscountEligibilityAsync(product)
     }
 
+#if os(iOS) || targetEnvironment(macCatalyst)
+    /**
+     * Displays price consent sheet if needed. You only need to call this manually if you implement
+     * ``PurchasesDelegate/shouldShowPriceConsent()`` and return false at some point.
+     *
+     * In most cases, you don't _*typically*_ implement ``PurchasesDelegate/shouldShowPriceConsent()``, therefore,
+     * you won't need to call this.
+     */
+    @available(iOS 13.4, macCatalyst 13.4, *)
+    @available(macOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    @objc func showPriceConsentIfNeeded() {
+        self.storeKitWrapper.showPriceConsentIfNeeded()
+    }
+#endif
+
     /**
      * Invalidates the cache for customer information.
      *
@@ -1410,7 +1427,7 @@ public extension Purchases {
      * promotional subscription is granted through the RevenueCat dashboard.
      */
     @objc func invalidateCustomerInfoCache() {
-        customerInfoManager.clearCustomerInfoCache(forAppUserID: appUserID)
+        self.customerInfoManager.clearCustomerInfoCache(forAppUserID: appUserID)
     }
 
 #if os(iOS)
@@ -1423,7 +1440,7 @@ public extension Purchases {
     @available(macOS, unavailable)
     @available(macCatalyst, unavailable)
     @objc func presentCodeRedemptionSheet() {
-        storeKitWrapper.presentCodeRedemptionSheet()
+        self.storeKitWrapper.presentCodeRedemptionSheet()
     }
 #endif
 
@@ -1828,6 +1845,17 @@ extension Purchases: PurchasesOrchestratorDelegate {
                                           purchase startPurchase: @escaping StartPurchaseBlock) {
         self.delegate?.purchases?(self, readyForPromotedProduct: product, purchase: startPurchase)
     }
+
+    #if os(iOS) || targetEnvironment(macCatalyst)
+    @objc
+    @available(iOS 13.4, macCatalyst 13.4, *)
+    @available(macOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    internal func shouldShowPriceConsent() -> Bool {
+        self.delegate?.shouldShowPriceConsent?() ?? true
+    }
+    #endif
 
 }
 

--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -1401,12 +1401,12 @@ public extension Purchases {
 #if os(iOS) || targetEnvironment(macCatalyst)
     /**
      * Displays price consent sheet if needed. You only need to call this manually if you implement
-     * ``PurchasesDelegate/shouldShowPriceConsent()`` and return false at some point.
+     * ``PurchasesDelegate/shouldShowPriceConsent`` and return false at some point.
      *
      * You may want to delay showing the sheet if it would interrupt your user’s interaction in your app. You can do
-     * this by implementing ``PurchasesDelegate/shouldShowPriceConsent()``.
+     * this by implementing ``PurchasesDelegate/shouldShowPriceConsent``.
      *
-     * In most cases, you don't _*typically*_ implement ``PurchasesDelegate/shouldShowPriceConsent()``, therefore,
+     * In most cases, you don't _*typically*_ implement ``PurchasesDelegate/shouldShowPriceConsent``, therefore,
      * you won't need to call this.
      *
      * ### Related Symbols
@@ -1854,7 +1854,7 @@ extension Purchases: PurchasesOrchestratorDelegate {
     #if os(iOS) || targetEnvironment(macCatalyst)
     @available(iOS 13.4, macCatalyst 13.4, *)
     func shouldShowPriceConsent() -> Bool {
-        self.delegate?.shouldShowPriceConsent?() ?? true
+        self.delegate?.shouldShowPriceConsent ?? true
     }
     #endif
 

--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -1853,7 +1853,7 @@ extension Purchases: PurchasesOrchestratorDelegate {
 
     #if os(iOS) || targetEnvironment(macCatalyst)
     @available(iOS 13.4, macCatalyst 13.4, *)
-    func shouldShowPriceConsent() -> Bool {
+    var shouldShowPriceConsent: Bool {
         self.delegate?.shouldShowPriceConsent ?? true
     }
     #endif

--- a/Sources/Purchasing/PurchasesDelegate.swift
+++ b/Sources/Purchasing/PurchasesDelegate.swift
@@ -80,7 +80,7 @@ import Foundation
      * The default return value for this optional method is true. By default, the system displays the price consent
      * sheet when you increase the subscription price in App Store Connect and the subscriber hasn’t yet taken action.
      *
-     * The system calls your delegate’s method, if appropriate, when RevenueCat starts observing the SKPaymentQueue,
+     * The system calls your delegate’s method, if appropriate, when RevenueCat starts observing the `SKPaymentQueue`,
      * and any time the app comes to foreground.
      *
      * If you return false, the system won’t show the price consent sheet. You can choose to display it later by

--- a/Sources/Purchasing/PurchasesDelegate.swift
+++ b/Sources/Purchasing/PurchasesDelegate.swift
@@ -84,7 +84,7 @@ import Foundation
      * and any time the app comes to foreground.
      *
      * If you return false, the system won’t show the price consent sheet. You can choose to display it later by
-     * calling ``Purchases.showPriceConsentIfNeeded()``.
+     * calling ``Purchases/showPriceConsentIfNeeded()``.
      * You may want to delay showing the sheet if it would interrupt your user’s interaction in your app.
      *
      * ### Related Articles

--- a/Sources/Purchasing/PurchasesDelegate.swift
+++ b/Sources/Purchasing/PurchasesDelegate.swift
@@ -94,6 +94,6 @@ import Foundation
     @available(macOS, unavailable)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
-    @objc optional func shouldShowPriceConsent() -> Bool
+    @objc optional var shouldShowPriceConsent: Bool { get }
 
 }

--- a/Sources/Purchasing/PurchasesDelegate.swift
+++ b/Sources/Purchasing/PurchasesDelegate.swift
@@ -76,4 +76,24 @@ import Foundation
                                   shouldPurchasePromoProduct product: StoreProduct,
                                   defermentBlock makeDeferredPurchase: @escaping StartPurchaseBlock)
 
+    /**
+     * The default return value for this optional method is true. By default, the system displays the price consent
+     * sheet when you increase the subscription price in App Store Connect and the subscriber hasn’t yet taken action.
+     *
+     * The system calls your delegate’s method, if appropriate, when RevenueCat starts observing the SKPaymentQueue,
+     * and any time the app comes to foreground.
+     *
+     * If you return false, the system won’t show the price consent sheet. You can choose to display it later by
+     * calling ``Purchases.showPriceConsentIfNeeded()``.
+     * You may want to delay showing the sheet if it would interrupt your user’s interaction in your app.
+     *
+     * ### Related Articles
+     * - [Apple Documentation](https://rev.cat/testing-promoted-in-app-purchases)
+     */
+    @available(iOS 13.4, macCatalyst 13.4, *)
+    @available(macOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    @objc optional func shouldShowPriceConsent() -> Bool
+
 }

--- a/Sources/Purchasing/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/PurchasesOrchestrator.swift
@@ -471,7 +471,7 @@ extension PurchasesOrchestrator: StoreKitWrapperDelegate {
     @available(macOS, unavailable)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
-    func storeKitWrapperShouldShowPriceConsent() -> Bool {
+    var storeKitWrapperShouldShowPriceConsent: Bool {
         return delegate?.shouldShowPriceConsent() ?? true
     }
 

--- a/Sources/Purchasing/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/PurchasesOrchestrator.swift
@@ -23,7 +23,7 @@ import StoreKit
     @available(macOS, unavailable)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
-    func shouldShowPriceConsent() -> Bool
+    var shouldShowPriceConsent: Bool { get }
 
 }
 
@@ -472,7 +472,7 @@ extension PurchasesOrchestrator: StoreKitWrapperDelegate {
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     var storeKitWrapperShouldShowPriceConsent: Bool {
-        return delegate?.shouldShowPriceConsent() ?? true
+        return delegate?.shouldShowPriceConsent ?? true
     }
 
 }

--- a/Sources/Purchasing/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/PurchasesOrchestrator.swift
@@ -19,6 +19,12 @@ import StoreKit
     func readyForPromotedProduct(_ product: StoreProduct,
                                  purchase startPurchase: @escaping StartPurchaseBlock)
 
+    @available(iOS 13.4, macCatalyst 13.4, *)
+    @available(macOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    func shouldShowPriceConsent() -> Bool
+
 }
 
 // swiftlint:disable file_length type_body_length
@@ -459,6 +465,14 @@ extension PurchasesOrchestrator: StoreKitWrapperDelegate {
         syncPurchases { _ in
             Logger.debug(Strings.purchase.purchases_synced)
         }
+    }
+
+    @available(iOS 13.4, macCatalyst 13.4, *)
+    @available(macOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    func storeKitWrapperShouldShowPriceConsent() -> Bool {
+        return delegate?.shouldShowPriceConsent() ?? true
     }
 
 }

--- a/Sources/Purchasing/StoreKit1/StoreKitWrapper.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKitWrapper.swift
@@ -27,6 +27,14 @@ protocol StoreKitWrapperDelegate: AnyObject {
     func storeKitWrapper(_ storeKitWrapper: StoreKitWrapper,
                          didRevokeEntitlementsForProductIdentifiers productIdentifiers: [String])
 
+    #if os(iOS) || targetEnvironment(macCatalyst)
+    @available(iOS 13.4, macCatalyst 13.4, *)
+    @available(macOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    func storeKitWrapperShouldShowPriceConsent() -> Bool
+    #endif
+
 }
 
 class StoreKitWrapper: NSObject, SKPaymentTransactionObserver {
@@ -101,6 +109,16 @@ class StoreKitWrapper: NSObject, SKPaymentTransactionObserver {
         return payment
     }
 
+#if os(iOS) || targetEnvironment(macCatalyst)
+    @available(iOS 13.4, macCatalyst 13.4, *)
+    @available(macOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    func showPriceConsentIfNeeded() {
+        paymentQueue.showPriceConsentIfNeeded()
+    }
+#endif
+
 }
 
 extension StoreKitWrapper: SKPaymentQueueDelegate {
@@ -139,5 +157,15 @@ extension StoreKitWrapper: SKPaymentQueueDelegate {
         )
         delegate?.storeKitWrapper(self, didRevokeEntitlementsForProductIdentifiers: productIdentifiers)
     }
+
+    #if os(iOS) || targetEnvironment(macCatalyst)
+    @available(iOS 13.4, macCatalyst 13.4, *)
+    @available(macOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    func paymentQueueShouldShowPriceConsent(_ paymentQueue: SKPaymentQueue) -> Bool {
+        return delegate?.storeKitWrapperShouldShowPriceConsent() ?? true
+    }
+    #endif
 
 }

--- a/Sources/Purchasing/StoreKit1/StoreKitWrapper.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKitWrapper.swift
@@ -29,9 +29,6 @@ protocol StoreKitWrapperDelegate: AnyObject {
 
     #if os(iOS) || targetEnvironment(macCatalyst)
     @available(iOS 13.4, macCatalyst 13.4, *)
-    @available(macOS, unavailable)
-    @available(tvOS, unavailable)
-    @available(watchOS, unavailable)
     func storeKitWrapperShouldShowPriceConsent() -> Bool
     #endif
 
@@ -111,9 +108,6 @@ class StoreKitWrapper: NSObject, SKPaymentTransactionObserver {
 
 #if os(iOS) || targetEnvironment(macCatalyst)
     @available(iOS 13.4, macCatalyst 13.4, *)
-    @available(macOS, unavailable)
-    @available(tvOS, unavailable)
-    @available(watchOS, unavailable)
     func showPriceConsentIfNeeded() {
         paymentQueue.showPriceConsentIfNeeded()
     }
@@ -160,9 +154,6 @@ extension StoreKitWrapper: SKPaymentQueueDelegate {
 
     #if os(iOS) || targetEnvironment(macCatalyst)
     @available(iOS 13.4, macCatalyst 13.4, *)
-    @available(macOS, unavailable)
-    @available(tvOS, unavailable)
-    @available(watchOS, unavailable)
     func paymentQueueShouldShowPriceConsent(_ paymentQueue: SKPaymentQueue) -> Bool {
         return delegate?.storeKitWrapperShouldShowPriceConsent() ?? true
     }

--- a/Sources/Purchasing/StoreKit1/StoreKitWrapper.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKitWrapper.swift
@@ -29,7 +29,7 @@ protocol StoreKitWrapperDelegate: AnyObject {
 
     #if os(iOS) || targetEnvironment(macCatalyst)
     @available(iOS 13.4, macCatalyst 13.4, *)
-    func storeKitWrapperShouldShowPriceConsent() -> Bool
+    var storeKitWrapperShouldShowPriceConsent: Bool { get }
     #endif
 
 }
@@ -155,7 +155,7 @@ extension StoreKitWrapper: SKPaymentQueueDelegate {
     #if os(iOS) || targetEnvironment(macCatalyst)
     @available(iOS 13.4, macCatalyst 13.4, *)
     func paymentQueueShouldShowPriceConsent(_ paymentQueue: SKPaymentQueue) -> Bool {
-        return delegate?.storeKitWrapperShouldShowPriceConsent() ?? true
+        return delegate?.storeKitWrapperShouldShowPriceConsent ?? true
     }
     #endif
 

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj/project.pbxproj
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj/project.pbxproj
@@ -284,6 +284,7 @@
 				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -320,6 +321,7 @@
 				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -178,6 +178,7 @@ BOOL isAnonymous;
     [p beginRefundRequestForEntitlement:@"" completion:^(RCRefundRequestStatus s, NSError * _Nullable e) { }];
     [p beginRefundRequestForActiveEntitlementWithCompletion:^(RCRefundRequestStatus s, NSError * _Nullable e) { }];
     [p showPriceConsentIfNeeded];
+    BOOL consent __unused = [p.delegate shouldShowPriceConsent];
 #endif
 
 #if TARGET_OS_IPHONE && !TARGET_OS_TV

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -177,6 +177,7 @@ BOOL isAnonymous;
     [p beginRefundRequestForProduct:@"1234" completion:^(RCRefundRequestStatus s, NSError * _Nullable e) { }];
     [p beginRefundRequestForEntitlement:@"" completion:^(RCRefundRequestStatus s, NSError * _Nullable e) { }];
     [p beginRefundRequestForActiveEntitlementWithCompletion:^(RCRefundRequestStatus s, NSError * _Nullable e) { }];
+    [p showPriceConsentIfNeeded];
 #endif
 
 #if TARGET_OS_IPHONE && !TARGET_OS_TV

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj/project.pbxproj
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj/project.pbxproj
@@ -243,6 +243,7 @@
 				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -275,6 +276,7 @@
 				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -299,7 +301,6 @@
 		A55F62BA26EAFFD200A1B466 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
@@ -311,7 +312,6 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -360,7 +360,6 @@
 		A55F62BB26EAFFD200A1B466 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
@@ -372,7 +371,6 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PromotionalOfferAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PromotionalOfferAPI.swift
@@ -23,5 +23,5 @@ func checkPromotionalOfferAPI() {
     let signature: String = signedData.signature
     let timestamp: Int = signedData.timestamp
 
-    print(discount, sk1Discount!, sk2Discount!)
+    print(discount, sk1Discount!, sk2Discount!, identifier, keyIdentifier, nonce, signature, timestamp)
 }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -150,6 +150,7 @@ private func checkPurchasesSupportAPI(purchases: Purchases) {
     #endif
     #if os(iOS) || targetEnvironment(macCatalyst)
     purchases.showPriceConsentIfNeeded()
+    _ = purchases.delegate?.shouldShowPriceConsent?()
     #endif
 }
 

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -148,6 +148,9 @@ private func checkPurchasesSupportAPI(purchases: Purchases) {
     #if os(iOS)
     purchases.showManageSubscriptions { _ in }
     #endif
+    #if os(iOS) || targetEnvironment(macCatalyst)
+    purchases.showPriceConsentIfNeeded()
+    #endif
 }
 
 private func checkPurchasesSubscriberAttributesAPI(purchases: Purchases) {

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -149,8 +149,8 @@ private func checkPurchasesSupportAPI(purchases: Purchases) {
     purchases.showManageSubscriptions { _ in }
     #endif
     #if os(iOS) || targetEnvironment(macCatalyst)
-    purchases.showPriceConsentIfNeeded()
-    _ = purchases.delegate?.shouldShowPriceConsent?()
+    _ = purchases.showPriceConsentIfNeeded
+    _ = purchases.delegate?.shouldShowPriceConsent
     #endif
 }
 

--- a/Tests/UnitTests/Purchasing/StoreKitWrapperTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKitWrapperTests.swift
@@ -37,18 +37,10 @@ class MockPaymentQueue: SKPaymentQueue {
 
 #if os(iOS) || targetEnvironment(macCatalyst)
     @available(iOS 13.4, macCatalyst 13.4, *)
-    @available(macOS, unavailable)
-    @available(tvOS, unavailable)
-    @available(watchOS, unavailable)
     func simulatePaymentQueueShouldShowPriceConsent() -> [Bool] {
-        var observersPriceConsentStatus: [Bool] = []
-        for observer in self.observers where observer is SKPaymentQueueDelegate {
-            if let consent = (observer as? SKPaymentQueueDelegate)?.paymentQueueShouldShowPriceConsent?(self) {
-                observersPriceConsentStatus.append(consent)
-            }
-
-        }
-        return observersPriceConsentStatus
+        return self.observers
+            .compactMap { $0 as? SKPaymentQueueDelegate }
+            .compactMap { $0.paymentQueueShouldShowPriceConsent?(self) }
     }
 #endif
 
@@ -281,8 +273,7 @@ class StoreKitWrapperTests: XCTestCase, StoreKitWrapperDelegate {
         self.shouldShowPriceConsent = false
 
         let consentStatuses = self.paymentQueue.simulatePaymentQueueShouldShowPriceConsent()
-        expect(consentStatuses.count) == 1
-        expect(consentStatuses.first) == false
+        expect(consentStatuses) == [false]
     }
 #endif
 

--- a/Tests/UnitTests/Purchasing/StoreKitWrapperTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKitWrapperTests.swift
@@ -80,10 +80,7 @@ class StoreKitWrapperTests: XCTestCase, StoreKitWrapperDelegate {
         return shouldAddPromo
     }
 
-    var shouldShowPriceConsent = true
-    func storeKitWrapperShouldShowPriceConsent() -> Bool {
-        return shouldShowPriceConsent
-    }
+    var storeKitWrapperShouldShowPriceConsent = true
 
     var productIdentifiersWithRevokedEntitlements: [String]?
 
@@ -268,9 +265,9 @@ class StoreKitWrapperTests: XCTestCase, StoreKitWrapperDelegate {
         guard #available(iOS 13.4, macCatalyst 13.4, *) else {
             throw XCTSkip()
         }
-        expect(self.shouldShowPriceConsent) == true
+        expect(self.storeKitWrapperShouldShowPriceConsent) == true
 
-        self.shouldShowPriceConsent = false
+        self.storeKitWrapperShouldShowPriceConsent = false
 
         let consentStatuses = self.paymentQueue.simulatePaymentQueueShouldShowPriceConsent()
         expect(consentStatuses) == [false]


### PR DESCRIPTION
As well as `Purchases.showPriceConsentIfNeeded()` to manually handle showing the price consent if `shouldShowPriceConsent` is set to `false`

Resolves [CF-69]


[CF-69]: https://revenuecats.atlassian.net/browse/CF-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ