### PR TITLE
`PurchasesOrchestrator`: using `PurchaseResultData` tuple value names

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -366,7 +366,7 @@ class PurchasesOrchestrator {
                 ))
 
                 DispatchQueue.main.async {
-                    completion(result.0, result.1, nil, result.2)
+                    completion(result.transaction, result.customerInfo, nil, result.userCancelled)
                 }
             } catch let error {
                 Logger.rcPurchaseError(Strings.purchase.product_purchase_failed(


### PR DESCRIPTION
Makes this more clear to read and easier maintain.