### PR TITLE
`Backend`: fixed potential race conditions introduced by `OperationDispatcher.dispatchOnWorkerThread(withRandomDelay:)`

### DIFF
--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -35,26 +35,26 @@ class CustomerInfoManager {
     func fetchAndCacheCustomerInfo(appUserID: String,
                                    isAppBackgrounded: Bool,
                                    completion: ((Result<CustomerInfo, BackendError>) -> Void)?) {
-        deviceCache.setCacheTimestampToNowToPreventConcurrentCustomerInfoUpdates(appUserID: appUserID)
-        operationDispatcher.dispatchOnWorkerThread(withRandomDelay: isAppBackgrounded) {
-            self.backend.getCustomerInfo(appUserID: appUserID) { result in
-                switch result {
-                case let .failure(error):
-                    self.deviceCache.clearCustomerInfoCacheTimestamp(appUserID: appUserID)
-                    Logger.warn(Strings.customerInfo.customerinfo_updated_from_network_error(error: error))
+        self.deviceCache.setCacheTimestampToNowToPreventConcurrentCustomerInfoUpdates(appUserID: appUserID)
 
-                case let .success(info):
-                    self.cache(customerInfo: info, appUserID: appUserID)
-                    Logger.rcSuccess(Strings.customerInfo.customerinfo_updated_from_network)
-                }
+        self.backend.getCustomerInfo(appUserID: appUserID,
+                                     withRandomDelay: isAppBackgrounded) { result in
+            switch result {
+            case let .failure(error):
+                self.deviceCache.clearCustomerInfoCacheTimestamp(appUserID: appUserID)
+                Logger.warn(Strings.customerInfo.customerinfo_updated_from_network_error(error: error))
 
-                if let completion = completion {
-                    self.operationDispatcher.dispatchOnMainThread {
-                        completion(result)
-                    }
-                }
-
+            case let .success(info):
+                self.cache(customerInfo: info, appUserID: appUserID)
+                Logger.rcSuccess(Strings.customerInfo.customerinfo_updated_from_network)
             }
+
+            if let completion = completion {
+                self.operationDispatcher.dispatchOnMainThread {
+                    completion(result)
+                }
+            }
+
         }
     }
 

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -25,6 +25,7 @@ class Backend {
                      systemInfo: SystemInfo,
                      httpClientTimeout: TimeInterval = Configuration.networkTimeoutDefault,
                      eTagManager: ETagManager,
+                     operationDispatcher: OperationDispatcher,
                      attributionFetcher: AttributionFetcher,
                      dateProvider: DateProvider = DateProvider()) {
         let httpClient = HTTPClient(apiKey: apiKey,
@@ -32,6 +33,7 @@ class Backend {
                                     eTagManager: eTagManager,
                                     requestTimeout: httpClientTimeout)
         let config = BackendConfiguration(httpClient: httpClient,
+                                          operationDispatcher: operationDispatcher,
                                           operationQueue: QueueProvider.createBackendQueue(),
                                           dateProvider: dateProvider)
         self.init(backendConfig: config, attributionFetcher: attributionFetcher)
@@ -76,8 +78,12 @@ class Backend {
                            completion: completion)
     }
 
-    func getCustomerInfo(appUserID: String, completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
-        self.customer.getCustomerInfo(appUserID: appUserID, completion: completion)
+    func getCustomerInfo(appUserID: String,
+                         withRandomDelay randomDelay: Bool,
+                         completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
+        self.customer.getCustomerInfo(appUserID: appUserID,
+                                      withRandomDelay: randomDelay,
+                                      completion: completion)
     }
 
     // swiftlint:disable:next function_parameter_count

--- a/Sources/Networking/BackendConfiguration.swift
+++ b/Sources/Networking/BackendConfiguration.swift
@@ -17,19 +17,37 @@ final class BackendConfiguration {
 
     let httpClient: HTTPClient
 
+    let operationDispatcher: OperationDispatcher
     let operationQueue: OperationQueue
     let dateProvider: DateProvider
 
     init(httpClient: HTTPClient,
+         operationDispatcher: OperationDispatcher,
          operationQueue: OperationQueue,
          dateProvider: DateProvider = DateProvider()) {
         self.httpClient = httpClient
+        self.operationDispatcher = operationDispatcher
         self.operationQueue = operationQueue
         self.dateProvider = dateProvider
     }
 
     func clearCache() {
         self.httpClient.clearCaches()
+    }
+
+}
+
+extension BackendConfiguration {
+
+    /// Adds the `operation` to the `OperationQueue` (based on `CallbackCacheStatus`) potentially adding a random delay.
+    func addCacheableOperation(
+        _ operation: CacheableNetworkOperation,
+        withRandomDelay randomDelay: Bool,
+        cacheStatus: CallbackCacheStatus
+    ) {
+        self.operationDispatcher.dispatchOnWorkerThread(withRandomDelay: randomDelay) {
+            self.operationQueue.addCacheableOperation(operation, cacheStatus: cacheStatus)
+        }
     }
 
 }

--- a/Sources/Networking/CustomerAPI.swift
+++ b/Sources/Networking/CustomerAPI.swift
@@ -28,7 +28,9 @@ class CustomerAPI {
         self.customerInfoCallbackCache = CallbackCache<CustomerInfoCallback>()
     }
 
-    func getCustomerInfo(appUserID: String, completion: @escaping CustomerInfoResponseHandler) {
+    func getCustomerInfo(appUserID: String,
+                         withRandomDelay randomDelay: Bool,
+                         completion: @escaping CustomerInfoResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
                                                                 appUserID: appUserID)
 
@@ -37,7 +39,9 @@ class CustomerAPI {
 
         let callback = CustomerInfoCallback(operation: operation, completion: completion)
         let cacheStatus = self.customerInfoCallbackCache.add(callback: callback)
-        self.backendConfig.operationQueue.addCacheableOperation(operation, cacheStatus: cacheStatus)
+        self.backendConfig.addCacheableOperation(operation,
+                                                 withRandomDelay: randomDelay,
+                                                 cacheStatus: cacheStatus)
     }
 
     func post(subscriberAttributes: SubscriberAttribute.Dictionary,

--- a/Sources/Networking/OfferingsAPI.swift
+++ b/Sources/Networking/OfferingsAPI.swift
@@ -27,7 +27,9 @@ class OfferingsAPI {
         self.offeringsCallbacksCache = CallbackCache<OfferingsCallback>()
     }
 
-    func getOfferings(appUserID: String, completion: @escaping OfferingsResponseHandler) {
+    func getOfferings(appUserID: String,
+                      withRandomDelay randomDelay: Bool,
+                      completion: @escaping OfferingsResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
                                                                 appUserID: appUserID)
         let getOfferingsOperation = GetOfferingsOperation(configuration: config,
@@ -36,7 +38,9 @@ class OfferingsAPI {
         let offeringsCallback = OfferingsCallback(cacheKey: getOfferingsOperation.cacheKey, completion: completion)
         let cacheStatus = self.offeringsCallbacksCache.add(callback: offeringsCallback)
 
-        self.backendConfig.operationQueue.addCacheableOperation(getOfferingsOperation, cacheStatus: cacheStatus)
+        self.backendConfig.addCacheableOperation(getOfferingsOperation,
+                                                 withRandomDelay: randomDelay,
+                                                 cacheStatus: cacheStatus)
     }
 
     func getIntroEligibility(appUserID: String,

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -38,7 +38,7 @@ class OfferingsManager {
     }
 
     func offerings(appUserID: String, completion: ((Result<Offerings, Error>) -> Void)?) {
-        guard let cachedOfferings = deviceCache.cachedOfferings else {
+        guard let cachedOfferings = self.deviceCache.cachedOfferings else {
             Logger.debug(Strings.offering.no_cached_offerings_fetching_from_network)
             systemInfo.isApplicationBackgrounded { isAppBackgrounded in
                 self.updateOfferingsCache(appUserID: appUserID,
@@ -71,16 +71,15 @@ class OfferingsManager {
         isAppBackgrounded: Bool,
         completion: ((Result<Offerings, Error>) -> Void)?
     ) {
-        deviceCache.setOfferingsCacheTimestampToNow()
-        operationDispatcher.dispatchOnWorkerThread(withRandomDelay: isAppBackgrounded) {
-            self.backend.offerings.getOfferings(appUserID: appUserID) { result in
-                switch result {
-                case let .success(response):
-                    self.handleOfferingsBackendResult(with: response, completion: completion)
+        self.deviceCache.setOfferingsCacheTimestampToNow()
 
-                case let .failure(error):
-                    self.handleOfferingsUpdateError(.backendError(error), completion: completion)
-                }
+        self.backend.offerings.getOfferings(appUserID: appUserID, withRandomDelay: isAppBackgrounded) { result in
+            switch result {
+            case let .success(response):
+                self.handleOfferingsBackendResult(with: response, completion: completion)
+
+            case let .failure(error):
+                self.handleOfferingsUpdateError(.backendError(error), completion: completion)
             }
         }
     }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -281,6 +281,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                               systemInfo: systemInfo,
                               httpClientTimeout: networkTimeout,
                               eTagManager: eTagManager,
+                              operationDispatcher: operationDispatcher,
                               attributionFetcher: attributionFetcher)
         let storeKitWrapper = StoreKitWrapper()
         let offeringsFactory = OfferingsFactory()

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -62,31 +62,24 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
     }
 
     func testFetchAndCacheCustomerInfoCallsBackendWithRandomDelayIfAppBackgrounded() {
-        mockOperationDispatcher.shouldInvokeDispatchOnWorkerThreadBlock = true
+        self.customerInfoManager.fetchAndCacheCustomerInfo(appUserID: Self.appUserID,
+                                                           isAppBackgrounded: true,
+                                                           completion: nil)
 
-        customerInfoManager.fetchAndCacheCustomerInfo(appUserID: Self.appUserID,
-                                                      isAppBackgrounded: true,
-                                                      completion: nil)
-
-        expect(self.mockOperationDispatcher.invokedDispatchOnWorkerThread).toEventually(beTrue())
         expect(self.mockBackend.invokedGetSubscriberDataCount) == 1
-        expect(self.mockOperationDispatcher.invokedDispatchOnWorkerThreadRandomDelayParam) == true
+        expect(self.mockBackend.invokedGetSubscriberDataParameters?.randomDelay) == true
     }
 
     func testFetchAndCacheCustomerInfoCallsBackendWithoutRandomDelayIfAppForegrounded() {
-        mockOperationDispatcher.shouldInvokeDispatchOnWorkerThreadBlock = true
+        self.customerInfoManager.fetchAndCacheCustomerInfo(appUserID: Self.appUserID,
+                                                           isAppBackgrounded: false,
+                                                           completion: nil)
 
-        customerInfoManager.fetchAndCacheCustomerInfo(appUserID: Self.appUserID,
-                                                      isAppBackgrounded: false,
-                                                      completion: nil)
-
-        expect(self.mockOperationDispatcher.invokedDispatchOnWorkerThread).toEventually(beTrue())
         expect(self.mockBackend.invokedGetSubscriberDataCount) == 1
-        expect(self.mockOperationDispatcher.invokedDispatchOnWorkerThreadRandomDelayParam) == false
+        expect(self.mockBackend.invokedGetSubscriberDataParameters?.randomDelay) == false
     }
 
     func testFetchAndCacheCustomerInfoPassesBackendErrors() throws {
-        mockOperationDispatcher.shouldInvokeDispatchOnWorkerThreadBlock = true
         let mockError: BackendError = .missingAppUserID()
         mockBackend.stubbedGetCustomerInfoResult = .failure(mockError)
 
@@ -101,7 +94,6 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
     }
 
     func testFetchAndCacheCustomerInfoClearsCustomerInfoTimestampIfBackendError() {
-        mockOperationDispatcher.shouldInvokeDispatchOnWorkerThreadBlock = true
         mockBackend.stubbedGetCustomerInfoResult = .failure(.missingAppUserID())
 
         var completionCalled = false
@@ -114,8 +106,6 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
     }
 
     func testFetchAndCacheCustomerInfoCachesIfSuccessful() {
-        mockOperationDispatcher.shouldInvokeDispatchOnWorkerThreadBlock = true
-        mockOperationDispatcher.shouldInvokeDispatchOnMainThreadBlock = true
         mockBackend.stubbedGetCustomerInfoResult = .success(mockCustomerInfo)
 
         var receivedCustomerInfo: CustomerInfo?
@@ -133,8 +123,6 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
     }
 
     func testFetchAndCacheCustomerInfoCallsCompletionOnMainThread() {
-        mockOperationDispatcher.shouldInvokeDispatchOnWorkerThreadBlock = true
-        mockOperationDispatcher.shouldInvokeDispatchOnMainThreadBlock = true
         mockBackend.stubbedGetCustomerInfoResult = .success(mockCustomerInfo)
 
         var completionCalled = false

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -38,6 +38,7 @@ class MockBackend: Backend {
                                         eTagManager: MockETagManager(),
                                         requestTimeout: 7)
         let backendConfig = BackendConfiguration(httpClient: httpClient,
+                                                 operationDispatcher: MockOperationDispatcher(),
                                                  operationQueue: QueueProvider.createBackendQueue(),
                                                  dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
         let identity = MockIdentityAPI(backendConfig: backendConfig)
@@ -77,17 +78,22 @@ class MockBackend: Backend {
 
     var invokedGetSubscriberData = false
     var invokedGetSubscriberDataCount = 0
-    var invokedGetSubscriberDataParameters: (appUserID: String?, completion: CustomerAPI.CustomerInfoResponseHandler?)?
+    var invokedGetSubscriberDataParameters: (appUserID: String?,
+                                             randomDelay: Bool,
+                                             completion: CustomerAPI.CustomerInfoResponseHandler?)?
     var invokedGetSubscriberDataParametersList = [(appUserID: String?,
+                                                   randomDelay: Bool,
                                                    completion: CustomerAPI.CustomerInfoResponseHandler?)]()
 
     var stubbedGetCustomerInfoResult: Result<CustomerInfo, BackendError> = .failure(.missingAppUserID())
 
-    override func getCustomerInfo(appUserID: String, completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
+    override func getCustomerInfo(appUserID: String,
+                                  withRandomDelay randomDelay: Bool,
+                                  completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
         invokedGetSubscriberData = true
         invokedGetSubscriberDataCount += 1
-        invokedGetSubscriberDataParameters = (appUserID, completion)
-        invokedGetSubscriberDataParametersList.append((appUserID, completion))
+        invokedGetSubscriberDataParameters = (appUserID, randomDelay, completion)
+        invokedGetSubscriberDataParametersList.append((appUserID, randomDelay, completion))
 
         completion(self.stubbedGetCustomerInfoResult)
     }

--- a/Tests/UnitTests/Mocks/MockIdentityAPI.swift
+++ b/Tests/UnitTests/Mocks/MockIdentityAPI.swift
@@ -25,6 +25,7 @@ class MockIdentityAPI: IdentityAPI {
                                         eTagManager: MockETagManager(),
                                         requestTimeout: 7)
         let backendConfig = BackendConfiguration(httpClient: httpClient,
+                                                 operationDispatcher: MockOperationDispatcher(),
                                                  operationQueue: Backend.QueueProvider.createBackendQueue(),
                                                  dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
         self.init(backendConfig: backendConfig)

--- a/Tests/UnitTests/Mocks/MockOfferingsAPI.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsAPI.swift
@@ -39,16 +39,17 @@ class MockOfferingsAPI: OfferingsAPI {
 
     var invokedGetOfferingsForAppUserID = false
     var invokedGetOfferingsForAppUserIDCount = 0
-    var invokedGetOfferingsForAppUserIDParameters: (appUserID: String?, completion: OfferingsAPI.OfferingsResponseHandler?)?
-    var invokedGetOfferingsForAppUserIDParametersList = [(appUserID: String?, completion: OfferingsAPI.OfferingsResponseHandler?)]()
+    var invokedGetOfferingsForAppUserIDParameters: (appUserID: String?, randomDelay: Bool, completion: OfferingsAPI.OfferingsResponseHandler?)?
+    var invokedGetOfferingsForAppUserIDParametersList = [(appUserID: String?, randomDelay: Bool, completion: OfferingsAPI.OfferingsResponseHandler?)]()
     var stubbedGetOfferingsCompletionResult: Result<OfferingsResponse, BackendError>?
 
     override func getOfferings(appUserID: String,
+                               withRandomDelay randomDelay: Bool,
                                completion: @escaping OfferingsResponseHandler) {
         self.invokedGetOfferingsForAppUserID = true
         self.invokedGetOfferingsForAppUserIDCount += 1
-        self.invokedGetOfferingsForAppUserIDParameters = (appUserID, completion)
-        self.invokedGetOfferingsForAppUserIDParametersList.append((appUserID, completion))
+        self.invokedGetOfferingsForAppUserIDParameters = (appUserID, randomDelay, completion)
+        self.invokedGetOfferingsForAppUserIDParametersList.append((appUserID, randomDelay, completion))
 
         completion(self.stubbedGetOfferingsCompletionResult!)
     }

--- a/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
@@ -29,8 +29,8 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
             response: .init(statusCode: .success, response: Self.validCustomerResponse)
         )
 
-        backend.getCustomerInfo(appUserID: Self.userID) { _ in }
-        backend.getCustomerInfo(appUserID: Self.userID) { _ in }
+        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) { _ in }
+        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) { _ in }
 
         expect(self.httpClient.calls).toEventually(haveCount(1))
     }
@@ -41,8 +41,8 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         httpClient.mock(requestPath: .getCustomerInfo(appUserID: Self.userID), response: response)
         httpClient.mock(requestPath: .getCustomerInfo(appUserID: userID2), response: response)
 
-        backend.getCustomerInfo(appUserID: Self.userID) { _ in }
-        backend.getCustomerInfo(appUserID: userID2) { _ in }
+        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) { _ in }
+        backend.getCustomerInfo(appUserID: userID2, withRandomDelay: false) { _ in }
 
         expect(self.httpClient.calls).toEventually(haveCount(2))
     }
@@ -53,7 +53,7 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
 
         self.httpClient.mock(requestPath: path, response: response)
 
-        backend.getCustomerInfo(appUserID: Self.userID) { _ in }
+        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) { _ in }
         expect(self.httpClient.calls).toEventually(haveCount(1))
     }
 
@@ -65,7 +65,7 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
 
         var customerInfo: Result<CustomerInfo, BackendError>?
 
-        backend.getCustomerInfo(appUserID: Self.userID) { result in
+        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) { result in
             customerInfo = result
         }
 
@@ -84,7 +84,7 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
 
         var customerInfo: Result<CustomerInfo, BackendError>?
 
-        backend.getCustomerInfo(appUserID: encodeableUserID) { result in
+        backend.getCustomerInfo(appUserID: encodeableUserID, withRandomDelay: false) { result in
             customerInfo = result
         }
 
@@ -102,7 +102,7 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
 
         var result: Result<CustomerInfo, BackendError>?
 
-        backend.getCustomerInfo(appUserID: Self.userID) {
+        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) {
             result = $0
         }
 
@@ -119,7 +119,7 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
 
         var result: Result<CustomerInfo, BackendError>?
 
-        backend.getCustomerInfo(appUserID: Self.userID) {
+        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) {
             result = $0
         }
 
@@ -147,11 +147,11 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         var firstResult: Result<CustomerInfo, BackendError>?
         var secondResult: Result<CustomerInfo, BackendError>?
 
-        backend.getCustomerInfo(appUserID: Self.userID) {
+        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) {
             firstResult = $0
         }
 
-        backend.getCustomerInfo(appUserID: Self.userID) {
+        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) {
             secondResult = $0
         }
 

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -399,7 +399,7 @@ class BackendPostReceiptDataTests: BaseBackendTests {
         var callOrder: (initialGet: Bool,
                         postResponse: Bool,
                         updatedGet: Bool) = (false, false, false)
-        backend.getCustomerInfo(appUserID: Self.userID) { result in
+        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) { result in
             originalSubscriberInfo = result.value
             callOrder.initialGet = true
 
@@ -418,7 +418,7 @@ class BackendPostReceiptDataTests: BaseBackendTests {
             postSubscriberInfo = result.value
         }
 
-        backend.getCustomerInfo(appUserID: Self.userID) { result in
+        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) { result in
             expect(callOrder) == (true, true, false)
             updatedSubscriberInfo = result.value
             callOrder.updatedGet = true

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -22,6 +22,7 @@ class BaseBackendTests: TestCase {
 
     private(set) var systemInfo: SystemInfo!
     private(set) var httpClient: MockHTTPClient!
+    private(set) var operationDispatcher: MockOperationDispatcher!
     private(set) var backend: Backend!
     private(set) var offerings: OfferingsAPI!
     private(set) var identity: IdentityAPI!
@@ -34,9 +35,12 @@ class BaseBackendTests: TestCase {
 
         self.systemInfo = try SystemInfo(platformInfo: nil, finishTransactions: true)
         self.httpClient = self.createClient()
+        self.operationDispatcher = MockOperationDispatcher()
+
         let attributionFetcher = AttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
                                                     systemInfo: self.systemInfo)
         let backendConfig = BackendConfiguration(httpClient: self.httpClient,
+                                                 operationDispatcher: operationDispatcher,
                                                  operationQueue: MockBackend.QueueProvider.createBackendQueue(),
                                                  dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
 

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/offerings"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testGetOfferingsCallsHTTPMethodWithRandomDelay.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
+  }
+}

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -216,6 +216,8 @@ extension OfferingsManagerTests {
         // given
         mockOfferings.stubbedGetOfferingsCompletionResult = .failure(MockData.unexpectedBackendResponseError)
         mockOfferingsFactory.emptyOfferings = true
+        mockSystemInfo.stubbedIsApplicationBackgrounded = false
+
         let expectedCallCount = 1
 
         // when
@@ -225,11 +227,14 @@ extension OfferingsManagerTests {
         expect(self.mockDeviceCache.setOfferingsCacheTimestampToNowCount).toEventually(equal(expectedCallCount))
         expect(self.mockOfferings.invokedGetOfferingsForAppUserIDCount).toEventually(equal(expectedCallCount))
         expect(self.mockDeviceCache.clearOfferingsCacheTimestampCount).toEventually(equal(expectedCallCount))
+        expect(self.mockOfferings.invokedGetOfferingsForAppUserIDParameters?.randomDelay) == false
     }
 
     func testUpdateOfferingsCacheOK() {
         // given
         mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsResponse)
+        mockSystemInfo.stubbedIsApplicationBackgrounded = true
+
         let expectedCallCount = 1
 
         // when
@@ -239,6 +244,7 @@ extension OfferingsManagerTests {
         expect(self.mockDeviceCache.setOfferingsCacheTimestampToNowCount).toEventually(equal(expectedCallCount))
         expect(self.mockOfferings.invokedGetOfferingsForAppUserIDCount).toEventually(equal(expectedCallCount))
         expect(self.mockDeviceCache.cacheOfferingsCount).toEventually(equal(expectedCallCount))
+        expect(self.mockOfferings.invokedGetOfferingsForAppUserIDParameters?.randomDelay) == true
     }
 
     func testGetMissingProductIDs() {

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -46,6 +46,7 @@ class BasePurchasesTests: TestCase {
         let apiKey = "mockAPIKey"
         let httpClient = MockHTTPClient(apiKey: apiKey, systemInfo: self.systemInfo, eTagManager: MockETagManager())
         let config = BackendConfiguration(httpClient: httpClient,
+                                          operationDispatcher: self.mockOperationDispatcher,
                                           operationQueue: MockBackend.QueueProvider.createBackendQueue(),
                                           dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
         self.backend = MockBackend(backendConfig: config, attributionFetcher: self.attributionFetcher)
@@ -258,7 +259,9 @@ extension BasePurchasesTests {
         var badOfferingsResponse = false
         var gotOfferings = 0
 
-        override func getOfferings(appUserID: String, completion: @escaping OfferingsAPI.OfferingsResponseHandler) {
+        override func getOfferings(appUserID: String,
+                                   withRandomDelay randomDelay: Bool,
+                                   completion: @escaping OfferingsAPI.OfferingsResponseHandler) {
             self.gotOfferings += 1
             if self.failOfferings {
                 completion(.failure(.unexpectedBackendResponse(.getOfferUnexpectedResponse)))
@@ -309,6 +312,7 @@ extension BasePurchasesTests {
         )
 
         override func getCustomerInfo(appUserID: String,
+                                      withRandomDelay randomDelay: Bool,
                                       completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
             self.getSubscriberCallCount += 1
             self.userID = appUserID

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -56,6 +56,7 @@ class BackendSubscriberAttributesTests: TestCase {
                                                     systemInfo: self.systemInfo)
 
         let config = BackendConfiguration(httpClient: mockHTTPClient,
+                                          operationDispatcher: MockOperationDispatcher(),
                                           operationQueue: MockBackend.QueueProvider.createBackendQueue(),
                                           dateProvider: dateProvider)
 


### PR DESCRIPTION
Fixes [CSDK-391]. As described in that ticket, calling a method that introduces a random delay before performing an API request could lead to a race condition. Example:

> Request 1: delay 0 seconds. Start now.
> Request 2: delay 2 seconds. Waiting…
> Request 1 finishes.
> Request 2: 2 seconds past. There is no in progress request, so we start it again

This also solves [CSDK-394]. If any part of our code (or users) call a method that would enqueue a request multiple times, we need to insert it into the callback queue right away.
That's what this does: it moves the random delay to *after* the callback has been added to the `CallbackCache`.

[CSDK-391]: https://revenuecats.atlassian.net/browse/CSDK-391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CSDK-394]: https://revenuecats.atlassian.net/browse/CSDK-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ