### PR TITLE
`EntitlementInfos`: added `activeInAnyEnvironment` and `activeInCurrentEnvironment`

### DIFF
--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -158,16 +158,21 @@ import Foundation
     private let data: Contents
 
     /// Initializes a `CustomerInfo` with the underlying data in the current schema version
-    convenience init(response: CustomerInfoResponse) {
-        self.init(data: .init(response: response, schemaVersion: Self.currentSchemaVersion))
+    convenience init(response: CustomerInfoResponse, sandboxEnvironmentDetector: SandboxEnvironmentDetector) {
+        self.init(data: .init(response: response, schemaVersion: Self.currentSchemaVersion),
+                  sandboxEnvironmentDetector: sandboxEnvironmentDetector)
     }
 
     /// Initializes a `CustomerInfo` creating a copy.
-    convenience init(customerInfo: CustomerInfo) {
-        self.init(data: customerInfo.data)
+    convenience init(customerInfo: CustomerInfo,
+                     sandboxEnvironmentDetector: SandboxEnvironmentDetector) {
+        self.init(data: customerInfo.data, sandboxEnvironmentDetector: sandboxEnvironmentDetector)
     }
 
-    fileprivate init(data: Contents) {
+    fileprivate init(
+        data: Contents,
+        sandboxEnvironmentDetector: SandboxEnvironmentDetector = DefaultSandboxEnvironmentDetector()
+    ) {
         let response = data.response
         let subscriber = response.subscriber
 
@@ -175,7 +180,8 @@ import Foundation
         self.entitlements = EntitlementInfos(
             entitlements: subscriber.entitlements,
             purchases: subscriber.allPurchasesByProductId,
-            requestDate: response.requestDate
+            requestDate: response.requestDate,
+            sandboxEnvironmentDetector: sandboxEnvironmentDetector
         )
         self.nonSubscriptionTransactions = TransactionsFactory.nonSubscriptionTransactions(
             withSubscriptionsData: subscriber.nonSubscriptions

--- a/Sources/Purchasing/EntitlementInfos.swift
+++ b/Sources/Purchasing/EntitlementInfos.swift
@@ -81,7 +81,8 @@ public extension EntitlementInfos {
     }
 
     /// Dictionary of active ``EntitlementInfo`` objects keyed by their identifiers.
-    /// - Note: these can be active on any environment.
+    /// - Note: When queried from the sandbox environment, it only returns entitlements active in sandbox.
+    /// When queried from production, this only returns entitlements active in production.
     /// - Seealso: ``activeInAnyEnvironment``
     @objc var activeInCurrentEnvironment: [String: EntitlementInfo] {
         return self.activeInAnyEnvironment.filter { [isSandbox = self.sandboxEnvironmentDetector.isSandbox] in
@@ -90,8 +91,7 @@ public extension EntitlementInfos {
     }
 
     /// Dictionary of active ``EntitlementInfo`` objects keyed by their identifiers.
-    /// - Note: this only returns entitlements active in sandbox when queried from the sandbox
-    /// or active in production when queried from production.
+    /// - Note: these can be active on any environment.
     /// - Seealso: ``activeInCurrentEnvironment``
     @objc var activeInAnyEnvironment: [String: EntitlementInfo] {
         return self.all.filter { $0.value.isActive }

--- a/Sources/Purchasing/EntitlementInfos.swift
+++ b/Sources/Purchasing/EntitlementInfos.swift
@@ -25,13 +25,6 @@ import Foundation
      */
     @objc public let all: [String: EntitlementInfo]
 
-    /**
-     Dictionary of active ``EntitlementInfo`` (`RCEntitlementInfo`) objects keyed by entitlement identifier.
-     */
-    @objc public var active: [String: EntitlementInfo] {
-        return self.all.filter { $0.value.isActive }
-    }
-
     /// #### Related Symbols
     /// `- `all``
     @objc public subscript(key: String) -> EntitlementInfo? {
@@ -50,8 +43,14 @@ import Foundation
         return self.isEqual(to: other)
     }
 
-    init(entitlements: [String: EntitlementInfo]) {
+    // MARK: -
+
+    init(
+        entitlements: [String: EntitlementInfo],
+        sandboxEnvironmentDetector: SandboxEnvironmentDetector
+    ) {
         self.all = entitlements
+        self.sandboxEnvironmentDetector = sandboxEnvironmentDetector
     }
 
     private func isEqual(to other: EntitlementInfos?) -> Bool {
@@ -66,6 +65,38 @@ import Foundation
         return self.all == other.all
     }
 
+    // MARK: -
+
+    private let sandboxEnvironmentDetector: SandboxEnvironmentDetector
+
+}
+
+public extension EntitlementInfos {
+
+    /// Dictionary of active ``EntitlementInfo`` objects keyed by their identifiers.
+    /// - Warning: this is equivalent to ``activeInAnyEnvironment``
+    /// - Seealso: ``activeInCurrentEnvironment``
+    @objc var active: [String: EntitlementInfo] {
+        return self.activeInAnyEnvironment
+    }
+
+    /// Dictionary of active ``EntitlementInfo`` objects keyed by their identifiers.
+    /// - Note: these can be active on any environment.
+    /// - Seealso: ``activeInAnyEnvironment``
+    @objc var activeInCurrentEnvironment: [String: EntitlementInfo] {
+        return self.activeInAnyEnvironment.filter { [isSandbox = self.sandboxEnvironmentDetector.isSandbox] in
+            $0.value.isSandbox == isSandbox
+        }
+    }
+
+    /// Dictionary of active ``EntitlementInfo`` objects keyed by their identifiers.
+    /// - Note: this only returns entitlements active in sandbox when queried from the sandbox
+    /// or active in production when queried from production.
+    /// - Seealso: ``activeInCurrentEnvironment``
+    @objc var activeInAnyEnvironment: [String: EntitlementInfo] {
+        return self.all.filter { $0.value.isActive }
+    }
+
 }
 
 extension EntitlementInfos {
@@ -73,24 +104,28 @@ extension EntitlementInfos {
     convenience init(
         entitlements: [String: CustomerInfoResponse.Entitlement],
         purchases: [String: CustomerInfoResponse.Subscription],
-        requestDate: Date?
+        requestDate: Date?,
+        sandboxEnvironmentDetector: SandboxEnvironmentDetector = DefaultSandboxEnvironmentDetector()
     ) {
-        self.init(
-            entitlements: Dictionary(
-                uniqueKeysWithValues: entitlements.compactMap { identifier, entitlement in
-                    guard let subscription = purchases[entitlement.productIdentifier] else {
-                        return nil
-                    }
-
-                    return (
-                        identifier,
-                        EntitlementInfo(identifier: identifier,
-                                        entitlement: entitlement,
-                                        subscription: subscription,
-                                        requestDate: requestDate)
-                    )
+        let allEntitlements: [String: EntitlementInfo] = .init(
+            uniqueKeysWithValues: entitlements.compactMap { identifier, entitlement in
+                guard let subscription = purchases[entitlement.productIdentifier] else {
+                    return nil
                 }
-            )
+
+                return (
+                    identifier,
+                    EntitlementInfo(identifier: identifier,
+                                    entitlement: entitlement,
+                                    subscription: subscription,
+                                    requestDate: requestDate)
+                )
+            }
+        )
+
+        self.init(
+            entitlements: allEntitlements,
+            sandboxEnvironmentDetector: sandboxEnvironmentDetector
         )
     }
 

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCEntitlementInfosAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCEntitlementInfosAPI.m
@@ -16,9 +16,11 @@
     RCEntitlementInfos *ei;
     NSDictionary<NSString *, RCEntitlementInfo *> *all = ei.all;
     NSDictionary<NSString *, RCEntitlementInfo *> *active = ei.active;
+    NSDictionary<NSString *, RCEntitlementInfo *> *activeInAnyEnvironment = ei.activeInAnyEnvironment;
+    NSDictionary<NSString *, RCEntitlementInfo *> *activeInCurrentEnvironment = ei.activeInCurrentEnvironment;
     RCEntitlementInfo *e = [ei objectForKeyedSubscript:@""];
 
-    NSLog(ei, all, active, e);
+    NSLog(ei, all, active, activeInAnyEnvironment, activeInCurrentEnvironment, e);
 }
 
 @end

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/EntitlementInfosAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/EntitlementInfosAPI.swift
@@ -18,7 +18,9 @@ var eis: EntitlementInfos!
 func checkEntitlementInfosAPI() {
     let all: [String: EntitlementInfo] = eis.all
     let active: [String: EntitlementInfo] = eis.active
+    let activeInAnyEnvironment: [String: EntitlementInfo] = eis.activeInAnyEnvironment
+    let activeInCurrentEnvironment: [String: EntitlementInfo] = eis.activeInCurrentEnvironment
     let enti: EntitlementInfo? = eis[""]
 
-    print(eis!, all, active, enti!)
+    print(eis!, all, active, activeInAnyEnvironment, activeInCurrentEnvironment, enti!)
 }

--- a/Tests/UnitTests/Misc/CustomerInfo+TestExtensions.swift
+++ b/Tests/UnitTests/Misc/CustomerInfo+TestExtensions.swift
@@ -18,8 +18,12 @@ extension CustomerInfo {
 
     /// Initializes the customer with a dictionary
     /// Useful only for backwards compatibility with old tests
-    convenience init(data: [String: Any]) throws {
-        self.init(customerInfo: try JSONDecoder.default.decode(dictionary: data))
+    convenience init(
+        data: [String: Any],
+        sandboxEnvironmentDetector: SandboxEnvironmentDetector = DefaultSandboxEnvironmentDetector()
+    ) throws {
+        self.init(customerInfo: try JSONDecoder.default.decode(dictionary: data),
+                  sandboxEnvironmentDetector: sandboxEnvironmentDetector)
     }
 
     func asData() throws -> Data {

--- a/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
+++ b/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
@@ -1054,6 +1054,78 @@ class EntitlementInfosTests: TestCase {
         try verifyRenewal(false)
     }
 
+    // MARK: - Active
+
+    private func stubResponseWithActiveEntitlement(inSandbox sandbox: Bool) {
+        self.stubResponse(
+            entitlements: [
+                "pro_cat": [
+                    "expires_date": "2221-01-10T02:35:25Z",
+                    "product_identifier": "rc_promo_pro_cat_lifetime",
+                    "purchase_date": "2021-02-27T02:35:25Z"
+                ],
+                "another_entitlement": [
+                    "expires_date": "2016-01-10T02:35:25Z",
+                    "product_identifier": "another_product",
+                    "purchase_date": "2015-02-27T02:35:25Z"
+                ]
+            ],
+            subscriptions: [
+                "rc_promo_pro_cat_lifetime": [
+                    "billing_issues_detected_at": nil,
+                    "expires_date": "2221-01-10T02:35:25Z",
+                    "is_sandbox": sandbox,
+                    "original_purchase_date": "2021-02-27T02:35:25Z",
+                    "period_type": "normal",
+                    "purchase_date": "2021-02-27T02:35:25Z",
+                    "store": "promotional",
+                    "unsubscribe_detected_at": nil
+                ]
+            ])
+    }
+
+    func testActiveInAnyEnvironmentIncludesSandboxInSandbox() throws {
+        self.stubResponseWithActiveEntitlement(inSandbox: true)
+        try self.verifyEntitlementActiveInAnyEnvironment(sandbox: true)
+    }
+
+    func testActiveInAnyEnvironmentIncludesProductionInProduction() throws {
+        self.stubResponseWithActiveEntitlement(inSandbox: false)
+        try self.verifyEntitlementActiveInAnyEnvironment(sandbox: false)
+    }
+
+    func testActiveInAnyEnvironmentIncludesSandboxInProduction() throws {
+        self.stubResponseWithActiveEntitlement(inSandbox: true)
+        try self.verifyEntitlementActiveInAnyEnvironment(sandbox: false)
+    }
+
+    func testActiveInAnyEnvironmentIncludesProductionInSandbox() throws {
+        self.stubResponseWithActiveEntitlement(inSandbox: false)
+        try self.verifyEntitlementActiveInAnyEnvironment(sandbox: true)
+    }
+
+    func testActiveInCurrentEnvironmentIncludesSandboxInSandbox() throws {
+        self.stubResponseWithActiveEntitlement(inSandbox: true)
+        try self.verifyEntitlementActiveInCurrentEnvironment(sandbox: true)
+    }
+
+    func testActiveInCurrentEnvironmentIncludesProductionInProduction() throws {
+        self.stubResponseWithActiveEntitlement(inSandbox: false)
+        try self.verifyEntitlementActiveInCurrentEnvironment(sandbox: false)
+    }
+
+    func testActiveInCurrentEnvironmentDoesNotIncludeSandboxInProduction() throws {
+        self.stubResponseWithActiveEntitlement(inSandbox: true)
+        try self.verifyEntitlementActiveInCurrentEnvironment(false, sandbox: false)
+    }
+
+    func testActiveInCurrentEnvironmentDoesNotIncludesProductionInSandbox() throws {
+        self.stubResponseWithActiveEntitlement(inSandbox: false)
+        try self.verifyEntitlementActiveInCurrentEnvironment(false, sandbox: true)
+    }
+
+    // MARK: -
+
     func testRawData() throws {
         let info = try CustomerInfo(data: self.response)
 
@@ -1061,6 +1133,7 @@ class EntitlementInfosTests: TestCase {
             !$0.rawData.isEmpty
         })
     }
+
 }
 
 private extension EntitlementInfosTests {
@@ -1106,6 +1179,50 @@ private extension EntitlementInfosTests {
         expect(file: file, line: line, subscriberInfo.entitlements.active.keys.contains(entitlement))
         == expectedEntitlementActive
         expect(file: file, line: line, proCat.isActive) == expectedEntitlementActive
+    }
+
+    private func extractEntitlements(identifier: String,
+                                     inSandbox sandbox: Bool) throws -> EntitlementInfos {
+        return try CustomerInfo(
+            data: self.response,
+            sandboxEnvironmentDetector: MockSandboxEnvironmentDetector(isSandbox: sandbox)
+        ).entitlements
+    }
+
+    func verifyEntitlementActiveInAnyEnvironment(
+        _ expectedEntitlementActive: Bool = true,
+        identifier: String = "pro_cat",
+        sandbox: Bool,
+        file: FileString = #file,
+        line: UInt = #line
+    ) throws {
+        let entitlements = try self.extractEntitlements(identifier: identifier, inSandbox: sandbox)
+        let entitlement = try XCTUnwrap(entitlements[identifier])
+
+        expect(file: file, line: line, entitlement.identifier) == identifier
+        expect(file: file, line: line, Set(entitlements.all.keys)).to(contain([identifier]))
+        expect(file: file, line: line, entitlement.isActive) == true
+
+        expect(file: file, line: line, Set(entitlements.activeInAnyEnvironment.keys))
+        == (expectedEntitlementActive ? [identifier] : [])
+    }
+
+    func verifyEntitlementActiveInCurrentEnvironment(
+        _ expectedEntitlementActive: Bool = true,
+        identifier: String = "pro_cat",
+        sandbox: Bool,
+        file: FileString = #file,
+        line: UInt = #line
+    ) throws {
+        let entitlements = try self.extractEntitlements(identifier: identifier, inSandbox: sandbox)
+        let entitlement = try XCTUnwrap(entitlements[identifier])
+
+        expect(file: file, line: line, entitlement.identifier) == identifier
+        expect(file: file, line: line, entitlements.all.keys).to(contain([identifier]))
+        expect(file: file, line: line, entitlement.isActive) == true
+
+        expect(file: file, line: line, Set(entitlements.activeInCurrentEnvironment.keys))
+        == (expectedEntitlementActive ? [identifier] : [])
     }
 
     func verifyRenewal(_ expectedWillRenew: Bool = true,
@@ -1239,4 +1356,5 @@ private extension EntitlementInfosTests {
             description: "Invalid product identifier"
         )
     }
+
 }


### PR DESCRIPTION
Fixes [CSDK-53].
Depends on #1645.

This is backwards compatible. `EntitlementInfos.active` maintains the previous behavior of returning `activeInAnyEnvironment`

[CSDK-53]: https://revenuecats.atlassian.net/browse/CSDK-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ