### PR TITLE
CircleCI: always store compressed result bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,7 +238,7 @@ jobs:
           command: bundle exec fastlane test_tvos
           no_output_timeout: 30m
       - compress_result_bundle:
-          directory: fastlane/test_output/xctest/ios
+          directory: fastlane/test_output/xctest/tvos
           bundle_name: RevenueCat
       - store_test_results:
           path: fastlane/test_output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ commands:
              tar -czf xcresult.tar.gz << parameters.bundle_name >>.xcresult && \
              rm -r << parameters.bundle_name >>.xcresult
           working_directory: << parameters.directory >>
+          when: always
 
   scan-and-archive:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,20 @@ commands:
       - run:
           name: Install xcbeautify
           command: brew install xcbeautify
+  
+  compress_result_bundle:
+    parameters:
+      directory:
+        type: string
+      bundle_name:
+        type: string
+    steps:
+      - run: 
+          name: Compress result bundle
+          command: |
+             tar -czf xcresult.tar.gz << parameters.bundle_name >>.xcresult && \
+             rm -r << parameters.bundle_name >>.xcresult
+          working_directory: << parameters.directory >>
 
   scan-and-archive:
     parameters:
@@ -185,6 +199,9 @@ jobs:
           no_output_timeout: 30m
           environment:
             SCAN_DEVICE: iPhone 13 (16.0)
+      - compress_result_bundle:
+          directory: fastlane/test_output/xctest/ios
+          bundle_name: RevenueCat
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:
@@ -202,6 +219,9 @@ jobs:
           no_output_timeout: 30m
           environment:
             SCAN_DEVICE: iPhone 13 (15.5)
+      - compress_result_bundle:
+          directory: fastlane/test_output/xctest/ios
+          bundle_name: RevenueCat
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:
@@ -217,6 +237,9 @@ jobs:
           name: Run tests
           command: bundle exec fastlane test_tvos
           no_output_timeout: 30m
+      - compress_result_bundle:
+          directory: fastlane/test_output/xctest/ios
+          bundle_name: RevenueCat
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:
@@ -234,6 +257,9 @@ jobs:
           no_output_timeout: 30m
           environment:
             SCAN_DEVICE: iPhone 8 (14.5)
+      - compress_result_bundle:
+          directory: fastlane/test_output/xctest/ios
+          bundle_name: RevenueCat
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:
@@ -255,6 +281,9 @@ jobs:
           no_output_timeout: 30m
           environment:
             SCAN_DEVICE: iPhone 8 (13.7)
+      - compress_result_bundle:
+          directory: fastlane/test_output/xctest/ios
+          bundle_name: RevenueCat
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:
@@ -277,6 +306,9 @@ jobs:
           no_output_timeout: 30m
           environment:
             SCAN_DEVICE: iPhone 6 (12.4)
+      - compress_result_bundle:
+          directory: fastlane/test_output/xctest/ios
+          bundle_name: RevenueCat
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:
@@ -307,19 +339,14 @@ jobs:
           no_output_timeout: 30m
           environment:
             SCAN_DEVICE: iPhone 11 Pro (15.5)
-      - run:
-          name: Compress result bundle
-          command: |
-             tar -czf ios/xcresult.tar.gz ios/BackendIntegrationTests.xcresult && \
-             rm -r ios/BackendIntegrationTests.xcresult
-          working_directory: fastlane/test_output/xctest
-          when: always
+      - compress_result_bundle:
+          directory: fastlane/test_output/xctest/ios
+          bundle_name: BackendIntegrationTests
       - store_test_results:
           path: fastlane/test_output
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
-
 
   release-checks: 
     <<: *base-job

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -73,6 +73,7 @@ platform :ios do
       prelaunch_simulator: true,
       output_types: 'junit',
       number_of_retries: 5,
+      result_bundle: true,
       testplan: "CI-AllTests",
       output_directory: "fastlane/test_output/xctest/ios"
     )
@@ -88,6 +89,7 @@ platform :ios do
       prelaunch_simulator: true,
       output_types: 'junit',
       number_of_retries: 5,
+      result_bundle: true,
       testplan: "CI-AllTests",
       output_directory: "fastlane/test_output/xctest/tvos"
     )


### PR DESCRIPTION
Follow up to #1771 for all test jobs. This allows us download the `.xcresult` file so we can look at all the test results in detail, including snapshot failures.

![image](https://user-images.githubusercontent.com/685609/181350351-40a0a617-904f-43e0-9ba3-5920aab22a34.png)