### PR TITLE
`Encodable.asDictionary()`: use `JSONEncoder.default`

### DIFF
--- a/Sources/FoundationExtensions/JSONDecoder+Extensions.swift
+++ b/Sources/FoundationExtensions/JSONDecoder+Extensions.swift
@@ -141,7 +141,7 @@ private extension ErrorUtils {
 extension Encodable {
 
     func asDictionary() throws -> [String: Any] {
-        let data = try JSONEncoder().encode(self)
+        let data = try JSONEncoder.default.encode(self)
         let result = try JSONSerialization.jsonObject(with: data, options: [])
 
         guard let result = result as? [String: Any] else {


### PR DESCRIPTION
The main difference is that `default` has `KeyEncodingStrategy.convertToSnakeCase`. Probably everything was still working because the types that use this explicitly define the keys.
Either way this makes more sense long term.