### PR TITLE
`HTTPClient`: added `X-Is-Sandbox` header

### DIFF
--- a/Sources/Networking/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient.swift
@@ -11,6 +11,8 @@
 //
 //  Created by César de la Vega on 7/22/21.
 
+// swiftlint:disable file_length
+
 import Foundation
 
 class HTTPClient {
@@ -132,7 +134,9 @@ private extension HTTPClient {
 private extension HTTPClient {
 
     var defaultHeaders: [String: String] {
-        let observerMode = systemInfo.finishTransactions ? "false" : "true"
+        let observerMode = (!self.systemInfo.finishTransactions).encodedString
+        let sandbox = self.systemInfo.isSandbox.encodedString
+
         var headers: [String: String] = [
             "content-type": "application/json",
             "X-Version": SystemInfo.frameworkVersion,
@@ -142,7 +146,8 @@ private extension HTTPClient {
             "X-Client-Version": SystemInfo.appVersion,
             "X-Client-Build-Version": SystemInfo.buildVersion,
             "X-StoreKit2-Setting": "\(self.systemInfo.storeKit2Setting.debugDescription)",
-            "X-Observer-Mode-Enabled": observerMode
+            "X-Observer-Mode-Enabled": observerMode,
+            "X-Is-Sandbox": sandbox
         ]
 
         if let platformFlavorVersion = self.systemInfo.platformFlavorVersion {
@@ -394,6 +399,14 @@ private extension Result where Success == Data? {
     /// Converts a `Result<Data?, Error>` into `Result<HTTPResponse<Data?>, Failure>`
     func mapSuccessToOptionalHTTPResult(_ statusCode: HTTPStatusCode) -> Result<HTTPResponse<Data?>, Failure> {
         return self.map { HTTPResponse(statusCode: statusCode, body: $0) }
+    }
+
+}
+
+private extension Bool {
+
+    var encodedString: String {
+        return self ? "true" : "false"
     }
 
 }

--- a/Sources/Networking/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient.swift
@@ -135,7 +135,6 @@ private extension HTTPClient {
 
     var defaultHeaders: [String: String] {
         let observerMode = !self.systemInfo.finishTransactions
-        let sandbox = self.systemInfo.isSandbox
 
         var headers: [String: String] = [
             "content-type": "application/json",
@@ -147,7 +146,7 @@ private extension HTTPClient {
             "X-Client-Build-Version": SystemInfo.buildVersion,
             "X-StoreKit2-Setting": "\(self.systemInfo.storeKit2Setting.debugDescription)",
             "X-Observer-Mode-Enabled": "\(observerMode)",
-            "X-Is-Sandbox": "\(sandbox)"
+            "X-Is-Sandbox": "\(self.systemInfo.isSandbox)"
         ]
 
         if let platformFlavorVersion = self.systemInfo.platformFlavorVersion {

--- a/Sources/Networking/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient.swift
@@ -134,8 +134,8 @@ private extension HTTPClient {
 private extension HTTPClient {
 
     var defaultHeaders: [String: String] {
-        let observerMode = (!self.systemInfo.finishTransactions).encodedString
-        let sandbox = self.systemInfo.isSandbox.encodedString
+        let observerMode = !self.systemInfo.finishTransactions
+        let sandbox = self.systemInfo.isSandbox
 
         var headers: [String: String] = [
             "content-type": "application/json",
@@ -146,8 +146,8 @@ private extension HTTPClient {
             "X-Client-Version": SystemInfo.appVersion,
             "X-Client-Build-Version": SystemInfo.buildVersion,
             "X-StoreKit2-Setting": "\(self.systemInfo.storeKit2Setting.debugDescription)",
-            "X-Observer-Mode-Enabled": observerMode,
-            "X-Is-Sandbox": sandbox
+            "X-Observer-Mode-Enabled": "\(observerMode)",
+            "X-Is-Sandbox": "\(sandbox)"
         ]
 
         if let platformFlavorVersion = self.systemInfo.platformFlavorVersion {
@@ -399,14 +399,6 @@ private extension Result where Success == Data? {
     /// Converts a `Result<Data?, Error>` into `Result<HTTPResponse<Data?>, Failure>`
     func mapSuccessToOptionalHTTPResult(_ statusCode: HTTPStatusCode) -> Result<HTTPResponse<Data?>, Failure> {
         return self.map { HTTPResponse(statusCode: statusCode, body: $0) }
-    }
-
-}
-
-private extension Bool {
-
-    var encodedString: String {
-        return self ? "true" : "false"
     }
 
 }

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -136,6 +136,44 @@ class HTTPClientTests: TestCase {
         expect(headerPresent.value).toEventually(equal(true))
     }
 
+    func testAlwaysPassesIsSandboxWhenEnabled() {
+        let headerName = "X-Is-Sandbox"
+        self.systemInfo.stubbedIsSandbox = true
+
+        let header: Atomic<String?> = .init(nil)
+
+        stub(condition: hasHeaderNamed(headerName)) { request in
+            header.value = request.value(forHTTPHeaderField: headerName)
+            return .emptySuccessResponse
+        }
+
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
+
+        self.client.perform(request, authHeaders: ["test_header": "value"]) { (_: EmptyResponse) in }
+
+        expect(header.value).toEventuallyNot(beNil())
+        expect(header.value) == "true"
+    }
+
+    func testAlwaysPassesIsSandboxWhenDisabled() {
+        let headerName = "X-Is-Sandbox"
+        self.systemInfo.stubbedIsSandbox = false
+
+        let header: Atomic<String?> = .init(nil)
+
+        stub(condition: hasHeaderNamed(headerName)) { request in
+            header.value = request.value(forHTTPHeaderField: headerName)
+            return .emptySuccessResponse
+        }
+
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
+
+        self.client.perform(request, authHeaders: ["test_header": "value"]) { (_: EmptyResponse) in }
+
+        expect(header.value).toEventuallyNot(beNil())
+        expect(header.value) == "false"
+    }
+
     func testCallsTheGivenPath() {
         let request = HTTPRequest(method: .post([:]), path: .mockPath)
 


### PR DESCRIPTION
Fixes [CF-649].

[CF-649]: https://revenuecats.atlassian.net/browse/CF-649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ