### PR TITLE
`Result.init(value:error:)`: avoid creating error if value is provided

### DIFF
--- a/Sources/FoundationExtensions/Result+Extensions.swift
+++ b/Sources/FoundationExtensions/Result+Extensions.swift
@@ -15,10 +15,10 @@ extension Result {
 
     /// Creates a `Result` from either a value or an error.
     /// This is useful for converting from old Objective-C closures to new APIs.
-    init( _ value: Success?, _ error: Failure?, file: StaticString = #fileID, line: UInt = #line) {
+    init( _ value: Success?, _ error: @autoclosure () -> Failure?, file: StaticString = #fileID, line: UInt = #line) {
         if let value = value {
             self = .success(value)
-        } else if let error = error {
+        } else if let error = error() {
             self = .failure(error)
         } else {
             fatalError("Unexpected nil value and nil error", file: file, line: line)

--- a/Tests/UnitTests/FoundationExtensions/ResultExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/ResultExtensionsTests.swift
@@ -40,6 +40,19 @@ class ResultExtensionsTests: TestCase {
         expect(Data(nil, .error1)) == .failure(.error1)
     }
 
+    func testErrorIsNotCreatedIfValueIsProvided() {
+        var errorCreated = false
+
+        func createError() -> Error {
+            errorCreated = true
+            return .error1
+        }
+
+        let result = Data("1", createError())
+        expect(result) == .success("1")
+        expect(errorCreated) == false
+    }
+
     func testInitWithNoValueOrError() {
         expectFatalError(expectedMessage: "Unexpected nil value and nil error") {
             _ = Data(nil, nil)


### PR DESCRIPTION
Our implementation of `ErrorUtils.error(with:message:underlyingError:extraUserInfo:)` always calls `ErrorUtils.logErrorIfNeeded`, this means that even though the error wasn't actually used, it was being logged as if it had occurred.
By using `@autoclosure` we avoid this and instead create it lazily.

This incorrect logging lead to [CSDK-112], which won't be confusing anymore.

[CSDK-112]: https://revenuecats.atlassian.net/browse/CSDK-112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ