### PR TITLE
Update doc reference to ``Purchases/customerInfo(fetchPolicy:)``

### DIFF
--- a/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
@@ -54,7 +54,7 @@ Most features require configuring the SDK before using it.
 
 ### Subscription Status
 - ``Purchases/getCustomerInfo(completion:)``
-- ``Purchases/customerInfo()``
+- ``Purchases/customerInfo(fetchPolicy:)``
 - ``Purchases/customerInfoStream``
 
 ### Identifying Users

--- a/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md
@@ -100,7 +100,7 @@ Or browse our iOS sample apps:
 - ``PurchasesDelegate``
 
 - ``Purchases/getCustomerInfo(completion:)``
-- ``Purchases/customerInfo()``
+- ``Purchases/customerInfo(fetchPolicy:)``
 - ``Purchases/customerInfoStream``
 
 ### Identifying Users

--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -1000,7 +1000,7 @@ public extension Purchases {
     ///
     /// #### Related Symbols
     /// - ``PurchasesDelegate/purchases(_:receivedUpdated:)``
-    /// - ``Purchases/customerInfo()``
+    /// - ``Purchases/customerInfo(fetchPolicy:)``
     ///
     /// #### Example:
     /// ```swift


### PR DESCRIPTION
Replace ``Purchases/customerInfo()`` with ``Purchases/customerInfo(fetchPolicy:)``

The proper name is `customerInfo(fetchPolicy:)`