### PR TITLE
[CF-601] Fix docs generation failure

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.5)
       rexml
-    activesupport (6.1.5)
+    activesupport (6.1.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -17,12 +17,12 @@ GEM
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.2.0)
-    aws-partitions (1.588.0)
-    aws-sdk-core (3.131.0)
+    aws-partitions (1.593.0)
+    aws-sdk-core (3.131.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
-      jmespath (~> 1.0)
+      jmespath (~> 1, >= 1.6.1)
     aws-sdk-kms (1.57.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
@@ -116,7 +116,7 @@ GEM
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     fastimage (2.2.6)
-    fastlane (2.206.0)
+    fastlane (2.206.2)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -199,7 +199,7 @@ GEM
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
     highline (2.0.3)
-    http-cookie (1.0.4)
+    http-cookie (1.0.5)
       domain_name (~> 0.5)
     httpclient (2.8.3)
     i18n (1.10.0)
@@ -274,7 +274,7 @@ GEM
     uber (0.1.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.8.1)
+    unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
     webrick (1.7.0)
     word_wrap (1.0.0)
@@ -304,4 +304,4 @@ DEPENDENCIES
   jazzy
 
 BUNDLED WITH
-   2.3.6
+   2.3.14

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -518,7 +518,7 @@ platform :ios do
               # and push the changes
               docs_destination_folder = "docs/#{version_number}"
               index_destination_path = "docs/index.html"
-              FileUtils.mv docs_generation_folder, docs_destination_folder
+              FileUtils.cp_r docs_generation_folder, docs_destination_folder
               FileUtils.cp docs_index_path, index_destination_path
 
               # using sh instead of fastlane commands because fastlane would run


### PR DESCRIPTION
Fixed a bug where we'd get an error after updating docs. 
The issue was that we're creating a temporary directory that gets automatically cleaned up, but we actually moved that directory before the cleanup code would happen.

So the cleanup code raised an error because there was nothing to clean up. 
