### PR TITLE
Added `Collection.onlyElement`

### DIFF
--- a/Sources/FoundationExtensions/Array+Extensions.swift
+++ b/Sources/FoundationExtensions/Array+Extensions.swift
@@ -23,3 +23,16 @@ extension Array {
     }
 
 }
+
+extension Collection {
+
+    /// - Returns: an element iff it's the only one in the collection
+    var onlyElement: Element? {
+        guard self.count == 1, let first = self.first else {
+            return nil
+        }
+
+        return first
+    }
+
+}

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -146,9 +146,7 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
 
         self.assertNoPurchases(try XCTUnwrap(self.purchasesDelegate.customerInfo))
 
-        let transactions = self.testSession.allTransactions()
-        expect(transactions).to(haveCount(1))
-        let transaction = transactions.first!
+        let transaction = try XCTUnwrap(self.testSession.allTransactions().onlyElement)
 
         try self.testSession.approveAskToBuyTransaction(identifier: transaction.identifier)
 
@@ -289,9 +287,9 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
 
         let offerings = try await Purchases.shared.offerings()
         let product = try XCTUnwrap(offerings.current?.monthly?.storeProduct)
+        let discount = try XCTUnwrap(product.discounts.onlyElement)
 
-        expect(product.discounts).to(haveCount(1))
-        expect(product.discounts.first?.offerIdentifier) == "com.revenuecat.monthly_4.99.1_free_week"
+        expect(discount.offerIdentifier) == "com.revenuecat.monthly_4.99.1_free_week"
 
         let offers = await product.eligiblePromotionalOffers()
         expect(offers).to(beEmpty())
@@ -327,9 +325,7 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
 
         // 3. Get eligible offer
 
-        let offers = await product.eligiblePromotionalOffers()
-        expect(offers).to(haveCount(1))
-        let offer = try XCTUnwrap(offers.first)
+        let offer = try await XCTAsyncUnwrap(await product.eligiblePromotionalOffers().onlyElement)
 
         // 4. Purchase with offer
 
@@ -351,8 +347,7 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
             .filter { $0.productID == product.productIdentifier }
             .extractValues()
 
-        expect(transactions).to(haveCount(1))
-        let transaction = try XCTUnwrap(transactions.first)
+        let transaction = try XCTUnwrap(transactions.onlyElement)
 
         expect(entitlement.latestPurchaseDate) != entitlement.originalPurchaseDate
         expect(transaction.offerID) == offer.discount.offerIdentifier

--- a/Tests/BackendIntegrationTests/SubscriberAttributesManagerIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/SubscriberAttributesManagerIntegrationTests.swift
@@ -88,11 +88,10 @@ class SubscriberAttributesManagerIntegrationTests: BaseBackendIntegrationTests {
         self.attribution.setEmail(invalidEmail)
 
         let errors = await self.syncAttributes()
-        expect(errors).to(haveCount(1))
+        let error = try XCTUnwrap(errors.onlyElement ?? nil) as NSError
 
         self.verifySyncedAttribute(self.userID, [reserved(.email): invalidEmail])
 
-        let error = try XCTUnwrap(errors.first ?? nil) as NSError
         expect(error.domain) == RCPurchasesErrorCodeDomain
         expect(error.code) == ErrorCode.invalidSubscriberAttributesError.rawValue
         expect(error.subscriberAttributesErrors) == [

--- a/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
@@ -65,9 +65,7 @@ class LocalReceiptParserStoreKitTests: StoreKitConfigTestCase {
 
         let receipt = try self.parser.parse(from: data)
 
-        expect(receipt.inAppPurchases.count) == 1
-
-        let firstPurchase = try XCTUnwrap(receipt.inAppPurchases.first)
+        let firstPurchase = try XCTUnwrap(receipt.inAppPurchases.onlyElement)
 
         expect(firstPurchase.quantity) == 1
         expect(firstPurchase.productId) == product.id

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -31,9 +31,8 @@ class ProductsManagerTests: StoreKitConfigTestCase {
 
         expect(receivedProducts).toEventuallyNot(beNil(), timeout: Self.requestDispatchTimeout)
         let unwrappedProducts = try XCTUnwrap(receivedProducts?.get())
-        expect(unwrappedProducts).to(haveCount(1))
 
-        let product = try XCTUnwrap(unwrappedProducts.first).product
+        let product = try XCTUnwrap(unwrappedProducts.onlyElement).product
 
         expect(product).to(beAnInstanceOf(SK1StoreProduct.self))
         expect(product.productIdentifier) == identifier
@@ -55,9 +54,8 @@ class ProductsManagerTests: StoreKitConfigTestCase {
 
         expect(receivedProducts).toEventuallyNot(beNil(), timeout: Self.requestDispatchTimeout)
         let unwrappedProducts = try XCTUnwrap(receivedProducts?.get())
-        expect(unwrappedProducts).to(haveCount(1))
 
-        let product = try XCTUnwrap(unwrappedProducts.first).product
+        let product = try XCTUnwrap(unwrappedProducts.onlyElement).product
 
         expect(product).to(beAnInstanceOf(SK2StoreProduct.self))
         expect(product.productIdentifier) == identifier

--- a/Tests/StoreKitUnitTests/StoreProductTests.swift
+++ b/Tests/StoreKitUnitTests/StoreProductTests.swift
@@ -67,9 +67,8 @@ class StoreProductTests: StoreKitConfigTestCase {
         product.mockDiscount = discount
 
         let storeProduct = StoreProduct(sk1Product: product)
-        expect(storeProduct.discounts).to(haveCount(1))
 
-        let storeDiscount = try XCTUnwrap(storeProduct.discounts.first)
+        let storeDiscount = try XCTUnwrap(storeProduct.discounts.onlyElement)
         expect(storeDiscount.currencyCode).to(beNil())
         expect(storeDiscount.localizedPriceString) == "$2.00"
     }
@@ -94,9 +93,8 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(result).toEventuallyNot(beNil(), timeout: Self.requestDispatchTimeout + .seconds(5))
 
         let products = try result.get()
-        expect(products).to(haveCount(1))
 
-        let sk1Product = try XCTUnwrap(products.first)
+        let sk1Product = try XCTUnwrap(products.onlyElement)
         let storeProduct = StoreProduct.from(product: sk1Product)
 
         expect(storeProduct.sk1Product) === sk1Product.underlyingSK1Product

--- a/Tests/UnitTests/FoundationExtensions/ArrayExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/ArrayExtensionsTests.swift
@@ -18,6 +18,8 @@ import XCTest
 
 class ArrayExtensionsTests: TestCase {
 
+    // MARK: - popFirst
+
     func testPopFirstWithEmptyArray() {
         var array: [Int] = []
 
@@ -39,6 +41,20 @@ class ArrayExtensionsTests: TestCase {
 
         expect(element) == 3
         expect(array) == [2, 1]
+    }
+
+    // MARK: - onlyElement
+
+    func testOnlyElementWithEmptyArray() {
+        expect([].onlyElement).to(beNil())
+    }
+
+    func testOnlyElementWithMultipleElements() {
+        expect([1, 2].onlyElement).to(beNil())
+    }
+
+    func testOnlyElementWithSingleElement() {
+        expect([1].onlyElement) == 1
     }
 
 }

--- a/Tests/UnitTests/Networking/Responses/PostOfferDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/PostOfferDecodingTests.swift
@@ -26,9 +26,7 @@ class PostOfferDecodingTests: BaseHTTPResponseTest {
     }
 
     func testResponseDataIsCorrect() throws {
-        expect(self.response.offers).to(haveCount(1))
-
-        let offer = try XCTUnwrap(self.response.offers.first)
+        let offer = try XCTUnwrap(self.response.offers.onlyElement)
 
         expect(offer.keyIdentifier) == "C815358F"
         expect(offer.offerIdentifier) == "com.revenuecat.monthly_4.99.1_free_week"

--- a/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
+++ b/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
@@ -54,8 +54,7 @@ class ErrorUtilsTests: TestCase {
     func testLoggedErrorsWithNoMessage() throws {
         let error = ErrorUtils.customerInfoError()
 
-        expect(self.loggedMessages).to(haveCount(1))
-        let loggedMessage = try XCTUnwrap(self.loggedMessages.first)
+        let loggedMessage = try XCTUnwrap(self.loggedMessages.onlyElement)
 
         expect(loggedMessage.level) == .error
         expect(loggedMessage.message) == "\(LogIntent.rcError.prefix) \(error.localizedDescription)"
@@ -65,8 +64,7 @@ class ErrorUtilsTests: TestCase {
         let message = Strings.customerInfo.no_cached_customerinfo.description
         _ = ErrorUtils.customerInfoError(withMessage: message)
 
-        expect(self.loggedMessages).to(haveCount(1))
-        let loggedMessage = try XCTUnwrap(self.loggedMessages.first)
+        let loggedMessage = try XCTUnwrap(self.loggedMessages.onlyElement)
 
         expect(loggedMessage.level) == .error
         expect(loggedMessage.message) == [
@@ -79,8 +77,7 @@ class ErrorUtilsTests: TestCase {
     func testLoggedErrorsDontDuplicateMessageIfEqualToErrorDescription() throws {
         _ = ErrorUtils.customerInfoError(withMessage: ErrorCode.customerInfoError.description)
 
-        expect(self.loggedMessages).to(haveCount(1))
-        let loggedMessage = try XCTUnwrap(self.loggedMessages.first)
+        let loggedMessage = try XCTUnwrap(self.loggedMessages.onlyElement)
 
         expect(loggedMessage.level) == .error
         expect(loggedMessage.message) == [
@@ -99,8 +96,7 @@ class ErrorUtilsTests: TestCase {
         let error: NetworkError = .errorResponse(errorResponse, .invalidRequest)
         _ = error.asPurchasesError
 
-        expect(self.loggedMessages).to(haveCount(1))
-        let loggedMessage = try XCTUnwrap(self.loggedMessages.first)
+        let loggedMessage = try XCTUnwrap(self.loggedMessages.onlyElement)
 
         expect(loggedMessage.level) == .error
         expect(loggedMessage.message) == [
@@ -119,8 +115,7 @@ class ErrorUtilsTests: TestCase {
         let error: NetworkError = .errorResponse(errorResponse, .invalidRequest)
         _ = error.asPurchasesError
 
-        expect(self.loggedMessages).to(haveCount(1))
-        let loggedMessage = try XCTUnwrap(self.loggedMessages.first)
+        let loggedMessage = try XCTUnwrap(self.loggedMessages.onlyElement)
 
         expect(loggedMessage.level) == .error
         expect(loggedMessage.message) == [


### PR DESCRIPTION
Simplifies the common pattern in tests:
```swift
expect(array).to(haveCount(1))
let element = try XCTUnwrap(array.first)
```

Into simply:
```swift
let element = try XCTUnwrap(array.onlyElement)
```