### PR TITLE
`CustomerInfoManager`: fixed thread-unsafe implementation

### DIFF
--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -239,8 +239,8 @@ class CustomerInfoManager {
             }
 
             self.lastSentCustomerInfo = customerInfo
-            operationDispatcher.dispatchOnMainThread {
-                for closure in self.customerInfoObserversByIdentifier.values {
+            self.operationDispatcher.dispatchOnMainThread { [observers = self.customerInfoObserversByIdentifier] in
+                for closure in observers.values {
                     closure(customerInfo)
                 }
             }


### PR DESCRIPTION
Thanks @aboedo for finding this.

`CustomerInfoManager` is made thread-safe through `customerInfoCacheLock`, but because of this thread-jump, `customerInfoObserversByIdentifier` was being accessed from 2 different threads.
This new implementation captures the values before invoking each closure in the main thread.