### PR TITLE
Introduced type-safe `PurchasesError` and fixed some incorrect returned error types

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -297,6 +297,8 @@
 		57ACB13728184CF1000DCC9F /* DecoderExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ACB13628184CF1000DCC9F /* DecoderExtensionTests.swift */; };
 		57BA943128330ACA00CD5FC5 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BA943028330ACA00CD5FC5 /* ConfigurationTests.swift */; };
 		57BD50AA27692B7500211D6D /* StoreKitError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */; };
+		57C2931528BFEF4F0054EDFC /* PurchasesError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C2931428BFEF4F0054EDFC /* PurchasesError.swift */; };
+		57C2932A28BFF89D0054EDFC /* ErrorMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E4A52028BD8F610095C793 /* ErrorMatcher.swift */; };
 		57C381B72791E593009E3940 /* StoreKit2TransactionListenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381B62791E593009E3940 /* StoreKit2TransactionListenerTests.swift */; };
 		57C381DA2796153D009E3940 /* SK1StoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381D92796153D009E3940 /* SK1StoreProductDiscount.swift */; };
 		57C381DC27961547009E3940 /* SK2StoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381DB27961547009E3940 /* SK2StoreProductDiscount.swift */; };
@@ -328,6 +330,8 @@
 		57E415EF284697A300EA5460 /* PurchasesDeferredPurchasesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E415EE284697A300EA5460 /* PurchasesDeferredPurchasesTests.swift */; };
 		57E415F12846997B00EA5460 /* PurchasesAttributionDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E415F02846997B00EA5460 /* PurchasesAttributionDataTests.swift */; };
 		57E415FF28469EAB00EA5460 /* PurchasesGetProductsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E415FE28469EAB00EA5460 /* PurchasesGetProductsTests.swift */; };
+		57E4A52128BD8F610095C793 /* ErrorMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E4A52028BD8F610095C793 /* ErrorMatcher.swift */; };
+		57E4A52228BD8F610095C793 /* ErrorMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E4A52028BD8F610095C793 /* ErrorMatcher.swift */; };
 		57EAE527274324C60060EB74 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE526274324C60060EB74 /* Lock.swift */; };
 		57EAE52B274332830060EB74 /* Obsoletions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE52A274332830060EB74 /* Obsoletions.swift */; };
 		57EAE52D274468900060EB74 /* RawDataContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE52C274468900060EB74 /* RawDataContainer.swift */; };
@@ -797,6 +801,7 @@
 		57B530E52858F3FD00FA4E37 /* SwiftStyleGuide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SwiftStyleGuide.swift; path = Contributing/SwiftStyleGuide.swift; sourceTree = "<group>"; };
 		57BA943028330ACA00CD5FC5 /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
 		57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoreKitError+Extensions.swift"; sourceTree = "<group>"; };
+		57C2931428BFEF4F0054EDFC /* PurchasesError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesError.swift; sourceTree = "<group>"; };
 		57C381B62791E593009E3940 /* StoreKit2TransactionListenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2TransactionListenerTests.swift; sourceTree = "<group>"; };
 		57C381D92796153D009E3940 /* SK1StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1StoreProductDiscount.swift; sourceTree = "<group>"; };
 		57C381DB27961547009E3940 /* SK2StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreProductDiscount.swift; sourceTree = "<group>"; };
@@ -823,6 +828,7 @@
 		57E415EE284697A300EA5460 /* PurchasesDeferredPurchasesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesDeferredPurchasesTests.swift; sourceTree = "<group>"; };
 		57E415F02846997B00EA5460 /* PurchasesAttributionDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesAttributionDataTests.swift; sourceTree = "<group>"; };
 		57E415FE28469EAB00EA5460 /* PurchasesGetProductsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesGetProductsTests.swift; sourceTree = "<group>"; };
+		57E4A52028BD8F610095C793 /* ErrorMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMatcher.swift; sourceTree = "<group>"; };
 		57EAE526274324C60060EB74 /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		57EAE52A274332830060EB74 /* Obsoletions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Obsoletions.swift; sourceTree = "<group>"; };
 		57EAE52C274468900060EB74 /* RawDataContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawDataContainer.swift; sourceTree = "<group>"; };
@@ -1656,6 +1662,7 @@
 				57DE80AD28075D77008D6C6F /* OSVersionEquivalent.swift */,
 				57057FF728B0048900995F21 /* TestLogHandler.swift */,
 				5705800228B0085200995F21 /* Box.swift */,
+				57E4A52028BD8F610095C793 /* ErrorMatcher.swift */,
 			);
 			path = TestHelpers;
 			sourceTree = "<group>";
@@ -1797,6 +1804,7 @@
 				35D0E5CF26A5886C0099EAD8 /* ErrorUtils.swift */,
 				2D971CC02744364C0093F35F /* SKError+Extensions.swift */,
 				57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */,
+				57C2931428BFEF4F0054EDFC /* PurchasesError.swift */,
 			);
 			path = "Error Handling";
 			sourceTree = "<group>";
@@ -2299,6 +2307,7 @@
 				B31C8BEF285BDD76001017B7 /* MockIdentityAPI.swift in Sources */,
 				571E7AD4279F2D0C003B3606 /* StoreKitTestHelpers.swift in Sources */,
 				2DFF6C56270CA28800ECAFAB /* MockRequestFetcher.swift in Sources */,
+				57E4A52228BD8F610095C793 /* ErrorMatcher.swift in Sources */,
 				5738F489278CC2500096D623 /* MockTransaction.swift in Sources */,
 				576C8ABC27D2997C0058FA6E /* SnapshotTesting+Extensions.swift in Sources */,
 				F5355164286B7125009CA47A /* MockOfferingsFactory.swift in Sources */,
@@ -2502,6 +2511,7 @@
 				B39E811A268E849900D31189 /* AttributionNetwork.swift in Sources */,
 				37E35C8515C5E2D01B0AF5C1 /* Strings.swift in Sources */,
 				2D9F4A5526C30CA800B07B43 /* PurchasesOrchestrator.swift in Sources */,
+				57C2931528BFEF4F0054EDFC /* PurchasesError.swift in Sources */,
 				37E3529267833EA8ED9F06BE /* DateFormatter+Extensions.swift in Sources */,
 				57C381DA2796153D009E3940 /* SK1StoreProductDiscount.swift in Sources */,
 				57DE807328074C76008D6C6F /* SK2Storefront.swift in Sources */,
@@ -2598,6 +2608,7 @@
 				351B51B826D450E800BD2BD7 /* StoreKitWrapperTests.swift in Sources */,
 				A56C2E012819C33500995421 /* BackendPostAdServicesTokenTests.swift in Sources */,
 				5766AAD5283E9B7400FA6091 /* PurchasesRestoreTests.swift in Sources */,
+				57E4A52128BD8F610095C793 /* ErrorMatcher.swift in Sources */,
 				FD18ED4E2837F89200C5AA4F /* StoreKitWorkaroundsTests.swift in Sources */,
 				B3CD0D8827F25E3E000793F5 /* BackendSubscriberAttributesTests.swift in Sources */,
 				2DDF41E624F6F5DC005BC22D /* MockSK1Product.swift in Sources */,
@@ -2702,6 +2713,7 @@
 				579234E327F7788900B39C68 /* BaseBackendIntegrationTests.swift in Sources */,
 				2DE20B6F264087FB004C597D /* StoreKitIntegrationTests.swift in Sources */,
 				2D3BFAD126DEA45C00370B11 /* MockSK1Product.swift in Sources */,
+				57C2932A28BFF89D0054EDFC /* ErrorMatcher.swift in Sources */,
 				2DE61A84264190830021CEA0 /* Constants.swift in Sources */,
 				579234E527F779FE00B39C68 /* SubscriberAttributesManagerIntegrationTests.swift in Sources */,
 				2D3BFAD226DEA46600370B11 /* MockProductsRequest.swift in Sources */,

--- a/Sources/Error Handling/BackendError.swift
+++ b/Sources/Error Handling/BackendError.swift
@@ -72,9 +72,9 @@ extension BackendError {
 
 }
 
-extension BackendError: ErrorCodeConvertible {
+extension BackendError: PurchasesErrorConvertible {
 
-    var asPurchasesError: Error {
+    var asPurchasesError: PurchasesError {
         switch self {
         case let .networkError(error):
             return error.asPurchasesError
@@ -84,8 +84,10 @@ extension BackendError: ErrorCodeConvertible {
                                                     functionName: source.function,
                                                     line: source.line)
 
-        case .emptySubscriberAttributes:
-            return ErrorCode.emptySubscriberAttributes
+        case let .emptySubscriberAttributes(source):
+            return ErrorUtils.emptySubscriberAttributesError(fileName: source.file,
+                                                             functionName: source.function,
+                                                             line: source.line)
 
         case let .missingReceiptFile(source):
             return ErrorUtils.missingReceiptFileError(fileName: source.file,

--- a/Sources/Error Handling/ErrorCode.swift
+++ b/Sources/Error Handling/ErrorCode.swift
@@ -277,19 +277,25 @@ extension ErrorCode {
 
 }
 
-/// An `Error` that can be converted into an ``ErrorCode``
-/// - Note: the return value is ``Error`` since that allows errors
-/// to be encoded into `NSError` to include additional context.
-protocol ErrorCodeConvertible: Swift.Error {
+// MARK: - PurchasesErrorConvertible
 
-    /// Convert the receiver into an `ErrorCode` with all the necessary context
+/// An `Error` that can be converted into a `PurchasesError`
+protocol PurchasesErrorConvertible: Swift.Error {
+
+    /// Convert the receiver into a `PurchasesError` with all the necessary context.
+    ///
     /// ### Related symbols:
     /// - ``ErrorUtils``
-    var asPurchasesError: Error { get }
+    /// - ``ErrorCode``
+    var asPurchasesError: PurchasesError { get }
 
 }
 
-extension ErrorCodeConvertible {
+extension PurchasesErrorConvertible {
+
+    var asPublicError: PublicError {
+        return self.asPurchasesError.asPublicError
+    }
 
     var description: String {
         return self.asPurchasesError.localizedDescription

--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -33,7 +33,7 @@ enum ErrorUtils {
         withUnderlyingError underlyingError: Error? = nil,
         extraUserInfo: [NSError.UserInfoKey: Any]? = nil,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
 
         let errorCode: ErrorCode
         if case NetworkError.dnsError(_, _, _)? = underlyingError {
@@ -54,7 +54,7 @@ enum ErrorUtils {
      */
     static func offlineConnectionError(
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         return error(with: .offlineConnectionError,
                      fileName: fileName, functionName: functionName, line: line)
     }
@@ -73,7 +73,7 @@ enum ErrorUtils {
     static func backendError(
         withBackendCode backendCode: BackendErrorCode, backendMessage: String?,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         return backendError(withBackendCode: backendCode, backendMessage: backendMessage, extraUserInfo: nil,
                             fileName: fileName, functionName: functionName, line: line)
     }
@@ -86,7 +86,7 @@ enum ErrorUtils {
     static func unexpectedBackendResponseError(
         extraUserInfo: [NSError.UserInfoKey: Any]? = nil,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         return error(with: ErrorCode.unexpectedBackendResponseError, extraUserInfo: extraUserInfo,
                      fileName: fileName, functionName: functionName, line: line)
     }
@@ -102,7 +102,7 @@ enum ErrorUtils {
         withSubError subError: Error?,
         extraContext: String? = nil,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         return backendResponseError(withSubError: subError,
                                     extraContext: extraContext,
                                     fileName: fileName, functionName: functionName, line: line)
@@ -116,8 +116,18 @@ enum ErrorUtils {
      */
     static func missingReceiptFileError(
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         return error(with: ErrorCode.missingReceiptFileError,
+                     fileName: fileName, functionName: functionName, line: line)
+    }
+
+    /**
+     * Constructs an Error with the ``ErrorCode/emptySubscriberAttributes`` code.
+     */
+    static func emptySubscriberAttributesError(
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> PurchasesError {
+        return error(with: .emptySubscriberAttributes,
                      fileName: fileName, functionName: functionName, line: line)
     }
 
@@ -129,7 +139,7 @@ enum ErrorUtils {
      */
     static func missingAppUserIDError(
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         return error(with: ErrorCode.invalidAppUserIdError,
                      fileName: fileName, functionName: functionName, line: line)
     }
@@ -142,7 +152,7 @@ enum ErrorUtils {
      */
     static func productDiscountMissingIdentifierError(
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         return error(with: ErrorCode.productDiscountMissingIdentifierError,
                      fileName: fileName, functionName: functionName, line: line)
     }
@@ -155,7 +165,7 @@ enum ErrorUtils {
      */
     static func productDiscountMissingSubscriptionGroupIdentifierError(
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         return error(with: ErrorCode.productDiscountMissingSubscriptionGroupIdentifierError,
                      fileName: fileName, functionName: functionName, line: line)
     }
@@ -168,7 +178,7 @@ enum ErrorUtils {
      */
     static func logOutAnonymousUserError(
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         return error(with: ErrorCode.logOutAnonymousUserError,
                      fileName: fileName, functionName: functionName, line: line)
     }
@@ -181,7 +191,7 @@ enum ErrorUtils {
      */
     static func paymentDeferredError(
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         return error(with: ErrorCode.paymentPendingError, message: "The payment is deferred.",
                      fileName: fileName, functionName: functionName, line: line)
     }
@@ -192,7 +202,7 @@ enum ErrorUtils {
     static func unknownError(
         message: String? = nil, error: Error? = nil,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         return ErrorUtils.error(with: ErrorCode.unknownError, message: message, underlyingError: error,
                                 fileName: fileName, functionName: functionName, line: line)
     }
@@ -205,7 +215,7 @@ enum ErrorUtils {
      */
     static func operationAlreadyInProgressError(
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         return error(with: ErrorCode.operationAlreadyInProgressForProductError,
                      fileName: fileName, functionName: functionName, line: line)
     }
@@ -220,10 +230,10 @@ enum ErrorUtils {
         message: String? = nil,
         underlyingError: Error? = nil,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
-        return error(with: ErrorCode.configurationError,
-                     message: message, underlyingError: underlyingError,
-                     fileName: fileName, functionName: functionName, line: line)
+    ) -> PurchasesError {
+        return self.error(with: ErrorCode.configurationError,
+                          message: message, underlyingError: underlyingError,
+                          fileName: fileName, functionName: functionName, line: line)
     }
 
     /**
@@ -234,7 +244,7 @@ enum ErrorUtils {
     static func purchasesError(
         withSKError error: Error,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         switch error {
         case let skError as SKError:
             return skError.asPurchasesError
@@ -257,12 +267,33 @@ enum ErrorUtils {
     static func purchasesError(
         withStoreKitError error: Error,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         switch error {
         case let storeKitError as StoreKitError:
             return storeKitError.asPurchasesError
         case let purchasesError as Product.PurchaseError:
             return purchasesError.asPurchasesError
+        default:
+            return ErrorUtils.unknownError(
+                error: error,
+                fileName: fileName, functionName: functionName, line: line
+            )
+        }
+    }
+
+    /**
+     * Maps an untyped `Error` into a `PurchasesError`.
+     * If the error is already a `PurchasesError`, this simply returns the same value,
+     * otherwise it wraps it into a ``ErrorCode/unknownError``.
+     */
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    static func purchasesError(
+        withUntypedError error: Error,
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> PurchasesError {
+        switch error {
+        case let purchasesError as PurchasesError:
+            return purchasesError
         default:
             return ErrorUtils.unknownError(
                 error: error,
@@ -279,7 +310,7 @@ enum ErrorUtils {
     static func purchaseCancelledError(
         error: Error? = nil,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         let errorCode = ErrorCode.purchaseCancelledError
         return ErrorUtils.error(with: errorCode,
                                 message: errorCode.description,
@@ -296,7 +327,7 @@ enum ErrorUtils {
     static func productNotAvailableForPurchaseError(
         error: Error? = nil,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         return ErrorUtils.error(with: .productNotAvailableForPurchaseError,
                                 underlyingError: error)
     }
@@ -307,7 +338,7 @@ enum ErrorUtils {
     static func productAlreadyPurchasedError(
         error: Error? = nil,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         return ErrorUtils.error(with: .productAlreadyPurchasedError,
                                 underlyingError: error)
     }
@@ -318,7 +349,7 @@ enum ErrorUtils {
     static func purchaseNotAllowedError(
         error: Error? = nil,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         return ErrorUtils.error(with: .purchaseNotAllowedError,
                                 underlyingError: error)
     }
@@ -329,7 +360,7 @@ enum ErrorUtils {
     static func purchaseInvalidError(
         error: Error? = nil,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         return ErrorUtils.error(with: .purchaseInvalidError,
                                 underlyingError: error)
     }
@@ -340,7 +371,7 @@ enum ErrorUtils {
     static func ineligibleError(
         error: Error? = nil,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         return ErrorUtils.error(with: .ineligibleError,
                                 underlyingError: error)
     }
@@ -351,7 +382,7 @@ enum ErrorUtils {
     static func invalidPromotionalOfferError(
         error: Error? = nil,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         return ErrorUtils.error(with: .invalidPromotionalOfferError,
                                 underlyingError: error)
     }
@@ -364,7 +395,7 @@ enum ErrorUtils {
     static func storeProblemError(
         withMessage message: String? = nil, error: Error? = nil,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         let errorCode = ErrorCode.storeProblemError
         return ErrorUtils.error(with: errorCode,
                                 message: message,
@@ -380,7 +411,7 @@ enum ErrorUtils {
     static func customerInfoError(
         withMessage message: String? = nil, error: Error? = nil,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         let errorCode = ErrorCode.customerInfoError
         return ErrorUtils.error(with: errorCode,
                                 message: message,
@@ -396,7 +427,7 @@ enum ErrorUtils {
     static func systemInfoError(
         withMessage message: String, error: Error? = nil,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         let errorCode = ErrorCode.systemInfoError
         return ErrorUtils.error(with: errorCode,
                                 message: message,
@@ -412,7 +443,7 @@ enum ErrorUtils {
     static func beginRefundRequestError(
         withMessage message: String, error: Error? = nil,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         let errorCode = ErrorCode.beginRefundRequestError
         return ErrorUtils.error(with: errorCode,
                                 message: message,
@@ -427,7 +458,7 @@ enum ErrorUtils {
      */
     static func productRequestTimedOutError(
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         return ErrorUtils.error(with: .productRequestTimedOut,
                                 fileName: fileName, functionName: functionName, line: line)
     }
@@ -441,7 +472,7 @@ extension ErrorUtils {
                              backendMessage: String? = nil,
                              extraUserInfo: [NSError.UserInfoKey: Any]? = nil,
                              fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         let errorCode = backendCode.toPurchasesErrorCode()
         let underlyingError = backendUnderlyingError(backendCode: backendCode, backendMessage: backendMessage)
 
@@ -462,7 +493,7 @@ private extension ErrorUtils {
                       extraUserInfo: [NSError.UserInfoKey: Any]? = nil,
                       fileName: String = #fileID,
                       functionName: String = #function,
-                      line: UInt = #line) -> Error {
+                      line: UInt = #line) -> PurchasesError {
         var userInfo = extraUserInfo ?? [:]
         userInfo[NSLocalizedDescriptionKey as NSError.UserInfoKey] = message ?? code.description
         if let underlyingError = underlyingError {
@@ -478,18 +509,14 @@ private extension ErrorUtils {
             fileName: fileName, functionName: functionName, line: line
         )
 
-        let nsError = code as NSError
-        let nsErrorWithUserInfo = NSError(domain: nsError.domain,
-                                          code: nsError.code,
-                                          userInfo: userInfo as [String: Any])
-        return nsErrorWithUserInfo as Error
+        return .init(error: code, userInfo: userInfo)
     }
 
     static func backendResponseError(
         withSubError subError: Error?,
         extraContext: String?,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         var userInfo: [NSError.UserInfoKey: Any] = [:]
         let describableSubError = subError as? DescribableError
         let errorDescription = describableSubError?.description ?? ErrorCode.unexpectedBackendResponseError.description
@@ -500,19 +527,13 @@ private extension ErrorUtils {
         userInfo[.file] = "\(fileName):\(line)"
         userInfo[.function] = functionName
 
-        let nsError = ErrorCode.unexpectedBackendResponseError as NSError
-        let nsErrorWithUserInfo = NSError(domain: nsError.domain,
-                                          code: nsError.code,
-                                          userInfo: userInfo as [String: Any])
-        return nsErrorWithUserInfo as Error
+        return .init(error: .unexpectedBackendResponseError, userInfo: userInfo)
     }
 
-    static func backendUnderlyingError(backendCode: BackendErrorCode, backendMessage: String?) -> Error {
-        let userInfo = [
+    static func backendUnderlyingError(backendCode: BackendErrorCode, backendMessage: String?) -> NSError {
+        return backendCode.addingUserInfo([
             NSLocalizedDescriptionKey: backendMessage ?? ""
-        ]
-
-        return backendCode.addingUserInfo(userInfo)
+        ])
     }
 
     // swiftlint:disable:next function_body_length
@@ -593,12 +614,16 @@ private extension ErrorUtils {
 
 extension Error {
 
-    func addingUserInfo(_ userInfo: [String: Any]) -> Error {
+    @_disfavoredOverload
+    func addingUserInfo<Result: NSError>(_ userInfo: [NSError.UserInfoKey: Any]) -> Result {
+        return self.addingUserInfo(userInfo as [String: Any])
+    }
+
+    func addingUserInfo<Result: NSError>(_ userInfo: [String: Any]) -> Result {
         let nsError = self as NSError
-        let nsErrorWithUserInfo = NSError(domain: nsError.domain,
-                                          code: nsError.code,
-                                          userInfo: nsError.userInfo + userInfo)
-        return nsErrorWithUserInfo as Error
+        return Result.init(domain: nsError.domain,
+                           code: nsError.code,
+                           userInfo: nsError.userInfo + userInfo)
     }
 
 }

--- a/Sources/Error Handling/PurchasesError.swift
+++ b/Sources/Error Handling/PurchasesError.swift
@@ -1,0 +1,67 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchasesError.swift
+//
+//  Created by Nacho Soto on 8/31/22.
+
+import Foundation
+
+/// An error returned by a `RevenueCat` public API.
+public typealias PublicError = NSError
+
+/// An internal error representation, containing an `ErrorCode` and additional `userInfo`.
+///
+/// `ErrorCode` is essentially only domain (`ErrorCode.domain`) and a code, but can't contain any more information
+/// unless it's converted into an `NSError`.
+/// This serves that same purpose, but allows us to pass these around in a type-safe manner,
+/// being able to distinguish them from any other `NSError`.
+internal struct PurchasesError: Error {
+
+    let error: ErrorCode
+    let userInfo: [String: Any]
+
+}
+
+extension PurchasesError {
+
+    /// Converts this error into an error that can be used in a public API.
+    /// The error returned by this can be converted to ``ErrorCode``.
+    /// Example:
+    /// ```
+    /// let error = ErrorUtils.unknownError().asPublicError
+    /// let errorCode = error as? ErrorCode
+    /// ```
+    var asPublicError: PublicError {
+        return NSError(domain: Self.errorDomain, code: self.errorCode, userInfo: self.userInfo)
+    }
+
+}
+
+// MARK: -
+
+extension PurchasesError: CustomNSError {
+
+    static let errorDomain: String = ErrorCode.errorDomain
+
+    var errorCode: Int { return (self.error as NSError).code }
+    var errorUserInfo: [String: Any] { return self.userInfo }
+
+}
+
+// MARK: -
+
+extension PurchasesError {
+
+    /// Overload of the default initializer with `NSError.UserInfoKey` as user info key type.
+    init(error: ErrorCode, userInfo: [NSError.UserInfoKey: Any]) {
+        self.init(error: error, userInfo: userInfo as [String: Any])
+    }
+
+}

--- a/Sources/Error Handling/SKError+Extensions.swift
+++ b/Sources/Error Handling/SKError+Extensions.swift
@@ -14,9 +14,9 @@
 import Foundation
 import StoreKit
 
-extension SKError: ErrorCodeConvertible {
+extension SKError: PurchasesErrorConvertible {
 
-    var asPurchasesError: Error {
+    var asPurchasesError: PurchasesError {
         switch self.code {
         case .cloudServiceNetworkConnectionFailed,
              .cloudServiceRevoked,

--- a/Sources/Error Handling/StoreKitError+Extensions.swift
+++ b/Sources/Error Handling/StoreKitError+Extensions.swift
@@ -15,9 +15,9 @@ import StoreKit
 
 /// - SeeAlso: SKError+Extensions
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-extension StoreKitError: ErrorCodeConvertible {
+extension StoreKitError: PurchasesErrorConvertible {
 
-    var asPurchasesError: Error {
+    var asPurchasesError: PurchasesError {
         switch self {
         case .userCancelled:
             return ErrorUtils.purchaseCancelledError(error: self)
@@ -50,9 +50,9 @@ extension StoreKitError: ErrorCodeConvertible {
 }
 
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-extension Product.PurchaseError: ErrorCodeConvertible {
+extension Product.PurchaseError: PurchasesErrorConvertible {
 
-    var asPurchasesError: Error {
+    var asPurchasesError: PurchasesError {
         switch self {
         case .invalidQuantity:
             return ErrorUtils.storeProblemError(error: self)

--- a/Sources/FoundationExtensions/Error+Extensions.swift
+++ b/Sources/FoundationExtensions/Error+Extensions.swift
@@ -13,31 +13,6 @@
 
 import Foundation
 
-extension Error {
-
-    /**
-     * Addes a sub-error to the userInfo of a new `error` object as some extra context. Sometimes we have multiple error
-     * Conditions but only a single place to surface them. This adds the second error as extra context to help during
-     * debugging.
-     * - Returns: a new error matching `self` but with the `extraContext` and `error` added.
-     */
-    func addingUnderlyingError(_ error: Error?, extraContext: String? = nil) -> Error {
-        guard let underlyingNSError = error as NSError? else {
-            return self
-        }
-
-        let asNSError = self as NSError
-        var userInfo = asNSError.userInfo as [NSError.UserInfoKey: Any]
-        userInfo[NSUnderlyingErrorKey as NSString] = underlyingNSError
-        userInfo[.extraContext] = extraContext ?? underlyingNSError.localizedDescription
-        let nsErrorWithUserInfo = NSError(domain: asNSError.domain,
-                                          code: asNSError.code,
-                                          userInfo: userInfo as [String: Any])
-        return nsErrorWithUserInfo as Error
-    }
-
-}
-
 extension NSError {
 
     var subscriberAttributesErrors: [String: String]? {

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -85,7 +85,7 @@ class IdentityManager: CurrentUserProvider {
         }
     }
 
-    func logOut(completion: @escaping (Error?) -> Void) {
+    func logOut(completion: @escaping (PurchasesError?) -> Void) {
         self.attributeSyncing.syncSubscriberAttributes(currentAppUserID: self.currentAppUserID) {
             self.performLogOut(completion: completion)
         }
@@ -128,7 +128,7 @@ private extension IdentityManager {
         }
     }
 
-    func performLogOut(completion: (Error?) -> Void) {
+    func performLogOut(completion: (PurchasesError?) -> Void) {
         Logger.info(Strings.identity.log_out_called_for_user)
 
         if self.currentUserIsAnonymous {

--- a/Sources/Networking/HTTPClient/HTTPResponse.swift
+++ b/Sources/Networking/HTTPClient/HTTPResponse.swift
@@ -75,7 +75,7 @@ extension ErrorResponse {
         file: String = #fileID,
         function: String = #function,
         line: UInt = #line
-    ) -> Error {
+    ) -> PurchasesError {
         var userInfo: [NSError.UserInfoKey: Any] = [
             .statusCode: statusCode.rawValue
         ]

--- a/Sources/Networking/HTTPClient/NetworkError.swift
+++ b/Sources/Networking/HTTPClient/NetworkError.swift
@@ -88,9 +88,9 @@ extension NetworkError {
 
 }
 
-extension NetworkError: ErrorCodeConvertible {
+extension NetworkError: PurchasesErrorConvertible {
 
-    var asPurchasesError: Error {
+    var asPurchasesError: PurchasesError {
         switch self {
         case let .decoding(error, source):
             return ErrorUtils.unexpectedBackendResponse(

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -189,9 +189,9 @@ extension OfferingsManager {
 
 }
 
-extension OfferingsManager.Error: ErrorCodeConvertible {
+extension OfferingsManager.Error: PurchasesErrorConvertible {
 
-    var asPurchasesError: Error {
+    var asPurchasesError: PurchasesError {
         switch self {
         case let .backendError(backendError):
             return backendError.asPurchasesError

--- a/Sources/Purchasing/Purchases/Attribution.swift
+++ b/Sources/Purchasing/Purchases/Attribution.swift
@@ -375,7 +375,7 @@ extension Attribution {
     /// - Returns: the number of attributes that will be synced
     @discardableResult
     func syncSubscriberAttributes(
-        syncedAttribute: (@Sendable (Error?) -> Void)? = nil,
+        syncedAttribute: (@Sendable (PurchasesError?) -> Void)? = nil,
         completion: (@Sendable () -> Void)? = nil
     ) -> Int {
         return self.subscriberAttributesManager.syncAttributesForAllUsers(currentAppUserID: self.appUserID,
@@ -389,7 +389,7 @@ extension Attribution {
 
     @discardableResult
     func syncAttributesForAllUsers(currentAppUserID: String,
-                                   syncedAttribute: (@Sendable (Error?) -> Void)? = nil,
+                                   syncedAttribute: (@Sendable (PurchasesError?) -> Void)? = nil,
                                    completion: (@Sendable () -> Void)? = nil) -> Int {
         self.subscriberAttributesManager.syncAttributesForAllUsers(currentAppUserID: currentAppUserID,
                                                                    syncedAttribute: syncedAttribute,

--- a/Sources/Purchasing/StoreKit1/ProductsFetcherSK1.swift
+++ b/Sources/Purchasing/StoreKit1/ProductsFetcherSK1.swift
@@ -16,7 +16,7 @@ import StoreKit
 
 final class ProductsFetcherSK1: NSObject {
 
-    typealias Callback = (Result<Set<SK1Product>, Error>) -> Void
+    typealias Callback = (Result<Set<SK1Product>, PurchasesError>) -> Void
 
     let requestTimeout: TimeInterval
     private let productsRequestFactory: ProductsRequestFactory
@@ -85,7 +85,7 @@ final class ProductsFetcherSK1: NSObject {
     }
 
     func products(withIdentifiers identifiers: Set<String>,
-                  completion: @escaping (Result<Set<SK1StoreProduct>, Error>) -> Void) {
+                  completion: @escaping (Result<Set<SK1StoreProduct>, PurchasesError>) -> Void) {
         self.sk1Products(withIdentifiers: identifiers) { skProducts in
             let result = skProducts
                 .map { Set($0.map(SK1StoreProduct.init)) }
@@ -172,7 +172,7 @@ extension ProductsFetcherSK1: SKProductsRequestDelegate {
                 self.completionHandlers.removeValue(forKey: productRequest.identifiers)
                 self.productsByRequests.removeValue(forKey: request)
                 for completion in completionBlocks {
-                    completion(.failure(error))
+                    completion(.failure(ErrorUtils.purchasesError(withSKError: error)))
                 }
             } else {
                 let delayInSeconds = Int((self.requestTimeout / 10).rounded())

--- a/Sources/Purchasing/StoreKit2/ProductsFetcherSK2.swift
+++ b/Sources/Purchasing/StoreKit2/ProductsFetcherSK2.swift
@@ -26,6 +26,7 @@ actor ProductsFetcherSK2 {
     /// Getter is declared as `internal` for testing purposes only.
     private(set) var cachedProductsByIdentifier: [String: SK2StoreProduct] = [:]
 
+    /// - Throws: `ProductsFetcherSK2.Error`
     func products(identifiers: Set<String>) async throws -> Set<SK2StoreProduct> {
         do {
             if let cachedProducts = await self.cachedProducts(withIdentifiers: identifiers) {

--- a/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -139,7 +139,7 @@ class SubscriberAttributesManager {
     /// - Returns: the number of attributes that will be synced
     @discardableResult
     func syncAttributesForAllUsers(currentAppUserID: String,
-                                   syncedAttribute: (@Sendable (Error?) -> Void)? = nil,
+                                   syncedAttribute: (@Sendable (PurchasesError?) -> Void)? = nil,
                                    completion: (@Sendable () -> Void)? = nil) -> Int {
         let unsyncedAttributesForAllUsers = unsyncedAttributesByKeyForAllUsers()
         let total = unsyncedAttributesForAllUsers.count
@@ -176,7 +176,7 @@ class SubscriberAttributesManager {
         return total
     }
 
-    func handleAttributesSynced(syncingAppUserId: String, currentAppUserId: String, error: Error?) {
+    func handleAttributesSynced(syncingAppUserId: String, currentAppUserId: String, error: BackendError?) {
         if error == nil {
             Logger.rcSuccess(Strings.attribution.attributes_sync_success(appUserID: syncingAppUserId))
             if syncingAppUserId != currentAppUserId {

--- a/Sources/Support/ManageSubscriptionsHelper.swift
+++ b/Sources/Support/ManageSubscriptionsHelper.swift
@@ -31,11 +31,11 @@ class ManageSubscriptionsHelper {
 
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
-    func showManageSubscriptions(completion: @escaping (Result<Void, Error>) -> Void) {
+    func showManageSubscriptions(completion: @escaping (Result<Void, PurchasesError>) -> Void) {
         let currentAppUserID = self.currentUserProvider.currentAppUserID
         self.customerInfoManager.customerInfo(appUserID: currentAppUserID,
                                               fetchPolicy: .cachedOrFetched) { result in
-            let result: Result<URL, Error> = result
+            let result: Result<URL, PurchasesError> = result
                 .mapError { error in
                     let message = Strings.failed_to_get_management_url_error_unknown(error: error)
                     return ErrorUtils.customerInfoError(withMessage: message.description, error: error)
@@ -79,7 +79,7 @@ extension ManageSubscriptionsHelper: @unchecked Sendable {}
 private extension ManageSubscriptionsHelper {
 
     func showAppleManageSubscriptions(managementURL: URL,
-                                      completion: @escaping (Result<Void, Error>) -> Void) {
+                                      completion: @escaping (Result<Void, PurchasesError>) -> Void) {
 #if os(iOS) && !targetEnvironment(macCatalyst)
         if #available(iOS 15.0, *),
            // showManageSubscriptions doesn't work on iOS apps running on Apple Silicon
@@ -95,7 +95,7 @@ private extension ManageSubscriptionsHelper {
         openURL(managementURL, completion: completion)
     }
 
-    func openURL(_ url: URL, completion: @escaping (Result<Void, Error>) -> Void) {
+    func openURL(_ url: URL, completion: @escaping (Result<Void, PurchasesError>) -> Void) {
 #if os(iOS)
         openURLIfNotAppExtension(url: url)
 #elseif os(macOS)
@@ -124,7 +124,7 @@ private extension ManageSubscriptionsHelper {
     @MainActor
     @available(iOS 15.0, *)
     @available(macOS, unavailable)
-    func showSK2ManageSubscriptions() async -> Result<Void, Error> {
+    func showSK2ManageSubscriptions() async -> Result<Void, PurchasesError> {
         guard let application = systemInfo.sharedUIApplication,
               let windowScene = application.currentWindowScene else {
                   let message = Strings.failed_to_get_window_scene

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -149,7 +149,7 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     let customerInfo: CustomerInfo? = nil
     purchases.delegate?.purchases?(purchases, receivedUpdated: customerInfo!)
 
-    let purchaseBlock = { (_: @MainActor @Sendable (StoreTransaction?, CustomerInfo?, Error?, Bool) -> Void) in }
+    let purchaseBlock = { (_: @MainActor @Sendable (StoreTransaction?, CustomerInfo?, PublicError?, Bool) -> Void) in }
     purchases.delegate?.purchases?(purchases, readyForPromotedProduct: storeProduct, purchase: purchaseBlock)
 }
 

--- a/Tests/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
+++ b/Tests/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
@@ -55,7 +55,7 @@ class ManageSubscriptionsHelperTests: TestCase {
 
     func testShowManageSubscriptions() throws {
         // given
-        var receivedResult: Result<Void, Error>?
+        var receivedResult: Result<Void, PurchasesError>?
         customerInfoManager.stubbedCustomerInfoResult = .success(try CustomerInfo(data: mockCustomerInfoData))
 
         // when
@@ -75,7 +75,7 @@ class ManageSubscriptionsHelperTests: TestCase {
         )
 
         // given
-        var receivedResult: Result<Void, Error>?
+        var receivedResult: Result<Void, PurchasesError>?
         customerInfoManager.stubbedCustomerInfoResult = .failure(error)
 
         // when
@@ -86,7 +86,7 @@ class ManageSubscriptionsHelperTests: TestCase {
         // then
         expect(receivedResult).toEventuallyNot(beNil())
 
-        let nonNilReceivedResult: Result<Void, Error> = try XCTUnwrap(receivedResult)
+        let nonNilReceivedResult = try XCTUnwrap(receivedResult)
         let expectedErrorMessage = "Failed to get managementURL from CustomerInfo. " +
         "Details: The operation couldn’t be completed"
         let expectedError = ErrorUtils.customerInfoError(withMessage: expectedErrorMessage,

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -23,7 +23,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         let manager = try createManager(storeKit2Setting: .disabled)
 
         let identifier = "com.revenuecat.monthly_4.99.1_week_intro"
-        var receivedProducts: Result<Set<StoreProduct>, Error>?
+        var receivedProducts: Result<Set<StoreProduct>, PurchasesError>?
 
         manager.products(withIdentifiers: Set([identifier])) { products in
             receivedProducts = products
@@ -46,7 +46,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         let manager = try createManager(storeKit2Setting: .enabledForCompatibleDevices)
 
         let identifier = "com.revenuecat.monthly_4.99.1_week_intro"
-        var receivedProducts: Result<Set<StoreProduct>, Error>?
+        var receivedProducts: Result<Set<StoreProduct>, PurchasesError>?
 
         manager.products(withIdentifiers: Set([identifier])) { products in
             receivedProducts = products

--- a/Tests/StoreKitUnitTests/StoreProductTests.swift
+++ b/Tests/StoreKitUnitTests/StoreProductTests.swift
@@ -84,7 +84,7 @@ class StoreProductTests: StoreKitConfigTestCase {
     }
 
     func testSk1DetailsWrapsCorrectly() throws {
-        var result: Result<Set<SK1StoreProduct>, Swift.Error>!
+        var result: Result<Set<SK1StoreProduct>, PurchasesError>!
 
         self.sk1Fetcher.products(withIdentifiers: Set([Self.productID])) { products in
             result = products

--- a/Tests/UnitTests/Mocks/MockIdentityManager.swift
+++ b/Tests/UnitTests/Mocks/MockIdentityManager.swift
@@ -64,11 +64,11 @@ class MockIdentityManager: IdentityManager {
 
     // MARK: - LogOut
 
-    var mockLogOutError: BackendError?
+    var mockLogOutError: PurchasesError?
     var invokedLogOut = false
     var invokedLogOutCount = 0
 
-    override func logOut(completion: @escaping (Error?) -> Void) {
+    override func logOut(completion: @escaping (PurchasesError?) -> Void) {
         self.invokedLogOut = true
         self.invokedLogOutCount += 1
 

--- a/Tests/UnitTests/Mocks/MockManageSubscriptionsHelper.swift
+++ b/Tests/UnitTests/Mocks/MockManageSubscriptionsHelper.swift
@@ -16,12 +16,12 @@ import Foundation
 
 class MockManageSubscriptionsHelper: ManageSubscriptionsHelper {
 
-    var mockError: Error?
+    var mockError: PurchasesError?
 
 #if os(iOS) || os(macOS)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
-    override func showManageSubscriptions(completion: @escaping (Result<Void, Error>) -> Void) {
+    override func showManageSubscriptions(completion: @escaping (Result<Void, PurchasesError>) -> Void) {
         if let error = mockError {
             completion(.failure(error))
         } else {

--- a/Tests/UnitTests/Mocks/MockProductsManager.swift
+++ b/Tests/UnitTests/Mocks/MockProductsManager.swift
@@ -13,10 +13,10 @@ class MockProductsManager: ProductsManager {
     var invokedProductsCount = 0
     var invokedProductsParameters: Set<String>?
     var invokedProductsParametersList = [(identifiers: Set<String>, Void)]()
-    var stubbedProductsCompletionResult: Result<Set<StoreProduct>, Error>?
+    var stubbedProductsCompletionResult: Result<Set<StoreProduct>, PurchasesError>?
 
     override func products(withIdentifiers identifiers: Set<String>,
-                           completion: @escaping (Result<Set<StoreProduct>, Error>) -> Void) {
+                           completion: @escaping (Result<Set<StoreProduct>, PurchasesError>) -> Void) {
         invokedProducts = true
         invokedProductsCount += 1
         invokedProductsParameters = identifiers

--- a/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
+++ b/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
@@ -296,7 +296,7 @@ class MockSubscriberAttributesManager: SubscriberAttributesManager {
 
     override func syncAttributesForAllUsers(
         currentAppUserID: String,
-        syncedAttribute: (@Sendable (Error?) -> Void)? = nil,
+        syncedAttribute: (@Sendable (PurchasesError?) -> Void)? = nil,
         completion: (@Sendable () -> Void)? = nil
     ) -> Int {
         invokedSyncAttributesForAllUsers = true

--- a/Tests/UnitTests/Networking/BaseErrorTests.swift
+++ b/Tests/UnitTests/Networking/BaseErrorTests.swift
@@ -19,10 +19,10 @@ import XCTest
 
 class BaseErrorTests: TestCase {
 
-    /// Compares the result of calling `asPurchasesError` on a `ErrorCodeConvertible`
+    /// Compares the result of calling `asPurchasesError` on a `PurchasesErrorConvertible`
     /// against the expected `ErrorCode`.
     final func verifyPurchasesError(
-        _ error: ErrorCodeConvertible,
+        _ error: PurchasesErrorConvertible,
         expectedCode: ErrorCode,
         underlyingError: Error? = nil,
         userInfoKeys: [NSError.UserInfoKey]? = nil,

--- a/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
+++ b/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
@@ -34,11 +34,11 @@ class ErrorUtilsTests: TestCase {
         super.tearDown()
     }
 
-    func testErrorsCanBeConvertedToErrorCode() throws {
-        let error = ErrorUtils.customerInfoError()
+    func testPublicErrorsCanBeConvertedToErrorCode() throws {
+        let error = ErrorUtils.customerInfoError().asPublicError
         let errorCode = try XCTUnwrap(error as? ErrorCode, "Error couldn't be converted to ErrorCode")
 
-        expect(errorCode).to(matchError(error))
+        expect(errorCode).to(matchError(error as Error))
     }
 
     func testPurchaseErrorsAreLoggedAsApppleErrors() {

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -154,7 +154,7 @@ extension OfferingsManagerTests {
     }
 
     func testOfferingsForAppUserIDReturnsConfigurationErrorIfProductsRequestsReturnsError() throws {
-        let error: Error = NSError(domain: SKErrorDomain, code: SKError.Code.storeProductNotAvailable.rawValue)
+        let error = ErrorUtils.unknownError()
 
         // given
         mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsResponse)

--- a/Tests/UnitTests/Purchasing/ProductsFetcherSK1Tests.swift
+++ b/Tests/UnitTests/Purchasing/ProductsFetcherSK1Tests.swift
@@ -27,7 +27,7 @@ class ProductsFetcherSK1Tests: TestCase {
 
     func testProductsWithIdentifiersCallsCompletionCorrectly() throws {
         let productIdentifiers = Set(["1", "2", "3"])
-        var receivedProducts: Result<Set<SK1Product>, Error>?
+        var receivedProducts: Result<Set<SK1Product>, PurchasesError>?
 
         productsFetcherSK1.sk1Products(withIdentifiers: productIdentifiers) { products in
             receivedProducts = products
@@ -98,7 +98,7 @@ class ProductsFetcherSK1Tests: TestCase {
         let fetcher = ProductsFetcherSK1(productsRequestFactory: productsRequestFactory,
                                          requestTimeout: timeout.seconds)
 
-        var receivedResult: Result<Set<SK1Product>, Error>?
+        var receivedResult: Result<Set<SK1Product>, PurchasesError>?
 
         fetcher.sk1Products(withIdentifiers: productIdentifiers) { result in
             receivedResult = result
@@ -117,7 +117,7 @@ class ProductsFetcherSK1Tests: TestCase {
         mockProducts.forEach { productsFetcherSK1.cacheProduct($0) }
 
         var completionCallCount = 0
-        var receivedProducts: Result<Set<SK1Product>, Error>?
+        var receivedProducts: Result<Set<SK1Product>, PurchasesError>?
 
         productsFetcherSK1.sk1Products(withIdentifiers: productIdentifiers) { products in
             receivedProducts = products
@@ -141,7 +141,7 @@ class ProductsFetcherSK1Tests: TestCase {
                                                 requestTimeout: tolerance.seconds)
 
         var completionCallCount = 0
-        var receivedResult: Result<Set<SKProduct>, Error>?
+        var receivedResult: Result<Set<SKProduct>, PurchasesError>?
 
         productsFetcherSK1.sk1Products(withIdentifiers: productIdentifiers) { result in
             receivedResult = result
@@ -152,8 +152,8 @@ class ProductsFetcherSK1Tests: TestCase {
                                                  timeout: productsRequestResponseTime + .milliseconds(30))
         expect(self.productsRequestFactory.invokedRequestCount) == 1
 
-        let error = try XCTUnwrap(receivedResult?.error as? ErrorCode)
-        expect(error) == ErrorCode.productRequestTimedOut
+        expect(receivedResult).to(beFailure())
+        expect(receivedResult?.error).to(matchError(ErrorCode.productRequestTimedOut))
         expect(request.cancelCalled) == true
     }
 
@@ -169,7 +169,7 @@ class ProductsFetcherSK1Tests: TestCase {
                                                 requestTimeout: tolerance.seconds)
 
         var completionCallCount = 0
-        var receivedResult: Result<Set<SKProduct>, Error>?
+        var receivedResult: Result<Set<SKProduct>, PurchasesError>?
 
         productsFetcherSK1.sk1Products(withIdentifiers: productIdentifiers) { result in
             receivedResult = result

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -19,8 +19,8 @@ import XCTest
 
 class PurchasesLogInTests: BasePurchasesTests {
 
-    private typealias LogInResult = Result<(customerInfo: CustomerInfo, created: Bool), Error>
-    private typealias LogOutResult = Result<CustomerInfo, Error>
+    private typealias LogInResult = Result<(customerInfo: CustomerInfo, created: Bool), PublicError>
+    private typealias LogOutResult = Result<CustomerInfo, PublicError>
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -60,7 +60,7 @@ class PurchasesLogInTests: BasePurchasesTests {
         expect(result).toEventuallyNot(beNil())
 
         expect(result).to(beFailure())
-        expect(result.error).to(matchError(error))
+        expect(result.error).to(matchError(error.asPurchasesError))
         expect(self.identityManager.invokedLogInCount) == 1
         expect(self.identityManager.invokedLogInParametersList) == [Self.appUserID]
     }
@@ -85,7 +85,7 @@ class PurchasesLogInTests: BasePurchasesTests {
     }
 
     func testLogOutWithFailure() {
-        let error: BackendError = .networkError(.offlineConnection())
+        let error = BackendError.networkError(.offlineConnection()).asPurchasesError
 
         self.identityManager.mockLogOutError = error
 
@@ -176,7 +176,7 @@ private extension PurchasesLogInTests {
     ]
 
     /// Converts the result of `Purchases.logIn` into `LogInResult`
-    private static func logInResult(_ info: CustomerInfo?, _ created: Bool, _ error: Error?) -> LogInResult {
+    private static func logInResult(_ info: CustomerInfo?, _ created: Bool, _ error: PublicError?) -> LogInResult {
         return .init(info.map { ($0, created) }, error)
     }
 

--- a/Tests/UnitTests/TestHelpers/ErrorMatcher.swift
+++ b/Tests/UnitTests/TestHelpers/ErrorMatcher.swift
@@ -1,0 +1,43 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ErrorMatcher.swift
+//
+//  Created by Nacho Soto on 8/29/22.
+
+import Nimble
+
+@testable import RevenueCat
+
+// Overloads for `Nimble.matchError` that allows comparing the domain/code between 2 errors
+// without failures because `ErrorCode` does not contain `userInfo`.
+
+/// Overload for `Nimble.matchError` that ignores the `PurchasesError` type and compares them as `Error`
+/// (comparing the domain and code)
+func matchError(_ error: PurchasesError) -> Predicate<Error> {
+    return Nimble.matchError(error as Error)
+}
+
+/// Overload for `Nimble.matchError` that ignores the `ErrorCode` type and compares them as `Error`
+/// (comparing the domain and code)
+func matchError(_ error: ErrorCode) -> Predicate<Error> {
+    return Nimble.matchError(error as Error)
+}
+
+/// Overload for `Nimble.throwError` that ignores the `PurchasesError` type and compares them as `Error`
+/// (comparing the domain and code)
+public func throwError<Out>(_ error: PurchasesError) -> Predicate<Out> {
+    return Nimble.throwError(error as Error)
+}
+
+/// Overload for `Nimble.throwError` that ignores the `ErrorCode` type and compares them as `Error`
+/// (comparing the domain and code)
+public func throwError<Out>(_ error: ErrorCode) -> Predicate<Out> {
+    return Nimble.throwError(error as Error)
+}


### PR DESCRIPTION
This is the last change from what was started with #1437. That PR introduced a few private error types, but for the errors returned in the public `APIs` we were still passing around `Error`s everywhere, which didn't provide any compile-time guarantees.

### Goals:
- Ensure that public APIs *only* return `ErrorCode`s wrapped with the additional `userInfo`, and not accidentally return other types like `SKError`, `BackendError`, `ErrorCode` directly, etc.
- Guarantee type-safety when passing errors around within our internal implementations instead of assuming certain thrown errors are of a particular type.

### Changes:
- Created `PurchasesError` for wrapping an `ErrorCode` with the additional `userInfo`.
- Changed returned errors from `Error` to `NSError`. This is a change in the API, but the new type is a more specific `Error` so it shouldn't lead to any changes in client apps.
- Because `PurchasesError` isn't implicitly convertible to `NSError`, this ensures that we don't return those values directly, and instead use `PurchasesError.asPublicError`.
- Changed `ErrorCodeConvertible` to a now more precise `PurchasesErrorConvertible`.

Thanks to this new type-safety this PR fixes at least 3 bugs where we were returning private errors instead of `ErrorCode`s.

### Testing:

Thanks to #1871 we know that the returned errors are still convertible to `ErrorCode` so users can `switch` over them.