### PR TITLE
Fixed warnings for unnecessary `try`

### DIFF
--- a/Tests/StoreKitUnitTests/OfferingsManagerStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/OfferingsManagerStoreKitTests.swift
@@ -62,7 +62,7 @@ extension OfferingsManagerStoreKitTests {
         expect(receivedProduct.currencyCode) == "USD"
 
         testSession.locale = Locale(identifier: "es_ES")
-        try await changeStorefront("ESP")
+        await changeStorefront("ESP")
 
         fetchedStoreProduct = try await fetchSk2StoreProduct()
         storeProduct = StoreProduct(sk2Product: fetchedStoreProduct.underlyingSK2Product)

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -76,7 +76,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         expect(unwrappedFirstProduct.currencyCode) == "USD"
 
         testSession.locale = Locale(identifier: "es_ES")
-        try await changeStorefront("ESP")
+        await changeStorefront("ESP")
 
         // Note: this test passes only because the method `invalidateAndReFetchCachedProductsIfAppropiate`
         // is manually executed. `ProductsManager` does not detect Storefront changes to invalidate the
@@ -106,7 +106,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         expect(unwrappedFirstProduct.currencyCode) == "USD"
 
         testSession.locale = Locale(identifier: "es_ES")
-        try await changeStorefront("ESP")
+        await changeStorefront("ESP")
 
         // Note: this test passes only because the method `invalidateAndReFetchCachedProductsIfAppropiate`
         // is manually executed. `ProductsManager` does not detect Storefront changes to invalidate the


### PR DESCRIPTION
I missed these in #1811.