### PR TITLE
Invalidates gem caches and separates danger and macOS caches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -487,7 +487,16 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
-      - bundle-install-with-cache
+      - restore_cache:
+          keys: 
+            - v1-danger-gem-cache-{{ checksum "Gemfile.lock" }}
+      - run: 
+          name: Bundle install
+          command: bundle install --clean --path vendor/bundle
+      - save_cache:
+          key: v1-danger-gem-cache-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
       - run: 
           name: Run Danger
           command: bundle exec danger --verbose

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,12 +62,13 @@ commands:
           name: Create simulator
           command: xcrun simctl create '<< parameters.sim-name >>' com.apple.CoreSimulator.SimDeviceType.<< parameters.sim-device-type >> com.apple.CoreSimulator.SimRuntime.<< parameters.sim-device-runtime >>
 
-  bundle-install-with-cache:
+  install-dependencies:
     parameters:
       directory:
         type: string
         default: .
     steps:
+      # Bundler
       - restore_cache:
           keys: 
             - v1-gem-cache-{{ checksum "Gemfile.lock" }}
@@ -82,15 +83,6 @@ commands:
           key: v1-gem-cache-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
-
-  install-dependencies:
-    parameters:
-      directory:
-        type: string
-        default: .
-    steps:
-      - bundle-install-with-cache:
-          directory: << parameters.directory >>
       - run:
           name: Install swiftlint
           command: brew install swiftlint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ commands:
       # Bundler
       - restore_cache:
           keys: 
-            - v1-gem-cache-{{ checksum "Gemfile.lock" }}
+            - v2-gem-cache-{{ checksum "Gemfile.lock" }}
       - run: 
           name: Bundle install
           working_directory: << parameters.directory >>
@@ -80,7 +80,7 @@ commands:
               bundle config set --local path 'vendor/bundle'
               bundle install
       - save_cache:
-          key: v1-gem-cache-{{ checksum "Gemfile.lock" }}
+          key: v2-gem-cache-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
       - run:
@@ -357,10 +357,10 @@ jobs:
       # Bundler
       - restore_cache:
           keys: 
-            - v1-gem-cache-{{ checksum "Gemfile.lock" }}
+            - v2-gem-cache-{{ checksum "Gemfile.lock" }}
       - run: bundle install --clean --path vendor/bundle
       - save_cache:
-          key: v1-gem-cache-{{ checksum "Gemfile.lock" }}
+          key: v2-gem-cache-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
       - update-spm-installation-commit


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/7590/workflows/f9b051cd-6b41-4d7b-b4b1-77edbec943a5

Restoring caches is taking long time because it's failing to restore caches that are stored in Danger's job, which runs on a Docker image. In a run from before the merge of the Danger changes, it’s finding the cache in Cached paths: `/Users/distiller/purchases-ios/vendor/bundle`. In the newer runs it’s failing in `/home/circleci/purchases-ios/vendor/bundle/`

CircleCI docs say:

> Warning: Caching files between different executors, for example, between Docker and machine, Linux, Windows or macOS, or CircleCI image and non-CircleCI image, can result in file permissions and path errors. These errors are often caused by missing users, users with different UIDs, and missing paths. Use extra care when caching files in these cases.
https://circleci.com/docs/caching

So it looks like the issue is with the paths. I think the best solution is to have two different caches, one for Danger and one for the MacOS executors
