### PR TITLE
Add Swift Package Index badges for Swift version and platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Version](https://img.shields.io/cocoapods/v/RevenueCat.svg?style=flat)](https://cocoapods.org/pods/RevenueCat)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://docs.revenuecat.com/docs/ios#section-install-via-carthage)
 [![SwiftPM compatible](https://img.shields.io/badge/SwiftPM-compatible-orange.svg)](https://docs.revenuecat.com/docs/ios#section-install-via-swift-package-manager)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FRevenueCat%2Fpurchases-ios%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/RevenueCat/purchases-ios)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FRevenueCat%2Fpurchases-ios%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/RevenueCat/purchases-ios)
 
 RevenueCat is a powerful, reliable, and free to use in-app purchase server with cross-platform support. Our open-source framework provides a backend and a wrapper around StoreKit and Google Play Billing to make implementing in-app purchases and subscriptions easy. 
 


### PR DESCRIPTION
### Motivation

I noticed while browsing Swift Package Index that there are badges for Swift Package Index that we can use for supported Swift versions and platforms.

These badges will automatically update with what SPI detects so we don't need to maintain these.

### Description

Adds two badgest into README

Totally fine if we don't want to merge this PR (if its too many badges) but figured I'd quickly make this PR to see if any interest 🤷‍♂️

<img width="956" alt="Screen Shot 2022-05-31 at 7 38 46 PM" src="https://user-images.githubusercontent.com/401294/171305562-636f5961-1493-4eb0-a580-330dac89ed86.png">

