### PR TITLE
`DeviceCache`: no longer set cache timestamp before beginning request

### DIFF
--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -35,8 +35,6 @@ class CustomerInfoManager {
     func fetchAndCacheCustomerInfo(appUserID: String,
                                    isAppBackgrounded: Bool,
                                    completion: ((Result<CustomerInfo, BackendError>) -> Void)?) {
-        self.deviceCache.setCacheTimestampToNowToPreventConcurrentCustomerInfoUpdates(appUserID: appUserID)
-
         self.backend.getCustomerInfo(appUserID: appUserID,
                                      withRandomDelay: isAppBackgrounded) { result in
             switch result {

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -71,8 +71,6 @@ class OfferingsManager {
         isAppBackgrounded: Bool,
         completion: ((Result<Offerings, Error>) -> Void)?
     ) {
-        self.deviceCache.setOfferingsCacheTimestampToNow()
-
         self.backend.offerings.getOfferings(appUserID: appUserID, withRandomDelay: isAppBackgrounded) { result in
             switch result {
             case let .success(response):

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -224,7 +224,6 @@ extension OfferingsManagerTests {
         offeringsManager.offerings(appUserID: MockData.anyAppUserID, completion: nil)
 
         // then
-        expect(self.mockDeviceCache.setOfferingsCacheTimestampToNowCount).toEventually(equal(expectedCallCount))
         expect(self.mockOfferings.invokedGetOfferingsForAppUserIDCount).toEventually(equal(expectedCallCount))
         expect(self.mockDeviceCache.clearOfferingsCacheTimestampCount).toEventually(equal(expectedCallCount))
         expect(self.mockOfferings.invokedGetOfferingsForAppUserIDParameters?.randomDelay) == false
@@ -241,7 +240,6 @@ extension OfferingsManagerTests {
         offeringsManager.offerings(appUserID: MockData.anyAppUserID, completion: nil)
 
         // then
-        expect(self.mockDeviceCache.setOfferingsCacheTimestampToNowCount).toEventually(equal(expectedCallCount))
         expect(self.mockOfferings.invokedGetOfferingsForAppUserIDCount).toEventually(equal(expectedCallCount))
         expect(self.mockDeviceCache.cacheOfferingsCount).toEventually(equal(expectedCallCount))
         expect(self.mockOfferings.invokedGetOfferingsForAppUserIDParameters?.randomDelay) == true


### PR DESCRIPTION
Follow up to [CSDK-391]. As pointed out by @aboedo, we have now 2 caching mechanisms: `CallbackCache` and `DeviceCache` timestamps.
These 2 calls to set the timestamp (through `InMemoryCachedObject.updateCacheTimestamp(date:)` _before_ starting requests was there before `CallbackCache` was a thing.

However, with that solution, especially after the fix in #1827, the timestamp change is unnecessary. Its purpose was to make sure that a subsequent request didn't trigger an update if it was already in progress, but again, that's already handled by `CallbackCache` now.

The benefit of removing this is also that if a request fails, the timestamp cache wouldn't be an invalid `Date`, since nothing was actually fetched. In practice this isn't an issue because we clear the date on failure (See `OfferingsManager.handleOfferingsUpdateError` for example), but now we wouldn't need to rely on that.