### PR TITLE
Don't fail test when expireSubscription fails us.

### DIFF
--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -471,10 +471,23 @@ private extension StoreKit1IntegrationTests {
         Logger.info("Expiring subscription for product '\(entitlement.productIdentifier)'")
 
         // Try expiring using `SKTestSession`
-        try self.testSession.expireSubscription(productIdentifier: entitlement.productIdentifier)
+        do {
+            try self.testSession.expireSubscription(productIdentifier: entitlement.productIdentifier)
+        } catch {
+            Logger.warn(
+                """
+                Failed testSession.expireSubscription, this is probably an Xcode bug.
+                Test will now wait for expiration instead of triggering it.
+                Error: \(error.localizedDescription)
+                """
+            )
+        }
 
         let secondsUntilExpiration = expirationDate.timeIntervalSince(Date())
-        guard secondsUntilExpiration > 0 else { return }
+        guard secondsUntilExpiration > 0 else {
+            Logger.info("Done waiting for subscription expiration, continuing test.")
+            return
+        }
 
         let timeToSleep = Int(secondsUntilExpiration.rounded(.up) + 1)
 


### PR DESCRIPTION
expireSubscription crashes with current betas 
resolves [CSDK-338]

[CSDK-338]: https://revenuecats.atlassian.net/browse/CSDK-338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ