### PR TITLE
`FatalErrorUtil`: don't override `fatalError` on release builds

### DIFF
--- a/Sources/Misc/FatalErrorUtil.swift
+++ b/Sources/Misc/FatalErrorUtil.swift
@@ -13,6 +13,8 @@
 
 import Foundation
 
+#if DEBUG
+
 enum FatalErrorUtil {
 
     fileprivate static var fatalErrorClosure: (String, StaticString, UInt) -> Never = defaultFatalErrorClosure
@@ -31,3 +33,5 @@ enum FatalErrorUtil {
 func fatalError(_ message: @autoclosure () -> String = "", file: StaticString = #fileID, line: UInt = #line) -> Never {
     FatalErrorUtil.fatalErrorClosure(message(), file, line)
 }
+
+#endif


### PR DESCRIPTION
This hack is useful for tests, but since it's not needed in production, better to avoid compiling it and overriding Swift's `fatalError`.