### PR TITLE
`PurchasesAttributionDataTests`: fixed potential race condition in flaky test

### DIFF
--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesAttributionDataTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesAttributionDataTests.swift
@@ -143,8 +143,9 @@ class PurchasesAttributionDataTests: BasePurchasesTests {
         Purchases.deprecated.addAttributionData(data, from: .adjust, forNetworkUserId: "newuser")
 
         self.setupPurchases(automaticCollection: true)
-        expect(self.backend.invokedPostAttributionDataParametersList.count) == 1
-        expect(self.subscriberAttributesManager.invokedConvertAttributionDataAndSetParametersList.count) == 1
+
+        expect(self.backend.invokedPostAttributionDataParametersList).toEventually(haveCount(1))
+        expect(self.subscriberAttributesManager.invokedConvertAttributionDataAndSetParametersList).to(haveCount(1))
     }
 
 }


### PR DESCRIPTION
Not sure how this passes normally in CI (probably only because of retries). It's flaky locally probably because the requests are asynchronous.