### PR TITLE
`CustomerInfo: Sendable` conformance

### DIFF
--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -231,7 +231,14 @@ extension CustomerInfo: RawDataContainer {
 
 }
 
+#if swift(>=5.7)
 extension CustomerInfo: Sendable {}
+#else
+// `@unchecked` because:
+// - `Date` is not `Sendable` until Swift 5.7
+// - `URL` is not `Sendable` until Swift 5.7
+extension CustomerInfo: @unchecked Sendable {}
+#endif
 
 /// `CustomerInfo`'s `Codable` implementation relies on `Data`
 extension CustomerInfo: Codable {

--- a/Sources/Purchasing/EntitlementInfo.swift
+++ b/Sources/Purchasing/EntitlementInfo.swift
@@ -308,7 +308,7 @@ extension EntitlementInfo: Identifiable {
 
 private extension EntitlementInfo {
 
-    struct Contents: Equatable, Hashable, Sendable {
+    struct Contents: Equatable, Hashable {
 
         let identifier: String
         let isActive: Bool
@@ -327,3 +327,11 @@ private extension EntitlementInfo {
     }
 
 }
+
+#if swift(>=5.7)
+extension EntitlementInfo.Contents: Sendable {}
+#else
+// `@unchecked` because:
+// - `Date` is not `Sendable` until Swift 5.7
+extension EntitlementInfo.Contents: @unchecked Sendable {}
+#endif

--- a/Sources/Purchasing/EntitlementInfo.swift
+++ b/Sources/Purchasing/EntitlementInfo.swift
@@ -43,6 +43,7 @@ import Foundation
 }
 
 extension Store: CaseIterable {}
+extension Store: Sendable {}
 
 extension Store: DefaultValueProvider {
 
@@ -66,6 +67,7 @@ extension Store: DefaultValueProvider {
 }
 
 extension PeriodType: CaseIterable {}
+extension PeriodType: Sendable {}
 
 extension PeriodType: DefaultValueProvider {
 
@@ -76,7 +78,7 @@ extension PeriodType: DefaultValueProvider {
 /**
  The EntitlementInfo object gives you access to all of the information about the status of a user entitlement.
  */
-@objc(RCEntitlementInfo) public class EntitlementInfo: NSObject {
+@objc(RCEntitlementInfo) public final class EntitlementInfo: NSObject {
 
     /**
      The entitlement identifier configured in the RevenueCat dashboard
@@ -243,6 +245,10 @@ extension PeriodType: DefaultValueProvider {
 
 extension EntitlementInfo: RawDataContainer {}
 
+// @unchecked because:
+// - `rawData` is `[String: Any]` which can't be `Sendable`
+extension EntitlementInfo: @unchecked Sendable {}
+
 public extension EntitlementInfo {
 
     /// True if the user has access to this entitlement,
@@ -302,7 +308,7 @@ extension EntitlementInfo: Identifiable {
 
 private extension EntitlementInfo {
 
-    struct Contents: Equatable, Hashable {
+    struct Contents: Equatable, Hashable, Sendable {
 
         let identifier: String
         let isActive: Bool

--- a/Sources/Purchasing/EntitlementInfos.swift
+++ b/Sources/Purchasing/EntitlementInfos.swift
@@ -17,7 +17,7 @@ import Foundation
 /**
  This class contains all the entitlements associated to the user.
  */
-@objc(RCEntitlementInfos) public class EntitlementInfos: NSObject {
+@objc(RCEntitlementInfos) public final class EntitlementInfos: NSObject {
     /**
      Dictionary of all EntitlementInfo (``EntitlementInfo``) objects (active and inactive) keyed by entitlement
      identifier. This dictionary can also be accessed by using an index subscript on ``EntitlementInfos``, e.g.
@@ -124,3 +124,5 @@ extension EntitlementInfos {
     }
 
 }
+
+extension EntitlementInfos: Sendable {}

--- a/Sources/Purchasing/NonSubscriptionTransaction.swift
+++ b/Sources/Purchasing/NonSubscriptionTransaction.swift
@@ -40,3 +40,5 @@ public final class NonSubscriptionTransaction: NSObject {
     }
 
 }
+
+extension NonSubscriptionTransaction: Sendable {}

--- a/Sources/Purchasing/NonSubscriptionTransaction.swift
+++ b/Sources/Purchasing/NonSubscriptionTransaction.swift
@@ -41,4 +41,10 @@ public final class NonSubscriptionTransaction: NSObject {
 
 }
 
+#if swift(>=5.7)
 extension NonSubscriptionTransaction: Sendable {}
+#else
+// `@unchecked` because:
+// - `Date` is not `Sendable` until Swift 5.7
+extension NonSubscriptionTransaction: @unchecked Sendable {}
+#endif

--- a/Sources/Purchasing/PurchaseOwnershipType.swift
+++ b/Sources/Purchasing/PurchaseOwnershipType.swift
@@ -35,6 +35,7 @@ import Foundation
 }
 
 extension PurchaseOwnershipType: CaseIterable {}
+extension PurchaseOwnershipType: Sendable {}
 
 extension PurchaseOwnershipType: DefaultValueProvider {
 


### PR DESCRIPTION
The type is now immutable, so the compiler ensures it's thread-safe.

For [CSDK-379].
Extracted from #1795 to make it easier to review this in isolation.

[CSDK-379]: https://revenuecats.atlassian.net/browse/CSDK-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ