### PR TITLE
Fixed crash on `async` SK1 cancelled purchase

### DIFF
--- a/Sources/Misc/Purchases+async.swift
+++ b/Sources/Misc/Purchases+async.swift
@@ -66,7 +66,7 @@ extension Purchases {
     func purchaseAsync(product: StoreProduct) async throws -> PurchaseResultData {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(product: product) { transaction, customerInfo, error, userCancelled in
-                continuation.resume(with: Result(customerInfo, error?.ignoreIfPurchaseCancelled(userCancelled))
+                continuation.resume(with: Result(customerInfo, error)
                                         .map { PurchaseResultData(transaction, $0, userCancelled) })
             }
         }
@@ -76,7 +76,7 @@ extension Purchases {
     func purchaseAsync(package: Package) async throws -> PurchaseResultData {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(package: package) { transaction, customerInfo, error, userCancelled in
-                continuation.resume(with: Result(customerInfo, error?.ignoreIfPurchaseCancelled(userCancelled))
+                continuation.resume(with: Result(customerInfo, error)
                                         .map { PurchaseResultData(transaction, $0, userCancelled) })
             }
         }
@@ -87,7 +87,7 @@ extension Purchases {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(product: product,
                      promotionalOffer: promotionalOffer) { transaction, customerInfo, error, userCancelled in
-                continuation.resume(with: Result(customerInfo, error?.ignoreIfPurchaseCancelled(userCancelled))
+                continuation.resume(with: Result(customerInfo, error)
                                         .map { PurchaseResultData(transaction, $0, userCancelled) })
             }
         }
@@ -98,7 +98,7 @@ extension Purchases {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(package: package,
                      promotionalOffer: promotionalOffer) { transaction, customerInfo, error, userCancelled in
-                continuation.resume(with: Result(customerInfo, error?.ignoreIfPurchaseCancelled(userCancelled))
+                continuation.resume(with: Result(customerInfo, error)
                                         .map { PurchaseResultData(transaction, $0, userCancelled) })
             }
         }
@@ -206,15 +206,5 @@ extension Purchases {
     }
 
 #endif
-
-}
-
-private extension Error {
-
-    /// This allows `async` APIs to return `userCancelled` in ``PurchaseResultData`` instead of throwing errors.
-    /// - Returns: `nil` if `cancelled` is `true`
-    func ignoreIfPurchaseCancelled(_ cancelled: Bool) -> Self? {
-        return cancelled ? nil : self
-    }
 
 }


### PR DESCRIPTION
Fixes #1868.
See https://github.com/RevenueCat/purchases-ios/issues/1868#issuecomment-1229614774 for a summary of the changes in #1841.

### Before #1841:
- SK1 / completion-block: no `CustomerInfo` + cancelled + `ErrorCode.purchaseCancelledError`
- SK1 / `async`: thrown `ErrorCode.purchaseCancelledError`
- SK2 / completion-block: `CustomerInfo` + cancelled + no error
- SK2 / `async`: `CustomerInfo` + cancelled (not error)

### After #1841:
- SK1 / completion-block:  no `CustomerInfo` + cancelled + `ErrorCode.purchaseCancelledError`
- SK1 / `async`: no `CustomerInfo` + ignored error -> crash! :rotating_light:
- SK2 / completion-block: `CustomerInfo` + cancelled + `ErrorCode.purchaseCancelledError`
- SK2 / `async`: `CustomerInfo` + cancelled (not error)

### After this PR:
- SK1 / completion-block:  no `CustomerInfo` + cancelled + `ErrorCode.purchaseCancelledError`
- **SK1 / `async`: thrown `ErrorCode.purchaseCancelledError`** :warning:
- SK2 / completion-block: `CustomerInfo` + cancelled + `ErrorCode.purchaseCancelledError`
- SK2 / `async`: `CustomerInfo` + cancelled (not error)

The change in #1841 was slightly incorrect. The `ignoreIfPurchaseCancelled` didn't make a lot of sense because `Result(value:error:)` already ignored the error if the value wasn't `nil`.

This change still doesn't get us to a fully consistent behavior across SK1 and SK2 but it adds coverage for this crash and temporarily fixes it.