### PR TITLE
Disable SK1's `StoreKitWrapper` if SK2 is enabled and available

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -286,6 +286,7 @@
 		5796A39927D6C1E000653165 /* BackendPostSubscriberAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A39827D6C1E000653165 /* BackendPostSubscriberAttributesTests.swift */; };
 		5796A3A927D7C43500653165 /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A3A827D7C43500653165 /* Deprecations.swift */; };
 		5796A3C027D7D64500653165 /* ResultExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5796A3BF27D7D64500653165 /* ResultExtensionsTests.swift */; };
+		579B67F428C5326A0094F7E8 /* PaymentQueueWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579B67F328C5326A0094F7E8 /* PaymentQueueWrapper.swift */; };
 		57A0FBF02749C0C2009E2FC3 /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */; };
 		57A0FBF22749CF66009E2FC3 /* SynchronizedUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */; };
 		57A17727276A721D0052D3A8 /* Set+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A17726276A721D0052D3A8 /* Set+Extensions.swift */; };
@@ -790,6 +791,7 @@
 		5796A39827D6C1E000653165 /* BackendPostSubscriberAttributesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendPostSubscriberAttributesTests.swift; sourceTree = "<group>"; };
 		5796A3A827D7C43500653165 /* Deprecations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deprecations.swift; sourceTree = "<group>"; };
 		5796A3BF27D7D64500653165 /* ResultExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultExtensionsTests.swift; sourceTree = "<group>"; };
+		579B67F328C5326A0094F7E8 /* PaymentQueueWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentQueueWrapper.swift; sourceTree = "<group>"; };
 		57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 		57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedUserDefaults.swift; sourceTree = "<group>"; };
 		57A17726276A721D0052D3A8 /* Set+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Set+Extensions.swift"; sourceTree = "<group>"; };
@@ -1128,6 +1130,7 @@
 				EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */,
 				2D991AC9268BA56900085481 /* StoreKitRequestFetcher.swift */,
 				2D4E926426990AB1000E10B0 /* StoreKitWrapper.swift */,
+				579B67F328C5326A0094F7E8 /* PaymentQueueWrapper.swift */,
 			);
 			path = StoreKit1;
 			sourceTree = "<group>";
@@ -2432,6 +2435,7 @@
 				2D22BF6526F3CB31001AE2F9 /* FatalErrorUtil.swift in Sources */,
 				2D1015DE275A57FC0086173F /* SubscriptionPeriod.swift in Sources */,
 				B3B5FBBF269E081E00104A0C /* InMemoryCachedObject.swift in Sources */,
+				579B67F428C5326A0094F7E8 /* PaymentQueueWrapper.swift in Sources */,
 				9A65E0802591977900DE00B0 /* ReceiptStrings.swift in Sources */,
 				B3DDB55926854865008CCF23 /* PurchaseOwnershipType.swift in Sources */,
 				57A0FBF02749C0C2009E2FC3 /* Atomic.swift in Sources */,

--- a/Sources/Logging/Strings/StoreKitStrings.swift
+++ b/Sources/Logging/Strings/StoreKitStrings.swift
@@ -28,6 +28,8 @@ enum StoreKitStrings {
 
     case skunknown_payment_mode(String)
 
+    case sk1_product_with_sk2_enabled
+
     case sk2_purchasing_added_promotional_offer_option(String)
 
     case sk2_unknown_product_type(String)
@@ -67,6 +69,9 @@ extension StoreKitStrings: CustomStringConvertible {
 
         case let .skunknown_payment_mode(name):
             return "Unrecognized PaymentMode: \(name)"
+
+        case .sk1_product_with_sk2_enabled:
+            return "This StoreProduct represents an SK1 product, but SK2 was expected."
 
         case let .sk2_purchasing_added_promotional_offer_option(discountIdentifier):
             return "Adding Product.PurchaseOption for discount '\(discountIdentifier)'"

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -249,6 +249,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     private let receiptFetcher: ReceiptFetcher
     private let requestFetcher: StoreKitRequestFetcher
     private let storeKitWrapper: StoreKitWrapper?
+    private let paymentQueueWrapper: PaymentQueueWrapper
     private let systemInfo: SystemInfo
     private var customerInfoObservationDisposable: (() -> Void)?
 
@@ -290,6 +291,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         let storeKitWrapper: StoreKitWrapper? = systemInfo.storeKit2Setting.shouldOnlyUseStoreKit2
         ? nil
         : StoreKitWrapper()
+        let paymentQueueWrapper = storeKitWrapper?.createPaymentQueueWrapper() ?? .init()
 
         let offeringsFactory = OfferingsFactory()
         let userDefaults = userDefaults ?? UserDefaults.standard
@@ -391,6 +393,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                   attributionPoster: attributionPoster,
                   backend: backend,
                   storeKitWrapper: storeKitWrapper,
+                  paymentQueueWrapper: paymentQueueWrapper,
                   notificationCenter: NotificationCenter.default,
                   systemInfo: systemInfo,
                   offeringsFactory: offeringsFactory,
@@ -413,6 +416,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
          attributionPoster: AttributionPoster,
          backend: Backend,
          storeKitWrapper: StoreKitWrapper?,
+         paymentQueueWrapper: PaymentQueueWrapper,
          notificationCenter: NotificationCenter,
          systemInfo: SystemInfo,
          offeringsFactory: OfferingsFactory,
@@ -441,6 +445,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.attributionPoster = attributionPoster
         self.backend = backend
         self.storeKitWrapper = storeKitWrapper
+        self.paymentQueueWrapper = paymentQueueWrapper
         self.offeringsFactory = offeringsFactory
         self.deviceCache = deviceCache
         self.identityManager = identityManager
@@ -1223,8 +1228,7 @@ public extension Purchases {
      */
     @available(iOS 13.4, macCatalyst 13.4, *)
     @objc func showPriceConsentIfNeeded() {
-        // TODO: SK2?
-        self.storeKitWrapper?.showPriceConsentIfNeeded()
+        self.paymentQueueWrapper.showPriceConsentIfNeeded()
     }
 #endif
 
@@ -1260,8 +1264,7 @@ public extension Purchases {
     @available(macOS, unavailable)
     @available(macCatalyst, unavailable)
     @objc func presentCodeRedemptionSheet() {
-        // TODO: SK2?
-        self.storeKitWrapper?.presentCodeRedemptionSheet()
+        self.paymentQueueWrapper.presentCodeRedemptionSheet()
     }
 #endif
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -248,7 +248,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     private let purchasesOrchestrator: PurchasesOrchestrator
     private let receiptFetcher: ReceiptFetcher
     private let requestFetcher: StoreKitRequestFetcher
-    private let storeKitWrapper: StoreKitWrapper
+    private let storeKitWrapper: StoreKitWrapper?
     private let systemInfo: SystemInfo
     private var customerInfoObservationDisposable: (() -> Void)?
 
@@ -287,7 +287,10 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                               eTagManager: eTagManager,
                               operationDispatcher: operationDispatcher,
                               attributionFetcher: attributionFetcher)
-        let storeKitWrapper = StoreKitWrapper()
+        let storeKitWrapper: StoreKitWrapper? = systemInfo.storeKit2Setting.shouldOnlyUseStoreKit2
+        ? nil
+        : StoreKitWrapper()
+
         let offeringsFactory = OfferingsFactory()
         let userDefaults = userDefaults ?? UserDefaults.standard
         let deviceCache = DeviceCache(sandboxEnvironmentDetector: systemInfo, userDefaults: userDefaults)
@@ -409,7 +412,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
          attributionFetcher: AttributionFetcher,
          attributionPoster: AttributionPoster,
          backend: Backend,
-         storeKitWrapper: StoreKitWrapper,
+         storeKitWrapper: StoreKitWrapper?,
          notificationCenter: NotificationCenter,
          systemInfo: SystemInfo,
          offeringsFactory: OfferingsFactory,
@@ -466,7 +469,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         }
 
         if self.systemInfo.dangerousSettings.autoSyncPurchases {
-            storeKitWrapper.delegate = purchasesOrchestrator
+            storeKitWrapper?.delegate = purchasesOrchestrator
         } else {
             Logger.warn(Strings.configure.autoSyncPurchasesDisabled)
         }
@@ -484,7 +487,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
     deinit {
         self.notificationCenter.removeObserver(self)
-        self.storeKitWrapper.delegate = nil
+        self.storeKitWrapper?.delegate = nil
         self.customerInfoObservationDisposable?()
         self.privateDelegate = nil
         Self.proxyURL = nil
@@ -1220,7 +1223,8 @@ public extension Purchases {
      */
     @available(iOS 13.4, macCatalyst 13.4, *)
     @objc func showPriceConsentIfNeeded() {
-        self.storeKitWrapper.showPriceConsentIfNeeded()
+        // TODO: SK2?
+        self.storeKitWrapper?.showPriceConsentIfNeeded()
     }
 #endif
 
@@ -1256,7 +1260,8 @@ public extension Purchases {
     @available(macOS, unavailable)
     @available(macCatalyst, unavailable)
     @objc func presentCodeRedemptionSheet() {
-        self.storeKitWrapper.presentCodeRedemptionSheet()
+        // TODO: SK2?
+        self.storeKitWrapper?.presentCodeRedemptionSheet()
     }
 #endif
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1688,6 +1688,11 @@ internal extension Purchases {
         return self.systemInfo.isSandbox
     }
 
+    /// For testing purposes
+    var isStoreKit1Configured: Bool {
+        return self.storeKitWrapper != nil
+    }
+
 }
 
 // MARK: Private

--- a/Sources/Purchasing/StoreKit1/PaymentQueueWrapper.swift
+++ b/Sources/Purchasing/StoreKit1/PaymentQueueWrapper.swift
@@ -48,4 +48,9 @@ final class PaymentQueueWrapper {
     }
 }
 
+#if swift(>=5.7)
 extension PaymentQueueWrapper: Sendable {}
+#else
+// `SKPaymentQueue` is not `Sendable` until Swift 5.7
+extension PaymentQueueWrapper: @unchecked Sendable {}
+#endif

--- a/Sources/Purchasing/StoreKit1/PaymentQueueWrapper.swift
+++ b/Sources/Purchasing/StoreKit1/PaymentQueueWrapper.swift
@@ -1,0 +1,51 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaymentQueueWrapper.swift
+//
+//  Created by Nacho Soto on 9/4/22.
+
+import Foundation
+import StoreKit
+
+final class PaymentQueueWrapper {
+
+    private let paymentQueue: SKPaymentQueue
+
+    init(paymentQueue: SKPaymentQueue = .default()) {
+        self.paymentQueue = paymentQueue
+    }
+
+    #if os(iOS) || targetEnvironment(macCatalyst)
+    @available(iOS 13.4, macCatalyst 13.4, *)
+    func showPriceConsentIfNeeded() {
+        self.paymentQueue.showPriceConsentIfNeeded()
+    }
+    #endif
+
+    @available(iOS 14.0, *)
+    @available(macOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    @available(macCatalyst, unavailable)
+    func presentCodeRedemptionSheet() {
+        // Even though the docs in `SKPaymentQueue.presentCodeRedemptionSheet`
+        // say that it's available on Catalyst 14.0, there is a note:
+        // This function doesn’t affect Mac apps built with Mac Catalyst.
+        // It crashes when called both from Catalyst and also when running as "Designed for iPad".
+        if self.paymentQueue.responds(to: #selector(SKPaymentQueue.presentCodeRedemptionSheet)) {
+            Logger.debug(Strings.purchase.presenting_code_redemption_sheet)
+            self.paymentQueue.presentCodeRedemptionSheet()
+        } else {
+            Logger.appleError(Strings.purchase.unable_to_present_redemption_sheet)
+        }
+    }
+}
+
+extension PaymentQueueWrapper: Sendable {}

--- a/Sources/Purchasing/StoreKit1/StoreKitWrapper.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKitWrapper.swift
@@ -87,7 +87,7 @@ class StoreKitWrapper: NSObject, SKPaymentTransactionObserver {
         return SKPaymentQueue.canMakePayments()
     }
 
-    func payment(withProduct product: SK1Product) -> SKMutablePayment {
+    func payment(with product: SK1Product) -> SKMutablePayment {
         let payment = SKMutablePayment(product: product)
 
         if #available(iOS 8.0, macOS 10.14, watchOS 6.2, macCatalyst 13.0, *) {
@@ -97,8 +97,8 @@ class StoreKitWrapper: NSObject, SKPaymentTransactionObserver {
     }
 
     @available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvOS 12.2, *)
-    func payment(withProduct product: SK1Product, discount: SKPaymentDiscount) -> SKMutablePayment {
-        let payment = self.payment(withProduct: product)
+    func payment(with product: SK1Product, discount: SKPaymentDiscount?) -> SKMutablePayment {
+        let payment = self.payment(with: product)
         payment.paymentDiscount = discount
         return payment
     }

--- a/Sources/Purchasing/StoreKit1/StoreKitWrapper.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKitWrapper.swift
@@ -87,24 +87,6 @@ class StoreKitWrapper: NSObject, SKPaymentTransactionObserver {
         return SKPaymentQueue.canMakePayments()
     }
 
-    @available(iOS 14.0, *)
-    @available(macOS, unavailable)
-    @available(tvOS, unavailable)
-    @available(watchOS, unavailable)
-    @available(macCatalyst, unavailable)
-    func presentCodeRedemptionSheet() {
-        // Even though the docs in `SKPaymentQueue.presentCodeRedemptionSheet`
-        // say that it's available on Catalyst 14.0, there is a note:
-        // This function doesn’t affect Mac apps built with Mac Catalyst.
-        // It crashes when called both from Catalyst and also when running as "Designed for iPad".
-        if self.paymentQueue.responds(to: #selector(SKPaymentQueue.presentCodeRedemptionSheet)) {
-            Logger.debug(Strings.purchase.presenting_code_redemption_sheet)
-            self.paymentQueue.presentCodeRedemptionSheet()
-        } else {
-            Logger.appleError(Strings.purchase.unable_to_present_redemption_sheet)
-        }
-    }
-
     func payment(withProduct product: SK1Product) -> SKMutablePayment {
         let payment = SKMutablePayment(product: product)
 
@@ -120,13 +102,6 @@ class StoreKitWrapper: NSObject, SKPaymentTransactionObserver {
         payment.paymentDiscount = discount
         return payment
     }
-
-#if os(iOS) || targetEnvironment(macCatalyst)
-    @available(iOS 13.4, macCatalyst 13.4, *)
-    func showPriceConsentIfNeeded() {
-        self.paymentQueue.showPriceConsentIfNeeded()
-    }
-#endif
 
 }
 
@@ -177,6 +152,15 @@ extension StoreKitWrapper: SKPaymentQueueDelegate {
     // Sent when the storefront for the payment queue has changed.
     func paymentQueueDidChangeStorefront(_ queue: SKPaymentQueue) {
         self.delegate?.storeKitWrapperDidChangeStorefront(self)
+    }
+
+}
+
+extension StoreKitWrapper {
+
+    /// Creates a `PaymentQueueWrapper` backed by the same `SKPaymentQueue`.
+    func createPaymentQueueWrapper() -> PaymentQueueWrapper {
+        return .init(paymentQueue: self.paymentQueue)
     }
 
 }

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -175,7 +175,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                               storeProduct: storeProduct,
                               offeringIdentifier: "offering")
 
-        let payment = storeKitWrapper.payment(withProduct: product)
+        let payment = storeKitWrapper.payment(with: product)
 
         _ = await withCheckedContinuation { continuation in
             orchestrator.purchase(sk1Product: product,
@@ -271,7 +271,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                               storeProduct: storeProduct,
                               offeringIdentifier: "offering")
 
-        let payment = self.storeKitWrapper.payment(withProduct: product)
+        let payment = self.storeKitWrapper.payment(with: product)
         payment.productIdentifier = ""
 
         let (transaction, customerInfo, error, cancelled) =

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -180,7 +180,8 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         _ = await withCheckedContinuation { continuation in
             orchestrator.purchase(sk1Product: product,
                                   payment: payment,
-                                  package: package) { transaction, customerInfo, error, userCancelled in
+                                  package: package,
+                                  wrapper: self.storeKitWrapper) { transaction, customerInfo, error, userCancelled in
                 continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
             }
         }
@@ -249,7 +250,8 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         _ = await withCheckedContinuation { continuation in
             orchestrator.purchase(sk1Product: product,
                                   promotionalOffer: offer,
-                                  package: package) { transaction, customerInfo, error, userCancelled in
+                                  package: package,
+                                  wrapper: self.storeKitWrapper) { transaction, customerInfo, error, userCancelled in
                 continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
             }
         }
@@ -274,9 +276,12 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         let (transaction, customerInfo, error, cancelled) =
         try await withCheckedThrowingContinuation { continuation in
-            self.orchestrator.purchase(sk1Product: product,
-                                       payment: payment,
-                                       package: package) { transaction, customerInfo, error, userCancelled in
+            self.orchestrator.purchase(
+                sk1Product: product,
+                payment: payment,
+                package: package,
+                wrapper: self.storeKitWrapper
+            ) { transaction, customerInfo, error, userCancelled in
                 continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
             }
         }

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -182,6 +182,7 @@ class BasePurchasesTests: TestCase {
                                    attributionPoster: self.attributionPoster,
                                    backend: self.backend,
                                    storeKitWrapper: self.storeKitWrapper,
+                                   paymentQueueWrapper: .init(),
                                    notificationCenter: self.notificationCenter,
                                    systemInfo: self.systemInfo,
                                    offeringsFactory: self.offeringsFactory,

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -236,4 +236,22 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expect(self.storeKitWrapper.delegate) === self.purchasesOrchestrator
     }
 
+    func testSetsSelfAsStoreKitWrapperDelegateForSK1() {
+        let configurationBuilder = Configuration.Builder(withAPIKey: "")
+            .with(usesStoreKit2IfAvailable: false)
+        let purchases = Purchases.configure(with: configurationBuilder.build())
+
+        expect(purchases.isStoreKit1Configured) == true
+    }
+
+    func testDoesNotInitializeSK1IfSK2Enabled() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        let configurationBuilder = Configuration.Builder(withAPIKey: "")
+            .with(usesStoreKit2IfAvailable: true)
+        let purchases = Purchases.configure(with: configurationBuilder.build())
+
+        expect(purchases.isStoreKit1Configured) == false
+    }
+
 }

--- a/Tests/UnitTests/Purchasing/StoreKitWrapperTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKitWrapperTests.swift
@@ -218,7 +218,7 @@ class StoreKitWrapperTests: TestCase, StoreKitWrapperDelegate {
 
         let productId = "mySuperProduct"
         let mockProduct = MockSK1Product(mockProductIdentifier: productId)
-        let payment = wrapper.payment(withProduct: mockProduct)
+        let payment = wrapper.payment(with: mockProduct)
         expect(payment.productIdentifier) == productId
     }
 
@@ -229,11 +229,11 @@ class StoreKitWrapperTests: TestCase, StoreKitWrapperDelegate {
         let mockProduct = MockSK1Product(mockProductIdentifier: "mySuperProduct")
 
         StoreKitWrapper.simulatesAskToBuyInSandbox = false
-        let payment1 = wrapper.payment(withProduct: mockProduct)
+        let payment1 = wrapper.payment(with: mockProduct)
         expect(payment1.simulatesAskToBuyInSandbox) == false
 
         StoreKitWrapper.simulatesAskToBuyInSandbox = true
-        let payment2 = wrapper.payment(withProduct: mockProduct)
+        let payment2 = wrapper.payment(with: mockProduct)
         expect(payment2.simulatesAskToBuyInSandbox) == true
     }
 
@@ -248,7 +248,7 @@ class StoreKitWrapperTests: TestCase, StoreKitWrapperDelegate {
 
         let mockProduct = MockSK1Product(mockProductIdentifier: productId)
         let mockDiscount = MockPaymentDiscount(mockIdentifier: discountId)
-        let payment = wrapper.payment(withProduct: mockProduct, discount: mockDiscount)
+        let payment = wrapper.payment(with: mockProduct, discount: mockDiscount)
         expect(payment.productIdentifier) == productId
         expect(payment.paymentDiscount) == mockDiscount
     }
@@ -263,11 +263,11 @@ class StoreKitWrapperTests: TestCase, StoreKitWrapperDelegate {
         let mockDiscount = MockPaymentDiscount(mockIdentifier: "mySuperDiscount")
 
         StoreKitWrapper.simulatesAskToBuyInSandbox = false
-        let payment1 = wrapper.payment(withProduct: mockProduct, discount: mockDiscount)
+        let payment1 = wrapper.payment(with: mockProduct, discount: mockDiscount)
         expect(payment1.simulatesAskToBuyInSandbox) == false
 
         StoreKitWrapper.simulatesAskToBuyInSandbox = true
-        let payment2 = wrapper.payment(withProduct: mockProduct)
+        let payment2 = wrapper.payment(with: mockProduct)
         expect(payment2.simulatesAskToBuyInSandbox) == true
     }
 

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -168,6 +168,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
                               attributionPoster: mockAttributionPoster,
                               backend: mockBackend,
                               storeKitWrapper: mockStoreKitWrapper,
+                              paymentQueueWrapper: .init(),
                               notificationCenter: mockNotificationCenter,
                               systemInfo: systemInfo,
                               offeringsFactory: mockOfferingsFactory,


### PR DESCRIPTION
When SK2 is enabled, `StoreKit2TransactionListener` is enough to handle transactions, so it's no longer necessary to have that and `StoreKitWrapper` both listening to them.

Depends on #1881 and #1879.

### TODO:

- [x] Improve handling of attempting to purchase SK1 products when it's implicitly disabled. This shouldn't happen (covered well in tests), but we need to handle that more gracefully.
- [x] What about `presentCodeRedemptionSheet` and `showPriceConsentIfNeeded`? We could have a dedicated "`SK1Wrapper`" with support for only those 2 functions, since they don't have an SK2 equivalent.
- [x] Add tests to verify this behavior.