### PR TITLE
Integration Tests / StoreKit tests: limit execution to 3 minutes

### DIFF
--- a/Tests/TestPlans/CI-AllTests.xctestplan
+++ b/Tests/TestPlans/CI-AllTests.xctestplan
@@ -10,6 +10,7 @@
   ],
   "defaultOptions" : {
     "codeCoverage" : false,
+    "maximumTestExecutionTimeAllowance" : 180,
     "targetForVariableExpansion" : {
       "containerPath" : "container:RevenueCat.xcodeproj",
       "identifier" : "2DEAC2D926EFE46E006914ED",

--- a/Tests/TestPlans/CI-BackendIntegration.xctestplan
+++ b/Tests/TestPlans/CI-BackendIntegration.xctestplan
@@ -10,6 +10,7 @@
   ],
   "defaultOptions" : {
     "codeCoverage" : false,
+    "maximumTestExecutionTimeAllowance" : 180,
     "targetForVariableExpansion" : {
       "containerPath" : "container:RevenueCat.xcodeproj",
       "identifier" : "2DEAC2D926EFE46E006914ED",


### PR DESCRIPTION
Reduced from the default of 10 minutes. If a test hasn't passed by then, it's probably stuck.