### PR TITLE
Introduced `TestLogHandler` to simplify how we test logged messages

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -205,6 +205,10 @@
 		37E3578711F5FDD5DC6458A8 /* AttributionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3521731D8DC16873F55F3 /* AttributionFetcher.swift */; };
 		37E35C8515C5E2D01B0AF5C1 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3507939634ED5A9280544 /* Strings.swift */; };
 		42F1DF385E3C1F9903A07FBF /* ProductsFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */; };
+		57057FF828B0048900995F21 /* TestLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57057FF728B0048900995F21 /* TestLogHandler.swift */; };
+		57057FF928B0048900995F21 /* TestLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57057FF728B0048900995F21 /* TestLogHandler.swift */; };
+		5705800328B0085200995F21 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5705800228B0085200995F21 /* Box.swift */; };
+		5705800428B0085200995F21 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5705800228B0085200995F21 /* Box.swift */; };
 		570FAF4B2864EC2300D3C769 /* NonSubscriptionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570FAF4A2864EC2300D3C769 /* NonSubscriptionTransaction.swift */; };
 		571E7AD4279F2D0C003B3606 /* StoreKitTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571E7AD3279F2D0C003B3606 /* StoreKitTestHelpers.swift */; };
 		572247D127BEC28E00C524A7 /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572247D027BEC28E00C524A7 /* Array+Extensions.swift */; };
@@ -698,6 +702,8 @@
 		37E35EEE7783629CDE41B70C /* SystemInfoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemInfoTests.swift; sourceTree = "<group>"; };
 		37E35F783903362B65FB7AF3 /* MockProductsRequestFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockProductsRequestFactory.swift; sourceTree = "<group>"; };
 		37E35FDA0A44EA03EA12DAA2 /* DateFormatter+ExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DateFormatter+ExtensionsTests.swift"; sourceTree = "<group>"; };
+		57057FF728B0048900995F21 /* TestLogHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestLogHandler.swift; sourceTree = "<group>"; };
+		5705800228B0085200995F21 /* Box.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
 		570814C128A308050018BAE3 /* BackendIntegrationTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = BackendIntegrationTests.xctestplan; path = Tests/TestPlans/BackendIntegrationTests.xctestplan; sourceTree = "<group>"; };
 		570896B227595C8100296F1C /* AllTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = AllTests.xctestplan; path = Tests/TestPlans/AllTests.xctestplan; sourceTree = "<group>"; };
 		570896B327595C8100296F1C /* RevenueCat.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = RevenueCat.xctestplan; path = Tests/TestPlans/RevenueCat.xctestplan; sourceTree = "<group>"; };
@@ -1642,6 +1648,8 @@
 				575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */,
 				576C8A9127D27DDD0058FA6E /* SnapshotTesting+Extensions.swift */,
 				57DE80AD28075D77008D6C6F /* OSVersionEquivalent.swift */,
+				57057FF728B0048900995F21 /* TestLogHandler.swift */,
+				5705800228B0085200995F21 /* Box.swift */,
 			);
 			path = TestHelpers;
 			sourceTree = "<group>";
@@ -2274,6 +2282,7 @@
 				2D90F8BC26FD20C2009B9142 /* MockReceiptParser.swift in Sources */,
 				57DE80812807529F008D6C6F /* MockStorefront.swift in Sources */,
 				57544C29285FA95E004E54D5 /* MockAttributeSyncing.swift in Sources */,
+				57057FF928B0048900995F21 /* TestLogHandler.swift in Sources */,
 				2D90F8C226FD20F7009B9142 /* MockETagManager.swift in Sources */,
 				2D90F8B526FD2093009B9142 /* MockSystemInfo.swift in Sources */,
 				2D90F8C126FD20F2009B9142 /* MockHTTPClient.swift in Sources */,
@@ -2294,6 +2303,7 @@
 				2D90F8C026FD20DF009B9142 /* MockAttributionDataMigrator.swift in Sources */,
 				F55FFA5D27634E1900995146 /* MockTransactionsManager.swift in Sources */,
 				57554CC2282AE1E3009A7E58 /* TestCase.swift in Sources */,
+				5705800428B0085200995F21 /* Box.swift in Sources */,
 				2D90F8B826FD20AA009B9142 /* MockReceiptFetcher.swift in Sources */,
 				2D90F8B626FD2099009B9142 /* MockSubscriberAttributesManager.swift in Sources */,
 				2D90F8BF26FD20D6009B9142 /* MockAttributionFetcher.swift in Sources */,
@@ -2521,6 +2531,7 @@
 				5752E8482892DC500069281E /* ErrorUtilsTests.swift in Sources */,
 				57554C88282AC293009A7E58 /* PurchaseOwnershipTypeTests.swift in Sources */,
 				57554C84282AC273009A7E58 /* PeriodTypeTests.swift in Sources */,
+				57057FF828B0048900995F21 /* TestLogHandler.swift in Sources */,
 				57E415F12846997B00EA5460 /* PurchasesAttributionDataTests.swift in Sources */,
 				2DDF41CF24F6F4C3005BC22D /* ReceiptParsing+TestsWithRealReceipts.swift in Sources */,
 				57FDAA962846BDE2009A48F1 /* PurchasesTransactionHandlingTests.swift in Sources */,
@@ -2588,6 +2599,7 @@
 				35E840CE2710E2EB00899AE2 /* MockManageSubscriptionsHelper.swift in Sources */,
 				F591492826B9956C00D32E58 /* MockTransaction.swift in Sources */,
 				5796A39427D6BD6900653165 /* BackendGetOfferingsTests.swift in Sources */,
+				5705800328B0085200995F21 /* Box.swift in Sources */,
 				5766AA42283C768600FA6091 /* OperatorExtensionsTests.swift in Sources */,
 				351B516A26D44CB300BD2BD7 /* ISOPeriodFormatterTests.swift in Sources */,
 				57DC9F4A27CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift in Sources */,

--- a/Sources/Logging/Logger.swift
+++ b/Sources/Logging/Logger.swift
@@ -52,7 +52,9 @@ enum Logger {
     #else
     static var logLevel: LogLevel = .info
     #endif
-    static var logHandler: VerboseLogHandler = { level, message, file, functionName, line in
+    static var logHandler: VerboseLogHandler = Self.defaultLogHandler
+
+    static let defaultLogHandler: VerboseLogHandler = { level, message, file, functionName, line in
         let fileContext: String
         if Logger.verbose, let file = file, let functionName = functionName {
             let fileName = (file as NSString)

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionListener.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionListener.swift
@@ -74,12 +74,3 @@ class MockStoreKit2TransactionListener: StoreKit2TransactionListener {
         return (false, mockTransaction.value)
     }
 }
-
-// Workaround for https://openradar.appspot.com/radar?id=4970535809187840 / https://bugs.swift.org/browse/SR-15825
-final class Box<T> {
-
-    var value: T
-
-    init(_ value: T) { self.value = value }
-
-}

--- a/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
+++ b/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
@@ -20,20 +20,16 @@ import StoreKit
 
 class ErrorUtilsTests: TestCase {
 
-    private var originalLogHandler: VerboseLogHandler!
-    private var loggedMessages: [(level: LogLevel, message: String)] = []
+    private var testLogHandler: TestLogHandler!
 
     override func setUp() {
         super.setUp()
 
-        self.originalLogHandler = Logger.logHandler
-        Logger.logHandler = { [weak self] level, message, _, _, _ in
-            self?.loggedMessages.append((level, message))
-        }
+        self.testLogHandler = TestLogHandler()
     }
 
     override func tearDown() {
-        Logger.logHandler = self.originalLogHandler
+        self.testLogHandler = nil
 
         super.tearDown()
     }
@@ -127,6 +123,10 @@ class ErrorUtilsTests: TestCase {
 
     // MARK: -
 
+    private var loggedMessages: [TestLogHandler.MessageData] {
+        return self.testLogHandler.messages
+    }
+
     private func expectLoggedError(
         _ error: Error,
         _ intent: LogIntent,
@@ -142,15 +142,17 @@ class ErrorUtilsTests: TestCase {
             .compactMap { $0 }
             .joined(separator: " ")
 
+        let messages = self.loggedMessages
+
         expect(
             file: file,
             line: line,
-            self.loggedMessages
+            messages
         ).to(
             containElementSatisfying { level, message in
                 level == .error && message == expectedMessage
             },
-            description: "Error '\(expectedMessage)' not found. Logged messages: \(self.loggedMessages)"
+            description: "Error '\(expectedMessage)' not found. Logged messages: \(messages)"
         )
     }
 

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -170,13 +170,7 @@ class BackendSubscriberAttributesTests: TestCase {
             subscriberAttribute2.key: subscriberAttribute2
         ]
 
-        var loggedMessages = [String]()
-        let originalLogHandler = Logger.logHandler
-        defer { Logger.logHandler = originalLogHandler }
-
-        Logger.logHandler = { _, message, _, _, _ in
-            loggedMessages.append(message)
-        }
+        let logHandler = TestLogHandler()
 
         var receivedCustomerInfo: CustomerInfo?
         backend.post(receiptData: receiptData,
@@ -190,6 +184,8 @@ class BackendSubscriberAttributesTests: TestCase {
         }
 
         expect(self.mockHTTPClient.calls).toEventually(haveCount(1))
+
+        let loggedMessages = logHandler.messages.map(\.message)
 
         expect(receivedCustomerInfo) == CustomerInfo(testData: self.validSubscriberResponse)
         expect(loggedMessages).to(

--- a/Tests/UnitTests/TestHelpers/Box.swift
+++ b/Tests/UnitTests/TestHelpers/Box.swift
@@ -1,0 +1,32 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Box.swift
+//
+//  Created by Nacho Soto on 8/19/22.
+
+import Foundation
+
+// Workaround for https://openradar.appspot.com/radar?id=4970535809187840 / https://bugs.swift.org/browse/SR-15825
+final class Box<T> {
+
+    var value: T
+
+    init(_ value: T) { self.value = value }
+
+}
+
+/// Holds a weak reference to an object.
+final class WeakBox<T: AnyObject> {
+
+    private(set) weak var value: T?
+
+    init(_ value: T) { self.value = value }
+
+}

--- a/Tests/UnitTests/TestHelpers/TestLogHandler.swift
+++ b/Tests/UnitTests/TestHelpers/TestLogHandler.swift
@@ -1,0 +1,133 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  TestLogHandler.swift
+//
+//  Created by Nacho Soto on 8/19/22.
+
+@testable import RevenueCat
+
+/// Provides a `Logger.VerboseLogHandler` that wraps the default implementation
+/// and allows introspecting logged messages.
+///
+/// - Warning: this will implicitly override `Purchases.verboseLogHandler`.
+/// - Note: this only _wraps_ the original implementation, so messages are still logged to the console.
+///
+/// This type can be used with the RAII pattern.
+///
+/// ### Examples:
+/// - Initialize `TestLogHandler` for every test. This ensures that the lifetime
+/// matches that of the test, and the observed logged messages are those that happen during the test:
+///
+/// ```swift
+/// private var testLogHandler: TestLogHandler!
+/// override func setUp() {
+///     super.setUp()
+///     self.testLogHandler = TestLogHandler()
+/// }
+///
+/// override func tearDown() {
+///     self.testLogHandler = nil
+///     super.tearDown()
+/// }
+/// ```
+///
+/// - Alternatively, `TestLogHandler` can be used locally within a single test:
+///
+/// ```swift
+/// func testExample() {
+///     let logHandler = TestLogHandler()
+///
+///     // Run some code
+///
+///     expect(logHandler.loggedMessages.onlyElement?.message) == "Expected log"
+/// }
+/// ```
+final class TestLogHandler {
+
+    typealias MessageData = (level: LogLevel, message: String)
+
+    var messages: [MessageData] { return self.loggedMessages.value }
+
+    init() { Self.sharedHandler.add(observer: self) }
+
+    deinit { Self.sharedHandler.remove(observer: self) }
+
+    private let loggedMessages: Atomic<[MessageData]> = .init([])
+
+    private static let sharedHandler: SharedTestLogHandler = {
+        let handler = SharedTestLogHandler()
+        handler.install()
+
+        return handler
+    }()
+
+}
+
+extension TestLogHandler: Sendable {}
+
+// MARK: - Private
+
+extension TestLogHandler: LogMessageObserver {
+
+    func didReceive(message: String, with level: LogLevel) {
+        self.loggedMessages.modify {
+            $0.append((level, message))
+
+            precondition(
+                $0.count < Self.messageLimit,
+                "\(Self.messageLimit) messages have been stored.\n" +
+                "This is likely a programming error and \(self) has leaked."
+            )
+        }
+    }
+
+    private static let messageLimit = 100
+
+}
+
+private final class SharedTestLogHandler {
+
+    private let observers: Atomic<[WeakBox<LogMessageObserver>]>
+    private let logHandler: VerboseLogHandler
+
+    init() {
+        self.observers = .init([])
+        self.logHandler = { [observers] level, message, file, function, line in
+            Logger.defaultLogHandler(level, message, file, function, line)
+
+            Self.notify(observers: observers.value, message: message, level: level)
+        }
+    }
+
+    func install() {
+        Purchases.verboseLogHandler = self.logHandler
+    }
+
+    func add(observer: LogMessageObserver) {
+        self.observers.modify { $0.append(.init(observer)) }
+    }
+
+    func remove(observer: LogMessageObserver) {
+        self.observers.modify { $0.removeAll { $0.value === observer } }
+    }
+
+    private static func notify(observers: [WeakBox<LogMessageObserver>], message: String, level: LogLevel) {
+        for observer in observers {
+            observer.value?.didReceive(message: message, with: level)
+        }
+    }
+
+}
+
+@objc protocol LogMessageObserver: AnyObject {
+
+    func didReceive(message: String, with level: LogLevel)
+
+}


### PR DESCRIPTION
We had this fragile pattern in several tests:
```swift
var loggedMessages = [String]()
let originalLogHandler = Logger.logHandler
defer { Logger.logHandler = originalLogHandler }

Logger.logHandler = { _, message, _, _, _ in
    loggedMessages.append(message)
}
```

Which was too verbose and error prone.

This new type works like an RAII type. Its lifetime scopes the messages that are observed, so simply having a reference around for the lifetime of the test allows observing only those messages.

This much simpler abstraction will make it easier for us to test more of what's logged by the SDK.

### Examples:

- Initialize in `setUp`:

```swift
private var testLogHandler: TestLogHandler!
override func setUp() {
    super.setUp()
    self.testLogHandler = TestLogHandler()
}
override func tearDown() {
    self.testLogHandler = nil
    super.tearDown()
}

func testExample() {
    // Run code

    expect(self.testLogHandler.messages).to(contain(...))
}
```

 - Alternatively, `TestLogHandler` can be used locally within a single test:

```swift
func testExample() {
    let logHandler = TestLogHandler()

    // Run some code

    expect(logHandler.loggedMessages.onlyElement?.message) == "Expected log"
}
```

### Notes:

This implicitly overrides `Purchases.shared.verboseLogHandler` while running tests, but it just wraps it by still invoking the default handler, so logs are still printed in the console.