### PR TITLE
Added `String.asData` to avoid dealing with `Data?`

### DIFF
--- a/Sources/FoundationExtensions/String+Extensions.swift
+++ b/Sources/FoundationExtensions/String+Extensions.swift
@@ -69,6 +69,10 @@ extension String {
         return self.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    var asData: Data {
+        return Data(self.utf8)
+    }
+
 }
 
 private enum ROT13 {

--- a/Sources/Purchasing/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/PurchasesOrchestrator.swift
@@ -337,7 +337,7 @@ class PurchasesOrchestrator {
 
         if let signedData = promotionalOffer?.signedData {
             Logger.debug(Strings.storeKit.sk2_purchasing_added_promotional_offer_option(signedData.identifier))
-            options.insert(try signedData.sk2PurchaseOption)
+            options.insert(signedData.sk2PurchaseOption)
         }
 
         let result: Product.PurchaseResult

--- a/Sources/Purchasing/StoreKitAbstractions/PromotionalOffer.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/PromotionalOffer.swift
@@ -81,41 +81,15 @@ extension PromotionalOffer.SignedData {
                                  timestamp: self.timestamp as NSNumber)
     }
 
-    /// - Throws: ``ErrorCode/unexpectedBackendResponseError`` if the signature cannot be encoded in UTF8
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     var sk2PurchaseOption: Product.PurchaseOption {
-        get throws {
-            guard let signatureData = self.signature.data(using: .utf8) else {
-                throw ErrorUtils.unexpectedBackendResponse(
-                    withSubError: PromotionalOffer.Error.invalidSignature(self.signature)
-                )
-            }
-
-            return .promotionalOffer(
-                offerID: self.identifier,
-                keyID: self.keyIdentifier,
-                nonce: self.nonce,
-                signature: signatureData,
-                timestamp: self.timestamp
-            )
-        }
-    }
-
-}
-
-extension PromotionalOffer {
-
-    enum Error: DescribableError {
-
-        case invalidSignature(String)
-
-        var description: String {
-            switch self {
-            case let .invalidSignature(signature):
-                return "PromotionalOffer.signature cannot be encoded in UTF8: '\(signature)'"
-            }
-        }
-
+        return .promotionalOffer(
+            offerID: self.identifier,
+            keyID: self.keyIdentifier,
+            nonce: self.nonce,
+            signature: self.signature.asData,
+            timestamp: self.timestamp
+        )
     }
 
 }

--- a/Tests/BackendIntegrationTests/SubscriberAttributesManagerIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/SubscriberAttributesManagerIntegrationTests.swift
@@ -82,7 +82,7 @@ class SubscriberAttributesManagerIntegrationTests: BaseBackendIntegrationTests {
     }
 
     func testPushTokenWithInvalidTokenDoesNotFail() async throws {
-        Purchases.shared.setPushToken("invalid token".data(using: .utf8))
+        Purchases.shared.setPushToken("invalid token".asData)
 
         let errors = await self.syncAttributes()
         verifyAttributesSyncedWithNoErrors(errors, 1)

--- a/Tests/UnitTests/Caching/DeviceCacheTests.swift
+++ b/Tests/UnitTests/Caching/DeviceCacheTests.swift
@@ -208,7 +208,7 @@ class DeviceCacheTests: TestCase {
             }
         """
         let offeringsData: OfferingsResponse.Offering = try JSONDecoder.default.decode(
-            jsonData: offeringsJSON.data(using: .utf8)!
+            jsonData: offeringsJSON.asData
         )
 
         let offering = try XCTUnwrap(

--- a/Tests/UnitTests/FoundationExtensions/DecoderExtensionTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/DecoderExtensionTests.swift
@@ -356,12 +356,11 @@ private extension Decodable where Self: Encodable {
 private extension Decodable {
 
     static func decode(_ json: String) throws -> Self {
-        return try JSONDecoder.default.decode(jsonData: json.data(using: .utf8)!)
+        return try JSONDecoder.default.decode(jsonData: json.asData)
     }
 
     static func decodeEmptyData() throws -> Self {
-        let json = "{}".data(using: .utf8)!
-        return try JSONDecoder.default.decode(jsonData: json)
+        return try self.decode("{}")
     }
 
 }

--- a/Tests/UnitTests/Networking/Backend/BackendPostOfferForSigningTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostOfferForSigningTests.swift
@@ -49,7 +49,7 @@ class BackendPostOfferForSigningTests: BaseBackendTests {
         let group = "sub_group"
         var completionCalled = false
         let offerIdentifier = "offerid"
-        let discountData = "an awesome discount".data(using: String.Encoding.utf8)!
+        let discountData = "an awesome discount".asData
 
         backend.post(offerIdForSigning: offerIdentifier,
                      productIdentifier: productIdentifier,

--- a/Tests/UnitTests/Networking/ETagManagerTests.swift
+++ b/Tests/UnitTests/Networking/ETagManagerTests.swift
@@ -203,7 +203,7 @@ class ETagManagerTests: TestCase {
         let request = URLRequest(url: url)
         let cacheKey = url.absoluteString
 
-        let actualResponse = "response".data(using: .utf8)!
+        let actualResponse = "response".asData
 
         let wrapper = OldWrapper(eTag: eTag,
                                  statusCode: HTTPStatusCode.success.rawValue,

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -556,7 +556,7 @@ class HTTPClientTests: TestCase {
             expect(requestNumber) == completionCallCount.value
 
             let json = "{\"message\": \"something is great up in the cloud\"}"
-            return HTTPStubsResponse(data: json.data(using: .utf8)!,
+            return HTTPStubsResponse(data: json.asData,
                                      statusCode: .success,
                                      headers: nil)
                 .responseTime(0.003)
@@ -630,7 +630,7 @@ class HTTPClientTests: TestCase {
             }
 
             let json = "{\"message\": \"something is great up in the cloud\"}"
-            return HTTPStubsResponse(data: json.data(using: .utf8)!,
+            return HTTPStubsResponse(data: json.asData,
                                      statusCode: .success,
                                      headers: nil)
                 .responseTime(responseTime)

--- a/Tests/UnitTests/Networking/HTTPResponseTests.swift
+++ b/Tests/UnitTests/Networking/HTTPResponseTests.swift
@@ -245,27 +245,13 @@ private extension ErrorResponseTests {
 
 private extension ErrorResponseTests {
 
-    enum Error: Swift.Error {
-
-        case unableToEncodeString
-
-    }
-
     func decode(_ response: String) throws -> ErrorResponse {
-        guard let data = response.data(using: .utf8) else {
-            throw Error.unableToEncodeString
-        }
-
-        return try JSONDecoder.default.decode(ErrorResponse.self, from: data)
+        return try JSONDecoder.default.decode(ErrorResponse.self, from: response.asData)
     }
 
     func decodeSupportingContainer(_ response: String) throws -> ErrorResponse {
-        guard let data = response.data(using: .utf8) else {
-            throw Error.unableToEncodeString
-        }
-
         return ErrorResponse.from(
-            try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
+            try JSONSerialization.jsonObject(with: response.asData) as? [String: Any] ?? [:]
         )
     }
 

--- a/Tests/UnitTests/Purchasing/OfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsTests.swift
@@ -204,7 +204,7 @@ class OfferingsTests: TestCase {
             "offerings": [],
             "current_offering_id": null
         }
-        """.data(using: .utf8)!
+        """.asData
 
         let offeringsResponse: OfferingsResponse = try JSONDecoder.default.decode(jsonData: json)
         let offerings = self.offeringsFactory.createOfferings(from: [:], data: offeringsResponse)

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -307,10 +307,10 @@ class PurchasesSubscriberAttributesTests: TestCase {
 
     func testSetAndClearPushToken() {
         setupPurchases()
-        purchases.setPushToken("atoken".data(using: .utf8))
+        purchases.setPushToken("atoken".asData)
         purchases.setPushToken(nil)
         expect(self.mockSubscriberAttributesManager.invokedSetPushTokenParametersList[0])
-            .to(equal(("atoken".data(using: .utf8), purchases.appUserID)))
+            .to(equal(("atoken".asData, purchases.appUserID)))
         expect(self.mockSubscriberAttributesManager.invokedSetPushTokenParametersList[1])
             .to(equal((nil, purchases.appUserID)))
     }
@@ -489,8 +489,8 @@ class PurchasesSubscriberAttributesTests: TestCase {
 
     func testSetPushTokenMakesRightCalls() {
         setupPurchases()
-        let tokenData = Data("ligai32g32ig".data(using: .utf8)!)
-        let tokenString = (tokenData as NSData).asString()
+        let tokenData = "ligai32g32ig".asData
+        let tokenString = tokenData.asString
 
         Purchases.shared.setPushToken(tokenData)
         expect(self.mockSubscriberAttributesManager.invokedSetPushTokenCount) == 1

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -288,7 +288,7 @@ class SubscriberAttributesManagerTests: TestCase {
     }
 
     func testSetPushToken() {
-        let tokenData = "ligai32g32ig".data(using: .utf8)!
+        let tokenData = "ligai32g32ig".asData
         self.subscriberAttributesManager.setPushToken(tokenData, appUserID: "kratos")
 
         expect(self.mockDeviceCache.invokedStoreCount) == 1
@@ -304,7 +304,7 @@ class SubscriberAttributesManagerTests: TestCase {
     }
 
     func testSetPushTokenSetsEmptyIfNil() {
-        let tokenData = "ligai32g32ig".data(using: .utf8)!
+        let tokenData = "ligai32g32ig".asData
         self.subscriberAttributesManager.setPushToken(tokenData, appUserID: "kratos")
 
         self.subscriberAttributesManager.setPushToken(nil, appUserID: "kratos")
@@ -320,7 +320,7 @@ class SubscriberAttributesManagerTests: TestCase {
     }
 
     func testSetPushTokenSkipsIfSameValue() {
-        let tokenData = "ligai32g32ig".data(using: .utf8)!
+        let tokenData = "ligai32g32ig".asData
         let tokenString = (tokenData as NSData).asString()
         self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$apnsTokens",
                                                                                     value: tokenString)
@@ -331,7 +331,7 @@ class SubscriberAttributesManagerTests: TestCase {
     }
 
     func testSetPushTokenOverwritesIfNewValue() {
-        let tokenData = "ligai32g32ig".data(using: .utf8)!
+        let tokenData = "ligai32g32ig".asData
         let tokenString = (tokenData as NSData).asString()
         let oldSyncTime = Date()
 


### PR DESCRIPTION
Turns out `Data(string.utf8)` is a much simpler way of converting `String` to `Data` that doesn't lead to an `Optional`.
UTF-8 can represent all valid Unicode code points, so this was always safe, but now we know at compile time.

The reason the old variant returned an `Optional` is because it accepts other encodings like `.ascii` which might not be able to represent everything in the `String`.

This simplifies several parts of the code that were dealing with an error that was impossible.