### PR TITLE
Lint: fixed `SubscriberAttributesManager`

### DIFF
--- a/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -214,10 +214,8 @@ class SubscriberAttributesManager {
         self.lock.perform {
             var unsyncedAttributes = self.unsyncedAttributesByKey(appUserID: appUserID)
 
-            for (key, attribute) in attributesToSync {
-                if unsyncedAttributes[key]?.value == attribute.value {
-                    unsyncedAttributes[key]?.isSynced = true
-                }
+            for (key, attribute) in attributesToSync where unsyncedAttributes[key]?.value == attribute.value {
+                unsyncedAttributes[key]?.isSynced = true
             }
 
             self.deviceCache.store(subscriberAttributesByKey: unsyncedAttributes, appUserID: appUserID)


### PR DESCRIPTION
This was caused by a new rule `for_where` in the latest version of SwiftLint.