### PR TITLE
Added obsoletion for `DeferredPromotionalPurchaseBlock`

### DIFF
--- a/Sources/Misc/Obsoletions.swift
+++ b/Sources/Misc/Obsoletions.swift
@@ -528,6 +528,12 @@ public extension Purchases {
 
 }
 
+@available(iOS, obsoleted: 1, renamed: "StartPurchaseBlock")
+@available(tvOS, obsoleted: 1, renamed: "StartPurchaseBlock")
+@available(watchOS, obsoleted: 1, renamed: "StartPurchaseBlock")
+@available(macOS, obsoleted: 1, renamed: "StartPurchaseBlock")
+public typealias DeferredPromotionalPurchaseBlock = StartPurchaseBlock
+
 @available(iOS, obsoleted: 1, renamed: "CustomerInfo")
 @available(tvOS, obsoleted: 1, renamed: "CustomerInfo")
 @available(watchOS, obsoleted: 1, renamed: "CustomerInfo")

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -97,6 +97,25 @@ private func checkStaticMethods() {
           forceUniversalAppStore, simulatesAskToBuyInSandbox, sharedPurchases, isPurchasesConfigured)
 }
 
+private func checkTypealiases(
+    transaction: StoreTransaction?,
+    customerInfo: CustomerInfo,
+    userCancelled: Bool
+) {
+    let purchaseResultData: PurchaseResultData = (transaction: transaction,
+                                                  customerInfo: customerInfo,
+                                                  userCancelled: userCancelled)
+
+    // swiftlint:disable:next line_length
+    let purchaseCompletedBlock: PurchaseCompletedBlock = { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) -> Void in }
+
+    let startPurchaseBlock: StartPurchaseBlock = { (_: PurchaseCompletedBlock) in }
+
+    print(purchaseResultData,
+          purchaseCompletedBlock,
+          startPurchaseBlock)
+}
+
 private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.getCustomerInfo { (_: CustomerInfo?, _: Error?) in }
     purchases.getOfferings { (_: Offerings?, _: Error?) in }


### PR DESCRIPTION
This was missed in #1460. To prevent this from happening again in the future, I've added the 3 `typealias`es to `SwiftAPITester`.