### PR TITLE
`ManageSubscriptionsHelper`: fixed discrepancy between `SystemInfo.isAppleSubscription(managementURL:)` and `SystemInfo.appleSubscriptionsURL`

### DIFF
--- a/Sources/Logging/Strings/ManageSubscriptionsStrings.swift
+++ b/Sources/Logging/Strings/ManageSubscriptionsStrings.swift
@@ -19,7 +19,6 @@ extension ManageSubscriptionsHelper {
 
     enum Strings {
 
-        case cant_form_apple_subscriptions_url
         case error_from_appstore_show_manage_subscription(error: Error)
         case failed_to_get_management_url_error_unknown(error: Error)
         case failed_to_get_window_scene
@@ -35,8 +34,6 @@ extension ManageSubscriptionsHelper.Strings: CustomStringConvertible {
 
     var description: String {
         switch self {
-        case .cant_form_apple_subscriptions_url:
-            return "Error when trying to form the Apple Subscriptions URL."
         case .error_from_appstore_show_manage_subscription(let error):
             return "Error when trying to show manage subscription: \(error.localizedDescription)"
         case .failed_to_get_management_url_error_unknown(let error):

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -25,7 +25,7 @@ import AppKit
 
 class SystemInfo {
 
-    let appleSubscriptionsURL = URL(string: "https://rev.cat/manage-apple-subscription")
+    static let appleSubscriptionsURL = URL(string: "https://apps.apple.com/account/subscriptions")!
 
     let storeKit2Setting: StoreKit2Setting
     var finishTransactions: Bool
@@ -132,7 +132,7 @@ class SystemInfo {
     }
     #endif
 
-    func isAppleSubscription(managementURL: URL) -> Bool {
+    static func isAppleSubscription(managementURL: URL) -> Bool {
         guard let host = managementURL.host else { return false }
         return host.contains("apple.com")
     }

--- a/Sources/Support/ManageSubscriptionsHelper.swift
+++ b/Sources/Support/ManageSubscriptionsHelper.swift
@@ -43,12 +43,7 @@ class ManageSubscriptionsHelper {
                     guard let managementURL = customerInfo.managementURL else {
                         Logger.debug(Strings.management_url_nil_opening_default)
 
-                        guard let appleSubscriptionsURL = self.systemInfo.appleSubscriptionsURL else {
-                            let message = Strings.cant_form_apple_subscriptions_url
-                            return .failure(ErrorUtils.systemInfoError(withMessage: message.description))
-                        }
-
-                        return .success(appleSubscriptionsURL)
+                        return .success(SystemInfo.appleSubscriptionsURL)
                     }
 
                     return .success(managementURL)
@@ -56,7 +51,7 @@ class ManageSubscriptionsHelper {
 
             switch result {
             case let .success(url):
-                if self.systemInfo.isAppleSubscription(managementURL: url) {
+                if SystemInfo.isAppleSubscription(managementURL: url) {
                     self.showAppleManageSubscriptions(managementURL: url, completion: completion)
                 } else {
                     self.openURL(url, completion: completion)

--- a/Tests/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
+++ b/Tests/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
@@ -50,67 +50,19 @@ class ManageSubscriptionsHelperTests: TestCase {
                                            currentUserProvider: currentUserProvider)
     }
 
-    func testShowManageSubscriptionsMakesRightCalls() throws {
-        guard #available(iOS 15.0, *) else { throw XCTSkip("Required API is not available for this test.") }
+    func testShowManageSubscriptions() throws {
         // given
-        var callbackCalled = false
-        customerInfoManager.stubbedCustomerInfoResult = .success(try CustomerInfo(data: mockCustomerInfoData))
-
-        // when
-        helper.showManageSubscriptions { _ in
-            callbackCalled = true
-        }
-
-        // then
-        expect(callbackCalled).toEventually(beTrue())
-        expect(self.customerInfoManager.invokedCustomerInfo) == true
-
-        // we'd ideally also patch the UIApplication (or NSWorkspace for mac), as well as
-        // AppStore, and check for the calls in those, but it gets very tricky.
-    }
-
-    func testShowManageSubscriptionsInIOS() throws {
-        guard #available(iOS 10.0, *) else {
-            throw XCTSkip("Not supported")
-        }
-
-        // given
-        var callbackCalled = false
         var receivedResult: Result<Void, Error>?
         customerInfoManager.stubbedCustomerInfoResult = .success(try CustomerInfo(data: mockCustomerInfoData))
 
         // when
         helper.showManageSubscriptions { result in
-            callbackCalled = true
             receivedResult = result
         }
 
         // then
-        expect(callbackCalled).toEventually(beTrue())
-        let nonNilReceivedResult: Result<Void, Error> = try XCTUnwrap(receivedResult)
-        expect(nonNilReceivedResult).to(beSuccess())
-    }
-
-    func testShowManageSubscriptionsSucceedsInMacOS() throws {
-        guard #available(macOS 11.0, *) else {
-            throw XCTSkip("Not supported")
-        }
-
-        // given
-        var callbackCalled = false
-        var receivedResult: Result<Void, Error>?
-        customerInfoManager.stubbedCustomerInfoResult = .success(try CustomerInfo(data: mockCustomerInfoData))
-
-        // when
-        helper.showManageSubscriptions { result in
-            callbackCalled = true
-            receivedResult = result
-        }
-
-        // then
-        expect(callbackCalled).toEventually(beTrue())
-        let nonNilReceivedResult: Result<Void, Error> = try XCTUnwrap(receivedResult)
-        expect(nonNilReceivedResult).to(beSuccess())
+        expect(receivedResult).toEventuallyNot(beNil())
+        expect(receivedResult).to(beSuccess())
     }
 
     func testShowManageSubscriptionsFailsIfCouldntGetCustomerInfo() throws {
@@ -120,18 +72,17 @@ class ManageSubscriptionsHelperTests: TestCase {
         )
 
         // given
-        var callbackCalled = false
         var receivedResult: Result<Void, Error>?
         customerInfoManager.stubbedCustomerInfoResult = .failure(error)
 
         // when
         helper.showManageSubscriptions { result in
-            callbackCalled = true
             receivedResult = result
         }
 
         // then
-        expect(callbackCalled).toEventually(beTrue())
+        expect(receivedResult).toEventuallyNot(beNil())
+
         let nonNilReceivedResult: Result<Void, Error> = try XCTUnwrap(receivedResult)
         let expectedErrorMessage = "Failed to get managementURL from CustomerInfo. " +
         "Details: The operation couldn’t be completed"

--- a/Tests/UnitTests/Misc/SystemInfoTests.swift
+++ b/Tests/UnitTests/Misc/SystemInfoTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 class SystemInfoTests: TestCase {
 
-    func testproxyURL() {
+    func testProxyURL() {
         let defaultURL = URL(string: "https://api.revenuecat.com")
         expect(SystemInfo.serverHostURL) == defaultURL
         expect(SystemInfo.proxyURL).to(beNil())
@@ -22,7 +22,7 @@ class SystemInfoTests: TestCase {
         expect(SystemInfo.serverHostURL) == defaultURL
     }
 
-    func testsystemVersion() {
+    func testSystemVersion() {
         expect(SystemInfo.systemVersion) == ProcessInfo().operatingSystemVersionString
     }
 
@@ -65,6 +65,20 @@ class SystemInfoTests: TestCase {
 
     func testIsNotSandboxIfNoReceiptURL() throws {
         expect(try SystemInfo.withReceiptResult(.nilURL).isSandbox) == false
+    }
+
+    func testIsAppleSubscriptionURLWithAnotherURL() {
+        expect(SystemInfo.isAppleSubscription(managementURL: URL(string: "www.google.com")!)) == false
+    }
+
+    func testIsAppleSubscriptionURLWithStandardURL() {
+        expect(SystemInfo.isAppleSubscription(managementURL: SystemInfo.appleSubscriptionsURL)) == true
+    }
+
+    func testIsAppleSubscriptionURLWithShortenedURL() {
+        expect(SystemInfo.isAppleSubscription(
+            managementURL: URL(string: "https://rev.cat/manage-apple-subscription")!
+        )) == false
     }
 
 }


### PR DESCRIPTION
Fixes [CF-684] and #1594.

`SystemInfo.appleSubscriptionsURL` was a short URL that didn't pass the `SystemInfo.isAppleSubscription(managementURL:)` test. This is fixed and covered by a test now.

### Other changes:
- Made `SystemInfo.isAppleSubscription(managementURL:)` and `SystemInfo.appleSubscriptionsURL` static since they don't need any properties in `SystemInfo`.
- Forced-unwrapped `SystemInfo.appleSubscriptionsURL` to remove unnecessary error handling. This is safe because the URL is provided statically at compile time. Per the docs "This initializer returns nil if the string doesn’t represent a valid URL. For example, an empty string or one containing characters that are illegal in a URL produces nil.". This is known at compile time, and covered by tests, so it could never return `nil`.
- Combined redundant tests in `ManageSubscriptionsHelper`. They were all doing exactly the same for both platforms.

[CF-684]: https://revenuecats.atlassian.net/browse/CF-684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ