### PR TITLE
`CustomerInfo`: moved deprecated property to `Deprecations`

### DIFF
--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -43,12 +43,6 @@ import Foundation
         return mostRecentDate
     }
 
-    /// Returns all product IDs of the non-subscription purchases a user has made.
-    @available(*, deprecated, message: "use nonSubscriptionTransactions")
-    @objc public var nonConsumablePurchases: Set<String> {
-        Set(self.nonSubscriptionTransactions.map { $0.productIdentifier })
-    }
-
     /**
      * Returns all the non-subscription purchases a user has made.
      * The purchases are ordered by purchase date in ascending order.

--- a/Sources/Misc/Deprecations.swift
+++ b/Sources/Misc/Deprecations.swift
@@ -59,6 +59,7 @@ public extension Purchases {
 }
 
 public extension StoreProduct {
+
     @available(iOS, introduced: 13.0, deprecated, renamed: "eligiblePromotionalOffers()")
     @available(tvOS, introduced: 13.0, deprecated, renamed: "eligiblePromotionalOffers()")
     @available(watchOS, introduced: 6.2, deprecated, renamed: "eligiblePromotionalOffers()")
@@ -67,4 +68,15 @@ public extension StoreProduct {
     func getEligiblePromotionalOffers() async -> [PromotionalOffer] {
         return await self.eligiblePromotionalOffers()
     }
+
+}
+
+extension CustomerInfo {
+
+    /// Returns all product IDs of the non-subscription purchases a user has made.
+    @available(*, deprecated, message: "use nonSubscriptionTransactions")
+    @objc public var nonConsumablePurchases: Set<String> {
+        return Set(self.nonSubscriptionTransactions.map { $0.productIdentifier })
+    }
+
 }


### PR DESCRIPTION
A small refactor taken out of #1496.