### PR TITLE
Disabled tests that rely on `StoreKitConfigTestCase.changeStorefront` on iOS 16.0

### DIFF
--- a/Tests/StoreKitUnitTests/PriceFormatterProviderTests.swift
+++ b/Tests/StoreKitUnitTests/PriceFormatterProviderTests.swift
@@ -33,7 +33,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
 
         let secondPriceFormatter = priceFormatterProvider.priceFormatterForSK1(with: locale)
 
-        XCTAssertIdentical(firstPriceFormatter, secondPriceFormatter)
+        expect(firstPriceFormatter) === secondPriceFormatter
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -45,7 +45,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
 
         let secondPriceFormatter = priceFormatterProvider.priceFormatterForSK2(withCurrencyCode: currencyCode)
 
-        XCTAssertIdentical(firstPriceFormatter, secondPriceFormatter)
+        expect(firstPriceFormatter) === secondPriceFormatter
     }
 
     @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
@@ -53,7 +53,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
         testSession.locale = Locale(identifier: "es_ES")
-        await changeStorefront("ESP")
+        await self.changeStorefront("ESP")
 
         let sk1Fetcher = ProductsFetcherSK1(requestTimeout: Configuration.storeKitRequestTimeoutDefault)
 
@@ -63,7 +63,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
         expect(priceFormatter.currencyCode) == "EUR"
 
         testSession.locale = Locale(identifier: "en_EN")
-        await changeStorefront("USA")
+        await self.changeStorefront("USA")
 
         // Note: this test passes only because the cache is manually
         // cleared. `ProductsFetcherSK1` does not detect Storefront
@@ -82,7 +82,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         testSession.locale = Locale(identifier: "es_ES")
-        await changeStorefront("ESP")
+        await self.changeStorefront("ESP")
 
         let sk2Fetcher = ProductsFetcherSK2()
 
@@ -92,7 +92,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
         expect(priceFormatter.currencyCode) == "EUR"
 
         testSession.locale = Locale(identifier: "en_EN")
-        await changeStorefront("USA")
+        await self.changeStorefront("USA")
 
         // Note: this test passes only because the cache is manually
         // cleared. `ProductsFetcherSK2` does not detect Storefront

--- a/Tests/StoreKitUnitTests/PriceFormatterProviderTests.swift
+++ b/Tests/StoreKitUnitTests/PriceFormatterProviderTests.swift
@@ -53,7 +53,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
         testSession.locale = Locale(identifier: "es_ES")
-        await self.changeStorefront("ESP")
+        try await self.changeStorefront("ESP")
 
         let sk1Fetcher = ProductsFetcherSK1(requestTimeout: Configuration.storeKitRequestTimeoutDefault)
 
@@ -63,7 +63,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
         expect(priceFormatter.currencyCode) == "EUR"
 
         testSession.locale = Locale(identifier: "en_EN")
-        await self.changeStorefront("USA")
+        try await self.changeStorefront("USA")
 
         // Note: this test passes only because the cache is manually
         // cleared. `ProductsFetcherSK1` does not detect Storefront
@@ -82,7 +82,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         testSession.locale = Locale(identifier: "es_ES")
-        await self.changeStorefront("ESP")
+        try await self.changeStorefront("ESP")
 
         let sk2Fetcher = ProductsFetcherSK2()
 
@@ -92,7 +92,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
         expect(priceFormatter.currencyCode) == "EUR"
 
         testSession.locale = Locale(identifier: "en_EN")
-        await self.changeStorefront("USA")
+        try await self.changeStorefront("USA")
 
         // Note: this test passes only because the cache is manually
         // cleared. `ProductsFetcherSK2` does not detect Storefront

--- a/Tests/StoreKitUnitTests/StoreProductTests.swift
+++ b/Tests/StoreKitUnitTests/StoreProductTests.swift
@@ -231,7 +231,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
         testSession.locale = Locale(identifier: "es_ES")
-        await changeStorefront("ESP")
+        try await self.changeStorefront("ESP")
 
         let sk1Fetcher = ProductsFetcherSK1(requestTimeout: Configuration.storeKitRequestTimeoutDefault)
 
@@ -248,7 +248,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(storeProduct.currencyCode) == "EUR"
 
         testSession.locale = Locale(identifier: "en_EN")
-        await changeStorefront("USA")
+        try await self.changeStorefront("USA")
 
         // Note: this test passes only because the cache is manually
         // cleared. `ProductsFetcherSK1` does not detect Storefront
@@ -272,7 +272,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         testSession.locale = Locale(identifier: "es_ES")
-        await changeStorefront("ESP")
+        try await self.changeStorefront("ESP")
 
         let sk2Fetcher = ProductsFetcherSK2()
 
@@ -289,7 +289,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(storeProduct.currencyCode) == "EUR"
 
         testSession.locale = Locale(identifier: "en_EN")
-        await changeStorefront("USA")
+        try await self.changeStorefront("USA")
 
         // Note: this test passes only because the cache is manually
         // cleared. `ProductsFetcherSK2` does not detect Storefront

--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
@@ -62,8 +62,12 @@ extension StoreKitConfigTestCase {
     /// Updates `SKTestSession.storefront` and waits for `Storefront.current` to reflect the change
     /// This is necessary because the change is aynchronous within `StoreKit`, and otherwise code that depends
     /// on the change might not see it in time, resulting in race conditions and flaky tests.
-    func changeStorefront(_ new: String) async {
-        testSession.storefront = new
+    func changeStorefront(
+        _ new: String,
+        file: FileString = #fileID,
+        line: UInt = #line
+    ) async {
+        self.testSession.storefront = new
 
         if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
             // Note: a better approach would be using `XCTestExpectation` and `self.wait(for:timeout:)`
@@ -86,7 +90,11 @@ extension StoreKitConfigTestCase {
             } while numberOfChecksLeft > 0
 
             let detected = await storefrontUpdateDetected
-            expect(detected).to(beTrue(), description: "Storefront change not detected")
+            expect(
+                file: file,
+                line: line,
+                detected
+            ).to(beTrue(), description: "Storefront change not detected")
         }
     }
 

--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
@@ -66,7 +66,12 @@ extension StoreKitConfigTestCase {
         _ new: String,
         file: FileString = #fileID,
         line: UInt = #line
-    ) async {
+    ) async throws {
+        guard #unavailable(iOS 16.0) else {
+            // See https://github.com/RevenueCat/purchases-ios/pull/1701
+            throw XCTSkip("Changing Storefront is currently not working in iOS 16.0")
+        }
+
         self.testSession.storefront = new
 
         if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {


### PR DESCRIPTION
This is currently broken on iOS 16.
I filed [CSDK-261] to make sure we review this before the GM is out.

I filed a Radar:
![Screen Shot 2022-06-14 at 11 34 34](https://user-images.githubusercontent.com/685609/173663713-9f413017-5726-43df-b0af-6d48d09dde83.png)

We might have to wait for a future beta, or find a workaround.


[CSDK-261]: https://revenuecats.atlassian.net/browse/CSDK-261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ