### PR TITLE
`HTTPClient`: added `X-Client-Bundle-ID` and logged on SDK initialization

### DIFF
--- a/Sources/Logging/Strings/ConfigureStrings.swift
+++ b/Sources/Logging/Strings/ConfigureStrings.swift
@@ -35,7 +35,9 @@ enum ConfigureStrings {
 
     case no_singleton_instance
 
-    case sdk_version(sdkVersion: String)
+    case sdk_version(String)
+
+    case bundle_id(String)
 
     case legacyAPIKey
 
@@ -72,8 +74,10 @@ extension ConfigureStrings: CustomStringConvertible {
         case .no_singleton_instance:
             return "There is no singleton instance. Make sure you configure Purchases before " +
                 "trying to get the default instance. More info here: https://errors.rev.cat/configuring-sdk"
-        case .sdk_version(let sdkVersion):
+        case let .sdk_version(sdkVersion):
             return "SDK Version - \(sdkVersion)"
+        case let .bundle_id(bundleID):
+            return "Bundle ID - \(bundleID)"
         case .legacyAPIKey:
             return "Looks like you're using a legacy API key.\n" +
             "This is still supported, but it's recommended to migrate to using platform-specific API key, " +

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -63,6 +63,10 @@ class SystemInfo {
         return Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
     }
 
+    static var bundleIdentifier: String {
+        return Bundle.main.bundleIdentifier ?? ""
+    }
+
     static var platformHeader: String {
         return Self.forceUniversalAppStore ? "iOS" : self.platformHeaderConstant
     }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -148,6 +148,7 @@ private extension HTTPClient {
             "X-Platform-Flavor": systemInfo.platformFlavor,
             "X-Client-Version": SystemInfo.appVersion,
             "X-Client-Build-Version": SystemInfo.buildVersion,
+            "X-Client-Bundle-ID": SystemInfo.bundleIdentifier,
             "X-StoreKit2-Setting": "\(self.systemInfo.storeKit2Setting.debugDescription)",
             "X-Observer-Mode-Enabled": "\(observerMode)",
             "X-Is-Sandbox": "\(self.systemInfo.isSandbox)"

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -402,6 +402,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                   trialOrIntroPriceEligibilityChecker: trialOrIntroPriceChecker)
     }
 
+    // swiftlint:disable:next function_body_length
     init(appUserID: String?,
          requestFetcher: StoreKitRequestFetcher,
          receiptFetcher: ReceiptFetcher,
@@ -427,7 +428,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         if systemInfo.storeKit2Setting == .enabledForCompatibleDevices {
             Logger.info(Strings.configure.store_kit_2_enabled, fileName: nil)
         }
-        Logger.debug(Strings.configure.sdk_version(sdkVersion: Self.frameworkVersion), fileName: nil)
+        Logger.debug(Strings.configure.sdk_version(Self.frameworkVersion), fileName: nil)
+        Logger.debug(Strings.configure.bundle_id(SystemInfo.bundleIdentifier), fileName: nil)
         Logger.user(Strings.configure.initial_app_user_id(isSet: appUserID != nil), fileName: nil)
 
         self.requestFetcher = requestFetcher

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -448,6 +448,23 @@ class HTTPClientTests: TestCase {
         expect(headerPresent.value).toEventually(equal(true))
     }
 
+    func testAlwaysPassesClientBundleID() throws {
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
+
+        let headerPresent: Atomic<Bool> = false
+
+        let bundleID = try XCTUnwrap(Bundle.main.bundleIdentifier)
+
+        stub(condition: hasHeaderNamed("X-Client-Bundle-ID", value: bundleID)) { _ in
+            headerPresent.value = true
+            return .emptySuccessResponse
+        }
+
+        self.client.perform(request) { (_: HTTPResponse<Data>.Result) in }
+
+        expect(headerPresent.value).toEventually(equal(true))
+    }
+
     #if os(macOS) || targetEnvironment(macCatalyst)
     func testAlwaysPassesAppleDeviceIdentifierWhenIsSandbox() {
         let request = HTTPRequest(method: .get, path: .mockPath)


### PR DESCRIPTION
Fixes [CSDK-461].

[CSDK-461]: https://revenuecats.atlassian.net/browse/CSDK-461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ