### PR TITLE
Created `TestCase` superclass to allow re-generating snapshots

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -19,6 +19,7 @@ opt_in_rules:
 custom_rules:
   xctestcase_superclass:
     included: ".*\\.swift"
+    excluded: Tests/BackendIntegrationTests
     regex: "\\: XCTestCase \\{"
     name: "XCTestCase Superclass"
     message: "Test classes must inherit `TestCase` instead."

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,6 +16,13 @@ opt_in_rules:
   - vertical_parameter_alignment
   - vertical_parameter_alignment_on_call
 
+custom_rules:
+  xctestcase_superclass:
+    included: ".*\\.swift"
+    regex: "\\: XCTestCase \\{"
+    name: "XCTestCase Superclass"
+    message: "Test classes must inherit `TestCase` instead."
+
 identifier_name:
   max_length: 
     warning: 60 

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -227,6 +227,8 @@
 		575137CF27F50D2F0064AB2C /* HTTPResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575137CE27F50D2F0064AB2C /* HTTPResponseBody.swift */; };
 		57536A2627851FFE00E2AE7F /* SK1StoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57536A2527851FFE00E2AE7F /* SK1StoreTransaction.swift */; };
 		57536A28278522B400E2AE7F /* SK2StoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57536A27278522B400E2AE7F /* SK2StoreTransaction.swift */; };
+		57554CC1282AE1E3009A7E58 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554CC0282AE1E3009A7E58 /* TestCase.swift */; };
+		57554CC2282AE1E3009A7E58 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554CC0282AE1E3009A7E58 /* TestCase.swift */; };
 		575A17AB2773A59300AA6F22 /* CurrentTestCaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */; };
 		576C8A8B27CFCB150058FA6E /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A8A27CFCB150058FA6E /* AnyEncodable.swift */; };
 		576C8A8F27CFCD110058FA6E /* AnyEncodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A8E27CFCD110058FA6E /* AnyEncodableTests.swift */; };
@@ -669,6 +671,7 @@
 		575137CE27F50D2F0064AB2C /* HTTPResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponseBody.swift; sourceTree = "<group>"; };
 		57536A2527851FFE00E2AE7F /* SK1StoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1StoreTransaction.swift; sourceTree = "<group>"; };
 		57536A27278522B400E2AE7F /* SK2StoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreTransaction.swift; sourceTree = "<group>"; };
+		57554CC0282AE1E3009A7E58 /* TestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCase.swift; sourceTree = "<group>"; };
 		575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentTestCaseTracker.swift; sourceTree = "<group>"; };
 		576C8A8A27CFCB150058FA6E /* AnyEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
 		576C8A8E27CFCD110058FA6E /* AnyEncodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodableTests.swift; sourceTree = "<group>"; };
@@ -1327,6 +1330,7 @@
 				57E2230627500BB1002DB06E /* AtomicTests.swift */,
 				5722482627C2BD3200C524A7 /* LockTests.swift */,
 				576C8A8E27CFCD110058FA6E /* AnyEncodableTests.swift */,
+				57554CC0282AE1E3009A7E58 /* TestCase.swift */,
 				2D22BF6626F3CBFB001AE2F9 /* XCTestCase+Extensions.swift */,
 			);
 			path = Misc;
@@ -2092,6 +2096,7 @@
 				57C381B72791E593009E3940 /* StoreKit2TransactionListenerTests.swift in Sources */,
 				2D90F8C026FD20DF009B9142 /* MockAttributionDataMigrator.swift in Sources */,
 				F55FFA5D27634E1900995146 /* MockTransactionsManager.swift in Sources */,
+				57554CC2282AE1E3009A7E58 /* TestCase.swift in Sources */,
 				2D90F8B826FD20AA009B9142 /* MockReceiptFetcher.swift in Sources */,
 				2D90F8B626FD2099009B9142 /* MockSubscriberAttributesManager.swift in Sources */,
 				2D90F8BF26FD20D6009B9142 /* MockAttributionFetcher.swift in Sources */,
@@ -2403,6 +2408,7 @@
 				351B517026D44E8D00BD2BD7 /* MockDateProvider.swift in Sources */,
 				2D1C3F3926B9D8B800112626 /* MockBundle.swift in Sources */,
 				351B515E26D44B9900BD2BD7 /* MockPurchasesDelegate.swift in Sources */,
+				57554CC1282AE1E3009A7E58 /* TestCase.swift in Sources */,
 				57A1772B276A726C0052D3A8 /* SetExtensionsTests.swift in Sources */,
 				351B515A26D44B6200BD2BD7 /* MockAttributionFetcher.swift in Sources */,
 				5796A38C27D6BA1600653165 /* BackendLoginTests.swift in Sources */,

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -26,7 +26,7 @@ final class TestPurchaseDelegate: NSObject, PurchasesDelegate {
 
 }
 
-class BaseBackendIntegrationTests: XCTestCase {
+class BaseBackendIntegrationTests: TestCase {
 
     private var userDefaults: UserDefaults!
     // swiftlint:disable:next weak_delegate

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -26,7 +26,7 @@ final class TestPurchaseDelegate: NSObject, PurchasesDelegate {
 
 }
 
-class BaseBackendIntegrationTests: TestCase {
+class BaseBackendIntegrationTests: XCTestCase {
 
     private var userDefaults: UserDefaults!
     // swiftlint:disable:next weak_delegate

--- a/Tests/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
+++ b/Tests/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
@@ -18,7 +18,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class BeginRefundRequestHelperTests: XCTestCase {
+class BeginRefundRequestHelperTests: TestCase {
 
     private var systemInfo: MockSystemInfo!
     private var customerInfoManager: MockCustomerInfoManager!

--- a/Tests/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
+++ b/Tests/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 #if os(macOS) || os(iOS)
 
-class ManageSubscriptionsHelperTests: XCTestCase {
+class ManageSubscriptionsHelperTests: TestCase {
 
     private var systemInfo: MockSystemInfo!
     private var customerInfoManager: MockCustomerInfoManager!

--- a/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -18,7 +18,7 @@ import StoreKitTest
 import XCTest
 
 @available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 6.2, *)
-class StoreKitConfigTestCase: XCTestCase {
+class StoreKitConfigTestCase: TestCase {
 
     static var requestTimeout: DispatchTimeInterval = .seconds(60)
 

--- a/Tests/UnitTests/Attribution/AttributionPosterTests.swift
+++ b/Tests/UnitTests/Attribution/AttributionPosterTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class AttributionPosterTests: XCTestCase {
+class AttributionPosterTests: TestCase {
 
     var attributionFetcher: AttributionFetcher!
     var attributionPoster: AttributionPoster!

--- a/Tests/UnitTests/Attribution/AttributionTypeFactoryTests.swift
+++ b/Tests/UnitTests/Attribution/AttributionTypeFactoryTests.swift
@@ -8,7 +8,7 @@ import Nimble
 @testable import RevenueCat
 import XCTest
 
-class AttributionTypeFactoryTests: XCTestCase {
+class AttributionTypeFactoryTests: TestCase {
 
     var attributionTypeFactory: AttributionTypeFactory!
 

--- a/Tests/UnitTests/Caching/DeviceCacheTests.swift
+++ b/Tests/UnitTests/Caching/DeviceCacheTests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class DeviceCacheTests: XCTestCase {
+class DeviceCacheTests: TestCase {
 
     private var systemInfo: MockSystemInfo! = nil
     private var mockUserDefaults: MockUserDefaults! = nil

--- a/Tests/UnitTests/Caching/InMemoryCachedObjectTests.swift
+++ b/Tests/UnitTests/Caching/InMemoryCachedObjectTests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class InMemoryCachedObjectTests: XCTestCase {
+class InMemoryCachedObjectTests: TestCase {
 
     // MARK: isCacheStaleWithDurationInSeconds:
 

--- a/Tests/UnitTests/FoundationExtensions/ArrayExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/ArrayExtensionsTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class ArrayExtensionsTests: XCTestCase {
+class ArrayExtensionsTests: TestCase {
 
     func testPopFirstWithEmptyArray() {
         var array: [Int] = []

--- a/Tests/UnitTests/FoundationExtensions/DateFormatter+ExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/DateFormatter+ExtensionsTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class DateFormatterExtensionTests: XCTestCase {
+class DateFormatterExtensionTests: TestCase {
 
     func testDateFromBytesReturnsCorrectValueIfPossible() throws {
         let timeZone = TimeZone(identifier: "UTC")

--- a/Tests/UnitTests/FoundationExtensions/DecoderExtensionTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/DecoderExtensionTests.swift
@@ -18,7 +18,7 @@ import XCTest
 
 // swiftlint:disable type_name identifier_name nesting
 
-class DecoderExtensionsDefaultValueTests: XCTestCase {
+class DecoderExtensionsDefaultValueTests: TestCase {
 
     private struct Data: Codable, Equatable {
         enum E: String, DefaultValueProvider, Codable, Equatable {
@@ -71,7 +71,7 @@ class DecoderExtensionsDefaultValueTests: XCTestCase {
 
 }
 
-class DecoderExtensionsIgnoreErrorsTests: XCTestCase {
+class DecoderExtensionsIgnoreErrorsTests: TestCase {
 
     private struct Data: Codable, Equatable {
         @IgnoreDecodeErrors var url: URL?
@@ -97,7 +97,7 @@ class DecoderExtensionsIgnoreErrorsTests: XCTestCase {
 
 }
 
-class DecoderExtensionsLossyCollectionTests: XCTestCase {
+class DecoderExtensionsLossyCollectionTests: TestCase {
 
     private struct Data: Codable, Equatable {
         struct Content: Codable, Equatable {
@@ -166,7 +166,7 @@ class DecoderExtensionsLossyCollectionTests: XCTestCase {
 
 }
 
-class DecoderExtensionsDefaultDecodableTests: XCTestCase {
+class DecoderExtensionsDefaultDecodableTests: TestCase {
 
     private struct Data: Codable, Equatable {
         @DefaultDecodable.True var bool1: Bool
@@ -233,7 +233,7 @@ class DecoderExtensionsDefaultDecodableTests: XCTestCase {
 
 }
 
- class DecoderExtensionsLossyAndDefaultCompositionTests: XCTestCase {
+ class DecoderExtensionsLossyAndDefaultCompositionTests: TestCase {
 
      private struct Data: Codable, Equatable {
          @DefaultDecodable.EmptyArray @LossyArray var list: [Int]

--- a/Tests/UnitTests/FoundationExtensions/DictionaryExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/DictionaryExtensionsTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class DictionaryExtensionsTests: XCTestCase {
+class DictionaryExtensionsTests: TestCase {
 
     func testRemovingNSNullValuesFiltersCorrectly() {
         let testValues: [String: Any] = [

--- a/Tests/UnitTests/FoundationExtensions/NSData+RCExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/NSData+RCExtensionsTests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class NSDataExtensionsTests: XCTestCase {
+class NSDataExtensionsTests: TestCase {
 
     func testAsString() {
         let data = Data([

--- a/Tests/UnitTests/FoundationExtensions/NSDate+RCExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/NSDate+RCExtensionsTests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class NSDateExtensionsTests: XCTestCase {
+class NSDateExtensionsTests: TestCase {
     func testMillisecondsSince1970ConvertsCorrectlyWithCurrentTime() {
         let date = NSDate()
         expect(date.millisecondsSince1970AsUInt64()) == (UInt64)(date.timeIntervalSince1970 * 1000)

--- a/Tests/UnitTests/FoundationExtensions/NSError+RCExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/NSError+RCExtensionsTests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class NSErrorRCExtensionsTests: XCTestCase {
+class NSErrorRCExtensionsTests: TestCase {
 
     func testSubscriberAttributesErrorsNilIfNoAttributesErrors() {
         let errorCode = ErrorCode.purchaseNotAllowedError.rawValue

--- a/Tests/UnitTests/FoundationExtensions/ResultExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/ResultExtensionsTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class ResultExtensionsTests: XCTestCase {
+class ResultExtensionsTests: TestCase {
 
     func testValue() {
         expect(Data.success("test").value) == "test"
@@ -48,7 +48,7 @@ class ResultExtensionsTests: XCTestCase {
 
 }
 
-class ResultAsOptionalResultTest: XCTestCase {
+class ResultAsOptionalResultTest: TestCase {
 
     private typealias Data = Result<String?, ResultExtensionsTests.Error>
     private typealias OptionalData = Result<String, ResultExtensionsTests.Error>?

--- a/Tests/UnitTests/FoundationExtensions/SetExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/SetExtensionsTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class SetExtensionsTests: XCTestCase {
+class SetExtensionsTests: TestCase {
 
     func testCreatingDictionaryWithEmptySet() {
         expect(Set<String>().dictionaryWithValues { $0 }) == [:]

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class CustomerInfoManagerTests: XCTestCase {
+class CustomerInfoManagerTests: TestCase {
     var mockBackend = MockBackend()
     var mockOperationDispatcher = MockOperationDispatcher()
     var mockDeviceCache: MockDeviceCache!

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class IdentityManagerTests: XCTestCase {
+class IdentityManagerTests: TestCase {
 
     private var mockDeviceCache: MockDeviceCache!
     private let mockBackend = MockBackend()

--- a/Tests/UnitTests/LocalReceiptParsing/Builders/ASN1ContainerBuilderTests.swift
+++ b/Tests/UnitTests/LocalReceiptParsing/Builders/ASN1ContainerBuilderTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class ASN1ContainerBuilderTests: XCTestCase {
+class ASN1ContainerBuilderTests: TestCase {
     var containerBuilder: ASN1ContainerBuilder!
     let mockContainerPayload: [UInt8] = [0b01, 0b01, 0b01, 0b01, 0b01, 0b01, 0b01, 0b01, 0b01]
     let lengthByteForIndefiniteLengthContainers = 0b10000000

--- a/Tests/UnitTests/LocalReceiptParsing/Builders/ASN1ObjectIdentifierBuilderTests.swift
+++ b/Tests/UnitTests/LocalReceiptParsing/Builders/ASN1ObjectIdentifierBuilderTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class ASN1ObjectIdentifierBuilderTests: XCTestCase {
+class ASN1ObjectIdentifierBuilderTests: TestCase {
 
     let encoder = ASN1ObjectIdentifierEncoder()
     func testBuildFromPayloadBuildsCorrectlyForDataPayload() {

--- a/Tests/UnitTests/LocalReceiptParsing/Builders/AppleReceiptBuilderTests.swift
+++ b/Tests/UnitTests/LocalReceiptParsing/Builders/AppleReceiptBuilderTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class AppleReceiptBuilderTests: XCTestCase {
+class AppleReceiptBuilderTests: TestCase {
     let containerFactory = ContainerFactory()
     var appleReceiptBuilder: AppleReceiptBuilder!
     var mockInAppPurchaseBuilder: MockInAppPurchaseBuilder!

--- a/Tests/UnitTests/LocalReceiptParsing/Builders/InAppPurchaseBuilderTests.swift
+++ b/Tests/UnitTests/LocalReceiptParsing/Builders/InAppPurchaseBuilderTests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class InAppPurchaseBuilderTests: XCTestCase {
+class InAppPurchaseBuilderTests: TestCase {
     // swiftlint:disable force_try
     let quantity = 2
     let productId = "com.revenuecat.sampleProduct"

--- a/Tests/UnitTests/LocalReceiptParsing/DataConverters/ArraySlice_UInt8+ExtensionsTests.swift
+++ b/Tests/UnitTests/LocalReceiptParsing/DataConverters/ArraySlice_UInt8+ExtensionsTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class ArraySliceUInt8ExtensionsTests: XCTestCase {
+class ArraySliceUInt8ExtensionsTests: TestCase {
     func testToUIntReturnsCorrectValue() {
         var arraySlice = ArraySlice([UInt8(0b10000000), UInt8(0b10000000)])
         expect(arraySlice.toUInt64()) == 0b10000000_10000000

--- a/Tests/UnitTests/LocalReceiptParsing/DataConverters/UInt8+ExtensionsTests.swift
+++ b/Tests/UnitTests/LocalReceiptParsing/DataConverters/UInt8+ExtensionsTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class UInt8ExtensionsTests: XCTestCase {
+class UInt8ExtensionsTests: TestCase {
 
     func testBitAtIndexGetsCorrectValue() {
         expect(try UInt8(0b10000000).bitAtIndex(0)) == 1

--- a/Tests/UnitTests/LocalReceiptParsing/ReceiptParserTests.swift
+++ b/Tests/UnitTests/LocalReceiptParsing/ReceiptParserTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class ReceiptParserTests: XCTestCase {
+class ReceiptParserTests: TestCase {
     var receiptParser: ReceiptParser!
     var mockAppleReceiptBuilder: MockAppleReceiptBuilder!
     var mockASN1ContainerBuilder: MockASN1ContainerBuilder!

--- a/Tests/UnitTests/LocalReceiptParsing/TestsAgainstRealReceipts/ReceiptParsing+TestsWithRealReceipts.swift
+++ b/Tests/UnitTests/LocalReceiptParsing/TestsAgainstRealReceipts/ReceiptParsing+TestsWithRealReceipts.swift
@@ -12,7 +12,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class ReceiptParsingRealReceiptTests: XCTestCase {
+class ReceiptParsingRealReceiptTests: TestCase {
 
     let receipt1Name = "base64encodedreceiptsample1"
 

--- a/Tests/UnitTests/Misc/AnyEncodableTests.swift
+++ b/Tests/UnitTests/Misc/AnyEncodableTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class AnyEncodableTests: XCTestCase {
+class AnyEncodableTests: TestCase {
 
     func testEmptyDictionary() {
         let empty: [String: Any] = [:]

--- a/Tests/UnitTests/Misc/AtomicTests.swift
+++ b/Tests/UnitTests/Misc/AtomicTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class AtomicTests: XCTestCase {
+class AtomicTests: TestCase {
     func testInitialValue() {
         let value = Int.random(in: 0..<100)
         let atomic = Atomic(value)

--- a/Tests/UnitTests/Misc/ISOPeriodFormatterTests.swift
+++ b/Tests/UnitTests/Misc/ISOPeriodFormatterTests.swift
@@ -13,7 +13,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class ISOPeriodFormatterTests: XCTestCase {
+class ISOPeriodFormatterTests: TestCase {
 
     func testStringFromProductSubscriptionPeriodDay() throws {
         guard #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, *) else {

--- a/Tests/UnitTests/Misc/LockTests.swift
+++ b/Tests/UnitTests/Misc/LockTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class LockTests: XCTestCase {
+class LockTests: TestCase {
 
     func testClosureIsCalled() {
         let lock = Lock()

--- a/Tests/UnitTests/Misc/SystemInfoTests.swift
+++ b/Tests/UnitTests/Misc/SystemInfoTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class SystemInfoTests: XCTestCase {
+class SystemInfoTests: TestCase {
 
     func testproxyURL() {
         let defaultURL = URL(string: "https://api.revenuecat.com")

--- a/Tests/UnitTests/Misc/TestCase.swift
+++ b/Tests/UnitTests/Misc/TestCase.swift
@@ -1,0 +1,47 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  TestCase.swift
+//
+//  Created by Nacho Soto on 5/10/22.
+
+import SnapshotTesting
+import XCTest
+
+// swiftlint:disable xctestcase_superclass
+
+/// Parent class for all test cases
+/// Provides automatic tracking of test cases using `CurrentTestCaseTracker` as well as snapshot testing helpers.
+class TestCase: XCTestCase {
+
+    override class func setUp() {
+        XCTestObservationCenter.shared.addTestObserver(CurrentTestCaseTracker.shared)
+
+        SnapshotTests.updateSnapshotsIfNeeded()
+    }
+
+    override class func tearDown() {
+        XCTestObservationCenter.shared.removeTestObserver(CurrentTestCaseTracker.shared)
+    }
+
+}
+
+private enum SnapshotTests {
+
+    private static var environmentVariableChecked = false
+
+    static func updateSnapshotsIfNeeded() {
+        guard !Self.environmentVariableChecked else { return }
+
+        if ProcessInfo.processInfo.environment["CIRCLECI_TESTS_GENERATE_SNAPSHOTS"] == "true" {
+            isRecording = true
+        }
+    }
+
+}

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -18,7 +18,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class BaseBackendTests: XCTestCase {
+class BaseBackendTests: TestCase {
 
     private(set) var systemInfo: SystemInfo!
     private(set) var httpClient: MockHTTPClient!
@@ -38,14 +38,6 @@ class BaseBackendTests: XCTestCase {
                                apiKey: Self.apiKey,
                                attributionFetcher: attributionFetcher,
                                dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
-    }
-
-    override class func setUp() {
-        XCTestObservationCenter.shared.addTestObserver(CurrentTestCaseTracker.shared)
-    }
-
-    override class func tearDown() {
-        XCTestObservationCenter.shared.removeTestObserver(CurrentTestCaseTracker.shared)
     }
 
     func createClient() -> MockHTTPClient {

--- a/Tests/UnitTests/Networking/BaseErrorTests.swift
+++ b/Tests/UnitTests/Networking/BaseErrorTests.swift
@@ -17,7 +17,7 @@ import Nimble
 @testable import RevenueCat
 import XCTest
 
-class BaseErrorTests: XCTestCase {
+class BaseErrorTests: TestCase {
 
     /// Compares the result of calling `asPurchasesError` on a `ErrorCodeConvertible`
     /// against the expected `ErrorCode`.

--- a/Tests/UnitTests/Networking/DNSCheckerTests.swift
+++ b/Tests/UnitTests/Networking/DNSCheckerTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class DNSCheckerTests: XCTestCase {
+class DNSCheckerTests: TestCase {
 
     private let apiURL = URL(string: "https://api.revenuecat.com")!
     private let fakeSubscribersURL1 = URL(string: "https://0.0.0.0/subscribers")!

--- a/Tests/UnitTests/Networking/ETagManagerTests.swift
+++ b/Tests/UnitTests/Networking/ETagManagerTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class ETagManagerTests: XCTestCase {
+class ETagManagerTests: TestCase {
 
     private var mockUserDefaults: MockUserDefaults! = nil
     private var eTagManager: ETagManager!

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -13,7 +13,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class HTTPClientTests: XCTestCase {
+class HTTPClientTests: TestCase {
 
     private typealias EmptyResponse = HTTPResponse<HTTPEmptyResponseBody>.Result
 

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class HTTPRequestTests: XCTestCase {
+class HTTPRequestTests: TestCase {
 
     // MARK: - Paths
 

--- a/Tests/UnitTests/Networking/HTTPResponseTests.swift
+++ b/Tests/UnitTests/Networking/HTTPResponseTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class ErrorResponseTests: XCTestCase {
+class ErrorResponseTests: TestCase {
 
     func testNormalErrorResponse() throws {
         let result = try self.decode(Self.withoutAttributeErrors)

--- a/Tests/UnitTests/Networking/HTTPStatusCodeTests.swift
+++ b/Tests/UnitTests/Networking/HTTPStatusCodeTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class HTTPStatusCodeTests: XCTestCase {
+class HTTPStatusCodeTests: TestCase {
 
     func testInitializeFromInteger() {
         func method(_ status: HTTPStatusCode) {

--- a/Tests/UnitTests/Networking/NetworkErrorTests.swift
+++ b/Tests/UnitTests/Networking/NetworkErrorTests.swift
@@ -93,7 +93,7 @@ class NetworkErrorAsPurchasesErrorTests: BaseErrorTests {
 
 }
 
-class NetworkErrorTests: XCTestCase {
+class NetworkErrorTests: TestCase {
 
     func testSuccessfullySyncedTrue() {
         let errors = [

--- a/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
@@ -12,13 +12,13 @@ import XCTest
 
 @testable import RevenueCat
 
-class EmptyCustomerInfoTests: XCTestCase {
+class EmptyCustomerInfoTests: TestCase {
     func testEmptyDataFails() throws {
         expect(try CustomerInfo(data: [:])).to(throwError())
     }
 }
 
-class BasicCustomerInfoTests: XCTestCase {
+class BasicCustomerInfoTests: TestCase {
     let validSubscriberResponse: [String: Any] = [
         "request_date": "2018-10-19T02:40:36Z",
         "request_date_ms": Int64(1563379533946),

--- a/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
+++ b/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class EntitlementInfosTests: XCTestCase {
+class EntitlementInfosTests: TestCase {
 
     private static let formatter = ISO8601DateFormatter()
     private var response: [String: Any] = [:]

--- a/Tests/UnitTests/Purchasing/ErrorCodeTests.swift
+++ b/Tests/UnitTests/Purchasing/ErrorCodeTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class ErrorCodeTests: XCTestCase {
+class ErrorCodeTests: TestCase {
 
     func testUnknownError() {
         ensureEnumCaseMatchesExpectedRawValue(errorCode: .unknownError, expectedRawValue: 0)

--- a/Tests/UnitTests/Purchasing/IntroEligibilityCalculatorTests.swift
+++ b/Tests/UnitTests/Purchasing/IntroEligibilityCalculatorTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import RevenueCat
 
 @available(iOS 12.0, macOS 10.14, macCatalyst 13.0, tvOS 12.0, watchOS 6.2, *)
-class IntroEligibilityCalculatorTests: XCTestCase {
+class IntroEligibilityCalculatorTests: TestCase {
 
     var calculator: IntroEligibilityCalculator!
     var systemInfo: MockSystemInfo!

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -16,7 +16,7 @@ import Nimble
 import StoreKit
 import XCTest
 
-class OfferingsManagerTests: XCTestCase {
+class OfferingsManagerTests: TestCase {
 
     var mockDeviceCache: MockDeviceCache!
     let mockOperationDispatcher = MockOperationDispatcher()

--- a/Tests/UnitTests/Purchasing/OfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsTests.swift
@@ -13,7 +13,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class OfferingsTests: XCTestCase {
+class OfferingsTests: TestCase {
 
     private let offeringsFactory = OfferingsFactory()
 

--- a/Tests/UnitTests/Purchasing/ProductRequestDataInitializationTests.swift
+++ b/Tests/UnitTests/Purchasing/ProductRequestDataInitializationTests.swift
@@ -4,7 +4,7 @@ import StoreKit
 import XCTest
 
 // swiftlint:disable:next type_name
-class ProductRequestDataSK1ProductInitializationTests: XCTestCase {
+class ProductRequestDataSK1ProductInitializationTests: TestCase {
 
     private var product: MockSK1Product!
     private var storefront: MockStorefront!

--- a/Tests/UnitTests/Purchasing/ProductRequestDataTests.swift
+++ b/Tests/UnitTests/Purchasing/ProductRequestDataTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class ProductRequestDataTests: XCTestCase {
+class ProductRequestDataTests: TestCase {
 
     func testAsDictionaryConvertsProductIdentifierCorrectly() throws {
         let productIdentifier = "cool_product"

--- a/Tests/UnitTests/Purchasing/ProductsFetcherSK1Tests.swift
+++ b/Tests/UnitTests/Purchasing/ProductsFetcherSK1Tests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class ProductsFetcherSK1Tests: XCTestCase {
+class ProductsFetcherSK1Tests: TestCase {
     var productsRequestFactory: MockProductsRequestFactory!
     var productsFetcherSK1: ProductsFetcherSK1!
 

--- a/Tests/UnitTests/Purchasing/PurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/PurchasesTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class PurchasesTests: XCTestCase {
+class PurchasesTests: TestCase {
 
     let emptyCustomerInfoData: [String: Any] = [
         "request_date": "2019-08-16T10:30:42Z",

--- a/Tests/UnitTests/Purchasing/ReceiptFetcherTests.swift
+++ b/Tests/UnitTests/Purchasing/ReceiptFetcherTests.swift
@@ -17,7 +17,7 @@ import XCTest
 import Nimble
 @testable import RevenueCat
 
-class ReceiptFetcherTests: XCTestCase {
+class ReceiptFetcherTests: TestCase {
     var receiptFetcher: ReceiptFetcher!
     var mockRequestFetcher: MockRequestFetcher!
     var mockBundle: MockBundle!

--- a/Tests/UnitTests/Purchasing/StoreKitAbstractions/SubscriptionPeriodTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKitAbstractions/SubscriptionPeriodTests.swift
@@ -17,7 +17,7 @@ import Nimble
 import StoreKit
 import XCTest
 
-class SubscriptionPeriodTests: XCTestCase {
+class SubscriptionPeriodTests: TestCase {
 
     func testFromSK1WorksCorrectly() throws {
         guard #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *) else {

--- a/Tests/UnitTests/Purchasing/StoreKitRequestFetcherTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKitRequestFetcherTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class StoreKitRequestFetcherTests: XCTestCase {
+class StoreKitRequestFetcherTests: TestCase {
 
     class MockReceiptRequest: SKReceiptRefreshRequest {
         // swiftlint:disable:next nesting

--- a/Tests/UnitTests/Purchasing/StoreKitWrapperTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKitWrapperTests.swift
@@ -46,7 +46,7 @@ class MockPaymentQueue: SKPaymentQueue {
 
 }
 
-class StoreKitWrapperTests: XCTestCase, StoreKitWrapperDelegate {
+class StoreKitWrapperTests: TestCase, StoreKitWrapperDelegate {
     let paymentQueue = MockPaymentQueue()
 
     var wrapper: StoreKitWrapper?

--- a/Tests/UnitTests/Purchasing/TransactionsFactoryTests.swift
+++ b/Tests/UnitTests/Purchasing/TransactionsFactoryTests.swift
@@ -10,7 +10,7 @@ import Nimble
 @testable import RevenueCat
 import XCTest
 
-class TransactionsFactoryTests: XCTestCase {
+class TransactionsFactoryTests: TestCase {
 
     let dateFormatter = DateFormatter()
 

--- a/Tests/UnitTests/StoreKitExtensions/SKPaymentTransactionExtensionsTests.swift
+++ b/Tests/UnitTests/StoreKitExtensions/SKPaymentTransactionExtensionsTests.swift
@@ -16,7 +16,7 @@ import Nimble
 import StoreKit
 import XCTest
 
-class SKPaymentTransactionExtensionsTests: XCTestCase {
+class SKPaymentTransactionExtensionsTests: TestCase {
 
     func testNilProductIdentifierIfPaymentIsMissing() {
         let transaction = SKPaymentTransaction()

--- a/Tests/UnitTests/SubscriberAttributes/AttributionDataMigratorTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/AttributionDataMigratorTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import RevenueCat
 
 // swiftlint:disable identifier_name
-class AttributionDataMigratorTests: XCTestCase {
+class AttributionDataMigratorTests: TestCase {
 
     static let defaultIdfa = "00000000-0000-0000-0000-000000000000"
     static let defaultIdfv = "A9CFE78C-51F8-4808-94FD-56B4535753C6"

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class BackendSubscriberAttributesTests: XCTestCase {
+class BackendSubscriberAttributesTests: TestCase {
 
     let appUserID = "abc123"
     let referenceDate = Date(timeIntervalSinceReferenceDate: 700000000) // 2023-03-08 20:26:40
@@ -69,14 +69,6 @@ class BackendSubscriberAttributesTests: XCTestCase {
                                                    dateProvider: dateProvider)
 
         try super.setUpWithError()
-    }
-
-    override class func setUp() {
-        XCTestObservationCenter.shared.addTestObserver(CurrentTestCaseTracker.shared)
-    }
-
-    override class func tearDown() {
-        XCTestObservationCenter.shared.removeTestObserver(CurrentTestCaseTracker.shared)
     }
 
     // MARK: PostReceipt with subscriberAttributes

--- a/Tests/UnitTests/SubscriberAttributes/DeviceCacheSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/DeviceCacheSubscriberAttributesTests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class DeviceCacheSubscriberAttributesTests: XCTestCase {
+class DeviceCacheSubscriberAttributesTests: TestCase {
 
     private var mockUserDefaults: MockUserDefaults! = nil
     private var deviceCache: DeviceCache! = nil

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class PurchasesSubscriberAttributesTests: XCTestCase {
+class PurchasesSubscriberAttributesTests: TestCase {
 
     var mockReceiptFetcher: MockReceiptFetcher!
     let mockRequestFetcher = MockRequestFetcher()

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributeTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributeTests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class SubscriberAttributeTests: XCTestCase {
+class SubscriberAttributeTests: TestCase {
     func testInitWithKeyValueSetsRightValues() {
         let now = Date()
         let dateProvider = MockDateProvider(stubbedNow: now)

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -15,7 +15,7 @@ import XCTest
 
 @testable import RevenueCat
 
-class SubscriberAttributesManagerTests: XCTestCase {
+class SubscriberAttributesManagerTests: TestCase {
 
     var mockBackend: MockBackend!
     var mockDeviceCache: MockDeviceCache!


### PR DESCRIPTION
## Motivation:

There is no way to run code statically like in Obj-C using `+ [NSObject initialize]`, so this ensures (through a new `SwiftLint` rule) that all test classes inherit this common test class instead of `XCTestCase` directly.
A future PR will make use of this new `CIRCLECI_TESTS_GENERATE_SNAPSHOTS` environment variable to allow regenerating snapshots in CI.

I've also moved the duplicated `CurrentTestCaseTracker` usages to a single point.