### PR TITLE
`Purchases.configure`: added overload taking a `Configuration.Builder`

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1442,6 +1442,35 @@ public extension Purchases {
     }
 
     /**
+     * Configures an instance of the Purchases SDK with a specified ``Configuration/Builder``.
+     *
+     * The instance will be set as a singleton.
+     * You should access the singleton instance using ``Purchases/shared``
+     *
+     * - Parameter builder: The ``Configuration/Builder`` object you wish to use to configure ``Purchases``
+     *
+     * - Returns: An instantiated ``Purchases`` object that has been set as a singleton.
+     *
+     * - Important: See ``Configuration/Builder`` for more information about configurable properties.
+     *
+     * ### Example
+     *
+     * ```swift
+     *  Purchases.configure(
+     *      with: .init(withAPIKey: Constants.apiKey)
+     *               .with(usesStoreKit2IfAvailable: true)
+     *               .with(observerMode: false)
+     *               .with(appUserID: "<app_user_id>")
+     *      )
+     * ```
+     *
+     */
+    @objc(configureWithConfigurationBuilder:)
+    @discardableResult static func configure(with builder: Configuration.Builder) -> Purchases {
+        return Self.configure(with: builder.build())
+    }
+
+    /**
      * Configures an instance of the Purchases SDK with a specified API key.
      *
      * The instance will be set as a singleton.

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -32,6 +32,7 @@ BOOL isAnonymous;
 + (void)checkAPI {
     RCPurchases *p = [RCPurchases configureWithAPIKey:@""];
     [RCPurchases configureWithConfiguration:[[RCConfiguration builderWithAPIKey:@""] build]];
+    [RCPurchases configureWithConfigurationBuilder:[RCConfiguration builderWithAPIKey:@""]];
     [RCPurchases configureWithAPIKey:@"" appUserID:@""];
     [RCPurchases configureWithAPIKey:@"" appUserID:nil];
     [RCPurchases configureWithAPIKey:@"" appUserID:@"" observerMode:false];

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -240,9 +240,8 @@ private func checkAsyncMethods(purchases: Purchases) async {
 }
 
 private func checkConfigure() -> Purchases {
-    Purchases
-        .configure(with: Configuration.Builder(withAPIKey: "")
-        .build())
+    Purchases.configure(with: Configuration.Builder(withAPIKey: ""))
+    Purchases.configure(with: Configuration.Builder(withAPIKey: "").build())
 
     return Purchases.configure(withAPIKey: "")
 }


### PR DESCRIPTION
Fixes [CF-780].

See https://github.com/RevenueCat/purchases-ios/issues/1717#issuecomment-1160718519 for an example of a user trying to do this.