### PR TITLE
willRenew update comment for lifetime will be false

### DIFF
--- a/Sources/Purchasing/EntitlementInfo.swift
+++ b/Sources/Purchasing/EntitlementInfo.swift
@@ -87,8 +87,7 @@ extension PeriodType: DefaultValueProvider {
 
     /**
      True if the underlying subscription is set to renew at the end of
-     the billing period (``expirationDate``). Will always be `true` if entitlement
-     is for lifetime access.
+     the billing period (``expirationDate``).
      */
     @objc public let willRenew: Bool
 


### PR DESCRIPTION
### Motivation
Inspired by https://github.com/RevenueCat/purchases-flutter/issues/361

### Description
The comment for entitlement's `willRenew` was wrong. Lifteime purchases will return `false`
