### PR TITLE
Added `@IgnoreEncodable` property wrapper

### DIFF
--- a/Sources/FoundationExtensions/Decoder+Extensions.swift
+++ b/Sources/FoundationExtensions/Decoder+Extensions.swift
@@ -77,9 +77,48 @@ extension DefaultValue: Encodable where Value: Encodable {
 
 }
 
+// MARK: - IgnoreEncodable
+
+/// A property wrapper that allows not encoding a value.
+/// - Example:
+/// ```
+/// struct Data {
+///     @IgnoreEncodable var data: String // this value won't be encoded
+/// }
+/// ```
+@propertyWrapper
+struct IgnoreEncodable<Value> {
+
+    var wrappedValue: Value
+
+}
+
+extension IgnoreEncodable: Decodable where Value: Decodable {
+
+    init(from decoder: Decoder) throws {
+        self.wrappedValue = try decoder.singleValueContainer().decode(Value.self)
+    }
+
+}
+
+extension IgnoreEncodable: Encodable {
+
+    func encode(to encoder: Encoder) throws {}
+
+}
+
+extension IgnoreEncodable: Equatable where Value: Equatable {}
+extension IgnoreEncodable: Hashable where Value: Hashable {}
+
+extension KeyedEncodingContainer {
+
+    mutating func encode<T>(_ value: IgnoreEncodable<T>, forKey key: K) throws {}
+
+}
+
 // MARK: - IgnoreDecodeErrors
 
-/// A property wrapper for that allows ignoring decoding errors for `Optional` properties
+/// A property wrapper that allows ignoring decoding errors for `Optional` properties
 /// - Example:
 /// ```
 /// struct Data {

--- a/Tests/UnitTests/FoundationExtensions/DecoderExtensionTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/DecoderExtensionTests.swift
@@ -275,6 +275,30 @@ class DecoderExtensionsDefaultDecodableTests: TestCase {
 
 }
 
+class IgnoreEncodableTests: TestCase {
+
+    private struct Data: Codable, Equatable {
+        var value: Int
+        @IgnoreEncodable var ignored: Int
+    }
+
+    func testValueIsNotEncoded() throws {
+        let data = Data(value: 2, ignored: 2)
+        let encoded = try XCTUnwrap(
+            String(data: try JSONEncoder.default.encode(data), encoding: .utf8)
+        )
+
+        expect(encoded) == "{\"value\":2}"
+    }
+
+    func testValueIsDecoded() throws {
+        let json = "{\"value\": 1, \"ignored\": 2}"
+
+        expect(try Data.decode(json)) == .init(value: 1, ignored: 2)
+    }
+
+}
+
  class DecoderExtensionsLossyAndDefaultCompositionTests: TestCase {
 
      private struct Data: Codable, Equatable {


### PR DESCRIPTION
This allows having properties in an `Encodable` type that won't be encoded.
This will be used to storing the `rawData` when decoding our types (see #1496).