### PR TITLE
Split `PurchasesTests` step 7: extracted `PurchasesDeferredPurchasesTests`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -317,6 +317,7 @@
 		57E0473B277260DE0082FE91 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 57E0473A277260DE0082FE91 /* SnapshotTesting */; };
 		57E2230727500BB1002DB06E /* AtomicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E2230627500BB1002DB06E /* AtomicTests.swift */; };
 		57E415EB2846962500EA5460 /* PurchasesSyncPurchasesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E415EA2846962500EA5460 /* PurchasesSyncPurchasesTests.swift */; };
+		57E415EF284697A300EA5460 /* PurchasesDeferredPurchasesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E415EE284697A300EA5460 /* PurchasesDeferredPurchasesTests.swift */; };
 		57EAE527274324C60060EB74 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE526274324C60060EB74 /* Lock.swift */; };
 		57EAE52B274332830060EB74 /* Obsoletions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE52A274332830060EB74 /* Obsoletions.swift */; };
 		57EAE52D274468900060EB74 /* RawDataContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE52C274468900060EB74 /* RawDataContainer.swift */; };
@@ -784,6 +785,7 @@
 		57E0474B27729A1E0082FE91 /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		57E2230627500BB1002DB06E /* AtomicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicTests.swift; sourceTree = "<group>"; };
 		57E415EA2846962500EA5460 /* PurchasesSyncPurchasesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesSyncPurchasesTests.swift; sourceTree = "<group>"; };
+		57E415EE284697A300EA5460 /* PurchasesDeferredPurchasesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesDeferredPurchasesTests.swift; sourceTree = "<group>"; };
 		57EAE526274324C60060EB74 /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		57EAE52A274332830060EB74 /* Obsoletions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Obsoletions.swift; sourceTree = "<group>"; };
 		57EAE52C274468900060EB74 /* RawDataContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawDataContainer.swift; sourceTree = "<group>"; };
@@ -1652,6 +1654,7 @@
 				5766AAD4283E9B7400FA6091 /* PurchasesRestoreTests.swift */,
 				5766AAE4283E9E9C00FA6091 /* PurchasesGetOfferingsTests.swift */,
 				57E415EA2846962500EA5460 /* PurchasesSyncPurchasesTests.swift */,
+				57E415EE284697A300EA5460 /* PurchasesDeferredPurchasesTests.swift */,
 			);
 			path = Purchases;
 			sourceTree = "<group>";
@@ -2441,6 +2444,7 @@
 				5796A38E27D6BB7D00653165 /* BackendCreateAliasTests.swift in Sources */,
 				5733B1AA27FFBCF900EC2045 /* BaseErrorTests.swift in Sources */,
 				578FB10E27ADDA8000F70709 /* AvailabilityChecks.swift in Sources */,
+				57E415EF284697A300EA5460 /* PurchasesDeferredPurchasesTests.swift in Sources */,
 				35F82BB226A98EC50051DF03 /* AttributionDataMigratorTests.swift in Sources */,
 				351B51BF26D450E800BD2BD7 /* StoreKitRequestFetcherTests.swift in Sources */,
 				2DDF41E224F6F527005BC22D /* MockProductsRequest.swift in Sources */,

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDeferredPurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDeferredPurchasesTests.swift
@@ -1,0 +1,78 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchasesDeferredPurchasesTests.swift
+//
+//  Created by Nacho Soto on 5/31/22.
+
+import Nimble
+import StoreKit
+import XCTest
+
+@testable import RevenueCat
+
+class PurchaseDeferredPurchasesTests: BasePurchasesTests {
+
+    private var storeKitWrapperDelegate: StoreKitWrapperDelegate!
+    private var product: MockSK1Product!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        self.setupPurchases()
+
+        self.product = MockSK1Product(mockProductIdentifier: "mock_product")
+        self.storeKitWrapperDelegate = try XCTUnwrap(self.storeKitWrapper.delegate)
+    }
+
+    func testDeferBlockMakesPayment() throws {
+        let payment = SKPayment(product: self.product)
+
+        _ = self.storeKitWrapperDelegate.storeKitWrapper(self.storeKitWrapper,
+                                                         shouldAddStorePayment: payment,
+                                                         for: self.product)
+
+        expect(self.purchasesDelegate.makeDeferredPurchase).toNot(beNil())
+        expect(self.storeKitWrapper.payment).to(beNil())
+
+        let makeDeferredPurchase = try XCTUnwrap(purchasesDelegate.makeDeferredPurchase)
+
+        makeDeferredPurchase { (_, _, _, _) in }
+
+        expect(self.storeKitWrapper.payment) === payment
+    }
+
+    func testDeferBlockCallsCompletionBlockAfterPurchaseCompletes() throws {
+        let payment = SKPayment(product: self.product)
+
+        _ = self.storeKitWrapperDelegate.storeKitWrapper(storeKitWrapper,
+                                                         shouldAddStorePayment: payment,
+                                                         for: self.product)
+
+        expect(self.purchasesDelegate.makeDeferredPurchase).toNot(beNil())
+        expect(self.storeKitWrapper.payment).to(beNil())
+
+        var completionCalled = false
+
+        let makeDeferredPurchase = try XCTUnwrap(self.purchasesDelegate.makeDeferredPurchase)
+
+        makeDeferredPurchase { (_, _, _, _) in
+            completionCalled = true
+        }
+
+        let transaction = MockTransaction()
+        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockState = SKPaymentTransactionState.purchased
+        self.storeKitWrapperDelegate.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+
+        expect(self.storeKitWrapper.payment) === payment
+        expect(completionCalled).toEventually(beTrue())
+    }
+
+}

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesTests.swift
@@ -399,35 +399,6 @@ class PurchasesTests: BasePurchasesTests {
         expect(self.mockProductsManager.invokedCacheProductParameter) == product
     }
 
-    func testDeferBlockMakesPayment() {
-        setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "mock_product")
-        let payment = SKPayment.init(product: product)
-
-        guard let storeKitWrapperDelegate = storeKitWrapper.delegate else {
-            fail("storeKitWrapperDelegate nil")
-            return
-        }
-
-        _ = storeKitWrapperDelegate.storeKitWrapper(storeKitWrapper,
-                                                    shouldAddStorePayment: payment,
-                                                    for: product)
-
-        expect(self.purchasesDelegate.makeDeferredPurchase).toNot(beNil())
-
-        expect(self.storeKitWrapper.payment).to(beNil())
-
-        guard let makeDeferredPurchase = purchasesDelegate.makeDeferredPurchase else {
-            fail("makeDeferredPurchase should have been nonNil")
-            return
-        }
-
-        makeDeferredPurchase { (_, _, _, _) in
-        }
-
-        expect(self.storeKitWrapper.payment).to(be(payment))
-    }
-
     func testGetEligibility() {
         setupPurchases()
         purchases.checkTrialOrIntroDiscountEligibility(productIdentifiers: []) { (_) in
@@ -558,39 +529,6 @@ class PurchasesTests: BasePurchasesTests {
         expect(receivedUserCancelled).toEventuallyNot(beNil())
         expect(receivedUserCancelled) == true
         expect(receivedError).to(matchError(ErrorCode.purchaseCancelledError))
-    }
-
-    func testDeferBlockCallsCompletionBlockAfterPurchaseCompletes() {
-        setupPurchases()
-        let product = MockSK1Product(mockProductIdentifier: "mock_product")
-        let payment = SKPayment.init(product: product)
-
-        _ = storeKitWrapper.delegate?.storeKitWrapper(storeKitWrapper,
-                                                      shouldAddStorePayment: payment,
-                                                      for: product)
-
-        expect(self.purchasesDelegate.makeDeferredPurchase).toNot(beNil())
-
-        expect(self.storeKitWrapper.payment).to(beNil())
-
-        var completionCalled = false
-
-        guard let makeDeferredPurchase = purchasesDelegate.makeDeferredPurchase else {
-            fail("makeDeferredPurchase nil")
-            return
-        }
-
-        makeDeferredPurchase { (_, _, _, _) in
-            completionCalled = true
-        }
-
-        let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
-        transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
-
-        expect(self.storeKitWrapper.payment).to(be(payment))
-        expect(completionCalled).toEventually(beTrue())
     }
 
     func testAttributionDataIsPostponedIfThereIsNoInstance() {


### PR DESCRIPTION
Follow up to #1609. 
I've also cleaned up the initialization of these tests.