### PR TITLE
`PurchasesOrchestrator`: replaced calls to `syncPurchases` with posting receipt for an individual product during SK2 purchases

### DIFF
--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
@@ -17,7 +17,7 @@ import StoreKit
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
 protocol StoreKit2TransactionListenerDelegate: AnyObject {
 
-    func transactionsUpdated() async throws -> CustomerInfo
+    func transactionsUpdated() async throws
 
 }
 
@@ -25,7 +25,7 @@ protocol StoreKit2TransactionListenerDelegate: AnyObject {
 class StoreKit2TransactionListener {
 
     /// Similar to ``PurchaseResultData`` but with an optional `CustomerInfo`
-    typealias ResultData = (userCancelled: Bool, customerInfo: CustomerInfo?, transaction: SK2Transaction?)
+    typealias ResultData = (userCancelled: Bool, transaction: SK2Transaction?)
 
     private(set) var taskHandle: Task<Void, Never>?
     weak var delegate: StoreKit2TransactionListenerDelegate?
@@ -41,7 +41,8 @@ class StoreKit2TransactionListener {
                 guard let self = self else { break }
 
                 do {
-                    _ = try await self.handle(transactionResult: result)
+                    _ = try await self.handle(transactionResult: result,
+                                              notifyDelegate: true)
                 } catch {
                     Logger.error(error.localizedDescription)
                 }
@@ -60,14 +61,15 @@ class StoreKit2TransactionListener {
         purchaseResult: StoreKit.Product.PurchaseResult
     ) async throws -> ResultData {
         switch purchaseResult {
-        case .success(let verificationResult):
-            let (transaction, customerInfo) = try await handle(transactionResult: verificationResult)
+        case let .success(verificationResult):
+            let transaction = try await self.handle(transactionResult: verificationResult,
+                                                    notifyDelegate: false)
 
-            return (false, customerInfo, transaction)
+            return (false, transaction)
         case .pending:
             throw ErrorUtils.paymentDeferredError()
         case .userCancelled:
-            return (true, nil, nil)
+            return (true, nil)
         @unknown default:
             throw ErrorUtils.storeProblemError(
                 withMessage: Strings.purchase.unknown_purchase_result(result: String(describing: purchaseResult))
@@ -82,9 +84,11 @@ class StoreKit2TransactionListener {
 private extension StoreKit2TransactionListener {
 
     /// - Throws: ``ErrorCode`` if the transaction fails to verify.
+    /// - Parameter notifyDelegate: `true` only for transactions detected outside of a manual purchase flow.
     func handle(
-        transactionResult: VerificationResult<StoreKit.Transaction>
-    ) async throws -> (SK2Transaction, CustomerInfo?) {
+        transactionResult: VerificationResult<StoreKit.Transaction>,
+        notifyDelegate: Bool
+    ) async throws -> SK2Transaction {
         switch transactionResult {
         case let .unverified(unverifiedTransaction, verificationError):
             throw ErrorUtils.storeProblemError(
@@ -96,19 +100,18 @@ private extension StoreKit2TransactionListener {
             )
 
         case .verified(let verifiedTransaction):
-            let customerInfo = try await self.finish(transaction: verifiedTransaction)
+            await self.finish(transaction: verifiedTransaction)
 
-            return (verifiedTransaction, customerInfo)
+            if notifyDelegate, let delegate = self.delegate {
+                _ = try await delegate.transactionsUpdated()
+            }
+
+            return verifiedTransaction
         }
     }
 
-    /// - Returns `nil` only if the delegate isn't set.
-    func finish(transaction: StoreKit.Transaction) async throws -> CustomerInfo? {
+    func finish(transaction: StoreKit.Transaction) async {
         await transaction.finish()
-
-        guard let delegate = self.delegate else { return nil }
-
-        return try await delegate.transactionsUpdated()
     }
 
 }

--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
@@ -41,8 +41,7 @@ class StoreKit2TransactionListener {
                 guard let self = self else { break }
 
                 do {
-                    _ = try await self.handle(transactionResult: result,
-                                              notifyDelegate: true)
+                    _ = try await self.handle(transactionResult: result, notifyDelegate: true)
                 } catch {
                     Logger.error(error.localizedDescription)
                 }
@@ -62,8 +61,8 @@ class StoreKit2TransactionListener {
     ) async throws -> ResultData {
         switch purchaseResult {
         case let .success(verificationResult):
-            let transaction = try await self.handle(transactionResult: verificationResult,
-                                                    notifyDelegate: false)
+            // No need to notify delegate since this method returns the transaction already.
+            let transaction = try await self.handle(transactionResult: verificationResult, notifyDelegate: false)
 
             return (false, transaction)
         case .pending:

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -361,11 +361,10 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
         backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
 
-        let customerInfo = try await orchestrator.transactionsUpdated()
+        try await self.orchestrator.transactionsUpdated()
 
         expect(self.backend.invokedPostReceiptData).to(beTrue())
         expect(self.backend.invokedPostReceiptDataParameters?.isRestore).to(beFalse())
-        expect(customerInfo) == mockCustomerInfo
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
@@ -378,11 +377,10 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
 
-        let customerInfo = try await orchestrator.transactionsUpdated()
+        try await self.orchestrator.transactionsUpdated()
 
         expect(self.backend.invokedPostReceiptData).to(beTrue())
         expect(self.backend.invokedPostReceiptDataParameters?.isRestore).to(beTrue())
-        expect(customerInfo) == mockCustomerInfo
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -160,6 +160,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         }
 
         expect(self.backend.invokedPostReceiptDataCount) == 1
+        expect(self.backend.invokedPostReceiptDataParameters?.productData).toNot(beNil())
     }
 
     func testPurchaseSK1PromotionalOffer() async throws {
@@ -225,6 +226,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         }
 
         expect(self.backend.invokedPostReceiptDataCount) == 1
+        expect(self.backend.invokedPostReceiptDataParameters?.productData).toNot(beNil())
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
@@ -295,6 +297,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         _ = try await orchestrator.purchase(sk2Product: product, promotionalOffer: nil)
 
         expect(self.backend.invokedPostReceiptDataCount) == 1
+        expect(self.backend.invokedPostReceiptDataParameters?.productData).toNot(beNil())
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
@@ -335,7 +338,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    func testPurchaseSK2PackageRetrunsCustomerInfoForFailedTransaction() async throws {
+    func testPurchaseSK2PackageReturnsCustomerInfoForFailedTransaction() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         self.customerInfoManager.stubbedCustomerInfoResult = .success(self.mockCustomerInfo)
@@ -426,6 +429,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         expect(self.backend.invokedPostOfferCount) == 1
         expect(self.backend.invokedPostOfferParameters?.offerIdentifier) == storeProductDiscount.offerIdentifier
+        expect(self.backend.invokedPostOfferParameters?.data).toNot(beNil())
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)

--- a/Tests/StoreKitUnitTests/StoreKit2TransactionListenerTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2TransactionListenerTests.swift
@@ -51,20 +51,18 @@ class StoreKit2TransactionListenerTests: StoreKitConfigTestCase {
 
         let fakeTransaction = try await createTransactionWithPurchase()
 
-        let (isCancelled, customerInfo, transaction) = try await self.listener.handle(
+        let (isCancelled, transaction) = try await self.listener.handle(
             purchaseResult: .success(.verified(fakeTransaction))
         )
         expect(isCancelled) == false
-        expect(customerInfo).to(beNil())
         expect(transaction) == fakeTransaction
     }
 
     func testIsCancelledIsTrueWhenPurchaseIsCancelled() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        let (isCancelled, customerInfo, transaction) = try await self.listener.handle(purchaseResult: .userCancelled)
+        let (isCancelled, transaction) = try await self.listener.handle(purchaseResult: .userCancelled)
         expect(isCancelled) == true
-        expect(customerInfo).to(beNil())
         expect(transaction).to(beNil())
     }
 

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionListener.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionListener.swift
@@ -71,7 +71,7 @@ class MockStoreKit2TransactionListener: StoreKit2TransactionListener {
         invokedHandleParameters = (.init(purchaseResult), ())
         invokedHandleParametersList.append((.init(purchaseResult), ()))
 
-        return (false, nil, mockTransaction.value)
+        return (false, mockTransaction.value)
     }
 }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
@@ -574,12 +574,12 @@ class PurchasesPurchasingTests: BasePurchasesTests {
             receivedUserCancelled = userCancelled
         }
 
-        expect(receivedInfo).toEventually(beNil())
         expect(receivedError).toEventuallyNot(beNil())
-        expect(receivedError?.domain).toEventually(equal(RCPurchasesErrorCodeDomain))
-        expect(receivedError?.code).toEventually(equal(ErrorCode.operationAlreadyInProgressForProductError.rawValue))
-        expect(self.storeKitWrapper.addPaymentCallCount).to(equal(1))
-        expect(receivedUserCancelled).toEventually(beFalse())
+        expect(receivedInfo).to(beNil())
+        expect(receivedError?.domain) == RCPurchasesErrorCodeDomain
+        expect(receivedError?.code) == ErrorCode.operationAlreadyInProgressForProductError.rawValue
+        expect(self.storeKitWrapper.addPaymentCallCount) == 1
+        expect(receivedUserCancelled) == false
     }
 
     func testTransitioningToPurchasing() {


### PR DESCRIPTION
Fixes [SDKONCALL-19].
SK2 purchases were always calling `syncPurchases`, which called `Backend.post(receiptData:...)` with no `productData`, which meant that after every SK2 purchase we never posted the price.

This refactor makes a lot of methods in `PurchasesOrchestrator` use `StoreTransaction` so they can be used during SK2 purchases as well. Specifically, `handlePurchasedTransaction` is now called after both SK1 and SK2 purchases.

### Other changes:

- `StoreKit2TransactionListenerDelegate` no longer needs to return `CustomerInfo`
- `StoreKit2TransactionListenerDelegate.handle(purchaseResult:)` no longer notifies the delegate (only done by `StoreKit.Transaction.updates`), which was leading to duplicate `syncPurchases` calls.
- If the purchase is cancelled, `syncPurchases` isn't called. Instead, the `CustomerInfo` is fetched from `CustomerInfoManager`

[SDKONCALL-19]: https://revenuecats.atlassian.net/browse/SDKONCALL-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ