### PR TITLE
fix another broken link in docC docs

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -757,7 +757,7 @@ public extension Purchases {
     /**
      * Fetches the ``StoreProduct``s for your IAPs for given `productIdentifiers`.
      *
-     * Use this method if you aren't using ``getOfferings(completion:)``.
+     * Use this method if you aren't using ``Purchases/getOfferings(completion:)``.
      * You should use ``getOfferings(completion:)`` though.
      *
      * - Note: `completion` may be called without ``StoreProduct``s that you are expecting. This is usually caused by


### PR DESCRIPTION
Fix another broken link. Again, not sure why we're not getting a warning