### PR TITLE
Fixed usages of `seealso`

### DIFF
--- a/Sources/Purchasing/EntitlementInfos.swift
+++ b/Sources/Purchasing/EntitlementInfos.swift
@@ -75,7 +75,9 @@ public extension EntitlementInfos {
 
     /// Dictionary of active ``EntitlementInfo`` objects keyed by their identifiers.
     /// - Warning: this is equivalent to ``activeInAnyEnvironment``
-    /// - Seealso: ``activeInCurrentEnvironment``
+    ///
+    /// #### Related Symbols
+    /// - ``activeInCurrentEnvironment``
     @objc var active: [String: EntitlementInfo] {
         return self.activeInAnyEnvironment
     }
@@ -83,7 +85,9 @@ public extension EntitlementInfos {
     /// Dictionary of active ``EntitlementInfo`` objects keyed by their identifiers.
     /// - Note: When queried from the sandbox environment, it only returns entitlements active in sandbox.
     /// When queried from production, this only returns entitlements active in production.
-    /// - Seealso: ``activeInAnyEnvironment``
+    ///
+    /// #### Related Symbols
+    /// - ``activeInAnyEnvironment``
     @objc var activeInCurrentEnvironment: [String: EntitlementInfo] {
         return self.activeInAnyEnvironment.filter { [isSandbox = self.sandboxEnvironmentDetector.isSandbox] in
             $0.value.isSandbox == isSandbox
@@ -92,7 +96,9 @@ public extension EntitlementInfos {
 
     /// Dictionary of active ``EntitlementInfo`` objects keyed by their identifiers.
     /// - Note: these can be active on any environment.
-    /// - Seealso: ``activeInCurrentEnvironment``
+    ///
+    /// #### Related Symbols
+    /// - ``activeInCurrentEnvironment``
     @objc var activeInAnyEnvironment: [String: EntitlementInfo] {
         return self.all.filter { $0.value.isActive }
     }

--- a/Sources/Purchasing/Offering.swift
+++ b/Sources/Purchasing/Offering.swift
@@ -103,7 +103,8 @@ import Foundation
             .first
     }
 
-    /// - Seealso: ``package(identifier:)``
+    /// #### Related Symbols
+    /// - ``package(identifier:)``
     @objc public subscript(key: String) -> Package? {
         return package(identifier: key)
     }

--- a/Sources/Purchasing/Offerings.swift
+++ b/Sources/Purchasing/Offerings.swift
@@ -60,7 +60,8 @@ import Foundation
         return all[identifier]
     }
 
-    /// - Seealso: ``offering(identifier:)``
+    /// #### Related Symbols
+    /// - ``offering(identifier:)``
     @objc public subscript(key: String) -> Offering? {
         return offering(identifier: key)
     }

--- a/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -129,7 +129,9 @@ internal protocol StoreProductType {
 
     /// The decimal representation of the cost of the product, in local currency.
     /// For a string representation of the price to display to customers, use ``localizedPriceString``.
-    /// - SeeAlso: ``pricePerMonth``.
+    ///
+    /// #### Related Symbols
+    /// - ``pricePerMonth``
     var price: Decimal { get }
 
     /// The price of this product using ``priceFormatter``.
@@ -146,7 +148,9 @@ internal protocol StoreProductType {
     ///
     /// Configure your in-app purchases to allow Family Sharing in App Store Connect.
     /// For more information about setting up Family Sharing, see Turn-on Family Sharing for in-app purchases.
-    /// - SeeAlso: https://support.apple.com/en-us/HT201079
+    ///
+    /// #### Related Articles
+    /// - https://support.apple.com/en-us/HT201079
     @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 8.0, *)
     var isFamilyShareable: Bool { get }
 
@@ -195,7 +199,9 @@ public extension StoreProduct {
     /// The decimal representation of the cost of the product, in local currency.
     /// For a string representation of the price to display to customers, use ``localizedPriceString``.
     /// - Note: this is meant for  Objective-C. For Swift, use ``price`` instead.
-    /// - SeeAlso: ``pricePerMonth``.
+    ///
+    /// #### Related Symbols
+    /// - ``pricePerMonth``
     @objc(price) var priceDecimalNumber: NSDecimalNumber {
         return self.price as NSDecimalNumber
     }


### PR DESCRIPTION
That's not supported by docC, so replaced with `Related Symbols` and `Related Articles`