### PR TITLE
Fixed `AnyDecodableTests.testNull` on iOS 12

### DIFF
--- a/Tests/UnitTests/Misc/AnyDecodableTests.swift
+++ b/Tests/UnitTests/Misc/AnyDecodableTests.swift
@@ -20,7 +20,7 @@ import XCTest
 class AnyDecodableTests: TestCase {
 
     func testNull() throws {
-        expect(try AnyDecodable.decode("null")) == .null
+        expect(try AnyDecodable.decode("{\"key\": null}")) == ["key": .null]
     }
 
     func testEmptyDictionary() throws {


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/6737/workflows/b945f5f6-6f31-4716-b1ac-6e16e3848c7e/jobs/26321

For some reason, on iOS 12.x only, this:
```swift
JSONDecoder.default.decode(jsonData: "null".data(using: .utf8)!)
```

Fails:
```
dataCorrupted(Swift.DecodingError.Context(codingPath: [], debugDescription: "The given data was not valid JSON.", underlyingError: Optional(Error Domain=NSCocoaErrorDomain Code=3840 "JSON text did not start with array or object and option to allow fragments not set." UserInfo={NSDebugDescription=JSON text did not start with array or object and option to allow fragments not set.})))
```

We don't rely on decoding fragments, so I just updated the test to check `.null` within a dictionary instead.