### PR TITLE
Integration Tests: ensure that environment is sandbox

### DIFF
--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -171,7 +171,7 @@ import Foundation
 
     fileprivate init(
         data: Contents,
-        sandboxEnvironmentDetector: SandboxEnvironmentDetector = DefaultSandboxEnvironmentDetector()
+        sandboxEnvironmentDetector: SandboxEnvironmentDetector = BundleSandboxEnvironmentDetector.default
     ) {
         let response = data.response
         let subscriber = response.subscriber

--- a/Sources/Misc/SandboxEnvironmentDetector.swift
+++ b/Sources/Misc/SandboxEnvironmentDetector.swift
@@ -21,7 +21,7 @@ protocol SandboxEnvironmentDetector {
 }
 
 /// ``SandboxEnvironmentDetector`` that uses a `Bundle` to detect the environment
-final class DefaultSandboxEnvironmentDetector: SandboxEnvironmentDetector {
+final class BundleSandboxEnvironmentDetector: SandboxEnvironmentDetector {
 
     private let bundle: Bundle
 
@@ -36,5 +36,12 @@ final class DefaultSandboxEnvironmentDetector: SandboxEnvironmentDetector {
 
         return url.path.contains("sandboxReceipt")
     }
+
+    #if DEBUG
+    // Mutable in tests so it can be overriden
+    static var `default`: SandboxEnvironmentDetector = BundleSandboxEnvironmentDetector()
+    #else
+    static let `default`: SandboxEnvironmentDetector = BundleSandboxEnvironmentDetector()
+    #endif
 
 }

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -110,7 +110,9 @@ class SystemInfo {
         self.operationDispatcher = operationDispatcher
         self.storeKit2Setting = storeKit2Setting
         self.dangerousSettings = dangerousSettings ?? DangerousSettings()
-        self.sandboxEnvironmentDetector = DefaultSandboxEnvironmentDetector(bundle: bundle)
+        self.sandboxEnvironmentDetector = bundle === Bundle.main
+            ? BundleSandboxEnvironmentDetector.default
+            : BundleSandboxEnvironmentDetector(bundle: bundle)
     }
 
     func isApplicationBackgrounded(completion: @escaping (Bool) -> Void) {

--- a/Sources/Purchasing/EntitlementInfos.swift
+++ b/Sources/Purchasing/EntitlementInfos.swift
@@ -111,7 +111,7 @@ extension EntitlementInfos {
         entitlements: [String: CustomerInfoResponse.Entitlement],
         purchases: [String: CustomerInfoResponse.Subscription],
         requestDate: Date?,
-        sandboxEnvironmentDetector: SandboxEnvironmentDetector = DefaultSandboxEnvironmentDetector()
+        sandboxEnvironmentDetector: SandboxEnvironmentDetector = BundleSandboxEnvironmentDetector.default
     ) {
         let allEntitlements: [String: EntitlementInfo] = .init(
             uniqueKeysWithValues: entitlements.compactMap { identifier, entitlement in

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1639,6 +1639,10 @@ internal extension Purchases {
         return self.productsManager.requestTimeout
     }
 
+    var isSandbox: Bool {
+        return self.systemInfo.isSandbox
+    }
+
 }
 
 // MARK: Private

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -36,6 +36,10 @@ class BaseBackendIntegrationTests: XCTestCase {
         return .default
     }
 
+    override class func setUp() {
+        BundleSandboxEnvironmentDetector.default = MockSandboxEnvironmentDetector()
+    }
+
     override func setUp() async throws {
         try await super.setUp()
 
@@ -80,17 +84,24 @@ private extension BaseBackendIntegrationTests {
     }
 
     func configurePurchases() {
-        purchasesDelegate = TestPurchaseDelegate()
+        self.purchasesDelegate = TestPurchaseDelegate()
+
         Purchases.configure(withAPIKey: Constants.apiKey,
                             appUserID: nil,
                             observerMode: false,
-                            userDefaults: userDefaults,
+                            userDefaults: self.userDefaults,
                             storeKit2Setting: Self.storeKit2Setting,
                             storeKitTimeout: Configuration.storeKitRequestTimeoutDefault,
                             networkTimeout: Configuration.networkTimeoutDefault,
                             dangerousSettings: nil)
         Purchases.logLevel = .debug
-        Purchases.shared.delegate = purchasesDelegate
+        Purchases.shared.delegate = self.purchasesDelegate
     }
+
+}
+
+private final class MockSandboxEnvironmentDetector: SandboxEnvironmentDetector {
+
+    let isSandbox: Bool = true
 
 }

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -11,7 +11,7 @@ import Nimble
 import StoreKitTest
 import XCTest
 
-// swiftlint:disable file_length
+// swiftlint:disable file_length type_body_length
 
 class StoreKit2IntegrationTests: StoreKit1IntegrationTests {
 
@@ -49,6 +49,10 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
         return .disabled
     }
 
+    func testIsSandbox() {
+        expect(Purchases.shared.isSandbox) == true
+    }
+
     func testCanGetOfferings() async throws {
         let receivedOfferings = try await Purchases.shared.offerings()
         expect(receivedOfferings.all).toNot(beEmpty())
@@ -56,6 +60,14 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
 
     func testCanMakePurchase() async throws {
         try await self.purchaseMonthlyOffering()
+    }
+
+    func testSubscriptionIsSandbox() async throws {
+        let info = try await self.purchaseMonthlyOffering().customerInfo
+
+        let entitlement = try XCTUnwrap(info.entitlements.active.first?.value)
+
+        expect(entitlement.isSandbox) == true
     }
 
     func testPurchaseUpdatesCustomerInfoDelegate() async throws {

--- a/Tests/UnitTests/Attribution/AttributionPosterTests.swift
+++ b/Tests/UnitTests/Attribution/AttributionPosterTests.swift
@@ -39,7 +39,7 @@ class AttributionPosterTests: TestCase {
         super.setUp()
 
         let userID = "userID"
-        self.deviceCache = MockDeviceCache(sandboxEnvironmentDetector: DefaultSandboxEnvironmentDetector(),
+        self.deviceCache = MockDeviceCache(sandboxEnvironmentDetector: BundleSandboxEnvironmentDetector.default,
                                            userDefaults: UserDefaults(suiteName: userDefaultsSuiteName)!)
         self.deviceCache.cache(appUserID: userID)
         self.backend = MockBackend()

--- a/Tests/UnitTests/Misc/CustomerInfo+TestExtensions.swift
+++ b/Tests/UnitTests/Misc/CustomerInfo+TestExtensions.swift
@@ -20,7 +20,7 @@ extension CustomerInfo {
     /// Useful only for backwards compatibility with old tests
     convenience init(
         data: [String: Any],
-        sandboxEnvironmentDetector: SandboxEnvironmentDetector = DefaultSandboxEnvironmentDetector()
+        sandboxEnvironmentDetector: SandboxEnvironmentDetector = BundleSandboxEnvironmentDetector.default
     ) throws {
         self.init(customerInfo: try JSONDecoder.default.decode(dictionary: data),
                   sandboxEnvironmentDetector: sandboxEnvironmentDetector)

--- a/Tests/UnitTests/Misc/SandboxEnvironmentDetectorTests.swift
+++ b/Tests/UnitTests/Misc/SandboxEnvironmentDetectorTests.swift
@@ -38,7 +38,7 @@ private extension SandboxEnvironmentDetector {
         let bundle = MockBundle()
         bundle.receiptURLResult = result
 
-        return DefaultSandboxEnvironmentDetector(bundle: bundle)
+        return BundleSandboxEnvironmentDetector(bundle: bundle)
     }
 
 }


### PR DESCRIPTION
For some reason the url is `[app_bundle]/StoreKit/receipt` in integration tests.
This is not correct, so I've added a couple of tests: one for entitlements, and another one to check the raw output value of that property.

This is necessary to make sure that receipts are loaded correctly after #1726.