### PR TITLE
Update documentation for presentCodeRedemptionSheet

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1228,7 +1228,7 @@ public extension Purchases {
 
 #if os(iOS)
 
-     /**
+    /**
      * Displays a sheet that enables users to redeem subscription offer codes that you generated in App Store Connect.
      *
      * - Important: Even though the docs in `SKPaymentQueue.presentCodeRedemptionSheet`

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1229,6 +1229,13 @@ public extension Purchases {
 #if os(iOS)
     /**
      * Displays a sheet that enables users to redeem subscription offer codes that you generated in App Store Connect.
+     *
+     * - Note: Even though the docs in `SKPaymentQueue.presentCodeRedemptionSheet`
+     * say that it's available on Catalyst 14.0, there is a note:
+     *
+     * `This function doesn’t affect Mac apps built with Mac Catalyst.`
+     *
+     * when, in fact, it crashes when called both from Catalyst and also when running as "Designed for iPad".
      */
     @available(iOS 14.0, *)
     @available(watchOS, unavailable)

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1230,7 +1230,7 @@ public extension Purchases {
     /**
      * Displays a sheet that enables users to redeem subscription offer codes that you generated in App Store Connect.
      *
-     * - Note: Even though the docs in `SKPaymentQueue.presentCodeRedemptionSheet`
+     * - Warning: Even though the docs in `SKPaymentQueue.presentCodeRedemptionSheet`
      * say that it's available on Catalyst 14.0, there is a note:
      *
      * `This function doesn’t affect Mac apps built with Mac Catalyst.`

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1227,18 +1227,15 @@ public extension Purchases {
     }
 
 #if os(iOS)
-    /**
+
+     /**
      * Displays a sheet that enables users to redeem subscription offer codes that you generated in App Store Connect.
      *
-     /**
- * Displays a sheet that enables users to redeem subscription offer codes that you generated in App Store Connect.
- *
- * - Important: Even though the docs in `SKPaymentQueue.presentCodeRedemptionSheet`
- * say that it's available on Catalyst 14.0, there is a note:
- * "`This function doesn’t affect Mac apps built with Mac Catalyst.`"
- * when, in fact, it crashes when called both from Catalyst and also when running as "Designed for iPad".
- * This is why RevenueCat's SDK makes it unavailable in mac catalyst.
- */
+     * - Important: Even though the docs in `SKPaymentQueue.presentCodeRedemptionSheet`
+     * say that it's available on Catalyst 14.0, there is a note:
+     * "`This function doesn’t affect Mac apps built with Mac Catalyst.`"
+     * when, in fact, it crashes when called both from Catalyst and also when running as "Designed for iPad".
+     * This is why RevenueCat's SDK makes it unavailable in mac catalyst.
      */
     @available(iOS 14.0, *)
     @available(watchOS, unavailable)

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1230,12 +1230,15 @@ public extension Purchases {
     /**
      * Displays a sheet that enables users to redeem subscription offer codes that you generated in App Store Connect.
      *
-     * - Warning: Even though the docs in `SKPaymentQueue.presentCodeRedemptionSheet`
-     * say that it's available on Catalyst 14.0, there is a note:
-     *
-     * `This function doesn’t affect Mac apps built with Mac Catalyst.`
-     *
-     * when, in fact, it crashes when called both from Catalyst and also when running as "Designed for iPad".
+     /**
+ * Displays a sheet that enables users to redeem subscription offer codes that you generated in App Store Connect.
+ *
+ * - Important: Even though the docs in `SKPaymentQueue.presentCodeRedemptionSheet`
+ * say that it's available on Catalyst 14.0, there is a note:
+ * "`This function doesn’t affect Mac apps built with Mac Catalyst.`"
+ * when, in fact, it crashes when called both from Catalyst and also when running as "Designed for iPad".
+ * This is why RevenueCat's SDK makes it unavailable in mac catalyst.
+ */
      */
     @available(iOS 14.0, *)
     @available(watchOS, unavailable)


### PR DESCRIPTION
Clarifies why it's not available for macCatalyst
improves https://github.com/RevenueCat/react-native-purchases/issues/401