### PR TITLE
`PurchasesOrchestrator`: don't log warning if `allowSharingAppStoreAccount` setting was never explicitly set

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -802,7 +802,9 @@ private extension PurchasesOrchestrator {
     func syncPurchases(receiptRefreshPolicy: ReceiptRefreshPolicy,
                        isRestore: Bool,
                        completion: (@Sendable (Result<CustomerInfo, PurchasesError>) -> Void)?) {
-        if !self.allowSharingAppStoreAccount {
+        // Don't log anything unless the flag was explicitly set.
+        let allowSharingAppStoreAccountSet = self._allowSharingAppStoreAccount.value != nil
+        if allowSharingAppStoreAccountSet, !self.allowSharingAppStoreAccount {
             Logger.warn(Strings.restore.restorepurchases_called_with_allow_sharing_appstore_account_false_warning)
         }
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -162,6 +162,8 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         self.storeKitWrapper.delegate = self.orchestrator
     }
 
+    // MARK: - tests
+
     func testPurchaseSK1PackageSendsReceiptToBackendIfSuccessful() async throws {
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
         backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
@@ -655,6 +657,59 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
             expect(error).to(matchError(expectedError))
             expect(error.localizedDescription).to(equal(expectedError.localizedDescription))
         }
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func testRestorePurchasesDoesNotLogWarningIfAllowSharingAppStoreAccountIsNotDefined() async throws {
+        let logger = TestLogHandler()
+
+        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
+
+        _ = try? await self.orchestrator.syncPurchases(receiptRefreshPolicy: .never,
+                                                       isRestore: false)
+
+        logger.verifyMessageWasNotLogged(
+            Strings
+                .restore
+                .restorepurchases_called_with_allow_sharing_appstore_account_false_warning
+        )
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func testRestorePurchasesDoesNotLogWarningIfAllowSharingAppStoreAccountIsTrue() async throws {
+        let logger = TestLogHandler()
+
+        self.orchestrator.allowSharingAppStoreAccount = true
+
+        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
+
+        _ = try? await self.orchestrator.syncPurchases(receiptRefreshPolicy: .never,
+                                                       isRestore: false)
+
+        logger.verifyMessageWasNotLogged(
+            Strings
+                .restore
+                .restorepurchases_called_with_allow_sharing_appstore_account_false_warning
+        )
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func testRestorePurchasesLogsWarningIfAllowSharingAppStoreAccountIsFalse() async throws {
+        let logger = TestLogHandler()
+
+        self.orchestrator.allowSharingAppStoreAccount = false
+
+        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
+
+        _ = try? await self.orchestrator.syncPurchases(receiptRefreshPolicy: .never,
+                                                       isRestore: false)
+
+        logger.verifyMessageWasLogged(
+            Strings
+                .restore
+                .restorepurchases_called_with_allow_sharing_appstore_account_false_warning,
+            level: .warn
+        )
     }
 
 }

--- a/Tests/UnitTests/TestHelpers/TestLogHandler.swift
+++ b/Tests/UnitTests/TestHelpers/TestLogHandler.swift
@@ -13,6 +13,8 @@
 
 @testable import RevenueCat
 
+import Nimble
+
 /// Provides a `Logger.VerboseLogHandler` that wraps the default implementation
 /// and allows introspecting logged messages.
 ///
@@ -71,6 +73,52 @@ final class TestLogHandler {
 }
 
 extension TestLogHandler: Sendable {}
+
+extension TestLogHandler {
+
+    func verifyMessageWasLogged(
+        _ message: CustomStringConvertible,
+        level: LogLevel? = nil,
+        file: FileString = #file,
+        line: UInt = #line
+    ) {
+        expect(
+            file: file,
+            line: line,
+            self.messages
+        )
+        .to(containElementSatisfying(Self.entryCondition(message: message, level: level)))
+    }
+
+    func verifyMessageWasNotLogged(
+        _ message: CustomStringConvertible,
+        level: LogLevel? = nil,
+        file: FileString = #file,
+        line: UInt = #line
+    ) {
+        expect(
+            file: file,
+            line: line,
+            self.messages
+        )
+        .toNot(containElementSatisfying(Self.entryCondition(message: message, level: level)))
+    }
+
+    private static func entryCondition(message: CustomStringConvertible, level: LogLevel?) -> (MessageData) -> Bool {
+        return { entry in
+            guard entry.message.contains(message.description) else {
+                return false
+            }
+
+            if let level = level, entry.level != level {
+                return false
+            }
+
+            return true
+        }
+    }
+
+}
 
 // MARK: - Private
 


### PR DESCRIPTION
Fixes [CSDK-454].

This should reduce a lot of the noise during initialization. The internal backing property was already `Bool?`, so we can check if it was ever set, and if not, not log anything.
Using `TestLogHandler` introduced in #1858 to verify this behavior.

[CSDK-454]: https://revenuecats.atlassian.net/browse/CSDK-454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ