### PR TITLE
Added `beginRefundRequest` overload with completion block

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 		42F1DF385E3C1F9903A07FBF /* ProductsFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */; };
 		570FAF4B2864EC2300D3C769 /* NonSubscriptionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570FAF4A2864EC2300D3C769 /* NonSubscriptionTransaction.swift */; };
 		571E7AD4279F2D0C003B3606 /* StoreKitTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571E7AD3279F2D0C003B3606 /* StoreKitTestHelpers.swift */; };
+		5721360F28B4602C006C46BE /* Purchases+nonasync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5721360E28B4602C006C46BE /* Purchases+nonasync.swift */; };
 		572247D127BEC28E00C524A7 /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572247D027BEC28E00C524A7 /* Array+Extensions.swift */; };
 		572247F727BF1ADF00C524A7 /* ArrayExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572247F627BF1ADF00C524A7 /* ArrayExtensionsTests.swift */; };
 		5722482727C2BD3200C524A7 /* LockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5722482627C2BD3200C524A7 /* LockTests.swift */; };
@@ -707,6 +708,7 @@
 		570896BD27596E8800296F1C /* ObjCAPITester.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ObjCAPITester.xcodeproj; path = Tests/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj; sourceTree = "<group>"; };
 		570FAF4A2864EC2300D3C769 /* NonSubscriptionTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonSubscriptionTransaction.swift; sourceTree = "<group>"; };
 		571E7AD3279F2D0C003B3606 /* StoreKitTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitTestHelpers.swift; sourceTree = "<group>"; };
+		5721360E28B4602C006C46BE /* Purchases+nonasync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Purchases+nonasync.swift"; sourceTree = "<group>"; };
 		572247D027BEC28E00C524A7 /* Array+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
 		572247F627BF1ADF00C524A7 /* ArrayExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtensionsTests.swift; sourceTree = "<group>"; };
 		5722482627C2BD3200C524A7 /* LockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockTests.swift; sourceTree = "<group>"; };
@@ -1243,6 +1245,7 @@
 				2CB8CF9227BF538F00C34DE3 /* PlatformInfo.swift */,
 				F5FCD3E927DA0D0B003BDC04 /* PriceFormatterProvider.swift */,
 				2DD9F4BD274EADC20031AE2C /* Purchases+async.swift */,
+				5721360E28B4602C006C46BE /* Purchases+nonasync.swift */,
 				57EAE52C274468900060EB74 /* RawDataContainer.swift */,
 				57CFB98327FE2258002A6730 /* StoreKit2Setting.swift */,
 				57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */,
@@ -2328,6 +2331,7 @@
 				B3B5FBBC269D121B00104A0C /* Offerings.swift in Sources */,
 				9A65E03B25918B0900DE00B0 /* CustomerInfoStrings.swift in Sources */,
 				57CFB98427FE2258002A6730 /* StoreKit2Setting.swift in Sources */,
+				5721360F28B4602C006C46BE /* Purchases+nonasync.swift in Sources */,
 				57DE806D28074976008D6C6F /* Storefront.swift in Sources */,
 				B3B5FBB6269CED6400104A0C /* ErrorDetails.swift in Sources */,
 				2D991ACA268BA56900085481 /* StoreKitRequestFetcher.swift in Sources */,

--- a/Sources/Misc/Purchases+nonasync.swift
+++ b/Sources/Misc/Purchases+nonasync.swift
@@ -1,0 +1,109 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Purchases+nonasync.swift
+//
+//  Created by Nacho Soto on 8/22/22.
+
+import Foundation
+
+/// This extension holds the biolerplate logic to convert async methods to completion blocks APIs.
+/// Because `async` APIs are implicitly available in Objective-C, these can be Swift only.
+public extension Purchases {
+
+    #if os(iOS)
+    /**
+     * Presents a refund request sheet in the current window scene for
+     * the latest transaction associated with the `productID`
+     *
+     * - Parameter productID: The `productID` to begin a refund request for.
+     * - Parameter completion: A completion block that is called when the ``RefundRequestStatus`` is returned.
+     * Keep in mind the status could be ``RefundRequestStatus/userCancelled``
+     * If the request was unsuccessful, no active entitlements could be found for the user,
+     * or multiple active entitlements were found for the user, an `Error` will be thrown.
+     */
+    @available(iOS 15.0, *)
+    @available(macOS, unavailable)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    func beginRefundRequest(
+        forProduct productID: String,
+        completion: @escaping (Result<RefundRequestStatus, Error>) -> Void
+    ) {
+        call(completion) {
+            try await self.beginRefundRequest(forProduct: productID)
+        }
+    }
+
+    /**
+     * Presents a refund request sheet in the current window scene for
+     * the latest transaction associated with the entitlement ID.
+     *
+     * - Parameter entitlementID: The entitlementID to begin a refund request for.
+     * - Parameter completion: A completion block that is called when the ``RefundRequestStatus`` is returned.
+     * Keep in mind the status could be ``RefundRequestStatus/userCancelled``
+     * If the request was unsuccessful, no active entitlements could be found for the user,
+     * or multiple active entitlements were found for the user, an `Error` will be thrown.
+     */
+    @available(iOS 15.0, *)
+    @available(macOS, unavailable)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    func beginRefundRequest(
+        forEntitlement entitlementID: String,
+        completion: @escaping (Result<RefundRequestStatus, Error>) -> Void
+    ) {
+        call(completion) {
+            try await self.beginRefundRequest(forEntitlement: entitlementID)
+        }
+    }
+
+    /**
+     * Presents a refund request sheet in the current window scene for
+     * the latest transaction associated with the active entitlement.
+     *
+     * - Parameter completion: A completion block that is called when the ``RefundRequestStatus`` is returned.
+     * Keep in mind the status could be ``RefundRequestStatus/userCancelled``
+     * If the request was unsuccessful, no active entitlements could be found for the user,
+     * or multiple active entitlements were found for the user, an `Error` will be thrown.
+     *
+     * - Important: This method should only be used if your user can only
+     * have a single active entitlement at a given time.
+     * If a user could have more than one entitlement at a time, use ``beginRefundRequest(forEntitlement:)`` instead.
+     */
+    @available(iOS 15.0, *)
+    @available(macOS, unavailable)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    func beginRefundRequestForActiveEntitlement(
+        completion: @escaping (Result<RefundRequestStatus, Error>) -> Void
+    ) {
+        call(completion) {
+            try await self.beginRefundRequestForActiveEntitlement()
+        }
+    }
+
+    #endif
+
+}
+
+/// Invokes an `async throws` method and calls `completion` with the result.
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+private func call<T>(
+    _ completion: @escaping (Result<T, Error>) -> Void,
+    asyncMethod method: @escaping () async throws -> T
+) {
+    _ = Task {
+        do {
+            completion(.success(try await method()))
+        } catch {
+            completion(.failure(error))
+        }
+    }
+}

--- a/Sources/Misc/Purchases+nonasync.swift
+++ b/Sources/Misc/Purchases+nonasync.swift
@@ -36,7 +36,7 @@ public extension Purchases {
         forProduct productID: String,
         completion: @escaping (Result<RefundRequestStatus, Error>) -> Void
     ) {
-        call(completion) {
+        call(with: completion) {
             try await self.beginRefundRequest(forProduct: productID)
         }
     }
@@ -59,7 +59,7 @@ public extension Purchases {
         forEntitlement entitlementID: String,
         completion: @escaping (Result<RefundRequestStatus, Error>) -> Void
     ) {
-        call(completion) {
+        call(with: completion) {
             try await self.beginRefundRequest(forEntitlement: entitlementID)
         }
     }
@@ -84,7 +84,7 @@ public extension Purchases {
     func beginRefundRequestForActiveEntitlement(
         completion: @escaping (Result<RefundRequestStatus, Error>) -> Void
     ) {
-        call(completion) {
+        call(with: completion) {
             try await self.beginRefundRequestForActiveEntitlement()
         }
     }
@@ -96,7 +96,7 @@ public extension Purchases {
 /// Invokes an `async throws` method and calls `completion` with the result.
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 private func call<T>(
-    _ completion: @escaping (Result<T, Error>) -> Void,
+    with completion: @escaping (Result<T, Error>) -> Void,
     asyncMethod method: @escaping () async throws -> T
 ) {
     _ = Task {

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -37,6 +37,8 @@ func checkPurchasesAPI() {
         _ = Task.init {
             await checkAsyncMethods(purchases: purch)
         }
+
+        checkNonAsyncMethods(purch)
     }
 }
 
@@ -232,10 +234,17 @@ private func checkAsyncMethods(purchases: Purchases) async {
         let _: RefundRequestStatus = try await purchases.beginRefundRequest(forEntitlement: "")
         let _: RefundRequestStatus = try await purchases.beginRefundRequestForActiveEntitlement()
 
-        // Deprecated
         let _: [PromotionalOffer] = await purchases.eligiblePromotionalOffers(forProduct: stp)
         #endif
     } catch {}
+}
+
+func checkNonAsyncMethods(_ purchases: Purchases) {
+    #if os(iOS)
+    purchases.beginRefundRequest(forProduct: "") { (_: Result<RefundRequestStatus, Error>) in }
+    purchases.beginRefundRequest(forEntitlement: "") { (_: Result<RefundRequestStatus, Error>) in }
+    purchases.beginRefundRequestForActiveEntitlement { (_: Result<RefundRequestStatus, Error>) in }
+    #endif
 }
 
 private func checkConfigure() -> Purchases {


### PR DESCRIPTION
Fixes [CSDK-218].

The underlying implementation provided by Apple is `async` only, which is still available to Objective-C. However, to be able to use it from Swift, it must be used with `await`.
This exposes an overload that allows using it with a completion-block based API. Because we don't need these in Objective-C (those are already available), these blocks can use the Swift-only `Result`.

[CSDK-218]: https://revenuecats.atlassian.net/browse/CSDK-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ