### PR TITLE
`Fastfile`: changed `CommonFastfile` `import` relative to current file

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,7 +10,7 @@
 #     https://docs.fastlane.tools/plugins/available-plugins
 #
 
-import("./CommonFastfile")
+import("#{File.expand_path(File.dirname(__FILE__))}/CommonFastfile")
 
 default_platform(:ios)
 


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/7382/workflows/91dd2e3a-9244-405e-b04c-44d2a4de047f/jobs/30748

With #1719 this was importing `CommonFastfile`. However, some release scripts have a different working directory, like `Tests/InstallationTests/CarthageInstallation`, that `import` the root `Fastfile`. When that happens, this `import` was being evaluated from that working directory, and failing to find `CommonFastfile`.