### PR TITLE
Fix replace version without prerelease modifiers

### DIFF
--- a/fastlane/CommonFastfile
+++ b/fastlane/CommonFastfile
@@ -215,13 +215,17 @@ lane :replace_version_number do |options|
   UI.user_error!("missing version") unless new_version_number
   files_to_update_string = ENV['FILES_TO_UPDATE_VERSION_STRING']
   UI.user_error!("missing files to update env") unless files_to_update_string
+  files_to_update_without_prerelease_modifiers_string = ENV['FILES_TO_UPDATE_VERSION_WITHOUT_PRERELEASE_MODIFIERS_STRING'] || ""
   files_to_update = files_to_update_string.split(",")
+  files_to_update_without_prerelease_modifiers = files_to_update_without_prerelease_modifiers_string.split(",")
   previous_version_number = current_version_number
   previous_version_number_without_prerelease_modifiers = previous_version_number.split("-")[0]
   new_version_number_without_prerelease_modifiers = new_version_number.split("-")[0]
 
   for file_to_update in files_to_update
     increment_build_number(previous_version_number, new_version_number, file_to_update.strip)
+  end
+  for file_to_update in files_to_update_without_prerelease_modifiers
     increment_build_number(previous_version_number_without_prerelease_modifiers, new_version_number_without_prerelease_modifiers, file_to_update.strip)
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,7 +22,9 @@ ENV["FILES_TO_UPDATE_VERSION_STRING"] = "
   ../.version,
   ../Examples/MagicWeather/MagicWeather.xcodeproj/project.pbxproj,
   ../Examples/MagicWeatherSwiftUI/Magic Weather SwiftUI.xcodeproj/project.pbxproj,
-  ../scripts/docs/index.html,
+  ../scripts/docs/index.html
+"
+ENV["FILES_TO_UPDATE_VERSION_WITHOUT_PRERELEASE_MODIFIERS_STRING"] = "
   ../Sources/Info.plist,
   ../Sources/Misc/SystemInfo.swift,
   ../Tests/BackendIntegrationTestApp/Info.plist,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,13 +20,11 @@ ENV["FILES_TO_UPDATE_VERSION_STRING"] = "
   ../Sources/Misc/SystemInfo.swift,
   ../.jazzy.yaml,
   ../.version,
-  ../Examples/MagicWeather/MagicWeather.xcodeproj/project.pbxproj,
-  ../Examples/MagicWeatherSwiftUI/Magic Weather SwiftUI.xcodeproj/project.pbxproj,
-  ../scripts/docs/index.html
+  ../scripts/docs/index.html,
+  ../Sources/Misc/SystemInfo.swift
 "
 ENV["FILES_TO_UPDATE_VERSION_WITHOUT_PRERELEASE_MODIFIERS_STRING"] = "
   ../Sources/Info.plist,
-  ../Sources/Misc/SystemInfo.swift,
   ../Tests/BackendIntegrationTestApp/Info.plist,
   ../Tests/BackendIntegrationTests/Info.plist,
   ../Tests/UnitTests/Info.plist,

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -13,10 +13,10 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 # Available Actions
 
-### bump
+### bump_version_update_changelog_create_pr
 
 ```sh
-[bundle exec] fastlane bump
+[bundle exec] fastlane bump_version_update_changelog_create_pr
 ```
 
 Bump version, edit changelog, and create pull request


### PR DESCRIPTION
### Description
In #1719 I extracted some of the logic to automate our versioning system. The change I made was wrong since it allowed `plist` files to include prerelease modifiers, which was not the previous behavior. This should fix it moving forward. Additionally, I removed a couple of files that didn't seem to contain any versions (at least in the last few releases)

