### PR TITLE
`OSVersionEquivalent.current`: evaluate only once

### DIFF
--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -60,8 +60,7 @@ class MockHTTPClient: HTTPClient {
         DispatchQueue.main.async {
             self.calls.append(call)
 
-            // swiftlint:disable:next force_try
-            let osVersionEquivalent = try! OSVersionEquivalent.current
+            let osVersionEquivalent = OSVersionEquivalent.current
             let testName = "iOS\(osVersionEquivalent.rawValue)/\(CurrentTestCaseTracker.sanitizedTestName)"
 
             assertSnapshot(matching: call,

--- a/Tests/UnitTests/TestHelpers/OSVersionEquivalent.swift
+++ b/Tests/UnitTests/TestHelpers/OSVersionEquivalent.swift
@@ -31,26 +31,24 @@ enum OSVersionEquivalent: Int {
 
 extension OSVersionEquivalent {
 
-    static var current: Self {
-        get throws {
-            #if os(macOS)
-                // Not currently supported
-                // Must convert e.g.: macOS 10.15 to iOS 13
-                throw Error.unknownOS()
-            #else
-                // Note: this is either iOS/tvOS/macCatalyst
-                // They all share equivalent versions
+    static let current: Self = {
+        #if os(macOS)
+        // Not currently supported
+        // Must convert e.g.: macOS 10.15 to iOS 13
+        fatalError(Error.unknownOS().localizedDescription)
+        #else
+        // Note: this is either iOS/tvOS/macCatalyst
+        // They all share equivalent versions
 
-                let majorVersion = ProcessInfo().operatingSystemVersion.majorVersion
+        let majorVersion = ProcessInfo().operatingSystemVersion.majorVersion
 
-                if let equivalent = Self(rawValue: majorVersion) {
-                    return equivalent
-                } else {
-                    throw Error.unknownOS()
-                }
-            #endif
+        guard let equivalent = Self(rawValue: majorVersion) else {
+            fatalError(Error.unknownOS().localizedDescription)
         }
-    }
+
+        return equivalent
+        #endif
+    }()
 
 }
 


### PR DESCRIPTION
This was a getter which meant that it was being evaluated unnecessarily for every mock network request. Now it's only set once.