### PR TITLE
`PurchasesDelegate`: added test for latest cached customer info always being sent

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -87,7 +87,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
             // Sends cached customer info (if exists) to delegate as latest
             // customer info may have already been observed and sent by the monitor
-            sendCachedCustomerInfoToDelegateIfExists()
+            self.sendCachedCustomerInfoToDelegateIfExists()
         }
     }
 
@@ -1729,14 +1729,11 @@ private extension Purchases {
 
     // Used when delegate is being set
     func sendCachedCustomerInfoToDelegateIfExists() {
-        guard let info = customerInfoManager.cachedCustomerInfo(appUserID: appUserID) else {
+        guard let info = self.customerInfoManager.cachedCustomerInfo(appUserID: self.appUserID) else {
             return
         }
 
-        operationDispatcher.dispatchOnMainThread { [weak self] in
-            guard let self = self else { return }
-            self.delegate?.purchases?(self, receivedUpdated: info)
-        }
+        self.delegate?.purchases?(self, receivedUpdated: info)
     }
 
 }

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -126,11 +126,14 @@ class BasePurchasesTests: TestCase {
 
     var purchases: Purchases!
 
-    func setupPurchases(automaticCollection: Bool = false) {
+    func setupPurchases(automaticCollection: Bool = false, withDelegate: Bool = true) {
         Purchases.deprecated.automaticAppleSearchAdsAttributionCollection = automaticCollection
         self.identityManager.mockIsAnonymous = false
 
-        self.initializePurchasesInstance(appUserId: self.identityManager.currentAppUserID)
+        self.initializePurchasesInstance(
+            appUserId: self.identityManager.currentAppUserID,
+            withDelegate: withDelegate
+        )
     }
 
     func setupAnonPurchases() {
@@ -144,7 +147,7 @@ class BasePurchasesTests: TestCase {
         self.initializePurchasesInstance(appUserId: nil)
     }
 
-    func initializePurchasesInstance(appUserId: String?) {
+    func initializePurchasesInstance(appUserId: String?, withDelegate: Bool = true) {
         self.purchasesOrchestrator = PurchasesOrchestrator(
             productsManager: self.mockProductsManager,
             storeKitWrapper: self.storeKitWrapper,
@@ -191,7 +194,10 @@ class BasePurchasesTests: TestCase {
                                    trialOrIntroPriceEligibilityChecker: self.trialOrIntroPriceEligibilityChecker)
 
         self.purchasesOrchestrator.delegate = self.purchases
-        self.purchases.delegate = self.purchasesDelegate
+
+        if withDelegate {
+            self.purchases.delegate = self.purchasesDelegate
+        }
 
         Purchases.setDefaultInstance(self.purchases)
     }


### PR DESCRIPTION
Fixes [CSDK-399]. Follow up to #1828.

Also changed the implementation to remove the `DispatchQueue.async` which wasn't necessary. I think it's reasonable to send the call on the same thread that the `delegate` was set.

[CSDK-399]: https://revenuecats.atlassian.net/browse/CSDK-399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ