### PR TITLE
Fixed thread unsafe usage of `toEventually`

### DIFF
--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -23,17 +23,15 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         let manager = try createManager(storeKit2Setting: .disabled)
 
         let identifier = "com.revenuecat.monthly_4.99.1_week_intro"
-        var completionCalled = false
         var receivedProducts: Result<Set<StoreProduct>, Error>?
 
         manager.products(withIdentifiers: Set([identifier])) { products in
-            completionCalled = true
             receivedProducts = products
         }
 
-        expect(completionCalled).toEventually(beTrue(), timeout: Self.requestDispatchTimeout)
+        expect(receivedProducts).toEventuallyNot(beNil(), timeout: Self.requestDispatchTimeout)
         let unwrappedProducts = try XCTUnwrap(receivedProducts?.get())
-        expect(unwrappedProducts.count) == 1
+        expect(unwrappedProducts).to(haveCount(1))
 
         let product = try XCTUnwrap(unwrappedProducts.first).product
 
@@ -49,17 +47,15 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         let manager = try createManager(storeKit2Setting: .enabledForCompatibleDevices)
 
         let identifier = "com.revenuecat.monthly_4.99.1_week_intro"
-        var completionCalled = false
         var receivedProducts: Result<Set<StoreProduct>, Error>?
 
         manager.products(withIdentifiers: Set([identifier])) { products in
-            completionCalled = true
             receivedProducts = products
         }
 
-        expect(completionCalled).toEventually(beTrue(), timeout: Self.requestDispatchTimeout)
+        expect(receivedProducts).toEventuallyNot(beNil(), timeout: Self.requestDispatchTimeout)
         let unwrappedProducts = try XCTUnwrap(receivedProducts?.get())
-        expect(unwrappedProducts.count) == 1
+        expect(unwrappedProducts).to(haveCount(1))
 
         let product = try XCTUnwrap(unwrappedProducts.first).product
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -478,15 +478,13 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     func testShowManageSubscriptionsCallsCompletionWithErrorIfThereIsAFailure() {
         let message = "Failed to get managementURL from CustomerInfo. Details: customerInfo is nil."
         mockManageSubsHelper.mockError = ErrorUtils.customerInfoError(withMessage: message)
+
         var receivedError: Error?
-        var completionCalled = false
         orchestrator.showManageSubscription { error in
-            completionCalled = true
             receivedError = error
         }
 
-        expect(completionCalled).toEventually(beTrue())
-        expect(receivedError).toNot(beNil())
+        expect(receivedError).toEventuallyNot(beNil())
         expect(receivedError).to(matchError(ErrorCode.customerInfoError))
     }
 

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
@@ -71,16 +71,15 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
         let stubbedEligibility = ["product_id": IntroEligibilityStatus.eligible]
         mockIntroEligibilityCalculator.stubbedCheckTrialOrIntroDiscountEligibilityResult = (stubbedEligibility, nil)
 
-        var completionCalled = false
         var eligibilities: [String: IntroEligibility]?
         trialOrIntroPriceEligibilityChecker!.sk1CheckEligibility([]) { (receivedEligibilities) in
-            completionCalled = true
             eligibilities = receivedEligibilities
         }
 
-        expect(completionCalled).toEventually(beTrue())
+        expect(eligibilities).toEventuallyNot(beNil())
+
         let receivedEligibilities = try XCTUnwrap(eligibilities)
-        expect(receivedEligibilities.count) == 1
+        expect(receivedEligibilities).to(haveCount(1))
     }
 
     func testSK1EligibilityProductsWithKnownIntroEligibilityStatus() throws {
@@ -121,16 +120,16 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
         let productId = "product_id"
         let stubbedEligibility = [productId: IntroEligibility(eligibilityStatus: IntroEligibilityStatus.eligible)]
         mockBackend.stubbedGetIntroEligibilityCompletionResult = (stubbedEligibility, nil)
-        var completionCalled = false
+
         var eligibilities: [String: IntroEligibility]?
         trialOrIntroPriceEligibilityChecker!.sk1CheckEligibility([productId]) { (receivedEligibilities) in
-            completionCalled = true
             eligibilities = receivedEligibilities
         }
 
-        expect(completionCalled).toEventually(beTrue())
+        expect(eligibilities).toEventuallyNot(beNil())
+
         let receivedEligibilities = try XCTUnwrap(eligibilities)
-        expect(receivedEligibilities.count) == 1
+        expect(receivedEligibilities).to(haveCount(1))
         expect(receivedEligibilities[productId]?.status) == IntroEligibilityStatus.eligible
 
         expect(self.mockBackend.invokedGetIntroEligibilityCount) == 1
@@ -153,16 +152,16 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
         let productId = "product_id"
         let stubbedEligibility = [productId: IntroEligibility(eligibilityStatus: IntroEligibilityStatus.eligible)]
         mockBackend.stubbedGetIntroEligibilityCompletionResult = (stubbedEligibility, nil)
-        var completionCalled = false
+
         var eligibilities: [String: IntroEligibility]?
         trialOrIntroPriceEligibilityChecker!.sk1CheckEligibility([productId]) { (receivedEligibilities) in
-            completionCalled = true
             eligibilities = receivedEligibilities
         }
 
-        expect(completionCalled).toEventually(beTrue())
+        expect(eligibilities).toEventuallyNot(beNil())
+
         let receivedEligibilities = try XCTUnwrap(eligibilities)
-        expect(receivedEligibilities.count) == 1
+        expect(receivedEligibilities).to(haveCount(1))
         expect(receivedEligibilities[productId]?.status) == IntroEligibilityStatus.noIntroOfferExists
 
         expect(self.mockBackend.invokedGetIntroEligibilityCount) == 0
@@ -179,16 +178,15 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
         mockIntroEligibilityCalculator.stubbedCheckTrialOrIntroDiscountEligibilityResult = ([:], stubbedError)
 
         mockBackend.stubbedGetIntroEligibilityCompletionResult = ([:], stubbedError)
-        var completionCalled = false
+
         var eligibilities: [String: IntroEligibility]?
         trialOrIntroPriceEligibilityChecker!.sk1CheckEligibility([productId]) { (receivedEligibilities) in
-            completionCalled = true
             eligibilities = receivedEligibilities
         }
 
-        expect(completionCalled).toEventually(beTrue())
+        expect(eligibilities).toEventuallyNot(beNil())
         let receivedEligibilities = try XCTUnwrap(eligibilities)
-        expect(receivedEligibilities.count) == 1
+        expect(receivedEligibilities).to(haveCount(1))
         expect(receivedEligibilities[productId]?.status) == IntroEligibilityStatus.unknown
     }
 

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
@@ -91,17 +91,15 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
                         "com.revenuecat.annual_39.99.2_week_intro": IntroEligibilityStatus.eligible,
                         "lifetime": IntroEligibilityStatus.noIntroOfferExists]
 
-        var completionCalled = false
         var eligibilities: [String: IntroEligibility]?
         trialOrIntroPriceEligibilityChecker.checkEligibility(productIdentifiers: products) { receivedEligibilities in
-            completionCalled = true
             eligibilities = receivedEligibilities
         }
 
-        expect(completionCalled).toEventually(beTrue())
+        expect(eligibilities).toEventuallyNot(beNil())
 
         let receivedEligibilities = try XCTUnwrap(eligibilities)
-        expect(receivedEligibilities.count) == expected.count
+        expect(receivedEligibilities).to(haveCount(expected.count))
 
         for (product, receivedEligibility) in receivedEligibilities {
             expect(receivedEligibility.status) == expected[product]
@@ -123,17 +121,15 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
         mockProductsManager?.stubbedSk2StoreProductsThrowsError = true
 
-        var completionCalled = false
         var eligibilities: [String: IntroEligibility]?
         trialOrIntroPriceEligibilityChecker.checkEligibility(productIdentifiers: products) { receivedEligibilities in
-            completionCalled = true
             eligibilities = receivedEligibilities
         }
 
-        expect(completionCalled).toEventually(beTrue())
+        expect(eligibilities).toEventuallyNot(beNil())
 
         let receivedEligibilities = try XCTUnwrap(eligibilities)
-        expect(receivedEligibilities.count) == expected.count
+        expect(receivedEligibilities).to(haveCount(expected.count))
 
         for (product, receivedEligibility) in receivedEligibilities {
             expect(receivedEligibility.status) == expected[product]

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -90,16 +90,13 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         let mockError: BackendError = .missingAppUserID()
         mockBackend.stubbedGetCustomerInfoResult = .failure(mockError)
 
-        var completionCalled = false
         var receivedError: BackendError?
         customerInfoManager.fetchAndCacheCustomerInfo(appUserID: Self.appUserID,
                                                       isAppBackgrounded: false) { result in
-            completionCalled = true
             receivedError = result.error
         }
 
-        expect(completionCalled).toEventually(beTrue())
-
+        expect(receivedError).toEventuallyNot(beNil())
         expect(receivedError) == mockError
     }
 
@@ -121,20 +118,18 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         mockOperationDispatcher.shouldInvokeDispatchOnMainThreadBlock = true
         mockBackend.stubbedGetCustomerInfoResult = .success(mockCustomerInfo)
 
-        var completionCalled = false
         var receivedCustomerInfo: CustomerInfo?
 
         customerInfoManager.fetchAndCacheCustomerInfo(appUserID: Self.appUserID,
                                                       isAppBackgrounded: false) { result in
-            completionCalled = true
             receivedCustomerInfo = result.value
         }
-        expect(completionCalled).toEventually(beTrue())
-        expect(receivedCustomerInfo) == mockCustomerInfo
+        expect(receivedCustomerInfo).toEventuallyNot(beNil())
+        expect(receivedCustomerInfo) == self.mockCustomerInfo
 
         expect(self.mockDeviceCache.cacheCustomerInfoCount) == 1
         expect(self.customerInfoManagerChangesCallCount) == 1
-        expect(self.customerInfoManagerLastCustomerInfo) == mockCustomerInfo
+        expect(self.customerInfoManagerLastCustomerInfo) == self.mockCustomerInfo
     }
 
     func testFetchAndCacheCustomerInfoCallsCompletionOnMainThread() {
@@ -272,17 +267,15 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
     func testCustomerInfoReturnsFromCacheIfAvailable() {
         customerInfoManager.cache(customerInfo: mockCustomerInfo, appUserID: Self.appUserID)
 
-        var completionCalled = false
         var receivedCustomerInfo: CustomerInfo?
 
         customerInfoManager.customerInfo(appUserID: Self.appUserID, fetchPolicy: .default) { result in
-            completionCalled = true
             receivedCustomerInfo = result.value
         }
 
-        expect(completionCalled).toEventually(beTrue())
+        expect(receivedCustomerInfo).toEventuallyNot(beNil())
+        expect(receivedCustomerInfo) == self.mockCustomerInfo
         expect(self.mockBackend.invokedGetSubscriberDataCount) == 0
-        expect(receivedCustomerInfo) == mockCustomerInfo
     }
 
     func testCustomerInfoReturnsFromCacheAndRefreshesIfStale() {

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -250,27 +250,28 @@ class IdentityManagerTests: TestCase {
         let manager = create(appUserID: nil)
 
         mockDeviceCache.stubbedAppUserID = IdentityManager.generateRandomID()
-        var completionCalled = false
-        var receivedError: Error?
+
+        var receivedError: NSError?
         manager.logOut { error in
-            completionCalled = true
-            receivedError = error
+            receivedError = error as NSError?
         }
-        expect(completionCalled).toEventually(beTrue())
-        expect(receivedError).toNot(beNil())
-        expect((receivedError as NSError?)?.code) == ErrorCode.logOutAnonymousUserError.rawValue
+
+        expect(receivedError).toEventuallyNot(beNil())
+        expect(receivedError?.code) == ErrorCode.logOutAnonymousUserError.rawValue
     }
 
     func testLogOutCallsCompletionWithNoErrorIfSuccessful() {
         let manager = create(appUserID: nil)
 
         mockDeviceCache.stubbedAppUserID = "myUser"
+
         var completionCalled = false
         var receivedError: Error?
         manager.logOut { error in
-            completionCalled = true
             receivedError = error
+            completionCalled = true
         }
+
         expect(completionCalled).toEventually(beTrue())
         expect(receivedError).to(beNil())
     }

--- a/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
@@ -139,15 +139,13 @@ class BackendGetOfferingsTests: BaseBackendTests {
     }
 
     func testGetOfferingsCallsCompletionWithErrorIfAppUserIDIsEmpty() {
-        var completionCalled = false
         var receivedError: BackendError?
 
         backend.getOfferings(appUserID: "") { result in
-            completionCalled = true
             receivedError = result.error
         }
 
-        expect(completionCalled).toEventually(beTrue())
+        expect(receivedError).toEventuallyNot(beNil())
         expect(receivedError) == .missingAppUserID()
     }
 

--- a/Tests/UnitTests/Purchasing/IntroEligibilityCalculatorTests.swift
+++ b/Tests/UnitTests/Purchasing/IntroEligibilityCalculatorTests.swift
@@ -27,9 +27,9 @@ class IntroEligibilityCalculatorTests: TestCase {
         var completionCalled = false
         calculator.checkEligibility(with: Data(),
                                     productIdentifiers: Set()) { eligibilityByProductId, error in
-            completionCalled = true
             receivedError = error
             receivedEligibility = eligibilityByProductId
+            completionCalled = true
         }
 
         expect(completionCalled).toEventually(beTrue())
@@ -48,9 +48,9 @@ class IntroEligibilityCalculatorTests: TestCase {
 
         calculator.checkEligibility(with: Data(),
                                     productIdentifiers: productIdentifiers) { eligibilityByProductId, error in
-            completionCalled = true
             receivedError = error
             receivedEligibility = eligibilityByProductId
+            completionCalled = true
         }
 
         expect(completionCalled).toEventually(beTrue())
@@ -109,9 +109,9 @@ class IntroEligibilityCalculatorTests: TestCase {
 
         calculator.checkEligibility(with: Data(),
                                     productIdentifiers: Set(candidateIdentifiers)) { eligibility, error in
-            completionCalled = true
             receivedError = error
             receivedEligibility = eligibility
+            completionCalled = true
         }
 
         expect(completionCalled).toEventually(beTrue())
@@ -139,9 +139,9 @@ class IntroEligibilityCalculatorTests: TestCase {
 
         calculator.checkEligibility(with: Data(),
                                     productIdentifiers: Set(candidateIdentifiers)) { eligibility, error in
-            completionCalled = true
             receivedError = error
             receivedEligibility = eligibility
+            completionCalled = true
         }
 
         expect(completionCalled).toEventually(beTrue())
@@ -168,9 +168,9 @@ class IntroEligibilityCalculatorTests: TestCase {
 
         calculator.checkEligibility(with: Data(),
                                     productIdentifiers: Set(candidateIdentifiers)) { eligibility, error in
-            completionCalled = true
             receivedError = error
             receivedEligibility = eligibility
+            completionCalled = true
         }
 
         expect(completionCalled).toEventually(beTrue())

--- a/Tests/UnitTests/Purchasing/ProductsFetcherSK1Tests.swift
+++ b/Tests/UnitTests/Purchasing/ProductsFetcherSK1Tests.swift
@@ -28,16 +28,15 @@ class ProductsFetcherSK1Tests: TestCase {
     func testProductsWithIdentifiersCallsCompletionCorrectly() throws {
         let productIdentifiers = Set(["1", "2", "3"])
         var receivedProducts: Result<Set<SK1Product>, Error>?
-        var completionCalled = false
 
         productsFetcherSK1.sk1Products(withIdentifiers: productIdentifiers) { products in
-            completionCalled = true
             receivedProducts = products
         }
 
-        expect(completionCalled).toEventually(beTrue(), timeout: Self.defaultTimeoutInterval)
+        expect(receivedProducts).toEventuallyNot(beNil(), timeout: Self.defaultTimeoutInterval)
+
         let unwrappedProducts = try XCTUnwrap(receivedProducts?.get())
-        expect(unwrappedProducts.count) == productIdentifiers.count
+        expect(unwrappedProducts).to(haveCount(productIdentifiers.count))
         let receivedProductsSet = Set(unwrappedProducts.map { $0.productIdentifier })
         expect(receivedProductsSet) == productIdentifiers
     }
@@ -100,14 +99,13 @@ class ProductsFetcherSK1Tests: TestCase {
                                          requestTimeout: timeout.seconds)
 
         var receivedResult: Result<Set<SK1Product>, Error>?
-        var completionCalled = false
 
         fetcher.sk1Products(withIdentifiers: productIdentifiers) { result in
-            completionCalled = true
             receivedResult = result
         }
-        expect(completionCalled).toEventually(beTrue(), timeout: timeout + .seconds(1))
-        expect(receivedResult?.error).toNot(beNil())
+
+        expect(receivedResult).toEventuallyNot(beNil(), timeout: timeout + .seconds(1))
+        expect(receivedResult).to(beFailure())
     }
 
     func testCacheProductCachesCorrectly() {
@@ -122,13 +120,13 @@ class ProductsFetcherSK1Tests: TestCase {
         var receivedProducts: Result<Set<SK1Product>, Error>?
 
         productsFetcherSK1.sk1Products(withIdentifiers: productIdentifiers) { products in
-            completionCallCount += 1
             receivedProducts = products
+            completionCallCount += 1
         }
 
         expect(completionCallCount).toEventually(equal(1), timeout: Self.defaultTimeoutInterval)
         expect(self.productsRequestFactory.invokedRequestCount).toEventually(equal(0))
-        try expect(receivedProducts?.get()) == mockProducts
+        expect(try receivedProducts?.get()) == mockProducts
     }
 
     func testProductsWithIdentifiersTimesOutIfMaxToleranceExceeded() throws {
@@ -146,8 +144,8 @@ class ProductsFetcherSK1Tests: TestCase {
         var receivedResult: Result<Set<SKProduct>, Error>?
 
         productsFetcherSK1.sk1Products(withIdentifiers: productIdentifiers) { result in
-            completionCallCount += 1
             receivedResult = result
+            completionCallCount += 1
         }
 
         expect(completionCallCount).toEventually(equal(1),
@@ -174,8 +172,8 @@ class ProductsFetcherSK1Tests: TestCase {
         var receivedResult: Result<Set<SKProduct>, Error>?
 
         productsFetcherSK1.sk1Products(withIdentifiers: productIdentifiers) { result in
-            completionCallCount += 1
             receivedResult = result
+            completionCallCount += 1
         }
 
         expect(completionCallCount).toEventually(equal(1), timeout: tolerance + .milliseconds(10))

--- a/Tests/UnitTests/Purchasing/ReceiptFetcherTests.swift
+++ b/Tests/UnitTests/Purchasing/ReceiptFetcherTests.swift
@@ -36,105 +36,97 @@ class ReceiptFetcherTests: TestCase {
     }
 
     func testReceiptDataWithRefreshPolicyNeverReturnsReceiptData() {
-        var completionCalled = false
         var receivedData: Data?
-        receiptFetcher.receiptData(refreshPolicy: .never) { data in
-            completionCalled = true
+        self.receiptFetcher.receiptData(refreshPolicy: .never) { data in
             receivedData = data
         }
-        expect(completionCalled).toEventually(beTrue())
-        expect(receivedData).toNot(beNil())
+
+        expect(receivedData).toEventuallyNot(beNil())
     }
 
     func testReceiptDataWithRefreshPolicyOnlyIfEmptyReturnsReceiptData() {
-        var completionCalled = false
         var receivedData: Data?
-        receiptFetcher.receiptData(refreshPolicy: .onlyIfEmpty) { data in
-            completionCalled = true
+        self.receiptFetcher.receiptData(refreshPolicy: .onlyIfEmpty) { data in
             receivedData = data
         }
-        expect(completionCalled).toEventually(beTrue())
-        expect(receivedData).toNot(beNil())
+
+        expect(receivedData).toEventuallyNot(beNil())
     }
 
     func testReceiptDataWithRefreshPolicyAlwaysReturnsReceiptData() {
-        var completionCalled = false
         var receivedData: Data?
-        receiptFetcher.receiptData(refreshPolicy: .always) { data in
-            completionCalled = true
+        self.receiptFetcher.receiptData(refreshPolicy: .always) { data in
             receivedData = data
         }
-        expect(completionCalled).toEventually(beTrue())
-        expect(receivedData).toNot(beNil())
+
+        expect(receivedData).toEventuallyNot(beNil())
     }
 
     func testReceiptDataWithRefreshPolicyNeverDoesntRefreshIfEmpty() {
-        var completionCalled = false
         mockBundle.receiptURLResult = .emptyReceipt
+
+        var completionCalled = false
         var receivedData: Data?
         receiptFetcher.receiptData(refreshPolicy: .never) { data in
-            completionCalled = true
             receivedData = data
+            completionCalled = true
         }
+
         expect(completionCalled).toEventually(beTrue())
         expect(self.mockRequestFetcher.refreshReceiptCalled) == false
         expect(receivedData).to(beNil())
     }
 
     func testReceiptDataWithRefreshPolicyOnlyIfEmptyRefreshesIfEmpty() {
-        var completionCalled = false
         mockBundle.receiptURLResult = .emptyReceipt
+
         var receivedData: Data?
         receiptFetcher.receiptData(refreshPolicy: .onlyIfEmpty) { data in
-            completionCalled = true
             receivedData = data
         }
-        expect(completionCalled).toEventually(beTrue())
-        expect(self.mockRequestFetcher.refreshReceiptCalled) == true
-        expect(receivedData).toNot(beNil())
+
+        expect(receivedData).toEventuallyNot(beNil())
         expect(receivedData).to(beEmpty())
+        expect(self.mockRequestFetcher.refreshReceiptCalled) == true
     }
 
     func testReceiptDataWithRefreshPolicyOnlyIfEmptyRefreshesIfNil() {
-        var completionCalled = false
         mockBundle.receiptURLResult = .nilURL
+
         var receivedData: Data?
         receiptFetcher.receiptData(refreshPolicy: .onlyIfEmpty) { data in
-            completionCalled = true
             receivedData = data
         }
-        expect(completionCalled).toEventually(beTrue())
-        expect(self.mockRequestFetcher.refreshReceiptCalled) == true
-        expect(receivedData).toNot(beNil())
+
+        expect(receivedData).toEventuallyNot(beNil())
         expect(receivedData).to(beEmpty())
+        expect(self.mockRequestFetcher.refreshReceiptCalled) == true
     }
 
     func testReceiptDataWithRefreshPolicyOnlyIfEmptyDoesntRefreshIfTheresData() {
-        var completionCalled = false
         mockBundle.receiptURLResult = .receiptWithData
+
         var receivedData: Data?
         receiptFetcher.receiptData(refreshPolicy: .onlyIfEmpty) { data in
-            completionCalled = true
             receivedData = data
         }
-        expect(completionCalled).toEventually(beTrue())
-        expect(self.mockRequestFetcher.refreshReceiptCalled) == false
-        expect(receivedData).toNot(beNil())
+
+        expect(receivedData).toEventuallyNot(beNil())
         expect(receivedData).toNot(beEmpty())
+        expect(self.mockRequestFetcher.refreshReceiptCalled) == false
     }
 
     func testReceiptDataWithRefreshPolicyAlwaysRefreshesEvenIfTheresData() {
-        var completionCalled = false
         mockBundle.receiptURLResult = .receiptWithData
+
         var receivedData: Data?
         receiptFetcher.receiptData(refreshPolicy: .always) { data in
-            completionCalled = true
             receivedData = data
         }
-        expect(completionCalled).toEventually(beTrue())
-        expect(self.mockRequestFetcher.refreshReceiptCalled) == true
-        expect(receivedData).toNot(beNil())
+
+        expect(receivedData).toEventuallyNot(beNil())
         expect(receivedData).toNot(beEmpty())
+        expect(receivedData).toNot(beNil())
     }
 
 }


### PR DESCRIPTION
Thanks @taquitos for finding this.

Our existing use as illustrated in the diff could lead to race conditions, because the `completionCalled.toEventually(beTrue())` would potentially evaluate before the next line, leading to flaky tests.