### PR TITLE
Fix small bug in docs

### DIFF
--- a/Sources/Purchasing/Purchases.swift
+++ b/Sources/Purchasing/Purchases.swift
@@ -919,7 +919,7 @@ public extension Purchases {
     /**
      * Fetch the configured ``Offerings`` for this user.
      *
-     *``Offerings`` allows you to configure your in-app products
+     * ``Offerings`` allows you to configure your in-app products
      * via RevenueCat and greatly simplifies management.
      *
      * ``Offerings`` will be fetched and cached on instantiation so that, by the time they are needed,
@@ -940,7 +940,7 @@ public extension Purchases {
     /**
      * Fetch the configured ``Offerings`` for this user.
      *
-     *``Offerings`` allows you to configure your in-app products
+     * ``Offerings`` allows you to configure your in-app products
      * via RevenueCat and greatly simplifies management.
      *
      * ``Offerings`` will be fetched and cached on instantiation so that, by the time they are needed,


### PR DESCRIPTION
Just noticed this small thing in docs, this fixes it. 

<img width="686" alt="Screen Shot 2022-06-09 at 3 25 54 PM" src="https://user-images.githubusercontent.com/3922667/172918808-1969b4ba-db69-4286-93cc-5e6ed28bb9fd.png">
 