### PR TITLE
Fix decoding issue caused by LossyDictionary for subscriptions and active entitlements

### DIFF
--- a/Sources/Networking/Responses/CustomerInfoResponse.swift
+++ b/Sources/Networking/Responses/CustomerInfoResponse.swift
@@ -36,11 +36,11 @@ extension CustomerInfoResponse {
         var originalApplicationVersion: String?
         var originalPurchaseDate: Date?
         var firstSeen: Date
-        @DefaultDecodable.EmptyDictionary @LossyDictionary
+        @DefaultDecodable.EmptyDictionary
         var subscriptions: [String: Subscription]
-        @DefaultDecodable.EmptyDictionary @LossyArrayDictionary
+        @DefaultDecodable.EmptyDictionary
         var nonSubscriptions: [String: [Transaction]]
-        @DefaultDecodable.EmptyDictionary @LossyDictionary
+        @DefaultDecodable.EmptyDictionary
         var entitlements: [String: Entitlement]
 
     }

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -321,7 +321,11 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
             "subscriber": [
                 "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-06-17T16:05:33Z",
-                "subscriptions": ["product_a": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]],
+                "subscriptions": [
+                    "product_a": ["expires_date": "2098-05-27T06:24:50Z", "period_type": "normal"],
+                    "Product_B": ["expires_date": "2098-05-27T06:24:50Z", "period_type": "normal"],
+                    "ProductC": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]
+                ],
                 "other_purchases": [:]
             ]])
 
@@ -331,6 +335,9 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         let receivedCustomerInfo = customerInfoManager.cachedCustomerInfo(appUserID: appUserID)
 
         expect(receivedCustomerInfo).toNot(beNil())
+        expect(receivedCustomerInfo?.activeSubscriptions.count) == 2
+        expect(receivedCustomerInfo?.activeSubscriptions.contains("product_a")) == true
+        expect(receivedCustomerInfo?.activeSubscriptions.contains("Product_B")) == true
         expect(receivedCustomerInfo!) == info
     }
 


### PR DESCRIPTION
### Motivation

Fixes https://revenuecats.atlassian.net/browse/SDKONCALL-20

### Description

`LossyDictionary` was trying to convert the keys of product identifiers with a `JSONEncoder` and `JSONDecoder` encoding strategy (snake and camel case) when writing and reading from the cache.

These keys should not be using any encoding strategies (since the product identifiers are not getting mapped to any properties). Removing the `LossyDictionary` allows the product identifier keys to remain as they case they were intended to be.

This also fixes the test that would have caught this. The test for `CustomerInfo` had two subscriptions that expired in `2018` to `activeSubscriptions` was returning empty array for pre-cache and post-cache. There also a few more product identifier case formats added to this to try and catch any other errors.