### PR TITLE
Fixed iOS 12 snapshot

### DIFF
--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess.1.json
@@ -24,6 +24,6 @@
       "observer_mode" : false
     },
     "method" : "POST",
-    "url" : "https:\/api.revenuecat.com\/v1\/receipts"
+    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
   }
 }


### PR DESCRIPTION
Follow up to #1783. I couldn't run iOS 12 tests locally (not working with Xcode 14), so I couldn't verify that this was wrong.
Downloading the full `.xcresult` from https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/7546/workflows/b47843e1-bf9a-40f3-9992-220581772f00/jobs/32130/artifacts (thanks to #1773) helped me see what was wrong.