### PR TITLE
`fastlane bump` lane passes `options` to `github_changelog`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -228,7 +228,7 @@ platform :ios do
     # Ask for new version number
     new_version_number = UI.input("New version number: ")
 
-    generated_contents = github_changelog
+    generated_contents = github_changelog(options)
     changelog_path = edit_changelog(generated_contents: generated_contents)
     changelog = File.read(changelog_path)
     


### PR DESCRIPTION
This allows creating a changelog from a different version using `bundle exec fastlane bump old_version:4.5.1`.