### PR TITLE
New public convenience setter for Firebase app instance ID

### DIFF
--- a/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
@@ -102,6 +102,7 @@ Most features require configuring the SDK before using it.
 - ``Purchases/setOnesignalID(_:)``
 - ``Purchases/setFBAnonymousID(_:)``
 - ``Purchases/setMixpanelDistinctID(_:)``
+- ``Purchases/setFirebaseAppInstanceID(_:)``
 
 ### Advanced Configuration
 - ``Purchases/finishTransactions``

--- a/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md
@@ -146,3 +146,4 @@ Or browse our iOS sample apps:
 - ``Purchases/setOnesignalID(_:)``
 - ``Purchases/setFBAnonymousID(_:)``
 - ``Purchases/setMixpanelDistinctID(_:)``
+- ``Purchases/setFirebaseAppInstanceID(_:)``

--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -628,6 +628,19 @@ extension Purchases {
     }
 
     /**
+     * Subscriber attribute associated with the Firebase App Instance ID for the user.
+     * Optional for the RevenueCat Firebase integration.
+     *
+     * #### Related Articles
+     * - [Firebase RevenueCat Integration](https://docs.revenuecat.com/docs/firebase-integration)
+     *
+     *- Parameter firebaseAppInstanceID: Empty String or `nil` will delete the subscriber attribute.
+     */
+    @objc public func setFirebaseAppInstanceID(_ firebaseAppInstanceID: String?) {
+        subscriberAttributesManager.setFirebaseAppInstanceID(firebaseAppInstanceID, appUserID: appUserID)
+    }
+
+    /**
      * Subscriber attribute associated with the install media source for the user.
      *
      * #### Related Articles

--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -629,7 +629,7 @@ extension Purchases {
 
     /**
      * Subscriber attribute associated with the Firebase App Instance ID for the user.
-     * Optional for the RevenueCat Firebase integration.
+     * Required for the RevenueCat Firebase integration.
      *
      * #### Related Articles
      * - [Firebase RevenueCat Integration](https://docs.revenuecat.com/docs/firebase-integration)

--- a/Sources/SubscriberAttributes/ReservedSubscriberAttributes.swift
+++ b/Sources/SubscriberAttributes/ReservedSubscriberAttributes.swift
@@ -39,6 +39,7 @@ enum ReservedSubscriberAttribute: String {
     case airshipChannelID = "$airshipChannelId"
     case cleverTapID = "$clevertapId"
     case mixpanelDistinctID = "$mixpanelDistinctId"
+    case firebaseAppInstanceID = "$firebaseAppInstanceId"
 
     case mediaSource = "$mediaSource"
     case campaign = "$campaign"

--- a/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -94,6 +94,10 @@ class SubscriberAttributesManager {
         setReservedAttribute(.mixpanelDistinctID, value: mixpanelDistinctID, appUserID: appUserID)
     }
 
+    func setFirebaseAppInstanceID(_ firebaseAppInstanceID: String?, appUserID: String) {
+        setReservedAttribute(.firebaseAppInstanceID, value: firebaseAppInstanceID, appUserID: appUserID)
+    }
+
     func setMediaSource(_ mediaSource: String?, appUserID: String) {
         setReservedAttribute(.mediaSource, value: mediaSource, appUserID: appUserID)
     }

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -127,6 +127,8 @@ BOOL isAnonymous;
     [p setCleverTapID: @""];
     [p setMixpanelDistinctID: nil];
     [p setMixpanelDistinctID: @""];
+    [p setFirebaseAppInstanceID: nil];
+    [p setFirebaseAppInstanceID: @""];
     [p setMediaSource: nil];
     [p setMediaSource: @""];
     [p setCampaign: nil];

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -163,6 +163,7 @@ private func checkPurchasesSubscriberAttributesAPI(purchases: Purchases) {
     purchases.setOnesignalID("")
     purchases.setCleverTapID("")
     purchases.setMixpanelDistinctID("")
+    purchases.setFirebaseAppInstanceID("")
     purchases.setMediaSource("")
     purchases.setCampaign("")
     purchases.setAdGroup("")

--- a/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
+++ b/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
@@ -178,6 +178,18 @@ class MockSubscriberAttributesManager: SubscriberAttributesManager {
         invokedSetMixpanelDistinctIDParametersList.append((mixpanelDistinctID, appUserID))
     }
 
+    var invokedSetFirebaseAppInstanceID = false
+    var invokedSetFirebaseAppInstanceIDCount = 0
+    var invokedSetFirebaseAppInstanceIDParameters: (firebaseAppInstanceID: String?, appUserID: String?)?
+    var invokedSetFirebaseAppInstanceIDParametersList = [(firebaseAppInstanceID: String?, appUserID: String?)]()
+
+    override func setFirebaseAppInstanceID(_ firebaseAppInstanceID: String?, appUserID: String) {
+        invokedSetFirebaseAppInstanceID = true
+        invokedSetFirebaseAppInstanceIDCount += 1
+        invokedSetFirebaseAppInstanceIDParameters = (firebaseAppInstanceID, appUserID)
+        invokedSetFirebaseAppInstanceIDParametersList.append((firebaseAppInstanceID, appUserID))
+    }
+
     var invokedSetMediaSource = false
     var invokedSetMediaSourceCount = 0
     var invokedSetMediaSourceParameters: (mediaSource: String?, appUserID: String?)?

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -395,6 +395,16 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
             .to(equal((nil, purchases.appUserID)))
     }
 
+    func testSetAndClearFirebaseAppInstanceID() {
+        setupPurchases()
+        purchases.setFirebaseAppInstanceID("fireb")
+        purchases.setFirebaseAppInstanceID(nil)
+        expect(self.mockSubscriberAttributesManager.invokedSetFirebaseAppInstanceIDParametersList[0])
+            .to(equal(("fireb", purchases.appUserID)))
+        expect(self.mockSubscriberAttributesManager.invokedSetFirebaseAppInstanceIDParametersList[1])
+            .to(equal((nil, purchases.appUserID)))
+    }
+
     func testSetAndClearMediaSource() {
         setupPurchases()
         purchases.setMediaSource("media")

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -556,6 +556,38 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
             .currentAppUserID
     }
 
+    func testSetAirshipChannelIDMakesRightCalls() {
+        setupPurchases()
+
+        Purchases.shared.setAirshipChannelID("123abc")
+        expect(self.mockSubscriberAttributesManager.invokedSetAirshipChannelIDCount) == 1
+        expect(self.mockSubscriberAttributesManager.invokedSetAirshipChannelIDParameters?.airshipChannelID) == "123abc"
+        expect(self.mockSubscriberAttributesManager.invokedSetAirshipChannelIDParameters?.appUserID) ==
+        mockIdentityManager.currentAppUserID
+    }
+
+    func testSetMixpanelDistinctIDMakesRightCalls() {
+        setupPurchases()
+
+        Purchases.shared.setMixpanelDistinctID("123abc")
+        expect(self.mockSubscriberAttributesManager.invokedSetMixpanelDistinctIDCount) == 1
+        expect(self.mockSubscriberAttributesManager.invokedSetMixpanelDistinctIDParameters?.mixpanelDistinctID) ==
+        "123abc"
+        expect(self.mockSubscriberAttributesManager.invokedSetMixpanelDistinctIDParameters?.appUserID) ==
+        mockIdentityManager.currentAppUserID
+    }
+
+    func testSetFirebaseAppInstanceIDMakesRightCalls() {
+        setupPurchases()
+
+        Purchases.shared.setFirebaseAppInstanceID("123abc")
+        expect(self.mockSubscriberAttributesManager.invokedSetFirebaseAppInstanceIDCount) == 1
+        expect(self.mockSubscriberAttributesManager.invokedSetFirebaseAppInstanceIDParameters?.firebaseAppInstanceID) ==
+        "123abc"
+        expect(self.mockSubscriberAttributesManager.invokedSetFirebaseAppInstanceIDParameters?.appUserID) ==
+        mockIdentityManager.currentAppUserID
+    }
+
     func testSetMediaSourceMakesRightCalls() {
         setupPurchases()
 

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -399,10 +399,10 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
         setupPurchases()
         purchases.setFirebaseAppInstanceID("fireb")
         purchases.setFirebaseAppInstanceID(nil)
-        expect(self.mockSubscriberAttributesManager.invokedSetFirebaseAppInstanceIDParametersList[0])
-            .to(equal(("fireb", purchases.appUserID)))
-        expect(self.mockSubscriberAttributesManager.invokedSetFirebaseAppInstanceIDParametersList[1])
-            .to(equal((nil, purchases.appUserID)))
+        expect(self.mockSubscriberAttributesManager.invokedSetFirebaseAppInstanceIDParametersList[0]) ==
+        ("fireb", purchases.appUserID)
+        expect(self.mockSubscriberAttributesManager.invokedSetFirebaseAppInstanceIDParametersList[1]) ==
+        (nil, purchases.appUserID)
     }
 
     func testSetAndClearMediaSource() {

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -1138,6 +1138,79 @@ class SubscriberAttributesManagerTests: XCTestCase {
         checkDeviceIdentifiersAreNotSet()
     }
     // endregion
+    // region FirebaseAppInstanceID
+    func testSetFirebaseAppInstanceID() throws {
+        let firebaseAppInstanceID = "firebaseAppInstanceID"
+
+        self.subscriberAttributesManager.setFirebaseAppInstanceID(firebaseAppInstanceID, appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$firebaseAppInstanceId"
+        expect(receivedAttribute.value) == firebaseAppInstanceID
+        expect(receivedAttribute.isSynced) == false
+    }
+
+    func testSetFirebaseAppInstanceIDSetsEmptyIfNil() throws {
+        let mixpanelDistinctID = "firebaseAppInstanceID"
+
+        self.subscriberAttributesManager.setFirebaseAppInstanceID(mixpanelDistinctID, appUserID: "kratos")
+        self.subscriberAttributesManager.setFirebaseAppInstanceID(nil, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 2
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$firebaseAppInstanceId"
+        expect(receivedAttribute.value) == ""
+        expect(receivedAttribute.isSynced) == false
+    }
+
+    func testSetFirebaseAppInstanceIDSkipsIfSameValue() {
+        let firebaseAppInstanceID = "firebaseAppInstanceID"
+
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$firebaseAppInstanceId",
+                                                                                    value: firebaseAppInstanceID)
+        self.subscriberAttributesManager.setFirebaseAppInstanceID(firebaseAppInstanceID, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 0
+    }
+
+    func testSetFirebaseAppInstanceIDOverwritesIfNewValue() throws {
+        let oldSyncTime = Date()
+        let firebaseAppInstanceID = "firebaseAppInstanceID"
+
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$firebaseAppInstanceId",
+                                                                                    value: "old_id",
+                                                                                    isSynced: true,
+                                                                                    setTime: oldSyncTime)
+
+        self.subscriberAttributesManager.setFirebaseAppInstanceID(firebaseAppInstanceID, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        let invokedParams = try XCTUnwrap(self.mockDeviceCache.invokedStoreParameters)
+        let receivedAttribute = invokedParams.attribute
+
+        expect(receivedAttribute.key) == "$firebaseAppInstanceId"
+        expect(receivedAttribute.value) == firebaseAppInstanceID
+        expect(receivedAttribute.isSynced) == false
+        expect(receivedAttribute.setTime) > oldSyncTime
+    }
+
+    func testSetFirebaseAppInstanceIDDoesNotSetDeviceIdentifiers() {
+        let firebaseAppInstanceID = "firebaseAppInstanceID"
+        self.subscriberAttributesManager.setFirebaseAppInstanceID(firebaseAppInstanceID, appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 1
+
+        checkDeviceIdentifiersAreNotSet()
+    }
+    // endregion
     // region Media source
     func testSetMediaSource() {
         let mediaSource = "mediaSource"

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -1154,9 +1154,9 @@ class SubscriberAttributesManagerTests: XCTestCase {
     }
 
     func testSetFirebaseAppInstanceIDSetsEmptyIfNil() throws {
-        let mixpanelDistinctID = "firebaseAppInstanceID"
+        let firebaseAppInstanceID = "firebaseAppInstanceID"
 
-        self.subscriberAttributesManager.setFirebaseAppInstanceID(mixpanelDistinctID, appUserID: "kratos")
+        self.subscriberAttributesManager.setFirebaseAppInstanceID(firebaseAppInstanceID, appUserID: "kratos")
         self.subscriberAttributesManager.setFirebaseAppInstanceID(nil, appUserID: "kratos")
 
         expect(self.mockDeviceCache.invokedStoreCount) == 2


### PR DESCRIPTION
For [CF-566]

### Motivation
We have convenience setter methods for reserved attributes, and `$firebaseAppInstanceID` is another reserved attribute that needs a setter.

### Description
Adds new public method to Purchases: `setFirebaseAppInstanceID(_:)`


[CF-566]: https://revenuecats.atlassian.net/browse/CF-566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ