### PR TITLE
`PurchasesOrchestrator`: removed `lazy` hack for properties with `@available`

### DIFF
--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -72,7 +72,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
     fileprivate func setUpStoreKit2Listener() {
         if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
-            orchestrator.storeKit2TransactionListener = MockStoreKit2TransactionListener()
+            orchestrator._storeKit2TransactionListener = MockStoreKit2TransactionListener()
         }
     }
 


### PR DESCRIPTION
Fixes [CF-682], and probably #1528.
Looks like possibly something was broken demangling `lazy` properties with `@available` in iOS 15.0 (per the 2 bug reports).

This changes the approach to simply having `Any?` as the value, and making the exposed `@available` property a derived one.

[CF-682]: https://revenuecats.atlassian.net/browse/CF-682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ