### PR TITLE
CF-653: Rename `AmazonStore` Store enum case to `Amazon` to match Android naming

### DIFF
--- a/Sources/CodableExtensions/Store+Extensions.swift
+++ b/Sources/CodableExtensions/Store+Extensions.swift
@@ -55,7 +55,7 @@ private extension Store {
         case .playStore: return "play_store"
         case .stripe: return "stripe"
         case .promotional: return "promotional"
-        case .amazonStore: return "amazon"
+        case .amazon: return "amazon"
         case .unknownStore: return nil
         }
     }

--- a/Sources/Purchasing/EntitlementInfo.swift
+++ b/Sources/Purchasing/EntitlementInfo.swift
@@ -38,7 +38,7 @@ import Foundation
     @objc(RCUnknownStore) case unknownStore = 5
 
     /// For entitlements granted via the Amazon Store.
-    @objc(RCAmazonStore) case amazonStore = 6
+    @objc(RCAmazon) case amazon = 6
 
 }
 

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCEntitlementInfoAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCEntitlementInfoAPI.m
@@ -39,7 +39,7 @@
         case RCPlayStore:
         case RCStripe:
         case RCPromotional:
-        case RCAmazonStore:
+        case RCAmazon:
         case RCUnknownStore:
             NSLog(@"%ld", (long)rs);
             break;

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/EntitlementInfoAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/EntitlementInfoAPI.swift
@@ -45,7 +45,7 @@ func checkEntitlementInfoEnums() {
          .playStore,
          .stripe,
          .promotional,
-         .amazonStore,
+         .amazon,
          .unknownStore:
         print(store!)
     @unknown default:

--- a/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
+++ b/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
@@ -685,7 +685,7 @@ class EntitlementInfosTests: TestCase {
                     "unsubscribe_detected_at": nil
                 ]
             ])
-        try verifyStore(.amazonStore)
+        try verifyStore(.amazon)
 
         stubResponse(
             entitlements: [
@@ -889,7 +889,7 @@ class EntitlementInfosTests: TestCase {
                 ],
                 subscriptions: [:]
         )
-        try verifyStore(.amazonStore)
+        try verifyStore(.amazon)
 
         stubResponse(
                 entitlements: [


### PR DESCRIPTION
### Description
This PR is a follow up to #1586 that renames the `Store` enum's `AmazonStore` case to `Amazon` to match the naming conventions used in the [Android SDK](https://github.com/RevenueCat/purchases-android/blob/8b81142904780aede258962b4aef350273cfaad7/public/src/main/java/com/revenuecat/purchases/EntitlementInfo.kt#L150).