### PR TITLE
`PurchasesOrchestrator`: unify finish transactions between SK1 and SK2

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -588,9 +588,7 @@ private extension PurchasesOrchestrator {
             }
         }
 
-        if finishTransactions {
-            storeKitWrapper.finishTransaction(transaction)
-        }
+        self.finishTransactionIfNeeded(storeTransaction)
     }
 
     func handleDeferredTransaction(_ transaction: SKPaymentTransaction) {
@@ -722,12 +720,6 @@ private extension PurchasesOrchestrator {
     func handleReceiptPost(withTransaction transaction: StoreTransaction,
                            result: Result<CustomerInfo, BackendError>,
                            subscriberAttributes: SubscriberAttribute.Dictionary?) {
-        func finishTransactionIfNeeded() {
-            if self.finishTransactions, let sk1Transaction = transaction.sk1Transaction {
-                self.storeKitWrapper.finishTransaction(sk1Transaction)
-            }
-        }
-
         self.operationDispatcher.dispatchOnMainThread {
             let appUserID = self.appUserID
             self.markSyncedIfNeeded(subscriberAttributes: subscriberAttributes,
@@ -743,7 +735,7 @@ private extension PurchasesOrchestrator {
                 self.customerInfoManager.cache(customerInfo: customerInfo, appUserID: appUserID)
                 completion?(transaction, customerInfo, nil, false)
 
-                finishTransactionIfNeeded()
+                self.finishTransactionIfNeeded(transaction)
 
             case let .failure(error):
                 let purchasesError = error.asPurchasesError
@@ -751,7 +743,7 @@ private extension PurchasesOrchestrator {
                 completion?(transaction, nil, purchasesError, false)
 
                 if finishable {
-                    finishTransactionIfNeeded()
+                    self.finishTransactionIfNeeded(transaction)
                 }
             }
         }
@@ -866,6 +858,12 @@ private extension PurchasesOrchestrator {
     func handleStorefrontChange() {
         self.productsManager.clearCachedProducts()
         self.deviceCache.clearCachedOfferings()
+    }
+
+    func finishTransactionIfNeeded(_ transaction: StoreTransaction) {
+        if self.finishTransactions {
+            transaction.finish(self.storeKitWrapper)
+        }
     }
 
 }

--- a/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
@@ -31,6 +31,10 @@ internal struct SK1StoreTransaction: StoreTransactionType {
     let transactionIdentifier: String
     let quantity: Int
 
+    func finish(_ wrapper: StoreKitWrapper) {
+        wrapper.finishTransaction(self.underlyingSK1Transaction)
+    }
+
 }
 
 extension SKPaymentTransaction {

--- a/Sources/Purchasing/StoreKitAbstractions/SK2StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK2StoreTransaction.swift
@@ -32,4 +32,10 @@ internal struct SK2StoreTransaction: StoreTransactionType {
     let transactionIdentifier: String
     let quantity: Int
 
+    func finish(_ wrapper: StoreKitWrapper) {
+        Task<Void, Never> {
+            await self.underlyingSK2Transaction.finish()
+        }
+    }
+
 }

--- a/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
@@ -42,6 +42,8 @@ public typealias SK2Transaction = StoreKit.Transaction
     @objc public var transactionIdentifier: String { self.transaction.transactionIdentifier }
     @objc public var quantity: Int { self.transaction.quantity }
 
+    internal func finish(_ wrapper: StoreKitWrapper) { self.transaction.finish(wrapper) }
+
     // swiftlint:enable missing_docs
 
     /// Creates an instance from any `StoreTransactionType`.
@@ -80,6 +82,10 @@ internal protocol StoreTransactionType {
     /// The number of consumable products purchased.
     /// - Note: multi-quantity purchases aren't currently supported.
     var quantity: Int { get }
+
+    /// Indicates to the App Store that the app delivered the purchased content
+    /// or enabled the service to finish the transaction.
+    func finish(_ wrapper: StoreKitWrapper)
 
 }
 

--- a/Sources/Purchasing/TransactionsFactory.swift
+++ b/Sources/Purchasing/TransactionsFactory.swift
@@ -54,4 +54,8 @@ private struct BackendParsedTransaction: StoreTransactionType {
         self.quantity = 1
     }
 
+    func finish(_ wrapper: StoreKitWrapper) {
+        // Nothing to do
+    }
+
 }


### PR DESCRIPTION
 Fixes [CSDK-122].

Before this change, transactions were finished separately for SK1 and SK2. Now this is combined through a common method in `StoreTransactionType`.

[CSDK-122]: https://revenuecats.atlassian.net/browse/CSDK-122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ