### PR TITLE
Update migration doc from didReceiveUpdatedCustomerInfo to receivedUpdatedCustomerInfo

### DIFF
--- a/Sources/DocCDocumentation/DocCDocumentation.docc/V4_API_Migration_guide.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/V4_API_Migration_guide.md
@@ -163,7 +163,7 @@ These types replace native StoreKit types in all public API methods that used th
 #### PurchasesDelegate
 | v3 | v4 |
 | ------------ | ------------------------------------- | 
-| purchases:didReceiveUpdatedPurchaserInfo: | purchases:didReceiveUpdatedCustomerInfo: |
+| purchases:didReceiveUpdatedPurchaserInfo: | purchases:receivedUpdatedCustomerInfo: |
 
 ### API changes
 

--- a/Sources/Logging/Strings/ConfigureStrings.swift
+++ b/Sources/Logging/Strings/ConfigureStrings.swift
@@ -76,7 +76,7 @@ extension ConfigureStrings: CustomStringConvertible {
             return "SDK Version - \(sdkVersion)"
         case .legacyAPIKey:
             return "Looks like you're using a legacy API key.\n" +
-            "This is still supported, but it's recomended to migrate to using platform-specific API key, " +
+            "This is still supported, but it's recommended to migrate to using platform-specific API key, " +
             "which should look like 'appl_1a2b3c4d5e6f7h'.\n" +
             "See https://rev.cat/auth for more details."
         case .invalidAPIKey:


### PR DESCRIPTION
### Motivation

Fixes [TRIAGE-55](https://revenuecats.atlassian.net/browse/TRIAGE-55)

### Description

Turns out the #1828 was not the solution for the delegate not being called. There was an issue in the migration docs with the wrong delegate name for Objective-C types.
