### PR TITLE
Directly send delegate customer info when delegate is set (always sends cached CustomerInfo value)

### DIFF
--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -220,6 +220,8 @@ class CustomerInfoManager {
             .map { $0 + 1 } // Next index
             ?? 0 // Or default to 0
 
+        print("nextIdentifier: \(nextIdentifier)")
+
         self.customerInfoObserversByIdentifier[nextIdentifier] = changes
 
         return { [weak self] in

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -220,8 +220,6 @@ class CustomerInfoManager {
             .map { $0 + 1 } // Next index
             ?? 0 // Or default to 0
 
-        print("nextIdentifier: \(nextIdentifier)")
-
         self.customerInfoObserversByIdentifier[nextIdentifier] = changes
 
         return { [weak self] in

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -85,12 +85,9 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             privateDelegate = newValue
             Logger.debug(Strings.configure.delegate_set)
 
-            if let info = customerInfoManager.cachedCustomerInfo(appUserID: appUserID) {
-                operationDispatcher.dispatchOnMainThread { [weak self] in
-                    guard let self = self else { return }
-                    self.privateDelegate?.purchases?(self, receivedUpdated: info)
-                }
-            }
+            // Sends cached customer info (if exists) to delegate as latest
+            // customer info may have already been observed and sent by the monitor
+            sendCachedCustomerInfoToDelegateIfExists()
         }
     }
 
@@ -1727,6 +1724,18 @@ private extension Purchases {
             self.offeringsManager.updateOfferingsCache(appUserID: self.appUserID,
                                                        isAppBackgrounded: isAppBackgrounded,
                                                        completion: nil)
+        }
+    }
+
+    // Used when delegate is being set
+    func sendCachedCustomerInfoToDelegateIfExists() {
+        guard let info = customerInfoManager.cachedCustomerInfo(appUserID: appUserID) else {
+            return
+        }
+
+        operationDispatcher.dispatchOnMainThread { [weak self] in
+            guard let self = self else { return }
+            self.delegate?.purchases?(self, receivedUpdated: info)
         }
     }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -83,8 +83,9 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             }
 
             privateDelegate = newValue
-            customerInfoManager.sendCachedCustomerInfoIfAvailable(appUserID: appUserID)
+
             Logger.debug(Strings.configure.delegate_set)
+            customerInfoManager.sendCachedCustomerInfoIfAvailable(appUserID: appUserID)
         }
     }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -83,9 +83,14 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             }
 
             privateDelegate = newValue
-
             Logger.debug(Strings.configure.delegate_set)
-            customerInfoManager.sendCachedCustomerInfoIfAvailable(appUserID: appUserID)
+
+            if let info = customerInfoManager.cachedCustomerInfo(appUserID: appUserID) {
+                operationDispatcher.dispatchOnMainThread { [weak self] in
+                    guard let self = self else { return }
+                    self.privateDelegate?.purchases?(self, receivedUpdated: info)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation

Fixes [TRIAGE-55](https://revenuecats.atlassian.net/browse/TRIAGE-55)

#### Issue

Delegate would not always/reliably call `didReceiveUpdatedCustomerInfo`. 

`customerInfoManager.sendCachedCustomerInfoIfAvailable` would only call the delegate when the latest customer info object was already sent.

☝️ This, according to a customer bug report, appears to be a breaking change between v3 and v4. It also appears to be a difference in behavior with `Purchases.shared.customerInfoStream` as this gets the initial customer value. 

##### Example

```swift
@main
struct PurchaseTesterApp: App {
    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
    @State private var revenueCatCustomerData = RevenueCatCustomerData()
    
    var body: some Scene {
        WindowGroup {
            ContentView()
                .environmentObject(revenueCatCustomerData)
                .task {
                    for await customerInfo in Purchases.shared.customerInfoStream {
                        // ✅ This worked fine before and after change
                        // This will get the initial customerInfo as soon as its set
                        self.revenueCatCustomerData.customerInfo = customerInfo
                        self.revenueCatCustomerData.appUserID = Purchases.shared.appUserID
                    }
                }
        }
    }
}

class AppDelegate: NSObject, UIApplicationDelegate {
    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {

        Purchases.logLevel = .debug
        Purchases.configure(with: Configuration
            .builder(withAPIKey: Constants.apiKey)
            .with(usesStoreKit2IfAvailable: true)
            .build())

        // ❌ This is one way that delegate would not be called right away with customer info
        // There might be other cases too
        // The customerInfo would already have been sent to an async stream and not be forced sent
        // to the new delegate
        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
            Purchases.shared.delegate = self
        }

        return true
    }
}

extension AppDelegate: PurchasesDelegate {
    func purchases(_ purchases: Purchases, receivedUpdated customerInfo: CustomerInfo) {
        print("New customer info: \(customerInfo)")
    }
}
```

#### Bonus Fix

The logs would show CusomterInfo was set to delegate before delegate was set.

```
2022-08-15 05:19:28.062200-0500 PurchaseTester[10812:71706] [Purchases] - DEBUG: ℹ️ SDK Version - 4.11.0-SNAPSHOT
2022-08-15 05:19:28.062249-0500 PurchaseTester[10812:71706] [Purchases] - DEBUG: 👤 No initial App User ID
2022-08-15 05:19:28.067297-0500 PurchaseTester[10812:71706] [Purchases] - DEBUG: ℹ️ Sending latest CustomerInfo to delegate.
2022-08-15 05:19:30.484881-0500 PurchaseTester[10812:71706] [Purchases] - DEBUG: ℹ️ Delegate set
```

### Description

- No longer relying on `customerInfoManager.sendCachedCustomerInfoIfAvailable` to call send a value to the delegate when delegate is being sent
  - Instead, sending initial cached customer info directly to the delegate
- Moved log of delegate set before potentially sending CustomerInfo (which will also log)
