### PR TITLE
`PurchasesOrchestrator`: don't listen for StoreKit 2 transactions if it's disabled

### DIFF
--- a/Sources/Purchasing/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/PurchasesOrchestrator.swift
@@ -99,7 +99,8 @@ class PurchasesOrchestrator {
         self.manageSubscriptionsHelper = manageSubscriptionsHelper
         self.beginRefundRequestHelper = beginRefundRequestHelper
 
-        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *),
+           systemInfo.storeKit2Setting == .enabledForCompatibleDevices {
             storeKit2TransactionListener.listenForTransactions()
             storeKit2StorefrontListener.listenForStorefrontChanges()
         }


### PR DESCRIPTION
I tried adding tests for this, but because the listener is created internally, there is no time to override it with the mock before verifying if `listenForTransactions` is called.

Will at least prevent #1528 if SK2 is disabled.