### PR TITLE
Added tests for `PurchasesOrchestrator` invoking `listenForTransactions` only if SK2 is enabled

### DIFF
--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -313,19 +313,44 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         let beginRefundRequestHelper = BeginRefundRequestHelper(systemInfo: systemInfo,
                                                                 customerInfoManager: customerInfoManager,
                                                                 currentUserProvider: identityManager)
-        let purchasesOrchestrator = PurchasesOrchestrator(productsManager: productsManager,
-                                                          storeKitWrapper: storeKitWrapper,
-                                                          systemInfo: systemInfo,
-                                                          subscriberAttributesManager: subscriberAttributesManager,
-                                                          operationDispatcher: operationDispatcher,
-                                                          receiptFetcher: receiptFetcher,
-                                                          customerInfoManager: customerInfoManager,
-                                                          backend: backend,
-                                                          currentUserProvider: identityManager,
-                                                          transactionsManager: transactionsManager,
-                                                          deviceCache: deviceCache,
-                                                          manageSubscriptionsHelper: manageSubsHelper,
-                                                          beginRefundRequestHelper: beginRefundRequestHelper)
+        let purchasesOrchestrator: PurchasesOrchestrator = {
+            if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+                return .init(
+                    productsManager: productsManager,
+                    storeKitWrapper: storeKitWrapper,
+                    systemInfo: systemInfo,
+                    subscriberAttributesManager: subscriberAttributesManager,
+                    operationDispatcher: operationDispatcher,
+                    receiptFetcher: receiptFetcher,
+                    customerInfoManager: customerInfoManager,
+                    backend: backend,
+                    currentUserProvider: identityManager,
+                    transactionsManager: transactionsManager,
+                    deviceCache: deviceCache,
+                    manageSubscriptionsHelper: manageSubsHelper,
+                    beginRefundRequestHelper: beginRefundRequestHelper,
+                    storeKit2TransactionListener: StoreKit2TransactionListener(delegate: nil),
+                    storeKit2StorefrontListener: StoreKit2StorefrontListener(delegate: nil)
+                )
+            } else {
+                return .init(
+                    productsManager: productsManager,
+                    storeKitWrapper: storeKitWrapper,
+                    systemInfo: systemInfo,
+                    subscriberAttributesManager: subscriberAttributesManager,
+                    operationDispatcher: operationDispatcher,
+                    receiptFetcher: receiptFetcher,
+                    customerInfoManager: customerInfoManager,
+                    backend: backend,
+                    currentUserProvider: identityManager,
+                    transactionsManager: transactionsManager,
+                    deviceCache: deviceCache,
+                    manageSubscriptionsHelper: manageSubsHelper,
+                    beginRefundRequestHelper: beginRefundRequestHelper
+                )
+            }
+        }()
+
         let trialOrIntroPriceChecker = TrialOrIntroPriceEligibilityChecker(systemInfo: systemInfo,
                                                                            receiptFetcher: receiptFetcher,
                                                                            introEligibilityCalculator: introCalculator,

--- a/Sources/Purchasing/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/PurchasesOrchestrator.swift
@@ -84,6 +84,51 @@ class PurchasesOrchestrator {
         return self._storeKit2StorefrontListener! as! StoreKit2StorefrontListener
     }
 
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+    convenience init(productsManager: ProductsManager,
+                     storeKitWrapper: StoreKitWrapper,
+                     systemInfo: SystemInfo,
+                     subscriberAttributesManager: SubscriberAttributesManager,
+                     operationDispatcher: OperationDispatcher,
+                     receiptFetcher: ReceiptFetcher,
+                     customerInfoManager: CustomerInfoManager,
+                     backend: Backend,
+                     currentUserProvider: CurrentUserProvider,
+                     transactionsManager: TransactionsManager,
+                     deviceCache: DeviceCache,
+                     manageSubscriptionsHelper: ManageSubscriptionsHelper,
+                     beginRefundRequestHelper: BeginRefundRequestHelper,
+                     storeKit2TransactionListener: StoreKit2TransactionListener,
+                     storeKit2StorefrontListener: StoreKit2StorefrontListener
+    ) {
+        self.init(
+            productsManager: productsManager,
+            storeKitWrapper: storeKitWrapper,
+            systemInfo: systemInfo,
+            subscriberAttributesManager: subscriberAttributesManager,
+            operationDispatcher: operationDispatcher,
+            receiptFetcher: receiptFetcher,
+            customerInfoManager: customerInfoManager,
+            backend: backend,
+            currentUserProvider: currentUserProvider,
+            transactionsManager: transactionsManager,
+            deviceCache: deviceCache,
+            manageSubscriptionsHelper: manageSubscriptionsHelper,
+            beginRefundRequestHelper: beginRefundRequestHelper
+        )
+
+        self._storeKit2TransactionListener = storeKit2TransactionListener
+        self._storeKit2StorefrontListener = storeKit2StorefrontListener
+
+        storeKit2TransactionListener.delegate = self
+        storeKit2StorefrontListener.delegate = self
+
+        if systemInfo.storeKit2Setting == .enabledForCompatibleDevices {
+            storeKit2TransactionListener.listenForTransactions()
+            storeKit2StorefrontListener.listenForStorefrontChanges()
+        }
+    }
+
     init(productsManager: ProductsManager,
          storeKitWrapper: StoreKitWrapper,
          systemInfo: SystemInfo,
@@ -110,19 +155,6 @@ class PurchasesOrchestrator {
         self.deviceCache = deviceCache
         self.manageSubscriptionsHelper = manageSubscriptionsHelper
         self.beginRefundRequestHelper = beginRefundRequestHelper
-
-        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
-            let transactionListener = StoreKit2TransactionListener(delegate: self)
-            let storefrontListener = StoreKit2StorefrontListener(delegate: self)
-
-            self._storeKit2TransactionListener = transactionListener
-            self._storeKit2StorefrontListener = storefrontListener
-
-            if systemInfo.storeKit2Setting == .enabledForCompatibleDevices {
-                transactionListener.listenForTransactions()
-                storefrontListener.listenForStorefrontChanges()
-            }
-        }
     }
 
     func restorePurchases(completion: ((Result<CustomerInfo, Error>) -> Void)?) {

--- a/Tests/UnitTests/Mocks/MockSystemInfo.swift
+++ b/Tests/UnitTests/Mocks/MockSystemInfo.swift
@@ -13,10 +13,11 @@ class MockSystemInfo: SystemInfo {
     var stubbedIsApplicationBackgrounded: Bool?
     var stubbedIsSandbox: Bool?
 
-    convenience init(finishTransactions: Bool) {
+    convenience init(finishTransactions: Bool, storeKit2Setting: StoreKit2Setting = .default) {
         // swiftlint:disable:next force_try
         try! self.init(platformInfo: nil,
-                       finishTransactions: finishTransactions)
+                       finishTransactions: finishTransactions,
+                       storeKit2Setting: storeKit2Setting)
     }
 
     override func isApplicationBackgrounded(completion: @escaping (Bool) -> Void) {


### PR DESCRIPTION
Follow up to #1593 and #1596.