### PR TITLE
`MagicWeatherSwiftUI`: fixed usage of `PurchaseDelegate`

### DIFF
--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/Lifecycle/PurchasesDelegateHandler.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/Lifecycle/PurchasesDelegateHandler.swift
@@ -38,9 +38,9 @@ extension PurchasesDelegateHandler: PurchasesDelegate {
      itms-services://?action=purchaseIntent&bundleId=<BUNDLE_ID>&productIdentifier=<SKPRODUCT_ID>
      */
     func purchases(_ purchases: Purchases,
-                   shouldPurchasePromoProduct product: StoreProduct,
-                   defermentBlock makeDeferredPurchase: @escaping DeferredPromotionalPurchaseBlock) {
-        makeDeferredPurchase { (transaction, info, error, cancelled) in
+                   readyForPromotedProduct product: StoreProduct,
+                   purchase startPurchase: @escaping StartPurchaseBlock) {
+        startPurchase { (transaction, info, error, cancelled) in
             if let info = info, error == nil, !cancelled {
                 UserViewModel.shared.customerInfo = info
             }


### PR DESCRIPTION
This was changed in #1460. Additionally, without #1600 this wasn't producing the correct rename, it wasn't finding `DeferredPromotionalPurchaseBlock` anywhere.