### PR TITLE
Fixed `ROT13.string` thread-safety

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -301,6 +301,7 @@
 		57D04BB827D947C6006DAC06 /* HTTPResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D04BB727D947C6006DAC06 /* HTTPResponseTests.swift */; };
 		57D5412E27F6311C004CC35C /* OfferingsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D5412D27F6311C004CC35C /* OfferingsResponse.swift */; };
 		57D5414227F656D9004CC35C /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D5414127F656D9004CC35C /* NetworkError.swift */; };
+		57D56FCA2853C005009E8E1E /* StringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D56FC92853C005009E8E1E /* StringExtensionsTests.swift */; };
 		57DC9F4627CC2E4900DA6AF9 /* HTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DC9F4527CC2E4900DA6AF9 /* HTTPRequest.swift */; };
 		57DC9F4A27CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DC9F4927CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift */; };
 		57DE806D28074976008D6C6F /* Storefront.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DE806C28074976008D6C6F /* Storefront.swift */; };
@@ -778,6 +779,7 @@
 		57D04BB727D947C6006DAC06 /* HTTPResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponseTests.swift; sourceTree = "<group>"; };
 		57D5412D27F6311C004CC35C /* OfferingsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferingsResponse.swift; sourceTree = "<group>"; };
 		57D5414127F656D9004CC35C /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		57D56FC92853C005009E8E1E /* StringExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensionsTests.swift; sourceTree = "<group>"; };
 		57DB9EE7281B3C6100BBAA21 /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		57DC9F4527CC2E4900DA6AF9 /* HTTPRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequest.swift; sourceTree = "<group>"; };
 		57DC9F4927CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCodeTests.swift; sourceTree = "<group>"; };
@@ -1574,6 +1576,7 @@
 				5796A3BF27D7D64500653165 /* ResultExtensionsTests.swift */,
 				57ACB13628184CF1000DCC9F /* DecoderExtensionTests.swift */,
 				5766AA41283C768600FA6091 /* OperatorExtensionsTests.swift */,
+				57D56FC92853C005009E8E1E /* StringExtensionsTests.swift */,
 			);
 			path = FoundationExtensions;
 			sourceTree = "<group>";
@@ -2496,6 +2499,7 @@
 				351B51C326D450F200BD2BD7 /* InMemoryCachedObjectTests.swift in Sources */,
 				576C8A8F27CFCD110058FA6E /* AnyEncodableTests.swift in Sources */,
 				351B517226D44EF300BD2BD7 /* MockInMemoryCachedOfferings.swift in Sources */,
+				57D56FCA2853C005009E8E1E /* StringExtensionsTests.swift in Sources */,
 				351B51A426D450BC00BD2BD7 /* NSError+RCExtensionsTests.swift in Sources */,
 				57E2230727500BB1002DB06E /* AtomicTests.swift in Sources */,
 				351B51B826D450E800BD2BD7 /* StoreKitWrapperTests.swift in Sources */,

--- a/Sources/FoundationExtensions/String+Extensions.swift
+++ b/Sources/FoundationExtensions/String+Extensions.swift
@@ -77,19 +77,20 @@ extension String {
 
 private enum ROT13 {
 
-    private static var key = [Character: Character]()
+    private static let key: [Character: Character] = {
+        var result: [Character: Character] = [:]
+        for number in 0 ..< 26 {
+            result[Self.uppercase[number]] = Self.uppercase[(number + 13) % 26]
+            result[Self.lowercase[number]] = Self.lowercase[(number + 13) % 26]
+        }
+
+        return result
+    }()
     private static let uppercase = Array("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
     private static let lowercase = Array("abcdefghijklmnopqrstuvwxyz")
 
     fileprivate static func string(_ string: String) -> String {
-        if ROT13.key.isEmpty {
-            for number in 0 ..< 26 {
-                ROT13.key[ROT13.uppercase[number]] = ROT13.uppercase[(number + 13) % 26]
-                ROT13.key[ROT13.lowercase[number]] = ROT13.lowercase[(number + 13) % 26]
-            }
-        }
-
-        let transformed = string.map { ROT13.key[$0] ?? $0 }
+        let transformed = string.map { Self.key[$0] ?? $0 }
         return String(transformed)
     }
 

--- a/Tests/UnitTests/FoundationExtensions/StringExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/StringExtensionsTests.swift
@@ -1,0 +1,30 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  StringExtensionsTests.swift
+//
+//  Created by Nacho Soto on 6/10/22.
+
+import Foundation
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+class StringExtensionsTests: TestCase {
+
+    func testROT13() {
+        let mangledTrackingClassName = "NGGenpxvatZnantre"
+        let mangledAuthStatusPropertyName = "genpxvatNhgubevmngvbaFgnghf"
+
+        expect(mangledTrackingClassName.rot13()) == "ATTrackingManager"
+        expect(mangledAuthStatusPropertyName.rot13()) == "trackingAuthorizationStatus"
+    }
+
+}


### PR DESCRIPTION
Fixes #1685.

### Description

Swift's `lazy` and `static` property initialization is always thread-safe. However, `key` was only created as an empty dictionary, and the evaluation of `ROT13.string`, which was the one initializing that data, wasn't isolated.
By creating `ROT13.key` inline, this ensures that the initialization is only done once in a thread-safe way.