### PR TITLE
`Snapshotting.formattedData`: use `JSONEncoder.OutputFormatting.withoutEscapingSlashes` if available

### DIFF
--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS13-testAliasCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS13-testAliasCallsBackendProperly.1.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS13-testCreateAliasCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS13-testCreateAliasCachesForSameUserIDs.1.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS13-testCreateAliasCachesWhenCallbackNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS13-testCreateAliasCachesWhenCallbackNil.1.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS13-testCreateAliasCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS13-testCreateAliasCallsAllCompletionBlocksInCache.1.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS13-testCreateAliasDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS13-testCreateAliasDoesntCacheForDifferentCurrentUserID.1.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS13-testCreateAliasDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS13-testCreateAliasDoesntCacheForDifferentCurrentUserID.2.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user2\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user2/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS13-testCreateAliasDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS13-testCreateAliasDoesntCacheForDifferentNewUserID.1.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS13-testCreateAliasDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS13-testCreateAliasDoesntCacheForDifferentNewUserID.2.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "another_new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS13-testNetworkErrorIsForwarded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS13-testNetworkErrorIsForwarded.1.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS14-testAliasCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS14-testAliasCallsBackendProperly.1.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS14-testCreateAliasCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS14-testCreateAliasCachesForSameUserIDs.1.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS14-testCreateAliasCachesWhenCallbackNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS14-testCreateAliasCachesWhenCallbackNil.1.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS14-testCreateAliasCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS14-testCreateAliasCallsAllCompletionBlocksInCache.1.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS14-testCreateAliasDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS14-testCreateAliasDoesntCacheForDifferentCurrentUserID.1.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS14-testCreateAliasDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS14-testCreateAliasDoesntCacheForDifferentCurrentUserID.2.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user2\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user2/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS14-testCreateAliasDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS14-testCreateAliasDoesntCacheForDifferentNewUserID.1.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS14-testCreateAliasDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS14-testCreateAliasDoesntCacheForDifferentNewUserID.2.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "another_new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS14-testNetworkErrorIsForwarded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS14-testNetworkErrorIsForwarded.1.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS15-testAliasCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS15-testAliasCallsBackendProperly.1.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS15-testCreateAliasCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS15-testCreateAliasCachesForSameUserIDs.1.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS15-testCreateAliasCachesWhenCallbackNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS15-testCreateAliasCachesWhenCallbackNil.1.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS15-testCreateAliasCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS15-testCreateAliasCallsAllCompletionBlocksInCache.1.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS15-testCreateAliasDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS15-testCreateAliasDoesntCacheForDifferentCurrentUserID.1.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS15-testCreateAliasDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS15-testCreateAliasDoesntCacheForDifferentCurrentUserID.2.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user2\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user2/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS15-testCreateAliasDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS15-testCreateAliasDoesntCacheForDifferentNewUserID.1.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS15-testCreateAliasDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS15-testCreateAliasDoesntCacheForDifferentNewUserID.2.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "another_new_alias"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS15-testNetworkErrorIsForwarded.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendCreateAliasTests/iOS15-testNetworkErrorIsForwarded.1.json
@@ -7,6 +7,6 @@
       "new_app_user_id" : "new"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testCachesCustomerGetsForSameCustomer.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user_id_2"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user_id_2"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testEncodesCustomerUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testEncodesCustomerUserID.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/userid%20with%20spaces"
+    "url" : "https://api.revenuecat.com/v1/subscribers/userid%20with%20spaces"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerCallsBackendProperly.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testGetsCustomerInfo.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesGetCustomerInfoErrors.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testHandlesInvalidJSON.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testCachesCustomerGetsForSameCustomer.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user_id_2"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user_id_2"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testEncodesCustomerUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testEncodesCustomerUserID.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/userid%20with%20spaces"
+    "url" : "https://api.revenuecat.com/v1/subscribers/userid%20with%20spaces"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerCallsBackendProperly.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testGetsCustomerInfo.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testHandlesGetCustomerInfoErrors.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testHandlesInvalidJSON.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testCachesCustomerGetsForSameCustomer.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user_id_2"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user_id_2"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testEncodesCustomerUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testEncodesCustomerUserID.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/userid%20with%20spaces"
+    "url" : "https://api.revenuecat.com/v1/subscribers/userid%20with%20spaces"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerCallsBackendProperly.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testGetsCustomerInfo.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesGetCustomerInfoErrors.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testHandlesInvalidJSON.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfError.1.json
@@ -12,6 +12,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/intro_eligibility"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/intro_eligibility"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testEligibilityUnknownIfUnknownError.1.json
@@ -12,6 +12,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/intro_eligibility"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/intro_eligibility"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS13-testPostsProductIdentifiers.1.json
@@ -13,6 +13,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/intro_eligibility"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/intro_eligibility"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testEligibilityUnknownIfError.1.json
@@ -12,6 +12,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/intro_eligibility"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/intro_eligibility"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testEligibilityUnknownIfUnknownError.1.json
@@ -12,6 +12,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/intro_eligibility"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/intro_eligibility"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS14-testPostsProductIdentifiers.1.json
@@ -13,6 +13,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/intro_eligibility"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/intro_eligibility"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfError.1.json
@@ -12,6 +12,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/intro_eligibility"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/intro_eligibility"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testEligibilityUnknownIfUnknownError.1.json
@@ -12,6 +12,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/intro_eligibility"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/intro_eligibility"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS15-testPostsProductIdentifiers.1.json
@@ -13,6 +13,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/intro_eligibility"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/intro_eligibility"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/offerings"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user_id_2\/offerings"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user_id_2/offerings"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCachesForSameUserID.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/offerings"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethod.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/offerings"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsFailSendsNil.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/offerings"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsNetworkErrorSendsError.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/offerings"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsOneOffering.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/offerings"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/offerings"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user_id_2\/offerings"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user_id_2/offerings"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCachesForSameUserID.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/offerings"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCallsHTTPMethod.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/offerings"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsFailSendsNil.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/offerings"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsNetworkErrorSendsError.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/offerings"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsOneOffering.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/offerings"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/offerings"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user_id_2\/offerings"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user_id_2/offerings"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCachesForSameUserID.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/offerings"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethod.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/offerings"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsFailSendsNil.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/offerings"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsNetworkErrorSendsError.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/offerings"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsOneOffering.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/offerings"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCachesForSameUserIDs.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id 2"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginMakesRightCalls.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCachesForSameUserIDs.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id 2"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginMakesRightCalls.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCachesForSameUserIDs.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id 2"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginMakesRightCalls.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -8,6 +8,6 @@
       "new_app_user_id" : "new id"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS13-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS13-testPostAttributesPutsDataInDataKey.1.json
@@ -11,6 +11,6 @@
       "network" : 0
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/attribution"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/attribution"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS14-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS14-testPostAttributesPutsDataInDataKey.1.json
@@ -11,6 +11,6 @@
       "network" : 0
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/attribution"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/attribution"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS15-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS15-testPostAttributesPutsDataInDataKey.1.json
@@ -11,6 +11,6 @@
       "network" : 0
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/attribution"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/attribution"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningCorrectly.1.json
@@ -15,6 +15,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/offers"
+    "url" : "https://api.revenuecat.com/v1/offers"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningEmptyOffersResponse.1.json
@@ -15,6 +15,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/offers"
+    "url" : "https://api.revenuecat.com/v1/offers"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNetworkError.1.json
@@ -15,6 +15,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/offers"
+    "url" : "https://api.revenuecat.com/v1/offers"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -15,6 +15,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/offers"
+    "url" : "https://api.revenuecat.com/v1/offers"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS13-testOfferForSigningSignatureErrorResponse.1.json
@@ -15,6 +15,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/offers"
+    "url" : "https://api.revenuecat.com/v1/offers"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningCorrectly.1.json
@@ -15,6 +15,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/offers"
+    "url" : "https://api.revenuecat.com/v1/offers"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningEmptyOffersResponse.1.json
@@ -15,6 +15,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/offers"
+    "url" : "https://api.revenuecat.com/v1/offers"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningNetworkError.1.json
@@ -15,6 +15,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/offers"
+    "url" : "https://api.revenuecat.com/v1/offers"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -15,6 +15,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/offers"
+    "url" : "https://api.revenuecat.com/v1/offers"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS14-testOfferForSigningSignatureErrorResponse.1.json
@@ -15,6 +15,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/offers"
+    "url" : "https://api.revenuecat.com/v1/offers"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningCorrectly.1.json
@@ -15,6 +15,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/offers"
+    "url" : "https://api.revenuecat.com/v1/offers"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningEmptyOffersResponse.1.json
@@ -15,6 +15,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/offers"
+    "url" : "https://api.revenuecat.com/v1/offers"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNetworkError.1.json
@@ -15,6 +15,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/offers"
+    "url" : "https://api.revenuecat.com/v1/offers"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -15,6 +15,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/offers"
+    "url" : "https://api.revenuecat.com/v1/offers"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS15-testOfferForSigningSignatureErrorResponse.1.json
@@ -15,6 +15,6 @@
       ]
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/offers"
+    "url" : "https://api.revenuecat.com/v1/offers"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testCachesRequestsForSameReceipt.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : true
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentCurrency.2.json
@@ -20,6 +20,6 @@
       "store_country" : "ESP"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentDiscounts.2.json
@@ -27,6 +27,6 @@
       "store_country" : "ESP"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.1.json
@@ -17,6 +17,6 @@
       "presented_offering_identifier" : "offering_a"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOffering.2.json
@@ -17,6 +17,6 @@
       "presented_offering_identifier" : "offering_b"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : true
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentOfferings.2.json
@@ -17,6 +17,6 @@
       "presented_offering_identifier" : "offering_a"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : true
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentReceipts.2.json
@@ -16,6 +16,6 @@
       "observer_mode" : true
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesntCacheForDifferentRestore.2.json
@@ -16,6 +16,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testFreeTrialPostsCorrectly.1.json
@@ -21,6 +21,6 @@
       "store_country" : "ESP"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -16,6 +16,6 @@
       "observer_mode" : true
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.3.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsUpdatedSubscriberInfoAfterPost.3.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testIndividualParamsCanBeNil.1.json
@@ -20,6 +20,6 @@
       "store_country" : "ESP"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayAsYouGoPostsCorrectly.1.json
@@ -21,6 +21,6 @@
       "store_country" : "ESP"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPayUpFrontPostsCorrectly.1.json
@@ -21,6 +21,6 @@
       "store_country" : "ESP"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostingReceiptCreatesASubscriberInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostingReceiptCreatesASubscriberInfoObject.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataCorrectly.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : true
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -28,6 +28,6 @@
       "subscription_group_id" : "sub_group"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -22,6 +22,6 @@
       "subscription_group_id" : "sub_group"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testCachesRequestsForSameReceipt.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentCurrency.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : true
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentCurrency.2.json
@@ -20,6 +20,6 @@
       "store_country" : "ESP"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentDiscounts.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentDiscounts.2.json
@@ -27,6 +27,6 @@
       "store_country" : "ESP"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOffering.1.json
@@ -17,6 +17,6 @@
       "presented_offering_identifier" : "offering_a"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOffering.2.json
@@ -17,6 +17,6 @@
       "presented_offering_identifier" : "offering_b"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOfferings.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : true
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentOfferings.2.json
@@ -17,6 +17,6 @@
       "presented_offering_identifier" : "offering_a"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentReceipts.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : true
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentReceipts.2.json
@@ -16,6 +16,6 @@
       "observer_mode" : true
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentRestore.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesntCacheForDifferentRestore.2.json
@@ -16,6 +16,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testFreeTrialPostsCorrectly.1.json
@@ -21,6 +21,6 @@
       "store_country" : "ESP"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -16,6 +16,6 @@
       "observer_mode" : true
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.3.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsUpdatedSubscriberInfoAfterPost.3.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testIndividualParamsCanBeNil.1.json
@@ -20,6 +20,6 @@
       "store_country" : "ESP"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPayAsYouGoPostsCorrectly.1.json
@@ -21,6 +21,6 @@
       "store_country" : "ESP"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPayUpFrontPostsCorrectly.1.json
@@ -21,6 +21,6 @@
       "store_country" : "ESP"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostingReceiptCreatesASubscriberInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostingReceiptCreatesASubscriberInfoObject.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataCorrectly.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : true
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -28,6 +28,6 @@
       "subscription_group_id" : "sub_group"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -22,6 +22,6 @@
       "subscription_group_id" : "sub_group"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testCachesRequestsForSameReceipt.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : true
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentCurrency.2.json
@@ -20,6 +20,6 @@
       "store_country" : "ESP"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentDiscounts.2.json
@@ -27,6 +27,6 @@
       "store_country" : "ESP"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.1.json
@@ -17,6 +17,6 @@
       "presented_offering_identifier" : "offering_a"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOffering.2.json
@@ -17,6 +17,6 @@
       "presented_offering_identifier" : "offering_b"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : true
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentOfferings.2.json
@@ -17,6 +17,6 @@
       "presented_offering_identifier" : "offering_a"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : true
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentReceipts.2.json
@@ -16,6 +16,6 @@
       "observer_mode" : true
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesntCacheForDifferentRestore.2.json
@@ -16,6 +16,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testFreeTrialPostsCorrectly.1.json
@@ -21,6 +21,6 @@
       "store_country" : "ESP"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -16,6 +16,6 @@
       "observer_mode" : true
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.3.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsUpdatedSubscriberInfoAfterPost.3.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testIndividualParamsCanBeNil.1.json
@@ -20,6 +20,6 @@
       "store_country" : "ESP"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayAsYouGoPostsCorrectly.1.json
@@ -21,6 +21,6 @@
       "store_country" : "ESP"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPayUpFrontPostsCorrectly.1.json
@@ -21,6 +21,6 @@
       "store_country" : "ESP"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptCreatesASubscriberInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostingReceiptCreatesASubscriberInfoObject.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataCorrectly.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : true
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -28,6 +28,6 @@
       "subscription_group_id" : "sub_group"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -22,6 +22,6 @@
       "subscription_group_id" : "sub_group"
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
@@ -138,7 +138,7 @@ class CustomerInfoDecodingTests: BaseHTTPResponseTest {
     }
 
     func testEncoding() {
-        assertSnapshot(matching: self.customerInfo, as: .formattedJson)
+        assertSnapshot(matching: self.customerInfo, as: .backwardsCompatibleFormattedJson)
     }
 
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesErrorsToCallbackIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesPassesErrorsToCallbackIfStatusCodeIsSuccess.1.json
@@ -24,6 +24,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -24,6 +24,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -24,6 +24,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -16,6 +16,6 @@
       }
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/abc123\/attributes"
+    "url" : "https://api.revenuecat.com/v1/subscribers/abc123/attributes"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -16,6 +16,6 @@
       }
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/abc123\/attributes"
+    "url" : "https://api.revenuecat.com/v1/subscribers/abc123/attributes"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -16,6 +16,6 @@
       }
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/abc123\/attributes"
+    "url" : "https://api.revenuecat.com/v1/subscribers/abc123/attributes"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -16,6 +16,6 @@
       }
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/abc123\/attributes"
+    "url" : "https://api.revenuecat.com/v1/subscribers/abc123/attributes"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -16,6 +16,6 @@
       }
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/abc123\/attributes"
+    "url" : "https://api.revenuecat.com/v1/subscribers/abc123/attributes"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesPassesErrorsToCallbackIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesPassesErrorsToCallbackIfStatusCodeIsSuccess.1.json
@@ -24,6 +24,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -24,6 +24,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -24,6 +24,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -16,6 +16,6 @@
       }
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/abc123\/attributes"
+    "url" : "https://api.revenuecat.com/v1/subscribers/abc123/attributes"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -16,6 +16,6 @@
       }
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/abc123\/attributes"
+    "url" : "https://api.revenuecat.com/v1/subscribers/abc123/attributes"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -16,6 +16,6 @@
       }
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/abc123\/attributes"
+    "url" : "https://api.revenuecat.com/v1/subscribers/abc123/attributes"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -16,6 +16,6 @@
       }
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/abc123\/attributes"
+    "url" : "https://api.revenuecat.com/v1/subscribers/abc123/attributes"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -16,6 +16,6 @@
       }
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/abc123\/attributes"
+    "url" : "https://api.revenuecat.com/v1/subscribers/abc123/attributes"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesErrorsToCallbackIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesPassesErrorsToCallbackIfStatusCodeIsSuccess.1.json
@@ -24,6 +24,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -24,6 +24,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -24,6 +24,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -16,6 +16,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https://api.revenuecat.com/v1/receipts"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -16,6 +16,6 @@
       }
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/abc123\/attributes"
+    "url" : "https://api.revenuecat.com/v1/subscribers/abc123/attributes"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -16,6 +16,6 @@
       }
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/abc123\/attributes"
+    "url" : "https://api.revenuecat.com/v1/subscribers/abc123/attributes"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -16,6 +16,6 @@
       }
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/abc123\/attributes"
+    "url" : "https://api.revenuecat.com/v1/subscribers/abc123/attributes"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -16,6 +16,6 @@
       }
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/abc123\/attributes"
+    "url" : "https://api.revenuecat.com/v1/subscribers/abc123/attributes"
   }
 }

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -16,6 +16,6 @@
       }
     },
     "method" : "POST",
-    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/abc123\/attributes"
+    "url" : "https://api.revenuecat.com/v1/subscribers/abc123/attributes"
   }
 }

--- a/Tests/UnitTests/TestHelpers/SnapshotTesting+Extensions.swift
+++ b/Tests/UnitTests/TestHelpers/SnapshotTesting+Extensions.swift
@@ -18,11 +18,22 @@ import SnapshotTesting
 
 extension Snapshotting where Value == Encodable, Format == String {
 
-    /// Equivalent to .json, but with `JSONEncoder.KeyEncodingStrategy.convertToSnakeCase`
+    /// Equivalent to `.json`, but with `JSONEncoder.KeyEncodingStrategy.convertToSnakeCase`
+    /// and `JSONEncoder.OutputFormatting.withoutEscapingSlashes` if available.
     static var formattedJson: Snapshotting {
+        return self.formattedJson(backwardsCompatible: false)
+    }
+
+    /// Equivalent to `.formattedJson`, but not using `JSONEncoder.OutputFormatting.withoutEscapingSlashes`
+    /// so its output is equivalent regardless of iOS version.
+    static var backwardsCompatibleFormattedJson: Snapshotting {
+        return self.formattedJson(backwardsCompatible: true)
+    }
+
+    private static func formattedJson(backwardsCompatible: Bool) -> Snapshotting {
         var snapshotting = SimplySnapshotting.lines.pullback { (data: Value) in
             // swiftlint:disable:next force_try
-            return try! data.asFormattedString()
+            return try! data.asFormattedString(backwardsCompatible: backwardsCompatible)
         }
         snapshotting.pathExtension = "json"
         return snapshotting
@@ -32,21 +43,36 @@ extension Snapshotting where Value == Encodable, Format == String {
 
 private extension Encodable {
 
-    func asFormattedString() throws -> String {
-        return String(decoding: try self.asFormattedData(), as: UTF8.self)
+    func asFormattedString(backwardsCompatible: Bool) throws -> String {
+        return String(decoding: try self.asFormattedData(backwardsCompatible: backwardsCompatible),
+                      as: UTF8.self)
     }
 
-    func asFormattedData() throws -> Data {
+    func asFormattedData(backwardsCompatible: Bool) throws -> Data {
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
-        encoder.outputFormatting = [
-            .prettyPrinted,
-            .sortedKeys
-        ]
-        // Note: formatting would be simpler with `.withoutEscapingSlashes`
-        // but that wouldn't be backwards compatible for running tests on iOS 12.0
+        encoder.outputFormatting = backwardsCompatible
+            ? backwardsCompatibleOutputFormatting
+            : outputFormatting
 
         return try encoder.encode(self)
     }
 
 }
+
+private let backwardsCompatibleOutputFormatting: JSONEncoder.OutputFormatting = {
+    return [
+        .prettyPrinted,
+        .sortedKeys
+    ]
+}()
+
+private let outputFormatting: JSONEncoder.OutputFormatting = {
+    var result = backwardsCompatibleOutputFormatting
+
+    if #available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *) {
+        result.update(with: .withoutEscapingSlashes)
+    }
+
+    return result
+}()


### PR DESCRIPTION
This was removed after a [PR review comment](https://github.com/RevenueCat/purchases-ios/pull/1366#discussion_r823106740) because it would have lead to different snapshots in iOS 12.

However, since #1504 we have separate snapshots for each iOS version, so this cleans up the output when possible.

### Example:
```diff
- "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/alias"
+ "url" : "https://api.revenuecat.com/v1/subscribers/user/alias"
```