### PR TITLE
`StoreKitConfigTestCase.changeStorefront`: re-enabled on iOS 16

### DIFF
--- a/Tests/StoreKitUnitTests/PriceFormatterProviderTests.swift
+++ b/Tests/StoreKitUnitTests/PriceFormatterProviderTests.swift
@@ -53,7 +53,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
         testSession.locale = Locale(identifier: "es_ES")
-        try await self.changeStorefront("ESP")
+        await self.changeStorefront("ESP")
 
         let sk1Fetcher = ProductsFetcherSK1(requestTimeout: Configuration.storeKitRequestTimeoutDefault)
 
@@ -63,7 +63,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
         expect(priceFormatter.currencyCode) == "EUR"
 
         testSession.locale = Locale(identifier: "en_EN")
-        try await self.changeStorefront("USA")
+        await self.changeStorefront("USA")
 
         // Note: this test passes only because the cache is manually
         // cleared. `ProductsFetcherSK1` does not detect Storefront
@@ -82,7 +82,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         testSession.locale = Locale(identifier: "es_ES")
-        try await self.changeStorefront("ESP")
+        await self.changeStorefront("ESP")
 
         let sk2Fetcher = ProductsFetcherSK2()
 
@@ -92,7 +92,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
         expect(priceFormatter.currencyCode) == "EUR"
 
         testSession.locale = Locale(identifier: "en_EN")
-        try await self.changeStorefront("USA")
+        await self.changeStorefront("USA")
 
         // Note: this test passes only because the cache is manually
         // cleared. `ProductsFetcherSK2` does not detect Storefront

--- a/Tests/StoreKitUnitTests/StoreProductTests.swift
+++ b/Tests/StoreKitUnitTests/StoreProductTests.swift
@@ -231,7 +231,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
         testSession.locale = Locale(identifier: "es_ES")
-        try await self.changeStorefront("ESP")
+        await self.changeStorefront("ESP")
 
         let sk1Fetcher = ProductsFetcherSK1(requestTimeout: Configuration.storeKitRequestTimeoutDefault)
 
@@ -248,7 +248,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(storeProduct.currencyCode) == "EUR"
 
         testSession.locale = Locale(identifier: "en_EN")
-        try await self.changeStorefront("USA")
+        await self.changeStorefront("USA")
 
         // Note: this test passes only because the cache is manually
         // cleared. `ProductsFetcherSK1` does not detect Storefront
@@ -272,7 +272,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         testSession.locale = Locale(identifier: "es_ES")
-        try await self.changeStorefront("ESP")
+        await self.changeStorefront("ESP")
 
         let sk2Fetcher = ProductsFetcherSK2()
 
@@ -289,7 +289,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(storeProduct.currencyCode) == "EUR"
 
         testSession.locale = Locale(identifier: "en_EN")
-        try await self.changeStorefront("USA")
+        await self.changeStorefront("USA")
 
         // Note: this test passes only because the cache is manually
         // cleared. `ProductsFetcherSK2` does not detect Storefront

--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
@@ -66,7 +66,7 @@ extension StoreKitConfigTestCase {
         _ new: String,
         file: FileString = #fileID,
         line: UInt = #line
-    ) async throws {
+    ) async {
         self.testSession.storefront = new
 
         if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {

--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
@@ -67,11 +67,6 @@ extension StoreKitConfigTestCase {
         file: FileString = #fileID,
         line: UInt = #line
     ) async throws {
-        guard #unavailable(iOS 16.0) else {
-            // See https://github.com/RevenueCat/purchases-ios/pull/1701
-            throw XCTSkip("Changing Storefront is currently not working in iOS 16.0")
-        }
-
         self.testSession.storefront = new
 
         if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {


### PR DESCRIPTION
See #1701.

Apple fixed this in beta 5!