### PR TITLE
expose signed data in promo offers

### DIFF
--- a/Sources/Purchasing/StoreKitAbstractions/PromotionalOffer.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/PromotionalOffer.swift
@@ -31,7 +31,8 @@ public final class PromotionalOffer: NSObject {
 
     /// The ``StoreProductDiscount`` in this offer.
     @objc public let discount: StoreProductDiscount
-    let signedData: SignedData
+    /// The ``SignedData-swift.class`` provides information about the ``PromotionalOffer``'s signature.
+    @objc public let signedData: SignedData
 
     init(discount: StoreProductDiscountType, signedData: SignedData) {
         self.discount = StoreProductDiscount.from(discount: discount)
@@ -42,15 +43,29 @@ public final class PromotionalOffer: NSObject {
 
 // MARK: - SignedData
 
-extension PromotionalOffer {
+@objc public extension PromotionalOffer {
 
     /// Contains the details of a promotional offer discount that you want to apply to a payment.
-    internal struct SignedData {
-        var identifier: String
-        var keyIdentifier: String
-        var nonce: UUID
-        var signature: String
-        var timestamp: Int
+    @objc class SignedData: NSObject {
+        /// The subscription offer identifier.
+        @objc public var identifier: String
+        /// The key identifier of the subscription key.
+        @objc public var keyIdentifier: String
+        /// The nonce used in the signature.
+        @objc public var nonce: UUID
+        /// The cryptographic signature of the offer parameters, generated on RevenueCat's server.
+        @objc public var signature: String
+        /// The UNIX time, in milliseconds, when the signature was generated.
+        @objc public var timestamp: Int
+
+        init(identifier: String, keyIdentifier: String, nonce: UUID, signature: String, timestamp: Int) {
+            self.identifier = identifier
+            self.keyIdentifier = keyIdentifier
+            self.nonce = nonce
+            self.signature = signature
+            self.timestamp = timestamp
+            super.init()
+        }
     }
 
 }

--- a/Sources/Purchasing/StoreKitAbstractions/PromotionalOffer.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/PromotionalOffer.swift
@@ -46,17 +46,18 @@ public final class PromotionalOffer: NSObject {
 @objc public extension PromotionalOffer {
 
     /// Contains the details of a promotional offer discount that you want to apply to a payment.
-    @objc class SignedData: NSObject {
+    @objc(RCPromotionalOfferSignedData)
+    class SignedData: NSObject {
         /// The subscription offer identifier.
-        @objc public var identifier: String
+        @objc public private(set) var identifier: String
         /// The key identifier of the subscription key.
-        @objc public var keyIdentifier: String
+        @objc public private(set) var keyIdentifier: String
         /// The nonce used in the signature.
-        @objc public var nonce: UUID
+        @objc public private(set) var nonce: UUID
         /// The cryptographic signature of the offer parameters, generated on RevenueCat's server.
-        @objc public var signature: String
+        @objc public private(set) var signature: String
         /// The UNIX time, in milliseconds, when the signature was generated.
-        @objc public var timestamp: Int
+        @objc public private(set) var timestamp: Int
 
         init(identifier: String, keyIdentifier: String, nonce: UUID, signature: String, timestamp: Int) {
             self.identifier = identifier

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPromotionalOfferAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPromotionalOfferAPI.m
@@ -14,6 +14,14 @@
     RCPromotionalOffer *po = nil;
     RCStoreProductDiscount *discount = po.discount;
 
+    RCPromotionalOfferSignedData *signedData = po.signedData;
+
+    NSString *identifier __unused = signedData.identifier;
+    NSString *keyIdentifier __unused = signedData.keyIdentifier;
+    NSUUID *nonce __unused = signedData.nonce;
+    NSString *signature __unused = signedData.signature;
+    NSInteger timestamp __unused = signedData.timestamp;
+
     NSLog(po, discount);
 }
 

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PromotionalOfferAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PromotionalOfferAPI.swift
@@ -15,5 +15,13 @@ func checkPromotionalOfferAPI() {
     let sk1Discount = offer.discount.sk1Discount
     let sk2Discount = offer.discount.sk2Discount
 
+    let signedData = offer.signedData
+
+    let identifier: String = signedData.identifier
+    let keyIdentifier: String = signedData.keyIdentifier
+    let nonce: UUID = signedData.nonce
+    let signature: String = signedData.signature
+    let timestamp: Int = signedData.timestamp
+
     print(discount, sk1Discount!, sk2Discount!)
 }


### PR DESCRIPTION
This is what's causing the tests in https://github.com/RevenueCat/purchases-hybrid-common/pull/129 to fail - the type isn't exposed, so I'm temporarily using `@testable` just to compile locally, but we really can't have that in production. 

This PR exposes the type, so that in turn purchases-hybrid-common can send it to the hybrids. 

I'm not 100% sure if the hybrids actually ever use the type, but this is kind of the path of least resistance 😅 Since it means one less breaking change in the hybrids. I also don't really see an issue with exposing the type