### PR TITLE
`Dangerfile`: added "next_release" as supported label

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,5 +1,5 @@
 def fail_if_no_supported_label_found
-  supported_types = ["breaking", "build", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test"]
+  supported_types = ["breaking", "build", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test", "next_release"]
 
   supported_labels_in_pr = supported_types & github.pr_labels
   no_supported_label = supported_labels_in_pr.empty?


### PR DESCRIPTION
See also https://github.com/RevenueCat/fastlane-plugin-revenuecat_internal/pull/17