### PR TITLE
`PurchasesOrchestrator.handlePurchasedTransaction`: always refresh receipt data

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -413,8 +413,7 @@ class PurchasesOrchestrator {
         let customerInfo: CustomerInfo
 
         if let transaction = transaction {
-            customerInfo = try await self.handlePurchasedTransaction(transaction,
-                                                                     refreshPolicy: .always)
+            customerInfo = try await self.handlePurchasedTransaction(transaction)
         } else {
             // `transaction` would be `nil` for `Product.PurchaseResult.pending` and
             // `Product.PurchaseResult.userCancelled`.
@@ -549,9 +548,8 @@ extension PurchasesOrchestrator: StoreKitWrapperDelegate {
 private extension PurchasesOrchestrator {
 
     func handlePurchasedTransaction(_ transaction: StoreTransaction,
-                                    refreshPolicy: ReceiptRefreshPolicy = .onlyIfEmpty,
                                     storefront: StorefrontType?) {
-        self.receiptFetcher.receiptData(refreshPolicy: refreshPolicy) { receiptData in
+        self.receiptFetcher.receiptData(refreshPolicy: .always) { receiptData in
             if let receiptData = receiptData,
                !receiptData.isEmpty {
                 self.fetchProductsAndPostReceipt(withTransaction: transaction,
@@ -891,10 +889,7 @@ private extension Error {
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 extension PurchasesOrchestrator {
 
-    private func handlePurchasedTransaction(
-        _ transaction: StoreTransaction,
-        refreshPolicy: ReceiptRefreshPolicy
-    ) async throws -> CustomerInfo {
+    private func handlePurchasedTransaction(_ transaction: StoreTransaction) async throws -> CustomerInfo {
         let storefront = await Storefront.currentStorefront
 
         return try await withCheckedThrowingContinuation { continuation in
@@ -905,9 +900,7 @@ extension PurchasesOrchestrator {
                 }
             )
 
-            self.handlePurchasedTransaction(transaction,
-                                            refreshPolicy: refreshPolicy,
-                                            storefront: storefront)
+            self.handlePurchasedTransaction(transaction, storefront: storefront)
         }
     }
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -164,6 +164,9 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
             }
         }
 
+        expect(self.receiptFetcher.receiptDataCalled) == true
+        expect(self.receiptFetcher.receiptDataReceivedRefreshPolicy) == .always
+
         expect(self.backend.invokedPostReceiptDataCount) == 1
         expect(self.backend.invokedPostReceiptDataParameters?.productData).toNot(beNil())
     }
@@ -300,6 +303,9 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         let product = try await fetchSk2Product()
 
         _ = try await orchestrator.purchase(sk2Product: product, promotionalOffer: nil)
+
+        expect(self.receiptFetcher.receiptDataCalled) == true
+        expect(self.receiptFetcher.receiptDataReceivedRefreshPolicy) == .always
 
         expect(self.backend.invokedPostReceiptDataCount) == 1
         expect(self.backend.invokedPostReceiptDataParameters?.productData).toNot(beNil())

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
@@ -638,7 +638,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         self.makeAPurchase()
 
         expect(self.receiptFetcher.receiptDataCalled) == true
-        expect(self.receiptFetcher.receiptDataReceivedRefreshPolicy) == .onlyIfEmpty
+        expect(self.receiptFetcher.receiptDataReceivedRefreshPolicy) == .always
     }
 
     func testPaymentSheetCancelledErrorIsParsedCorrectly() {


### PR DESCRIPTION
Fixes [CSDK-120].
See conversation: https://github.com/RevenueCat/purchases-ios/pull/1666#discussion_r892423490

> why do we have `onlyIfEmpty` in this case? If we're calling this method, we know that there was a purchase, right? I feel like we should always refresh in that case, there's a good chance that the receipt isn't up to date otherwise

[CSDK-120]: https://revenuecats.atlassian.net/browse/CSDK-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ