### PR TITLE
README updates

### DIFF
--- a/Examples/MagicWeather/README.md
+++ b/Examples/MagicWeather/README.md
@@ -33,16 +33,18 @@ See minimum platform version requirements for RevenueCat's *Purchases* SDK [here
     - You must sign the [Paid Applications Agreement](https://docs.revenuecat.com/docs/getting-started#3-store-setup) and complete your [bank/tax information](https://docs.revenuecat.com/docs/getting-started#3-store-setup) to test In-App Purchases.
 - Be sure to set up a [Sandbox Tester Account](https://help.apple.com/app-store-connect/#/dev8b997bee1) for testing purposes.
 - Add your [App-Specific Shared Secret](https://docs.revenuecat.com/docs/itunesconnect-app-specific-shared-secret) to RevenueCat. If you don't have a RevenueCat account yet, sign up for free [here](https://app.revenuecat.com/signup).
-- Be sure to set up at least one subscription on the App Store and link it to RevenueCat:
+- Be sure to set up at least one subscription on the App Store following our [guide](https://docs.revenuecat.com/docs/apple-app-store) and link it to RevenueCat:
     - Add the [product](https://docs.revenuecat.com/docs/entitlements#products) (e.g. `rc_3999_1y`) to RevenueCat's dashboard. It should match the product ID on the App Store.
     - Attach the product to an [entitlement](https://docs.revenuecat.com/docs/entitlements#creating-an-entitlement), e.g. `premium`.
     - Attach the product to a [package](https://docs.revenuecat.com/docs/entitlements#adding-packages) (e.g. `Annual`) inside an [offering](https://docs.revenuecat.com/docs/entitlements#creating-an-offering) (e.g. `sale` or `default`).
-- If you're testing on a simulator instead of a physical device, be sure to set up your [StoreKit configuration files](https://docs.revenuecat.com/docs/apple-app-store#ios-14-only-testing-on-the-simulator).
 - Get your [API key](https://docs.revenuecat.com/docs/authentication#obtaining-api-keys) from your RevenueCat project.
 
 ### Steps to Run
-1. Open the file `MagicWeather.xcodeproj` in Xcode.
-2. On the **General** tab of the project editor, match the bundle ID to your bundle ID in App Store Connect and RevenueCat.
+1. Download or clone this repository
+    >git clone https://github.com/RevenueCat/purchases-ios.git
+
+2. Navigate to the `Examples` directory and open the file `MagicWeather.xcodeproj` in Xcode.
+3. On the **General** tab of the project editor, match the bundle ID to your bundle ID in App Store Connect and RevenueCat.
     
     <img src="https://i.imgur.com/1z32GRo.png" alt="General tab in Xcode" width="250px" />
 4. On the **Signing & Capabilities** tab of the project editor, select the correct development team from the **Team** dropdown.  

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Sign up to [get started for free](https://app.revenuecat.com/signup).
 🔀 | [Integrations](https://www.revenuecat.com/integrations) - over a dozen integrations to easily send purchase data where you need it
 💯 | Well maintained - [frequent releases](https://github.com/RevenueCat/purchases-ios/releases)
 📮 | Great support - [Help Center](https://community.revenuecat.com)
-🤩 | Awesome [new features](https://trello.com/b/RZRnWRbI/revenuecat-product-roadmap)  
 
 ## Getting Started
 For more detailed information, you can view our complete documentation at [docs.revenuecat.com](https://docs.revenuecat.com/docs).

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Or view our iOS sample apps:
 - [MagicWeather SwiftUI](Examples/MagicWeatherSwiftUI)
 
 ## Requirements
-- XCode 10.2+
-- Minimum target: iOS 9.0+
+- Xcode 13.2+
+- Minimum target: iOS 11.0+
 
 ## SDK Reference
 Our full SDK reference [can be found here](https://revenuecat.github.io/purchases-ios-docs).

--- a/README.md
+++ b/README.md
@@ -51,7 +51,13 @@ Or view our iOS sample apps:
 
 ## Requirements
 - Xcode 13.2+
-- Minimum target: iOS 11.0+
+
+| Platform | Minimum target |
+| --- | --- |
+| iOS | 11.0+ |
+| tvOS | 11.0+ |
+| macOS | 10.13+ |
+| watchOS | 6.2+ |
 
 ## SDK Reference
 Our full SDK reference [can be found here](https://revenuecat.github.io/purchases-ios-docs).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h3 align="center">😻 In-App Subscriptions Made Easy 😻</h1>
+<h3 align="center">😻 In-App Subscriptions Made Easy 😻</h3>
 
 [![License](https://img.shields.io/cocoapods/l/RevenueCat.svg?style=flat)](http://cocoapods.org/pods/RevenueCat)
 [![Version](https://img.shields.io/cocoapods/v/RevenueCat.svg?style=flat)](https://cocoapods.org/pods/RevenueCat)
@@ -39,13 +39,20 @@ Sign up to [get started for free](https://app.revenuecat.com/signup).
 🔀 | [Integrations](https://www.revenuecat.com/integrations) - over a dozen integrations to easily send purchase data where you need it
 💯 | Well maintained - [frequent releases](https://github.com/RevenueCat/purchases-ios/releases)
 📮 | Great support - [Help Center](https://community.revenuecat.com)
+🤩 | Awesome [new features](https://trello.com/b/RZRnWRbI/revenuecat-product-roadmap)  
 
 ## Getting Started
 For more detailed information, you can view our complete documentation at [docs.revenuecat.com](https://docs.revenuecat.com/docs).
 
-Or browse our iOS sample apps:
+Please follow the [Quickstart Guide](https://docs.revenuecat.com/docs/) for more information on how to install the SDK.
+
+Or view our iOS sample apps:
 - [MagicWeather](Examples/MagicWeather)
 - [MagicWeather SwiftUI](Examples/MagicWeatherSwiftUI)
+
+## Requirements
+- XCode 10.2+
+- Minimum target: iOS 9.0+
 
 ## SDK Reference
 Our full SDK reference [can be found here](https://revenuecat.github.io/purchases-ios-docs).


### PR DESCRIPTION
Main README and MagicWeather README updated to be consistent with docs in purchases-android repository.

### Checklist
- [ x ] If applicable, unit tests
- [ x ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
These are minor formatting tweaks that will make the READMEs more consistent with the purchases-android READMEs.

### Description
<!-- Describe your changes in detail -->
Most changes include moving the order of the information or adding a link to docs.revenuecat.com

<!-- Please describe in detail how you tested your changes -->
I don't know how to test a readme 🙃
