### PR TITLE
Purchase cancellations: unify behavior between SK1 and SK2

### DIFF
--- a/Sources/Misc/Purchases+async.swift
+++ b/Sources/Misc/Purchases+async.swift
@@ -66,7 +66,7 @@ extension Purchases {
     func purchaseAsync(product: StoreProduct) async throws -> PurchaseResultData {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(product: product) { transaction, customerInfo, error, userCancelled in
-                continuation.resume(with: Result(customerInfo, error)
+                continuation.resume(with: Result(customerInfo, error?.ignoreIfPurchaseCancelled(userCancelled))
                                         .map { PurchaseResultData(transaction, $0, userCancelled) })
             }
         }
@@ -76,7 +76,7 @@ extension Purchases {
     func purchaseAsync(package: Package) async throws -> PurchaseResultData {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(package: package) { transaction, customerInfo, error, userCancelled in
-                continuation.resume(with: Result(customerInfo, error)
+                continuation.resume(with: Result(customerInfo, error?.ignoreIfPurchaseCancelled(userCancelled))
                                         .map { PurchaseResultData(transaction, $0, userCancelled) })
             }
         }
@@ -87,7 +87,7 @@ extension Purchases {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(product: product,
                      promotionalOffer: promotionalOffer) { transaction, customerInfo, error, userCancelled in
-                continuation.resume(with: Result(customerInfo, error)
+                continuation.resume(with: Result(customerInfo, error?.ignoreIfPurchaseCancelled(userCancelled))
                                         .map { PurchaseResultData(transaction, $0, userCancelled) })
             }
         }
@@ -98,7 +98,7 @@ extension Purchases {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(package: package,
                      promotionalOffer: promotionalOffer) { transaction, customerInfo, error, userCancelled in
-                continuation.resume(with: Result(customerInfo, error)
+                continuation.resume(with: Result(customerInfo, error?.ignoreIfPurchaseCancelled(userCancelled))
                                         .map { PurchaseResultData(transaction, $0, userCancelled) })
             }
         }
@@ -206,5 +206,13 @@ extension Purchases {
     }
 
 #endif
+
+}
+
+private extension Error {
+
+    func ignoreIfPurchaseCancelled(_ cancelled: Bool) -> Self? {
+        return cancelled ? nil : self
+    }
 
 }

--- a/Sources/Misc/Purchases+async.swift
+++ b/Sources/Misc/Purchases+async.swift
@@ -211,6 +211,8 @@ extension Purchases {
 
 private extension Error {
 
+    /// This allows `async` APIs to return `userCancelled` in ``PurchaseResultData`` instead of throwing errors.
+    /// - Returns: `nil` if `cancelled` is `true`
     func ignoreIfPurchaseCancelled(_ cancelled: Bool) -> Self? {
         return cancelled ? nil : self
     }

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -371,7 +371,11 @@ class PurchasesOrchestrator {
                 ))
 
                 DispatchQueue.main.async {
-                    completion(result.transaction, result.customerInfo, nil, result.userCancelled)
+                    completion(result.transaction,
+                               result.customerInfo,
+                               // Forward an error if purchase was cancelled to match SK1 behavior.
+                               result.userCancelled ? ErrorUtils.purchaseCancelledError() : nil,
+                               result.userCancelled)
                 }
             } catch let error {
                 Logger.rcPurchaseError(Strings.purchase.product_purchase_failed(


### PR DESCRIPTION
Fixes [CSDK-113] and https://github.com/RevenueCat/purchases-flutter/issues/403

### Changes:

- SK2 purchase now forwards an error (`ErrorCode.purchaseCancelledError`) if the purchase is cancelled. This matches the behavior in SK1.
- In order to retain the behavior on `async` APIs, this error is ignored if `userCancelled` is `true`, to ensure that `PurchaseResultData` is returned instead of an error being thrown.

Unfortunately, as explained in [CSDK-113], we can't test this because there's no way to fake cancellations (_FB10300403_).

[CSDK-113]: https://revenuecats.atlassian.net/browse/CSDK-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CSDK-113]: https://revenuecats.atlassian.net/browse/CSDK-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ