### PR TITLE
`StoreKit 2` purchases: don't throw when purchase is cancelled

### DIFF
--- a/Sources/Purchasing/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/PurchasesOrchestrator.swift
@@ -348,6 +348,12 @@ class PurchasesOrchestrator {
 
         do {
             result = try await sk2Product.purchase(options: options)
+        } catch StoreKitError.userCancelled {
+            return (
+                transaction: nil,
+                customerInfo: try await self.syncPurchases(receiptRefreshPolicy: .always, isRestore: false),
+                userCancelled: true
+            )
         } catch {
             throw ErrorUtils.purchasesError(withStoreKitError: error)
         }


### PR DESCRIPTION
Fixes #1598.
Without this `catch`, we were throwing `ErrorCode.purchaseCancelledError`, which then was being logged as a failed purchase and returned as such.
Now this correctly returns no error, and `userCancelled` `true`.

Unfortunately we can't cover this in tests because `SKTestSession.failureError` doesn't allow mocking cancellations (yet?)