### PR TITLE
Replaced `CustomerInfo.nonSubscriptionTransactions` with a new non-`StoreTransaction` type

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -206,6 +206,7 @@
 		37E3578711F5FDD5DC6458A8 /* AttributionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3521731D8DC16873F55F3 /* AttributionFetcher.swift */; };
 		37E35C8515C5E2D01B0AF5C1 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3507939634ED5A9280544 /* Strings.swift */; };
 		42F1DF385E3C1F9903A07FBF /* ProductsFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */; };
+		570FAF4B2864EC2300D3C769 /* NonSubscriptionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570FAF4A2864EC2300D3C769 /* NonSubscriptionTransaction.swift */; };
 		571E7AD4279F2D0C003B3606 /* StoreKitTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571E7AD3279F2D0C003B3606 /* StoreKitTestHelpers.swift */; };
 		572247D127BEC28E00C524A7 /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572247D027BEC28E00C524A7 /* Array+Extensions.swift */; };
 		572247F727BF1ADF00C524A7 /* ArrayExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572247F627BF1ADF00C524A7 /* ArrayExtensionsTests.swift */; };
@@ -696,6 +697,7 @@
 		570896B527595C8100296F1C /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = UnitTests.xctestplan; path = Tests/TestPlans/UnitTests.xctestplan; sourceTree = "<group>"; };
 		570896B727596E8800296F1C /* SwiftAPITester.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SwiftAPITester.xcodeproj; path = Tests/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj; sourceTree = "<group>"; };
 		570896BD27596E8800296F1C /* ObjCAPITester.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ObjCAPITester.xcodeproj; path = Tests/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj; sourceTree = "<group>"; };
+		570FAF4A2864EC2300D3C769 /* NonSubscriptionTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonSubscriptionTransaction.swift; sourceTree = "<group>"; };
 		571E7AD3279F2D0C003B3606 /* StoreKitTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitTestHelpers.swift; sourceTree = "<group>"; };
 		572247D027BEC28E00C524A7 /* Array+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
 		572247F627BF1ADF00C524A7 /* ArrayExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtensionsTests.swift; sourceTree = "<group>"; };
@@ -1468,6 +1470,7 @@
 				B3AA6235268A81C700894871 /* EntitlementInfos.swift */,
 				B3DF6A4F269524080030D57C /* IntroEligibility.swift */,
 				2D97458E24BDFCEF006245E9 /* IntroEligibilityCalculator.swift */,
+				570FAF4A2864EC2300D3C769 /* NonSubscriptionTransaction.swift */,
 				B3083A122699334C007B5503 /* Offering.swift */,
 				B3B5FBBB269D121B00104A0C /* Offerings.swift */,
 				35549322269E298B005F9AE9 /* OfferingsFactory.swift */,
@@ -2326,6 +2329,7 @@
 				9A65E03625918B0500DE00B0 /* ConfigureStrings.swift in Sources */,
 				B34605C9279A6E380031CA74 /* GetIntroEligibilityOperation.swift in Sources */,
 				354895D6267BEDE3001DC5B1 /* ReservedSubscriberAttributes.swift in Sources */,
+				570FAF4B2864EC2300D3C769 /* NonSubscriptionTransaction.swift in Sources */,
 				2D11F5E1250FF886005A70E8 /* AttributionStrings.swift in Sources */,
 				2CD72944268A826F00BFC976 /* Date+Extensions.swift in Sources */,
 				B34605C5279A6E380031CA74 /* CustomerInfoResponseHandler.swift in Sources */,

--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -29,7 +29,7 @@ import Foundation
     /// All product identifiers purchases by the user regardless of expiration.
     @objc public private(set) lazy var allPurchasedProductIdentifiers: Set<String> = {
         return Set(self.expirationDatesByProductId.keys)
-            .union(self.nonSubscriptionTransactions.map { $0.productIdentifier })
+            .union(self.nonSubscriptions.map { $0.productIdentifier })
     }()
 
     /// Returns the latest expiration date of all products, nil if there are none.
@@ -46,7 +46,7 @@ import Foundation
      * Returns all the non-subscription purchases a user has made.
      * The purchases are ordered by purchase date in ascending order.
      */
-    @objc public let nonSubscriptionTransactions: [StoreTransaction]
+    @objc public let nonSubscriptions: [NonSubscriptionTransaction]
 
     /**
      * Returns the fetch date of this CustomerInfo.
@@ -144,7 +144,7 @@ import Foundation
             latestExpirationDate=\(String(describing: self.latestExpirationDate)),
             activeEntitlements=\(activeEntitlementsDescription),
             activeSubscriptions=\(activeSubsDescription),
-            nonSubscriptionTransactions=\(self.nonSubscriptionTransactions),
+            nonSubscriptions=\(self.nonSubscriptions),
             requestDate=\(String(describing: self.requestDate)),
             firstSeen=\(String(describing: self.firstSeen)),
             originalAppUserId=\(self.originalAppUserId),
@@ -183,7 +183,7 @@ import Foundation
             requestDate: response.requestDate,
             sandboxEnvironmentDetector: sandboxEnvironmentDetector
         )
-        self.nonSubscriptionTransactions = TransactionsFactory.nonSubscriptionTransactions(
+        self.nonSubscriptions = TransactionsFactory.nonSubscriptionTransactions(
             withSubscriptionsData: subscriber.nonSubscriptions
         )
         self.requestDate = response.requestDate

--- a/Sources/Misc/Deprecations.swift
+++ b/Sources/Misc/Deprecations.swift
@@ -14,7 +14,7 @@
 import Foundation
 import StoreKit
 
-// swiftlint:disable line_length missing_docs
+// swiftlint:disable file_length line_length missing_docs
 
 public extension Purchases {
 
@@ -366,6 +366,40 @@ extension CustomerInfo {
     @available(*, deprecated, message: "use nonSubscriptionTransactions")
     @objc public var nonConsumablePurchases: Set<String> {
         return Set(self.nonSubscriptionTransactions.map { $0.productIdentifier })
+    }
+
+    /**
+     * Returns all the non-subscription purchases a user has made.
+     * The purchases are ordered by purchase date in ascending order.
+     */
+    @available(*, deprecated, renamed: "nonSubscriptions")
+    @objc public var nonSubscriptionTransactions: [StoreTransaction] {
+        return self.nonSubscriptions
+            .map(BackendParsedTransaction.init)
+            .map(StoreTransaction.init)
+    }
+
+    @available(*, deprecated, message: "Use NonSubscriptionTransaction")
+    private struct BackendParsedTransaction: StoreTransactionType {
+
+        let productIdentifier: String
+        let purchaseDate: Date
+        let transactionIdentifier: String
+        let quantity: Int
+
+        init(with transaction: NonSubscriptionTransaction) {
+            self.productIdentifier = transaction.productIdentifier
+            self.purchaseDate = transaction.purchaseDate
+            self.transactionIdentifier = transaction.transactionIdentifier
+
+            // Defaulting to `1` since multi-quantity purchases aren't currently supported.
+            self.quantity = 1
+        }
+
+        func finish(_ wrapper: StoreKitWrapper) {
+            // Nothing to do
+        }
+
     }
 
 }

--- a/Sources/Purchasing/NonSubscriptionTransaction.swift
+++ b/Sources/Purchasing/NonSubscriptionTransaction.swift
@@ -1,0 +1,42 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  NonPurchaseTransaction.swift
+//
+//  Created by Nacho Soto on 6/23/22.
+
+import Foundation
+
+/// Information that represents a non-subscription purchase made by a user.
+@objc(RCNonSubscriptionTransaction)
+public final class NonSubscriptionTransaction: NSObject {
+
+    /// The product identifier.
+    @objc public let productIdentifier: String
+
+    /// The date that App Store charged the user’s account.
+    @objc public let purchaseDate: Date
+
+    /// The unique identifier for the transaction.
+    @objc public let transactionIdentifier: String
+
+    init?(with transaction: CustomerInfoResponse.Transaction, productID: String) {
+        guard let transactionIdentifier = transaction.transactionIdentifier,
+              let purchaseDate = transaction.purchaseDate else {
+            Logger.error("Couldn't initialize NonSubscriptionTransaction. " +
+                         "Reason: missing data: \(transaction).")
+            return nil
+        }
+
+        self.transactionIdentifier = transactionIdentifier
+        self.purchaseDate = purchaseDate
+        self.productIdentifier = productID
+    }
+
+}

--- a/Sources/Purchasing/TransactionsFactory.swift
+++ b/Sources/Purchasing/TransactionsFactory.swift
@@ -18,44 +18,14 @@ enum TransactionsFactory {
 
     static func nonSubscriptionTransactions(
         withSubscriptionsData subscriptionsData: [String: [CustomerInfoResponse.Transaction]]
-    ) -> [StoreTransaction] {
+    ) -> [NonSubscriptionTransaction] {
         subscriptionsData
-            .flatMap { (productID, transactions) -> [StoreTransaction] in
+            .flatMap { (productID, transactions) -> [NonSubscriptionTransaction] in
                 transactions
                     .lazy
-                    .compactMap { BackendParsedTransaction(with: $0, productID: productID) }
-                    .map { StoreTransaction($0) }
+                    .compactMap { NonSubscriptionTransaction(with: $0, productID: productID) }
             }
             .sorted { $0.purchaseDate < $1.purchaseDate }
-    }
-
-}
-
-/// `StoreTransactionType` backed by data parsed from the server
-private struct BackendParsedTransaction: StoreTransactionType {
-
-    let productIdentifier: String
-    let purchaseDate: Date
-    let transactionIdentifier: String
-    let quantity: Int
-
-    init?(with transaction: CustomerInfoResponse.Transaction, productID: String) {
-        guard let transactionIdentifier = transaction.transactionIdentifier,
-                let purchaseDate = transaction.purchaseDate else {
-            Logger.error("Couldn't initialize Transaction. " +
-                         "Reason: missing data: \(transaction).")
-            return nil
-        }
-
-        self.transactionIdentifier = transactionIdentifier
-        self.purchaseDate = purchaseDate
-        self.productIdentifier = productID
-        // Defaulting to `1` since multi-quantity purchases aren't currently supported.
-        self.quantity = 1
-    }
-
-    func finish(_ wrapper: StoreKitWrapper) {
-        // Nothing to do
     }
 
 }

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj/project.pbxproj
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		2DD77914270E23870079CBD4 /* RCOfferingAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614DF26EBE84F007DDB75 /* RCOfferingAPI.m */; };
 		2DD77915270E23870079CBD4 /* RCPackageAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614DE26EBE84F007DDB75 /* RCPackageAPI.m */; };
 		2DD77916270E23870079CBD4 /* RCTransactionAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = A5D614F426EBE84F007DDB75 /* RCTransactionAPI.m */; };
+		570FAF502864ECB000D3C769 /* RCNonSubscriptionTransactionAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 570FAF4F2864ECB000D3C769 /* RCNonSubscriptionTransactionAPI.m */; };
 		5738F428278672070096D623 /* RCStoreProductDiscountAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 5738F427278672070096D623 /* RCStoreProductDiscountAPI.m */; };
 		5738F42D278674710096D623 /* RCSubscriptionPeriodAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 5738F42C278674710096D623 /* RCSubscriptionPeriodAPI.m */; };
 		5738F42E2786755E0096D623 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = A519264C26EBCEF6007D0BD1 /* main.m */; };
@@ -48,6 +49,8 @@
 
 /* Begin PBXFileReference section */
 		2DD778F5270E235B0079CBD4 /* ObjCAPITester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ObjCAPITester.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		570FAF4E2864ECB000D3C769 /* RCNonSubscriptionTransactionAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCNonSubscriptionTransactionAPI.h; sourceTree = "<group>"; };
+		570FAF4F2864ECB000D3C769 /* RCNonSubscriptionTransactionAPI.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCNonSubscriptionTransactionAPI.m; sourceTree = "<group>"; };
 		5738F426278672070096D623 /* RCStoreProductDiscountAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCStoreProductDiscountAPI.h; sourceTree = "<group>"; };
 		5738F427278672070096D623 /* RCStoreProductDiscountAPI.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCStoreProductDiscountAPI.m; sourceTree = "<group>"; };
 		5738F42B278674710096D623 /* RCSubscriptionPeriodAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCSubscriptionPeriodAPI.h; sourceTree = "<group>"; };
@@ -142,6 +145,8 @@
 				A5D614E926EBE84F007DDB75 /* RCEntitlementInfosAPI.m */,
 				A5D614E326EBE84F007DDB75 /* RCIntroEligibilityAPI.h */,
 				A5D614F226EBE84F007DDB75 /* RCIntroEligibilityAPI.m */,
+				570FAF4E2864ECB000D3C769 /* RCNonSubscriptionTransactionAPI.h */,
+				570FAF4F2864ECB000D3C769 /* RCNonSubscriptionTransactionAPI.m */,
 				A5D614E426EBE84F007DDB75 /* RCOfferingAPI.h */,
 				A5D614DF26EBE84F007DDB75 /* RCOfferingAPI.m */,
 				A5D614F326EBE84F007DDB75 /* RCOfferingsAPI.h */,
@@ -270,6 +275,7 @@
 				2DD7790E270E23870079CBD4 /* RCIntroEligibilityAPI.m in Sources */,
 				5738F42D278674710096D623 /* RCSubscriptionPeriodAPI.m in Sources */,
 				2DD77916270E23870079CBD4 /* RCTransactionAPI.m in Sources */,
+				570FAF502864ECB000D3C769 /* RCNonSubscriptionTransactionAPI.m in Sources */,
 				2DD7790F270E23870079CBD4 /* RCPurchasesAPI.m in Sources */,
 				B378153D2857A750000A7B93 /* RCAttributionAPI.m in Sources */,
 				5758EE5227864A8500B3B703 /* RCStoreProductAPI.m in Sources */,

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCCustomerInfoAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCCustomerInfoAPI.m
@@ -20,6 +20,7 @@
     NSSet<NSString *> *appis = ci.allPurchasedProductIdentifiers;
     NSDate *led = ci.latestExpirationDate;
     NSSet<NSString *> *ncp = ci.nonConsumablePurchases;
+    NSArray<RCNonSubscriptionTransaction *> *ns = ci.nonSubscriptions;
     NSArray<RCStoreTransaction *> *nst = ci.nonSubscriptionTransactions;
     NSString *oav = ci.originalApplicationVersion;
     NSDate *opd = ci.originalPurchaseDate;
@@ -37,7 +38,7 @@
 
     NSDictionary<NSString *, id> *rawData = [ci rawData];
     
-    NSLog(ci, ei, as, appis, led, ncp, nst, oav, opd, rd, fs, oaud, murl, edfpi, pdfpi, exdf, pdfe, d, rawData);
+    NSLog(ci, ei, as, appis, led, ncp, ns, nst, oav, opd, rd, fs, oaud, murl, edfpi, pdfpi, exdf, pdfe, d, rawData);
 }
 
 + (void)checkCacheFetchPolicyEnum:(RCCacheFetchPolicy) policy {

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCNonSubscriptionTransactionAPI.h
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCNonSubscriptionTransactionAPI.h
@@ -1,0 +1,18 @@
+//
+//  RCNonSubscriptionTransactionAPI.h
+//  ObjCAPITester
+//
+//  Created by Nacho Soto on 6/23/22.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCNonSubscriptionTransactionAPI : NSObject
+
++ (void)checkAPI;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCNonSubscriptionTransactionAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCNonSubscriptionTransactionAPI.m
@@ -1,0 +1,22 @@
+//
+//  RCNonSubscriptionTransactionAPI.m
+//  ObjCAPITester
+//
+//  Created by Nacho Soto on 6/23/22.
+//
+
+#import "RCNonSubscriptionTransactionAPI.h"
+
+@import RevenueCat;
+
+@implementation RCNonSubscriptionTransactionAPI
+
++ (void)checkAPI {
+    RCNonSubscriptionTransaction *transaction;
+
+    NSString *pid __unused = transaction.productIdentifier;
+    NSDate *pd __unused = transaction.purchaseDate;
+    NSString *tid __unused = transaction.transactionIdentifier;
+}
+
+@end

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/main.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/main.m
@@ -13,6 +13,7 @@
 #import "RCEntitlementInfoAPI.h"
 #import "RCEntitlementInfosAPI.h"
 #import "RCIntroEligibilityAPI.h"
+#import "RCNonSubscriptionTransactionAPI.h"
 #import "RCOfferingAPI.h"
 #import "RCOfferingsAPI.h"
 #import "RCPackageAPI.h"
@@ -42,6 +43,8 @@ int main(int argc, const char * argv[]) {
 
         [RCIntroEligibilityAPI checkAPI];
         [RCIntroEligibilityAPI checkEnums];
+
+        [RCNonSubscriptionTransactionAPI checkAPI];
 
         [RCOfferingAPI checkAPI];
         [RCOfferingsAPI checkAPI];

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj/project.pbxproj
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		2DD778ED270E23460079CBD4 /* OfferingAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C726EBE7EA007DDB75 /* OfferingAPI.swift */; };
 		2DD778EE270E23460079CBD4 /* EntitlementInfosAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C526EBE7EA007DDB75 /* EntitlementInfosAPI.swift */; };
 		2DD778EF270E23460079CBD4 /* EntitlementInfoAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C826EBE7EA007DDB75 /* EntitlementInfoAPI.swift */; };
+		570FAF562864EE1D00D3C769 /* NonSubscriptionTransactionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570FAF552864EE1D00D3C769 /* NonSubscriptionTransactionAPI.swift */; };
 		5738F40C27866DD00096D623 /* StoreProductDiscountAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5738F40B27866DD00096D623 /* StoreProductDiscountAPI.swift */; };
 		5738F42127866F8F0096D623 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C626EBE7EA007DDB75 /* main.swift */; };
 		5738F42A278673A80096D623 /* SubscriptionPeriodAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5738F429278673A80096D623 /* SubscriptionPeriodAPI.swift */; };
@@ -48,6 +49,7 @@
 
 /* Begin PBXFileReference section */
 		2DD778D0270E233F0079CBD4 /* SwiftAPITester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftAPITester.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		570FAF552864EE1D00D3C769 /* NonSubscriptionTransactionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonSubscriptionTransactionAPI.swift; sourceTree = "<group>"; };
 		5738F40B27866DD00096D623 /* StoreProductDiscountAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProductDiscountAPI.swift; sourceTree = "<group>"; };
 		5738F429278673A80096D623 /* SubscriptionPeriodAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPeriodAPI.swift; sourceTree = "<group>"; };
 		575885972748271100CA2169 /* RevenueCat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RevenueCat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -123,6 +125,7 @@
 				A5D614C226EBE7EA007DDB75 /* ErrorCodesAPI.swift */,
 				A5D614CD26EBE7EA007DDB75 /* IntroEligibilityAPI.swift */,
 				A5D614C626EBE7EA007DDB75 /* main.swift */,
+				570FAF552864EE1D00D3C769 /* NonSubscriptionTransactionAPI.swift */,
 				A5D614C726EBE7EA007DDB75 /* OfferingAPI.swift */,
 				A5D614C326EBE7EA007DDB75 /* OfferingsAPI.swift */,
 				A5D614C926EBE7EA007DDB75 /* PackageAPI.swift */,
@@ -216,6 +219,7 @@
 				5738F42127866F8F0096D623 /* main.swift in Sources */,
 				A513AD35272B4C0100E0C1BA /* RefundRequestStatusAPI.swift in Sources */,
 				2DD778E8270E23460079CBD4 /* PackageAPI.swift in Sources */,
+				570FAF562864EE1D00D3C769 /* NonSubscriptionTransactionAPI.swift in Sources */,
 				57DE807528074D9C008D6C6F /* StorefrontAPI.swift in Sources */,
 				2DD778E6270E23460079CBD4 /* PurchasesAPI.swift in Sources */,
 				2DD778EF270E23460079CBD4 /* EntitlementInfoAPI.swift in Sources */,

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/CustomerInfoAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/CustomerInfoAPI.swift
@@ -21,7 +21,7 @@ func checkCustomerInfoAPI() {
     let appis: Set<String> = customerInfo.allPurchasedProductIdentifiers
     let led: Date? = customerInfo.latestExpirationDate
 
-    let nst: [StoreTransaction] = customerInfo.nonSubscriptionTransactions
+    let nst: [NonSubscriptionTransaction] = customerInfo.nonSubscriptions
     let oav: String? = customerInfo.originalApplicationVersion
     let opd: Date? = customerInfo.originalPurchaseDate
     let rDate: Date? = customerInfo.requestDate
@@ -56,4 +56,5 @@ func checkCacheFetchPolicyEnum(_ policy: CacheFetchPolicy) {
 @available(*, deprecated) // Ignore deprecation warnings
 func checkDeprecatedAPI() {
     let _: Set<String> = customerInfo.nonConsumablePurchases
+    let _: [StoreTransaction] = customerInfo.nonSubscriptionTransactions
 }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/NonSubscriptionTransactionAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/NonSubscriptionTransactionAPI.swift
@@ -1,0 +1,17 @@
+//
+//  NonSubscriptionTransaction.swift
+//  SwiftAPITester
+//
+//  Created by Nacho Soto on 6/23/22.
+//
+
+import Foundation
+import RevenueCat
+
+private var transaction: NonSubscriptionTransaction!
+
+func checkNonSubscriptionTransactionAPI() {
+    let _: String = transaction.productIdentifier
+    let _: Date = transaction.purchaseDate
+    let _: String = transaction.transactionIdentifier
+}

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/StoreTransactionAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/StoreTransactionAPI.swift
@@ -9,7 +9,7 @@ import StoreKit
 
 import RevenueCat
 
-var transaction: StoreTransaction!
+private  var transaction: StoreTransaction!
 func checkStoreTransactionAPI() {
     let productIdentifier: String = transaction.productIdentifier
     let purchaseDate: Date = transaction.purchaseDate

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/main.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/main.swift
@@ -47,6 +47,7 @@ func main() -> Int {
 
     checkRefundRequestStatusEnum()
 
+    checkNonSubscriptionTransactionAPI()
     checkTransactionAPI()
 
     checkStoreProductAPI()

--- a/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
@@ -111,11 +111,25 @@ class BasicCustomerInfoTests: TestCase {
         expect(latestExpiration) == self.customerInfo.expirationDate(forProductIdentifier: "onemonth_freetrial")
     }
 
-    func testParsesOtherPurchases() {
-        let nonConsumables = self.customerInfo.nonSubscriptionTransactions
-
+    func testnonSubscriptions() throws {
+        let nonConsumables = self.customerInfo.nonSubscriptions
         expect(nonConsumables).to(haveCount(1))
-        expect(nonConsumables.first?.productIdentifier) == "onetime_purchase"
+
+        let transaction = try XCTUnwrap(nonConsumables.first)
+        expect(transaction.productIdentifier) == "onetime_purchase"
+        expect(transaction.purchaseDate) == ISO8601DateFormatter.default.date(from: "1990-08-30T02:40:36Z")
+        expect(transaction.transactionIdentifier) == "d6c007ba74"
+    }
+
+    @available(*, deprecated) // Ignore deprecation warnings
+    func testNonSubscriptionTransactions() throws {
+        let nonConsumables = self.customerInfo.nonSubscriptionTransactions
+        expect(nonConsumables).to(haveCount(1))
+
+        let transaction = try XCTUnwrap(nonConsumables.first)
+        expect(transaction.productIdentifier) == "onetime_purchase"
+        expect(transaction.purchaseDate) == ISO8601DateFormatter.default.date(from: "1990-08-30T02:40:36Z")
+        expect(transaction.transactionIdentifier) == "d6c007ba74"
     }
 
     @available(*, deprecated) // Ignore deprecation warnings

--- a/Tests/UnitTests/Purchasing/TransactionsFactoryTests.swift
+++ b/Tests/UnitTests/Purchasing/TransactionsFactoryTests.swift
@@ -89,7 +89,7 @@ private extension TransactionsFactory {
 
     static func nonSubscriptionTransactions(
         withSubscriptionsData data: [String: Any]
-    ) throws -> [StoreTransaction] {
+    ) throws -> [NonSubscriptionTransaction] {
         let data = try JSONSerialization.data(withJSONObject: data)
         let transactions: [String: [CustomerInfoResponse.Transaction]] = try JSONDecoder.default.decode(
             jsonData: data


### PR DESCRIPTION
Fixes [CF-781]

Making `CustomerInfo.nonSubscriptionTransactions` return type a `StoreTransaction` was my mistake from an earlier refactor. I saw the two types were similar, so I made them conform to the same interface.
However, they represent different concepts.

### Changes:

- Added new `NonSubscriptionTransaction` type
- Deprecated `CustomerInfo.nonSubscriptionTransactions` with a `renamed` for a new `nonSubscriptions`
- Made the old `BackendParsedTransaction` initialization depend on the new type to avoid duplicating code
- Add new test to cover the new method, and left the existing one
- Added more checks in `CustomerInfoTest` for missing properties
- Updated all APITesters

[CF-781]: https://revenuecats.atlassian.net/browse/CF-781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ