### PR TITLE
Added more failing tests for `CustomerInfo` encoding regression

### DIFF
--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -315,7 +315,6 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
     }
 
     func testCachedCustomerInfoParsesCorrectly() throws {
-        let appUserID = "myUser"
         let info = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
@@ -324,21 +323,24 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                 "subscriptions": [
                     "product_a": ["expires_date": "2098-05-27T06:24:50Z", "period_type": "normal"],
                     "Product_B": ["expires_date": "2098-05-27T06:24:50Z", "period_type": "normal"],
-                    "ProductC": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]
+                    "ProductC": ["expires_date": "2098-05-27T06:24:50Z", "period_type": "normal"],
+                    "ProductD": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]
                 ],
                 "other_purchases": [:]
             ]])
 
         let object = try info.asData()
-        mockDeviceCache.cachedCustomerInfo[appUserID] = object
+        self.mockDeviceCache.cachedCustomerInfo[Self.appUserID] = object
 
-        let receivedCustomerInfo = customerInfoManager.cachedCustomerInfo(appUserID: appUserID)
+        let receivedCustomerInfo = try XCTUnwrap(self.customerInfoManager.cachedCustomerInfo(appUserID: Self.appUserID))
 
-        expect(receivedCustomerInfo).toNot(beNil())
-        expect(receivedCustomerInfo?.activeSubscriptions.count) == 2
-        expect(receivedCustomerInfo?.activeSubscriptions.contains("product_a")) == true
-        expect(receivedCustomerInfo?.activeSubscriptions.contains("Product_B")) == true
-        expect(receivedCustomerInfo!) == info
+        expect(receivedCustomerInfo.activeSubscriptions).to(haveCount(3))
+        expect(receivedCustomerInfo.activeSubscriptions).to(contain([
+            "product_a",
+            "Product_B",
+            "ProductC"
+        ]))
+        expect(receivedCustomerInfo) == info
     }
 
     func testCachedCustomerInfoReturnsNilIfNotAvailable() {

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -324,6 +324,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                     "product_a": ["expires_date": "2098-05-27T06:24:50Z", "period_type": "normal"],
                     "Product_B": ["expires_date": "2098-05-27T06:24:50Z", "period_type": "normal"],
                     "ProductC": ["expires_date": "2098-05-27T06:24:50Z", "period_type": "normal"],
+                    "Pro": ["expires_date": "2098-05-27T06:24:50Z", "period_type": "normal"],
                     "ProductD": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]
                 ],
                 "other_purchases": [:]
@@ -334,11 +335,12 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
 
         let receivedCustomerInfo = try XCTUnwrap(self.customerInfoManager.cachedCustomerInfo(appUserID: Self.appUserID))
 
-        expect(receivedCustomerInfo.activeSubscriptions).to(haveCount(3))
+        expect(receivedCustomerInfo.activeSubscriptions).to(haveCount(4))
         expect(receivedCustomerInfo.activeSubscriptions).to(contain([
             "product_a",
             "Product_B",
-            "ProductC"
+            "ProductC",
+            "Pro"
         ]))
         expect(receivedCustomerInfo) == info
     }

--- a/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
@@ -65,7 +65,10 @@ class CustomerInfoDecodingTests: BaseHTTPResponseTest {
     func testSubscriptions() throws {
         let subscriber = self.customerInfo.subscriber
 
-        expect(Set(subscriber.subscriptions.keys)) == [Self.subscriptionID]
+        expect(Set(subscriber.subscriptions.keys)) == [
+            Self.subscriptionID,
+            "com.revenuecat.ABCDNA12U.ProductName"
+        ]
         let subscription = try XCTUnwrap(subscriber.subscriptions[Self.subscriptionID])
 
         expect(subscription.billingIssuesDetectedAt).to(beNil())

--- a/Tests/UnitTests/Networking/Responses/Fixtures/CustomerInfo.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/CustomerInfo.json
@@ -26,6 +26,17 @@
             }
         },
         "subscriptions": {
+            "com.revenuecat.ABCDNA12U.ProductName": {
+                "billing_issues_detected_at": null,
+                "expires_date": "2022-04-12T00:03:35Z",
+                "grace_period_expires_date": null,
+                "is_sandbox": true,
+                "original_purchase_date": "2022-04-12T00:03:28Z",
+                "period_type": "intro",
+                "purchase_date": "2022-04-12T00:03:28Z",
+                "store": "app_store",
+                "unsubscribe_detected_at": null
+            },
             "com.revenuecat.monthly_4.99.1_week_intro": {
                 "billing_issues_detected_at": null,
                 "expires_date": "2022-04-12T00:03:35Z",

--- a/Tests/UnitTests/Networking/Responses/__Snapshots__/CustomerInfoDecodingTests/testEncoding.1.json
+++ b/Tests/UnitTests/Networking/Responses/__Snapshots__/CustomerInfoDecodingTests/testEncoding.1.json
@@ -30,6 +30,15 @@
     "original_application_version" : "1.0",
     "original_purchase_date" : 671414604,
     "subscriptions" : {
+      "com.revenuecat.ABCDNA12U.ProductName" : {
+        "expires_date" : 671414615,
+        "is_sandbox" : true,
+        "original_purchase_date" : 671414608,
+        "ownership_type" : "PURCHASED",
+        "period_type" : "intro",
+        "purchase_date" : 671414608,
+        "store" : "app_store"
+      },
       "com.revenuecat.monthly_4.99.1_week_intro" : {
         "expires_date" : 671414615,
         "is_sandbox" : true,


### PR DESCRIPTION
See #1650.

I've added a failing subscription identifier in the fixture `CustomerInfo.json` so that the `CustomerInfoDecodingTests` would catch this.
Also updated the test introduced in #1651 to include one more case and improved the assertions.