### PR TITLE
`release-train`: set `github_rate_limit` to deal with rate limiting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -539,7 +539,7 @@ jobs:
       - install-rubydocker-dependencies
       - run: 
           name: Create automatic PR
-          command: bundle exec fastlane automatic_bump
+          command: bundle exec fastlane automatic_bump github_rate_limit:10
 
 workflows:
   version: 2


### PR DESCRIPTION
This should fix https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/7845/workflows/c2cbb588-56b3-4357-a244-27735694a957/jobs/34700