### PR TITLE
`BackendPostReceiptDataTests`: added new test with `ProductRequestData`

### DIFF
--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -51,6 +51,35 @@ class BackendPostReceiptDataTests: BaseBackendTests {
         expect(completionCalled).toEventually(beTrue())
     }
 
+    func testPostsReceiptDataWithProductDataCorrectly() throws {
+        let path: HTTPRequest.Path = .postReceiptData
+
+        httpClient.mock(
+            requestPath: path,
+            response: .init(statusCode: .success, response: Self.validCustomerResponse)
+        )
+
+        var completionCalled = false
+
+        let isRestore = false
+        let observerMode = true
+        let productData: ProductRequestData = .createMockProductData(currencyCode: "USD")
+
+        backend.post(receiptData: Self.receiptData,
+                     appUserID: Self.userID,
+                     isRestore: isRestore,
+                     productData: productData,
+                     presentedOfferingIdentifier: nil,
+                     observerMode: observerMode,
+                     subscriberAttributes: nil,
+                     completion: { _ in
+            completionCalled = true
+        })
+
+        expect(completionCalled).toEventually(beTrue())
+        expect(self.httpClient.calls).to(haveCount(1))
+    }
+
     func testCachesRequestsForSameReceipt() {
         httpClient.mock(
             requestPath: .postReceiptData,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -1,0 +1,25 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "notDetermined"
+        }
+      },
+      "currency" : "USD",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : true,
+      "price" : "15.99",
+      "product_id" : "product_id",
+      "store_country" : "ESP"
+    },
+    "method" : "POST",
+    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -1,0 +1,25 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "notDetermined"
+        }
+      },
+      "currency" : "USD",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : true,
+      "price" : "15.99",
+      "product_id" : "product_id",
+      "store_country" : "ESP"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -1,0 +1,25 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "currency" : "USD",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : true,
+      "price" : "15.99",
+      "product_id" : "product_id",
+      "store_country" : "ESP"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -1,0 +1,25 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "currency" : "USD",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : true,
+      "price" : "15.99",
+      "product_id" : "product_id",
+      "store_country" : "ESP"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}


### PR DESCRIPTION
Looking into [SDKONCALL-19], realized that there's no test that explicitly checks the `ProductRequestData` is sent along with the receipt data.

## TODO:
- [x] Add new snapshots for other iOS versions (cough #1561).

[SDKONCALL-19]: https://revenuecats.atlassian.net/browse/SDKONCALL-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ