### PR TITLE
Added `Dictionary.mapKeys` and `Dictionary.compactMapKeys`

### DIFF
--- a/Sources/FoundationExtensions/Dictionary+Extensions.swift
+++ b/Sources/FoundationExtensions/Dictionary+Extensions.swift
@@ -89,6 +89,26 @@ extension Dictionary {
 
 }
 
+extension Dictionary {
+
+    func mapKeys<NewKey: Hashable>(_ transformer: (Key) -> NewKey) -> [NewKey: Value] {
+        return self.compactMapKeys(transformer)
+    }
+
+    func compactMapKeys<NewKey: Hashable>(_ transformer: (Key) -> NewKey?) -> [NewKey: Value] {
+        var result = [NewKey: Value](minimumCapacity: self.count)
+
+        for (key, value) in self {
+            if let newKey = transformer(key) {
+                result.updateValue(value, forKey: newKey)
+            }
+        }
+
+        return result
+    }
+
+}
+
 extension Sequence {
 
     /// Creates a `Dictionary` with the values in the receiver sequence, and the keys provided by `key`.

--- a/Tests/UnitTests/FoundationExtensions/DictionaryExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/DictionaryExtensionsTests.swift
@@ -43,7 +43,11 @@ class DictionaryExtensionsTests: TestCase {
         }
     }
 
-    func testMergeDictionariesWithMergeStrategyKeepOriginalValue() {
+}
+
+class DictionaryExtensionsMergingTests: TestCase {
+
+    func testMergeStrategyKeepOriginalValue() {
         let dict = ["a": "1", "b": "1"]
         let dict2 = ["a": "2", "b": "2", "c": "2"]
         let expectedDict = ["a": "1", "b": "1", "c": "2"]
@@ -54,7 +58,7 @@ class DictionaryExtensionsTests: TestCase {
         expect(obtainedDict).to(equal(expectedDict))
     }
 
-    func testMergeDictionariesWithMergeStrategyOverwriteValue() {
+    func testMergeStrategyOverwriteValue() {
         let dict = ["a": "1", "b": "1"]
         let dict2 = ["a": "2", "b": "2", "c": "2"]
         let expectedDict = ["a": "2", "b": "2", "c": "2"]
@@ -65,7 +69,7 @@ class DictionaryExtensionsTests: TestCase {
         expect(obtainedDict).to(equal(expectedDict))
     }
 
-    func testMergeDictionariesWithDefaultMergeStrategy() {
+    func testDefaultMergeStrategy() {
         let dict = ["a": "1", "b": "1"]
         let dict2 = ["a": "2", "b": "2", "c": "2"]
         let expectedDict = ["a": "2", "b": "2", "c": "2"]
@@ -97,6 +101,11 @@ class DictionaryExtensionsTests: TestCase {
         expect(original.keys.count).to(equal(expectedDict.keys.count))
         expect(original).to(equal(expectedDict))
     }
+
+}
+
+// swiftlint:disable:next type_name
+class DictionaryExtensionsDictionaryWithKeysTests: TestCase {
 
     func testCreatingDictionaryWithNoValues() {
         expect([String]().dictionaryWithKeys { $0 }) == [:]
@@ -133,4 +142,87 @@ class DictionaryExtensionsTests: TestCase {
             3: "3"
         ]
     }
+
+}
+
+class DictionaryExtensionsMapKeysTests: TestCase {
+
+    private typealias Input = [Int: Int]
+    private typealias Output = [String: Int]
+
+    private let transformer: (Int) -> String = { String($0) }
+
+    func testMapEmptyDictionary() {
+        expect(Input().mapKeys(self.transformer)) == [:]
+    }
+
+    func testMapDictionaryWithOneKey() {
+        expect([1: "test"].mapKeys(self.transformer)) == [
+            "1": "test"
+        ]
+    }
+
+    func testMapDictionary() {
+        let input: Input = [
+            1: 1,
+            2: 2,
+            3: 3
+        ]
+        expect(input.mapKeys(self.transformer)) == [
+            "1": 1,
+            "2": 2,
+            "3": 3
+        ]
+    }
+
+    func tetMapKeysWithOverlappingKeys() {
+        let input: [String: Int] = [
+            "a1": 1,
+            "a2": 2,
+            "b3": 3
+        ]
+
+        let output = input.mapKeys { String($0.prefix(1)) }
+        expect(output).to(haveCount(2))
+        expect(output["b"]) == 3
+        expect(output["a"]).to(satisfyAnyOf(
+            equal(1),
+            equal(2)
+        ))
+    }
+
+    func testCompactMapEmptyDictionary() {
+        expect(Input().compactMapKeys(self.transformer)) == [:]
+    }
+
+    func testCompactMapDictionaryWithOneKey() {
+        expect([1: "test"].compactMapKeys(self.transformer)) == [
+            "1": "test"
+        ]
+    }
+
+    func testCompactMapDictionaryResultingInEmptyDictionary() {
+        expect([1: "test"].compactMapKeys { _ in nil }) == [:]
+    }
+
+    func tetCompactMapKeys() {
+        let input: [Int: Int] = [
+            1: 1,
+            2: 2,
+            3: 3,
+            4: 4,
+            5: 5
+        ]
+
+        let output = input.compactMapKeys {
+            $0.isMultiple(of: 2)
+                ? String($0)
+                : nil
+        }
+        expect(output) == [
+            2: 2,
+            4: 4
+        ]
+    }
+
 }

--- a/Tests/UnitTests/FoundationExtensions/DictionaryExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/DictionaryExtensionsTests.swift
@@ -175,7 +175,7 @@ class DictionaryExtensionsMapKeysTests: TestCase {
         ]
     }
 
-    func tetMapKeysWithOverlappingKeys() {
+    func testMapKeysWithOverlappingKeys() {
         let input: [String: Int] = [
             "a1": 1,
             "a2": 2,
@@ -205,7 +205,7 @@ class DictionaryExtensionsMapKeysTests: TestCase {
         expect([1: "test"].compactMapKeys { _ in nil }) == [:]
     }
 
-    func tetCompactMapKeys() {
+    func testCompactMapKeys() {
         let input: [Int: Int] = [
             1: 1,
             2: 2,
@@ -220,8 +220,8 @@ class DictionaryExtensionsMapKeysTests: TestCase {
                 : nil
         }
         expect(output) == [
-            2: 2,
-            4: 4
+            "2": 2,
+            "4": 4
         ]
     }
 


### PR DESCRIPTION
Fixes [CSDK-105].

This came up in https://github.com/RevenueCat/purchases-ios/pull/1534#discussion_r891433648 and will simplify some of the code in #1727.

[CSDK-105]: https://revenuecats.atlassian.net/browse/CSDK-105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ