### PR TITLE
`fastlane current_version_number`: added `strip` to deal with line break

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -678,5 +678,5 @@ def replace_in(previous_text, new_text, path, allow_empty=false)
 end
 
 def current_version_number
-  File.read("../.version")
+  File.read("../.version").strip
 end


### PR DESCRIPTION
`.version` ended up with a line break (see https://github.com/RevenueCat/purchases-ios/blob/78bd65f/.version) which is breaking our release script. This fixes it.