### PR TITLE
`CircleCI`: added job for building SDK with `SPM`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,6 @@ jobs:
     <<: *base-job
     steps:
       - checkout
-      - install-dependencies
       - run:
           name: SPM Build
           command: swift build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,6 +210,16 @@ commands:
               bundle exec fastlane update_carthage_commit
 
 jobs:
+  spm-build:
+    <<: *base-job
+    steps:
+      - checkout
+      - install-dependencies
+      - run:
+          name: SPM Build
+          command: swift build
+          no_output_timeout: 30m
+
   run-test-ios-16:
     <<: *base-job
     steps:
@@ -552,6 +562,8 @@ workflows:
           xcode_version: '13.4.1'
       - run-test-ios-16:
           xcode_version: '14.0.0'
+      - spm-build:
+          xcode_version: '13.4.1'
       - run-test-ios-15:
           xcode_version: '13.4.1'
       - run-test-tvos:


### PR DESCRIPTION
Fixes [CSDK-221].

SPM requires explicit `import Foundation` statements. Missing these could go unnoticed, so this new step will ensure that we don't break compilation with SPM.

- Example of [successful build](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/7913/workflows/129b5e08-cdbe-4b3e-8606-8709655df205/jobs/35323/parallel-runs/0/steps/0-107).
- Example of [failed build from a missing `import Foundation`](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/7914/workflows/4296ba99-f966-40d0-8fac-f8ece4db39aa/jobs/35329/parallel-runs/0/steps/0-102
).

[CSDK-221]: https://revenuecats.atlassian.net/browse/CSDK-221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ