### PR TITLE
expose setPushTokenString method

### DIFF
--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -524,6 +524,18 @@ extension Purchases {
     }
 
     /**
+     * Subscriber attribute associated with the push token for the user.
+     *
+     * #### Related Articles
+     * -  [Subscriber attributes](https://docs.revenuecat.com/docs/subscriber-attributes)
+     *
+     * - Parameter pushToken: `nil` will delete the subscriber attribute.
+     */
+    @objc public func setPushTokenString(_ pushToken: String?) {
+        subscriberAttributesManager.setPushTokenString(pushToken, appUserID: appUserID)
+    }
+
+    /**
      * Subscriber attribute associated with the Adjust Id for the user.
      * Required for the RevenueCat Adjust integration.
      *

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -113,6 +113,8 @@ BOOL isAnonymous;
     [p setDisplayName: @""];
     [p setPushToken: nil];
     [p setPushToken: [@"" dataUsingEncoding: NSUTF8StringEncoding]];
+    [p setPushTokenString: @""];
+    [p setPushTokenString: nil];
     [p setAdjustID: nil];
     [p setAdjustID: @""];
     [p setAppsflyerID: nil];

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -156,6 +156,8 @@ private func checkPurchasesSubscriberAttributesAPI(purchases: Purchases) {
     purchases.setPhoneNumber("")
     purchases.setDisplayName("")
     purchases.setPushToken("".data(using: String.Encoding.utf8)!)
+    purchases.setPushToken("")
+    purchases.setPushToken(nil)
     purchases.setAdjustID("")
     purchases.setAppsflyerID("")
     purchases.setFBAnonymousID("")

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -315,6 +315,16 @@ class PurchasesSubscriberAttributesTests: XCTestCase {
             .to(equal((nil, purchases.appUserID)))
     }
 
+    func testSetAndClearPushTokenString() {
+        setupPurchases()
+        purchases.setPushToken("atoken")
+        purchases.setPushToken(nil)
+        expect(self.mockSubscriberAttributesManager.invokedSetPushTokenParametersList[0])
+            .to(equal(("atoken", purchases.appUserID)))
+        expect(self.mockSubscriberAttributesManager.invokedSetPushTokenParametersList[1])
+            .to(equal((nil, purchases.appUserID)))
+    }
+
     func testSetAndClearAdjustID() {
         setupPurchases()
         purchases.setAdjustID("adjustIt")


### PR DESCRIPTION
`purchases-hybrid-common` sets the push token as a string, since we can't send Data in the hybrids. 

It used to use a header that would expose the method, but that's not compatible with purchases-ios v4, since it was essentially exploiting how message-passing works for objc. 

This exposes the method, which I don't think is a bad thing, it seems kind of convenient if for whatever reason you already have it as a string. 