### PR TITLE
Use xcode 14 for docs generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -478,5 +478,5 @@ workflows:
           xcode_version: '13.3.1'
           <<: *release-tags
       - docs-deploy:
-          xcode_version: '13.3.1'
+          xcode_version: '14.0.0'
           <<: *release-tags


### PR DESCRIPTION
Updated to use Xcode 14 for docs generation, so we get: 
- A navigation side bar
- Obj-C APIs in the docs
- Search bar
I tried running it manually with Xcode 14 and it looks stable enough:

https://revenuecat.github.io/purchases-ios-docs/4.6.0/documentation/revenuecat/

Although the language selector doesn't work just yet 😅 
Still, it'll hopefully start working in future betas. 