### PR TITLE
`MacDevice`: changed usage of `kIOMasterPortDefault` to fix Catalyst compilation on Xcode 14

### DIFF
--- a/Sources/Misc/MacDevice.swift
+++ b/Sources/Misc/MacDevice.swift
@@ -50,7 +50,9 @@ enum MacDevice {
 
     #if canImport(IOKit)
     static private func getIOService(named name: String, wantBuiltIn: Bool) -> io_service_t? {
-        let defaultPort = kIOMasterPortDefault
+        // 0 is `kIOMasterPortDefault` / `kIOMainPortDefault`, but the first is deprecated
+        // And the second isn't available in Catalyst on Xcode 14.
+        let defaultPort: mach_port_t = 0
         var iterator = io_iterator_t()
         defer {
             if iterator != IO_OBJECT_NULL {


### PR DESCRIPTION
From the docs:
```
@abstract The default mach port used to initiate communication with IOKit.
@discussion When specifying a main port to IOKit functions, the NULL argument indicates "use the default". This is a synonym for NULL, if you'd rather use a named constant.
extern
const mach_port_t kIOMainPortDefault
```

`kIOMasterPortDefault` is deprecated, and `kIOMainPortDefault` isn't available on Catalyst in Xcode 14. This fixes compilation by simply using `NULL` (0).

Fixes [CSDK-106].

[CSDK-106]: https://revenuecats.atlassian.net/browse/CSDK-106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ