### PR TITLE
3.x.x - add `s.deprecated_in_favor_of ` to reduce confusion when v4 not installed

### DIFF
--- a/Purchases.podspec
+++ b/Purchases.podspec
@@ -13,6 +13,9 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/revenuecat/purchases-ios.git", :tag => s.version.to_s }
   s.documentation_url = "https://docs.revenuecat.com/"
 
+  s.deprecated = true
+  s.deprecated_in_favor_of = "RevenueCat"
+
   s.framework      = 'StoreKit'
   s.swift_version       = '5.0'
 


### PR DESCRIPTION
### Motivation
This question comes up quite often on why `v4` has was not installed when running `pod install` or `pod update` and its because `v4` is associated with the pod name `RevenueCat` and not `Purchases`

### Description
Sets `deprecated` and `deprecated_in_favor_of` in the v3 `Purchases` podspec that will output the `RevenueCat` in now favored

![Screen Shot 2022-04-29 at 10 39 18 AM](https://user-images.githubusercontent.com/401294/165978308-50dc2bce-c13c-4d1c-b607-8b739cdbc434.png)

