### PR TITLE
Integration Tests: store result bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,6 +307,13 @@ jobs:
           no_output_timeout: 30m
           environment:
             SCAN_DEVICE: iPhone 11 Pro (15.5)
+      - run:
+          name: Compress result bundle
+          command: |
+             tar -czf ios/xcresult.tar.gz ios/BackendIntegrationTests.xcresult && \
+             rm -r ios/BackendIntegrationTests.xcresult
+          working_directory: fastlane/test_output/xctest
+          when: always
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -262,6 +262,7 @@ platform :ios do
       derived_data_path: "scan_derived_data",
       output_types: 'junit',
       number_of_retries: 3,
+      result_bundle: true,
       testplan: "CI-BackendIntegration",
       output_directory: "fastlane/test_output/xctest/ios"
     )


### PR DESCRIPTION
Equivalent to https://github.com/RevenueCat/purchases-hybrid-common/pull/181

This allows us to get more details on the failures. I'm planning to do the same for regular iOS tests as well, which will allow us to look at snapshot test failures, etc.