### PR TITLE
Allow CircleCI to generate new test snapshots

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,11 @@ orbs:
 
 version: 2.1
 
+parameters:
+  generate_snapshots:
+    default: false
+    type: boolean
+
 aliases:
   base-job: &base-job
     resource_class: macos.x86.medium.gen2
@@ -11,6 +16,8 @@ aliases:
     parameters:
       xcode_version:
         type: string
+    environment:
+      CIRCLECI_TESTS_GENERATE_SNAPSHOTS: << pipeline.parameters.generate_snapshots >> 
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
   release-tags-and-branches: &release-tags-and-branches
@@ -190,6 +197,12 @@ jobs:
           no_output_timeout: 30m
           environment:
             SCAN_DEVICE: iPhone 13 (15.2)
+      - when:
+          condition: << pipeline.parameters.generate_snapshots >>
+          steps:
+            - run:
+                name: Run create_snapshot_pr 
+                command: bundle exec fastlane create_snapshot_pr version:"ios-15"
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:
@@ -222,11 +235,18 @@ jobs:
           no_output_timeout: 30m
           environment:
             SCAN_DEVICE: iPhone 8 (14.5)
+      - when:
+          condition: << pipeline.parameters.generate_snapshots >>
+          steps:
+            - run:
+                name: Run create_snapshot_pr 
+                command: bundle exec fastlane create_snapshot_pr version:"ios-14"
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
+
   run-test-ios-13:
     <<: *base-job
     steps:
@@ -243,6 +263,12 @@ jobs:
           no_output_timeout: 30m
           environment:
             SCAN_DEVICE: iPhone 8 (13.7)
+      - when:
+          condition: << pipeline.parameters.generate_snapshots >>
+          steps:
+            - run:
+                name: Run create_snapshot_pr 
+                command: bundle exec fastlane create_snapshot_pr version:"ios-13"
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:
@@ -265,6 +291,12 @@ jobs:
           no_output_timeout: 30m
           environment:
             SCAN_DEVICE: iPhone 6 (12.4)
+      - when:
+          condition: << pipeline.parameters.generate_snapshots >>
+          steps:
+            - run:
+                name: Run create_snapshot_pr 
+                command: bundle exec fastlane create_snapshot_pr version:"ios-12"
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:
@@ -435,7 +467,20 @@ jobs:
 
 workflows:
   version: 2
+  generate-snapshot:
+    when: << pipeline.parameters.generate_snapshots >>
+    jobs:
+      - run-test-ios-15:
+          xcode_version: '13.3.1'
+      - run-test-ios-14:
+          xcode_version: '13.3.1'
+      - run-test-ios-13:
+          xcode_version: '13.3.1'
+      - run-test-ios-12:
+          xcode_version: '13.3.1'
   build-test:
+    when:
+      not: << pipeline.parameters.generate_snapshots >>
     jobs:
       - lint:
           xcode_version: '13.3.1'

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,6 @@ gem 'fastlane'
 gem 'cocoapods'
 gem 'jazzy'
 gem 'cocoapods-trunk'
+gem 'rest-client'
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.5)
       rexml
-    activesupport (6.1.5)
+    activesupport (6.1.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -199,6 +199,7 @@ GEM
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
     highline (2.0.3)
+    http-accept (1.7.0)
     http-cookie (1.0.4)
       domain_name (~> 0.5)
     httpclient (2.8.3)
@@ -219,6 +220,9 @@ GEM
     jwt (2.3.0)
     liferaft (0.0.6)
     memoist (0.16.2)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     minitest (5.15.0)
@@ -241,6 +245,11 @@ GEM
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     retriable (3.1.2)
     rexml (3.2.5)
     rouge (2.0.7)
@@ -294,7 +303,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
-  ruby
+  arm64-darwin-21
 
 DEPENDENCIES
   cocoapods
@@ -302,6 +311,7 @@ DEPENDENCIES
   fastlane
   fastlane-plugin-create_xcframework
   jazzy
+  rest-client
 
 BUNDLED WITH
-   2.3.6
+   2.2.32

--- a/Tests/UnitTests/Misc/AnyDecodableTests.swift
+++ b/Tests/UnitTests/Misc/AnyDecodableTests.swift
@@ -20,7 +20,7 @@ import XCTest
 class AnyDecodableTests: TestCase {
 
     func testNull() throws {
-        expect(try AnyDecodable.decode("null")) == .null
+        expect(try AnyDecodable.decode("{\"key\": null}")) == ["key": .null]
     }
 
     func testEmptyDictionary() throws {

--- a/Tests/UnitTests/TestHelpers/SnapshotTesting+Extensions.swift
+++ b/Tests/UnitTests/TestHelpers/SnapshotTesting+Extensions.swift
@@ -39,14 +39,22 @@ private extension Encodable {
     func asFormattedData() throws -> Data {
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
-        encoder.outputFormatting = [
-            .prettyPrinted,
-            .sortedKeys
-        ]
-        // Note: formatting would be simpler with `.withoutEscapingSlashes`
-        // but that wouldn't be backwards compatible for running tests on iOS 12.0
+        encoder.outputFormatting = outputFormatting
 
         return try encoder.encode(self)
     }
 
 }
+
+private let outputFormatting: JSONEncoder.OutputFormatting = {
+    var result: JSONEncoder.OutputFormatting = [
+        .prettyPrinted,
+        .sortedKeys
+    ]
+
+    if #available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *) {
+        result.update(with: .withoutEscapingSlashes)
+    }
+
+    return result
+}()

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -40,6 +40,8 @@ platform :ios do
 
   desc "Runs all the iOS tests"
   lane :test_ios do |options|
+    generate_snapshots = ENV["CIRCLECI_TESTS_GENERATE_SNAPSHOTS"] == "true"
+
     scan(
       step_name: "scan - iPhone", 
       device: ENV['SCAN_DEVICE'] || "iPhone 12 (15.2)",
@@ -47,8 +49,9 @@ platform :ios do
       testplan: "AllTests",
       prelaunch_simulator: true,
       output_types: 'junit',
-      number_of_retries: 5,
-      output_directory: "fastlane/test_output/xctest/ios"
+      number_of_retries: generate_snapshots ? 0 : 5,
+      output_directory: "fastlane/test_output/xctest/ios",
+      fail_build: !generate_snapshots
     )
   end
 
@@ -292,6 +295,66 @@ platform :ios do
     puts formatted if options[:print]
 
     formatted
+  end
+
+  desc "Trigger CircleCI job to generate snapshots"
+  lane :generate_snapshots do 
+    require 'rest-client'
+
+    # Prompt branch
+    default_branch = git_branch
+    branch = UI.input("Branch (defaults to #{default_branch}): ")
+    branch = default_branch if branch == ""
+
+    # Get CircleCI token
+    circle_token = ENV["CIRCLE_TOKEN"]
+    UI.user_error! "Please set the CIRCLE_TOKEN environment variable" unless circle_token
+
+    # Make request
+    headers = {"Circle-Token": circle_token, "Content-Type": "application/json", "Accept": "application/json"}
+    data = {parameters: {generate_snapshots: true}, branch: branch}
+    url = "https://circleci.com/api/v2/project/github/RevenueCat/purchases-ios/pipeline"
+
+    resp = RestClient.post url, data.to_json, headers
+
+    # Print workflow url
+    number = JSON.parse(resp.body)["number"]
+    workflow_url = "https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/#{number}"
+
+    UI.important "Workflow: #{workflow_url}"
+  end
+
+  desc "Creates a new PR after new snapshot files were generated"
+  lane :create_snapshot_pr do |options|
+    version = options[:version]
+    base_branch = ENV["CIRCLE_BRANCH"]
+
+    build_number = ENV["CIRCLE_BUILD_NUM"] 
+
+    branch_name = "generated_snapshots/#{base_branch}-#{build_number}-#{version}"
+    sh("git", "checkout", "-b", branch_name)
+
+    sh("git", "add", "../Tests")
+    file_count = sh("git diff --cached --numstat | wc -l").strip.to_i
+
+    if file_count == 0
+      UI.important("No files to be committed")
+    else
+      sh("git", "commit", "-m", "Generating new test snapshots")
+      push_to_git_remote
+
+      circle_user = ENV["CIRCLE_USERNAME"]
+      body = "Requested by @#{circle_user}"
+
+      create_pull_request(
+        repo: "revenuecat/purchases-ios",
+        title: "Generating new test snapshots - #{version}",
+        body: body,
+        base: base_branch,
+        api_token: ENV["GITHUB_TOKEN"],
+        head: branch_name
+      )
+    end
   end
 
   desc "Creates RevenueCat-Swift.h for a new release"

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -170,6 +170,22 @@ Bump version, edit changelog, and create pull request
 
 Generate changelog from GitHub compare and PR data for mentioning GitHub usernames in release notes
 
+### ios generate_snapshots
+
+```sh
+[bundle exec] fastlane ios generate_snapshots
+```
+
+Trigger CircleCI job to generate snapshots
+
+### ios create_snapshot_pr
+
+```sh
+[bundle exec] fastlane ios create_snapshot_pr
+```
+
+Creates a new PR after new snapshot files were generated
+
 ### ios prepare_next_version
 
 ```sh


### PR DESCRIPTION
Depends on https://github.com/RevenueCat/purchases-ios/pull/1589

### Motivation
Our snapshot testing sometimes needs regeneration and it requires regeneration of iOS 12. iOS 12 simulators only run on Intel machines and not all of us have them.

This PR will allow a CircleCI job to be manually triggered to regenerate snapshot tests

### Description


#### Step 1: Trigger CircleCI workflow
Run `bundle exec fastlane generate_snapshots`

#### Step 2: Run CircleCI workflow with generate snapshots
This will start a series of jobs on CircleCI that will have the `CIRCLECI_TESTS_GENERATE_SNAPSHOTS` set to `true` that will regenerate new/updated snapshot test assets.

<img width="677" alt="Screen Shot 2022-05-12 at 9 02 43 PM" src="https://user-images.githubusercontent.com/401294/168196597-4da1e5cf-e14e-4b4b-afd8-57cfa5345a5a.png">

#### Step 3: Create pull requests

If there are any files changed, a new PR will be created against the base branch (set earlier in the `generate_snapshots` lane)

Example PR 👉  https://github.com/RevenueCat/purchases-ios/pull/1578

<img width="1308" alt="Screen Shot 2022-05-12 at 8 57 46 PM" src="https://user-images.githubusercontent.com/401294/168196195-61f0c151-1f00-4a2e-a722-3a512942cfeb.png">

