### PR TITLE
`Offering`: improved confusing log for `PackageType.custom`

### DIFF
--- a/Sources/Logging/Strings/OfferingStrings.swift
+++ b/Sources/Logging/Strings/OfferingStrings.swift
@@ -38,6 +38,8 @@ enum OfferingStrings {
     case configuration_error_no_products_for_offering
     case offering_empty(offeringIdentifier: String)
     case product_details_empty_title(productIdentifier: String)
+    case unknown_package_type(Package)
+    case custom_package_type(Package)
 
 }
 
@@ -126,6 +128,11 @@ extension OfferingStrings: CustomStringConvertible {
         case let .product_details_empty_title(identifier):
             return "Empty Product titles are not supported. Found in product with identifier: \(identifier)"
 
+        case let .unknown_package_type(package):
+            return "Unknown subscription length for package '\(package.offeringIdentifier)'. Ignoring."
+
+        case let .custom_package_type(package):
+            return "Package '\(package.offeringIdentifier)' has a custom duration. Ignoring."
         }
     }
 

--- a/Sources/Purchasing/Offering.swift
+++ b/Sources/Purchasing/Offering.swift
@@ -109,6 +109,7 @@ import Foundation
         return package(identifier: key)
     }
 
+    // swiftlint:disable:next cyclomatic_complexity
     init(identifier: String, serverDescription: String, availablePackages: [Package]) {
         self.identifier = identifier
         self.serverDescription = serverDescription
@@ -138,11 +139,13 @@ import Foundation
             case .custom where package.storeProduct.productCategory == .nonSubscription:
                 // Non-subscription product, ignoring
                 continue
-            case .unknown, .custom:
-                Logger.warn(
-                    "Unknown subscription length for package '\(package.offeringIdentifier)': " +
-                    "\(package.packageType). Ignoring."
-                )
+
+            case .custom:
+                Logger.debug(Strings.offering.custom_package_type(package))
+                continue
+
+            case .unknown:
+                Logger.warn(Strings.offering.unknown_package_type(package))
                 continue
             }
 


### PR DESCRIPTION
Fixes [CSDK-450].

We were logging a message for packages with custom duration that says "Unknown subscription length for package, ignoring."
This is very confusing for customers, as it looks like something is wrong. However it’s expected and normal behavior for packages with custom duration.

[CSDK-450]: https://revenuecats.atlassian.net/browse/CSDK-450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ