### PR TITLE
Created `@LossyArray` and `@LossyDictionary`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -220,6 +220,7 @@
 		573A10D52800A7C800F976E5 /* SKErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573A10D42800A7C800F976E5 /* SKErrorTests.swift */; };
 		573A10D92800ADCD00F976E5 /* StoreKitErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573A10D82800ADCD00F976E5 /* StoreKitErrorTests.swift */; };
 		573A10DB2800AF4700F976E5 /* PurchaseErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573A10DA2800AF4700F976E5 /* PurchaseErrorTests.swift */; };
+		573E7EB728189936007C9128 /* LossyCollections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573E7EB628189936007C9128 /* LossyCollections.swift */; };
 		5746508C27586B2E0053AB09 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5746508B27586B2E0053AB09 /* Result+Extensions.swift */; };
 		5746508E275949F20053AB09 /* DispatchTimeInterval+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5746508D275949F20053AB09 /* DispatchTimeInterval+Extensions.swift */; };
 		5751379527F4C4D80064AB2C /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5751379427F4C4D80064AB2C /* Optional+Extensions.swift */; };
@@ -661,6 +662,7 @@
 		573A10D42800A7C800F976E5 /* SKErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKErrorTests.swift; sourceTree = "<group>"; };
 		573A10D82800ADCD00F976E5 /* StoreKitErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitErrorTests.swift; sourceTree = "<group>"; };
 		573A10DA2800AF4700F976E5 /* PurchaseErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseErrorTests.swift; sourceTree = "<group>"; };
+		573E7EB628189936007C9128 /* LossyCollections.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LossyCollections.swift; sourceTree = "<group>"; };
 		5746508B27586B2E0053AB09 /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
 		5746508D275949F20053AB09 /* DispatchTimeInterval+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchTimeInterval+Extensions.swift"; sourceTree = "<group>"; };
 		5751379427F4C4D80064AB2C /* Optional+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
@@ -911,6 +913,7 @@
 				57A17726276A721D0052D3A8 /* Set+Extensions.swift */,
 				B35F9E0826B4BEED00095C3F /* String+Extensions.swift */,
 				2D9C7BB226D838FC006838BE /* UIApplication+RCExtensions.swift */,
+				573E7EB628189936007C9128 /* LossyCollections.swift */,
 			);
 			path = FoundationExtensions;
 			sourceTree = "<group>";
@@ -2263,6 +2266,7 @@
 				B34605BF279A6E380031CA74 /* LogInCallback.swift in Sources */,
 				9A65DFDE258AD60A00DE00B0 /* LogIntent.swift in Sources */,
 				B35042C626CDD3B100905B95 /* PurchasesDelegate.swift in Sources */,
+				573E7EB728189936007C9128 /* LossyCollections.swift in Sources */,
 				0313FD41268A506400168386 /* DateProvider.swift in Sources */,
 				5733B18E27FF586A00EC2045 /* BackendError.swift in Sources */,
 				B39E811A268E849900D31189 /* AttributionNetwork.swift in Sources */,

--- a/Sources/FoundationExtensions/JSONDecoder+Extensions.swift
+++ b/Sources/FoundationExtensions/JSONDecoder+Extensions.swift
@@ -97,7 +97,8 @@ extension JSONSerialization {
 }
 
 // MARK: Decoding Error handling
-private extension ErrorUtils {
+
+extension ErrorUtils {
 
     static func logDecodingError(_ error: Error) {
         guard let decodingError = error as? DecodingError else {

--- a/Sources/FoundationExtensions/LossyCollections.swift
+++ b/Sources/FoundationExtensions/LossyCollections.swift
@@ -1,0 +1,221 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  LossyCollections.swift
+//
+//  Created by Nacho Soto on 4/26/22.
+
+import Foundation
+
+// Inspired by https://github.com/marksands/BetterCodable/blob/master/Sources/BetterCodable/
+
+// MARK: - LossyArray
+
+/// A property wrapper that allows decoding `Array`s and ignore elements that fail to decode.
+/// For example, this will ignore any elements that aren't numbers, instead of failing to decode altogether.
+/// ```
+/// struct Data: Decodable {
+///     @LossyArray var list: [Int]
+/// }
+/// ```
+/// This does require that the value is an `Array`,
+/// but this wrapper can be composed with `@DefaultDecodable.EmptyArray`
+/// to make it produce an empty array in case of any other type error.
+/// ```
+/// struct Data: Decodable {
+///      @DefaultDecodable.EmptyArray @LossyArray var list: [Int]
+/// }
+/// ```
+@propertyWrapper
+struct LossyArray<Value> {
+
+    var wrappedValue: [Value]
+
+    init(wrappedValue: [Value]) { self.wrappedValue = wrappedValue }
+
+}
+
+extension LossyArray: Decodable where Value: Decodable {
+
+    private struct AnyDecodableValue: Decodable {}
+
+    init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+
+        var elements: [Value] = []
+        while !container.isAtEnd {
+            do {
+                elements.append(try container.decode(Value.self))
+            } catch {
+                do {
+                    // Attempt to decode anything to skip this element
+                    _ = try container.decode(AnyDecodableValue.self)
+                } catch {
+                    ErrorUtils.logDecodingError(error)
+                }
+            }
+        }
+
+        self.wrappedValue = elements
+    }
+
+}
+
+extension LossyArray: Encodable where Value: Encodable {
+
+    func encode(to encoder: Encoder) throws {
+        try wrappedValue.encode(to: encoder)
+    }
+
+}
+
+extension LossyArray: Equatable where Value: Equatable { }
+extension LossyArray: Hashable where Value: Hashable { }
+
+extension LossyArray: ExpressibleByArrayLiteral {
+
+    init(arrayLiteral elements: Value...) {
+        self.wrappedValue = elements
+    }
+
+}
+
+// MARK: - LossyDictionary
+
+/// A property wrapper that allows decoding `Dictionary`s and ignore elements that fail to decode.
+/// For example, this will ignore any elements that aren't numbers, instead of failing to decode altogether.
+/// ```
+/// struct Data: Decodable {
+///     @LossyDictionary var map: [String: Int]
+/// }
+/// ```
+/// This does require that the value is a `Dictionary`,
+/// but this wrapper can be composed with `@DefaultDecodable.EmptyDictionary`
+/// to make it produce an empty dictionary in case of any other type error.
+/// ```
+/// struct Data: Decodable {
+///      @DefaultDecodable.EmptyDictionary @LossyDictionary var map: [String: Int]
+/// }
+/// ```
+/// - Note: if the values of the dictionary are an array, consider using `LossyArrayDictionary`.
+@propertyWrapper
+struct LossyDictionary<Value: Decodable> {
+
+    var wrappedValue: [String: Value]
+
+    init(wrappedValue: [String: Value]) {
+        self.wrappedValue = wrappedValue
+    }
+
+}
+
+/// A property wrapper that allows decoding `Dictionary`s of `Array`s and ignore elements that fail to decode.
+/// This is a composition of `LossyArray` and `LossyDictionary`, that due to limitations of property wrappers,
+/// it necessitates its own type.
+@propertyWrapper
+struct LossyArrayDictionary<Value: Decodable> {
+
+    var wrappedValue: [String: [Value]]
+
+    init(wrappedValue: [String: [Value]]) {
+        self.wrappedValue = wrappedValue
+    }
+
+}
+
+// MARK: - LossyDictionary implementation
+
+private struct DictionaryCodingKey: CodingKey {
+
+    let stringValue: String
+    var intValue: Int? { return Int(self.stringValue) }
+
+    init?(intValue: Int) { self.stringValue = String(intValue) }
+    init?(stringValue: String) { self.stringValue = stringValue }
+
+}
+
+extension LossyDictionary: Decodable {
+
+    init(from decoder: Decoder) throws {
+        var elements: [String: Value] = [:]
+
+        let container = try decoder.container(keyedBy: DictionaryCodingKey.self)
+
+        for key in container.allKeys {
+            do {
+                elements[key.stringValue] = try container.decode(Value.self, forKey: key)
+            } catch {
+                ErrorUtils.logDecodingError(error)
+            }
+        }
+
+        self.wrappedValue = elements
+    }
+
+}
+
+extension LossyArrayDictionary: Decodable {
+
+    init(from decoder: Decoder) throws {
+        var elements: [String: [Value]] = [:]
+
+        let container = try decoder.container(keyedBy: DictionaryCodingKey.self)
+
+        for key in container.allKeys {
+            do {
+                let arrayDecoder = try container.superDecoder(forKey: key)
+                elements[key.stringValue] = try LossyArray(from: arrayDecoder).wrappedValue
+            } catch {
+                ErrorUtils.logDecodingError(error)
+            }
+        }
+
+        self.wrappedValue = elements
+    }
+
+}
+
+extension LossyDictionary: Encodable where Value: Encodable {
+
+    func encode(to encoder: Encoder) throws {
+        try wrappedValue.encode(to: encoder)
+    }
+
+}
+
+extension LossyDictionary: Equatable where Value: Equatable { }
+extension LossyDictionary: Hashable where Value: Hashable { }
+
+extension LossyDictionary: ExpressibleByDictionaryLiteral {
+
+    init(dictionaryLiteral elements: (String, Value)...) {
+        self.wrappedValue = Dictionary(uniqueKeysWithValues: elements)
+    }
+
+}
+
+extension LossyArrayDictionary: Encodable where Value: Encodable {
+
+    func encode(to encoder: Encoder) throws {
+        try wrappedValue.encode(to: encoder)
+    }
+
+}
+
+extension LossyArrayDictionary: Equatable where Value: Equatable { }
+extension LossyArrayDictionary: Hashable where Value: Hashable { }
+
+extension LossyArrayDictionary: ExpressibleByDictionaryLiteral {
+
+    init(dictionaryLiteral elements: (String, [Value])...) {
+        self.wrappedValue = Dictionary(uniqueKeysWithValues: elements)
+    }
+
+}


### PR DESCRIPTION
Inspired by https://github.com/marksands/BetterCodable/blob/master/Sources/BetterCodable but supporting nested collections and with simplified code.

These property wrappers allows decoding `Array`s and `Dictionary`s and ignore elements that fail to decode.
For example, this will ignore any elements that aren't numbers, instead of failing to decode altogether.
```swift
struct Data: Decodable {
    @LossyArray var list: [Int]
    @LossyDictionary var map: [String: Int]
}
```
This does require that the values are the right type, but these wrappers can be composed with `@DefaultDecodable.EmptyArray` and `@DefaultDecodable.EmptyDictionary` introduced in #1537 to make it produce an empty array in case of any other type error:
```swift
struct Data: Decodable {
     @DefaultDecodable.EmptyArray @LossyArray var list: [Int]
     @DefaultDecodable.EmptyDictionary @LossyDictionary var map: [String: Int]
}
```

Because of limitations of the property wrappers in Swift, an extra type `LossyArrayDictionary` allows lossy decoding of types `[String: [Decodable]`.

This will be used to vastly simplify #1496.