### PR TITLE
`Purchases.canMakePayments`: moved implementation to `StoreKitWrapper`

### DIFF
--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -142,7 +142,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
      * Indicates whether the user is allowed to make payments.
      * [More information on when this might be `false` here](https://rev.cat/can-make-payments-apple)
      */
-    @objc public static func canMakePayments() -> Bool { SKPaymentQueue.canMakePayments() }
+    @objc public static func canMakePayments() -> Bool { StoreKitWrapper.canMakePayments() }
 
     /**
      * Set a custom log handler for redirecting logs to your own logging system.

--- a/Sources/Purchasing/StoreKit1/StoreKitWrapper.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKitWrapper.swift
@@ -80,6 +80,10 @@ class StoreKitWrapper: NSObject, SKPaymentTransactionObserver {
         paymentQueue.finishTransaction(transaction)
     }
 
+    static func canMakePayments() -> Bool {
+        return SKPaymentQueue.canMakePayments()
+    }
+
     @available(iOS 14.0, *)
     @available(macOS, unavailable)
     @available(tvOS, unavailable)


### PR DESCRIPTION
Fixes [CF-571]