### PR TITLE
`@LossyDictionary`: workaround for decoding snake case dictionary keys

### DIFF
--- a/Sources/FoundationExtensions/LossyCollections.swift
+++ b/Sources/FoundationExtensions/LossyCollections.swift
@@ -165,16 +165,17 @@ extension LossyDictionary: Decodable {
     fileprivate static func extractKeys(
         from decoder: Decoder,
         container: KeyedDecodingContainer<DictionaryCodingKey>
-    ) throws -> [(DictionaryCodingKey, String)] {
+    ) throws -> AnySequence<(DictionaryCodingKey, String)> {
         // Decode a dictionary ignoring the values to decode the original keys
         // without using the `JSONDecoder.KeyDecodingStrategy`.
         let keys = try decoder.singleValueContainer().decode([String: AnyDecodableValue].self).keys
 
-        return zip(
-            container.allKeys.sorted(by: { $0.stringValue < $1.stringValue }),
-            keys.sorted()
+        return AnySequence(
+            zip(
+                container.allKeys.sorted(by: { $0.stringValue < $1.stringValue }),
+                keys.sorted()
+            )
         )
-        .map { ($0, $1) }
     }
 
 }

--- a/Sources/FoundationExtensions/LossyCollections.swift
+++ b/Sources/FoundationExtensions/LossyCollections.swift
@@ -143,20 +143,38 @@ private struct DictionaryCodingKey: CodingKey {
 
 extension LossyDictionary: Decodable {
 
+    private struct AnyDecodableValue: Decodable {}
+
     init(from decoder: Decoder) throws {
         var elements: [String: Value] = [:]
 
         let container = try decoder.container(keyedBy: DictionaryCodingKey.self)
+        let keys = try Self.extractKeys(from: decoder, container: container)
 
-        for key in container.allKeys {
+        for (key, stringKey) in keys {
             do {
-                elements[key.stringValue] = try container.decode(Value.self, forKey: key)
+                elements[stringKey] = try container.decode(Value.self, forKey: key)
             } catch {
                 ErrorUtils.logDecodingError(error)
             }
         }
 
         self.wrappedValue = elements
+    }
+
+    fileprivate static func extractKeys(
+        from decoder: Decoder,
+        container: KeyedDecodingContainer<DictionaryCodingKey>
+    ) throws -> [(DictionaryCodingKey, String)] {
+        // Decode a dictionary ignoring the values to decode the original keys
+        // without using the `JSONDecoder.KeyDecodingStrategy`.
+        let keys = try decoder.singleValueContainer().decode([String: AnyDecodableValue].self).keys
+
+        return zip(
+            container.allKeys.sorted(by: { $0.stringValue < $1.stringValue }),
+            keys.sorted()
+        )
+        .map { ($0, $1) }
     }
 
 }
@@ -167,11 +185,12 @@ extension LossyArrayDictionary: Decodable {
         var elements: [String: [Value]] = [:]
 
         let container = try decoder.container(keyedBy: DictionaryCodingKey.self)
+        let keys = try LossyDictionary<Value>.extractKeys(from: decoder, container: container)
 
-        for key in container.allKeys {
+        for (key, stringKey) in keys {
             do {
                 let arrayDecoder = try container.superDecoder(forKey: key)
-                elements[key.stringValue] = try LossyArray(from: arrayDecoder).wrappedValue
+                elements[stringKey] = try LossyArray(from: arrayDecoder).wrappedValue
             } catch {
                 ErrorUtils.logDecodingError(error)
             }

--- a/Tests/UnitTests/FoundationExtensions/DecoderExtensionTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/DecoderExtensionTests.swift
@@ -124,6 +124,27 @@ class DecoderExtensionsLossyCollectionTests: XCTestCase {
         expect(decodedData) == data
     }
 
+    func testDictionaryKeysAreSnakeCase() throws {
+        let keys: Set<String> = [
+            "snake_case",
+            "com.revenuecat.monthly_4.99.1_week_intro",
+            "com.revenuecat.monthly_4.99.no_intro",
+            "pro.1"
+        ]
+
+        let data = Data(list: [],
+                        map1: keys.dictionaryWithValues { .init(string: $0) },
+                        map2: [:])
+        let decodedData = try data.encodeAndDecode()
+
+        expect(Set(decodedData.map1.keys)) == keys
+        expect(decodedData) == data
+
+        for key in keys {
+            expect(decodedData.map1[key]?.string) == key
+        }
+    }
+
     func testIgnoresArrayErrors() throws {
         let json = "{\"list\": [\"not a number\"], \"map1\": {}, \"map2\": {}}"
         let data = try Data.decode(json)
@@ -162,6 +183,27 @@ class DecoderExtensionsLossyCollectionTests: XCTestCase {
         let data = try Data.decode(json)
 
         expect(data.map2) == ["3": [.init(string: "test")]]
+    }
+
+    func testArrayDictionaryKeysAreSnakeCase() throws {
+        let keys: Set<String> = [
+            "snake_case",
+            "com.revenuecat.monthly_4.99.1_week_intro",
+            "com.revenuecat.monthly_4.99.no_intro",
+            "pro.1"
+        ]
+
+        let data = Data(list: [],
+                        map1: [:],
+                        map2: keys.dictionaryWithValues { [.init(string: $0)] })
+        let decodedData = try data.encodeAndDecode()
+
+        expect(decodedData) == data
+        expect(Set(decodedData.map2.keys)) == keys
+
+        for key in keys {
+            expect(decodedData.map2[key]) == [.init(string: key)]
+        }
     }
 
 }


### PR DESCRIPTION
The new test illustrates the behavior change that adding `@LossyDictionary` to a `[String: Decodable]` property had. Keys were being converted to camel case, which is inconsistent from the default behavior that `container.decode([String: Value].self, forKey: key)` would have.
The reason for this is some implementation detail on Foundation that ignores the `keyDecodingStrategy` when decoding "raw" dictionaries versus property names. To deal with this, we decode the strings first as "raw", and then match them to the corresponding converted key.

This was necessary to make sure that keys [like these](https://github.com/RevenueCat/purchases-ios/blob/4.3.0/Tests/UnitTests/Purchasing/CustomerInfoTests.swift#L58) aren't incorrectly converted to camel case, which is required for #1496.