### PR TITLE
CF-653: Add `AmazonStore` to `Store` enum

### DIFF
--- a/Sources/CodableExtensions/Store+Extensions.swift
+++ b/Sources/CodableExtensions/Store+Extensions.swift
@@ -55,6 +55,7 @@ private extension Store {
         case .playStore: return "play_store"
         case .stripe: return "stripe"
         case .promotional: return "promotional"
+        case .amazonStore: return "amazon_store"
         case .unknownStore: return nil
         }
     }

--- a/Sources/CodableExtensions/Store+Extensions.swift
+++ b/Sources/CodableExtensions/Store+Extensions.swift
@@ -55,7 +55,7 @@ private extension Store {
         case .playStore: return "play_store"
         case .stripe: return "stripe"
         case .promotional: return "promotional"
-        case .amazonStore: return "amazon_store"
+        case .amazonStore: return "amazon"
         case .unknownStore: return nil
         }
     }

--- a/Sources/Purchasing/EntitlementInfo.swift
+++ b/Sources/Purchasing/EntitlementInfo.swift
@@ -36,6 +36,9 @@ import Foundation
 
     /// For entitlements granted via an unknown store.
     @objc(RCUnknownStore) case unknownStore = 5
+    
+    /// For entitlements granted via the Amazon Store.
+    @objc(RCAmazonStore) case amazonStore = 6
 
 }
 

--- a/Sources/Purchasing/EntitlementInfo.swift
+++ b/Sources/Purchasing/EntitlementInfo.swift
@@ -36,7 +36,7 @@ import Foundation
 
     /// For entitlements granted via an unknown store.
     @objc(RCUnknownStore) case unknownStore = 5
-    
+
     /// For entitlements granted via the Amazon Store.
     @objc(RCAmazonStore) case amazonStore = 6
 

--- a/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
@@ -21,7 +21,8 @@ public typealias SK1Transaction = SKPaymentTransaction
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 public typealias SK2Transaction = StoreKit.Transaction
 
-/// Abstract class that provides access to properties of a transaction. ``StoreTransaction``s can represent transactions from StoreKit 1, StoreKit 2 or
+/// Abstract class that provides access to properties of a transaction.
+/// ``StoreTransaction``s can represent transactions from StoreKit 1, StoreKit 2 or
 /// transactions made from other places, like Stripe, Google Play or Amazon Store.
 @objc(RCStoreTransaction) public final class StoreTransaction: NSObject, StoreTransactionType {
 

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCEntitlementInfoAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCEntitlementInfoAPI.m
@@ -39,8 +39,10 @@
         case RCPlayStore:
         case RCStripe:
         case RCPromotional:
+        case RCAmazonStore:
         case RCUnknownStore:
             NSLog(@"%ld", (long)rs);
+            break;
     }
 
 

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/EntitlementInfoAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/EntitlementInfoAPI.swift
@@ -45,6 +45,7 @@ func checkEntitlementInfoEnums() {
          .playStore,
          .stripe,
          .promotional,
+         .amazonStore,
          .unknownStore:
         print(store!)
     @unknown default:

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -296,7 +296,9 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
             XCTFail("Expected error")
         } catch {
             expect(self.backend.invokedPostReceiptData) == false
-            let mockListener = try XCTUnwrap(orchestrator.storeKit2TransactionListener as? MockStoreKit2TransactionListener)
+            let mockListener = try XCTUnwrap(
+                orchestrator.storeKit2TransactionListener as? MockStoreKit2TransactionListener
+            )
             expect(mockListener.invokedHandle) == false
         }
     }
@@ -317,7 +319,9 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         } catch {
             expect(error).to(matchError(expectedError))
 
-            let mockListener = try XCTUnwrap(orchestrator.storeKit2TransactionListener as? MockStoreKit2TransactionListener)
+            let mockListener = try XCTUnwrap(
+                orchestrator.storeKit2TransactionListener as? MockStoreKit2TransactionListener
+            )
             expect(mockListener.invokedHandle) == true
         }
     }

--- a/Tests/StoreKitUnitTests/StoreKit2StorefrontListenerTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2StorefrontListenerTests.swift
@@ -16,7 +16,7 @@ import Nimble
 import XCTest
 
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-class StoreKit2StorefrontListenerTests: XCTestCase {
+class StoreKit2StorefrontListenerTests: TestCase {
 
     private var listener: StoreKit2StorefrontListener! = nil
 

--- a/Tests/StoreKitUnitTests/StorefrontTests.swift
+++ b/Tests/StoreKitUnitTests/StorefrontTests.swift
@@ -27,8 +27,7 @@ class StorefrontTests: StoreKitConfigTestCase {
 
         expect(currentStorefront.identifier) == expectedStorefront.id
         expect(currentStorefront.countryCode) == expectedStorefront.countryCode
-        
-        
+
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, macCatalyst 13.1, *)

--- a/Tests/StoreKitUnitTests/StorefrontTests.swift
+++ b/Tests/StoreKitUnitTests/StorefrontTests.swift
@@ -27,6 +27,8 @@ class StorefrontTests: StoreKitConfigTestCase {
 
         expect(currentStorefront.identifier) == expectedStorefront.id
         expect(currentStorefront.countryCode) == expectedStorefront.countryCode
+        
+        
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, macCatalyst 13.1, *)

--- a/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
+++ b/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
@@ -681,6 +681,28 @@ class EntitlementInfosTests: TestCase {
                     "original_purchase_date": "2019-07-26T23:30:41Z",
                     "period_type": "normal",
                     "purchase_date": "2019-07-26T23:45:40Z",
+                    "store": "amazon",
+                    "unsubscribe_detected_at": nil
+                ]
+            ])
+        try verifyStore(.amazonStore)
+
+        stubResponse(
+            entitlements: [
+                "pro_cat": [
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "product_identifier": "monthly_freetrial",
+                    "purchase_date": "2019-07-26T23:45:40Z"
+                ]
+            ],
+            subscriptions: [
+                "monthly_freetrial": [
+                    "billing_issues_detected_at": nil,
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "is_sandbox": false,
+                    "original_purchase_date": "2019-07-26T23:30:41Z",
+                    "period_type": "normal",
+                    "purchase_date": "2019-07-26T23:45:40Z",
                     "store": "tienda",
                     "unsubscribe_detected_at": nil
                 ]

--- a/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
+++ b/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
@@ -860,6 +860,36 @@ class EntitlementInfosTests: TestCase {
                 subscriptions: [:]
         )
         try verifyStore(.stripe)
+        
+        stubResponse(
+                entitlements: [
+                    "pro_cat": [
+                        "expires_date": nil,
+                        "product_identifier": "lifetime",
+                        "purchase_date": "2019-07-26T23:45:40Z"
+                    ]
+                ],
+                nonSubscriptions: [
+                    "lifetime": [
+                        [
+                            "id": "5b9ba226bc",
+                            "is_sandbox": false,
+                            "original_purchase_date": "2019-07-26T22:10:27Z",
+                            "purchase_date": "2019-07-26T22:10:27Z",
+                            "store": "app_store"
+                        ],
+                        [
+                            "id": "ea820afcc4",
+                            "is_sandbox": false,
+                            "original_purchase_date": "2019-07-26T23:45:40Z",
+                            "purchase_date": "2019-07-26T23:45:40Z",
+                            "store": "amazon"
+                        ]
+                    ]
+                ],
+                subscriptions: [:]
+        )
+        try verifyStore(.amazonStore)
 
         stubResponse(
                 entitlements: [

--- a/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
+++ b/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
@@ -860,7 +860,7 @@ class EntitlementInfosTests: TestCase {
                 subscriptions: [:]
         )
         try verifyStore(.stripe)
-        
+
         stubResponse(
                 entitlements: [
                     "pro_cat": [


### PR DESCRIPTION
This PR adds `AmazonStore` to the `Store` enum.

### Checklist
- TODO: Create corresponding PRs for hybrid SDKs

### Motivation
Resolves [CF-653](https://revenuecats.atlassian.net/browse/CF-653).

### Description
- Added the `AmazonStore` value to the `Store` enum with a value of `6` to ensure that any implementations relying on `Unknown` being `5` don't break.
- Ensured that the `name` value of the case matches the value used by the backend.
- Updated relevant `switch` statements to include the new case.
- Fixed a few Swiftlint warnings to get the CI to pass