### PR TITLE
`PriceFormatterProvider: Sendable` conformance and fixed thread-safety

### DIFF
--- a/Sources/Misc/Atomic.swift
+++ b/Sources/Misc/Atomic.swift
@@ -43,7 +43,7 @@ import Foundation
  * foo.value = MyClass()
  * ```
  **/
-internal final class Atomic<T>: @unchecked Sendable {
+internal final class Atomic<T> {
 
     private let lock: Lock
     private var _value: T
@@ -81,3 +81,6 @@ extension Atomic: ExpressibleByNilLiteral where T: OptionalType {
     }
 
 }
+
+// `@unchecked` because of the mutable `_value`, but it's thread-safety is guaranteed with `Lock`.
+extension Atomic: @unchecked Sendable {}

--- a/Sources/Misc/Atomic.swift
+++ b/Sources/Misc/Atomic.swift
@@ -43,7 +43,7 @@ import Foundation
  * foo.value = MyClass()
  * ```
  **/
-internal final class Atomic<T> {
+internal final class Atomic<T>: @unchecked Sendable {
 
     private let lock: Lock
     private var _value: T

--- a/Sources/Misc/Lock.swift
+++ b/Sources/Misc/Lock.swift
@@ -13,7 +13,7 @@
 
 import Foundation
 
-internal final class Lock {
+internal final class Lock: Sendable {
 
     private let recursiveLock: NSRecursiveLock = {
         let lock = NSRecursiveLock()

--- a/Sources/Misc/Lock.swift
+++ b/Sources/Misc/Lock.swift
@@ -13,7 +13,7 @@
 
 import Foundation
 
-internal final class Lock: Sendable {
+internal final class Lock {
 
     private let recursiveLock: NSRecursiveLock = {
         let lock = NSRecursiveLock()
@@ -31,3 +31,10 @@ internal final class Lock: Sendable {
     }
 
 }
+
+#if swift(>=5.7)
+extension Lock: Sendable {}
+#else
+// `NSRecursiveLock` isn't `Sendable` until iOS 16.0 / Swift 5.7
+extension Lock: @unchecked Sendable {}
+#endif

--- a/Sources/Misc/PriceFormatterProvider.swift
+++ b/Sources/Misc/PriceFormatterProvider.swift
@@ -15,9 +15,9 @@ import Foundation
 
 /// A `NumberFormatter` provider class for prices.
 /// This provider caches the formatter to improve the performance.
-class PriceFormatterProvider {
+final class PriceFormatterProvider: Sendable {
 
-    private var cachedPriceFormatterForSK1: NumberFormatter?
+    private let cachedPriceFormatterForSK1: Atomic<NumberFormatter?> = nil
 
     func priceFormatterForSK1(with locale: Locale) -> NumberFormatter {
         func makePriceFormatterForSK1(with locale: Locale) -> NumberFormatter {
@@ -27,18 +27,23 @@ class PriceFormatterProvider {
             return formatter
         }
 
-        if self.cachedPriceFormatterForSK1 == nil || self.cachedPriceFormatterForSK1?.locale != locale {
-            self.cachedPriceFormatterForSK1 = makePriceFormatterForSK1(with: locale)
-        }
+        return self.cachedPriceFormatterForSK1.modify { formatter in
+            guard let formatter = formatter, formatter.locale == locale else {
+                let newFormatter =  makePriceFormatterForSK1(with: locale)
+                formatter = newFormatter
 
-        return self.cachedPriceFormatterForSK1!
+                return newFormatter
+            }
+
+            return formatter
+        }
     }
 
-    private var cachedPriceFormatterForSK2: NumberFormatter?
+    private let cachedPriceFormatterForSK2: Atomic<NumberFormatter?> = nil
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func priceFormatterForSK2(withCurrencyCode currencyCode: String) -> NumberFormatter {
-        func makePriceFormatterForSK2(withCurrencyCode currencyCode: String) -> NumberFormatter {
+        func makePriceFormatterForSK2(with currencyCode: String) -> NumberFormatter {
             let formatter = NumberFormatter()
             formatter.numberStyle = .currency
             formatter.locale = .autoupdatingCurrent
@@ -46,11 +51,16 @@ class PriceFormatterProvider {
             return formatter
         }
 
-        if self.cachedPriceFormatterForSK2 == nil || self.cachedPriceFormatterForSK2?.currencyCode != currencyCode {
-            self.cachedPriceFormatterForSK2 = makePriceFormatterForSK2(withCurrencyCode: currencyCode)
-        }
+        return self.cachedPriceFormatterForSK2.modify { formatter in
+            guard let formatter = formatter, formatter.currencyCode == currencyCode else {
+                let newFormatter = makePriceFormatterForSK2(with: currencyCode)
+                formatter = newFormatter
 
-        return self.cachedPriceFormatterForSK2!
+                return newFormatter
+            }
+
+            return formatter
+        }
     }
 
 }

--- a/Tests/StoreKitUnitTests/PriceFormatterProviderTests.swift
+++ b/Tests/StoreKitUnitTests/PriceFormatterProviderTests.swift
@@ -29,9 +29,9 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
 
     func testReturnsCachedPriceFormatterForSK1() {
         let locale = Locale(identifier: "en_US")
-        let firstPriceFormatter = priceFormatterProvider.priceFormatterForSK1(with: locale)
+        let firstPriceFormatter = self.priceFormatterProvider.priceFormatterForSK1(with: locale)
 
-        let secondPriceFormatter = priceFormatterProvider.priceFormatterForSK1(with: locale)
+        let secondPriceFormatter = self.priceFormatterProvider.priceFormatterForSK1(with: locale)
 
         expect(firstPriceFormatter) === secondPriceFormatter
     }
@@ -41,9 +41,9 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         let currencyCode = "USD"
-        let firstPriceFormatter = priceFormatterProvider.priceFormatterForSK2(withCurrencyCode: currencyCode)
+        let firstPriceFormatter = self.priceFormatterProvider.priceFormatterForSK2(withCurrencyCode: currencyCode)
 
-        let secondPriceFormatter = priceFormatterProvider.priceFormatterForSK2(withCurrencyCode: currencyCode)
+        let secondPriceFormatter = self.priceFormatterProvider.priceFormatterForSK2(withCurrencyCode: currencyCode)
 
         expect(firstPriceFormatter) === secondPriceFormatter
     }
@@ -52,7 +52,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
     func testSk1PriceFormatterUsesCurrentStorefront() async throws {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
-        testSession.locale = Locale(identifier: "es_ES")
+        self.testSession.locale = Locale(identifier: "es_ES")
         try await self.changeStorefront("ESP")
 
         let sk1Fetcher = ProductsFetcherSK1(requestTimeout: Configuration.storeKitRequestTimeoutDefault)
@@ -62,7 +62,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
         var priceFormatter = try XCTUnwrap(storeProduct.priceFormatter)
         expect(priceFormatter.currencyCode) == "EUR"
 
-        testSession.locale = Locale(identifier: "en_EN")
+        self.testSession.locale = Locale(identifier: "en_EN")
         try await self.changeStorefront("USA")
 
         // Note: this test passes only because the cache is manually
@@ -81,7 +81,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
     func testSk2PriceFormatterUsesCurrentStorefront() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        testSession.locale = Locale(identifier: "es_ES")
+        self.testSession.locale = Locale(identifier: "es_ES")
         try await self.changeStorefront("ESP")
 
         let sk2Fetcher = ProductsFetcherSK2()
@@ -91,7 +91,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
         var priceFormatter = try XCTUnwrap(storeProduct.priceFormatter)
         expect(priceFormatter.currencyCode) == "EUR"
 
-        testSession.locale = Locale(identifier: "en_EN")
+        self.testSession.locale = Locale(identifier: "en_EN")
         try await self.changeStorefront("USA")
 
         // Note: this test passes only because the cache is manually


### PR DESCRIPTION
For [CSDK-379].

This class was used all over the place **but it wasn't thread-safe**. The Swift compiler enforces this now that it conforms to Sendable (note it's not unchecked!).
Because `Atomic` guarantees correctness, this thread-safety can be enforced now by the compiler.

[CSDK-379]: https://revenuecats.atlassian.net/browse/CSDK-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ