### PR TITLE
Extracted `SandboxEnvironmentDetector`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -325,6 +325,9 @@
 		57EFDC6B27BC1F370057EC39 /* ProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EFDC6A27BC1F370057EC39 /* ProductType.swift */; };
 		57FDAA962846BDE2009A48F1 /* PurchasesTransactionHandlingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDAA952846BDE2009A48F1 /* PurchasesTransactionHandlingTests.swift */; };
 		57FDAA9A2846C2BD009A48F1 /* PurchasesDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDAA992846C2BD009A48F1 /* PurchasesDelegateTests.swift */; };
+		57FDAABA284937A0009A48F1 /* SandboxEnvironmentDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDAAB9284937A0009A48F1 /* SandboxEnvironmentDetector.swift */; };
+		57FDAABE28493A29009A48F1 /* SandboxEnvironmentDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDAABD28493A29009A48F1 /* SandboxEnvironmentDetectorTests.swift */; };
+		57FDAAC028493C13009A48F1 /* MockSandboxEnvironmentDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDAABF28493C13009A48F1 /* MockSandboxEnvironmentDetector.swift */; };
 		6E38843A0CAFD551013D0A3F /* StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECF627761D375C8431EB866 /* StoreProduct.swift */; };
 		805B60C97993B311CEC93EAF /* ProductsFetcherSK2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3628C1F100BB3C1782860D24 /* ProductsFetcherSK2.swift */; };
 		80E80EF226970E04008F245A /* ReceiptFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E80EF026970DC3008F245A /* ReceiptFetcher.swift */; };
@@ -796,6 +799,9 @@
 		57EFDC6A27BC1F370057EC39 /* ProductType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductType.swift; sourceTree = "<group>"; };
 		57FDAA952846BDE2009A48F1 /* PurchasesTransactionHandlingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesTransactionHandlingTests.swift; sourceTree = "<group>"; };
 		57FDAA992846C2BD009A48F1 /* PurchasesDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesDelegateTests.swift; sourceTree = "<group>"; };
+		57FDAAB9284937A0009A48F1 /* SandboxEnvironmentDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxEnvironmentDetector.swift; sourceTree = "<group>"; };
+		57FDAABD28493A29009A48F1 /* SandboxEnvironmentDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxEnvironmentDetectorTests.swift; sourceTree = "<group>"; };
+		57FDAABF28493C13009A48F1 /* MockSandboxEnvironmentDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSandboxEnvironmentDetector.swift; sourceTree = "<group>"; };
 		80E80EF026970DC3008F245A /* ReceiptFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptFetcher.swift; sourceTree = "<group>"; };
 		84C3F1AC1D7E1E64341D3936 /* Pods_RevenueCat_PurchasesTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RevenueCat_PurchasesTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9A65DFDD258AD60A00DE00B0 /* LogIntent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogIntent.swift; sourceTree = "<group>"; };
@@ -1206,6 +1212,7 @@
 				57CFB98327FE2258002A6730 /* StoreKit2Setting.swift */,
 				57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */,
 				B3AA6237268B926F00894871 /* SystemInfo.swift */,
+				57FDAAB9284937A0009A48F1 /* SandboxEnvironmentDetector.swift */,
 			);
 			path = Misc;
 			sourceTree = "<group>";
@@ -1320,6 +1327,7 @@
 				57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */,
 				57CFB96B27FE0E79002A6730 /* MockCurrentUserProvider.swift */,
 				57DE807F2807529F008D6C6F /* MockStorefront.swift */,
+				57FDAABF28493C13009A48F1 /* MockSandboxEnvironmentDetector.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -1410,6 +1418,7 @@
 				2D22BF6626F3CBFB001AE2F9 /* XCTestCase+Extensions.swift */,
 				5766AA59283D4CAB00FA6091 /* IgnoreHashableTests.swift */,
 				57ACB12328174B9F000DCC9F /* CustomerInfo+TestExtensions.swift */,
+				57FDAABD28493A29009A48F1 /* SandboxEnvironmentDetectorTests.swift */,
 			);
 			path = Misc;
 			sourceTree = "<group>";
@@ -2395,6 +2404,7 @@
 				9A65DFDE258AD60A00DE00B0 /* LogIntent.swift in Sources */,
 				B35042C626CDD3B100905B95 /* PurchasesDelegate.swift in Sources */,
 				0313FD41268A506400168386 /* DateProvider.swift in Sources */,
+				57FDAABA284937A0009A48F1 /* SandboxEnvironmentDetector.swift in Sources */,
 				5733B18E27FF586A00EC2045 /* BackendError.swift in Sources */,
 				B39E811A268E849900D31189 /* AttributionNetwork.swift in Sources */,
 				37E35C8515C5E2D01B0AF5C1 /* Strings.swift in Sources */,
@@ -2537,6 +2547,7 @@
 				351B515826D44B3E00BD2BD7 /* MockOfferingsFactory.swift in Sources */,
 				351B51A526D450BC00BD2BD7 /* NSDate+RCExtensionsTests.swift in Sources */,
 				B390F5BA271DDC7400B64D65 /* PurchasesDeprecation.swift in Sources */,
+				57FDAABE28493A29009A48F1 /* SandboxEnvironmentDetectorTests.swift in Sources */,
 				57BA943128330ACA00CD5FC5 /* ConfigurationTests.swift in Sources */,
 				2D4D6AF424F717B800B656BE /* ASN1ObjectIdentifierEncoder.swift in Sources */,
 				5774F9C22805EA6900997128 /* CustomerInfoDecodingTests.swift in Sources */,
@@ -2553,6 +2564,7 @@
 				5733B1A427FF9F8300EC2045 /* NetworkErrorTests.swift in Sources */,
 				351B517026D44E8D00BD2BD7 /* MockDateProvider.swift in Sources */,
 				2D1C3F3926B9D8B800112626 /* MockBundle.swift in Sources */,
+				57FDAAC028493C13009A48F1 /* MockSandboxEnvironmentDetector.swift in Sources */,
 				5766AAD1283E981700FA6091 /* PurchasesPurchasingTests.swift in Sources */,
 				351B515E26D44B9900BD2BD7 /* MockPurchasesDelegate.swift in Sources */,
 				57554CC1282AE1E3009A7E58 /* TestCase.swift in Sources */,

--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -28,7 +28,7 @@ class DeviceCache {
     }
     var cachedOfferings: Offerings? { offeringsCachedObject.cachedInstance() }
 
-    private let systemInfo: SystemInfo
+    private let sandboxEnvironmentDetector: SandboxEnvironmentDetector
     private let userDefaults: SynchronizedUserDefaults
     private let notificationCenter: NotificationCenter
     private let offeringsCachedObject: InMemoryCachedObject<Offerings>
@@ -37,20 +37,20 @@ class DeviceCache {
     /// cleared from under the SDK
     private var appUserIDHasBeenSet: Bool = false
 
-    convenience init(systemInfo: SystemInfo,
+    convenience init(sandboxEnvironmentDetector: SandboxEnvironmentDetector,
                      userDefaults: UserDefaults = UserDefaults.standard) {
-        self.init(systemInfo: systemInfo,
+        self.init(sandboxEnvironmentDetector: sandboxEnvironmentDetector,
                   userDefaults: userDefaults,
                   offeringsCachedObject: nil,
                   notificationCenter: nil)
     }
 
-    init(systemInfo: SystemInfo,
+    init(sandboxEnvironmentDetector: SandboxEnvironmentDetector,
          userDefaults: UserDefaults = UserDefaults.standard,
          offeringsCachedObject: InMemoryCachedObject<Offerings>? = InMemoryCachedObject(),
          notificationCenter: NotificationCenter? = NotificationCenter.default) {
 
-        self.systemInfo = systemInfo
+        self.sandboxEnvironmentDetector = sandboxEnvironmentDetector
         self.offeringsCachedObject = offeringsCachedObject ?? InMemoryCachedObject()
         self.notificationCenter = notificationCenter ?? NotificationCenter.default
         self.userDefaults = .init(userDefaults: userDefaults)
@@ -133,8 +133,10 @@ class DeviceCache {
             }
 
             let timeSinceLastCheck = cachesLastUpdated.timeIntervalSinceNow * -1
-            let cacheDurationInSeconds = self.cacheDurationInSeconds(isAppBackgrounded: isAppBackgrounded,
-                                                                     isSandbox: self.systemInfo.isSandbox)
+            let cacheDurationInSeconds = self.cacheDurationInSeconds(
+                isAppBackgrounded: isAppBackgrounded,
+                isSandbox: self.sandboxEnvironmentDetector.isSandbox
+            )
 
             return timeSinceLastCheck >= cacheDurationInSeconds
         }
@@ -174,7 +176,7 @@ class DeviceCache {
     func isOfferingsCacheStale(isAppBackgrounded: Bool) -> Bool {
         return offeringsCachedObject.isCacheStale(
             durationInSeconds: self.cacheDurationInSeconds(isAppBackgrounded: isAppBackgrounded,
-                                                           isSandbox: self.systemInfo.isSandbox)
+                                                           isSandbox: self.sandboxEnvironmentDetector.isSandbox)
         )
     }
 

--- a/Sources/Misc/SandboxEnvironmentDetector.swift
+++ b/Sources/Misc/SandboxEnvironmentDetector.swift
@@ -1,0 +1,40 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SandboxEnvironmentDetector.swift
+//
+//  Created by Nacho Soto on 6/2/22.
+
+import Foundation
+
+/// A type that can determine if the current environment is sandbox.
+protocol SandboxEnvironmentDetector {
+
+    var isSandbox: Bool { get }
+
+}
+
+/// ``SandboxEnvironmentDetector`` that uses a `Bundle` to detect the environment
+final class DefaultSandboxEnvironmentDetector: SandboxEnvironmentDetector {
+
+    private let bundle: Bundle
+
+    init(bundle: Bundle = .main) {
+        self.bundle = bundle
+    }
+
+    var isSandbox: Bool {
+        guard let url = self.bundle.appStoreReceiptURL else {
+            return false
+        }
+
+        return url.path.contains("sandboxReceipt")
+    }
+
+}

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -26,6 +26,7 @@ import AppKit
 class SystemInfo {
 
     static let appleSubscriptionsURL = URL(string: "https://apps.apple.com/account/subscriptions")!
+    static var forceUniversalAppStore: Bool = false
 
     let storeKit2Setting: StoreKit2Setting
     var finishTransactions: Bool
@@ -35,15 +36,10 @@ class SystemInfo {
     let bundle: Bundle
     let dangerousSettings: DangerousSettings
 
-    static var forceUniversalAppStore: Bool = false
-    var isSandbox: Bool {
-        let url = self.bundle.appStoreReceiptURL
-        guard let url = url else {
-            return false
-        }
+    private let sandboxEnvironmentDetector: SandboxEnvironmentDetector
 
-        let receiptURLString = url.path
-        return receiptURLString.contains("sandboxReceipt")
+    var isSandbox: Bool {
+        return self.sandboxEnvironmentDetector.isSandbox
     }
 
     static var frameworkVersion: String {
@@ -114,6 +110,7 @@ class SystemInfo {
         self.operationDispatcher = operationDispatcher
         self.storeKit2Setting = storeKit2Setting
         self.dangerousSettings = dangerousSettings ?? DangerousSettings()
+        self.sandboxEnvironmentDetector = DefaultSandboxEnvironmentDetector(bundle: bundle)
     }
 
     func isApplicationBackgrounded(completion: @escaping (Bool) -> Void) {
@@ -138,6 +135,8 @@ class SystemInfo {
     }
 
 }
+
+extension SystemInfo: SandboxEnvironmentDetector {}
 
 extension SystemInfo {
 

--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -273,7 +273,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         let storeKitWrapper = StoreKitWrapper()
         let offeringsFactory = OfferingsFactory()
         let userDefaults = userDefaults ?? UserDefaults.standard
-        let deviceCache = DeviceCache(systemInfo: systemInfo, userDefaults: userDefaults)
+        let deviceCache = DeviceCache(sandboxEnvironmentDetector: systemInfo, userDefaults: userDefaults)
         let receiptParser = ReceiptParser()
         let transactionsManager = TransactionsManager(storeKit2Setting: systemInfo.storeKit2Setting,
                                                       receiptParser: receiptParser)

--- a/Tests/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
+++ b/Tests/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
@@ -36,15 +36,18 @@ class BeginRefundRequestHelperTests: TestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        systemInfo = MockSystemInfo(finishTransactions: true)
-        customerInfoManager = MockCustomerInfoManager(operationDispatcher: MockOperationDispatcher(),
-                                                      deviceCache: MockDeviceCache(systemInfo: systemInfo),
-                                                      backend: MockBackend(),
-                                                      systemInfo: systemInfo)
-        currentUserProvider = MockCurrentUserProvider(mockAppUserID: "appUserID")
-        helper = BeginRefundRequestHelper(systemInfo: systemInfo,
-                                          customerInfoManager: customerInfoManager,
-                                          currentUserProvider: currentUserProvider)
+
+        self.systemInfo = MockSystemInfo(finishTransactions: true)
+        self.customerInfoManager = MockCustomerInfoManager(
+            operationDispatcher: MockOperationDispatcher(),
+            deviceCache: MockDeviceCache(sandboxEnvironmentDetector: self.systemInfo),
+            backend: MockBackend(),
+            systemInfo: self.systemInfo
+        )
+        self.currentUserProvider = MockCurrentUserProvider(mockAppUserID: "appUserID")
+        self.helper = BeginRefundRequestHelper(systemInfo: self.systemInfo,
+                                               customerInfoManager: self.customerInfoManager,
+                                               currentUserProvider: self.currentUserProvider)
 
         if #available(iOS 15.0, macCatalyst 15.0, *) {
             sk2Helper = MockSK2BeginRefundRequestHelper()

--- a/Tests/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
+++ b/Tests/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
@@ -39,15 +39,18 @@ class ManageSubscriptionsHelperTests: TestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        systemInfo = MockSystemInfo(finishTransactions: true)
-        customerInfoManager = MockCustomerInfoManager(operationDispatcher: MockOperationDispatcher(),
-                                                      deviceCache: MockDeviceCache(systemInfo: systemInfo),
-                                                      backend: MockBackend(),
-                                                      systemInfo: systemInfo)
-        currentUserProvider = MockCurrentUserProvider(mockAppUserID: "appUserID")
-        helper = ManageSubscriptionsHelper(systemInfo: systemInfo,
-                                           customerInfoManager: customerInfoManager,
-                                           currentUserProvider: currentUserProvider)
+
+        self.systemInfo = MockSystemInfo(finishTransactions: true)
+        self.customerInfoManager = MockCustomerInfoManager(
+            operationDispatcher: MockOperationDispatcher(),
+            deviceCache: MockDeviceCache(sandboxEnvironmentDetector: self.systemInfo),
+            backend: MockBackend(),
+            systemInfo: self.systemInfo
+        )
+        self.currentUserProvider = MockCurrentUserProvider(mockAppUserID: "appUserID")
+        self.helper = ManageSubscriptionsHelper(systemInfo: self.systemInfo,
+                                                customerInfoManager: self.customerInfoManager,
+                                                currentUserProvider: self.currentUserProvider)
     }
 
     func testShowManageSubscriptions() throws {

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -42,7 +42,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                                               requestTimeout: Configuration.storeKitRequestTimeoutDefault)
         operationDispatcher = MockOperationDispatcher()
         receiptFetcher = MockReceiptFetcher(requestFetcher: MockRequestFetcher(), systemInfo: systemInfo)
-        deviceCache = MockDeviceCache(systemInfo: systemInfo)
+        deviceCache = MockDeviceCache(sandboxEnvironmentDetector: self.systemInfo)
         backend = MockBackend()
         customerInfoManager = MockCustomerInfoManager(operationDispatcher: OperationDispatcher(),
                                                       deviceCache: deviceCache,

--- a/Tests/UnitTests/Attribution/AttributionPosterTests.swift
+++ b/Tests/UnitTests/Attribution/AttributionPosterTests.swift
@@ -39,25 +39,25 @@ class AttributionPosterTests: TestCase {
         super.setUp()
 
         let userID = "userID"
-        deviceCache = MockDeviceCache(systemInfo: MockSystemInfo(finishTransactions: false),
-                                      userDefaults: UserDefaults(suiteName: userDefaultsSuiteName)!)
-        deviceCache.cache(appUserID: userID)
-        backend = MockBackend()
-        attributionFetcher = AttributionFetcher(attributionFactory: attributionFactory, systemInfo: systemInfo)
-        subscriberAttributesManager = MockSubscriberAttributesManager(
+        self.deviceCache = MockDeviceCache(sandboxEnvironmentDetector: DefaultSandboxEnvironmentDetector(),
+                                           userDefaults: UserDefaults(suiteName: userDefaultsSuiteName)!)
+        self.deviceCache.cache(appUserID: userID)
+        self.backend = MockBackend()
+        self.attributionFetcher = AttributionFetcher(attributionFactory: attributionFactory, systemInfo: systemInfo)
+        self.subscriberAttributesManager = MockSubscriberAttributesManager(
             backend: self.backend,
             deviceCache: self.deviceCache,
             operationDispatcher: MockOperationDispatcher(),
             attributionFetcher: self.attributionFetcher,
             attributionDataMigrator: AttributionDataMigrator())
-        currentUserProvider = MockCurrentUserProvider(mockAppUserID: userID)
-        attributionPoster = AttributionPoster(deviceCache: deviceCache,
-                                              currentUserProvider: currentUserProvider,
-                                              backend: backend,
-                                              attributionFetcher: attributionFetcher,
-                                              subscriberAttributesManager: subscriberAttributesManager)
-        resetAttributionStaticProperties()
-        backend.stubbedPostAttributionDataCompletionResult = (nil, ())
+        self.currentUserProvider = MockCurrentUserProvider(mockAppUserID: userID)
+        self.attributionPoster = AttributionPoster(deviceCache: self.deviceCache,
+                                                   currentUserProvider: self.currentUserProvider,
+                                                   backend: self.backend,
+                                                   attributionFetcher: self.attributionFetcher,
+                                                   subscriberAttributesManager: self.subscriberAttributesManager)
+        self.resetAttributionStaticProperties()
+        self.backend.stubbedPostAttributionDataCompletionResult = (nil, ())
     }
 
     private func resetAttributionStaticProperties() {

--- a/Tests/UnitTests/Caching/DeviceCacheTests.swift
+++ b/Tests/UnitTests/Caching/DeviceCacheTests.swift
@@ -10,15 +10,15 @@ import XCTest
 
 class DeviceCacheTests: TestCase {
 
-    private var systemInfo: MockSystemInfo! = nil
+    private var sandboxEnvironmentDetector: MockSandboxEnvironmentDetector! = nil
     private var mockUserDefaults: MockUserDefaults! = nil
     private var deviceCache: DeviceCache! = nil
 
     override func setUp() {
-        self.systemInfo = MockSystemInfo(finishTransactions: false)
+        self.sandboxEnvironmentDetector = MockSandboxEnvironmentDetector(isSandbox: false)
         self.mockUserDefaults = MockUserDefaults()
-        self.deviceCache = DeviceCache(systemInfo: self.systemInfo,
-                                       userDefaults: mockUserDefaults)
+        self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
+                                       userDefaults: self.mockUserDefaults)
     }
 
     func testLegacyCachedUserIDUsesRightKey() {
@@ -138,7 +138,7 @@ class DeviceCacheTests: TestCase {
 
     func testCustomerInfoCacheIsStaleIfLongerThanFiveMinutes() {
         let oldDate: Date! = Calendar.current.date(byAdding: .minute, value: -(6), to: Date())
-        self.deviceCache = DeviceCache(systemInfo: self.systemInfo,
+        self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults)
         let appUserID = "waldo"
         deviceCache.cache(customerInfo: Data(), appUserID: appUserID)
@@ -155,7 +155,7 @@ class DeviceCacheTests: TestCase {
 
     func testOfferingsCacheIsStaleIfCachedObjectIsStale() {
         let mockCachedObject = MockInMemoryCachedOfferings<Offerings>()
-        self.deviceCache = DeviceCache(systemInfo: self.systemInfo,
+        self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
                                        offeringsCachedObject: mockCachedObject,
                                        notificationCenter: nil)
@@ -224,7 +224,7 @@ class DeviceCacheTests: TestCase {
         let mockNotificationCenter = MockNotificationCenter()
         mockUserDefaults.mockValues["com.revenuecat.userdefaults.appUserID.new"] = "Rage Against the Machine"
 
-        self.deviceCache = DeviceCache(systemInfo: self.systemInfo,
+        self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
                                        offeringsCachedObject: nil,
                                        notificationCenter: mockNotificationCenter)
@@ -244,7 +244,7 @@ class DeviceCacheTests: TestCase {
     func testDoesntCrashIfOtherSettingIsDeletedAndAppUserIDHadntBeenSet() {
         let mockNotificationCenter = MockNotificationCenter()
         mockUserDefaults.mockValues["com.revenuecat.userdefaults.appUserID.new"] = nil
-        self.deviceCache = DeviceCache(systemInfo: self.systemInfo,
+        self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
                                        offeringsCachedObject: nil,
                                        notificationCenter: mockNotificationCenter)
@@ -258,7 +258,7 @@ class DeviceCacheTests: TestCase {
         let fourMinutesAgo = Calendar.current.date(byAdding: .minute, value: -4, to: Date())
         let cackeKey = "com.revenuecat.userdefaults.purchaserInfoLastUpdated.\(appUserID)"
         mockUserDefaults.mockValues[cackeKey] = fourMinutesAgo
-        self.deviceCache = DeviceCache(systemInfo: self.systemInfo,
+        self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
                                        offeringsCachedObject: nil,
                                        notificationCenter: mockNotificationCenter)
@@ -272,7 +272,7 @@ class DeviceCacheTests: TestCase {
         let appUserID = "myUser"
         let fourDaysAgo = Calendar.current.date(byAdding: .day, value: -4, to: Date())
         mockUserDefaults.mockValues["com.revenuecat.userdefaults.purchaserInfoLastUpdated.\(appUserID)"] = fourDaysAgo
-        self.deviceCache = DeviceCache(systemInfo: self.systemInfo,
+        self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
                                        offeringsCachedObject: nil,
                                        notificationCenter: mockNotificationCenter)
@@ -284,7 +284,7 @@ class DeviceCacheTests: TestCase {
     func testNewDeviceCacheInstanceWithNoCachedCustomerInfoCacheIsStale() {
         let mockNotificationCenter = MockNotificationCenter()
         let appUserID = "myUser"
-        self.deviceCache = DeviceCache(systemInfo: self.systemInfo,
+        self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
                                        offeringsCachedObject: nil,
                                        notificationCenter: mockNotificationCenter)
@@ -296,7 +296,7 @@ class DeviceCacheTests: TestCase {
     func testIsCustomerInfoCacheStaleForBackground() {
         let mockNotificationCenter = MockNotificationCenter()
         let appUserID = "myUser"
-        self.deviceCache = DeviceCache(systemInfo: self.systemInfo,
+        self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
                                        offeringsCachedObject: nil,
                                        notificationCenter: mockNotificationCenter)
@@ -316,7 +316,7 @@ class DeviceCacheTests: TestCase {
     func testIsCustomerInfoCacheStaleForForeground() {
         let mockNotificationCenter = MockNotificationCenter()
         let appUserID = "myUser"
-        self.deviceCache = DeviceCache(systemInfo: self.systemInfo,
+        self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
                                        offeringsCachedObject: nil,
                                        notificationCenter: mockNotificationCenter)
@@ -336,7 +336,7 @@ class DeviceCacheTests: TestCase {
     func testIsCustomerInfoCacheWithCachedInfoButNoTimestamp() {
         let mockNotificationCenter = MockNotificationCenter()
         let appUserID = "myUser"
-        self.deviceCache = DeviceCache(systemInfo: self.systemInfo,
+        self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
                                        offeringsCachedObject: nil,
                                        notificationCenter: mockNotificationCenter)
@@ -356,7 +356,7 @@ class DeviceCacheTests: TestCase {
         let mockNotificationCenter = MockNotificationCenter()
         let otherAppUserID = "some other user"
         let currentAppUserID = "myUser"
-        self.deviceCache = DeviceCache(systemInfo: self.systemInfo,
+        self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
                                        offeringsCachedObject: nil,
                                        notificationCenter: mockNotificationCenter)
@@ -371,7 +371,7 @@ class DeviceCacheTests: TestCase {
         let mockNotificationCenter = MockNotificationCenter()
         let mockCachedObject = InMemoryCachedObject<Offerings>()
 
-        self.deviceCache = DeviceCache(systemInfo: self.systemInfo,
+        self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
                                        offeringsCachedObject: mockCachedObject,
                                        notificationCenter: mockNotificationCenter)

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -33,7 +33,7 @@ class BaseCustomerInfoManagerTests: TestCase {
                 "original_application_version": NSNull()
             ]])
 
-        self.mockDeviceCache = MockDeviceCache(systemInfo: self.mockSystemInfo)
+        self.mockDeviceCache = MockDeviceCache(sandboxEnvironmentDetector: self.mockSystemInfo)
         self.customerInfoManagerChangesCallCount = 0
         self.customerInfoManagerLastCustomerInfo = nil
         self.customerInfoManager = CustomerInfoManager(operationDispatcher: self.mockOperationDispatcher,

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -37,7 +37,7 @@ class IdentityManagerTests: TestCase {
 
         let systemInfo = MockSystemInfo(finishTransactions: false)
 
-        self.mockDeviceCache = MockDeviceCache(systemInfo: systemInfo)
+        self.mockDeviceCache = MockDeviceCache(sandboxEnvironmentDetector: systemInfo)
         self.mockCustomerInfoManager = MockCustomerInfoManager(operationDispatcher: MockOperationDispatcher(),
                                                                deviceCache: self.mockDeviceCache,
                                                                backend: MockBackend(),

--- a/Tests/UnitTests/Misc/SandboxEnvironmentDetectorTests.swift
+++ b/Tests/UnitTests/Misc/SandboxEnvironmentDetectorTests.swift
@@ -1,0 +1,44 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SandboxEnvironmentDetectorTests.swift
+//
+//  Created by Nacho Soto on 6/2/22.
+
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+class SandboxEnvironmentDetectorTests: TestCase {
+
+    func testIsSandbox() throws {
+        expect(try SystemInfo.withReceiptResult(.sandboxReceipt).isSandbox) == true
+    }
+
+    func testIsNotSandbox() throws {
+        expect(try SystemInfo.withReceiptResult(.receiptWithData).isSandbox) == false
+    }
+
+    func testIsNotSandboxIfNoReceiptURL() throws {
+        expect(try SystemInfo.withReceiptResult(.nilURL).isSandbox) == false
+    }
+
+}
+
+private extension SandboxEnvironmentDetector {
+
+    static func withReceiptResult(_ result: MockBundle.ReceiptURLResult) throws -> SandboxEnvironmentDetector {
+        let bundle = MockBundle()
+        bundle.receiptURLResult = result
+
+        return DefaultSandboxEnvironmentDetector(bundle: bundle)
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -221,4 +221,5 @@ class MockDeviceCache: DeviceCache {
         invokedClearLatestNetworkAndAdvertisingIdsSentParameters = (appUserID, ())
         invokedClearLatestNetworkAndAdvertisingIdsSentParametersList.append((appUserID, ()))
     }
+
 }

--- a/Tests/UnitTests/Mocks/MockIdentityManager.swift
+++ b/Tests/UnitTests/Mocks/MockIdentityManager.swift
@@ -20,7 +20,7 @@ class MockIdentityManager: IdentityManager {
         let mockSystemInfo = try! MockSystemInfo(platformInfo: nil,
                                                  finishTransactions: false,
                                                  dangerousSettings: nil)
-        let mockDeviceCache = MockDeviceCache(systemInfo: mockSystemInfo)
+        let mockDeviceCache = MockDeviceCache(sandboxEnvironmentDetector: mockSystemInfo)
         let mockBackend = MockBackend()
 
         self.mockAppUserID = mockAppUserID

--- a/Tests/UnitTests/Mocks/MockSandboxEnvironmentDetector.swift
+++ b/Tests/UnitTests/Mocks/MockSandboxEnvironmentDetector.swift
@@ -1,0 +1,24 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockSandboxEnvironmentDetector.swift
+//
+//  Created by Nacho Soto on 6/2/22.
+
+@testable import RevenueCat
+
+final class MockSandboxEnvironmentDetector: SandboxEnvironmentDetector {
+
+    init(isSandbox: Bool = true) {
+        self.isSandbox = isSandbox
+    }
+
+    let isSandbox: Bool
+
+}

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -31,7 +31,7 @@ class OfferingsManagerTests: TestCase {
     override func setUp() {
         super.setUp()
 
-        mockDeviceCache = MockDeviceCache(systemInfo: mockSystemInfo)
+        mockDeviceCache = MockDeviceCache(sandboxEnvironmentDetector: self.mockSystemInfo)
         mockProductsManager = MockProductsManager(systemInfo: mockSystemInfo,
                                                   requestTimeout: Configuration.storeKitRequestTimeoutDefault)
         offeringsManager = OfferingsManager(deviceCache: mockDeviceCache,

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -26,7 +26,8 @@ class BasePurchasesTests: TestCase {
 
         self.userDefaults = UserDefaults(suiteName: Self.userDefaultsSuiteName)
         self.systemInfo = MockSystemInfo(finishTransactions: true)
-        self.deviceCache = MockDeviceCache(systemInfo: self.systemInfo, userDefaults: self.userDefaults)
+        self.deviceCache = MockDeviceCache(sandboxEnvironmentDetector: self.systemInfo,
+                                           userDefaults: self.userDefaults)
         self.requestFetcher = MockRequestFetcher()
         self.mockProductsManager = MockProductsManager(systemInfo: self.systemInfo,
                                                        requestTimeout: Configuration.storeKitRequestTimeoutDefault)

--- a/Tests/UnitTests/SubscriberAttributes/DeviceCacheSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/DeviceCacheSubscriberAttributesTests.swift
@@ -16,8 +16,8 @@ class DeviceCacheSubscriberAttributesTests: TestCase {
     override func setUp() {
         UserDefaults.resetStandardUserDefaults()
         self.mockUserDefaults = MockUserDefaults()
-        self.deviceCache = DeviceCache(systemInfo: MockSystemInfo(finishTransactions: false),
-                                       userDefaults: mockUserDefaults)
+        self.deviceCache = DeviceCache(sandboxEnvironmentDetector: MockSandboxEnvironmentDetector(),
+                                       userDefaults: self.mockUserDefaults)
         setUpSubscriberAttributes()
     }
 

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -63,7 +63,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
         try super.setUpWithError()
 
         userDefaults = UserDefaults(suiteName: "TestDefaults")
-        self.mockDeviceCache = MockDeviceCache(systemInfo: self.systemInfo,
+        self.mockDeviceCache = MockDeviceCache(sandboxEnvironmentDetector: self.systemInfo,
                                                userDefaults: self.userDefaults)
 
         self.subscriberAttributeHeight = SubscriberAttribute(withKey: "height",

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -33,7 +33,7 @@ class SubscriberAttributesManagerTests: TestCase {
         let systemInfo = try MockSystemInfo(platformInfo: platformInfo,
                                             finishTransactions: true)
 
-        self.mockDeviceCache = MockDeviceCache(systemInfo: systemInfo)
+        self.mockDeviceCache = MockDeviceCache(sandboxEnvironmentDetector: systemInfo)
         self.mockBackend = MockBackend()
         self.mockAttributionFetcher = MockAttributionFetcher(attributionFactory: AttributionTypeFactory(),
                                                              systemInfo: systemInfo)


### PR DESCRIPTION
### Motivation:

For [CSDK-53], `EntitlementInfos` will need access to the environment. This provides a lighter interface for that, as well as a simple implementation to inject that doesn't require the entire `SystemInfo`

[CSDK-53]: https://revenuecats.atlassian.net/browse/CSDK-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ