### PR TITLE
Split `PurchasesTests` step 4: extracted `PurchasesRestoreTests`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -250,6 +250,7 @@
 		5766AAC5283E843300FA6091 /* PurchasesConfiguringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5766AAC4283E843300FA6091 /* PurchasesConfiguringTests.swift */; };
 		5766AAC9283E88CF00FA6091 /* PurchasesGetCustomerInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5766AAC8283E88CF00FA6091 /* PurchasesGetCustomerInfoTests.swift */; };
 		5766AAD1283E981700FA6091 /* PurchasesPurchasingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5766AAD0283E981700FA6091 /* PurchasesPurchasingTests.swift */; };
+		5766AAD5283E9B7400FA6091 /* PurchasesRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5766AAD4283E9B7400FA6091 /* PurchasesRestoreTests.swift */; };
 		576C8A8B27CFCB150058FA6E /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A8A27CFCB150058FA6E /* AnyEncodable.swift */; };
 		576C8A8F27CFCD110058FA6E /* AnyEncodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A8E27CFCD110058FA6E /* AnyEncodableTests.swift */; };
 		576C8A9227D27DDD0058FA6E /* SnapshotTesting+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A9127D27DDD0058FA6E /* SnapshotTesting+Extensions.swift */; };
@@ -721,6 +722,7 @@
 		5766AAC4283E843300FA6091 /* PurchasesConfiguringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesConfiguringTests.swift; sourceTree = "<group>"; };
 		5766AAC8283E88CF00FA6091 /* PurchasesGetCustomerInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesGetCustomerInfoTests.swift; sourceTree = "<group>"; };
 		5766AAD0283E981700FA6091 /* PurchasesPurchasingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesPurchasingTests.swift; sourceTree = "<group>"; };
+		5766AAD4283E9B7400FA6091 /* PurchasesRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesRestoreTests.swift; sourceTree = "<group>"; };
 		576C8A8A27CFCB150058FA6E /* AnyEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
 		576C8A8E27CFCD110058FA6E /* AnyEncodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodableTests.swift; sourceTree = "<group>"; };
 		576C8A9027D180540058FA6E /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
@@ -1643,6 +1645,7 @@
 				5766AAC4283E843300FA6091 /* PurchasesConfiguringTests.swift */,
 				5766AAC8283E88CF00FA6091 /* PurchasesGetCustomerInfoTests.swift */,
 				5766AAD0283E981700FA6091 /* PurchasesPurchasingTests.swift */,
+				5766AAD4283E9B7400FA6091 /* PurchasesRestoreTests.swift */,
 			);
 			path = Purchases;
 			sourceTree = "<group>";
@@ -2464,6 +2467,7 @@
 				351B51A426D450BC00BD2BD7 /* NSError+RCExtensionsTests.swift in Sources */,
 				57E2230727500BB1002DB06E /* AtomicTests.swift in Sources */,
 				351B51B826D450E800BD2BD7 /* StoreKitWrapperTests.swift in Sources */,
+				5766AAD5283E9B7400FA6091 /* PurchasesRestoreTests.swift in Sources */,
 				FD18ED4E2837F89200C5AA4F /* StoreKitWorkaroundsTests.swift in Sources */,
 				B3CD0D8827F25E3E000793F5 /* BackendSubscriberAttributesTests.swift in Sources */,
 				2DDF41E624F6F5DC005BC22D /* MockSK1Product.swift in Sources */,

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesRestoreTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesRestoreTests.swift
@@ -1,0 +1,185 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchasesRestoreTests.swift
+//
+//  Created by Nacho Soto on 5/25/22.
+
+import Nimble
+import StoreKit
+import XCTest
+
+@testable import RevenueCat
+
+class PurchasesRestoreTests: BasePurchasesTests {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        self.setupPurchases()
+    }
+
+    func testRestoresDontPostMissingReceipts() {
+        self.receiptFetcher.shouldReturnReceipt = false
+        var receivedError: NSError?
+        self.purchases.restorePurchases { (_, error) in
+            receivedError = error as NSError?
+        }
+
+        expect(receivedError?.code).toEventually(equal(ErrorCode.missingReceiptFileError.rawValue))
+    }
+
+    func testRestorePurchasesCallsCompletionOnMainThreadWhenMissingReceipts() {
+        self.receiptFetcher.shouldReturnReceipt = false
+        var receivedError: NSError?
+        self.purchases.restorePurchases { (_, error) in
+            receivedError = error as NSError?
+        }
+
+        expect(self.mockOperationDispatcher.invokedDispatchOnMainThreadCount) == 1
+        expect(receivedError?.code).toEventually(equal(ErrorCode.missingReceiptFileError.rawValue))
+    }
+
+    func testRestoringPurchasesPostsTheReceipt() {
+        self.purchases.restorePurchases()
+        expect(self.backend.postReceiptDataCalled).to(beTrue())
+    }
+
+    func testRestoringPurchasesPostsIfReceiptEmptyAndCustomerInfoNotLoaded() {
+        self.mockTransactionsManager.stubbedCustomerHasTransactionsCompletionParameter = false
+
+        self.purchases.restorePurchases()
+
+        expect(self.backend.postReceiptDataCalled) == true
+    }
+
+    func testRestoringPurchasesPostsIfReceiptHasTransactionsAndCustomerInfoLoaded() throws {
+        let info = try CustomerInfo(data: Self.emptyCustomerInfoData)
+
+        let object = try info.asData()
+        self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
+
+        self.mockTransactionsManager.stubbedCustomerHasTransactionsCompletionParameter = true
+
+        self.purchases.restorePurchases()
+
+        expect(self.backend.postReceiptDataCalled) == true
+    }
+
+    func testRestoringPurchasesPostsIfReceiptHasTransactionsAndCustomerInfoNotLoaded() {
+        self.mockTransactionsManager.stubbedCustomerHasTransactionsCompletionParameter = true
+
+        self.purchases.restorePurchases()
+
+        expect(self.backend.postReceiptDataCalled) == true
+    }
+
+    func testRestoringPurchasesAlwaysRefreshesAndPostsTheReceipt() {
+        self.receiptFetcher.shouldReturnReceipt = true
+        self.purchases.restorePurchases()
+
+        expect(self.receiptFetcher.receiptDataTimesCalled).to(equal(1))
+    }
+
+    func testRestoringPurchasesSetsIsRestore() {
+        self.purchases.restorePurchases()
+        expect(self.backend.postedIsRestore!).to(beTrue())
+    }
+
+    func testRestoringPurchasesSetsIsRestoreForAnon() {
+        self.setupAnonPurchases()
+        self.purchases.restorePurchases()
+
+        expect(self.backend.postedIsRestore!).to(beTrue())
+    }
+
+    func testRestoringPurchasesCallsSuccessDelegateMethod() throws {
+        let customerInfo = try CustomerInfo(data: Self.emptyCustomerInfoData)
+        self.backend.postReceiptResult = .success(customerInfo)
+
+        var receivedCustomerInfo: CustomerInfo?
+
+        self.purchases.restorePurchases { (info, _) in
+            receivedCustomerInfo = info
+        }
+
+        expect(receivedCustomerInfo).toEventually(be(customerInfo))
+    }
+
+    func testRestorePurchasesPassesErrorOnFailure() {
+        let error: BackendError = .missingAppUserID()
+
+        self.backend.postReceiptResult = .failure(error)
+        self.purchasesDelegate.customerInfo = nil
+
+        var receivedError: Error?
+
+        self.purchases.restorePurchases { (_, newError) in
+            receivedError = newError
+        }
+
+        expect(receivedError).toEventuallyNot(beNil())
+        expect(receivedError).to(matchError(error.asPurchasesError))
+    }
+
+    func testFetchVersionSendsAReceiptIfNoVersion() throws {
+        self.backend.postReceiptResult = .success(try CustomerInfo(data: [
+            "request_date": "2019-08-16T10:30:42Z",
+            "subscriber": [
+                "first_seen": "2019-07-17T00:05:54Z",
+                "original_app_user_id": Self.appUserID,
+                "subscriptions": [:],
+                "other_purchases": [:],
+                "original_application_version": "1.0",
+                "original_purchase_date": "2018-10-26T23:17:53Z"
+            ]
+        ]))
+
+        var receivedCustomerInfo: CustomerInfo?
+
+        self.purchases.restorePurchases { (info, _) in
+            receivedCustomerInfo = info
+        }
+
+        expect(receivedCustomerInfo?.originalApplicationVersion).toEventually(equal("1.0"))
+        expect(receivedCustomerInfo?.originalPurchaseDate)
+            .toEventually(equal(Date(timeIntervalSinceReferenceDate: 562288673)))
+        expect(self.backend.userID).toEventuallyNot(beNil())
+        expect(self.backend.postReceiptDataCalled).toEventuallyNot(beFalse())
+    }
+
+}
+
+class PurchasesRestoreNoSetupTests: BasePurchasesTests {
+
+    func testRestoringPurchasesDoesntPostIfReceiptEmptyAndCustomerInfoLoaded() throws {
+        let info = try CustomerInfo(data: [
+            "request_date": "2019-08-16T10:30:42Z",
+            "subscriber": [
+                "original_app_user_id": Self.appUserID,
+                "first_seen": "2019-07-17T00:05:54Z",
+                "subscriptions": [:],
+                "other_purchases": [:],
+                "original_application_version": "1.0",
+                "original_purchase_date": "2018-10-26T23:17:53Z"
+            ]])
+
+        let object = try info.asData()
+
+        self.deviceCache.cachedCustomerInfo[self.identityManager.currentAppUserID] = object
+
+        self.mockTransactionsManager.stubbedCustomerHasTransactionsCompletionParameter = false
+
+        self.setupPurchases()
+        self.purchases.restorePurchases()
+
+        expect(self.backend.postReceiptDataCalled) == false
+    }
+
+}


### PR DESCRIPTION
Follow up to #1609.