### PR TITLE
`SwiftLint`: cleaned up output

### DIFF
--- a/scripts/swiftlint.sh
+++ b/scripts/swiftlint.sh
@@ -22,7 +22,8 @@ if which swiftlint >/dev/null; then
   echo "linter command: ${lint_command}"
   
   pushd "${source_path}"
-  $lint_command
+  # Run swiftlint but filter out "Linting ..." to clean up output
+  $lint_command 2>&1 | grep -v 'Linting '
   popd
 else
   echo "Warning: SwiftLint not installed in ${HOMEBREW_BINARY_DESTINATION}, download from https://github.com/realm/SwiftLint"


### PR DESCRIPTION
The output of `SwiftLint` is pretty noisy, which sometimes makes it hard to see other build warnings or errors in Xcode:

<img width="664" alt="Screenshot 2022-08-12 at 12 23 31" src="https://user-images.githubusercontent.com/685609/184502439-09881cff-df2b-424d-9d3e-96b238e8c45a.png">

This removes the "Linting... " lines when ran from Xcode.