### PR TITLE
 `Storefront`: added `sk1CurrentStorefront` for Objective-C

### DIFF
--- a/Sources/Purchasing/StoreKitAbstractions/Storefront.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Storefront.swift
@@ -78,9 +78,14 @@ public extension Storefront {
                 let sk2Storefront = await StoreKit.Storefront.current
                 return sk2Storefront.map(SK2Storefront.init)
             } else {
-                return SKPaymentQueue.default().storefront.map(SK1Storefront.init)
+                return Self.sk1CurrentStorefrontType
             }
         }
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, macCatalyst 13.1, *)
+    private static var sk1CurrentStorefrontType: StorefrontType? {
+        return SKPaymentQueue.default().storefront.map(SK1Storefront.init)
     }
 
     /// The current App Store storefront for the device.
@@ -89,6 +94,14 @@ public extension Storefront {
         get async {
             return await self.currentStorefrontType.map(Storefront.from(storefront: ))
         }
+    }
+
+    /// The current App Store storefront for the device obtained from StoreKit 1 only.
+    /// - Note: this method is intended to be used only from Objective-C.
+    /// In Swift, ``Storefront/currentStorefront`` is preferred.
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, macCatalyst 13.1, *)
+    @objc static var sk1CurrentStorefront: Storefront? {
+        return self.sk1CurrentStorefrontType.map(Storefront.from(storefront: ))
     }
 
 }

--- a/Sources/Purchasing/StoreKitAbstractions/Storefront.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Storefront.swift
@@ -97,8 +97,7 @@ public extension Storefront {
     }
 
     /// The current App Store storefront for the device obtained from StoreKit 1 only.
-    /// - Note: this method is intended to be used only from Objective-C.
-    /// In Swift, ``Storefront/currentStorefront`` is preferred.
+    @available(swift, obsoleted: 0.0.1, renamed: "currentStorefront")
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, macCatalyst 13.1, *)
     @objc static var sk1CurrentStorefront: Storefront? {
         return self.sk1CurrentStorefrontType.map(Storefront.from(storefront: ))

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCStorefrontAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCStorefrontAPI.m
@@ -19,7 +19,9 @@
 
     SKStorefront *sk1storefront = storefront.sk1Storefront;
 
-    NSLog(identifier, countryCode, sk1storefront);
+    RCStorefront *currentStorefront = [RCStorefront sk1CurrentStorefront];
+
+    NSLog(identifier, countryCode, sk1storefront, currentStorefront);
 }
 
 @end

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/StorefrontAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/StorefrontAPI.swift
@@ -16,7 +16,6 @@ func checkStorefrontAPI() {
 
     let sk1Storefront: SKStorefront? = storefront.sk1Storefront
     let sk2Storefront: StoreKit.Storefront? = storefront.sk2Storefront
-    let sk1CurrentStorefront: RevenueCat.Storefront? = Storefront.sk1CurrentStorefront
 
     _ = Task {
         let _: RevenueCat.Storefront? = await Storefront.currentStorefront
@@ -24,7 +23,6 @@ func checkStorefrontAPI() {
 
     print(identifier,
           countryCode,
-          sk1CurrentStorefront!,
           sk1Storefront!,
           sk2Storefront!)
 }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/StorefrontAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/StorefrontAPI.swift
@@ -16,6 +16,7 @@ func checkStorefrontAPI() {
 
     let sk1Storefront: SKStorefront? = storefront.sk1Storefront
     let sk2Storefront: StoreKit.Storefront? = storefront.sk2Storefront
+    let sk1CurrentStorefront: RevenueCat.Storefront? = Storefront.sk1CurrentStorefront
 
     _ = Task {
         let _: RevenueCat.Storefront? = await Storefront.currentStorefront
@@ -23,6 +24,7 @@ func checkStorefrontAPI() {
 
     print(identifier,
           countryCode,
+          sk1CurrentStorefront!,
           sk1Storefront!,
           sk2Storefront!)
 }

--- a/Tests/StoreKitUnitTests/StorefrontTests.swift
+++ b/Tests/StoreKitUnitTests/StorefrontTests.swift
@@ -16,6 +16,7 @@ import Nimble
 import StoreKit
 import XCTest
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, macCatalyst 13.1, *)
 class StorefrontTests: StoreKitConfigTestCase {
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -30,7 +31,6 @@ class StorefrontTests: StoreKitConfigTestCase {
 
     }
 
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, macCatalyst 13.1, *)
     func testCurrentStorefrontSK1() async throws {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
@@ -43,6 +43,16 @@ class StorefrontTests: StoreKitConfigTestCase {
         } else {
             throw XCTSkip("This test is for pre-iOS 15 APIs")
         }
+    }
+
+    func testSK1CurrentStorefront() throws {
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
+        let expectedStorefront = try XCTUnwrap(SKPaymentQueue.default().storefront)
+        let currentStorefront = try XCTUnwrap(Storefront.sk1CurrentStorefront)
+
+        expect(currentStorefront.identifier) == expectedStorefront.identifier
+        expect(currentStorefront.countryCode) == expectedStorefront.countryCode
     }
 
 }

--- a/Tests/StoreKitUnitTests/StorefrontTests.swift
+++ b/Tests/StoreKitUnitTests/StorefrontTests.swift
@@ -45,14 +45,4 @@ class StorefrontTests: StoreKitConfigTestCase {
         }
     }
 
-    func testSK1CurrentStorefront() throws {
-        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
-
-        let expectedStorefront = try XCTUnwrap(SKPaymentQueue.default().storefront)
-        let currentStorefront = try XCTUnwrap(Storefront.sk1CurrentStorefront)
-
-        expect(currentStorefront.identifier) == expectedStorefront.identifier
-        expect(currentStorefront.countryCode) == expectedStorefront.countryCode
-    }
-
 }


### PR DESCRIPTION
Fixes https://community.revenuecat.com/sdks-51/objective-c-how-to-access-rcstorefront-1647?postid=5154#post5154

`RCStoreFront` does have a `currentStorefront` property which supports StoreKit 1 and StoreKit 2, but due to the fact that the SK2 way of obtaining the current storefront is `async`, this property is only `async`, which means that it indeed isn’t available on Objective-C.

This adds a way to be able to access the current storefront from Objective-C.