### PR TITLE
`TrialOrIntroPriceEligibilityChecker`: fixed integration test to ensure receipt is always loaded

### DIFF
--- a/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -82,7 +82,9 @@ class TrialOrIntroPriceEligibilityChecker {
 
     func sk1CheckEligibility(_ productIdentifiers: [String],
                              completion: @escaping ReceiveIntroEligibilityBlock) {
-        receiptFetcher.receiptData(refreshPolicy: .never) { data in
+        // We don't want to refresh receipts because it will likely prompt the user for their credentials,
+        // and intro eligibility is triggered programmatically.
+        self.receiptFetcher.receiptData(refreshPolicy: .never) { data in
             if #available(iOS 12.0, macOS 10.14, tvOS 12.0, watchOS 6.2, *),
                let data = data {
                 self.sk1CheckEligibility(with: data,

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -208,6 +208,12 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
     func testEligibleForIntroBeforePurchase() async throws {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
+        if Self.storeKit2Setting == .disabled {
+            // SK1 implementation relies on the receipt being loaded already.
+            // See `TrialOrIntroPriceEligibilityChecker.sk1CheckEligibility`
+            _ = try await Purchases.shared.restorePurchases()
+        }
+
         let product = try await self.monthlyPackage.storeProduct
 
         let eligibility = await Purchases.shared.checkTrialOrIntroDiscountEligibility(product: product)

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
@@ -64,7 +64,7 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
 
         expect(self.receiptFetcher.receiptDataCalled) == false
 
-        trialOrIntroPriceEligibilityChecker!.sk1CheckEligibility([]) { _ in }
+        self.trialOrIntroPriceEligibilityChecker.sk1CheckEligibility([]) { _ in }
 
         expect(self.receiptFetcher.receiptDataCalled) == true
         expect(self.receiptFetcher.receiptDataReceivedRefreshPolicy) == .never


### PR DESCRIPTION
The reason the receipt data is required, is because if it's `nil`, it ends up becoming empty because of `data ?? Data()`, but `GetIntroEligibilityOperation` never actually runs because that's empty.

To make sure the test doesn't fail, we begin by ensuring the receipt data is loaded first.

Also documented the reason for `ReceiptRefreshPolicy.never`.