### PR TITLE
`ErrorUtils`: added test to verify that returned errors can be converted to `ErrorCode`

### DIFF
--- a/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
+++ b/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
@@ -38,6 +38,13 @@ class ErrorUtilsTests: TestCase {
         super.tearDown()
     }
 
+    func testErrorsCanBeConvertedToErrorCode() throws {
+        let error = ErrorUtils.customerInfoError()
+        let errorCode = try XCTUnwrap(error as? ErrorCode, "Error couldn't be converted to ErrorCode")
+
+        expect(errorCode).to(matchError(error))
+    }
+
     func testPurchaseErrorsAreLoggedAsApppleErrors() {
         let underlyingError = NSError(domain: SKErrorDomain, code: SKError.Code.paymentInvalid.rawValue)
         let error = ErrorUtils.purchaseNotAllowedError(error: underlyingError)


### PR DESCRIPTION
This is a key part of how we document error handling in [`V4_API_Migration_guide.md`](https://github.com/RevenueCat/purchases-ios/blob/4.10.3/Sources/DocCDocumentation/DocCDocumentation.docc/V4_API_Migration_guide.md#error-handling).

I'm working on an error type-safety refactor that broke this invariant, which wasn't covered in any test.