### PR TITLE
Pass CircleCI branch to prepare_next_version job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,7 +411,7 @@ jobs:
       - trust-github-key
       - run:
           name: Prepare next version
-          command: bundle exec fastlane prepare_next_version
+          command: bundle exec fastlane prepare_next_version branch:$CIRCLE_BRANCH
 
   installation-tests-cocoapods:
     <<: *base-job


### PR DESCRIPTION
### Description
This is a copy of the android PR https://github.com/RevenueCat/purchases-android/pull/583. Basically with the changes to the fastlane plugin, I added a validation step that checked that the branch was `main` when creating the next snapshot PR. This actually shouldn't be like that since this job is executed from the tag. I removed the validation for this action in https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/pull/12 but until that's merged, copying the fix from android here.