### PR TITLE
`BackendGetIntroEligibilityTests`: fixed test that was passing before anything ran

### DIFF
--- a/Tests/UnitTests/Networking/Backend/BackendGetIntroEligibilityTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetIntroEligibilityTests.swift
@@ -24,14 +24,16 @@ class BackendGetIntroEligibilityTests: BaseBackendTests {
     }
 
     func testEmptyEligibilityCheckDoesNothing() {
+        var error: NSError??
+
         backend.getIntroEligibility(appUserID: Self.userID,
                                     receiptData: Data(),
-                                    productIdentifiers: [],
-                                    completion: { _, error in
-            expect(error).to(beNil())
-        })
+                                    productIdentifiers: []) {
+            error = $1 as NSError?
+        }
 
-        expect(self.httpClient.calls.count).to(equal(0))
+        expect(error).toEventually(equal(.some(nil)))
+        expect(self.httpClient.calls.count) == 0
     }
 
     func testPostsProductIdentifiers() throws {


### PR DESCRIPTION
Operations run asynchronously, but this test was not waiting, and therefore the only assertion always passed no matter what.
Now this actually ensures that when the operation ends, there are still no requests being made.