### PR TITLE
`ReceiptParser: Sendable` conformance

### DIFF
--- a/Sources/LocalReceiptParsing/Builders/ASN1ContainerBuilder.swift
+++ b/Sources/LocalReceiptParsing/Builders/ASN1ContainerBuilder.swift
@@ -44,6 +44,10 @@ class ASN1ContainerBuilder {
     }
 }
 
+// @unchecked because:
+// - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
+extension ASN1ContainerBuilder: @unchecked Sendable {}
+
 private extension ASN1ContainerBuilder {
 
     func buildInternalContainers(payload: ArraySlice<UInt8>) throws -> [ASN1Container] {

--- a/Sources/LocalReceiptParsing/Builders/ASN1ObjectIdentifierBuilder.swift
+++ b/Sources/LocalReceiptParsing/Builders/ASN1ObjectIdentifierBuilder.swift
@@ -14,10 +14,10 @@
 
 import Foundation
 
-class ASN1ObjectIdentifierBuilder {
+enum ASN1ObjectIdentifierBuilder {
 
     // info on the format: https://docs.microsoft.com/en-us/windows/win32/seccertenroll/about-object-identifier
-    func build(fromPayload payload: ArraySlice<UInt8>) throws -> ASN1ObjectIdentifier? {
+    static func build(fromPayload payload: ArraySlice<UInt8>) throws -> ASN1ObjectIdentifier? {
         guard let firstByte = payload.first else { return nil }
 
         var objectIdentifierNumbers: [UInt] = []
@@ -37,7 +37,7 @@ class ASN1ObjectIdentifierBuilder {
 private extension ASN1ObjectIdentifierBuilder {
 
     // https://en.wikipedia.org/wiki/Variable-length_quantity
-    func decodeVariableLengthQuantity(payload: ArraySlice<UInt8>) throws -> [UInt] {
+    static func decodeVariableLengthQuantity(payload: ArraySlice<UInt8>) throws -> [UInt] {
         var decodedNumbers = [UInt]()
 
         var currentBuffer: UInt = 0

--- a/Sources/LocalReceiptParsing/Builders/AppleReceiptBuilder.swift
+++ b/Sources/LocalReceiptParsing/Builders/AppleReceiptBuilder.swift
@@ -113,3 +113,7 @@ class AppleReceiptBuilder {
     }
 
 }
+
+// @unchecked because:
+// - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
+extension AppleReceiptBuilder: @unchecked Sendable {}

--- a/Sources/LocalReceiptParsing/Builders/InAppPurchaseBuilder.swift
+++ b/Sources/LocalReceiptParsing/Builders/InAppPurchaseBuilder.swift
@@ -6,6 +6,7 @@
 import Foundation
 
 class InAppPurchaseBuilder {
+
     private let containerBuilder: ASN1ContainerBuilder
     private let typeContainerIndex = 0
     private let versionContainerIndex = 1 // unused
@@ -96,4 +97,9 @@ class InAppPurchaseBuilder {
                              webOrderLineItemId: webOrderLineItemId,
                              promotionalOfferIdentifier: promotionalOfferIdentifier)
     }
+
 }
+
+// @unchecked because:
+// - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
+extension InAppPurchaseBuilder: @unchecked Sendable {}

--- a/Sources/LocalReceiptParsing/ReceiptParser.swift
+++ b/Sources/LocalReceiptParsing/ReceiptParser.swift
@@ -16,14 +16,11 @@ import Foundation
 
 class ReceiptParser {
 
-    private let objectIdentifierBuilder: ASN1ObjectIdentifierBuilder
     private let containerBuilder: ASN1ContainerBuilder
     private let receiptBuilder: AppleReceiptBuilder
 
-    init(objectIdentifierBuilder: ASN1ObjectIdentifierBuilder = ASN1ObjectIdentifierBuilder(),
-         containerBuilder: ASN1ContainerBuilder = ASN1ContainerBuilder(),
+    init(containerBuilder: ASN1ContainerBuilder = ASN1ContainerBuilder(),
          receiptBuilder: AppleReceiptBuilder = AppleReceiptBuilder()) {
-        self.objectIdentifierBuilder = objectIdentifierBuilder
         self.containerBuilder = containerBuilder
         self.receiptBuilder = receiptBuilder
     }
@@ -53,6 +50,12 @@ class ReceiptParser {
     }
 }
 
+// @unchecked because:
+// - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
+extension ReceiptParser: @unchecked Sendable {}
+
+// MARK: -
+
 private extension ReceiptParser {
 
     func findASN1Container(withObjectId objectId: ASN1ObjectIdentifier,
@@ -60,7 +63,7 @@ private extension ReceiptParser {
         if container.encodingType == .constructed {
             for (index, internalContainer) in container.internalContainers.enumerated() {
                 if internalContainer.containerIdentifier == .objectIdentifier {
-                    let objectIdentifier = try objectIdentifierBuilder.build(
+                    let objectIdentifier = try ASN1ObjectIdentifierBuilder.build(
                         fromPayload: internalContainer.internalPayload)
                     if objectIdentifier == objectId && index < container.internalContainers.count - 1 {
                         // the container that holds the data comes right after the one with the object identifier

--- a/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
@@ -40,7 +40,7 @@ class LocalReceiptParserStoreKitTests: StoreKitConfigTestCase {
     }
 
     func testReceiptParserParsesEmptyReceipt() async throws {
-        let data = try await XCTAsyncUnwrap(await receiptFetcher.receiptData(refreshPolicy: .always))
+        let data = try await XCTAsyncUnwrap(await self.receiptFetcher.receiptData(refreshPolicy: .always))
 
         let receipt = try self.parser.parse(from: data)
 

--- a/Tests/UnitTests/LocalReceiptParsing/Builders/ASN1ObjectIdentifierBuilderTests.swift
+++ b/Tests/UnitTests/LocalReceiptParsing/Builders/ASN1ObjectIdentifierBuilderTests.swift
@@ -8,42 +8,42 @@ class ASN1ObjectIdentifierBuilderTests: TestCase {
     let encoder = ASN1ObjectIdentifierEncoder()
     func testBuildFromPayloadBuildsCorrectlyForDataPayload() {
         let payload = encoder.objectIdentifierPayload(.data)
-        expect(try ASN1ObjectIdentifierBuilder().build(fromPayload: payload)) == .data
+        expect(try ASN1ObjectIdentifierBuilder.build(fromPayload: payload)) == .data
     }
 
     func testBuildFromPayloadBuildsCorrectlyForSignedDataPayload() {
         let payload = encoder.objectIdentifierPayload(.signedData)
-        expect(try ASN1ObjectIdentifierBuilder().build(fromPayload: payload)) == .signedData
+        expect(try ASN1ObjectIdentifierBuilder.build(fromPayload: payload)) == .signedData
     }
 
     func testBuildFromPayloadBuildsCorrectlyForEnvelopedDataPayload() {
         let payload = encoder.objectIdentifierPayload(.envelopedData)
-        expect(try ASN1ObjectIdentifierBuilder().build(fromPayload: payload)) == .envelopedData
+        expect(try ASN1ObjectIdentifierBuilder.build(fromPayload: payload)) == .envelopedData
     }
 
     func testBuildFromPayloadBuildsCorrectlyForSignedAndEnvelopedDataPayload() {
         let payload = encoder.objectIdentifierPayload(.signedAndEnvelopedData)
-        expect(try ASN1ObjectIdentifierBuilder().build(fromPayload: payload)) == .signedAndEnvelopedData
+        expect(try ASN1ObjectIdentifierBuilder.build(fromPayload: payload)) == .signedAndEnvelopedData
     }
 
     func testBuildFromPayloadBuildsCorrectlyForDigestedDataPayload() {
         let payload = encoder.objectIdentifierPayload(.digestedData)
-        expect(try ASN1ObjectIdentifierBuilder().build(fromPayload: payload)) == .digestedData
+        expect(try ASN1ObjectIdentifierBuilder.build(fromPayload: payload)) == .digestedData
     }
 
     func testBuildFromPayloadBuildsCorrectlyForEncryptedDataPayload() {
         let payload = encoder.objectIdentifierPayload(.encryptedData)
-        expect(try ASN1ObjectIdentifierBuilder().build(fromPayload: payload)) == .encryptedData
+        expect(try ASN1ObjectIdentifierBuilder.build(fromPayload: payload)) == .encryptedData
     }
 
     func testBuildFromPayloadReturnsNilIfIdentifierNotRecognized() {
         let unknownObjectID = [1, 3, 23, 534643, 7454, 1, 7, 2]
         let payload = encoder.encodeASN1ObjectIdentifier(numbers: unknownObjectID)
-        expect(try ASN1ObjectIdentifierBuilder().build(fromPayload: payload)).to(beNil())
+        expect(try ASN1ObjectIdentifierBuilder.build(fromPayload: payload)).to(beNil())
     }
 
     func testBuildFromPayloadReturnsNilIfIdentifierPayloadEmpty() {
         let payload: ArraySlice<UInt8> = ArraySlice([])
-        expect(try ASN1ObjectIdentifierBuilder().build(fromPayload: payload)).to(beNil())
+        expect(try ASN1ObjectIdentifierBuilder.build(fromPayload: payload)).to(beNil())
     }
 }

--- a/Tests/UnitTests/LocalReceiptParsing/ReceiptParserTests.swift
+++ b/Tests/UnitTests/LocalReceiptParsing/ReceiptParserTests.swift
@@ -14,8 +14,7 @@ class ReceiptParserTests: TestCase {
         super.setUp()
         mockAppleReceiptBuilder = MockAppleReceiptBuilder()
         mockASN1ContainerBuilder = MockASN1ContainerBuilder()
-        receiptParser = ReceiptParser(objectIdentifierBuilder: ASN1ObjectIdentifierBuilder(),
-                                      containerBuilder: mockASN1ContainerBuilder,
+        receiptParser = ReceiptParser(containerBuilder: mockASN1ContainerBuilder,
                                       receiptBuilder: mockAppleReceiptBuilder)
     }
 

--- a/Tests/UnitTests/Mocks/MockReceiptParser.swift
+++ b/Tests/UnitTests/Mocks/MockReceiptParser.swift
@@ -23,8 +23,7 @@ class MockReceiptParser: ReceiptParser {
                                           inAppPurchases: [])
 
     convenience init() {
-        self.init(objectIdentifierBuilder: ASN1ObjectIdentifierBuilder(),
-                  containerBuilder: MockASN1ContainerBuilder(),
+        self.init(containerBuilder: MockASN1ContainerBuilder(),
                   receiptBuilder: MockAppleReceiptBuilder())
     }
 


### PR DESCRIPTION
For [CSDK-379].
Extracted from #1795 to make it easier to review this in isolation.

Also made `ASN1ObjectIdentifierBuilder` an `enum` since we don't need to create instances of it to use it.

[CSDK-379]: https://revenuecats.atlassian.net/browse/CSDK-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ