### PR TITLE
Added `@IgnoreHashable` property wrapper

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -236,6 +236,8 @@
 		57554CC1282AE1E3009A7E58 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554CC0282AE1E3009A7E58 /* TestCase.swift */; };
 		57554CC2282AE1E3009A7E58 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554CC0282AE1E3009A7E58 /* TestCase.swift */; };
 		575A17AB2773A59300AA6F22 /* CurrentTestCaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */; };
+		5766AA56283D4C5400FA6091 /* IgnoreHashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5766AA55283D4C5400FA6091 /* IgnoreHashable.swift */; };
+		5766AA5A283D4CAB00FA6091 /* IgnoreHashableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5766AA59283D4CAB00FA6091 /* IgnoreHashableTests.swift */; };
 		576C8A8B27CFCB150058FA6E /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A8A27CFCB150058FA6E /* AnyEncodable.swift */; };
 		576C8A8F27CFCD110058FA6E /* AnyEncodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A8E27CFCD110058FA6E /* AnyEncodableTests.swift */; };
 		576C8A9227D27DDD0058FA6E /* SnapshotTesting+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A9127D27DDD0058FA6E /* SnapshotTesting+Extensions.swift */; };
@@ -689,6 +691,8 @@
 		57554C87282AC293009A7E58 /* PurchaseOwnershipTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseOwnershipTypeTests.swift; sourceTree = "<group>"; };
 		57554CC0282AE1E3009A7E58 /* TestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCase.swift; sourceTree = "<group>"; };
 		575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentTestCaseTracker.swift; sourceTree = "<group>"; };
+		5766AA55283D4C5400FA6091 /* IgnoreHashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoreHashable.swift; sourceTree = "<group>"; };
+		5766AA59283D4CAB00FA6091 /* IgnoreHashableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IgnoreHashableTests.swift; sourceTree = "<group>"; };
 		576C8A8A27CFCB150058FA6E /* AnyEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
 		576C8A8E27CFCD110058FA6E /* AnyEncodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodableTests.swift; sourceTree = "<group>"; };
 		576C8A9027D180540058FA6E /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
@@ -1155,6 +1159,7 @@
 				57CFB98327FE2258002A6730 /* StoreKit2Setting.swift */,
 				57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */,
 				B3AA6237268B926F00894871 /* SystemInfo.swift */,
+				5766AA55283D4C5400FA6091 /* IgnoreHashable.swift */,
 			);
 			path = Misc;
 			sourceTree = "<group>";
@@ -1357,6 +1362,7 @@
 				574A2EE8282C403800150D40 /* AnyDecodableTests.swift */,
 				57554CC0282AE1E3009A7E58 /* TestCase.swift */,
 				2D22BF6626F3CBFB001AE2F9 /* XCTestCase+Extensions.swift */,
+				5766AA59283D4CAB00FA6091 /* IgnoreHashableTests.swift */,
 			);
 			path = Misc;
 			sourceTree = "<group>";
@@ -2314,6 +2320,7 @@
 				B3766F1E26BDA95100141450 /* IntroEligibilityResponse.swift in Sources */,
 				B34605CD279A6E380031CA74 /* PostAttributionDataOperation.swift in Sources */,
 				B34605C1279A6E380031CA74 /* NetworkOperation.swift in Sources */,
+				5766AA56283D4C5400FA6091 /* IgnoreHashable.swift in Sources */,
 				35E840CC270FB70D00899AE2 /* ManageSubscriptionsHelper.swift in Sources */,
 				6E38843A0CAFD551013D0A3F /* StoreProduct.swift in Sources */,
 				B34605BD279A6E380031CA74 /* CallbackCacheStatus.swift in Sources */,
@@ -2331,6 +2338,7 @@
 				2DDF41E824F6F61B005BC22D /* MockSKProductDiscount.swift in Sources */,
 				35272E2226D0048D00F22C3B /* HTTPClientTests.swift in Sources */,
 				2DDF41CB24F6F4C3005BC22D /* ASN1ObjectIdentifierBuilderTests.swift in Sources */,
+				5766AA5A283D4CAB00FA6091 /* IgnoreHashableTests.swift in Sources */,
 				B36824BF268FBC8700957E4C /* SubscriberAttributeTests.swift in Sources */,
 				351B51BC26D450E800BD2BD7 /* OfferingsTests.swift in Sources */,
 				5796A38827D6B85900653165 /* BackendPostReceiptDataTests.swift in Sources */,

--- a/Sources/Misc/IgnoreHashable.swift
+++ b/Sources/Misc/IgnoreHashable.swift
@@ -1,0 +1,54 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  IgnoreHashable.swift
+//
+//  Created by Nacho Soto on 5/24/22.
+
+import Foundation
+
+/// A property wrapper that allows ignoring a value from the `Hashable` / `Equatable` implementation
+/// - Example:
+/// ```
+/// struct Data {
+///     var string1: String // Data equality / hash only uses this value
+///     @IgnoreHashable var string2: String
+/// }
+/// ```
+@propertyWrapper
+struct IgnoreHashable<Value> {
+
+    var wrappedValue: Value
+
+}
+
+extension IgnoreHashable: Hashable {
+
+    static func == (lhs: Self, rhs: Self) -> Bool { return true }
+
+    func hash(into hasher: inout Hasher) {}
+
+}
+
+extension IgnoreHashable: Decodable where Value: Decodable {
+
+    init(from decoder: Decoder) throws {
+        self.init(wrappedValue: try Value.init(from: decoder))
+    }
+
+}
+
+extension IgnoreHashable: Encodable where Value: Encodable {
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.wrappedValue)
+    }
+
+}

--- a/Tests/UnitTests/Misc/IgnoreHashableTests.swift
+++ b/Tests/UnitTests/Misc/IgnoreHashableTests.swift
@@ -1,0 +1,58 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  IgnoreHashableTests.swift
+//
+//  Created by Nacho Soto on 5/24/22.
+
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+class IgnoreHashableTests: TestCase {
+
+    func testEqualityIgnoresValue() throws {
+        expect(Self.data1) == Self.data1
+        expect(Self.data1) != Self.data2
+        expect(Self.data1) == Self.data3
+    }
+
+    func testHashIgnoresValue() throws {
+        expect(Self.data1.hashValue) == Self.data1.hashValue
+        expect(Self.data1.hashValue) != Self.data2.hashValue
+        expect(Self.data1.hashValue) == Self.data3.hashValue
+    }
+
+    func testValueIsEncoded() throws {
+        let reEncodedData = try Self.data1.encodeAndDecode()
+
+        expect(reEncodedData) == Self.data1
+        expect(reEncodedData.string2) == Self.data1.string2
+    }
+
+}
+
+private extension IgnoreHashableTests {
+
+    struct Data: Codable, Hashable {
+        var string1: String
+        @IgnoreHashable var string2: String
+
+        init(_ string1: String, _ string2: String) {
+            self.string1 = string1
+            self.string2 = string2
+        }
+    }
+
+    static let data1: Data = .init("a", "1")
+    static let data2: Data = .init("b", "2")
+    static let data3: Data = .init("a", "3")
+
+}


### PR DESCRIPTION
This will be used for the new implementation of `CustomerInfoResponse`, and also for `var rawData: [String: Any]` properties that can't conform to `Hashable`, and that we wouldn't want to use for comparison since they contain duplicated data.