### PR TITLE
`LocalReceiptParserStoreKitTests`: relaxed `purchaseDate` expectation

### DIFF
--- a/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
@@ -75,7 +75,7 @@ class LocalReceiptParserStoreKitTests: StoreKitConfigTestCase {
         expect(firstPurchase.originalTransactionId).to(beNil())
         expect(firstPurchase.productType).to(beNil())
 
-        expect(firstPurchase.purchaseDate).to(beCloseTo(Date(), within: 1))
+        expect(firstPurchase.purchaseDate).to(beCloseTo(Date(), within: 5))
         expect(firstPurchase.originalPurchaseDate).to(beNil())
 
         expect(firstPurchase.expiresDate).toNot(beNil())


### PR DESCRIPTION
I often get failures when running all tests in parallel because this test takes more than 1 second to run.

Example:
> failed - expected to be close to <2022-05-24 10:59:18.3370> (within 1), got <2022-05-24 10:58:18.0000>

To allow the test to take a few more seconds, I think this is a reasonable compromise.