### PR TITLE
Extract Backend dependencies into a BackendConfiguration object

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -390,6 +390,7 @@
 		B36824BF268FBC8700957E4C /* SubscriberAttributeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8DB34A24072AAE00BE3D31 /* SubscriberAttributeTests.swift */; };
 		B372EC54268FEDC60099171E /* StoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = B372EC53268FEDC60099171E /* StoreProductDiscount.swift */; };
 		B372EC56268FEF020099171E /* ProductRequestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = B372EC55268FEF020099171E /* ProductRequestData.swift */; };
+		B37815492857F1E7000A7B93 /* BackendConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37815482857F1E7000A7B93 /* BackendConfiguration.swift */; };
 		B380D69B27726AB500984578 /* DNSCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B380D69A27726AB500984578 /* DNSCheckerTests.swift */; };
 		B3852FA026C1ED1F005384F8 /* IdentityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3852F9F26C1ED1F005384F8 /* IdentityManager.swift */; };
 		B390F5BA271DDC7400B64D65 /* PurchasesDeprecation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B390F5B9271DDC7400B64D65 /* PurchasesDeprecation.swift */; };
@@ -851,6 +852,7 @@
 		B36824BD268FBC5B00957E4C /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		B372EC53268FEDC60099171E /* StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProductDiscount.swift; sourceTree = "<group>"; };
 		B372EC55268FEF020099171E /* ProductRequestData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRequestData.swift; sourceTree = "<group>"; };
+		B37815482857F1E7000A7B93 /* BackendConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendConfiguration.swift; sourceTree = "<group>"; };
 		B380D69A27726AB500984578 /* DNSCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DNSCheckerTests.swift; sourceTree = "<group>"; };
 		B3852F9F26C1ED1F005384F8 /* IdentityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityManager.swift; sourceTree = "<group>"; };
 		B390F5B9271DDC7400B64D65 /* PurchasesDeprecation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesDeprecation.swift; sourceTree = "<group>"; };
@@ -1517,6 +1519,7 @@
 				B34605AA279A6E380031CA74 /* Operations */,
 				57D5412C27F63108004CC35C /* Responses */,
 				B3C4AAD426B8911300E1B3C8 /* Backend.swift */,
+				B37815482857F1E7000A7B93 /* BackendConfiguration.swift */,
 				B3F3E8D9277158FE0047A5B9 /* DNSChecker.swift */,
 				35D832CC262A5B7500E60AC5 /* ETagManager.swift */,
 				35F82BB326A9A74D0051DF03 /* HTTPClient.swift */,
@@ -2394,6 +2397,7 @@
 				B34605BE279A6E380031CA74 /* OfferingsCallback.swift in Sources */,
 				B34605BF279A6E380031CA74 /* LogInCallback.swift in Sources */,
 				9A65DFDE258AD60A00DE00B0 /* LogIntent.swift in Sources */,
+				B37815492857F1E7000A7B93 /* BackendConfiguration.swift in Sources */,
 				B35042C626CDD3B100905B95 /* PurchasesDelegate.swift in Sources */,
 				0313FD41268A506400168386 /* DateProvider.swift in Sources */,
 				57FDAABA284937A0009A48F1 /* SandboxEnvironmentDetector.swift in Sources */,

--- a/Sources/Error Handling/ErrorCode.swift
+++ b/Sources/Error Handling/ErrorCode.swift
@@ -62,6 +62,21 @@ import Foundation
 
 }
 
+extension ErrorCode {
+
+    /**
+     * When an ErrorCode has been deprecated and then removed, add it to the reserved list so that we do not
+     * accidentally reuse it. For example:
+     * `@objc(RCMissingAppUserIDForAliasCreationError) case missingAppUserIDForAliasCreationError = 27` was removed,
+     * so we add its rawValue of `27` to the `reservedRawValues` array. That way our unit tests will catch if we
+     * accidentally add `27` back into the enumeration.
+     */
+    static var reservedRawValues: Set<RawValue> {
+        return [27]
+    }
+
+}
+
 extension ErrorCode: CaseIterable { }
 
 extension ErrorCode: DescribableError {

--- a/Sources/Error Handling/ErrorCode.swift
+++ b/Sources/Error Handling/ErrorCode.swift
@@ -62,21 +62,6 @@ import Foundation
 
 }
 
-extension ErrorCode {
-
-    /**
-     * When an ErrorCode has been deprecated and then removed, add it to the reserved list so that we do not
-     * accidentally reuse it. For example:
-     * `@objc(RCMissingAppUserIDForAliasCreationError) case missingAppUserIDForAliasCreationError = 27` was removed,
-     * so we add its rawValue of `27` to the `reservedRawValues` array. That way our unit tests will catch if we
-     * accidentally add `27` back into the enumeration.
-     */
-    static var reservedRawValues: Set<RawValue> {
-        return [27]
-    }
-
-}
-
 extension ErrorCode: CaseIterable { }
 
 extension ErrorCode: DescribableError {

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -35,12 +35,11 @@ class Backend {
                      eTagManager: ETagManager,
                      attributionFetcher: AttributionFetcher,
                      dateProvider: DateProvider = DateProvider()) {
-        let httpClient = HTTPClient(systemInfo: systemInfo,
+        let httpClient = HTTPClient(apiKey: apiKey,
+                                    systemInfo: systemInfo,
                                     eTagManager: eTagManager,
                                     requestTimeout: httpClientTimeout)
-        let config = BackendConfiguration(apiKey: apiKey,
-                                          authHeaders: HTTPClient.authorizationHeader(withAPIKey: apiKey),
-                                          httpClient: httpClient,
+        let config = BackendConfiguration(httpClient: httpClient,
                                           operationQueue: QueueProvider.queue,
                                           dateProvider: dateProvider)
         self.init(backendConfig: config, attributionFetcher: attributionFetcher)
@@ -101,7 +100,6 @@ class Backend {
               appUserID: String,
               completion: @escaping OfferSigningResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.config.httpClient,
-                                                                authHeaders: self.config.authHeaders,
                                                                 appUserID: appUserID)
 
         let postOfferData = PostOfferForSigningOperation.PostOfferForSigningData(offerIdentifier: offerIdentifier,
@@ -119,7 +117,6 @@ class Backend {
               appUserID: String,
               completion: SimpleResponseHandler?) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.config.httpClient,
-                                                                authHeaders: self.config.authHeaders,
                                                                 appUserID: appUserID)
         let postAttributionDataOperation = PostAttributionDataOperation(configuration: config,
                                                                         attributionData: attributionData,
@@ -132,7 +129,6 @@ class Backend {
                newAppUserID: String,
                completion: @escaping LogInResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.config.httpClient,
-                                                                authHeaders: self.config.authHeaders,
                                                                 appUserID: currentAppUserID)
         let loginOperation = LogInOperation(configuration: config,
                                             newAppUserID: newAppUserID,
@@ -146,7 +142,6 @@ class Backend {
 
     func getOfferings(appUserID: String, completion: @escaping OfferingsResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.config.httpClient,
-                                                                authHeaders: self.config.authHeaders,
                                                                 appUserID: appUserID)
         let getOfferingsOperation = GetOfferingsOperation(configuration: config,
                                                           offeringsCallbackCache: self.offeringsCallbacksCache)
@@ -162,7 +157,6 @@ class Backend {
                              productIdentifiers: [String],
                              completion: @escaping IntroEligibilityResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.config.httpClient,
-                                                                authHeaders: self.config.authHeaders,
                                                                 appUserID: appUserID)
         let getIntroEligibilityOperation = GetIntroEligibilityOperation(configuration: config,
                                                                         receiptData: receiptData,

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -24,15 +24,10 @@ class Backend {
     typealias SimpleResponseHandler = (BackendError?) -> Void
     typealias LogInResponseHandler = (Result<(info: CustomerInfo, created: Bool), BackendError>) -> Void
 
-    private let apiKey: String
-    private let authHeaders: [String: String]
-    private let httpClient: HTTPClient
+    private let config: BackendConfiguration
     private let subscribersAPI: SubscribersAPI
-    private let operationQueue: OperationQueue
-
     private let logInCallbacksCache: CallbackCache<LogInCallback>
     private let offeringsCallbacksCache: CallbackCache<OfferingsCallback>
-    private let callbackQueue = DispatchQueue(label: "Backend callbackQueue")
 
     convenience init(apiKey: String,
                      systemInfo: SystemInfo,
@@ -43,37 +38,28 @@ class Backend {
         let httpClient = HTTPClient(systemInfo: systemInfo,
                                     eTagManager: eTagManager,
                                     requestTimeout: httpClientTimeout)
-        self.init(httpClient: httpClient,
-                  apiKey: apiKey,
-                  attributionFetcher: attributionFetcher,
-                  dateProvider: dateProvider)
+        let config = BackendConfiguration(apiKey: apiKey,
+                                          authHeaders: HTTPClient.authorizationHeader(withAPIKey: apiKey),
+                                          httpClient: httpClient,
+                                          operationQueue: QueueProvider.queue,
+                                          dateProvider: dateProvider)
+        self.init(backendConfig: config, attributionFetcher: attributionFetcher)
     }
 
-    required init(httpClient: HTTPClient,
-                  apiKey: String,
-                  attributionFetcher: AttributionFetcher,
-                  dateProvider: DateProvider = DateProvider()) {
-        self.operationQueue = OperationQueue()
-        self.operationQueue.name = "Backend Queue"
-        self.operationQueue.maxConcurrentOperationCount = 1
+    required init(backendConfig: BackendConfiguration,
+                  attributionFetcher: AttributionFetcher) {
+        self.config = backendConfig
+        self.offeringsCallbacksCache = CallbackCache<OfferingsCallback>(callbackQueue: self.config.callbackQueue)
+        self.logInCallbacksCache = CallbackCache<LogInCallback>(callbackQueue: self.config.callbackQueue)
 
-        self.httpClient = httpClient
-        self.apiKey = apiKey
-        self.offeringsCallbacksCache = CallbackCache<OfferingsCallback>(callbackQueue: self.callbackQueue)
-        self.logInCallbacksCache = CallbackCache<LogInCallback>(callbackQueue: self.callbackQueue)
-        self.authHeaders = HTTPClient.authorizationHeader(withAPIKey: apiKey)
-
-        let customerInfoCallbackCache = CallbackCache<CustomerInfoCallback>(callbackQueue: callbackQueue)
-        self.subscribersAPI = SubscribersAPI(httpClient: httpClient,
+        let customerInfoCallbackCache = CallbackCache<CustomerInfoCallback>(callbackQueue: self.config.callbackQueue)
+        self.subscribersAPI = SubscribersAPI(backendConfig: self.config,
                                              attributionFetcher: attributionFetcher,
-                                             authHeaders: self.authHeaders,
-                                             operationQueue: self.operationQueue,
-                                             customerInfoCallbackCache: customerInfoCallbackCache,
-                                             dateProvider: dateProvider)
+                                             customerInfoCallbackCache: customerInfoCallbackCache)
     }
 
     func clearHTTPClientCaches() {
-        self.httpClient.clearCaches()
+        self.config.clearCache()
     }
 
     func getCustomerInfo(appUserID: String, completion: @escaping CustomerInfoResponseHandler) {
@@ -114,8 +100,8 @@ class Backend {
               receiptData: Data,
               appUserID: String,
               completion: @escaping OfferSigningResponseHandler) {
-        let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.httpClient,
-                                                                authHeaders: self.authHeaders,
+        let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.config.httpClient,
+                                                                authHeaders: self.config.authHeaders,
                                                                 appUserID: appUserID)
 
         let postOfferData = PostOfferForSigningOperation.PostOfferForSigningData(offerIdentifier: offerIdentifier,
@@ -125,28 +111,28 @@ class Backend {
         let postOfferForSigningOperation = PostOfferForSigningOperation(configuration: config,
                                                                         postOfferForSigningData: postOfferData,
                                                                         responseHandler: completion)
-        self.operationQueue.addOperation(postOfferForSigningOperation)
+        self.config.operationQueue.addOperation(postOfferForSigningOperation)
     }
 
     func post(attributionData: [String: Any],
               network: AttributionNetwork,
               appUserID: String,
               completion: SimpleResponseHandler?) {
-        let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.httpClient,
-                                                                authHeaders: self.authHeaders,
+        let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.config.httpClient,
+                                                                authHeaders: self.config.authHeaders,
                                                                 appUserID: appUserID)
         let postAttributionDataOperation = PostAttributionDataOperation(configuration: config,
                                                                         attributionData: attributionData,
                                                                         network: network,
                                                                         responseHandler: completion)
-        self.operationQueue.addOperation(postAttributionDataOperation)
+        self.config.operationQueue.addOperation(postAttributionDataOperation)
     }
 
     func logIn(currentAppUserID: String,
                newAppUserID: String,
                completion: @escaping LogInResponseHandler) {
-        let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.httpClient,
-                                                                authHeaders: self.authHeaders,
+        let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.config.httpClient,
+                                                                authHeaders: self.config.authHeaders,
                                                                 appUserID: currentAppUserID)
         let loginOperation = LogInOperation(configuration: config,
                                             newAppUserID: newAppUserID,
@@ -155,12 +141,12 @@ class Backend {
         let loginCallback = LogInCallback(cacheKey: loginOperation.cacheKey, completion: completion)
         let cacheStatus = self.logInCallbacksCache.add(callback: loginCallback)
 
-        self.operationQueue.addCacheableOperation(loginOperation, cacheStatus: cacheStatus)
+        self.config.operationQueue.addCacheableOperation(loginOperation, cacheStatus: cacheStatus)
     }
 
     func getOfferings(appUserID: String, completion: @escaping OfferingsResponseHandler) {
-        let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.httpClient,
-                                                                authHeaders: self.authHeaders,
+        let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.config.httpClient,
+                                                                authHeaders: self.config.authHeaders,
                                                                 appUserID: appUserID)
         let getOfferingsOperation = GetOfferingsOperation(configuration: config,
                                                           offeringsCallbackCache: self.offeringsCallbacksCache)
@@ -168,21 +154,36 @@ class Backend {
         let offeringsCallback = OfferingsCallback(cacheKey: getOfferingsOperation.cacheKey, completion: completion)
         let cacheStatus = self.offeringsCallbacksCache.add(callback: offeringsCallback)
 
-        self.operationQueue.addCacheableOperation(getOfferingsOperation, cacheStatus: cacheStatus)
+        self.config.operationQueue.addCacheableOperation(getOfferingsOperation, cacheStatus: cacheStatus)
     }
 
     func getIntroEligibility(appUserID: String,
                              receiptData: Data,
                              productIdentifiers: [String],
                              completion: @escaping IntroEligibilityResponseHandler) {
-        let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.httpClient,
-                                                                authHeaders: self.authHeaders,
+        let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.config.httpClient,
+                                                                authHeaders: self.config.authHeaders,
                                                                 appUserID: appUserID)
         let getIntroEligibilityOperation = GetIntroEligibilityOperation(configuration: config,
                                                                         receiptData: receiptData,
                                                                         productIdentifiers: productIdentifiers,
                                                                         responseHandler: completion)
-        self.operationQueue.addOperation(getIntroEligibilityOperation)
+        self.config.operationQueue.addOperation(getIntroEligibilityOperation)
+    }
+
+}
+
+extension Backend {
+
+    enum QueueProvider {
+
+        static var queue: OperationQueue {
+            let operationQueue = OperationQueue()
+            operationQueue.name = "Backend Queue"
+            operationQueue.maxConcurrentOperationCount = 1
+            return operationQueue
+        }
+
     }
 
 }
@@ -191,7 +192,7 @@ class Backend {
 extension Backend {
 
     var networkTimeout: TimeInterval {
-        return self.httpClient.timeout
+        return self.config.httpClient.timeout
     }
 
 }

--- a/Sources/Networking/BackendConfiguration.swift
+++ b/Sources/Networking/BackendConfiguration.swift
@@ -15,22 +15,16 @@ import Foundation
 
 class BackendConfiguration {
 
-    let apiKey: String
-    let authHeaders: [String: String]
     let httpClient: HTTPClient
 
     let callbackQueue: DispatchQueue
     let operationQueue: OperationQueue
     let dateProvider: DateProvider
 
-    init(apiKey: String,
-         authHeaders: [String: String],
-         httpClient: HTTPClient,
+    init(httpClient: HTTPClient,
          operationQueue: OperationQueue,
          callbackQueue: DispatchQueue = DispatchQueue(label: "Backend callbackQueue"),
          dateProvider: DateProvider = DateProvider()) {
-        self.apiKey = apiKey
-        self.authHeaders = authHeaders
         self.httpClient = httpClient
         self.operationQueue = operationQueue
         self.callbackQueue = callbackQueue

--- a/Sources/Networking/BackendConfiguration.swift
+++ b/Sources/Networking/BackendConfiguration.swift
@@ -1,0 +1,44 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  BackendConfiguration.swift
+//
+//  Created by Joshua Liebowitz on 6/13/22.
+
+import Foundation
+
+class BackendConfiguration {
+
+    let apiKey: String
+    let authHeaders: [String: String]
+    let httpClient: HTTPClient
+
+    let callbackQueue: DispatchQueue
+    let operationQueue: OperationQueue
+    let dateProvider: DateProvider
+
+    init(apiKey: String,
+         authHeaders: [String: String],
+         httpClient: HTTPClient,
+         operationQueue: OperationQueue,
+         callbackQueue: DispatchQueue = DispatchQueue(label: "Backend callbackQueue"),
+         dateProvider: DateProvider = DateProvider()) {
+        self.apiKey = apiKey
+        self.authHeaders = authHeaders
+        self.httpClient = httpClient
+        self.operationQueue = operationQueue
+        self.callbackQueue = callbackQueue
+        self.dateProvider = dateProvider
+    }
+
+    func clearCache() {
+        self.httpClient.clearCaches()
+    }
+
+}

--- a/Sources/Networking/Operations/GetCustomerInfoOperation.swift
+++ b/Sources/Networking/Operations/GetCustomerInfoOperation.swift
@@ -61,10 +61,7 @@ private extension GetCustomerInfoOperation {
         let request = HTTPRequest(method: .get,
                                   path: .getCustomerInfo(appUserID: appUserID))
 
-        httpClient.perform(
-            request,
-            authHeaders: self.authHeaders
-        ) { (response: HTTPResponse<CustomerInfoResponseHandler.Response>.Result) in
+        httpClient.perform(request) { (response: HTTPResponse<CustomerInfoResponseHandler.Response>.Result) in
             self.customerInfoCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 self.customerInfoResponseHandler.handle(customerInfoResponse: response,
                                                         completion: callback.completion)

--- a/Sources/Networking/Operations/GetIntroEligibilityOperation.swift
+++ b/Sources/Networking/Operations/GetIntroEligibilityOperation.swift
@@ -75,7 +75,7 @@ private extension GetIntroEligibilityOperation {
                                   path: .getIntroEligibility(appUserID: appUserID))
 
         httpClient.perform(
-            request, authHeaders: self.authHeaders
+            request
         ) { (response: HTTPResponse<GetIntroEligibilityResponse>.Result) in
             self.handleIntroEligibility(result: response,
                                         productIdentifiers: self.productIdentifiers,

--- a/Sources/Networking/Operations/GetOfferingsOperation.swift
+++ b/Sources/Networking/Operations/GetOfferingsOperation.swift
@@ -46,8 +46,7 @@ private extension GetOfferingsOperation {
 
         let request = HTTPRequest(method: .get, path: .getOfferings(appUserID: appUserID))
 
-        httpClient.perform(request,
-                           authHeaders: self.authHeaders) { (response: HTTPResponse<OfferingsResponse>.Result) in
+        httpClient.perform(request) { (response: HTTPResponse<OfferingsResponse>.Result) in
             defer {
                 completion()
             }

--- a/Sources/Networking/Operations/LogInOperation.swift
+++ b/Sources/Networking/Operations/LogInOperation.swift
@@ -51,8 +51,7 @@ private extension LogInOperation {
                                                      newAppUserID: newAppUserID)),
                                   path: .logIn)
 
-        self.httpClient.perform(request,
-                                authHeaders: self.authHeaders) { (response: HTTPResponse<CustomerInfo>.Result) in
+        self.httpClient.perform(request) { (response: HTTPResponse<CustomerInfo>.Result) in
             self.loginCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callbackObject in
                 self.handleLogin(response, completion: callbackObject.completion)
             }

--- a/Sources/Networking/Operations/NetworkOperation.swift
+++ b/Sources/Networking/Operations/NetworkOperation.swift
@@ -35,7 +35,6 @@ class CacheableNetworkOperation: NetworkOperation, CacheKeyProviding {
 class NetworkOperation: Operation {
 
     let httpClient: HTTPClient
-    let authHeaders: [String: String]
 
     private var _isExecuting: Atomic<Bool> = .init(false)
     private(set) override final var isExecuting: Bool {
@@ -75,7 +74,6 @@ class NetworkOperation: Operation {
 
     init(configuration: NetworkConfiguration) {
         self.httpClient = configuration.httpClient
-        self.authHeaders = configuration.authHeaders
 
         super.init()
     }
@@ -136,14 +134,12 @@ class NetworkOperation: Operation {
     struct Configuration: NetworkConfiguration {
 
         let httpClient: HTTPClient
-        let authHeaders: [String: String]
 
     }
 
     struct UserSpecificConfiguration: AppUserConfiguration, NetworkConfiguration {
 
         let httpClient: HTTPClient
-        let authHeaders: [String: String]
         let appUserID: String
 
     }
@@ -159,6 +155,5 @@ protocol AppUserConfiguration {
 protocol NetworkConfiguration {
 
     var httpClient: HTTPClient { get }
-    var authHeaders: [String: String] { get }
 
 }

--- a/Sources/Networking/Operations/PostAttributionDataOperation.swift
+++ b/Sources/Networking/Operations/PostAttributionDataOperation.swift
@@ -47,10 +47,7 @@ class PostAttributionDataOperation: NetworkOperation {
         let request = HTTPRequest(method: .post(Body(network: self.network, attributionData: self.attributionData)),
                                   path: .postAttributionData(appUserID: appUserID))
 
-        self.httpClient.perform(
-            request,
-            authHeaders: self.authHeaders
-        ) { (response: HTTPResponse<HTTPEmptyResponseBody>.Result) in
+        self.httpClient.perform(request) { (response: HTTPResponse<HTTPEmptyResponseBody>.Result) in
             defer {
                 completion()
             }

--- a/Sources/Networking/Operations/PostOfferForSigningOperation.swift
+++ b/Sources/Networking/Operations/PostOfferForSigningOperation.swift
@@ -50,8 +50,7 @@ class PostOfferForSigningOperation: NetworkOperation {
             path: .postOfferForSigning
         )
 
-        self.httpClient.perform(request,
-                                authHeaders: self.authHeaders) { (response: HTTPResponse<PostOfferResponse>.Result) in
+        self.httpClient.perform(request) { (response: HTTPResponse<PostOfferResponse>.Result) in
             let result: Result<PostOfferForSigningOperation.SigningData, BackendError> = response
                 .mapError { error -> BackendError in
                     if case .decoding = error {

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -59,10 +59,7 @@ class PostReceiptDataOperation: CacheableNetworkOperation {
     private func post(completion: @escaping () -> Void) {
         let request = HTTPRequest(method: .post(self.postData), path: .postReceiptData)
 
-        httpClient.perform(
-            request,
-            authHeaders: self.authHeaders
-        ) { (response: HTTPResponse<CustomerInfoResponseHandler.Response>.Result) in
+        httpClient.perform(request) { (response: HTTPResponse<CustomerInfoResponseHandler.Response>.Result) in
             self.customerInfoCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callbackObject in
                 self.customerInfoResponseHandler.handle(customerInfoResponse: response,
                                                         completion: callbackObject.completion)

--- a/Sources/Networking/Operations/PostSubscriberAttributesOperation.swift
+++ b/Sources/Networking/Operations/PostSubscriberAttributesOperation.swift
@@ -51,8 +51,7 @@ class PostSubscriberAttributesOperation: NetworkOperation {
         let request = HTTPRequest(method: .post(Body(self.subscriberAttributes)),
                                   path: .postSubscriberAttributes(appUserID: appUserID))
 
-        httpClient.perform(request,
-                           authHeaders: self.authHeaders) { (response: HTTPResponse<HTTPEmptyResponseBody>.Result) in
+        httpClient.perform(request) { (response: HTTPResponse<HTTPEmptyResponseBody>.Result) in
             defer {
                 completion()
             }

--- a/Sources/Networking/SubscribersAPI.swift
+++ b/Sources/Networking/SubscribersAPI.swift
@@ -29,7 +29,6 @@ class SubscribersAPI {
 
     func getCustomerInfo(appUserID: String, completion: @escaping Backend.CustomerInfoResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
-                                                                authHeaders: self.backendConfig.authHeaders,
                                                                 appUserID: appUserID)
 
         let operation = GetCustomerInfoOperation(configuration: config,
@@ -44,7 +43,6 @@ class SubscribersAPI {
               appUserID: String,
               completion: Backend.SimpleResponseHandler?) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
-                                                                authHeaders: self.backendConfig.authHeaders,
                                                                 appUserID: appUserID)
         let operation = PostSubscriberAttributesOperation(configuration: config,
                                                           subscriberAttributes: subscriberAttributes,
@@ -69,7 +67,6 @@ class SubscribersAPI {
         subscriberAttributesByKey[ReservedSubscriberAttribute.consentStatus.key] = consentStatus
 
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
-                                                                authHeaders: self.backendConfig.authHeaders,
                                                                 appUserID: appUserID)
 
         let postData = PostReceiptDataOperation.PostData(appUserID: appUserID,

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -35,11 +35,11 @@ class MockBackend: Backend {
         let attributionFetcher = AttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
                                                     systemInfo: systemInfo)
         let mockAPIKey = "mockAPIKey"
-        let httpClient = MockHTTPClient(systemInfo: systemInfo, eTagManager: MockETagManager(), requestTimeout: 7)
-        let authHeaders = MockHTTPClient.authorizationHeader(withAPIKey: mockAPIKey)
-        let backendConfig = BackendConfiguration(apiKey: mockAPIKey,
-                                                 authHeaders: authHeaders,
-                                                 httpClient: httpClient,
+        let httpClient = MockHTTPClient(apiKey: mockAPIKey,
+                                        systemInfo: systemInfo,
+                                        eTagManager: MockETagManager(),
+                                        requestTimeout: 7)
+        let backendConfig = BackendConfiguration(httpClient: httpClient,
                                                  operationQueue: QueueProvider.queue,
                                                  dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
         self.init(backendConfig: backendConfig, attributionFetcher: attributionFetcher)

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -34,10 +34,15 @@ class MockBackend: Backend {
         let systemInfo = try! MockSystemInfo(platformInfo: nil, finishTransactions: false, dangerousSettings: nil)
         let attributionFetcher = AttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
                                                     systemInfo: systemInfo)
-        self.init(httpClient: MockHTTPClient(systemInfo: systemInfo, eTagManager: MockETagManager(), requestTimeout: 7),
-                  apiKey: "mockAPIKey",
-                  attributionFetcher: attributionFetcher,
-                  dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
+        let mockAPIKey = "mockAPIKey"
+        let httpClient = MockHTTPClient(systemInfo: systemInfo, eTagManager: MockETagManager(), requestTimeout: 7)
+        let authHeaders = MockHTTPClient.authorizationHeader(withAPIKey: mockAPIKey)
+        let backendConfig = BackendConfiguration(apiKey: mockAPIKey,
+                                                 authHeaders: authHeaders,
+                                                 httpClient: httpClient,
+                                                 operationQueue: QueueProvider.queue,
+                                                 dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
+        self.init(backendConfig: backendConfig, attributionFetcher: attributionFetcher)
     }
 
     override func post(receiptData: Data,

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -37,16 +37,16 @@ class MockHTTPClient: HTTPClient {
     var mocks: [HTTPRequest.Path: Response] = [:]
     var calls: [Call] = []
 
-    init(
-        systemInfo: SystemInfo,
-        eTagManager: ETagManager,
-        dnsChecker: DNSCheckerType.Type = DNSChecker.self,
-        requestTimeout: TimeInterval = 7,
-        sourceTestFile: StaticString = #file
-    ) {
+    init(apiKey: String,
+         systemInfo: SystemInfo,
+         eTagManager: ETagManager,
+         dnsChecker: DNSCheckerType.Type = DNSChecker.self,
+         requestTimeout: TimeInterval = 7,
+         sourceTestFile: StaticString = #file) {
         self.sourceTestFile = sourceTestFile
 
-        super.init(systemInfo: systemInfo,
+        super.init(apiKey: apiKey,
+                   systemInfo: systemInfo,
                    eTagManager: eTagManager,
                    dnsChecker: dnsChecker,
                    requestTimeout: requestTimeout)
@@ -54,9 +54,7 @@ class MockHTTPClient: HTTPClient {
 
     private let sourceTestFile: StaticString
 
-    override func perform<Value: HTTPResponseBody>(_ request: HTTPRequest,
-                                                   authHeaders: RequestHeaders,
-                                                   completionHandler: Completion<Value>?) {
+    override func perform<Value: HTTPResponseBody>(_ request: HTTPRequest, completionHandler: Completion<Value>?) {
         let call = Call(request: request, headers: authHeaders)
 
         DispatchQueue.main.async {

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -34,10 +34,7 @@ class BaseBackendTests: TestCase {
         self.httpClient = self.createClient()
         let attributionFetcher = AttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
                                                     systemInfo: self.systemInfo)
-        let authHeaders = type(of: self.httpClient).authorizationHeader(withAPIKey: Self.apiKey)
-        let backendConfig = BackendConfiguration(apiKey: Self.apiKey,
-                                                 authHeaders: authHeaders,
-                                                 httpClient: self.httpClient,
+        let backendConfig = BackendConfiguration(httpClient: self.httpClient,
                                                  operationQueue: MockBackend.QueueProvider.queue,
                                                  dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
         self.backend = Backend(backendConfig: backendConfig, attributionFetcher: attributionFetcher)
@@ -55,7 +52,8 @@ extension BaseBackendTests {
     final func createClient(_ file: StaticString) -> MockHTTPClient {
         let eTagManager = MockETagManager(userDefaults: MockUserDefaults())
 
-        return MockHTTPClient(systemInfo: self.systemInfo,
+        return MockHTTPClient(apiKey: Self.apiKey,
+                              systemInfo: self.systemInfo,
                               eTagManager: eTagManager,
                               sourceTestFile: file)
     }

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -34,10 +34,13 @@ class BaseBackendTests: TestCase {
         self.httpClient = self.createClient()
         let attributionFetcher = AttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
                                                     systemInfo: self.systemInfo)
-        self.backend = Backend(httpClient: self.httpClient,
-                               apiKey: Self.apiKey,
-                               attributionFetcher: attributionFetcher,
-                               dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
+        let authHeaders = type(of: self.httpClient).authorizationHeader(withAPIKey: Self.apiKey)
+        let backendConfig = BackendConfiguration(apiKey: Self.apiKey,
+                                                 authHeaders: authHeaders,
+                                                 httpClient: self.httpClient,
+                                                 operationQueue: MockBackend.QueueProvider.queue,
+                                                 dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
+        self.backend = Backend(backendConfig: backendConfig, attributionFetcher: attributionFetcher)
     }
 
     func createClient() -> MockHTTPClient {

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -16,7 +16,7 @@ import XCTest
 class HTTPClientTests: TestCase {
 
     private typealias EmptyResponse = HTTPResponse<HTTPEmptyResponseBody>.Result
-
+    let apiKey = "MockAPIKey"
     let systemInfo = MockSystemInfo(finishTransactions: true)
     var client: HTTPClient!
     var userDefaults: UserDefaults!
@@ -31,12 +31,11 @@ class HTTPClientTests: TestCase {
         operationDispatcher = OperationDispatcher()
         MockDNSChecker.resetData()
 
-        client = HTTPClient(
-            systemInfo: systemInfo,
-            eTagManager: eTagManager,
-            dnsChecker: MockDNSChecker.self,
-            requestTimeout: 3
-        )
+        client = HTTPClient(apiKey: apiKey,
+                            systemInfo: systemInfo,
+                            eTagManager: eTagManager,
+                            dnsChecker: MockDNSChecker.self,
+                            requestTimeout: 3)
     }
 
     override func tearDown() {
@@ -55,7 +54,7 @@ class HTTPClientTests: TestCase {
         }
 
         let request = HTTPRequest(method: .get, path: .mockPath)
-        self.client.perform(request, authHeaders: [:]) { (_: EmptyResponse) in }
+        self.client.perform(request) { (_: EmptyResponse) in }
 
         expect(hostCorrect.value).toEventually(equal(true), timeout: .seconds(1))
     }
@@ -63,15 +62,13 @@ class HTTPClientTests: TestCase {
     func testPassesHeaders() {
         let headerPresent: Atomic<Bool> = .init(false)
 
-        stub(condition: hasHeaderNamed("test_header")) { _ in
+        stub(condition: hasHeaderNamed("Authorization")) { _ in
             headerPresent.value = true
             return .emptySuccessResponse
         }
 
         let request = HTTPRequest(method: .post([:]), path: .mockPath)
-        self.client.perform(request,
-                            authHeaders: ["test_header": "value"]) { (_: EmptyResponse) in
-        }
+        self.client.perform(request) { (_: EmptyResponse) in }
 
         expect(headerPresent.value).toEventually(equal(true), timeout: .seconds(1))
     }
@@ -86,7 +83,7 @@ class HTTPClientTests: TestCase {
 
         let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
-        self.client.perform(request, authHeaders: ["test_header": "value"]) { (_: EmptyResponse) in }
+        self.client.perform(request) { (_: EmptyResponse) in }
 
         expect(headerPresent.value).toEventually(equal(true), timeout: .seconds(1))
     }
@@ -101,7 +98,7 @@ class HTTPClientTests: TestCase {
 
         let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
-        self.client.perform(request, authHeaders: ["test_header": "value"]) { (_: EmptyResponse) in }
+        self.client.perform(request) { (_: EmptyResponse) in }
 
         expect(headerPresent.value).toEventually(equal(true))
     }
@@ -116,7 +113,7 @@ class HTTPClientTests: TestCase {
 
         let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
-        self.client.perform(request, authHeaders: ["test_header": "value"]) { (_: EmptyResponse) in }
+        self.client.perform(request) { (_: EmptyResponse) in }
 
         expect(headerPresent.value).toEventually(equal(true))
     }
@@ -131,7 +128,7 @@ class HTTPClientTests: TestCase {
 
         let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
-        self.client.perform(request, authHeaders: ["test_header": "value"]) { (_: EmptyResponse) in }
+        self.client.perform(request) { (_: EmptyResponse) in }
 
         expect(headerPresent.value).toEventually(equal(true))
     }
@@ -149,7 +146,7 @@ class HTTPClientTests: TestCase {
 
         let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
-        self.client.perform(request, authHeaders: ["test_header": "value"]) { (_: EmptyResponse) in }
+        self.client.perform(request) { (_: EmptyResponse) in }
 
         expect(header.value).toEventuallyNot(beNil())
         expect(header.value) == "true"
@@ -168,7 +165,7 @@ class HTTPClientTests: TestCase {
 
         let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
-        self.client.perform(request, authHeaders: ["test_header": "value"]) { (_: EmptyResponse) in }
+        self.client.perform(request) { (_: EmptyResponse) in }
 
         expect(header.value).toEventuallyNot(beNil())
         expect(header.value) == "false"
@@ -184,7 +181,7 @@ class HTTPClientTests: TestCase {
             return .emptySuccessResponse
         }
 
-        self.client.perform(request, authHeaders: [:]) { (_: EmptyResponse) in }
+        self.client.perform(request) { (_: EmptyResponse) in }
 
         expect(pathHit.value).toEventually(equal(true), timeout: .seconds(1))
     }
@@ -201,7 +198,7 @@ class HTTPClientTests: TestCase {
         }
         let request = HTTPRequest(method: .post(body), path: .mockPath)
 
-        self.client.perform(request, authHeaders: [:]) { (_: EmptyResponse) in }
+        self.client.perform(request) { (_: EmptyResponse) in }
 
         expect(pathHit.value).toEventually(equal(true))
     }
@@ -215,7 +212,7 @@ class HTTPClientTests: TestCase {
             return .emptySuccessResponse
         }
 
-        self.client.perform(request, authHeaders: [:]) { (_: EmptyResponse) in
+        self.client.perform(request) { (_: EmptyResponse) in
             completionCalled.value = true
         }
 
@@ -233,7 +230,7 @@ class HTTPClientTests: TestCase {
             response.error = error
             return response
         }
-        self.client.perform(request, authHeaders: [:]) { (result: EmptyResponse) in
+        self.client.perform(request) { (result: EmptyResponse) in
             receivedError.value = result.error
         }
 
@@ -263,7 +260,7 @@ class HTTPClientTests: TestCase {
             )
         }
 
-        self.client.perform(request, authHeaders: [:]) { (response: HTTPResponse<Data>.Result) in
+        self.client.perform(request) { (response: HTTPResponse<Data>.Result) in
             result.value = response
         }
 
@@ -292,7 +289,7 @@ class HTTPClientTests: TestCase {
             )
         }
 
-        self.client.perform(request, authHeaders: [:]) { (response: HTTPResponse<Data>.Result) in
+        self.client.perform(request) { (response: HTTPResponse<Data>.Result) in
             result.value = response
         }
 
@@ -322,7 +319,7 @@ class HTTPClientTests: TestCase {
             )
         }
 
-        self.client.perform(request, authHeaders: [:]) { (response: HTTPResponse<Data>.Result) in
+        self.client.perform(request) { (response: HTTPResponse<Data>.Result) in
             result.value = response
         }
 
@@ -350,7 +347,7 @@ class HTTPClientTests: TestCase {
             )
         }
 
-        self.client.perform(request, authHeaders: [:]) { (response: HTTPResponse<CustomResponse>.Result) in
+        self.client.perform(request) { (response: HTTPResponse<CustomResponse>.Result) in
             result.value = response
         }
 
@@ -380,7 +377,7 @@ class HTTPClientTests: TestCase {
                                      headers: nil)
         }
 
-        self.client.perform(request, authHeaders: [:]) { (response: HTTPResponse<Data>.Result) in
+        self.client.perform(request) { (response: HTTPResponse<Data>.Result) in
             result.value = response
         }
 
@@ -407,7 +404,7 @@ class HTTPClientTests: TestCase {
                                      headers: nil)
         }
 
-        self.client.perform(request, authHeaders: [:]) { (response: HTTPResponse<CustomResponse>.Result) in
+        self.client.perform(request) { (response: HTTPResponse<CustomResponse>.Result) in
             result.value = response
         }
 
@@ -429,7 +426,7 @@ class HTTPClientTests: TestCase {
             return .emptySuccessResponse
         }
 
-        self.client.perform(request, authHeaders: ["test_header": "value"]) { (_: HTTPResponse<Data>.Result) in }
+        self.client.perform(request) { (_: HTTPResponse<Data>.Result) in }
 
         expect(headerPresent.value).toEventually(equal(true))
     }
@@ -446,7 +443,7 @@ class HTTPClientTests: TestCase {
             return .emptySuccessResponse
         }
 
-        self.client.perform(request, authHeaders: ["test_header": "value"]) { (_: HTTPResponse<Data>.Result) in }
+        self.client.perform(request) { (_: HTTPResponse<Data>.Result) in }
 
         expect(headerPresent.value).toEventually(equal(true))
     }
@@ -465,7 +462,7 @@ class HTTPClientTests: TestCase {
             return .emptySuccessResponse
         }
 
-        self.client.perform(request, authHeaders: ["test_header": "value"]) { (_: HTTPResponse<Data>.Result) in }
+        self.client.perform(request) { (_: HTTPResponse<Data>.Result) in }
 
         expect(headerPresent.value).toEventually(equal(true))
     }
@@ -492,7 +489,7 @@ class HTTPClientTests: TestCase {
             return .emptySuccessResponse
         }
 
-            self.client.perform(request, authHeaders: ["test_header": "value"]) { (_: HTTPResponse<Data>.Result) in }
+            self.client.perform(request) { (_: HTTPResponse<Data>.Result) in }
 
         expect(headerPresent.value).toEventually(equal(true))
     }
@@ -508,7 +505,7 @@ class HTTPClientTests: TestCase {
             return .emptySuccessResponse
         }
 
-        self.client.perform(request, authHeaders: ["test_header": "value"]) { (_: HTTPResponse<Data>.Result) in }
+        self.client.perform(request) { (_: HTTPResponse<Data>.Result) in }
 
         expect(headerPresent.value).toEventually(equal(true))
     }
@@ -526,8 +523,8 @@ class HTTPClientTests: TestCase {
         let systemInfo = try SystemInfo(platformInfo: platformInfo,
                                         finishTransactions: true)
 
-        let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
-        client.perform(request, authHeaders: ["test_header": "value"]) { (_: HTTPResponse<Data>.Result) in }
+        let client = HTTPClient(apiKey: self.apiKey, systemInfo: systemInfo, eTagManager: eTagManager)
+        client.perform(request) { (_: HTTPResponse<Data>.Result) in }
 
         expect(headerPresent.value).toEventually(equal(true))
     }
@@ -544,9 +541,9 @@ class HTTPClientTests: TestCase {
         let platformInfo = Purchases.PlatformInfo(flavor: "react-native", version: "1.2.3")
         let systemInfo = try SystemInfo(platformInfo: platformInfo,
                                         finishTransactions: true)
-        let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
+        let client = HTTPClient(apiKey: self.apiKey, systemInfo: systemInfo, eTagManager: eTagManager)
 
-        client.perform(request, authHeaders: ["test_header": "value"]) { (_: HTTPResponse<Data>.Result) in }
+        client.perform(request) { (_: HTTPResponse<Data>.Result) in }
 
         expect(headerPresent.value).toEventually(equal(true))
     }
@@ -561,9 +558,9 @@ class HTTPClientTests: TestCase {
             return .emptySuccessResponse
         }
         let systemInfo = try SystemInfo(platformInfo: nil, finishTransactions: true)
-        let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
+        let client = HTTPClient(apiKey: self.apiKey, systemInfo: systemInfo, eTagManager: eTagManager)
 
-        client.perform(request, authHeaders: ["test_header": "value"]) { (_: HTTPResponse<Data>.Result) in }
+        client.perform(request) { (_: HTTPResponse<Data>.Result) in }
 
         expect(headerPresent.value).toEventually(equal(true))
     }
@@ -578,9 +575,9 @@ class HTTPClientTests: TestCase {
             return .emptySuccessResponse
         }
         let systemInfo = try SystemInfo(platformInfo: nil, finishTransactions: false)
-        let client = HTTPClient(systemInfo: systemInfo, eTagManager: eTagManager)
+        let client = HTTPClient(apiKey: self.apiKey, systemInfo: systemInfo, eTagManager: eTagManager)
 
-        client.perform(request, authHeaders: ["test_header": "value"]) { (_: HTTPResponse<Data>.Result) in }
+        client.perform(request) { (_: HTTPResponse<Data>.Result) in }
 
         expect(headerPresent.value).toEventually(equal(true))
     }
@@ -603,8 +600,7 @@ class HTTPClientTests: TestCase {
 
         let serialRequests = 10
         for requestNumber in 0..<serialRequests {
-            client.perform(.init(method: .requestNumber(requestNumber), path: path),
-                           authHeaders: [:]) { (_: HTTPResponse<Data>.Result) in
+            client.perform(.init(method: .requestNumber(requestNumber), path: path)) { (_: HTTPResponse<Data>.Result) in
                 completionCallCount.value += 1
             }
         }
@@ -631,13 +627,11 @@ class HTTPClientTests: TestCase {
                 .responseTime(0.1)
         }
 
-        self.client.perform(.init(method: .requestNumber(1), path: path),
-                            authHeaders: [:]) { (_: HTTPResponse<Data>.Result) in
+        self.client.perform(.init(method: .requestNumber(1), path: path)) { (_: HTTPResponse<Data>.Result) in
             firstRequestFinished.value = true
         }
 
-        self.client.perform(.init(method: .requestNumber(2), path: path),
-                            authHeaders: [:]) { (_: HTTPResponse<Data>.Result) in
+        self.client.perform(.init(method: .requestNumber(2), path: path)) { (_: HTTPResponse<Data>.Result) in
             secondRequestFinished.value = true
         }
 
@@ -675,18 +669,15 @@ class HTTPClientTests: TestCase {
                 .responseTime(responseTime)
         }
 
-        self.client.perform(.init(method: .requestNumber(1), path: path),
-                            authHeaders: [:]) { (_: HTTPResponse<Data>.Result) in
+        self.client.perform(.init(method: .requestNumber(1), path: path)) { (_: HTTPResponse<Data>.Result) in
             firstRequestFinished.value = true
         }
 
-        self.client.perform(.init(method: .requestNumber(2), path: path),
-                            authHeaders: [:]) { (_: HTTPResponse<Data>.Result) in
+        self.client.perform(.init(method: .requestNumber(2), path: path)) { (_: HTTPResponse<Data>.Result) in
             secondRequestFinished.value = true
         }
 
-        self.client.perform(.init(method: .requestNumber(3), path: path),
-                            authHeaders: [:]) { (_: HTTPResponse<Data>.Result) in
+        self.client.perform(.init(method: .requestNumber(3), path: path)) { (_: HTTPResponse<Data>.Result) in
             thirdRequestFinished.value = true
         }
 
@@ -698,8 +689,7 @@ class HTTPClientTests: TestCase {
     func testPerformRequestExitsWithErrorIfBodyCouldntBeParsedIntoJSON() throws {
         let response: Atomic<HTTPResponse<Data>.Result?> = .init(nil)
 
-        self.client.perform(.init(method: .invalidBody(), path: .mockPath),
-                            authHeaders: [:]) { (result: HTTPResponse<Data>.Result) in
+        self.client.perform(.init(method: .invalidBody(), path: .mockPath)) { (result: HTTPResponse<Data>.Result) in
             response.value = result
         }
 
@@ -720,8 +710,7 @@ class HTTPClientTests: TestCase {
             return .emptySuccessResponse
         }
 
-        self.client.perform(.init(method: .invalidBody(), path: path),
-                            authHeaders: [:]) { (_: HTTPResponse<Data>.Result) in
+        self.client.perform(.init(method: .invalidBody(), path: path)) { (_: HTTPResponse<Data>.Result) in
             completionCalled.value = true
         }
 
@@ -745,8 +734,7 @@ class HTTPClientTests: TestCase {
 
         self.eTagManager.shouldReturnResultFromBackend = false
         self.eTagManager.stubbedHTTPResultFromCacheOrBackendResult = nil
-        self.client.perform(.init(method: .get, path: path),
-                            authHeaders: [:]) { (_: HTTPResponse<Data>.Result) in
+        self.client.perform(.init(method: .get, path: path)) { (_: HTTPResponse<Data>.Result) in
             completionCalled.value = true
         }
 
@@ -774,7 +762,7 @@ class HTTPClientTests: TestCase {
                          headers: nil)
         }
 
-        self.client.perform(.init(method: .get, path: path), authHeaders: [:]) { (result: HTTPResponse<Data>.Result) in
+        self.client.perform(.init(method: .get, path: path)) { (result: HTTPResponse<Data>.Result) in
             response.value = result
         }
 
@@ -796,7 +784,7 @@ class HTTPClientTests: TestCase {
             return response
         }
 
-        self.client.perform(.init(method: .get, path: path), authHeaders: [:]) { (_: HTTPResponse<Data>.Result) in }
+        self.client.perform(.init(method: .get, path: path)) { (_: HTTPResponse<Data>.Result) in }
 
         expect(MockDNSChecker.invokedIsBlockedAPIError.value).toEventually(equal(true))
         expect(MockDNSChecker.invokedErrorWithBlockedHostFromError.value).toEventually(equal(false))
@@ -814,7 +802,7 @@ class HTTPClientTests: TestCase {
             return response
         }
 
-        self.client.perform(.init(method: .post([:]), path: path), authHeaders: [:]) { (_: HTTPResponse<Data>.Result) in
+        self.client.perform(.init(method: .post([:]), path: path)) { (_: HTTPResponse<Data>.Result) in
         }
 
         expect(MockDNSChecker.invokedIsBlockedAPIError.value).toEventually(equal(true))
@@ -837,7 +825,7 @@ class HTTPClientTests: TestCase {
             return response
         }
 
-        self.client.perform(.init(method: .post([:]), path: path), authHeaders: [:]) { (_: HTTPResponse<Data>.Result) in
+        self.client.perform(.init(method: .post([:]), path: path)) { (_: HTTPResponse<Data>.Result) in
         }
 
         expect(MockDNSChecker.invokedIsBlockedAPIError.value).toEventually(equal(true))
@@ -860,7 +848,7 @@ class HTTPClientTests: TestCase {
             return response
         }
 
-        self.client.perform(.init(method: .get, path: path), authHeaders: [:]) { (_: HTTPResponse<Data>.Result) in }
+        self.client.perform(.init(method: .get, path: path)) { (_: HTTPResponse<Data>.Result) in }
 
         expect(MockDNSChecker.invokedIsBlockedAPIError.value).toEventually(equal(true))
         expect(MockDNSChecker.invokedErrorWithBlockedHostFromError.value).toEventually(equal(true))
@@ -878,7 +866,7 @@ class HTTPClientTests: TestCase {
         }
 
         let obtainedError: Atomic<NetworkError?> = .init(nil)
-        self.client.perform(.init(method: .get, path: path), authHeaders: [:]) { (result: HTTPResponse<Data>.Result) in
+        self.client.perform(.init(method: .get, path: path)) { (result: HTTPResponse<Data>.Result) in
             obtainedError.value = result.error
         }
 
@@ -912,7 +900,7 @@ class HTTPClientTests: TestCase {
         }
 
         let obtainedError: Atomic<NetworkError?> = .init(nil)
-        self.client.perform(.init(method: .get, path: path), authHeaders: [:]) { (result: HTTPResponse<Data>.Result) in
+        self.client.perform(.init(method: .get, path: path)) { (result: HTTPResponse<Data>.Result) in
             obtainedError.value = result.error
         }
 
@@ -944,7 +932,7 @@ class HTTPClientTests: TestCase {
             return response
         }
 
-        self.client.perform(.init(method: .get, path: path), authHeaders: [:]) { (_: HTTPResponse<Data>.Result) in }
+        self.client.perform(.init(method: .get, path: path)) { (_: HTTPResponse<Data>.Result) in }
 
         expect(MockDNSChecker.invokedIsBlockedAPIError.value).toEventually(equal(true))
         expect(MockDNSChecker.invokedErrorWithBlockedHostFromError.value).toEventually(equal(false))

--- a/Tests/UnitTests/Purchasing/ProductsFetcherSK1Tests.swift
+++ b/Tests/UnitTests/Purchasing/ProductsFetcherSK1Tests.swift
@@ -149,7 +149,7 @@ class ProductsFetcherSK1Tests: TestCase {
         }
 
         expect(completionCallCount).toEventually(equal(1),
-                                                 timeout: productsRequestResponseTime + .milliseconds(10))
+                                                 timeout: productsRequestResponseTime + .milliseconds(30))
         expect(self.productsRequestFactory.invokedRequestCount) == 1
 
         let error = try XCTUnwrap(receivedResult?.error as? ErrorCode)

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -42,10 +42,15 @@ class BasePurchasesTests: TestCase {
         self.receiptFetcher = MockReceiptFetcher(requestFetcher: self.requestFetcher, systemInfo: systemInfoAttribution)
         self.attributionFetcher = MockAttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
                                                          systemInfo: systemInfoAttribution)
-        self.backend = MockBackend(httpClient: MockHTTPClient(systemInfo: self.systemInfo,
-                                                              eTagManager: MockETagManager()),
-                                   apiKey: "mockAPIKey",
-                                   attributionFetcher: self.attributionFetcher)
+
+        let apiKey = "mockAPIKey"
+        let httpClient = MockHTTPClient(systemInfo: self.systemInfo, eTagManager: MockETagManager())
+        let config = BackendConfiguration(apiKey: apiKey,
+                                          authHeaders: MockHTTPClient.authorizationHeader(withAPIKey: apiKey),
+                                          httpClient: httpClient,
+                                          operationQueue: MockBackend.QueueProvider.queue,
+                                          dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
+        self.backend = MockBackend(backendConfig: config, attributionFetcher: self.attributionFetcher)
         self.subscriberAttributesManager = MockSubscriberAttributesManager(
             backend: self.backend,
             deviceCache: self.deviceCache,
@@ -223,6 +228,9 @@ extension BasePurchasesTests {
 extension BasePurchasesTests {
 
     final class MockBackend: Backend {
+
+        static let referenceDate = Date(timeIntervalSinceReferenceDate: 700000000) // 2023-03-08 20:26:40
+
         var userID: String?
         var originalApplicationVersion: String?
         var originalPurchaseDate: Date?

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -44,10 +44,8 @@ class BasePurchasesTests: TestCase {
                                                          systemInfo: systemInfoAttribution)
 
         let apiKey = "mockAPIKey"
-        let httpClient = MockHTTPClient(systemInfo: self.systemInfo, eTagManager: MockETagManager())
-        let config = BackendConfiguration(apiKey: apiKey,
-                                          authHeaders: MockHTTPClient.authorizationHeader(withAPIKey: apiKey),
-                                          httpClient: httpClient,
+        let httpClient = MockHTTPClient(apiKey: apiKey, systemInfo: self.systemInfo, eTagManager: MockETagManager())
+        let config = BackendConfiguration(httpClient: httpClient,
                                           operationQueue: MockBackend.QueueProvider.queue,
                                           dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
         self.backend = MockBackend(backendConfig: config, attributionFetcher: self.attributionFetcher)

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -55,9 +55,7 @@ class BackendSubscriberAttributesTests: TestCase {
         let attributionFetcher = AttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
                                                     systemInfo: self.systemInfo)
 
-        let config = BackendConfiguration(apiKey: Self.apiKey,
-                                          authHeaders: MockHTTPClient.authorizationHeader(withAPIKey: Self.apiKey),
-                                          httpClient: mockHTTPClient,
+        let config = BackendConfiguration(httpClient: mockHTTPClient,
                                           operationQueue: MockBackend.QueueProvider.queue,
                                           dateProvider: dateProvider)
 
@@ -324,7 +322,10 @@ class BackendSubscriberAttributesTests: TestCase {
         let eTagManager = MockETagManager(userDefaults: MockUserDefaults())
         self.mockETagManager = eTagManager
 
-        return MockHTTPClient(systemInfo: self.systemInfo, eTagManager: eTagManager, sourceTestFile: file)
+        return MockHTTPClient(apiKey: Self.apiKey,
+                              systemInfo: self.systemInfo,
+                              eTagManager: eTagManager,
+                              sourceTestFile: file)
     }
 
 }

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -55,10 +55,13 @@ class BackendSubscriberAttributesTests: TestCase {
         let attributionFetcher = AttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
                                                     systemInfo: self.systemInfo)
 
-        self.backend = Backend(httpClient: mockHTTPClient,
-                               apiKey: Self.apiKey,
-                               attributionFetcher: attributionFetcher,
-                               dateProvider: dateProvider)
+        let config = BackendConfiguration(apiKey: Self.apiKey,
+                                          authHeaders: MockHTTPClient.authorizationHeader(withAPIKey: Self.apiKey),
+                                          httpClient: mockHTTPClient,
+                                          operationQueue: MockBackend.QueueProvider.queue,
+                                          dateProvider: dateProvider)
+
+        self.backend = Backend(backendConfig: config, attributionFetcher: attributionFetcher)
 
         subscriberAttribute1 = SubscriberAttribute(withKey: "a key",
                                                    value: "a value",


### PR DESCRIPTION
Extract various dependencies that are required to instantiate the `Backend` object.

Refactor to assist with the next few PRs that extract out other pieces
See [CSDK-82]
Resolves [CSDK-155]
Depends on [CSDK-152]

Blocked by https://github.com/RevenueCat/purchases-ios/pull/1695

[CSDK-82]: https://revenuecats.atlassian.net/browse/CSDK-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CSDK-155]: https://revenuecats.atlassian.net/browse/CSDK-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CSDK-152]: https://revenuecats.atlassian.net/browse/CSDK-152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ