### PR TITLE
iOS 16: added new snapshots

### DIFF
--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testCachesCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testCachesCustomerGetsForSameCustomer.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testDoesntCacheCustomerGetsForSameCustomer.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testDoesntCacheCustomerGetsForSameCustomer.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testDoesntCacheCustomerGetsForSameCustomer.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testDoesntCacheCustomerGetsForSameCustomer.2.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user_id_2"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testEncodesCustomerUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testEncodesCustomerUserID.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/userid%20with%20spaces"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerCallsBackendProperly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerCallsBackendProperly.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetCustomerInfoDoesNotMakeTwoRequests.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetsCustomerInfo.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testGetsCustomerInfo.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testHandlesGetCustomerInfoErrors.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testHandlesGetCustomerInfoErrors.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testHandlesInvalidJSON.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testHandlesInvalidJSON.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testEligibilityUnknownIfError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testEligibilityUnknownIfError.1.json
@@ -1,0 +1,17 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "fetch_token" : "AQI=",
+      "product_identifiers" : [
+        "producta",
+        "productb",
+        "productc"
+      ]
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/intro_eligibility"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testEligibilityUnknownIfUnknownError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testEligibilityUnknownIfUnknownError.1.json
@@ -1,0 +1,17 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "fetch_token" : "AQI=",
+      "product_identifiers" : [
+        "producta",
+        "productb",
+        "productc"
+      ]
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/intro_eligibility"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testPostsProductIdentifiers.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetIntroEligibilityTests/iOS16-testPostsProductIdentifiers.1.json
@@ -1,0 +1,18 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "fetch_token" : "AQID",
+      "product_identifiers" : [
+        "producta",
+        "productb",
+        "productc",
+        "productd"
+      ]
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/intro_eligibility"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetEntitlementsDoesntCacheForMultipleUserID.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetEntitlementsDoesntCacheForMultipleUserID.2.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user_id_2/offerings"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCachesForSameUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCachesForSameUserID.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCallsHTTPMethod.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCallsHTTPMethod.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsFailSendsNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsFailSendsNil.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsNetworkErrorSendsError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsNetworkErrorSendsError.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsOneOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsOneOffering.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCachesForSameUserIDs.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCachesForSameUserIDs.1.json
@@ -1,0 +1,13 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "old id",
+      "new_app_user_id" : "new id"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsAllCompletionBlocksInCache.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsAllCompletionBlocksInCache.1.json
@@ -1,0 +1,13 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "old id",
+      "new_app_user_id" : "new id"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf200.1.json
@@ -1,0 +1,13 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "old id",
+      "new_app_user_id" : "new id"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithCustomerInfoAndCreatedFalseIf201.1.json
@@ -1,0 +1,13 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "old id",
+      "new_app_user_id" : "new id"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginCallsCompletionWithErrorIfCustomerInfoIsEmpty.1.json
@@ -1,0 +1,13 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "old id",
+      "new_app_user_id" : "new id"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentCurrentUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentCurrentUserID.1.json
@@ -1,0 +1,13 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "old id",
+      "new_app_user_id" : "new id"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentCurrentUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentCurrentUserID.2.json
@@ -1,0 +1,13 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "old id 2",
+      "new_app_user_id" : "new id"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentNewUserID.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentNewUserID.1.json
@@ -1,0 +1,13 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "old id",
+      "new_app_user_id" : "new id"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentNewUserID.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginDoesntCacheForDifferentNewUserID.2.json
@@ -1,0 +1,13 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "old id",
+      "new_app_user_id" : "new id 2"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginMakesRightCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginMakesRightCalls.1.json
@@ -1,0 +1,13 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "old id",
+      "new_app_user_id" : "new id"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginPassesNetworkErrorIfCouldntCommunicate.1.json
@@ -1,0 +1,13 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "old id",
+      "new_app_user_id" : "new id"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS16-testPostAttributesPutsDataInDataKey.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostAttributionDataTests/iOS16-testPostAttributesPutsDataInDataKey.1.json
@@ -1,0 +1,16 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "data" : {
+        "a" : "b",
+        "c" : "d"
+      },
+      "network" : 0
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/attribution"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningCorrectly.1.json
@@ -1,0 +1,20 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "fetch_token" : "YW4gYXdlc29tZSBkaXNjb3VudA==",
+      "generate_offers" : [
+        {
+          "offer_id" : "offerid",
+          "product_id" : "a_great_product",
+          "subscription_group" : "sub_group"
+        }
+      ]
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/offers"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningEmptyOffersResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningEmptyOffersResponse.1.json
@@ -1,0 +1,20 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "fetch_token" : "YW4gYXdlc29tZSBkaXNjb3VudA==",
+      "generate_offers" : [
+        {
+          "offer_id" : "offerid",
+          "product_id" : "a_great_product",
+          "subscription_group" : "sub_group"
+        }
+      ]
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/offers"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningNetworkError.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningNetworkError.1.json
@@ -1,0 +1,20 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "fetch_token" : "YW4gYXdlc29tZSBkaXNjb3VudA==",
+      "generate_offers" : [
+        {
+          "offer_id" : "offerid",
+          "product_id" : "a_great_product",
+          "subscription_group" : "sub_group"
+        }
+      ]
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/offers"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningNoDataAndNoSignatureErrorResponse.1.json
@@ -1,0 +1,20 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "fetch_token" : "YW4gYXdlc29tZSBkaXNjb3VudA==",
+      "generate_offers" : [
+        {
+          "offer_id" : "offerid",
+          "product_id" : "a_great_product",
+          "subscription_group" : "sub_group"
+        }
+      ]
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/offers"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningSignatureErrorResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostOfferForSigningTests/iOS16-testOfferForSigningSignatureErrorResponse.1.json
@@ -1,0 +1,20 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "fetch_token" : "YW4gYXdlc29tZSBkaXNjb3VudA==",
+      "generate_offers" : [
+        {
+          "offer_id" : "offerid",
+          "product_id" : "a_great_product",
+          "subscription_group" : "sub_group"
+        }
+      ]
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/offers"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testCachesRequestsForSameReceipt.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testCachesRequestsForSameReceipt.1.json
@@ -1,0 +1,21 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : true,
+      "observer_mode" : false
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentCurrency.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentCurrency.1.json
@@ -1,0 +1,21 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : true
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentCurrency.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentCurrency.2.json
@@ -1,0 +1,25 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "currency" : "USD",
+      "fetch_token" : "YW4gYXdlc29tZWVyIHJlY2VpcHQ=",
+      "is_restore" : false,
+      "observer_mode" : true,
+      "price" : "15.99",
+      "product_id" : "product_id",
+      "store_country" : "ESP"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentDiscounts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentDiscounts.1.json
@@ -1,0 +1,21 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : true,
+      "observer_mode" : false
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentDiscounts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentDiscounts.2.json
@@ -1,0 +1,32 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "currency" : "UYU",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : true,
+      "observer_mode" : false,
+      "offers" : [
+        {
+          "offer_identifier" : "offerid",
+          "payment_mode" : 0,
+          "price" : "12"
+        }
+      ],
+      "price" : "15.99",
+      "product_id" : "product_id",
+      "store_country" : "ESP"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOffering.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOffering.1.json
@@ -1,0 +1,22 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : true,
+      "observer_mode" : false,
+      "presented_offering_identifier" : "offering_a"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOffering.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOffering.2.json
@@ -1,0 +1,22 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZWVyIHJlY2VpcHQ=",
+      "is_restore" : true,
+      "observer_mode" : false,
+      "presented_offering_identifier" : "offering_b"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOfferings.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOfferings.1.json
@@ -1,0 +1,21 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : true
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOfferings.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentOfferings.2.json
@@ -1,0 +1,22 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : true,
+      "presented_offering_identifier" : "offering_a"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentReceipts.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentReceipts.1.json
@@ -1,0 +1,21 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : true,
+      "observer_mode" : true
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentReceipts.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentReceipts.2.json
@@ -1,0 +1,21 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZWVyIHJlY2VpcHQ=",
+      "is_restore" : true,
+      "observer_mode" : true
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentRestore.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentRestore.1.json
@@ -1,0 +1,21 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : false
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentRestore.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesntCacheForDifferentRestore.2.json
@@ -1,0 +1,21 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : true,
+      "observer_mode" : false
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testErrorIsForwardedForCustomerInfoCalls.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testErrorIsForwardedForCustomerInfoCalls.1.json
@@ -1,0 +1,21 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : true,
+      "observer_mode" : false
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testFreeTrialPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testFreeTrialPostsCorrectly.1.json
@@ -1,0 +1,26 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "currency" : "UYU",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : false,
+      "payment_mode" : 2,
+      "price" : "15.99",
+      "product_id" : "product_id",
+      "store_country" : "ESP"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.2.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.2.json
@@ -1,0 +1,21 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : true
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.3.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsUpdatedSubscriberInfoAfterPost.3.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testIndividualParamsCanBeNil.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testIndividualParamsCanBeNil.1.json
@@ -1,0 +1,25 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "currency" : "UYU",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : false,
+      "price" : "15.99",
+      "product_id" : "product_id",
+      "store_country" : "ESP"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPayAsYouGoPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPayAsYouGoPostsCorrectly.1.json
@@ -1,0 +1,26 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "currency" : "UYU",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : false,
+      "payment_mode" : 0,
+      "price" : "15.99",
+      "product_id" : "product_id",
+      "store_country" : "ESP"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPayUpFrontPostsCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPayUpFrontPostsCorrectly.1.json
@@ -1,0 +1,26 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "currency" : "UYU",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : false,
+      "payment_mode" : 1,
+      "price" : "15.99",
+      "product_id" : "product_id",
+      "store_country" : "ESP"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptCreatesASubscriberInfoObject.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostingReceiptCreatesASubscriberInfoObject.1.json
@@ -1,0 +1,21 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : false
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataCorrectly.1.json
@@ -1,0 +1,21 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : true
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithDiscountInfoCorrectly.1.json
@@ -1,0 +1,33 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "currency" : "BFD",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : false,
+      "offers" : [
+        {
+          "offer_identifier" : "offerid",
+          "payment_mode" : 0,
+          "price" : "12.1"
+        }
+      ],
+      "price" : "15.99",
+      "product_id" : "a_great_product",
+      "store_country" : "ESP",
+      "subscription_group_id" : "sub_group"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithProductDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithProductDataCorrectly.1.json
@@ -1,0 +1,25 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "currency" : "USD",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : true,
+      "price" : "15.99",
+      "product_id" : "product_id",
+      "store_country" : "ESP"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithProductRequestDataCorrectly.1.json
@@ -1,0 +1,27 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "currency" : "BFD",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : false,
+      "presented_offering_identifier" : "a_offering",
+      "price" : "10.98",
+      "product_id" : "a_great_product",
+      "store_country" : "ESP",
+      "subscription_group_id" : "sub_group"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesPassesErrorsToCallbackIfStatusCodeIsSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesPassesErrorsToCallbackIfStatusCodeIsSuccess.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer the api key"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "abc123",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        },
+        "a key" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "a value"
+        },
+        "another key" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "another value"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : false
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesReturnsBadJson.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer the api key"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "abc123",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        },
+        "a key" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "a value"
+        },
+        "another key" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "another value"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : false
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithSubscriberAttributesSendsThemCorrectly.1.json
@@ -1,0 +1,29 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer the api key"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "abc123",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        },
+        "a key" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "a value"
+        },
+        "another key" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "another value"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : false
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithoutSubscriberAttributesSkipsThem.1.json
@@ -1,0 +1,21 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer the api key"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "abc123",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "is_restore" : false,
+      "observer_mode" : false
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionInNetworkErrorCase.1.json
@@ -1,0 +1,21 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer the api key"
+  },
+  "request" : {
+    "body" : {
+      "attributes" : {
+        "a key" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "a value"
+        },
+        "another key" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "another value"
+        }
+      }
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/abc123/attributes"
+  }
+}

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionInSuccessCase.1.json
@@ -1,0 +1,21 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer the api key"
+  },
+  "request" : {
+    "body" : {
+      "attributes" : {
+        "a key" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "a value"
+        },
+        "another key" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "another value"
+        }
+      }
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/abc123/attributes"
+  }
+}

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesCallsCompletionWithErrorInBadRequestCase.1.json
@@ -1,0 +1,21 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer the api key"
+  },
+  "request" : {
+    "body" : {
+      "attributes" : {
+        "a key" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "a value"
+        },
+        "another key" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "another value"
+        }
+      }
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/abc123/attributes"
+  }
+}

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesSendsAttributesErrorsIfAny.1.json
@@ -1,0 +1,21 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer the api key"
+  },
+  "request" : {
+    "body" : {
+      "attributes" : {
+        "a key" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "a value"
+        },
+        "another key" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "another value"
+        }
+      }
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/abc123/attributes"
+  }
+}

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesSendsRightParameters.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostSubscriberAttributesSendsRightParameters.1.json
@@ -1,0 +1,21 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer the api key"
+  },
+  "request" : {
+    "body" : {
+      "attributes" : {
+        "a key" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "a value"
+        },
+        "another key" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "another value"
+        }
+      }
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/abc123/attributes"
+  }
+}

--- a/Tests/UnitTests/TestHelpers/OSVersionEquivalent.swift
+++ b/Tests/UnitTests/TestHelpers/OSVersionEquivalent.swift
@@ -25,6 +25,7 @@ enum OSVersionEquivalent: Int {
     case iOS13 = 13
     case iOS14 = 14
     case iOS15 = 15
+    case iOS16 = 16
 
 }
 


### PR DESCRIPTION
Also added this version to iOS `OSVersionEquivalent`

I've created these by simply copying the iOS 15 version, which allows us to verify that the existing snapshots still make the iOS 16 tests pass with no changes.