### PR TITLE
`PostOfferForSigningOperation`: changed response parsing to using `Decodable`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -227,6 +227,8 @@
 		574A2EE7282C3F0800150D40 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574A2EE6282C3F0800150D40 /* AnyDecodable.swift */; };
 		574A2EE9282C403800150D40 /* AnyDecodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574A2EE8282C403800150D40 /* AnyDecodableTests.swift */; };
 		574A2F3F282D75E300150D40 /* OfferingsDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574A2F3E282D75E300150D40 /* OfferingsDecodingTests.swift */; };
+		574A2F4B282D7AEA00150D40 /* PostOfferResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574A2F4A282D7AEA00150D40 /* PostOfferResponse.swift */; };
+		574A2F4F282D7B9E00150D40 /* PostOfferDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574A2F4E282D7B9E00150D40 /* PostOfferDecodingTests.swift */; };
 		5751379527F4C4D80064AB2C /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5751379427F4C4D80064AB2C /* Optional+Extensions.swift */; };
 		575137CF27F50D2F0064AB2C /* HTTPResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575137CE27F50D2F0064AB2C /* HTTPResponseBody.swift */; };
 		57536A2627851FFE00E2AE7F /* SK1StoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57536A2527851FFE00E2AE7F /* SK1StoreTransaction.swift */; };
@@ -690,6 +692,8 @@
 		574A2EE6282C3F0800150D40 /* AnyDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyDecodable.swift; sourceTree = "<group>"; };
 		574A2EE8282C403800150D40 /* AnyDecodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyDecodableTests.swift; sourceTree = "<group>"; };
 		574A2F3E282D75E300150D40 /* OfferingsDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferingsDecodingTests.swift; sourceTree = "<group>"; };
+		574A2F4A282D7AEA00150D40 /* PostOfferResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostOfferResponse.swift; sourceTree = "<group>"; };
+		574A2F4E282D7B9E00150D40 /* PostOfferDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostOfferDecodingTests.swift; sourceTree = "<group>"; };
 		5751379427F4C4D80064AB2C /* Optional+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
 		575137CE27F50D2F0064AB2C /* HTTPResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponseBody.swift; sourceTree = "<group>"; };
 		57536A2527851FFE00E2AE7F /* SK1StoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1StoreTransaction.swift; sourceTree = "<group>"; };
@@ -1624,6 +1628,7 @@
 				5774F9B92805E6E200997128 /* CustomerInfoDecodingTests.swift */,
 				5774F9C02805EA3000997128 /* BaseHTTPResponseTest.swift */,
 				574A2F3E282D75E300150D40 /* OfferingsDecodingTests.swift */,
+				574A2F4E282D7B9E00150D40 /* PostOfferDecodingTests.swift */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -1663,6 +1668,7 @@
 			children = (
 				57D5412D27F6311C004CC35C /* OfferingsResponse.swift */,
 				5774F9B52805E6CC00997128 /* CustomerInfoResponse.swift */,
+				574A2F4A282D7AEA00150D40 /* PostOfferResponse.swift */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -2300,6 +2306,7 @@
 				A55D08302722368600D919E0 /* SK2BeginRefundRequestHelper.swift in Sources */,
 				35D832CD262A5B7500E60AC5 /* ETagManager.swift in Sources */,
 				2DDF41BC24F6F392005BC22D /* ArraySlice_UInt8+Extensions.swift in Sources */,
+				574A2F4B282D7AEA00150D40 /* PostOfferResponse.swift in Sources */,
 				F575858D26C088FE00C12B97 /* OfferingsManager.swift in Sources */,
 				B34605CB279A6E380031CA74 /* PostReceiptDataOperation.swift in Sources */,
 				354895D4267AE4B4001DC5B1 /* AttributionKey.swift in Sources */,
@@ -2475,6 +2482,7 @@
 				2DDF41EA24F6F844005BC22D /* SKProductSubscriptionDurationExtensions.swift in Sources */,
 				351B517A26D44FF000BD2BD7 /* MockRequestFetcher.swift in Sources */,
 				351B514E26D44ACE00BD2BD7 /* SubscriberAttributesManagerTests.swift in Sources */,
+				574A2F4F282D7B9E00150D40 /* PostOfferDecodingTests.swift in Sources */,
 				2DDF41CE24F6F4C3005BC22D /* InAppPurchaseBuilderTests.swift in Sources */,
 				573A10DB2800AF4700F976E5 /* PurchaseErrorTests.swift in Sources */,
 				B300E4BF26D436F900B22262 /* LogIntent.swift in Sources */,

--- a/Sources/Logging/Strings/BackendErrorStrings.swift
+++ b/Sources/Logging/Strings/BackendErrorStrings.swift
@@ -19,14 +19,8 @@ enum BackendErrorStrings {
     // Backend tried to instantiate a CustomerInfo but for some reason it couldn't.
     case customer_info_instantiation_error(response: [String: Any]?)
 
-    // getOfferings response was totally empty.
-    case offerings_empty_response
-
-    // getOfferings object was missing from response.
-    case offerings_response_json_error(response: [String: Any])
-
     // getOfferings response contained no offerings.
-    case no_offerings_response_json(response: [String: Any])
+    case offerings_response_no_offerings
 
     // Posting offerIdForSigning failed due to a signature problem.
     case signature_error(signatureDataString: Any?)
@@ -43,12 +37,8 @@ extension BackendErrorStrings: CustomStringConvertible {
                 message += " from:\n \(response.debugDescription)"
             }
             return message
-        case .offerings_empty_response:
-            return "Unable to parse Offerings object from empty response"
-        case .offerings_response_json_error(let response):
-            return "Unable to parse Offerings from response:\n\(String(describing: response["offers"]))"
-        case .no_offerings_response_json(let response):
-            return "No offerings found in response:\n\(String(describing: response["offers"]))"
+        case .offerings_response_no_offerings:
+            return "Offerings response contained no offerings"
         case .signature_error(let signatureDataString):
             return "Missing 'signatureData' or its structure changed:\n\(String(describing: signatureDataString))"
         }

--- a/Sources/Networking/Operations/PostOfferForSigningOperation.swift
+++ b/Sources/Networking/Operations/PostOfferForSigningOperation.swift
@@ -51,26 +51,28 @@ class PostOfferForSigningOperation: NetworkOperation {
         )
 
         self.httpClient.perform(request,
-                                authHeaders: self.authHeaders) { (response: HTTPResponse<[String: Any]>.Result) in
+                                authHeaders: self.authHeaders) { (response: HTTPResponse<PostOfferResponse>.Result) in
             let result: Result<PostOfferForSigningOperation.SigningData, BackendError> = response
-                .mapError(BackendError.networkError)
+                .mapError { error -> BackendError in
+                    if case .decoding = error {
+                        return .unexpectedBackendResponse(.postOfferIdSignature,
+                                                          extraContext: error.localizedDescription)
+                    } else {
+                        return .networkError(error)
+                    }
+                }
                 .flatMap { response in
                     let (statusCode, response) = (response.statusCode, response.body)
 
-                    guard let offers = response["offers"] as? [[String: Any]] else {
-                        Logger.debug(Strings.backendError.offerings_response_json_error(response: response))
+                    let offers = response.offers
 
-                        return .failure(.unexpectedBackendResponse(.postOfferIdBadResponse,
-                                                                   extraContext: response.stringRepresentation))
-                    }
-
-                    guard offers.count > 0 else {
-                        Logger.debug(Strings.backendError.no_offerings_response_json(response: response))
+                    guard let firstOffer = offers.first else {
+                        Logger.debug(Strings.backendError.offerings_response_no_offerings)
 
                         return .failure(.unexpectedBackendResponse(.postOfferIdMissingOffersInResponse))
                     }
 
-                    return Self.handleOffer(offers[0], statusCode: statusCode)
+                    return Self.handleOffer(firstOffer, statusCode: statusCode)
                 }
 
             self.responseHandler(result)
@@ -79,22 +81,30 @@ class PostOfferForSigningOperation: NetworkOperation {
     }
 
     private static func handleOffer(
-        _ offer: [String: Any],
+        _ offer: PostOfferResponse.Offer,
         statusCode: HTTPStatusCode
     ) -> Result<PostOfferForSigningOperation.SigningData, BackendError> {
-        if let signatureError = offer["signature_error"] as? [String: Any] {
+        if let signatureError = offer.signatureError {
             return .failure(
-                .networkError(.errorResponse(ErrorResponse.from(signatureError), statusCode))
+                .networkError(.errorResponse(signatureError, statusCode))
             )
-        } else if let signatureData = offer["signature_data"] as? [String: Any],
-                  let signature = signatureData["signature"] as? String,
-                  let keyIdentifier = offer["key_id"] as? String,
-                  let nonce = (signatureData["nonce"] as? String).flatMap({ UUID(uuidString: $0) }),
-                  let timestamp = signatureData["timestamp"] as? Int {
-            return .success((signature, keyIdentifier, nonce, timestamp))
+        } else if let signingData = offer.asSigningData {
+            return .success(signingData)
         } else {
-            return .failure(.unexpectedBackendResponse(.postOfferIdSignature, extraContext: offer.stringRepresentation))
+            return .failure(
+                .unexpectedBackendResponse(.postOfferIdSignature, extraContext: "\(offer)")
+            )
         }
+    }
+
+}
+
+private extension PostOfferResponse.Offer {
+
+    var asSigningData: PostOfferForSigningOperation.SigningData? {
+        guard let signature = self.signatureData else { return nil }
+
+        return (signature.signature, self.keyIdentifier, signature.nonce, signature.timestamp)
     }
 
 }

--- a/Sources/Networking/Operations/PostOfferForSigningOperation.swift
+++ b/Sources/Networking/Operations/PostOfferForSigningOperation.swift
@@ -102,9 +102,9 @@ class PostOfferForSigningOperation: NetworkOperation {
 private extension PostOfferResponse.Offer {
 
     var asSigningData: PostOfferForSigningOperation.SigningData? {
-        guard let signature = self.signatureData else { return nil }
+        guard let data = self.signatureData else { return nil }
 
-        return (signature.signature, self.keyIdentifier, signature.nonce, signature.timestamp)
+        return (data.signature, self.keyIdentifier, data.nonce, data.timestamp)
     }
 
 }

--- a/Sources/Networking/Responses/PostOfferResponse.swift
+++ b/Sources/Networking/Responses/PostOfferResponse.swift
@@ -1,0 +1,57 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PostOfferResponse.swift
+//
+//  Created by Nacho Soto on 5/12/22.
+
+import Foundation
+
+// swiftlint:disable nesting
+
+struct PostOfferResponse {
+
+    struct Offer {
+
+        struct SignatureData {
+
+            let nonce: UUID
+            let signature: String
+            let timestamp: Int
+
+        }
+
+        let keyIdentifier: String
+        let offerIdentifier: String
+        let productIdentifier: String
+        let signatureData: SignatureData?
+        let signatureError: ErrorResponse?
+
+    }
+
+    let offers: [Offer]
+}
+
+extension PostOfferResponse.Offer.SignatureData: Decodable {}
+extension PostOfferResponse.Offer: Decodable {
+
+    enum CodingKeys: String, CodingKey {
+
+        case keyIdentifier = "keyId"
+        case offerIdentifier = "offerId"
+        case productIdentifier = "productId"
+        case signatureError
+        case signatureData
+
+    }
+
+}
+
+extension PostOfferResponse: Decodable {}
+extension PostOfferResponse: HTTPResponseBody {}

--- a/Tests/UnitTests/Networking/Responses/Fixtures/PostOffer.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/PostOffer.json
@@ -1,0 +1,15 @@
+{
+    "offers": [
+        {
+            "key_id": "C815358F",
+            "offer_id": "com.revenuecat.monthly_4.99.1_free_week",
+            "product_id": "com.revenuecat.monthly_4.99.1_week_intro",
+            "signature_data": {
+                "nonce": "aea2714d-37cb-4a40-b3fa-3a39cf2ac4ed",
+                "signature": "MEUCIQDDMArMh1PHNa75EZ49ntaNoqLIE7ueO8gjcdFYVbe57wIgLO+7M9AeIMUVMybj8ir982nDo6CfDFjTuqd5YSm8NG4=",
+                "timestamp": 1646761777900
+            },
+            "signature_error": null
+        }
+    ]
+}

--- a/Tests/UnitTests/Networking/Responses/Fixtures/PostOffer.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/PostOffer.json
@@ -9,7 +9,10 @@
                 "signature": "MEUCIQDDMArMh1PHNa75EZ49ntaNoqLIE7ueO8gjcdFYVbe57wIgLO+7M9AeIMUVMybj8ir982nDo6CfDFjTuqd5YSm8NG4=",
                 "timestamp": 1646761777900
             },
-            "signature_error": null
+            "signature_error": {
+                "code": 7234,
+                "message": "Ineligible for some reason"
+            }
         }
     ]
 }

--- a/Tests/UnitTests/Networking/Responses/PostOfferDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/PostOfferDecodingTests.swift
@@ -1,0 +1,45 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PostOfferDecodingTests.swift
+//
+//  Created by Nacho Soto on 5/12/22.
+
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+class PostOfferDecodingTests: BaseHTTPResponseTest {
+
+    private var response: PostOfferResponse!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        self.response = try self.decodeFixture("PostOffer")
+    }
+
+    func testResponseDataIsCorrect() throws {
+        expect(self.response.offers).to(haveCount(1))
+
+        let offer = try XCTUnwrap(self.response.offers.first)
+
+        expect(offer.keyIdentifier) == "C815358F"
+        expect(offer.offerIdentifier) == "com.revenuecat.monthly_4.99.1_free_week"
+        expect(offer.productIdentifier) == "com.revenuecat.monthly_4.99.1_week_intro"
+        expect(offer.signatureError).to(beNil())
+
+        let signature = try XCTUnwrap(offer.signatureData)
+        expect(signature.nonce) == UUID(uuidString: "aea2714d-37cb-4a40-b3fa-3a39cf2ac4ed")
+        expect(signature.signature) ==
+        "MEUCIQDDMArMh1PHNa75EZ49ntaNoqLIE7ueO8gjcdFYVbe57wIgLO+7M9AeIMUVMybj8ir982nDo6CfDFjTuqd5YSm8NG4="
+        expect(signature.timestamp) == 1646761777900
+    }
+
+}

--- a/Tests/UnitTests/Networking/Responses/PostOfferDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/PostOfferDecodingTests.swift
@@ -33,7 +33,11 @@ class PostOfferDecodingTests: BaseHTTPResponseTest {
         expect(offer.keyIdentifier) == "C815358F"
         expect(offer.offerIdentifier) == "com.revenuecat.monthly_4.99.1_free_week"
         expect(offer.productIdentifier) == "com.revenuecat.monthly_4.99.1_week_intro"
-        expect(offer.signatureError).to(beNil())
+
+        let error = try XCTUnwrap(offer.signatureError)
+        expect(error.code) == .invalidAppleSubscriptionKey
+        expect(error.message) == "Ineligible for some reason"
+        expect(error.attributeErrors).to(beEmpty())
 
         let signature = try XCTUnwrap(offer.signatureData)
         expect(signature.nonce) == UUID(uuidString: "aea2714d-37cb-4a40-b3fa-3a39cf2ac4ed")


### PR DESCRIPTION
## Changes:
- Added `PostOfferResponse`
- Added `PostOfferDecodingTests` tests
- Using the automatic deserialization by `HTTPClient` by simply changing the callback to `HTTPResponse<PostOfferResponse>.Result`
- All tests in `BackendPostOfferForSigningTests` (which are very exhaustive) pass with no changes!