### PR TITLE
`MagicWeatherSwiftUI`: updated to use `async` APIs

### DIFF
--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/ViewModels/UserViewModel.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/ViewModels/UserViewModel.swift
@@ -34,18 +34,18 @@ class UserViewModel: ObservableObject {
      Read more about Identifying Users here: https://docs.revenuecat.com/docs/user-ids
      */
     #warning("Public-facing usernames aren't optimal for user ID's - you should use something non-guessable, like a non-public database ID. For more information, visit https://docs.revenuecat.com/docs/user-ids.")
-    func login(userId: String) {
-        Purchases.shared.logIn(userId) { _, _, _ in }
+    func login(userId: String) async {
+        _ = try? await Purchases.shared.logIn(userId)
     }
     
-    func logout() {
+    func logout() async {
         /**
          The current user ID is no longer valid for your instance of *Purchases* since the user is logging out, and is no longer authorized to access customerInfo for that user ID.
          
-         `reset` clears the cache and regenerates a new anonymous user ID.
+         `logOut` clears the cache and regenerates a new anonymous user ID.
          
-         - Note: Each time you call `reset`, a new installation will be logged in the RevenueCat dashboard as that metric tracks unique user ID's that are in-use. Since this method generates a new anonymous ID, it counts as a new user ID in-use.
+         - Note: Each time you call `logOut`, a new installation will be logged in the RevenueCat dashboard as that metric tracks unique user ID's that are in-use. Since this method generates a new anonymous ID, it counts as a new user ID in-use.
          */
-        Purchases.shared.logOut(completion: nil)
+        _ = try? await Purchases.shared.logOut()
     }
 }

--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/Views/UserView.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/Views/UserView.swift
@@ -42,7 +42,9 @@ struct UserView: View {
                 Spacer()
 
                 Button("Logout") {
-                    model.logout()
+                    Task {
+                        await model.logout()
+                    }
                 }
                 .foregroundColor(.red)
                 .font(.headline)
@@ -58,10 +60,10 @@ struct UserView: View {
                 TextField("Enter App User ID", text: $newUserId) { (isEditing) in
                     
                 } onCommit: {
-                    guard !newUserId.isEmpty else { return }
-                    
-                    model.login(userId: newUserId)
-                    newUserId = ""
+                    guard !self.newUserId.isEmpty else { return }
+
+                    _ = Task { await self.model.login(userId: newUserId) }
+                    self.newUserId = ""
                     
                 }.multilineTextAlignment(.center)
                 .padding(.top, 8.0)
@@ -71,7 +73,9 @@ struct UserView: View {
                        
             /// - You should always give users the option to restore purchases to connect their purchase to their current app user ID
             Button("Restore Purchases") {
-                Purchases.shared.restorePurchases(completion: nil)
+                Task {
+                    try? await Purchases.shared.restorePurchases()
+                }
             }
             .foregroundColor(.blue)
             .font(.headline)

--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/Views/WeatherView.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/Views/WeatherView.swift
@@ -13,6 +13,7 @@ import RevenueCat
  */
 
 struct WeatherView: View {
+
     @Binding var paywallPresented: Bool
     @ObservedObject var model = WeatherViewModel.shared
     @ObservedObject var userModel = UserViewModel.shared
@@ -40,12 +41,11 @@ struct WeatherView: View {
             /// - we'll change the environment in a future update, disable for now
             .allowsHitTesting(false)
 
-            
             Spacer()
             
             /// - The magic button that is disabled behind our paywall
             Button("✨ Change the Weather") {
-                performMagic()
+                self.performMagic()
             }
             .foregroundColor(.white)
             .font(.headline)
@@ -56,18 +56,15 @@ struct WeatherView: View {
 
     }
     
-    func performMagic() {
+    private func performMagic() {
         /*
          We should check if we can magically change the weather (subscription active) and if not, display the paywall.
          */
-        Purchases.shared.getCustomerInfo { (_, _) in
-            if userModel.subscriptionActive {
-                self.model.currentData = SampleWeatherData.generateSampleData(for: self.model.currentEnvironment)
-            } else {
-                self.paywallPresented.toggle()
-            }
+        if self.userModel.subscriptionActive {
+            self.model.currentData = SampleWeatherData.generateSampleData(for: self.model.currentEnvironment)
+        } else {
+            self.paywallPresented.toggle()
         }
     }
+
 }
-
-


### PR DESCRIPTION
I was testing some of these with a recent change, and I realized that it's probably best to have this example use the "modern" APIs anyway.
Not the best implementation, since we should move these methods to the view model, but this was the simplest way to do it for now without a huge refactor.

It's also not ideal that we were and are ignoring errors, but luckily the SDK logs them.