### PR TITLE
Ensure SubscriptionPeriods are represented as 1week instead of 7days

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -230,11 +230,11 @@
 		575137CF27F50D2F0064AB2C /* HTTPResponseBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575137CE27F50D2F0064AB2C /* HTTPResponseBody.swift */; };
 		57536A2627851FFE00E2AE7F /* SK1StoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57536A2527851FFE00E2AE7F /* SK1StoreTransaction.swift */; };
 		57536A28278522B400E2AE7F /* SK2StoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57536A27278522B400E2AE7F /* SK2StoreTransaction.swift */; };
-		57554CC1282AE1E3009A7E58 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554CC0282AE1E3009A7E58 /* TestCase.swift */; };
-		57554CC2282AE1E3009A7E58 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554CC0282AE1E3009A7E58 /* TestCase.swift */; };
 		57554C62282ABFD9009A7E58 /* StoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554C61282ABFD9009A7E58 /* StoreTests.swift */; };
 		57554C84282AC273009A7E58 /* PeriodTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554C83282AC273009A7E58 /* PeriodTypeTests.swift */; };
 		57554C88282AC293009A7E58 /* PurchaseOwnershipTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554C87282AC293009A7E58 /* PurchaseOwnershipTypeTests.swift */; };
+		57554CC1282AE1E3009A7E58 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554CC0282AE1E3009A7E58 /* TestCase.swift */; };
+		57554CC2282AE1E3009A7E58 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554CC0282AE1E3009A7E58 /* TestCase.swift */; };
 		575A17AB2773A59300AA6F22 /* CurrentTestCaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */; };
 		576C8A8B27CFCB150058FA6E /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A8A27CFCB150058FA6E /* AnyEncodable.swift */; };
 		576C8A8F27CFCD110058FA6E /* AnyEncodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A8E27CFCD110058FA6E /* AnyEncodableTests.swift */; };
@@ -412,6 +412,7 @@
 		F5C0196926E880800005D61E /* StoreKitStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5C0196826E880800005D61E /* StoreKitStrings.swift */; };
 		F5FCD3EA27DA0D0B003BDC04 /* PriceFormatterProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5FCD3E927DA0D0B003BDC04 /* PriceFormatterProvider.swift */; };
 		F5FCD3FC27DA2034003BDC04 /* PriceFormatterProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5FCD3FB27DA2034003BDC04 /* PriceFormatterProviderTests.swift */; };
+		FD18ED4E2837F89200C5AA4F /* StoreKitWorkaroundsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD18ED4D2837F89200C5AA4F /* StoreKitWorkaroundsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -682,10 +683,10 @@
 		575137CE27F50D2F0064AB2C /* HTTPResponseBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponseBody.swift; sourceTree = "<group>"; };
 		57536A2527851FFE00E2AE7F /* SK1StoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1StoreTransaction.swift; sourceTree = "<group>"; };
 		57536A27278522B400E2AE7F /* SK2StoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreTransaction.swift; sourceTree = "<group>"; };
-		57554CC0282AE1E3009A7E58 /* TestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCase.swift; sourceTree = "<group>"; };
 		57554C61282ABFD9009A7E58 /* StoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreTests.swift; sourceTree = "<group>"; };
 		57554C83282AC273009A7E58 /* PeriodTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodTypeTests.swift; sourceTree = "<group>"; };
 		57554C87282AC293009A7E58 /* PurchaseOwnershipTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseOwnershipTypeTests.swift; sourceTree = "<group>"; };
+		57554CC0282AE1E3009A7E58 /* TestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCase.swift; sourceTree = "<group>"; };
 		575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentTestCaseTracker.swift; sourceTree = "<group>"; };
 		576C8A8A27CFCB150058FA6E /* AnyEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
 		576C8A8E27CFCD110058FA6E /* AnyEncodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodableTests.swift; sourceTree = "<group>"; };
@@ -848,6 +849,7 @@
 		F5C0196826E880800005D61E /* StoreKitStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitStrings.swift; sourceTree = "<group>"; };
 		F5FCD3E927DA0D0B003BDC04 /* PriceFormatterProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceFormatterProvider.swift; sourceTree = "<group>"; };
 		F5FCD3FB27DA2034003BDC04 /* PriceFormatterProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceFormatterProviderTests.swift; sourceTree = "<group>"; };
+		FD18ED4D2837F89200C5AA4F /* StoreKitWorkaroundsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitWorkaroundsTests.swift; sourceTree = "<group>"; };
 		FECF627761D375C8431EB866 /* StoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProduct.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -965,6 +967,7 @@
 			isa = PBXGroup;
 			children = (
 				2D1015E0275A676F0086173F /* SubscriptionPeriodTests.swift */,
+				FD18ED4D2837F89200C5AA4F /* StoreKitWorkaroundsTests.swift */,
 			);
 			path = StoreKitAbstractions;
 			sourceTree = "<group>";
@@ -2376,6 +2379,7 @@
 				351B51A426D450BC00BD2BD7 /* NSError+RCExtensionsTests.swift in Sources */,
 				57E2230727500BB1002DB06E /* AtomicTests.swift in Sources */,
 				351B51B826D450E800BD2BD7 /* StoreKitWrapperTests.swift in Sources */,
+				FD18ED4E2837F89200C5AA4F /* StoreKitWorkaroundsTests.swift in Sources */,
 				B3CD0D8827F25E3E000793F5 /* BackendSubscriberAttributesTests.swift in Sources */,
 				2DDF41E624F6F5DC005BC22D /* MockSK1Product.swift in Sources */,
 				351B51BA26D450E800BD2BD7 /* ProductRequestDataExtensions.swift in Sources */,

--- a/Sources/Purchasing/StoreKitAbstractions/StoreKitWorkarounds.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreKitWorkarounds.swift
@@ -75,3 +75,34 @@ extension SK1Product {
     }
 
 }
+
+extension SubscriptionPeriod {
+
+    /// This function simplifies large numbers of days into months and large numbers
+    /// of months into years if there are no leftover units after the conversion.
+    ///
+    /// Occassionally, StoreKit seems to send back a value 7 days for a 7day trial
+    /// instesad of a value of 1 week for a trial of 7 days in length.
+    /// Source: https://github.com/RevenueCat/react-native-purchases/issues/348
+    internal static func normalizeValueAndUnits(
+        value: Int,
+        unit: Unit
+    ) -> (value: Int, unit: Unit) {
+        switch unit {
+        case .day:
+            if value % 7 == 0 {
+                let numberOfWeeks = value / 7
+                return (value: numberOfWeeks, unit: .week)
+            }
+        case .month:
+            if value % 12 == 0 {
+                let numberOfYears = value / 12
+                return (value: numberOfYears, unit: .year)
+            }
+        case .week, .year:
+            break
+        }
+
+        return (value: value, unit: unit)
+    }
+}

--- a/Sources/Purchasing/StoreKitAbstractions/StoreKitWorkarounds.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreKitWorkarounds.swift
@@ -82,7 +82,7 @@ extension SubscriptionPeriod {
     /// of months into years if there are no leftover units after the conversion.
     ///
     /// Occassionally, StoreKit seems to send back a value 7 days for a 7day trial
-    /// instesad of a value of 1 week for a trial of 7 days in length.
+    /// instead of a value of 1 week for a trial of 7 days in length.
     /// Source: https://github.com/RevenueCat/react-native-purchases/issues/348
     internal static func normalizeValueAndUnits(
         value: Int,

--- a/Sources/Purchasing/StoreKitAbstractions/StoreKitWorkarounds.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreKitWorkarounds.swift
@@ -89,17 +89,17 @@ extension SubscriptionPeriod {
         case .day:
             if value.isMultiple(of: 7) {
                 let numberOfWeeks = value / 7
-                return SubscriptionPeriod(value: numberOfWeeks, unit: .week)
+                return .init(value: numberOfWeeks, unit: .week)
             }
         case .month:
             if value.isMultiple(of: 12) {
                 let numberOfYears = value / 12
-                return SubscriptionPeriod(value: numberOfYears, unit: .year)
+                return .init(value: numberOfYears, unit: .year)
             }
         case .week, .year:
             break
         }
 
-        return SubscriptionPeriod(value: value, unit: unit)
+        return self
     }
 }

--- a/Sources/Purchasing/StoreKitAbstractions/StoreKitWorkarounds.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreKitWorkarounds.swift
@@ -84,25 +84,22 @@ extension SubscriptionPeriod {
     /// Occassionally, StoreKit seems to send back a value 7 days for a 7day trial
     /// instead of a value of 1 week for a trial of 7 days in length.
     /// Source: https://github.com/RevenueCat/react-native-purchases/issues/348
-    internal static func normalizeValueAndUnits(
-        value: Int,
-        unit: Unit
-    ) -> (value: Int, unit: Unit) {
+    internal func normalized() -> SubscriptionPeriod {
         switch unit {
         case .day:
-            if value % 7 == 0 {
+            if value.isMultiple(of: 7) {
                 let numberOfWeeks = value / 7
-                return (value: numberOfWeeks, unit: .week)
+                return SubscriptionPeriod(value: numberOfWeeks, unit: .week)
             }
         case .month:
-            if value % 12 == 0 {
+            if value.isMultiple(of: 12) {
                 let numberOfYears = value / 12
-                return (value: numberOfYears, unit: .year)
+                return SubscriptionPeriod(value: numberOfYears, unit: .year)
             }
         case .week, .year:
             break
         }
 
-        return (value: value, unit: unit)
+        return SubscriptionPeriod(value: value, unit: unit)
     }
 }

--- a/Sources/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
@@ -29,7 +29,8 @@ public class SubscriptionPeriod: NSObject {
     public init(value: Int, unit: Unit) {
         assert(value > 0, "Invalid value: \(value)")
 
-        (self.value, self.unit) = Self.normalizeValueAndUnits(value: value, unit: unit)
+        self.value = value
+        self.unit = unit
     }
 
     /// Units of time used to describe subscription periods.
@@ -54,6 +55,7 @@ public class SubscriptionPeriod: NSObject {
         }
 
         return .init(value: sk1SubscriptionPeriod.numberOfUnits, unit: unit)
+            .normalized()
     }
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8, *)
@@ -63,6 +65,7 @@ public class SubscriptionPeriod: NSObject {
         }
 
         return .init(value: sk2SubscriptionPeriod.value, unit: unit)
+            .normalized()
     }
 
     public override func isEqual(_ object: Any?) -> Bool {

--- a/Sources/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
@@ -29,8 +29,7 @@ public class SubscriptionPeriod: NSObject {
     public init(value: Int, unit: Unit) {
         assert(value > 0, "Invalid value: \(value)")
 
-        self.value = value
-        self.unit = unit
+        (self.value, self.unit) = Self.normalizeValueAndUnits(value: value, unit: unit)
     }
 
     /// Units of time used to describe subscription periods.

--- a/Tests/UnitTests/Purchasing/StoreKitAbstractions/StoreKitWorkaroundsTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKitAbstractions/StoreKitWorkaroundsTests.swift
@@ -34,7 +34,7 @@ class StoreKitWorkaroundsTests: TestCase {
             (112, .day, 16, .week),
             (356, .day, 356, .day),
             (712, .day, 712, .day),
-            // Test week simplicfication
+            // Test week simplification
             (1, .week, 1, .week),
             (4, .week, 4, .week),
             (24, .week, 24, .week),
@@ -50,13 +50,20 @@ class StoreKitWorkaroundsTests: TestCase {
         ]
 
         for expectation in expectations {
-            let (outputValue, outputUnit) = SubscriptionPeriod.normalizeValueAndUnits(
+            let outputPeriod = SubscriptionPeriod(
                 value: expectation.inputValue,
                 unit: expectation.inputUnit
-            )
+            ).normalized()
 
-            expect(outputValue).to(equal(expectation.expectedValue))
-            expect(outputUnit).to(equal(expectation.expectedUnit))
+            expect(expectation.expectedValue).to(
+                equal(outputPeriod.value),
+                description: "Expected input value \(expectation.inputValue) to become \(expectation.expectedValue)."
+            )
+            expect(outputPeriod.unit).to(
+                equal(expectation.expectedUnit),
+                description: "Expected input unit \(expectation.inputUnit) to become \(expectation.expectedUnit)."
+            )
         }
     }
+
 }

--- a/Tests/UnitTests/Purchasing/StoreKitAbstractions/StoreKitWorkaroundsTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKitAbstractions/StoreKitWorkaroundsTests.swift
@@ -50,18 +50,19 @@ class StoreKitWorkaroundsTests: TestCase {
         ]
 
         for expectation in expectations {
-            let outputPeriod = SubscriptionPeriod(
+            let period = SubscriptionPeriod(
                 value: expectation.inputValue,
                 unit: expectation.inputUnit
-            ).normalized()
-
-            expect(expectation.expectedValue).to(
-                equal(outputPeriod.value),
-                description: "Expected input value \(expectation.inputValue) to become \(expectation.expectedValue)."
             )
-            expect(outputPeriod.unit).to(
-                equal(expectation.expectedUnit),
-                description: "Expected input unit \(expectation.inputUnit) to become \(expectation.expectedUnit)."
+            let normalized = period.normalized()
+            let expected = SubscriptionPeriod(
+                value: expectation.expectedValue,
+                unit: expectation.expectedUnit
+            )
+
+            expect(normalized).to(
+                equal(expected),
+                description: "Expected \(period.debugDescription) to become \(expected.debugDescription)."
             )
         }
     }

--- a/Tests/UnitTests/Purchasing/StoreKitAbstractions/StoreKitWorkaroundsTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKitAbstractions/StoreKitWorkaroundsTests.swift
@@ -1,0 +1,62 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  StoreKitWorkaroundsTests.swift
+//
+//  Created by Will Taylor on 5/20/22.
+
+import Foundation
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+class StoreKitWorkaroundsTests: TestCase {
+
+    func testSimplifyValueAndUnits() {
+        let expectations: [(
+            inputValue: Int, inputUnit: SubscriptionPeriod.Unit,
+            expectedValue: Int, expectedUnit: SubscriptionPeriod.Unit
+        )] = [
+            // Test day simplification
+            (1, .day, 1, .day),
+            (7, .day, 1, .week),
+            (14, .day, 2, .week),
+            (21, .day, 3, .week),
+            (28, .day, 4, .week),
+            (30, .day, 30, .day),
+            (56, .day, 8, .week),
+            (112, .day, 16, .week),
+            (356, .day, 356, .day),
+            (712, .day, 712, .day),
+            // Test week simplicfication
+            (1, .week, 1, .week),
+            (4, .week, 4, .week),
+            (24, .week, 24, .week),
+            (52, .week, 52, .week),
+            (104, .week, 104, .week),
+            // Test month simplification
+            (1, .month, 1, .month),
+            (12, .month, 1, .year),
+            (24, .month, 2, .year),
+            // Ensure year inputs return the same value
+            (1, .year, 1, .year),
+            (2, .year, 2, .year)
+        ]
+
+        for expectation in expectations {
+            let (outputValue, outputUnit) = SubscriptionPeriod.normalizeValueAndUnits(
+                value: expectation.inputValue,
+                unit: expectation.inputUnit
+            )
+
+            expect(outputValue).to(equal(expectation.expectedValue))
+            expect(outputUnit).to(equal(expectation.expectedUnit))
+        }
+    }
+}

--- a/Tests/UnitTests/Purchasing/StoreKitAbstractions/SubscriptionPeriodTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKitAbstractions/SubscriptionPeriodTests.swift
@@ -104,7 +104,7 @@ class SubscriptionPeriodTests: TestCase {
             expect(normalizedPeriod).to(
                 equal(expected),
                 description: """
-                    Expected \(description(for: sk1SubscriptionPeriod)) to become \(expected.debugDescription).
+                    Expected \(sk1SubscriptionPeriod.testDescription) to become \(expected.debugDescription).
                     """
             )
         }
@@ -130,6 +130,30 @@ class SubscriptionPeriodTests: TestCase {
         }
 
         return "SKProductSubscriptionPeriod: \(skProductSubscriptionPeriod.numberOfUnits) \(periodUnit)"
+    }
+
+}
+
+@available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
+extension SKProductSubscriptionPeriod {
+
+    internal var testDescription: String {
+        let periodUnit: String
+
+        switch self.unit {
+        case .day:
+            periodUnit = "days"
+        case .week:
+            periodUnit = "weeks"
+        case .month:
+            periodUnit = "months"
+        case .year:
+            periodUnit = "years"
+        @unknown default:
+            periodUnit = "unknown"
+        }
+
+        return "SKProductSubscriptionPeriod: \(numberOfUnits) \(periodUnit)"
     }
 
 }


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids (N/A)

### Motivation
This PR resolves [CF-659](https://revenuecats.atlassian.net/browse/CF-659) & `react-native-purchases` issue [#348](https://github.com/RevenueCat/react-native-purchases/issues/348).

Occasionally, StoreKit will state that a period is 7 days instead of 1 week. This unexpected behavior can cause unintended issues for customers on their paywalls and generally decreases developer confidence in the Offerings/Products provided by the SDK.

### Description
- Implemented a `normalization` function to be run on the input parameters of the `SubscriptionPeriod` class that, if possible to do so evenly, converts days into weeks and months into years.
- This function is static since it needs to be executed before the `SubscriptionPeriod` class has completed instantiation.
- Conversion of weeks to months and weeks to years was intentionally left out since those conversion rates don't use whole numbers (variable number of weeks in a month and 52.14 weeks per year)
