### PR TITLE
`DeviceCache`: added default `sandboxEnvironmentDetector` value

### DIFF
--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -37,7 +37,7 @@ class DeviceCache {
     /// cleared from under the SDK
     private var appUserIDHasBeenSet: Bool = false
 
-    convenience init(sandboxEnvironmentDetector: SandboxEnvironmentDetector,
+    convenience init(sandboxEnvironmentDetector: SandboxEnvironmentDetector = BundleSandboxEnvironmentDetector.default,
                      userDefaults: UserDefaults = UserDefaults.standard) {
         self.init(sandboxEnvironmentDetector: sandboxEnvironmentDetector,
                   userDefaults: userDefaults,


### PR DESCRIPTION
Turns out that `purchases-hybrid-common` relied on the previous constructor.
For backwards compatibility, we can provide this default value.