### PR TITLE
Improved purchasing logs, added promotional offer information

### DIFF
--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -28,8 +28,10 @@ enum PurchaseStrings {
     case presenting_code_redemption_sheet
     case unable_to_present_redemption_sheet
     case purchases_synced
-    case purchasing_product_from_package(productIdentifier: String, offeringIdentifier: String)
-    case purchasing_product(productIdentifier: String)
+    case purchasing_product(StoreProduct)
+    case purchasing_product_from_package(StoreProduct, Package)
+    case purchasing_product_with_offer(StoreProduct, StoreProductDiscount)
+    case purchasing_product_from_package_with_offer(StoreProduct, Package, StoreProductDiscount)
     case purchased_product(productIdentifier: String)
     case product_purchase_failed(productIdentifier: String, error: Error)
     case skpayment_missing_from_skpaymenttransaction
@@ -126,11 +128,19 @@ extension PurchaseStrings: CustomStringConvertible {
         case .purchases_synced:
             return "Purchases synced."
 
-        case let .purchasing_product_from_package(productIdentifier, offeringIdentifier):
-            return "Purchasing product from package '\(productIdentifier)' in Offering '\(offeringIdentifier)'"
+        case let .purchasing_product(product):
+            return "Purchasing Product '\(product.productIdentifier)'"
 
-        case .purchasing_product(let productIdentifier):
-            return "Purchasing product '\(productIdentifier)'"
+        case let .purchasing_product_from_package(product, package):
+            return "Purchasing Product '\(product.productIdentifier)' from package " +
+            "in Offering '\(package.offeringIdentifier)'"
+
+        case let .purchasing_product_with_offer(product, discount):
+            return "Purchasing Product '\(product.productIdentifier)' with Offer '\(discount.offerIdentifier ?? "")'"
+
+        case let .purchasing_product_from_package_with_offer(product, package, discount):
+            return "Purchasing Product '\(product.productIdentifier)' from package in Offering " +
+            "'\(package.offeringIdentifier)' with Offer '\(discount.offerIdentifier ?? "")'"
 
         case let .purchased_product(productIdentifier):
             return "Purchased product - '\(productIdentifier)'"

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -265,7 +265,7 @@ class PurchasesOrchestrator {
                   package: Package?,
                   promotionalOffer: PromotionalOffer,
                   completion: @escaping PurchaseCompletedBlock) {
-        Self.logPurchase(product: product, package: package)
+        Self.logPurchase(product: product, package: package, offer: promotionalOffer)
 
         if let sk1Product = product.sk1Product {
             purchase(sk1Product: sk1Product,
@@ -868,17 +868,19 @@ private extension PurchasesOrchestrator {
 
 private extension PurchasesOrchestrator {
 
-    static func logPurchase(product: StoreProduct, package: Package?) {
-        if let package = package {
-            Logger.purchase(
-                Strings.purchase.purchasing_product_from_package(
-                    productIdentifier: product.productIdentifier,
-                    offeringIdentifier: package.offeringIdentifier
-                )
-            )
-        } else {
-            Logger.purchase(Strings.purchase.purchasing_product(productIdentifier: product.productIdentifier))
-        }
+    static func logPurchase(product: StoreProduct, package: Package?, offer: PromotionalOffer? = nil) {
+        let string: PurchaseStrings = {
+            switch (package, offer) {
+            case (nil, nil): return .purchasing_product(product)
+            case let (package?, nil): return .purchasing_product_from_package(product, package)
+            case let (nil, offer?): return .purchasing_product_with_offer(product, offer.discount)
+            case let (package?, offer?): return .purchasing_product_from_package_with_offer(product,
+                                                                                            package,
+                                                                                            offer.discount)
+            }
+        }()
+
+        Logger.purchase(string)
     }
 
 }


### PR DESCRIPTION
Example:
```
💰 Purchasing Product 'com.revenuecat.weekly_1.99.no_intro' with Offer 'com.revenuecat.weekly_1.99.3_free_days'
```