### PR TITLE
`DeviceCache`: `Sendable` conformance and fixed thread-safety

### DIFF
--- a/Sources/Misc/SynchronizedUserDefaults.swift
+++ b/Sources/Misc/SynchronizedUserDefaults.swift
@@ -16,7 +16,7 @@ import Foundation
 /// A `UserDefaults` wrapper to synchronize access and writes.
 ///
 /// - SeeAlso: `Atomic`.
-internal class SynchronizedUserDefaults {
+internal final class SynchronizedUserDefaults {
 
     private let atomic: Atomic<UserDefaults>
 
@@ -45,3 +45,5 @@ internal class SynchronizedUserDefaults {
     }
 
 }
+
+extension SynchronizedUserDefaults: Sendable {}


### PR DESCRIPTION
For [CSDK-379].
Extracted #1795 to make it easier to review this fix in isolation.

`handleUserDefaultsChanged` isn't guaranteed to be called from any particular thread, so its access to `appUserIDHasBeenSet` wasn't thread-safe.

This is now guaranteed by `Sendable`.

_In theory. In practice we are required to use `@unchecked` for now because of `NotificationCenter` and the class not being `final`. But without those I verified that the class does compile with `Sendable`, which means that there aren't any other potential issues._

[CSDK-379]: https://revenuecats.atlassian.net/browse/CSDK-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ