### PR TITLE
Added tests and fix to ensure `RawDataContainer` includes all data

### DIFF
--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -220,9 +220,8 @@ extension CustomerInfo: RawDataContainer {
 
     // Docs inherited from protocol
     // swiftlint:disable missing_docs
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    public var underlyingData: some Encodable {
-        return self.data.response
+    public var rawData: [String: Any] {
+        return self.data.response.rawData
     }
 
 }

--- a/Sources/Networking/Responses/CustomerInfoResponse.swift
+++ b/Sources/Networking/Responses/CustomerInfoResponse.swift
@@ -13,6 +13,8 @@
 
 import Foundation
 
+/// The representation of ``CustomerInfo`` as sent by the backend.
+/// Thanks to `@IgnoreHashable`, only `subscriber` is used for equality / hash.
 struct CustomerInfoResponse {
 
     var subscriber: Subscriber
@@ -94,6 +96,8 @@ extension CustomerInfoResponse.Entitlement: Hashable {}
 extension CustomerInfoResponse.Entitlement: Encodable {}
 extension CustomerInfoResponse.Entitlement: Decodable {
 
+    // Note: this must be manually implemented because of the custom call to `decodeRawData`
+    // which can't be abstracted as a property wrapper.
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
@@ -122,6 +126,8 @@ extension CustomerInfoResponse.Transaction: Codable, Hashable {
 
 extension CustomerInfoResponse: Codable {
 
+    // Note: this must be manually implemented because of the custom call to `decodeRawData`
+    // which can't be abstracted as a property wrapper.
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 

--- a/Sources/Purchasing/EntitlementInfo.swift
+++ b/Sources/Purchasing/EntitlementInfo.swift
@@ -282,9 +282,8 @@ extension PeriodType: DefaultValueProvider {
 
      // Docs inherited from protocol
      // swiftlint:disable missing_docs
-     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-     public var underlyingData: some Encodable {
-         return self.entitlement
+     public var rawData: [String: Any] {
+         return self.entitlement.rawData
      }
 
  }

--- a/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
@@ -94,6 +94,38 @@ class CustomerInfoDecodingTests: BaseHTTPResponseTest {
         expect(entitlement2.purchaseDate) == Self.dateFormatter.date(from: "1990-09-30T02:40:36Z")
     }
 
+    func testEntitlementsContainAllRawData() throws {
+        let entitlement = try XCTUnwrap(self.customerInfo.subscriber.entitlements["premium"])
+
+        let futureData = try XCTUnwrap(
+            entitlement.rawData["future_data"],
+            "Unparsed key is not included in raw data"
+        )
+        let parsedData = try XCTUnwrap(
+            futureData as? [String: String],
+            "Data is the wrong type: \(futureData)"
+        )
+
+        expect(parsedData) == ["is_included": "in_raw_data"]
+    }
+
+    func testRawDataIsNotEncoded() throws {
+        expect(try self.customerInfo.asDictionary().keys).toNot(contain("raw_data"))
+    }
+
+    func testRawDataIncludesUnparsedKeys() throws {
+        let futureData = try XCTUnwrap(
+            self.customerInfo.rawData["future_data"],
+            "Unparsed key is not included in raw data"
+        )
+        let parsedData = try XCTUnwrap(
+            futureData as? [String: String],
+            "Data is the wrong type: \(futureData)"
+        )
+
+        expect(parsedData) == ["is_included": "in_raw_data"]
+    }
+
     func testReencoding() {
         expect(try self.customerInfo.encodeAndDecode()) == self.customerInfo
     }

--- a/Tests/UnitTests/Networking/Responses/Fixtures/CustomerInfo.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/CustomerInfo.json
@@ -42,7 +42,10 @@
             "premium": {
                 "expires_date": "1990-08-30T02:40:36Z",
                 "product_identifier": "com.revenuecat.monthly_4.99.1_week_intro",
-                "purchase_date": "1990-08-30T02:40:36Z"
+                "purchase_date": "1990-08-30T02:40:36Z",
+                "future_data": {
+                    "is_included": "in_raw_data"
+                }
             },
             "tip": {
                 "expires_date": null,
@@ -50,5 +53,8 @@
                 "purchase_date": "1990-09-30T02:40:36Z"
             }
         }
+    },
+    "future_data": {
+        "is_included": "in_raw_data"
     }
 }

--- a/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
@@ -261,10 +261,11 @@ class BasicCustomerInfoTests: TestCase {
 
     }
 
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func testPreservesOriginalJSONSerializableObject() throws {
-        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+    func testDecodesRawData() throws {
+        expect(self.customerInfo.rawData).toNot(beEmpty())
+    }
 
+    func testPreservesOriginalJSONSerializableObject() throws {
         expect(try CustomerInfo(data: self.customerInfo.rawData)) == self.customerInfo
     }
 

--- a/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
+++ b/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
@@ -1053,6 +1053,14 @@ class EntitlementInfosTests: TestCase {
 
         try verifyRenewal(false)
     }
+
+    func testRawData() throws {
+        let info = try CustomerInfo(data: self.response)
+
+        expect(info.entitlements.all.values).to(allPass {
+            !$0.rawData.isEmpty
+        })
+    }
 }
 
 private extension EntitlementInfosTests {


### PR DESCRIPTION
Follow up to #1496. Depends on ~~#1567,  #1568, #1604~~.

The solution implemented in #1496 was very simple, but [as pointed out by @joshdholtz](https://github.com/RevenueCat/purchases-ios/pull/1496#discussion_r869463028), it was only encoding the data that was formally decoded by the `struct`s.
We had no test coverage for this, so it went unnoticed.

The new solution adds a new field:
```swift
@IgnoreEncodable @IgnoreHashable
var rawData: [String: Any]
```

Which, together with a new helper method `decodeRawData()`, allows storing all the data to be used by `CustomerInfo`'s `RawDataContainer` implementation.

Unfortunately, despite many attempts, I realized that this can't be abstracted into a property wrapper, because a `KeyedDecodingContainer` can't access the parent `Decoder`.
That's why the `CustomerInfoResponse` and `CustomerInfoResponse.Entitlement` must manually call this method.