### PR TITLE
Fixed `ErrorUtils.logDecodingError`

### DIFF
--- a/Sources/CodableExtensions/PeriodType+Extensions.swift
+++ b/Sources/CodableExtensions/PeriodType+Extensions.swift
@@ -24,7 +24,7 @@ extension PeriodType: Decodable {
         }
 
         guard let type = Self.mapping[periodTypeString] else {
-            throw CodableError.unexpectedValue(PeriodType.self)
+            throw CodableError.unexpectedValue(PeriodType.self, periodTypeString)
         }
 
         self = type

--- a/Sources/CodableExtensions/PurchaseOwnershipType+Extensions.swift
+++ b/Sources/CodableExtensions/PurchaseOwnershipType+Extensions.swift
@@ -26,7 +26,8 @@ extension PurchaseOwnershipType: Decodable {
         if let type = Self.mapping[purchaseOwnershipTypeString] {
             self = type
         } else {
-            Logger.error(Strings.codable.unexpectedValueError(type: PurchaseOwnershipType.self))
+            Logger.error(Strings.codable.unexpectedValueError(type: PurchaseOwnershipType.self,
+                                                              value: purchaseOwnershipTypeString))
             self = .unknown
         }
     }

--- a/Sources/CodableExtensions/Store+Extensions.swift
+++ b/Sources/CodableExtensions/Store+Extensions.swift
@@ -23,7 +23,7 @@ extension Store: Decodable {
         }
 
         guard let type = Self.mapping[storeString] else {
-            throw CodableError.unexpectedValue(Store.self)
+            throw CodableError.unexpectedValue(Store.self, storeString)
         }
 
         self = type

--- a/Sources/FoundationExtensions/JSONDecoder+Extensions.swift
+++ b/Sources/FoundationExtensions/JSONDecoder+Extensions.swift
@@ -13,22 +13,25 @@
 
 import Foundation
 
-enum CodableError: Error, CustomStringConvertible {
+enum CodableError: Error, CustomStringConvertible, LocalizedError {
 
-    case unexpectedValue(Any.Type)
+    case unexpectedValue(Any.Type, Any)
     case valueNotFound(value: Any.Type, context: DecodingError.Context)
     case invalidJSONObject(value: [String: Any])
 
     var description: String {
         switch self {
-        case let .unexpectedValue(type):
-            return Strings.codable.unexpectedValueError(type: type).description
+        case let .unexpectedValue(type, value):
+            return Strings.codable.unexpectedValueError(type: type, value: value).description
         case let .valueNotFound(value, context):
             return Strings.codable.valueNotFoundError(value: value, context: context).description
         case let .invalidJSONObject(value):
             return Strings.codable.invalid_json_error(jsonData: value).description
         }
     }
+
+    var errorDescription: String? { return self.description }
+
 }
 
 extension JSONDecoder {
@@ -104,7 +107,7 @@ extension JSONSerialization {
         let object = try JSONSerialization.jsonObject(with: data)
 
         guard let object = object as? [String: Any] else {
-            throw CodableError.unexpectedValue(type(of: object))
+            throw CodableError.unexpectedValue(type(of: object), object)
         }
 
         return object
@@ -122,14 +125,14 @@ private extension ErrorUtils {
         }
 
         switch decodingError {
-        case .dataCorrupted(let context):
+        case let .dataCorrupted(context):
             Logger.error(Strings.codable.corrupted_data_error(context: context))
-        case .keyNotFound(let key, let context):
+        case let .keyNotFound(key, context):
             // This is expected to happen occasionally, the backend doesn't always populate all key/values.
             Logger.debug(Strings.codable.keyNotFoundError(key: key, context: context))
-        case .valueNotFound(let value, let context):
+        case let .valueNotFound(value, context):
             Logger.debug(Strings.codable.valueNotFoundError(value: value, context: context))
-        case .typeMismatch(let type, let context):
+        case let .typeMismatch(type, context):
             Logger.error(Strings.codable.typeMismatch(type: type, context: context))
         @unknown default:
             Logger.error("Unhandled DecodingError: \(decodingError)\n\(Strings.codable.decoding_error(decodingError))")
@@ -145,7 +148,7 @@ extension Encodable {
         let result = try JSONSerialization.jsonObject(with: data, options: [])
 
         guard let result = result as? [String: Any] else {
-            throw CodableError.unexpectedValue(type(of: result))
+            throw CodableError.unexpectedValue(type(of: result), result)
         }
 
         return result

--- a/Sources/Logging/Strings/CodableStrings.swift
+++ b/Sources/Logging/Strings/CodableStrings.swift
@@ -16,7 +16,7 @@ import Foundation
 // swiftlint:disable identifier_name
 enum CodableStrings {
 
-    case unexpectedValueError(type: Any.Type)
+    case unexpectedValueError(type: Any.Type, value: Any)
     case valueNotFoundError(value: Any.Type, context: DecodingError.Context)
     case keyNotFoundError(key: CodingKey, context: DecodingError.Context)
     case invalid_json_error(jsonData: [String: Any])
@@ -30,21 +30,21 @@ extension CodableStrings: CustomStringConvertible {
 
     var description: String {
         switch self {
-        case .unexpectedValueError(let type):
-            return "Found unexpected value for type: \(type)"
-        case .valueNotFoundError(let value, let context):
+        case let .unexpectedValueError(type, value):
+            return "Found unexpected value '\(value)' for type '\(type)'"
+        case let .valueNotFoundError(value, context):
             let description = context.debugDescription
             return "No value found for: \(value), codingPath: \(context.codingPath), description:\n\(description)"
-        case .keyNotFoundError(let key, let context):
+        case let .keyNotFoundError(key, context):
             let description = context.debugDescription
             return "Key '\(key)' not found, codingPath: \(context.codingPath), description:\n\(description)"
-        case .invalid_json_error(let jsonData):
+        case let .invalid_json_error(jsonData):
             return "The given json data was not valid: \n\(jsonData)"
-        case .decoding_error(let error):
-            return "Couldn't decode data from json. Error:\n\(error.localizedDescription))"
-        case .corrupted_data_error(let context):
+        case let .decoding_error(error):
+            return "Couldn't decode data from json. Error:\n\(error.localizedDescription)"
+        case let .corrupted_data_error(context):
             return "Couldn't decode data from json, it was corrupted: \(context)"
-        case .typeMismatch(let type, let context):
+        case let .typeMismatch(type, context):
             let description = context.debugDescription
             return "Type '\(type)' mismatch, codingPath:\(context.codingPath), description:\n\(description)"
         }


### PR DESCRIPTION
## Changes:

- Improved output of decoding errors:

#### Before:
```
[Purchases] - ERROR: 😿‼️ Couldn't decode data from json. Error:
The operation couldn’t be completed. (RevenueCat.CodableError error 0.))
```

#### After:
```
[Purchases] - ERROR: 😿‼️ Couldn't decode data from json. Error:
Found unexpected value 'tienda' for type 'Store'
```

- `CodableStrings.decodingError` relied on `Error.localizedDescription`, so `CodableError` now conforms to `LocalizedError` to provide that as well
- Added incorrect `value` to the error to find out why it was invalid
- Removed extra `)` at the end of the error string
- Cleaned up `switch`es to use a single `let` syntax
