### PR TITLE
`Fastfile`: fixed `replace_version_number` lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -606,7 +606,7 @@ def replace_in(previous_text, new_text, path, allow_empty=false)
   if new_text.to_s.strip.empty? and not allow_empty
     fail "Missing `new_text` in call to `replace_in`, looking for replacement for #{previous_text} 😵."
   end
-  sed_regex = 's|' + previous_text + '|' + new_text + '|'
+  sed_regex = 's|' + previous_text.sub(".", "\\.") + '|' + new_text + '|'
   backup_extension = '.bck'
   sh("sed", '-i', backup_extension, sed_regex, path)
 end


### PR DESCRIPTION
See #1533.
The previous regular expression would incorrectly replace `55413C0025B778E200ECCA5A` with `554.4.0-SNAPSHOT025B778E200ECCA5A`, for example, because the `.`s in the previous version weren't escaped.