### PR TITLE
AdServices: Fix failing tests on main in iOS 12 and 13 - IOSAttributionPosterTests

### DIFF
--- a/Tests/UnitTests/Attribution/AttributionPosterTests.swift
+++ b/Tests/UnitTests/Attribution/AttributionPosterTests.swift
@@ -184,6 +184,11 @@ class AttributionPosterTests: BaseAttributionPosterTests {
 @available(*, deprecated)
 class IOSAttributionPosterTests: BaseAttributionPosterTests {
 
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try AvailabilityChecks.iOS14APIAvailableOrSkipTest()
+    }
+
     func testPostAppleSearchAdsAttributionIfNeededSkipsIfATTFrameworkNotIncludedOnNewOS() throws {
         systemInfo.stubbedIsOperatingSystemAtLeastVersion = true
         MockAttributionTypeFactory.shouldReturnAdClientProxy = true


### PR DESCRIPTION
### Checklist
- [x] If applicable, unit tests
- [x] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Fixed failing iOS 12 and 13 tests - https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/7598/workflows/ba30c2e5-cae0-4a15-837a-8a972821a6b6

### Description
Forgot to add `try AvailabilityChecks.iOS14APIAvailableOrSkipTest()` in `IOSAttributionPosterTests`
