### PR TITLE
`CodableStrings.decoding_error`: added underlying error information

### DIFF
--- a/Sources/Logging/Strings/CodableStrings.swift
+++ b/Sources/Logging/Strings/CodableStrings.swift
@@ -44,7 +44,14 @@ extension CodableStrings: CustomStringConvertible {
         case let .encoding_error(error):
             return "Couldn't encode data into json. Error:\n\(error.localizedDescription)"
         case let .decoding_error(error):
-            return "Couldn't decode data from json. Error:\n\(error.localizedDescription)"
+            let underlyingErrorMessage: String
+            if let underlyingError = (error as NSError).userInfo[NSUnderlyingErrorKey] as? NSError {
+                underlyingErrorMessage = "\nUnderlying error: \(underlyingError.debugDescription)"
+            } else {
+                underlyingErrorMessage = ""
+            }
+
+            return "Couldn't decode data from json.\nError: \(error.localizedDescription)." + underlyingErrorMessage
         case let .corrupted_data_error(context):
             return "Couldn't decode data from json, it was corrupted: \(context)"
         case let .typeMismatch(type, context):


### PR DESCRIPTION
While debugging `CustomerInfo` decoding errors for example, this is the existing error logged in the console:
```
ERROR: 😿‼️ Couldn't decode data from json. Error:
There was a problem related to the customer info.
```

With this change:
```
ERROR: 😿‼️ Couldn't decode data from json.
Error: There was a problem related to the customer info..
Underlying error: Swift.DecodingError.typeMismatch(Swift.Dictionary<Swift.String, RevenueCat.CustomerInfoResponse.Subscription>, Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "subscriber", intValue: nil), CodingKeys(stringValue: "subscriptions", intValue: nil)], debugDescription: "Expected to decode Dictionary<String, Subscription> but found an array instead.", underlyingError: nil))
```