### PR TITLE
`EntitlementInfo`: added `isActiveInCurrentEnvironment` and `isActiveInAnyEnvironment`

### DIFF
--- a/Sources/Purchasing/EntitlementInfos.swift
+++ b/Sources/Purchasing/EntitlementInfos.swift
@@ -45,12 +45,8 @@ import Foundation
 
     // MARK: -
 
-    init(
-        entitlements: [String: EntitlementInfo],
-        sandboxEnvironmentDetector: SandboxEnvironmentDetector
-    ) {
+    init(entitlements: [String: EntitlementInfo]) {
         self.all = entitlements
-        self.sandboxEnvironmentDetector = sandboxEnvironmentDetector
     }
 
     private func isEqual(to other: EntitlementInfos?) -> Bool {
@@ -64,10 +60,6 @@ import Foundation
 
         return self.all == other.all
     }
-
-    // MARK: -
-
-    private let sandboxEnvironmentDetector: SandboxEnvironmentDetector
 
 }
 
@@ -89,9 +81,7 @@ public extension EntitlementInfos {
     /// #### Related Symbols
     /// - ``activeInAnyEnvironment``
     @objc var activeInCurrentEnvironment: [String: EntitlementInfo] {
-        return self.activeInAnyEnvironment.filter { [isSandbox = self.sandboxEnvironmentDetector.isSandbox] in
-            $0.value.isSandbox == isSandbox
-        }
+        return self.all.filter { $0.value.isActiveInCurrentEnvironment }
     }
 
     /// Dictionary of active ``EntitlementInfo`` objects keyed by their identifiers.
@@ -100,7 +90,7 @@ public extension EntitlementInfos {
     /// #### Related Symbols
     /// - ``activeInCurrentEnvironment``
     @objc var activeInAnyEnvironment: [String: EntitlementInfo] {
-        return self.all.filter { $0.value.isActive }
+        return self.all.filter { $0.value.isActiveInAnyEnvironment }
     }
 
 }
@@ -124,15 +114,13 @@ extension EntitlementInfos {
                     EntitlementInfo(identifier: identifier,
                                     entitlement: entitlement,
                                     subscription: subscription,
+                                    sandboxEnvironmentDetector: sandboxEnvironmentDetector,
                                     requestDate: requestDate)
                 )
             }
         )
 
-        self.init(
-            entitlements: allEntitlements,
-            sandboxEnvironmentDetector: sandboxEnvironmentDetector
-        )
+        self.init(entitlements: allEntitlements)
     }
 
 }

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCEntitlementInfoAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCEntitlementInfoAPI.m
@@ -16,6 +16,8 @@
     RCEntitlementInfo *ri;
     NSString *i = ri.identifier;
     BOOL ia = [ri isActive];
+    BOOL iaae = [ri isActiveInAnyEnvironment];
+    BOOL iace = [ri isActiveInCurrentEnvironment];
     BOOL wr = [ri willRenew];
     RCPeriodType pt = [ri periodType];
     NSDate *lpd = [ri latestPurchaseDate];
@@ -29,7 +31,7 @@
     RCPurchaseOwnershipType ot = [ri ownershipType];
     NSDictionary<NSString *, id> *rawData = [ri rawData];
 
-    NSLog(i, ia, ri, wr, pt, lpd, opd, ed, s, pi, is, uda, bida, ot, rawData);
+    NSLog(i, ia, iaae, iace, ri, wr, pt, lpd, opd, ed, s, pi, is, uda, bida, ot, rawData);
 }
 
 + (void)checkEnums {

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/EntitlementInfoAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/EntitlementInfoAPI.swift
@@ -18,6 +18,8 @@ var entitlementInfo: EntitlementInfo!
 func checkEntitlementInfoAPI() {
     let ident: String = entitlementInfo.identifier
     let isActive: Bool = entitlementInfo.isActive
+    let isActiveInAnyEnvironment: Bool = entitlementInfo.isActiveInAnyEnvironment
+    let isActiveInCurrentEnvironment: Bool = entitlementInfo.isActiveInCurrentEnvironment
     let willRenew: Bool = entitlementInfo.willRenew
     let pType: PeriodType = entitlementInfo.periodType
     let lpd: Date? = entitlementInfo.latestPurchaseDate
@@ -32,8 +34,8 @@ func checkEntitlementInfoAPI() {
 
     let rawData: [String: Any] = entitlementInfo.rawData
 
-    print(entitlementInfo!, ident, isActive, willRenew, pType, lpd!, opd!, eDate!,
-          store, pId, iss, uda!, bida!, oType, rawData)
+    print(entitlementInfo!, ident, isActive, isActiveInAnyEnvironment, isActiveInCurrentEnvironment,
+          willRenew, pType, lpd!, opd!, eDate!, store, pId, iss, uda!, bida!, oType, rawData)
 }
 
 var store: Store!

--- a/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
+++ b/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
@@ -1232,6 +1232,7 @@ private extension EntitlementInfosTests {
         expect(file: file, line: line, entitlement.identifier) == identifier
         expect(file: file, line: line, Set(entitlements.all.keys)).to(contain([identifier]))
         expect(file: file, line: line, entitlement.isActive) == true
+        expect(file: file, line: line, entitlement.isActiveInAnyEnvironment) == expectedEntitlementActive
 
         expect(file: file, line: line, Set(entitlements.activeInAnyEnvironment.keys))
         == (expectedEntitlementActive ? [identifier] : [])
@@ -1250,6 +1251,7 @@ private extension EntitlementInfosTests {
         expect(file: file, line: line, entitlement.identifier) == identifier
         expect(file: file, line: line, entitlements.all.keys).to(contain([identifier]))
         expect(file: file, line: line, entitlement.isActive) == true
+        expect(file: file, line: line, entitlement.isActiveInCurrentEnvironment) == expectedEntitlementActive
 
         expect(file: file, line: line, Set(entitlements.activeInCurrentEnvironment.keys))
         == (expectedEntitlementActive ? [identifier] : [])


### PR DESCRIPTION
A while ago, #1647 added these properties to `EntitlementInfos`: `activeInCurrentEnvironment` and `activeInAnyEnvironment`.
However, the only way to use them was by filtering the `EntitlementInfos`.

A common pattern is to use:
```swift
customerInfo.entitlements.all[entitlementIdentifier].isActive
```

So this adds a couple more properties to allow filtering using the `all` dictionary, directly from the `EntitlementInfo` itself.

For that, I moved the logic down one level, and made the existing methods rely on those new ones instead.
To test the new properties I simply added 2 new expectations to the shared methods used [in the existing tests](https://github.com/RevenueCat/purchases-ios/blob/829b69041da4bd53c5de3b1beb3034d8e8f2532a/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift#L1116-LL1154).