### PR TITLE
Added tests for `PeriodType`/`PurchaseOwnershipType`/`Store`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -229,6 +229,9 @@
 		57536A28278522B400E2AE7F /* SK2StoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57536A27278522B400E2AE7F /* SK2StoreTransaction.swift */; };
 		57554CC1282AE1E3009A7E58 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554CC0282AE1E3009A7E58 /* TestCase.swift */; };
 		57554CC2282AE1E3009A7E58 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554CC0282AE1E3009A7E58 /* TestCase.swift */; };
+		57554C62282ABFD9009A7E58 /* StoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554C61282ABFD9009A7E58 /* StoreTests.swift */; };
+		57554C84282AC273009A7E58 /* PeriodTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554C83282AC273009A7E58 /* PeriodTypeTests.swift */; };
+		57554C88282AC293009A7E58 /* PurchaseOwnershipTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554C87282AC293009A7E58 /* PurchaseOwnershipTypeTests.swift */; };
 		575A17AB2773A59300AA6F22 /* CurrentTestCaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */; };
 		576C8A8B27CFCB150058FA6E /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A8A27CFCB150058FA6E /* AnyEncodable.swift */; };
 		576C8A8F27CFCD110058FA6E /* AnyEncodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A8E27CFCD110058FA6E /* AnyEncodableTests.swift */; };
@@ -672,6 +675,9 @@
 		57536A2527851FFE00E2AE7F /* SK1StoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1StoreTransaction.swift; sourceTree = "<group>"; };
 		57536A27278522B400E2AE7F /* SK2StoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreTransaction.swift; sourceTree = "<group>"; };
 		57554CC0282AE1E3009A7E58 /* TestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCase.swift; sourceTree = "<group>"; };
+		57554C61282ABFD9009A7E58 /* StoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreTests.swift; sourceTree = "<group>"; };
+		57554C83282AC273009A7E58 /* PeriodTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodTypeTests.swift; sourceTree = "<group>"; };
+		57554C87282AC293009A7E58 /* PurchaseOwnershipTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseOwnershipTypeTests.swift; sourceTree = "<group>"; };
 		575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentTestCaseTracker.swift; sourceTree = "<group>"; };
 		576C8A8A27CFCB150058FA6E /* AnyEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
 		576C8A8E27CFCD110058FA6E /* AnyEncodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodableTests.swift; sourceTree = "<group>"; };
@@ -1404,6 +1410,9 @@
 				F5BE4244269676E200254A30 /* StoreKitRequestFetcherTests.swift */,
 				37E352F86A0A8EB05BAD77C4 /* StoreKitWrapperTests.swift */,
 				3597021124BF6AAC0010506E /* TransactionsFactoryTests.swift */,
+				57554C61282ABFD9009A7E58 /* StoreTests.swift */,
+				57554C83282AC273009A7E58 /* PeriodTypeTests.swift */,
+				57554C87282AC293009A7E58 /* PurchaseOwnershipTypeTests.swift */,
 			);
 			path = Purchasing;
 			sourceTree = "<group>";
@@ -2308,6 +2317,8 @@
 				B36824BF268FBC8700957E4C /* SubscriberAttributeTests.swift in Sources */,
 				351B51BC26D450E800BD2BD7 /* OfferingsTests.swift in Sources */,
 				5796A38827D6B85900653165 /* BackendPostReceiptDataTests.swift in Sources */,
+				57554C88282AC293009A7E58 /* PurchaseOwnershipTypeTests.swift in Sources */,
+				57554C84282AC273009A7E58 /* PeriodTypeTests.swift in Sources */,
 				2DDF41CF24F6F4C3005BC22D /* ReceiptParsing+TestsWithRealReceipts.swift in Sources */,
 				575A17AB2773A59300AA6F22 /* CurrentTestCaseTracker.swift in Sources */,
 				351B514326D449C100BD2BD7 /* MockSubscriberAttributesManager.swift in Sources */,
@@ -2317,6 +2328,7 @@
 				351B514726D44A0D00BD2BD7 /* MockSystemInfo.swift in Sources */,
 				B300E4C226D439B700B22262 /* IntroEligibilityCalculatorTests.swift in Sources */,
 				5796A39B27D6C20A00653165 /* BackendPostAttributionDataTests.swift in Sources */,
+				57554C62282ABFD9009A7E58 /* StoreTests.swift in Sources */,
 				2DDF41CA24F6F4C3005BC22D /* ArraySlice_UInt8+ExtensionsTests.swift in Sources */,
 				2DDF41E124F6F527005BC22D /* MockReceiptParser.swift in Sources */,
 				351B514D26D44A8600BD2BD7 /* MockHTTPClient.swift in Sources */,

--- a/Sources/CodableExtensions/PurchaseOwnershipType+Extensions.swift
+++ b/Sources/CodableExtensions/PurchaseOwnershipType+Extensions.swift
@@ -18,6 +18,12 @@ extension PurchaseOwnershipType: Decodable {
     // swiftlint:disable:next missing_docs
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
+
+        guard !container.decodeNil() else {
+            self = .unknown
+            return
+        }
+
         guard let purchaseOwnershipTypeString = try? container.decode(String.self) else {
             throw decoder.throwValueNotFoundError(expectedType: PurchaseOwnershipType.self,
                                                   message: "Unable to extract an purchaseOwnershipTypeString")

--- a/Sources/CodableExtensions/Store+Extensions.swift
+++ b/Sources/CodableExtensions/Store+Extensions.swift
@@ -18,6 +18,12 @@ extension Store: Decodable {
     // swiftlint:disable:next missing_docs
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
+
+        guard !container.decodeNil() else {
+            self = .unknownStore
+            return
+        }
+
         guard let storeString = try? container.decode(String.self) else {
             throw decoder.throwValueNotFoundError(expectedType: Store.self, message: "Unable to extract a storeString")
         }

--- a/Tests/UnitTests/FoundationExtensions/DecoderExtensionTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/DecoderExtensionTests.swift
@@ -301,7 +301,7 @@ class DecoderExtensionsDefaultDecodableTests: TestCase {
 
  }
 
-private extension Decodable where Self: Encodable {
+extension Decodable where Self: Encodable {
 
     func encodeAndDecode() throws -> Self {
         return try JSONDecoder.default.decode(
@@ -311,7 +311,7 @@ private extension Decodable where Self: Encodable {
 
 }
 
-private extension Decodable {
+extension Decodable {
 
     static func decode(_ json: String) throws -> Self {
         return try JSONDecoder.default.decode(jsonData: json.data(using: .utf8)!)

--- a/Tests/UnitTests/Purchasing/PeriodTypeTests.swift
+++ b/Tests/UnitTests/Purchasing/PeriodTypeTests.swift
@@ -1,0 +1,30 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PeriodTypeTests.swift
+//
+//  Created by Nacho Soto on 5/10/22.
+
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+class PeriodTypeTests: TestCase {
+
+    func testCodable() throws {
+        for type in PeriodType.allCases {
+            expect(try type.encodeAndDecode()) == type
+        }
+    }
+
+    func testUnknownStringThrows() throws {
+        expect(try PeriodType.decode("\"invalid\"")).to(throwError(errorType: CodableError.self))
+    }
+
+}

--- a/Tests/UnitTests/Purchasing/PurchaseOwnershipTypeTests.swift
+++ b/Tests/UnitTests/Purchasing/PurchaseOwnershipTypeTests.swift
@@ -1,0 +1,34 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchaseOwnershipTypeTests.swift
+//
+//  Created by Nacho Soto on 5/10/22.
+
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+class PurchaseOwnershipTypeTests: TestCase {
+
+    func testCodable() throws {
+        for type in PurchaseOwnershipType.allCases {
+            expect(try type.encodeAndDecode()) == type
+        }
+    }
+
+    func testUnknownStringBecomesUnknown() throws {
+        expect(try PurchaseOwnershipType.decode("\"invalid\"")) == .unknown
+    }
+
+    func testNullBecomesUnknown() throws {
+        expect(try PurchaseOwnershipType.decode("null")) == .unknown
+    }
+
+}

--- a/Tests/UnitTests/Purchasing/StoreTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreTests.swift
@@ -1,0 +1,34 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  StoreTests.swift
+//
+//  Created by Nacho Soto on 5/10/22.
+
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+class StoreTests: TestCase {
+
+    func testCodable() throws {
+        for store in Store.allCases {
+            expect(try store.encodeAndDecode()) == store
+        }
+    }
+
+    func testUnknownStringThrows() throws {
+        expect(try Store.decode("\"invalid\"")).to(throwError(errorType: CodableError.self))
+    }
+
+    func testNullBecomesUnknown() throws {
+        expect(try Store.decode("null")) == .unknownStore
+    }
+
+}


### PR DESCRIPTION
Follow up to #1551. Using `Codable.encodeAndDecode` we ensure that each value can be bidirectionally converted.
These tests exposed that unknown values were being encoded as `null`, but then failed to decode.

I've updated the implementation and added a few more tests to cover this behavior.