### PR TITLE
`Configuration.builder.with(usesStoreKit2IfAvailable:)`: fixed docstring

### DIFF
--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -130,7 +130,7 @@ import Foundation
 
         /**
          * Set `usesStoreKit2IfAvailable`.
-         * - Parameter useStoreKit2IfAvailable: EXPERIMENTAL. opt in to using StoreKit 2 on devices that support it.
+         * - Parameter usesStoreKit2IfAvailable: EXPERIMENTAL. opt in to using StoreKit 2 on devices that support it.
          * Purchases will be made using StoreKit 2 under the hood automatically.
          *
          * - Important: Support for purchases using StoreKit 2 is currently in an experimental phase.


### PR DESCRIPTION
Fixes warning:
> Parameter 'useStoreKit2IfAvailable' not found in the function declaration