### PR TITLE
Added Integration Test for upgrading subscription with a different entitlement

### DIFF
--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -83,6 +83,7 @@ class BaseStoreKitIntegrationTests: BaseBackendIntegrationTests {
 extension BaseStoreKitIntegrationTests {
 
     static let entitlementIdentifier = "premium"
+    static let superEntitlementIdentifier = "super_premium"
     static let consumable10Coins = "consumable.10_coins"
     static let monthlyNoIntroProductID = "com.revenuecat.monthly_4.99.no_intro"
     static let group3MonthlyTrialProductID = "com.revenuecat.monthly.1.99.1_free_week"

--- a/Tests/TestingApps/PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit
+++ b/Tests/TestingApps/PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit
@@ -197,6 +197,40 @@
           "referenceName" : "weekly free trial",
           "subscriptionGroupID" : "7096FF06",
           "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "9.99",
+          "familyShareable" : true,
+          "groupNumber" : 1,
+          "internalID" : "42778756",
+          "introductoryOffer" : {
+            "internalID" : "AA450462",
+            "paymentMode" : "free",
+            "subscriptionPeriod" : "P1W"
+          },
+          "localizations" : [
+            {
+              "description" : "Monthly subscription with a 1-week free trial",
+              "displayName" : "Super Premium Monthly",
+              "locale" : "en_US"
+            },
+            {
+              "description" : "Subscripción mensual con 1 semana gratis",
+              "displayName" : "Super Premium mensual",
+              "locale" : "es_ES"
+            }
+          ],
+          "productID" : "com.revenuecat.monthly_9.99.super_premium.1_week_intro",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "super premium monthly free trial",
+          "subscriptionGroupID" : "7096FF06",
+          "type" : "RecurringSubscription"
         }
       ]
     },


### PR DESCRIPTION
See [CF-788].
Fixed by https://github.com/RevenueCat/khepri/pull/4165.

Blocked by [TRIAGE-124].

[CF-788]: https://revenuecats.atlassian.net/browse/CF-788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[TRIAGE-124]: https://revenuecats.atlassian.net/browse/TRIAGE-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ