### PR TITLE
Update Configuration.swift

### DIFF
--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -168,7 +168,7 @@ import Foundation
         }
 
         /// Set `platformInfo`.
-        internal func with(platformInfo: Purchases.PlatformInfo) -> Builder {
+        @objc public func with(platformInfo: Purchases.PlatformInfo) -> Builder {
             self.platformInfo = platformInfo
             return self
         }

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCConfigurationAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCConfigurationAPI.m
@@ -13,13 +13,14 @@
 
 + (void)checkAPI {
     RCConfigurationBuilder *builder = [RCConfiguration builderWithAPIKey:@""];
-    RCConfiguration *config = [[[[[[[[[builder withApiKey:@""]
-                                      withObserverMode:false]
-                                     withUserDefaults:NSUserDefaults.standardUserDefaults]
-                                    withAppUserID:@""]
-                                   withDangerousSettings:[[RCDangerousSettings alloc] init]]
-                                  withNetworkTimeout:1]
-                                 withStoreKit1Timeout: 1]
+    RCConfiguration *config = [[[[[[[[[[builder withApiKey:@""]
+                                       withObserverMode:false]
+                                      withUserDefaults:NSUserDefaults.standardUserDefaults]
+                                     withAppUserID:@""]
+                                    withDangerousSettings:[[RCDangerousSettings alloc] init]]
+                                   withNetworkTimeout:1]
+                                  withStoreKit1Timeout: 1]
+                                 withPlatformInfo:[[RCPlatformInfo alloc] initWithFlavor:@"" version:@""]]
                                 withUsesStoreKit2IfAvailable:false] build];
     NSLog(@"%@", config);
 }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
@@ -19,6 +19,7 @@ func checkConfigurationAPI() {
         .with(networkTimeout: 1)
         .with(storeKit1Timeout: 1)
         .with(usesStoreKit2IfAvailable: false)
+        .with(platformInfo: Purchases.PlatformInfo(flavor: "", version: ""))
         .build()
     print(configuration)
 }


### PR DESCRIPTION
internal protection level is not accessible to PurchasesHybridCommon through our Purchases extension.
Need to expose it publicly.

Double-checked locally with PurchasesHybridCommon pointing to local dev.

🤦‍♂️