### PR TITLE
Replace usages of replace_in with replace_text_in_files action

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -320,8 +320,8 @@ platform :ios do
   desc "Update swift package commit"
   lane :update_swift_package_commit do
     project_file_locations = [
-      '../Tests/InstallationTests/SPMInstallation/SPMInstallation.xcodeproj/project.pbxproj',
-      '../Examples/MagicWeather/MagicWeather.xcodeproj/project.pbxproj'
+      './Tests/InstallationTests/SPMInstallation/SPMInstallation.xcodeproj/project.pbxproj',
+      './Examples/MagicWeather/MagicWeather.xcodeproj/project.pbxproj'
     ]
 
     old_kind_line = "kind = branch;"
@@ -331,10 +331,17 @@ platform :ios do
     old_branch_line = "branch = main;"
     new_revision_line = "revision = #{commit_hash};"
 
-    project_file_locations.each { |project_file_location|
-      Fastlane::Helper::RevenuecatInternalHelper.replace_in(old_kind_line, new_kind_line, project_file_location)
-      Fastlane::Helper::RevenuecatInternalHelper.replace_in(old_branch_line, new_revision_line, project_file_location)
-    }
+    replace_text_in_files(
+      previous_text: old_kind_line,
+      new_text: new_kind_line,
+      paths_of_files_to_update: project_file_locations
+    )
+
+    replace_text_in_files(
+      previous_text: old_branch_line,
+      new_text: new_revision_line,
+      paths_of_files_to_update: project_file_locations
+    )
   end
 
   desc "Preview docs"


### PR DESCRIPTION
### Description
This was fixed by @joshdholtz in #1800. However, we created an action to replace text in a list of files so this changes that to use that action.

