### PR TITLE
`TrialOrIntroPriceEligibilityChecker`: return `.noIntroOfferExists` if the product has no introductory offer

### DIFF
--- a/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -101,27 +101,27 @@ class TrialOrIntroPriceEligibilityChecker {
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func sk2CheckEligibility(_ productIdentifiers: [String]) async throws -> [String: IntroEligibility] {
         let identifiers = Set(productIdentifiers)
-        var introDict = productIdentifiers.reduce(into: [:]) { resultDict, productId in
-            resultDict[productId] = IntroEligibility(eligibilityStatus: IntroEligibilityStatus.unknown)
+        var introDictionary: [String: IntroEligibility] = identifiers.dictionaryWithValues { _ in
+                .init(eligibilityStatus: .unknown)
         }
 
-        let products = try await productsManager.sk2StoreProducts(withIdentifiers: identifiers)
+        let products = try await self.productsManager.sk2StoreProducts(withIdentifiers: identifiers)
         for sk2StoreProduct in products {
             let sk2Product = sk2StoreProduct.underlyingSK2Product
 
             let eligibilityStatus: IntroEligibilityStatus
 
-            if let subscription = sk2Product.subscription {
+            if let subscription = sk2Product.subscription, subscription.introductoryOffer != nil {
                 let isEligible = await subscription.isEligibleForIntroOffer
                 eligibilityStatus = isEligible ? .eligible : .ineligible
             } else {
                 eligibilityStatus = .noIntroOfferExists
             }
 
-            introDict[sk2StoreProduct.productIdentifier] =
-            IntroEligibility(eligibilityStatus: eligibilityStatus)
+            introDictionary[sk2StoreProduct.productIdentifier] = .init(eligibilityStatus: eligibilityStatus)
         }
-        return introDict
+
+        return introDictionary
     }
 
 }

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -213,6 +213,15 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
         expect(eligibility) == .eligible
     }
 
+    func testNoIntroOfferIfProductHasNoIntro() async throws {
+        let product = try await XCTAsyncUnwrap(
+            await Purchases.shared.products(["com.revenuecat.weekly_1.99.no_intro"]).onlyElement
+        )
+
+        let eligibility = await Purchases.shared.checkTrialOrIntroDiscountEligibility(product: product)
+        expect(eligibility) == .noIntroOfferExists
+    }
+
     func testIneligibleForIntroAfterPurchase() async throws {
         let product = try await self.monthlyPackage.storeProduct
 


### PR DESCRIPTION
Fixes [CSDK-432].

The SK1 implementation [was checking](https://github.com/RevenueCat/purchases-ios/blob/39746c7e2a3f2ad3ba491cd1c5bbb3643e4aac89/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift#L161) if the product actually had an intro offer.
However, the SK2 version only checked if `Product` had a `SubscriptionInfo`, and relied on `isEligibleForIntroOffer`. But we needed to verify that the `SubscriptionOffer` actually contained an `introductoryOffer`.

[CSDK-432]: https://revenuecats.atlassian.net/browse/CSDK-432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ