### PR TITLE
`StoreKitConfigTestCase`: delete `Bundle.appStoreReceiptURL` after every test

### DIFF
--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -70,7 +70,7 @@ private extension BaseBackendIntegrationTests {
     func clearReceiptIfExists() {
         let manager = FileManager.default
 
-        guard let url = Bundle.main.appStoreReceiptURL, manager.fileExists(atPath: url.absoluteString) else { return }
+        guard let url = Bundle.main.appStoreReceiptURL, manager.fileExists(atPath: url.path) else { return }
 
         do {
             try manager.removeItem(at: url)

--- a/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -48,6 +48,12 @@ class StoreKitConfigTestCase: TestCase {
         userDefaults.removePersistentDomain(forName: suiteName)
     }
 
+    override func tearDown() {
+        super.tearDown()
+
+        self.clearReceiptIfExists()
+    }
+
     // MARK: - Transactions observation
 
     private static var transactionsObservation: Task<Void, Never>?
@@ -86,6 +92,18 @@ private extension StoreKitConfigTestCase {
 
                 Self.hasWaited = true
             }
+        }
+    }
+
+    func clearReceiptIfExists() {
+        let manager = FileManager.default
+
+        guard let url = Bundle.main.appStoreReceiptURL, manager.fileExists(atPath: url.path) else { return }
+
+        do {
+            try manager.removeItem(at: url)
+        } catch {
+            Logger.appleWarning("Error attempting to remove receipt URL '\(url)': \(error)")
         }
     }
 


### PR DESCRIPTION
Equivalent to #1671 but for unit tests.

In iOS 16 (as of beta 1), the receipt persists across tests, despite the use of `SKTestSession.resetToDefaultState`.
This might also help with flaky tests pre-iOS 16 too.

Also note that I fixed this method in `BaseBackendIntegrationTests`. Using `URL.absoluteString` was incorrect there, so the file was probably never deleted.

I filed a feedback for this:
![Screen Shot 2022-06-14 at 11 27 13](https://user-images.githubusercontent.com/685609/173662482-edae8bb9-48a2-432a-9823-c07a46e8861a.png)

