### PR TITLE
`logErrorIfNeeded`: also log message if present

### DIFF
--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -518,7 +518,7 @@ private extension ErrorUtils {
                                          fileName: String = #fileID,
                                          functionName: String = #function,
                                          line: UInt = #line) {
-        let message = code.description + (message.map { " " + $0 } ?? "")
+        let formattedMessage = code.description + (message.map { " " + $0 } ?? "")
 
         switch code {
         case .networkError,
@@ -544,7 +544,7 @@ private extension ErrorUtils {
                 .invalidPromotionalOfferError,
                 .offlineConnectionError:
                 Logger.error(
-                    message,
+                    formattedMessage,
                     fileName: fileName,
                     functionName: functionName,
                     line: line
@@ -564,7 +564,7 @@ private extension ErrorUtils {
                 .paymentPendingError,
                 .productRequestTimedOut:
                 Logger.appleError(
-                    message,
+                    formattedMessage,
                     fileName: fileName,
                     functionName: functionName,
                     line: line
@@ -572,7 +572,7 @@ private extension ErrorUtils {
 
         @unknown default:
             Logger.error(
-                message,
+                formattedMessage,
                 fileName: fileName,
                 functionName: functionName,
                 line: line

--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -471,6 +471,7 @@ private extension ErrorUtils {
 
         Self.logErrorIfNeeded(
             code,
+            message: message,
             fileName: fileName, functionName: functionName, line: line
         )
 
@@ -513,9 +514,12 @@ private extension ErrorUtils {
 
     // swiftlint:disable:next function_body_length
     private static func logErrorIfNeeded(_ code: ErrorCode,
+                                         message: String?,
                                          fileName: String = #fileID,
                                          functionName: String = #function,
                                          line: UInt = #line) {
+        let message = code.description + (message.map { " " + $0 } ?? "")
+
         switch code {
         case .networkError,
                 .unknownError,
@@ -540,7 +544,7 @@ private extension ErrorUtils {
                 .invalidPromotionalOfferError,
                 .offlineConnectionError:
                 Logger.error(
-                    code.description,
+                    message,
                     fileName: fileName,
                     functionName: functionName,
                     line: line
@@ -560,7 +564,7 @@ private extension ErrorUtils {
                 .paymentPendingError,
                 .productRequestTimedOut:
                 Logger.appleError(
-                    code.description,
+                    message,
                     fileName: fileName,
                     functionName: functionName,
                     line: line
@@ -568,7 +572,7 @@ private extension ErrorUtils {
 
         @unknown default:
             Logger.error(
-                code.description,
+                message,
                 fileName: fileName,
                 functionName: functionName,
                 line: line


### PR DESCRIPTION
### Before:

For errors with a custom `message` it turns out that we were never logging it.
This was extra confusing for `OfferingsManager.Error.configurationError`, which ended up displaying this:

> 😿‼️ There is an issue with your configuration. Check the underlying error for more details.

With no underlying details.

### After:

> 😿‼️ There is an issue with your configuration. Check the underlying error for more details.
> There's a problem with your configuration. None of the products registered in the RevenueCat dashboard could be fetched from App Store Connect (or the StoreKit Configuration file if one is being used).
> More information: https://rev.cat/why-are-offerings-empty