### PR TITLE
`SwiftLint`: fixed build warning

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -2220,6 +2220,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		B3C302D926D8066F002B72D1 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);


### PR DESCRIPTION
Starting with `Xcode 14`, building the SDK results in this warning:
> warning build: Run script build phase 'SwiftLint' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase.

See https://github.com/realm/SwiftLint/issues/4015
We've always linted all files when building, so this isn't a change. In the future we could make this smarter to avoid linting everything all the time, but `SwiftLint` is already pretty fast.