### PR TITLE
`CustomerInfoDecodingTests`: added test to check decoding invalid data behavior

### DIFF
--- a/Sources/Networking/Responses/CustomerInfoResponse.swift
+++ b/Sources/Networking/Responses/CustomerInfoResponse.swift
@@ -31,7 +31,7 @@ extension CustomerInfoResponse {
     struct Subscriber {
 
         var originalAppUserId: String
-        @IgnoreDecodeErrors
+        @IgnoreDecodeErrors<URL?>
         var managementUrl: URL?
         var originalApplicationVersion: String?
         var originalPurchaseDate: Date?
@@ -47,18 +47,18 @@ extension CustomerInfoResponse {
 
     struct Subscription {
 
-        @DefaultValue<PeriodType>
+        @IgnoreDecodeErrors<PeriodType>
         var periodType: PeriodType
         var purchaseDate: Date?
         var originalPurchaseDate: Date?
         var expiresDate: Date?
-        @DefaultValue<Store>
+        @IgnoreDecodeErrors<Store>
         var store: Store
         @DefaultDecodable.False
         var isSandbox: Bool
         var unsubscribeDetectedAt: Date?
         var billingIssuesDetectedAt: Date?
-        @DefaultValue<PurchaseOwnershipType>
+        @IgnoreDecodeErrors<PurchaseOwnershipType>
         var ownershipType: PurchaseOwnershipType
 
     }
@@ -68,7 +68,7 @@ extension CustomerInfoResponse {
         var purchaseDate: Date?
         var originalPurchaseDate: Date?
         var transactionIdentifier: String?
-        @DefaultValue<Store>
+        @IgnoreDecodeErrors<Store>
         var store: Store
         var isSandbox: Bool
 

--- a/Tests/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
+++ b/Tests/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
@@ -255,7 +255,7 @@ private extension BeginRefundRequestHelperTests {
                 "original_app_user_id": "app_user_id",
                 "original_application_version": "2083",
                 "first_seen": "2019-06-17T16:05:33Z",
-                "non_subscriptions": [],
+                "non_subscriptions": [:],
                 "subscriptions": [
                     "onemonth_freetrial": [:]
                 ],
@@ -277,7 +277,7 @@ private extension BeginRefundRequestHelperTests {
                 "original_app_user_id": "app_user_id",
                 "original_application_version": "2083",
                 "first_seen": "2019-06-17T16:05:33Z",
-                "non_subscriptions": [],
+                "non_subscriptions": [:],
                 "subscriptions": [
                     "onemonth_freetrial": [:],
                     "onemonth_freetrial2": [:]
@@ -305,8 +305,8 @@ private extension BeginRefundRequestHelperTests {
                 "original_app_user_id": "app_user_id",
                 "original_application_version": "2083",
                 "first_seen": "2019-06-17T16:05:33Z",
-                "non_subscriptions": [],
-                "subscriptions": [],
+                "non_subscriptions": [:],
+                "subscriptions": [:],
                 "entitlements": [
                     "\(mockEntitlementID)": [
                         "expires_date": "2000-08-30T02:40:36Z",
@@ -325,8 +325,8 @@ private extension BeginRefundRequestHelperTests {
                 "original_app_user_id": "app_user_id",
                 "original_application_version": "2083",
                 "first_seen": "2019-06-17T16:05:33Z",
-                "non_subscriptions": [],
-                "subscriptions": [],
+                "non_subscriptions": [:],
+                "subscriptions": [:],
                 "entitlements": [
                     "pro": [
                         "expires_date": "2100-08-30T02:40:36Z",

--- a/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
@@ -137,7 +137,7 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "user",
-                "subscriptions": []
+                "subscriptions": [:]
             ]
         ]
         let path: HTTPRequest.Path = .getCustomerInfo(appUserID: Self.userID)

--- a/Tests/UnitTests/Networking/Backend/BackendLoginTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendLoginTests.swift
@@ -224,7 +224,7 @@ private extension BackendLoginTests {
     static let mockCustomerInfoData: [String: Any] = [
         "request_date": "2019-08-16T10:30:42Z",
         "subscriber": [
-            "subscriptions": [],
+            "subscriptions": [:],
             "first_seen": "2019-07-17T00:05:54Z",
             "original_app_user_id": "",
             "other_purchases": [:]

--- a/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
@@ -142,3 +142,14 @@ class CustomerInfoDecodingTests: BaseHTTPResponseTest {
     }
 
 }
+
+class CustomerInfoInvalidDataDecodingTests: BaseHTTPResponseTest {
+
+    func testDecodingCustomerInfoWithInvalidSubscriptionFailsToDecode() throws {
+        expect {
+            let _: CustomerInfo = try self.decodeFixture("CustomerInfoWithInvalidSubscription")
+        }
+        .to(throwError(ErrorCode.customerInfoError))
+    }
+
+}

--- a/Tests/UnitTests/Networking/Responses/Fixtures/CustomerInfoWithInvalidSubscription.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/CustomerInfoWithInvalidSubscription.json
@@ -1,0 +1,39 @@
+{
+    "schema_version": "4",
+    "request_date": "2022-03-08T17:42:58Z",
+    "request_date_ms": 1646761378845,
+    "subscriber": {
+        "first_seen": "2022-03-08T17:42:58Z",
+        "last_seen": "2022-03-08T17:42:58Z",
+        "management_url": "https://apps.apple.com/account/subscriptions",
+        "non_subscriptions": {},
+        "original_app_user_id": "$RCAnonymousID:5b6fdbac3a0c4f879e43d269ecdf9ba1",
+        "original_application_version": "1.0",
+        "original_purchase_date": "2022-04-12T00:03:24Z",
+        "other_purchases": {},
+        "subscriptions": {
+            "sub1": {
+                "billing_issues_detected_at": null,
+                "expires_date": [],
+                "grace_period_expires_date": null,
+                "original_purchase_date": "this is not a date",
+                "period_type": true,
+                "purchase_date": false,
+                "store": "invalid_store",
+                "unsubscribe_detected_at": null
+            },
+            "sub2": {
+                "billing_issues_detected_at": null,
+                "expires_date": "2022-04-12T00:03:35Z",
+                "grace_period_expires_date": null,
+                "is_sandbox": true,
+                "original_purchase_date": "2022-04-12T00:03:28Z",
+                "period_type": "intro",
+                "purchase_date": "2022-04-12T00:03:28Z",
+                "store": "app_store",
+                "unsubscribe_detected_at": null
+            }
+        },
+        "entitlements": {}
+    }
+}

--- a/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
@@ -410,12 +410,15 @@ class BasicCustomerInfoTests: TestCase {
                 ],
                 "entitlements": [
                     "pro": [
+                        "product_identifier": "onemonth_freetrial",
                         "expires_date": "2100-08-30T02:40:36Z"
                     ],
                     "old_pro": [
+                        "product_identifier": "onemonth_freetrial",
                         "expires_date": "1990-08-30T02:40:36Z"
                     ],
                     "forever_pro": [
+                        "product_identifier": "threemonth_freetrial",
                         "expires_date": nil
                     ]
                 ]


### PR DESCRIPTION
See also #1658.
This updates the behavior of `CustomerInfoResponse` decoding so that having invalid content inside of one of the structures fails more loudly instead of getting ignored.

For that, `@DefaultValue` no longer ignores errors, and instead `@IgnoreDecodeErrors` must be used.
For some of the values in `CustomerInfoResponse` this makes sense (like `Store`), but not for things like subscriptions where we would be losing data.