### PR TITLE
Update to latest fastlane plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,7 +403,7 @@ jobs:
       - trust-github-key
       - run:
           name: Prepare next version
-          command: bundle exec fastlane prepare_next_version branch:$CIRCLE_BRANCH
+          command: bundle exec fastlane prepare_next_version
 
   installation-tests-cocoapods:
     <<: *base-job

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: a271972db563fc91c682c235146afbc83cd82203
+  revision: 805c34fc9b7e13047a83d6d6411e87fc787143ba
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal
-  revision: 4082cf43e9a21b61adbb53456e4692bb1e4257bf
+  revision: a271972db563fc91c682c235146afbc83cd82203
   specs:
     fastlane-plugin-revenuecat_internal (0.1.0)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -71,8 +71,7 @@ platform :ios do
       repo_name: repo_name,
       github_pr_token: ENV["GITHUB_PULL_REQUEST_API_TOKEN"],
       files_to_update: files_with_version_number,
-      files_to_update_without_prerelease_modifiers: files_with_version_number_without_prerelease_modifiers,
-      branch: options[:branch] || 'main'
+      files_to_update_without_prerelease_modifiers: files_with_version_number_without_prerelease_modifiers
     )
   end
 


### PR DESCRIPTION
### Description
Updates to latest fastlane plugin with this change: https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/pull/12. Now we won't validate the current branch when running the `prepare_next_version` lane.
