### PR TITLE
`StoreKitIntegrationTests`: added test to check applying a promotional offer during subscription

### DIFF
--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -442,7 +442,9 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
         entitlement = try await self.verifyEntitlementWentThrough(customerInfo)
         let transaction = try await Self.findTransaction(for: product.productIdentifier)
 
-        self.verifyPromotionalOffer(offer, entitlement, transaction)
+        expect(entitlement.latestPurchaseDate) != entitlement.originalPurchaseDate
+        expect(transaction.offerID) == offer.discount.offerIdentifier
+        expect(transaction.offerType) == .promotional
     }
 
 }
@@ -591,28 +593,6 @@ private extension StoreKit1IntegrationTests {
             beEmpty(),
             description: "Expected no entitlements. Got: \(customerInfo.entitlements.all)"
         )
-    }
-
-    @available(iOS 15.2, tvOS 15.2, macOS 12.1, watchOS 8.3, *)
-    func verifyPromotionalOffer(
-        _ offer: PromotionalOffer,
-        _ entitlement: EntitlementInfo,
-        _ transaction: Transaction,
-        file: FileString = #file,
-        line: UInt = #line
-    ) {
-        expect(
-            file: file, line: line,
-            entitlement.latestPurchaseDate
-        ) != entitlement.originalPurchaseDate
-        expect(
-            file: file, line: line,
-            transaction.offerID
-        ) == offer.discount.offerIdentifier
-        expect(
-            file: file, line: line,
-            transaction.offerType
-        ) == .promotional
     }
 
     func expireSubscription(_ entitlement: EntitlementInfo) async throws {

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -401,12 +401,9 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
 
         customerInfo = try await Purchases.shared.purchase(product: product, promotionalOffer: offer).customerInfo
 
-        // 4. Verify offer was applied
+        // 4. Verify purchase went through
 
         let entitlement = try await self.verifyEntitlementWentThrough(customerInfo)
-        let transaction = try await Self.findTransaction(for: product.productIdentifier)
-
-        self.verifyPromotionalOffer(offer, entitlement, transaction)
     }
 
     @available(iOS 15.2, tvOS 15.2, macOS 12.1, watchOS 8.3, *)

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -387,8 +387,7 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
 
         // 1. Purchase subscription
 
-        _ = try await Purchases.shared.purchase(product: product)
-        var customerInfo = try await Purchases.shared.syncPurchases()
+        var customerInfo = try await Purchases.shared.purchase(product: product).customerInfo
 
         try await self.verifyEntitlementWentThrough(customerInfo)
 
@@ -400,8 +399,7 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
 
         // 3. Purchase offer
 
-        _ = try await Purchases.shared.purchase(product: product, promotionalOffer: offer)
-        customerInfo = try await Purchases.shared.syncPurchases()
+        customerInfo = try await Purchases.shared.purchase(product: product, promotionalOffer: offer).customerInfo
 
         // 4. Verify offer was applied
 
@@ -424,9 +422,7 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
 
         // 1. Purchase subscription
 
-        _ = try await Purchases.shared.purchase(product: product)
-        var customerInfo = try await Purchases.shared.syncPurchases()
-
+        var customerInfo = try await Purchases.shared.purchase(product: product).customerInfo
         var entitlement = try await self.verifyEntitlementWentThrough(customerInfo)
 
         // 2. Expire subscription
@@ -442,8 +438,7 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
 
         // 4. Purchase with offer
 
-        _ = try await Purchases.shared.purchase(product: product, promotionalOffer: offer)
-        customerInfo = try await Purchases.shared.syncPurchases()
+        customerInfo = try await Purchases.shared.purchase(product: product, promotionalOffer: offer).customerInfo
 
         // 5. Verify offer was applied
 


### PR DESCRIPTION
See [iOS 15.5 release notes](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-15_5-release-notes):

> Fixed an issue so developers using StoreKit 2 can now initiate a subscription offer purchase for a product that the customer currently subscribes to. (89152302).

This adds a test to verify this behavior.

Blocked for #2020.

## TODO:

- [x] Update CircleCI: https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions