### PR TITLE
`OfferingsManager`: expose underlying error when `ProductsManager` returns an error

### DIFF
--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -15,7 +15,7 @@
 import Foundation
 import StoreKit
 
-// swiftlint:disable file_length multiline_parameters
+// swiftlint:disable file_length multiline_parameters type_body_length
 
 enum ErrorUtils {
 
@@ -218,9 +218,11 @@ enum ErrorUtils {
      */
     static func configurationError(
         message: String? = nil,
+        underlyingError: Error? = nil,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
     ) -> Error {
-        return error(with: ErrorCode.configurationError, message: message,
+        return error(with: ErrorCode.configurationError,
+                     message: message, underlyingError: underlyingError,
                      fileName: fileName, functionName: functionName, line: line)
     }
 

--- a/Sources/Logging/Strings/OfferingStrings.swift
+++ b/Sources/Logging/Strings/OfferingStrings.swift
@@ -19,7 +19,7 @@ import StoreKit
 enum OfferingStrings {
 
     case cannot_find_product_configuration_error(identifiers: Set<String>)
-    case fetching_offerings_error(error: String)
+    case fetching_offerings_error(error: OfferingsManager.Error, underlyingError: Error?)
     case found_existing_product_request(identifiers: Set<String>)
     case no_cached_offerings_fetching_from_network
     case no_cached_requests_and_products_starting_skproduct_request(identifiers: Set<String>)
@@ -46,14 +46,19 @@ extension OfferingStrings: CustomStringConvertible {
 
     var description: String {
         switch self {
-
         case .cannot_find_product_configuration_error(let identifiers):
             return "Could not find SKProduct for \(identifiers) " +
                 "\nThere is a problem with your configuration in App Store Connect. " +
                 "\nMore info here: https://errors.rev.cat/configuring-products"
 
-        case .fetching_offerings_error(let error):
-            return "Error fetching offerings - \(error)"
+        case let .fetching_offerings_error(error, underlyingError):
+            var result = "Error fetching offerings - \(error.localizedDescription)"
+
+            if let underlyingError = underlyingError {
+                result += "\nUnderlying error: \(underlyingError.localizedDescription)"
+            }
+
+            return result
 
         case .found_existing_product_request(let identifiers):
             return "Found an existing request for products: \(identifiers), appending " +

--- a/Tests/StoreKitUnitTests/OfferingsManagerStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/OfferingsManagerStoreKitTests.swift
@@ -55,7 +55,7 @@ extension OfferingsManagerStoreKitTests {
         mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsResponse)
         var fetchedStoreProduct = try await fetchSk2StoreProduct()
         var storeProduct = StoreProduct(sk2Product: fetchedStoreProduct.underlyingSK2Product)
-        mockProductsManager.stubbedProductsCompletionResult = Set([storeProduct])
+        mockProductsManager.stubbedProductsCompletionResult = .success(Set([storeProduct]))
 
         var receivedOfferings = try await offeringsManager.offerings(appUserID: MockData.anyAppUserID)
         var receivedProduct = try XCTUnwrap(receivedOfferings.current?.availablePackages.first?.storeProduct)
@@ -66,7 +66,7 @@ extension OfferingsManagerStoreKitTests {
 
         fetchedStoreProduct = try await fetchSk2StoreProduct()
         storeProduct = StoreProduct(sk2Product: fetchedStoreProduct.underlyingSK2Product)
-        mockProductsManager.stubbedProductsCompletionResult = Set([storeProduct])
+        mockProductsManager.stubbedProductsCompletionResult = .success(Set([storeProduct]))
 
         // Note: this test passes only because the method `invalidateAndReFetchCachedOfferingsIfAppropiate`
         // is manually executed. `OfferingsManager` does not detect Storefront changes to invalidate the

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
@@ -100,7 +100,7 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
 
         var finalResults: [String: IntroEligibility] = [:]
 
-        self.mockProductsManager.stubbedProductsCompletionResult = Set(storeProducts)
+        self.mockProductsManager.stubbedProductsCompletionResult = .success(Set(storeProducts))
         trialOrIntroPriceEligibilityChecker.productsWithKnownIntroEligibilityStatus(
             productIdentifiers: productIdentifiers) { results in
             finalResults = results
@@ -114,7 +114,7 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
     }
 
     func testSK1EligibilityIsFetchedFromBackendIfErrorCalculatingEligibilityAndStoreKitDoesNotHaveIt() throws {
-        self.mockProductsManager.stubbedProductsCompletionResult = Set()
+        self.mockProductsManager.stubbedProductsCompletionResult = .success([])
         let stubbedError = NSError(domain: RCPurchasesErrorCodeDomain,
                                    code: ErrorCode.invalidAppUserIdError.rawValue,
                                    userInfo: [:])
@@ -148,9 +148,9 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
         sk1Product.mockDiscount = nil
         let storeProduct =  StoreProduct(sk1Product: sk1Product)
 
-        self.mockProductsManager.stubbedProductsCompletionResult = Set(
-            [storeProduct]
-        )
+        self.mockProductsManager.stubbedProductsCompletionResult = .success([
+            storeProduct
+        ])
 
         let productId = "product_id"
         let stubbedEligibility = [productId: IntroEligibility(eligibilityStatus: IntroEligibilityStatus.eligible)]
@@ -171,7 +171,7 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
     }
 
     func testSK1ErrorFetchingFromBackendAfterErrorCalculatingEligibility() throws {
-        self.mockProductsManager.stubbedProductsCompletionResult = Set()
+        self.mockProductsManager.stubbedProductsCompletionResult = .success([])
         let productId = "product_id"
 
         let stubbedError: BackendError = .networkError(

--- a/Tests/UnitTests/Mocks/MockProductsManager.swift
+++ b/Tests/UnitTests/Mocks/MockProductsManager.swift
@@ -13,7 +13,7 @@ class MockProductsManager: ProductsManager {
     var invokedProductsCount = 0
     var invokedProductsParameters: Set<String>?
     var invokedProductsParametersList = [(identifiers: Set<String>, Void)]()
-    var stubbedProductsCompletionResult: Set<StoreProduct>?
+    var stubbedProductsCompletionResult: Result<Set<StoreProduct>, Error>?
 
     override func products(withIdentifiers identifiers: Set<String>,
                            completion: @escaping (Result<Set<StoreProduct>, Error>) -> Void) {
@@ -21,8 +21,8 @@ class MockProductsManager: ProductsManager {
         invokedProductsCount += 1
         invokedProductsParameters = identifiers
         invokedProductsParametersList.append((identifiers, ()))
-        if let result = stubbedProductsCompletionResult {
-            completion(.success(result))
+        if let result = self.stubbedProductsCompletionResult {
+            completion(result)
         } else {
             let products: [StoreProduct] = identifiers
                 .map { (identifier) -> MockSK1Product in
@@ -44,12 +44,13 @@ class MockProductsManager: ProductsManager {
     @available(iOS 13.0, tvOS 13.0, watchOS 6.2, macOS 10.15, *)
     override func products(
         withIdentifiers identifiers: Set<String>
-    ) async -> Set<StoreProduct> {
+    ) async throws -> Set<StoreProduct> {
         invokedProducts = true
         invokedProductsCount += 1
         invokedProductsParameters = identifiers
         invokedProductsParametersList.append((identifiers, ()))
-        return stubbedProductsCompletionResult ?? Set()
+
+        return try self.stubbedProductsCompletionResult?.get() ?? []
     }
 
     var invokedCacheProduct = false

--- a/Tests/UnitTests/Purchasing/IntroEligibilityCalculatorTests.swift
+++ b/Tests/UnitTests/Purchasing/IntroEligibilityCalculatorTests.swift
@@ -66,10 +66,12 @@ class IntroEligibilityCalculatorTests: TestCase {
         mockReceiptParser.stubbedParseResult = receipt
         let receiptIdentifiers = receipt.purchasedIntroOfferOrFreeTrialProductIdentifiers()
 
-        mockProductsManager.stubbedProductsCompletionResult = Set(
-            ["a", "b"]
-                .map { MockSK1Product(mockProductIdentifier: $0) }
-                .map(StoreProduct.init(sk1Product:))
+        mockProductsManager.stubbedProductsCompletionResult = .success(
+            Set(
+                ["a", "b"]
+                    .map { MockSK1Product(mockProductIdentifier: $0) }
+                    .map(StoreProduct.init(sk1Product:))
+            )
         )
 
         let candidateIdentifiers = Set(["a", "b", "c"])
@@ -98,9 +100,8 @@ class IntroEligibilityCalculatorTests: TestCase {
                                       mockSubscriptionGroupIdentifier: "group2")
         product2.mockDiscount = MockSKProductDiscount()
 
-        mockProductsManager.stubbedProductsCompletionResult = Set(
-            [product1, product2]
-                .map(StoreProduct.init(sk1Product:))
+        mockProductsManager.stubbedProductsCompletionResult = .success(
+            Set([product1, product2].map(StoreProduct.init(sk1Product:)))
         )
 
         let candidateIdentifiers = Set(["com.revenuecat.product1",
@@ -133,7 +134,7 @@ class IntroEligibilityCalculatorTests: TestCase {
         let mockProduct = MockSK1Product(mockProductIdentifier: "com.revenuecat.product1",
                                          mockSubscriptionGroupIdentifier: "group1")
         mockProduct.mockDiscount = nil
-        mockProductsManager.stubbedProductsCompletionResult = Set([StoreProduct(sk1Product: mockProduct)])
+        mockProductsManager.stubbedProductsCompletionResult = .success([StoreProduct(sk1Product: mockProduct)])
 
         let candidateIdentifiers = Set(["com.revenuecat.product1"])
 
@@ -162,7 +163,7 @@ class IntroEligibilityCalculatorTests: TestCase {
                                          mockSubscriptionGroupIdentifier: "group1")
         mockProduct.mockDiscount = nil
         mockProduct.mockSubscriptionPeriod = nil
-        mockProductsManager.stubbedProductsCompletionResult = Set([StoreProduct(sk1Product: mockProduct)])
+        mockProductsManager.stubbedProductsCompletionResult = .success([StoreProduct(sk1Product: mockProduct)])
 
         let candidateIdentifiers = Set(["lifetime"])
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesTransactionHandlingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesTransactionHandlingTests.swift
@@ -167,7 +167,7 @@ class PurchasesTransactionHandlingTests: BasePurchasesTests {
     }
 
     func testProductIsRemovedButPresentInTheQueuedTransaction() throws {
-        self.mockProductsManager.stubbedProductsCompletionResult = []
+        self.mockProductsManager.stubbedProductsCompletionResult = .success([])
 
         let customerInfoBeforePurchase = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",


### PR DESCRIPTION
This will help figure out the reason behind #1765.
We were currently ignoring the error returned by `ProductsManager`.

In the example below, we can see the underlying issue is `SKErrorDomain` code 5.

### Before:
> Error fetching offerings - The operation couldn’t be completed. (RevenueCat.OfferingsManager.Error error 1.)

### After:
> Error fetching offerings - The operation couldn’t be completed. (RevenueCat.OfferingsManager.Error error 1.)
_**Underlying error: The operation couldn’t be completed. (SKErrorDomain error 5.)**_
ERROR: 😿‼️ There is an issue with your configuration. Check the underlying error for more details. There's a problem with your configuration. None of the products registered in the RevenueCat dashboard could be fetched from App Store Connect (or the StoreKit Configuration file if one is being used). 
More information: https://rev.cat/why-are-offerings-empty