### PR TITLE
`Offering`/`StoreProductType`: `Sendable` conformance

### DIFF
--- a/Sources/Purchasing/Package.swift
+++ b/Sources/Purchasing/Package.swift
@@ -23,7 +23,7 @@ import Foundation
 /// - ``Offering``
 /// - ``Offerings``
 ///
-@objc(RCPackage) public class Package: NSObject {
+@objc(RCPackage) public final class Package: NSObject {
 
     /// The identifier for this Package.
     @objc public let identifier: String
@@ -105,3 +105,5 @@ extension Package: Identifiable {
     public var id: String { return self.identifier }
 
 }
+
+extension Package: Sendable {}

--- a/Sources/Purchasing/PackageType.swift
+++ b/Sources/Purchasing/PackageType.swift
@@ -44,6 +44,8 @@ import Foundation
 
 extension PackageType: CaseIterable {}
 
+extension PackageType: Sendable {}
+
 extension PackageType: CustomDebugStringConvertible {
 
     /// A textual description of the type suitable for debugging.

--- a/Sources/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
@@ -96,3 +96,8 @@ extension SK1StoreProduct: Hashable {
     }
 
 }
+
+#if swift(<5.7)
+// `SK1Product` isn't `Sendable` until iOS 16.0 / Swift 5.7
+extension SK1StoreProduct: @unchecked Sendable {}
+#endif

--- a/Sources/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
@@ -61,6 +61,14 @@ internal struct SK1StoreProductDiscount: StoreProductDiscountType {
 
 }
 
+#if swift(<5.7)
+// `SK1ProductDiscount` isn't `Sendable` until iOS 16.0 / Swift 5.7
+@available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)
+extension SK1StoreProductDiscount: @unchecked Sendable {}
+#endif
+
+// MARK: - Private
+
 private extension StoreProductDiscount.PaymentMode {
 
     @available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *)

--- a/Sources/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
@@ -116,3 +116,9 @@ extension SK2StoreProduct: Hashable {
     }
 
 }
+
+#if swift(<5.7)
+// `SK2Product` isn't `Sendable` until iOS 16.0 / Swift 5.7
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+extension SK2StoreProduct: @unchecked Sendable {}
+#endif

--- a/Sources/Purchasing/StoreKitAbstractions/SK2StoreProductDiscount.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK2StoreProductDiscount.swift
@@ -46,6 +46,14 @@ internal struct SK2StoreProductDiscount: StoreProductDiscountType {
     var localizedPriceString: String { underlyingSK2Discount.displayPrice }
 }
 
+#if swift(<5.7)
+// `SK2ProductDiscount` isn't `Sendable` until iOS 16.0 / Swift 5.7
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+extension SK2StoreProductDiscount: @unchecked Sendable {}
+#endif
+
+// MARK: - Private
+
 private extension StoreProductDiscount.PaymentMode {
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)

--- a/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -99,7 +99,7 @@ public typealias SK2Product = StoreKit.Product
 }
 
 /// Type that provides access to all of `StoreKit`'s product type's properties.
-internal protocol StoreProductType {
+internal protocol StoreProductType: Sendable {
 
     /// The category of this product, whether a subscription or a one-time purchase.
 

--- a/Sources/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -98,6 +98,10 @@ public final class StoreProductDiscount: NSObject, StoreProductDiscountType {
 
 }
 
+extension StoreProductDiscount: Sendable {}
+extension StoreProductDiscount.PaymentMode: Sendable {}
+extension StoreProductDiscount.DiscountType: Sendable {}
+
 public extension StoreProductDiscount {
 
     /// The discount price of the product in the local currency.
@@ -136,7 +140,7 @@ extension StoreProductDiscount {
 }
 
 /// The details of an introductory offer or a promotional offer for an auto-renewable subscription.
-internal protocol StoreProductDiscountType {
+internal protocol StoreProductDiscountType: Sendable {
 
     // Note: this is only `nil` for SK1 products before iOS 12.2.
     // It can become `String` once it's not longer supported.

--- a/Sources/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SubscriptionPeriod.swift
@@ -18,7 +18,7 @@ import StoreKit
 /// Use the value and the unit together to determine the subscription period.
 /// For example, if the unit is  `.month`, and the value is `3`, the subscription period is three months.
 @objc(RCSubscriptionPeriod)
-public class SubscriptionPeriod: NSObject {
+public final class SubscriptionPeriod: NSObject {
 
     /// The number of period units.
     @objc public let value: Int
@@ -97,6 +97,9 @@ public extension SubscriptionPeriod {
     @objc var numberOfUnits: Int { fatalError() }
 
 }
+
+extension SubscriptionPeriod.Unit: Sendable {}
+extension SubscriptionPeriod: Sendable {}
 
 extension SubscriptionPeriod {
     func pricePerMonth(withTotalPrice price: Decimal) -> Decimal {


### PR DESCRIPTION
The type is now immutable, so the compiler ensures it's thread-safe.

For [CSDK-379].
Extracted from #1795 to make it easier to review this in isolation.

[CSDK-379]: https://revenuecats.atlassian.net/browse/CSDK-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ