### PR TITLE
Fixed iOS 12 `Codable` tests

### DIFF
--- a/Tests/UnitTests/Purchasing/PeriodTypeTests.swift
+++ b/Tests/UnitTests/Purchasing/PeriodTypeTests.swift
@@ -15,7 +15,15 @@ import Nimble
 @testable import RevenueCat
 import XCTest
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 class PeriodTypeTests: TestCase {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        // iOS 12 does not allow decoding fragments (top-level objects)
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+    }
 
     func testCodable() throws {
         for type in PeriodType.allCases {

--- a/Tests/UnitTests/Purchasing/PurchaseOwnershipTypeTests.swift
+++ b/Tests/UnitTests/Purchasing/PurchaseOwnershipTypeTests.swift
@@ -15,7 +15,15 @@ import Nimble
 @testable import RevenueCat
 import XCTest
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 class PurchaseOwnershipTypeTests: TestCase {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        // iOS 12 does not allow decoding fragments (top-level objects)
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+    }
 
     func testCodable() throws {
         for type in PurchaseOwnershipType.allCases {

--- a/Tests/UnitTests/Purchasing/StoreTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreTests.swift
@@ -15,7 +15,15 @@ import Nimble
 @testable import RevenueCat
 import XCTest
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 class StoreTests: TestCase {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        // iOS 12 does not allow decoding fragments (top-level objects)
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+    }
 
     func testCodable() throws {
         for store in Store.allCases {


### PR DESCRIPTION
Follow up to #1589.
Fixes https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/6805/workflows/550827f9-ff8e-469d-b7a7-889417582eff/jobs/26743

Turns out the tests introduced in #1558 weren't compatible with iOS 12. As explained in #1589.
For some reason, on iOS 12.x only, this:
```
JSONDecoder.default.decode(jsonData: "null".data(using: .utf8)!)
```
Fails:

> dataCorrupted(Swift.DecodingError.Context(codingPath: [], debugDescription: "The given data was not valid JSON.", underlyingError: Optional(Error Domain=NSCocoaErrorDomain Code=3840 "JSON text did not start with array or object and option to allow fragments not set." UserInfo={NSDebugDescription=JSON text did not start with array or object and option to allow fragments not set.})))

Since iOS 12.x doesn't allow decoding top-level objects, I've simply disabled these tests. Decoding this types is already tested as part of other types. These new types only added more explicit testing.