### PR TITLE
`CallbackCache`: simplified implementation using `Atomic`

### DIFF
--- a/Sources/Networking/BackendConfiguration.swift
+++ b/Sources/Networking/BackendConfiguration.swift
@@ -13,21 +13,18 @@
 
 import Foundation
 
-class BackendConfiguration {
+final class BackendConfiguration {
 
     let httpClient: HTTPClient
 
-    let callbackQueue: DispatchQueue
     let operationQueue: OperationQueue
     let dateProvider: DateProvider
 
     init(httpClient: HTTPClient,
          operationQueue: OperationQueue,
-         callbackQueue: DispatchQueue = DispatchQueue(label: "Backend callbackQueue"),
          dateProvider: DateProvider = DateProvider()) {
         self.httpClient = httpClient
         self.operationQueue = operationQueue
-        self.callbackQueue = callbackQueue
         self.dateProvider = dateProvider
     }
 

--- a/Sources/Networking/CustomerAPI.swift
+++ b/Sources/Networking/CustomerAPI.swift
@@ -25,7 +25,7 @@ class CustomerAPI {
     init(backendConfig: BackendConfiguration, attributionFetcher: AttributionFetcher) {
         self.backendConfig = backendConfig
         self.attributionFetcher = attributionFetcher
-        self.customerInfoCallbackCache = CallbackCache<CustomerInfoCallback>(callbackQueue: backendConfig.callbackQueue)
+        self.customerInfoCallbackCache = CallbackCache<CustomerInfoCallback>()
     }
 
     func getCustomerInfo(appUserID: String, completion: @escaping CustomerInfoResponseHandler) {

--- a/Sources/Networking/IdentityAPI.swift
+++ b/Sources/Networking/IdentityAPI.swift
@@ -22,7 +22,7 @@ class IdentityAPI {
 
     init(backendConfig: BackendConfiguration) {
         self.backendConfig = backendConfig
-        self.logInCallbacksCache = CallbackCache<LogInCallback>(callbackQueue: backendConfig.callbackQueue)
+        self.logInCallbacksCache = CallbackCache<LogInCallback>()
     }
 
     func logIn(currentAppUserID: String,

--- a/Sources/Networking/OfferingsAPI.swift
+++ b/Sources/Networking/OfferingsAPI.swift
@@ -24,7 +24,7 @@ class OfferingsAPI {
 
     init(backendConfig: BackendConfiguration) {
         self.backendConfig = backendConfig
-        self.offeringsCallbacksCache = CallbackCache<OfferingsCallback>(callbackQueue: self.backendConfig.callbackQueue)
+        self.offeringsCallbacksCache = CallbackCache<OfferingsCallback>()
     }
 
     func getOfferings(appUserID: String, completion: @escaping OfferingsResponseHandler) {

--- a/Sources/Networking/Operations/GetCustomerInfoOperation.swift
+++ b/Sources/Networking/Operations/GetCustomerInfoOperation.swift
@@ -84,14 +84,13 @@ private extension CallbackCache where T == CustomerInfoCallback {
     }
 
     private func callbacks(ofType type: NetworkOperation.Type) -> Int {
-        return self.callbackQueue.sync {
-            self
-                .cachedCallbacksByKey
-                .lazy
-                .flatMap(\.value)
-                .filter { $0.source == type }
-                .count
-        }
+        return self
+            .cachedCallbacksByKey
+            .value
+            .lazy
+            .flatMap(\.value)
+            .filter { $0.source == type }
+            .count
     }
 
 }


### PR DESCRIPTION
We don't actually need to share a single queue to synchronize all the callback caches.
This new implementation also avoids using the risky `DispatchQueue.sync`.

This also fixes potential issues because `cachedCallbacksByKey` was exposed, and it could have been read without synchronizing access with the queue. This is now impossible.