### PR TITLE
Renamed `Decoder.throwValueNotFoundError`

### DIFF
--- a/Sources/CodableExtensions/PeriodType+Extensions.swift
+++ b/Sources/CodableExtensions/PeriodType+Extensions.swift
@@ -19,8 +19,8 @@ extension PeriodType: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         guard let periodTypeString = try? container.decode(String.self) else {
-            throw decoder.throwValueNotFoundError(expectedType: PeriodType.self,
-                                                  message: "Unable to extract a periodTypeString")
+            throw decoder.valueNotFoundError(expectedType: PeriodType.self,
+                                             message: "Unable to extract a periodTypeString")
         }
 
         guard let type = Self.mapping[periodTypeString] else {

--- a/Sources/CodableExtensions/PurchaseOwnershipType+Extensions.swift
+++ b/Sources/CodableExtensions/PurchaseOwnershipType+Extensions.swift
@@ -19,8 +19,8 @@ extension PurchaseOwnershipType: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         guard let purchaseOwnershipTypeString = try? container.decode(String.self) else {
-            throw decoder.throwValueNotFoundError(expectedType: PurchaseOwnershipType.self,
-                                                  message: "Unable to extract an purchaseOwnershipTypeString")
+            throw decoder.valueNotFoundError(expectedType: PurchaseOwnershipType.self,
+                                             message: "Unable to extract an purchaseOwnershipTypeString")
         }
 
         if let type = Self.mapping[purchaseOwnershipTypeString] {

--- a/Sources/CodableExtensions/Store+Extensions.swift
+++ b/Sources/CodableExtensions/Store+Extensions.swift
@@ -19,7 +19,7 @@ extension Store: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         guard let storeString = try? container.decode(String.self) else {
-            throw decoder.throwValueNotFoundError(expectedType: Store.self, message: "Unable to extract a storeString")
+            throw decoder.valueNotFoundError(expectedType: Store.self, message: "Unable to extract a storeString")
         }
 
         guard let type = Self.mapping[storeString] else {

--- a/Sources/FoundationExtensions/Decoder+Extensions.swift
+++ b/Sources/FoundationExtensions/Decoder+Extensions.swift
@@ -17,7 +17,7 @@ import Foundation
 
 extension Decoder {
 
-    func throwValueNotFoundError(expectedType: Any.Type, message: String) -> CodableError {
+    func valueNotFoundError(expectedType: Any.Type, message: String) -> CodableError {
         let context = DecodingError.Context(codingPath: codingPath,
                                             debugDescription: message,
                                             underlyingError: nil)


### PR DESCRIPTION
The method doesn't actually throw, so calling `throw decoder.throwValueNotFoundError()` was confusing. Now the code reads `throw decoder.valueNotFoundError()`.