### PR TITLE
`Purchases.customerInfo(fetchPolicy:)`: actually use `fetchPolicy` parameter

### DIFF
--- a/Sources/Misc/Purchases+async.swift
+++ b/Sources/Misc/Purchases+async.swift
@@ -45,9 +45,9 @@ extension Purchases {
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func customerInfoAsync() async throws -> CustomerInfo {
+    func customerInfoAsync(fetchPolicy: CacheFetchPolicy) async throws -> CustomerInfo {
         return try await withCheckedThrowingContinuation { continuation in
-            getCustomerInfo { customerInfo, error in
+            getCustomerInfo(fetchPolicy: fetchPolicy) { customerInfo, error in
                 continuation.resume(with: Result(customerInfo, error))
             }
         }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -723,7 +723,7 @@ public extension Purchases {
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func customerInfo(fetchPolicy: CacheFetchPolicy = .default) async throws -> CustomerInfo {
-        return try await self.customerInfoAsync()
+        return try await self.customerInfoAsync(fetchPolicy: fetchPolicy)
     }
 
     /// Returns an `AsyncStream` of ``CustomerInfo`` changes, starting from the last known value.


### PR DESCRIPTION
This was being ignored in the `async` method