### PR TITLE
`Purchases.customerInfo()`: added overload with a new `CacheFetchPolicy`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -252,6 +252,7 @@
 		5766AAD1283E981700FA6091 /* PurchasesPurchasingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5766AAD0283E981700FA6091 /* PurchasesPurchasingTests.swift */; };
 		5766AAD5283E9B7400FA6091 /* PurchasesRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5766AAD4283E9B7400FA6091 /* PurchasesRestoreTests.swift */; };
 		5766AAE5283E9E9C00FA6091 /* PurchasesGetOfferingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5766AAE4283E9E9C00FA6091 /* PurchasesGetOfferingsTests.swift */; };
+		5766AAB0283D8CDC00FA6091 /* CacheFetchPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5766AAAF283D8CDC00FA6091 /* CacheFetchPolicy.swift */; };
 		576C8A8B27CFCB150058FA6E /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A8A27CFCB150058FA6E /* AnyEncodable.swift */; };
 		576C8A8F27CFCD110058FA6E /* AnyEncodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A8E27CFCD110058FA6E /* AnyEncodableTests.swift */; };
 		576C8A9227D27DDD0058FA6E /* SnapshotTesting+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A9127D27DDD0058FA6E /* SnapshotTesting+Extensions.swift */; };
@@ -728,6 +729,7 @@
 		5766AAD0283E981700FA6091 /* PurchasesPurchasingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesPurchasingTests.swift; sourceTree = "<group>"; };
 		5766AAD4283E9B7400FA6091 /* PurchasesRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesRestoreTests.swift; sourceTree = "<group>"; };
 		5766AAE4283E9E9C00FA6091 /* PurchasesGetOfferingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesGetOfferingsTests.swift; sourceTree = "<group>"; };
+		5766AAAF283D8CDC00FA6091 /* CacheFetchPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheFetchPolicy.swift; sourceTree = "<group>"; };
 		576C8A8A27CFCB150058FA6E /* AnyEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
 		576C8A8E27CFCD110058FA6E /* AnyEncodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodableTests.swift; sourceTree = "<group>"; };
 		576C8A9027D180540058FA6E /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
@@ -1456,6 +1458,7 @@
 				3597020F24BF6A710010506E /* TransactionsFactory.swift */,
 				F56E2E7627622B5E009FED5B /* TransactionsManager.swift */,
 				359E8E3E26DEBEEB00B869F9 /* TrialOrIntroPriceEligibilityChecker.swift */,
+				5766AAAF283D8CDC00FA6091 /* CacheFetchPolicy.swift */,
 			);
 			path = Purchasing;
 			sourceTree = "<group>";
@@ -2378,6 +2381,7 @@
 				5746508C27586B2E0053AB09 /* Result+Extensions.swift in Sources */,
 				B34D2AA0269606E400D88C3A /* IntroEligibility.swift in Sources */,
 				F516BD29282434070083480B /* StoreKit2StorefrontListener.swift in Sources */,
+				5766AAB0283D8CDC00FA6091 /* CacheFetchPolicy.swift in Sources */,
 				B302206E2728B798008F1A0D /* BackendErrorStrings.swift in Sources */,
 				2D8D03B52799A2B90044C2ED /* DocCDocumentation.docc in Sources */,
 				576C8A8B27CFCB150058FA6E /* AnyEncodable.swift in Sources */,

--- a/Sources/Error Handling/BackendError.swift
+++ b/Sources/Error Handling/BackendError.swift
@@ -23,6 +23,7 @@ enum BackendError: Error, Equatable {
     case emptySubscriberAttributes(Source)
     case missingReceiptFile(Source)
     case missingTransactionProductIdentifier(Source)
+    case missingCachedCustomerInfo(Source)
     case unexpectedBackendResponse(UnexpectedBackendResponseError, extraContext: String?, Source)
 
 }
@@ -51,6 +52,12 @@ extension BackendError {
         file: String = #fileID, function: String = #function, line: UInt = #line
     ) -> Self {
         return .missingReceiptFile(.init(file: file, function: function, line: line))
+    }
+
+    static func missingCachedCustomerInfo(
+        file: String = #fileID, function: String = #function, line: UInt = #line
+    ) -> Self {
+        return .missingCachedCustomerInfo(.init(file: file, function: function, line: line))
     }
 
     static func unexpectedBackendResponse(
@@ -93,6 +100,12 @@ extension BackendError: ErrorCodeConvertible {
                 line: source.line
             )
 
+        case let .missingCachedCustomerInfo(source):
+            return ErrorUtils.customerInfoError(withMessage: Strings.purchase.missing_cached_customer_info.description,
+                                                fileName: source.file,
+                                                functionName: source.function,
+                                                line: source.line)
+
         case let .unexpectedBackendResponse(error, extraContext, source):
             return ErrorUtils.unexpectedBackendResponse(withSubError: error,
                                                         extraContext: extraContext,
@@ -128,6 +141,7 @@ extension BackendError {
              .emptySubscriberAttributes,
              .missingReceiptFile,
              .missingTransactionProductIdentifier,
+             .missingCachedCustomerInfo,
              .unexpectedBackendResponse:
             return nil
         }

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -130,6 +130,27 @@ class CustomerInfoManager {
                                                       isAppBackgrounded: isAppBackgrounded,
                                                       completion: completionIfNotCalledAlready)
             }
+
+        case .notStaleCachedOrFetched:
+            let infoFromCache = self.cachedCustomerInfo(appUserID: appUserID)
+
+            self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
+                let isCacheStale = self.deviceCache.isCustomerInfoCacheStale(appUserID: appUserID,
+                                                                             isAppBackgrounded: isAppBackgrounded)
+
+                if let infoFromCache = infoFromCache, !isCacheStale {
+                    Logger.debug(Strings.customerInfo.vending_cache)
+                    if let completion = completion {
+                        self.operationDispatcher.dispatchOnMainThread {
+                            completion(.success(infoFromCache))
+                        }
+                    }
+                } else {
+                    self.fetchAndCacheCustomerInfo(appUserID: appUserID,
+                                                   isAppBackgrounded: isAppBackgrounded,
+                                                   completion: completion)
+                }
+            }
         }
     }
 

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -81,7 +81,8 @@ class IdentityManager: CurrentUserProvider {
 
         guard newAppUserID != currentAppUserID else {
             Logger.warn(Strings.identity.logging_in_with_same_appuserid)
-            customerInfoManager.customerInfo(appUserID: currentAppUserID) { result in
+            self.customerInfoManager.customerInfo(appUserID: currentAppUserID,
+                                                  fetchPolicy: .cachedOrFetched) { result in
                 completion(
                     result.map { (info: $0, created: false) }
                 )

--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -61,6 +61,7 @@ enum PurchaseStrings {
     case cached_app_user_id_deleted
     case check_eligibility_no_identifiers
     case check_eligibility_failed(productIdentifier: String, error: Error)
+    case missing_cached_customer_info
 
 }
 
@@ -229,6 +230,9 @@ extension PurchaseStrings: CustomStringConvertible {
         case let .check_eligibility_failed(productIdentifier, error):
             return "Error checking discount eligibility for product '\(productIdentifier)': \(error).\n" +
             "Will be considered not eligible."
+
+        case .missing_cached_customer_info:
+            return "Requested a cached CustomerInfo but it's not available."
         }
     }
 

--- a/Sources/Purchasing/CacheFetchPolicy.swift
+++ b/Sources/Purchasing/CacheFetchPolicy.swift
@@ -1,0 +1,30 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CacheFetchPolicy.swift
+//
+//  Created by Nacho Soto on 5/24/22.
+
+/// Specifies the behavior for a caching API.
+@objc(RCCacheFetchPolicy)
+public enum CacheFetchPolicy: Int {
+
+    /// Returns values from the cache, or throws an error if not available.
+    case fromCacheOnly
+
+    /// Always fetch the most up-to-date data.
+    case fetchCurrent
+
+    /// Default behavior: returns the cache data if available and not stale, or fetches up-to-date data.
+    case cachedOrFetched
+
+    /// Default ``CacheFetchPolicy`` behavior.
+    public static let `default`: Self = .cachedOrFetched
+
+}

--- a/Sources/Purchasing/CacheFetchPolicy.swift
+++ b/Sources/Purchasing/CacheFetchPolicy.swift
@@ -21,7 +21,10 @@ public enum CacheFetchPolicy: Int {
     /// Always fetch the most up-to-date data.
     case fetchCurrent
 
-    /// Default behavior: returns the cache data if available and not stale, or fetches up-to-date data.
+    /// Returns the cached data if available and not stale, or fetches up-to-date data.
+    case notStaleCachedOrFetched
+
+    /// Default behavior: returns the cached data if available (even if stale), or fetches up-to-date data.
     case cachedOrFetched
 
     /// Default ``CacheFetchPolicy`` behavior.

--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -957,6 +957,7 @@ public extension Purchases {
 }
 
 // MARK: Purchasing
+
 public extension Purchases {
 
     /**
@@ -966,21 +967,33 @@ public extension Purchases {
      * Called immediately if ``CustomerInfo`` is cached. Customer info can be nil if an error occurred.
      */
     @objc func getCustomerInfo(completion: @escaping (CustomerInfo?, Error?) -> Void) {
-        customerInfoManager.customerInfo(appUserID: appUserID) { result in
-            completion(result.value, result.error)
-        }
+        self.getCustomerInfo(fetchPolicy: .default, completion: completion)
     }
 
     /**
      * Get latest available customer  info.
-     * Returns a value immediately if ``CustomerInfo`` is cached.
+     *
+     * - Parameter fetchPolicy: The behavior for what to do regarding caching.
+     * - Parameter completion: A completion block called when customer info is available and not stale.
+     */
+    @objc func getCustomerInfo(fetchPolicy: CacheFetchPolicy, completion: @escaping (CustomerInfo?, Error?) -> Void) {
+        self.customerInfoManager.customerInfo(appUserID: self.appUserID,
+                                              fetchPolicy: fetchPolicy) { result in
+            completion(result.value, result.error?.asPurchasesError)
+        }
+    }
+
+    /**
+     * Get latest available customer info.
+     *
+     * - Parameter fetchPolicy: The behavior for what to do regarding caching.
      *
      * #### Related Symbols
      * - ``Purchases/customerInfoStream``
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func customerInfo() async throws -> CustomerInfo {
-        return try await customerInfoAsync()
+    func customerInfo(fetchPolicy: CacheFetchPolicy = .default) async throws -> CustomerInfo {
+        return try await self.customerInfoAsync()
     }
 
     /// Returns an `AsyncStream` of ``CustomerInfo`` changes, starting from the last known value.

--- a/Sources/Support/BeginRefundRequestHelper.swift
+++ b/Sources/Support/BeginRefundRequestHelper.swift
@@ -93,7 +93,8 @@ private extension BeginRefundRequestHelper {
 
         do {
             customerInfo = try await self.customerInfoManager.customerInfo(
-                appUserID: self.currentUserProvider.currentAppUserID
+                appUserID: self.currentUserProvider.currentAppUserID,
+                fetchPolicy: .cachedOrFetched
             )
         } catch {
             let message = Strings.purchase.begin_refund_customer_info_error(entitlementID: entitlementID)

--- a/Sources/Support/ManageSubscriptionsHelper.swift
+++ b/Sources/Support/ManageSubscriptionsHelper.swift
@@ -33,7 +33,8 @@ class ManageSubscriptionsHelper {
     @available(tvOS, unavailable)
     func showManageSubscriptions(completion: @escaping (Result<Void, Error>) -> Void) {
         let currentAppUserID = self.currentUserProvider.currentAppUserID
-        customerInfoManager.customerInfo(appUserID: currentAppUserID) { result in
+        self.customerInfoManager.customerInfo(appUserID: currentAppUserID,
+                                              fetchPolicy: .cachedOrFetched) { result in
             let result: Result<URL, Error> = result
                 .mapError { error in
                     let message = Strings.failed_to_get_management_url_error_unknown(error: error)

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCCustomerInfoAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCCustomerInfoAPI.m
@@ -39,4 +39,14 @@
     
     NSLog(ci, ei, as, appis, led, ncp, nst, oav, opd, rd, fs, oaud, murl, edfpi, pdfpi, exdf, pdfe, d, rawData);
 }
+
++ (void)checkCacheFetchPolicyEnum:(RCCacheFetchPolicy) policy {
+    switch (policy) {
+        case RCCacheFetchPolicyFetchCurrent:
+        case RCCacheFetchPolicyCachedOrFetched:
+        case RCCacheFetchPolicyFromCacheOnly:
+            break;
+    }
+}
+
 @end

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCCustomerInfoAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCCustomerInfoAPI.m
@@ -45,6 +45,7 @@
         case RCCacheFetchPolicyFetchCurrent:
         case RCCacheFetchPolicyCachedOrFetched:
         case RCCacheFetchPolicyFromCacheOnly:
+        case RCCacheFetchPolicyNotStaleCachedOrFetched:
             break;
     }
 }

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -146,6 +146,8 @@ BOOL isAnonymous;
     [p setCreative: @""];
     [p collectDeviceIdentifiers];
     
+    [p getCustomerInfoWithFetchPolicy:RCCacheFetchPolicyFetchCurrent completion:^(RCCustomerInfo *customerInfo,
+                                                                                  NSError *error) {}];
     [p getCustomerInfoWithCompletion:^(RCCustomerInfo *info, NSError *error) {}];
     [p getOfferingsWithCompletion:^(RCOfferings *info, NSError *error) {}];
     [p getProductsWithIdentifiers:@[@""] completion:^(NSArray<RCStoreProduct *> *products) { }];

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/CustomerInfoAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/CustomerInfoAPI.swift
@@ -43,3 +43,13 @@ func checkCustomerInfoAPI() {
     print(customerInfo!, entitlementInfo, asubs, appis, led!, ncp, nst, oav!, opd!, rDate!, fSeen, oaud!, murl!,
           edfpi!, pdfpi!, exdf!, pdfe!, desc, rawData)
 }
+
+func checkCacheFetchPolicyEnum(_ policy: CacheFetchPolicy) {
+    switch policy {
+    case .fromCacheOnly: break
+    case .fetchCurrent: break
+    case .cachedOrFetched: break
+
+    @unknown default: break
+    }
+}

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/CustomerInfoAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/CustomerInfoAPI.swift
@@ -49,6 +49,7 @@ func checkCacheFetchPolicyEnum(_ policy: CacheFetchPolicy) {
     case .fromCacheOnly: break
     case .fetchCurrent: break
     case .cachedOrFetched: break
+    case .notStaleCachedOrFetched: break
 
     @unknown default: break
     }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -111,6 +111,7 @@ private func checkTypealiases(
 
 private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.getCustomerInfo { (_: CustomerInfo?, _: Error?) in }
+    purchases.getCustomerInfo(fetchPolicy: .default) { (_: CustomerInfo?, _: Error?) in }
     purchases.getOfferings { (_: Offerings?, _: Error?) in }
     purchases.getProducts([String]()) { (_: [StoreProduct]) in }
 
@@ -218,6 +219,7 @@ private func checkAsyncMethods(purchases: Purchases) async {
         let _: (StoreTransaction?, CustomerInfo, Bool) = try await purchases.purchase(product: stp,
                                                                                       promotionalOffer: offer)
         let _: CustomerInfo = try await purchases.customerInfo()
+        let _: CustomerInfo = try await purchases.customerInfo(fetchPolicy: .default)
         let _: CustomerInfo = try await purchases.restorePurchases()
         let _: CustomerInfo = try await purchases.syncPurchases()
 

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -64,7 +64,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
     func testFetchAndCacheCustomerInfoCallsBackendWithRandomDelayIfAppBackgrounded() {
         mockOperationDispatcher.shouldInvokeDispatchOnWorkerThreadBlock = true
 
-        customerInfoManager.fetchAndCacheCustomerInfo(appUserID: "myUser",
+        customerInfoManager.fetchAndCacheCustomerInfo(appUserID: Self.appUserID,
                                                       isAppBackgrounded: true,
                                                       completion: nil)
 
@@ -76,7 +76,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
     func testFetchAndCacheCustomerInfoCallsBackendWithoutRandomDelayIfAppForegrounded() {
         mockOperationDispatcher.shouldInvokeDispatchOnWorkerThreadBlock = true
 
-        customerInfoManager.fetchAndCacheCustomerInfo(appUserID: "myUser",
+        customerInfoManager.fetchAndCacheCustomerInfo(appUserID: Self.appUserID,
                                                       isAppBackgrounded: false,
                                                       completion: nil)
 
@@ -92,7 +92,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
 
         var completionCalled = false
         var receivedError: BackendError?
-        customerInfoManager.fetchAndCacheCustomerInfo(appUserID: "myUser",
+        customerInfoManager.fetchAndCacheCustomerInfo(appUserID: Self.appUserID,
                                                       isAppBackgrounded: false) { result in
             completionCalled = true
             receivedError = result.error
@@ -108,7 +108,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         mockBackend.stubbedGetCustomerInfoResult = .failure(.missingAppUserID())
 
         var completionCalled = false
-        customerInfoManager.fetchAndCacheCustomerInfo(appUserID: "myUser",
+        customerInfoManager.fetchAndCacheCustomerInfo(appUserID: Self.appUserID,
                                                       isAppBackgrounded: false) { _ in
             completionCalled = true
         }
@@ -124,7 +124,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         var completionCalled = false
         var receivedCustomerInfo: CustomerInfo?
 
-        customerInfoManager.fetchAndCacheCustomerInfo(appUserID: "myUser",
+        customerInfoManager.fetchAndCacheCustomerInfo(appUserID: Self.appUserID,
                                                       isAppBackgrounded: false) { result in
             completionCalled = true
             receivedCustomerInfo = result.value
@@ -143,7 +143,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         mockBackend.stubbedGetCustomerInfoResult = .success(mockCustomerInfo)
 
         var completionCalled = false
-        customerInfoManager.fetchAndCacheCustomerInfo(appUserID: "myUser",
+        customerInfoManager.fetchAndCacheCustomerInfo(appUserID: Self.appUserID,
                                                       isAppBackgrounded: false) { _ in
             completionCalled = true
         }
@@ -159,14 +159,13 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         var firstCompletionCalled = false
         var secondCompletionCalled = false
 
-        let appUserID = "myUser"
-        customerInfoManager.fetchAndCacheCustomerInfoIfStale(appUserID: appUserID,
+        customerInfoManager.fetchAndCacheCustomerInfoIfStale(appUserID: Self.appUserID,
                                                              isAppBackgrounded: false) { _ in
             firstCompletionCalled = true
         }
         mockDeviceCache.stubbedIsCustomerInfoCacheStale = false
-        customerInfoManager.cache(customerInfo: mockCustomerInfo, appUserID: appUserID)
-        customerInfoManager.fetchAndCacheCustomerInfoIfStale(appUserID: appUserID,
+        customerInfoManager.cache(customerInfo: mockCustomerInfo, appUserID: Self.appUserID)
+        customerInfoManager.fetchAndCacheCustomerInfoIfStale(appUserID: Self.appUserID,
                                                              isAppBackgrounded: false) { _ in
             secondCompletionCalled = true
         }
@@ -177,12 +176,11 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
     }
 
     func testFetchAndCacheCustomerInfoIfStaleFetchesIfStale() {
-        let appUserID = "myUser"
-        customerInfoManager.cache(customerInfo: mockCustomerInfo, appUserID: appUserID)
+        customerInfoManager.cache(customerInfo: mockCustomerInfo, appUserID: Self.appUserID)
         mockDeviceCache.stubbedIsCustomerInfoCacheStale = true
         var completionCalled = false
 
-        customerInfoManager.fetchAndCacheCustomerInfoIfStale(appUserID: appUserID,
+        customerInfoManager.fetchAndCacheCustomerInfoIfStale(appUserID: Self.appUserID,
                                                              isAppBackgrounded: false) { _ in
             completionCalled = true
         }
@@ -195,7 +193,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         mockDeviceCache.stubbedIsCustomerInfoCacheStale = false
         var completionCalled = false
 
-        customerInfoManager.fetchAndCacheCustomerInfoIfStale(appUserID: "myUser",
+        customerInfoManager.fetchAndCacheCustomerInfoIfStale(appUserID: Self.appUserID,
                                                              isAppBackgrounded: false) { _ in
             completionCalled = true
         }
@@ -208,17 +206,16 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         let info = try CustomerInfo(data: [
         "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
-                "original_app_user_id": "app_user_id",
+                "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-06-17T16:05:33Z",
                 "subscriptions": [:],
                 "other_purchases": [:]
             ]])
 
         let object = try info.asData()
-        let appUserID = "myUser"
-        self.mockDeviceCache.cachedCustomerInfo[appUserID] = object
+        self.mockDeviceCache.cachedCustomerInfo[Self.appUserID] = object
 
-        customerInfoManager.sendCachedCustomerInfoIfAvailable(appUserID: appUserID)
+        customerInfoManager.sendCachedCustomerInfoIfAvailable(appUserID: Self.appUserID)
 
         expect(self.customerInfoManagerChangesCallCount) == 1
     }
@@ -227,7 +224,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         let oldInfo = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
-                "original_app_user_id": "app_user_id",
+                "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-06-17T16:05:33Z",
                 "subscriptions": [:],
                 "other_purchases": [:]
@@ -235,24 +232,23 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
 
         var object = try oldInfo.asData()
 
-        let appUserID = "myUser"
-        mockDeviceCache.cachedCustomerInfo[appUserID] = object
+        mockDeviceCache.cachedCustomerInfo[Self.appUserID] = object
 
-        customerInfoManager.sendCachedCustomerInfoIfAvailable(appUserID: appUserID)
+        customerInfoManager.sendCachedCustomerInfoIfAvailable(appUserID: Self.appUserID)
 
         let newInfo = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
-                "original_app_user_id": "app_user_id",
+                "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-06-17T16:05:33Z",
                 "subscriptions": ["product_a": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]],
                 "other_purchases": [:]
             ]])
 
         object = try newInfo.asData()
-        mockDeviceCache.cachedCustomerInfo[appUserID] = object
+        mockDeviceCache.cachedCustomerInfo[Self.appUserID] = object
 
-        customerInfoManager.sendCachedCustomerInfoIfAvailable(appUserID: appUserID)
+        customerInfoManager.sendCachedCustomerInfoIfAvailable(appUserID: Self.appUserID)
         expect(self.customerInfoManagerChangesCallCount) == 2
     }
 
@@ -260,28 +256,26 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         let oldInfo = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
-                "original_app_user_id": "app_user_id",
+                "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-06-17T16:05:33Z",
                 "subscriptions": [:],
                 "other_purchases": [:]
             ]])
 
         let object = try oldInfo.asData()
-        let appUserID = "myUser"
-        mockDeviceCache.cachedCustomerInfo[appUserID] = object
+        mockDeviceCache.cachedCustomerInfo[Self.appUserID] = object
 
-        customerInfoManager.sendCachedCustomerInfoIfAvailable(appUserID: appUserID)
+        customerInfoManager.sendCachedCustomerInfoIfAvailable(appUserID: Self.appUserID)
         expect(self.mockOperationDispatcher.invokedDispatchOnMainThreadCount) == 1
     }
 
     func testCustomerInfoReturnsFromCacheIfAvailable() {
-        let appUserID = "myUser"
-        customerInfoManager.cache(customerInfo: mockCustomerInfo, appUserID: appUserID)
+        customerInfoManager.cache(customerInfo: mockCustomerInfo, appUserID: Self.appUserID)
 
         var completionCalled = false
         var receivedCustomerInfo: CustomerInfo?
 
-        customerInfoManager.customerInfo(appUserID: appUserID, fetchPolicy: .default) { result in
+        customerInfoManager.customerInfo(appUserID: Self.appUserID, fetchPolicy: .default) { result in
             completionCalled = true
             receivedCustomerInfo = result.value
         }
@@ -292,14 +286,13 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
     }
 
     func testCustomerInfoReturnsFromCacheAndRefreshesIfStale() {
-        let appUserID = "myUser"
         mockDeviceCache.stubbedIsCustomerInfoCacheStale = true
         mockBackend.stubbedGetCustomerInfoResult = .success(mockCustomerInfo)
 
-        customerInfoManager.cache(customerInfo: mockCustomerInfo, appUserID: appUserID)
+        customerInfoManager.cache(customerInfo: mockCustomerInfo, appUserID: Self.appUserID)
 
         var completionCalled = false
-        customerInfoManager.customerInfo(appUserID: appUserID, fetchPolicy: .default) { _ in
+        customerInfoManager.customerInfo(appUserID: Self.appUserID, fetchPolicy: .default) { _ in
             completionCalled = true
         }
 
@@ -326,7 +319,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         let info = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
-                "original_app_user_id": "app_user_id",
+                "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-06-17T16:05:33Z",
                 "subscriptions": ["product_a": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]],
                 "other_purchases": [:]
@@ -350,7 +343,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         let info = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
-                "original_app_user_id": "app_user_id",
+                "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-06-17T16:05:33Z",
                 "subscriptions": ["product_a": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]],
                 "other_purchases": [:]
@@ -378,7 +371,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
             "request_date": "2019-08-16T10:30:42Z",
             "schema_version": "\(oldSchemaVersion)",
             "subscriber": [
-                "original_app_user_id": "app_user_id",
+                "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-06-17T16:05:33Z",
                 "subscriptions": ["product_a": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]],
                 "other_purchases": [:]

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -515,6 +515,21 @@ class CustomerInfoManagerGetCustomerInfoTests: BaseCustomerInfoManagerTests {
         expect(result) === self.mockRefreshedCustomerInfo
     }
 
+    func testCustomerInfoCachedOrFetchedReturnsErrorIfNoCacheAndFailsToFetch() async throws {
+        let expectedError: BackendError = .networkError(.offlineConnection())
+
+        self.mockBackend.stubbedGetCustomerInfoResult = .failure(expectedError)
+
+        do {
+            _ = try await self.customerInfoManager.customerInfo(appUserID: Self.appUserID,
+                                                                fetchPolicy: .cachedOrFetched)
+
+            fail("Expected error")
+        } catch {
+            expect(error).to(matchError(expectedError))
+        }
+    }
+
     // MARK: - CacheFetchPolicy.notStaleCachedOrFetched
 
     func testCustomerInfoNotStaleCachedOrFetchedReturnsFromCacheIfAvailableAndNotStale() async throws {
@@ -560,6 +575,23 @@ class CustomerInfoManagerGetCustomerInfoTests: BaseCustomerInfoManagerTests {
 
         expect(self.mockBackend.invokedGetSubscriberDataCount) == 1
         expect(result) === self.mockRefreshedCustomerInfo
+    }
+
+    func testCustomerInfoNotStaleCachedOrFetchedReturnsErrorIfNoCacheAndFailsToFetch() async throws {
+        let expectedError: BackendError = .networkError(.offlineConnection())
+
+        self.mockDeviceCache.stubbedIsCustomerInfoCacheStale = true
+        self.customerInfoManager.cache(customerInfo: self.mockCustomerInfo, appUserID: Self.appUserID)
+        self.mockBackend.stubbedGetCustomerInfoResult = .failure(expectedError)
+
+        do {
+            _ = try await self.customerInfoManager.customerInfo(appUserID: Self.appUserID,
+                                                                fetchPolicy: .notStaleCachedOrFetched)
+
+            fail("Expected error")
+        } catch {
+            expect(error).to(matchError(expectedError))
+        }
     }
 
     // MARK: - CacheFetchPolicy.fetchCurrent

--- a/Tests/UnitTests/Mocks/MockCustomerInfoManager.swift
+++ b/Tests/UnitTests/Mocks/MockCustomerInfoManager.swift
@@ -58,17 +58,22 @@ class MockCustomerInfoManager: CustomerInfoManager {
 
     var invokedCustomerInfo = false
     var invokedCustomerInfoCount = 0
-    var invokedCustomerInfoParameters: (appUserID: String, completion: ((Result<CustomerInfo, BackendError>) -> Void)?)?
-    var invokedCustomerInfoParametersList = [(appUserID: String, completion: ((Result<CustomerInfo, BackendError>) -> Void)?)]()
+    var invokedCustomerInfoParameters: (appUserID: String,
+                                        fetchPolicy: CacheFetchPolicy,
+                                        completion: ((Result<CustomerInfo, BackendError>) -> Void)?)?
+    var invokedCustomerInfoParametersList: [(appUserID: String,
+                                             fetchPolicy: CacheFetchPolicy,
+                                             completion: ((Result<CustomerInfo, BackendError>) -> Void)?)] = []
 
     var stubbedCustomerInfoResult: Result<CustomerInfo, BackendError> = .failure(.missingAppUserID())
 
     override func customerInfo(appUserID: String,
+                               fetchPolicy: CacheFetchPolicy,
                                completion: ((Result<CustomerInfo, BackendError>) -> Void)?) {
         invokedCustomerInfo = true
         invokedCustomerInfoCount += 1
-        invokedCustomerInfoParameters = (appUserID, completion)
-        invokedCustomerInfoParametersList.append((appUserID, completion))
+        invokedCustomerInfoParameters = (appUserID, fetchPolicy, completion)
+        invokedCustomerInfoParametersList.append((appUserID, fetchPolicy, completion))
         completion?(self.stubbedCustomerInfoResult)
     }
 


### PR DESCRIPTION
Fixes [CF-19].
This allows specifying `CustomerInfoManager` fetching behavior, both as a public API for users, and also internally.
Some future uses of `CustomerInfoManager` might want to ensure that we don't rely on cached data, for example.

Thanks to the `APITester` we know that the existing methods still work, this is purely an additive change.

This is the core of the change:
```swift
/// Specifies the behavior for a caching API.
@objc(RCCacheFetchPolicy)
public enum CacheFetchPolicy: Int {
    /// Returns values from the cache, or throws an error if not available.
    case fromCacheOnly

    /// Always fetch the most up-to-date data.
    case fetchCurrent

    /// Returns the cached data if available and not stale, or fetches up-to-date data.
    case notStaleCachedOrFetched

    /// Default behavior: returns the cached data if available (even if stale), or fetches up-to-date data.
    case cachedOrFetched

    /// Default ``CacheFetchPolicy`` behavior.
    public static let `default`: Self = .cachedOrFetched
}
```

The new `CustomerInfoManagerGetCustomerInfoTests` check all the different combinations of fetching behavior.
I've taken some of the existing tests and refactored them to be `async`, as well as added a bunch more tests.

> **Note**: 
There is also one big hidden bug fix:

`Purchases.getCustomerInfo` now calls `BackendError.asPurchasesError`, so we don't end up returning an internal error type.
This was missed because we always return generic `Error` types, so we have no way to know at compile time that we only return `ErrorCode`s.

[CF-19]: https://revenuecats.atlassian.net/browse/CF-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ