### PR TITLE
Renamed `StoreKitWrapper` to `StoreKit1Wrapper`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -34,7 +34,7 @@
 		2D4D6AF524F717B800B656BE /* ContainerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35092F0E41512E0D610BA /* ContainerFactory.swift */; };
 		2D4D6AF624F7193700B656BE /* verifyReceiptSample1.txt in Resources */ = {isa = PBXBuildFile; fileRef = 2DDE559A24C8B5E300DCB087 /* verifyReceiptSample1.txt */; };
 		2D4D6AF724F7193700B656BE /* base64encodedreceiptsample1.txt in Resources */ = {isa = PBXBuildFile; fileRef = 2DDE559B24C8B5E300DCB087 /* base64encodedreceiptsample1.txt */; };
-		2D4E926526990AB1000E10B0 /* StoreKitWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4E926426990AB1000E10B0 /* StoreKitWrapper.swift */; };
+		2D4E926526990AB1000E10B0 /* StoreKit1Wrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4E926426990AB1000E10B0 /* StoreKit1Wrapper.swift */; };
 		2D735F7E26EFF198004E82A7 /* UnitTestsConfiguration.storekit in Resources */ = {isa = PBXBuildFile; fileRef = 2D43017726EBFD7100BAB891 /* UnitTestsConfiguration.storekit */; };
 		2D803F6326F144830069D717 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 2D803F6226F144830069D717 /* Nimble */; };
 		2D803F6626F144BF0069D717 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 2D803F6526F144BF0069D717 /* Nimble */; };
@@ -158,7 +158,7 @@
 		351B51A726D450D400BD2BD7 /* SystemInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E35EEE7783629CDE41B70C /* SystemInfoTests.swift */; };
 		351B51B526D450E800BD2BD7 /* ProductsFetcherSK1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E351F0E21361EAEC078A0D /* ProductsFetcherSK1Tests.swift */; };
 		351B51B626D450E800BD2BD7 /* ReceiptFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D84458826B9CD270033B5A3 /* ReceiptFetcherTests.swift */; };
-		351B51B826D450E800BD2BD7 /* StoreKitWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E352F86A0A8EB05BAD77C4 /* StoreKitWrapperTests.swift */; };
+		351B51B826D450E800BD2BD7 /* StoreKit1WrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E352F86A0A8EB05BAD77C4 /* StoreKit1WrapperTests.swift */; };
 		351B51B926D450E800BD2BD7 /* TransactionsFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3597021124BF6AAC0010506E /* TransactionsFactoryTests.swift */; };
 		351B51BA26D450E800BD2BD7 /* ProductRequestDataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3583675928C01D92E3166 /* ProductRequestDataExtensions.swift */; };
 		351B51BB26D450E800BD2BD7 /* ProductRequestDataInitializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3548189DA008320B3FC98 /* ProductRequestDataInitializationTests.swift */; };
@@ -551,7 +551,7 @@
 		2D294E5B26DECFD500B8FE4F /* StoreKit2TransactionListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2TransactionListener.swift; sourceTree = "<group>"; };
 		2D34D9D127481D9B00C05DB6 /* TrialOrIntroPriceEligibilityCheckerSK2Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrialOrIntroPriceEligibilityCheckerSK2Tests.swift; sourceTree = "<group>"; };
 		2D43017726EBFD7100BAB891 /* UnitTestsConfiguration.storekit */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = UnitTestsConfiguration.storekit; sourceTree = "<group>"; };
-		2D4E926426990AB1000E10B0 /* StoreKitWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitWrapper.swift; sourceTree = "<group>"; };
+		2D4E926426990AB1000E10B0 /* StoreKit1Wrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit1Wrapper.swift; sourceTree = "<group>"; };
 		2D5BB46A24C8E8ED00E27537 /* ReceiptParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptParser.swift; sourceTree = "<group>"; };
 		2D69384426DFF93300FCDBC0 /* StoreProductTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProductTests.swift; sourceTree = "<group>"; };
 		2D84458826B9CD270033B5A3 /* ReceiptFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptFetcherTests.swift; sourceTree = "<group>"; };
@@ -678,7 +678,7 @@
 		37E351F0E21361EAEC078A0D /* ProductsFetcherSK1Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductsFetcherSK1Tests.swift; sourceTree = "<group>"; };
 		37E3521731D8DC16873F55F3 /* AttributionFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributionFetcher.swift; sourceTree = "<group>"; };
 		37E35294EBC1E5A879C95540 /* IdentityManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IdentityManagerTests.swift; sourceTree = "<group>"; };
-		37E352F86A0A8EB05BAD77C4 /* StoreKitWrapperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreKitWrapperTests.swift; sourceTree = "<group>"; };
+		37E352F86A0A8EB05BAD77C4 /* StoreKit1WrapperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreKit1WrapperTests.swift; sourceTree = "<group>"; };
 		37E353AF2CAD3CEDE6D9B368 /* NSError+RCExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSError+RCExtensionsTests.swift"; sourceTree = "<group>"; };
 		37E353CBE9CF2572A72A347F /* HTTPClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPClientTests.swift; sourceTree = "<group>"; };
 		37E353FD94A8FD5CD8796530 /* DateFormatter+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Extensions.swift"; sourceTree = "<group>"; };
@@ -1129,7 +1129,7 @@
 			children = (
 				EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */,
 				2D991AC9268BA56900085481 /* StoreKitRequestFetcher.swift */,
-				2D4E926426990AB1000E10B0 /* StoreKitWrapper.swift */,
+				2D4E926426990AB1000E10B0 /* StoreKit1Wrapper.swift */,
 				579B67F328C5326A0094F7E8 /* PaymentQueueWrapper.swift */,
 			);
 			path = StoreKit1;
@@ -1552,7 +1552,7 @@
 				5766AABB283E809D00FA6091 /* Purchases */,
 				2D84458826B9CD270033B5A3 /* ReceiptFetcherTests.swift */,
 				F5BE4244269676E200254A30 /* StoreKitRequestFetcherTests.swift */,
-				37E352F86A0A8EB05BAD77C4 /* StoreKitWrapperTests.swift */,
+				37E352F86A0A8EB05BAD77C4 /* StoreKit1WrapperTests.swift */,
 				3597021124BF6AAC0010506E /* TransactionsFactoryTests.swift */,
 				57554C61282ABFD9009A7E58 /* StoreTests.swift */,
 				57554C83282AC273009A7E58 /* PeriodTypeTests.swift */,
@@ -2373,7 +2373,7 @@
 				B3022072272B3DDC008F1A0D /* DescribableError.swift in Sources */,
 				57BD50AA27692B7500211D6D /* StoreKitError+Extensions.swift in Sources */,
 				F5C0196926E880800005D61E /* StoreKitStrings.swift in Sources */,
-				2D4E926526990AB1000E10B0 /* StoreKitWrapper.swift in Sources */,
+				2D4E926526990AB1000E10B0 /* StoreKit1Wrapper.swift in Sources */,
 				2DDF419624F6F331005BC22D /* ProductsRequestFactory.swift in Sources */,
 				2DDF419724F6F331005BC22D /* DateExtensions.swift in Sources */,
 				9A65E0A52591A23500DE00B0 /* PurchaseStrings.swift in Sources */,
@@ -2609,7 +2609,7 @@
 				351B51A426D450BC00BD2BD7 /* NSError+RCExtensionsTests.swift in Sources */,
 				A524378B284FFF0200E788BD /* AttributionPosterTests.swift in Sources */,
 				57E2230727500BB1002DB06E /* AtomicTests.swift in Sources */,
-				351B51B826D450E800BD2BD7 /* StoreKitWrapperTests.swift in Sources */,
+				351B51B826D450E800BD2BD7 /* StoreKit1WrapperTests.swift in Sources */,
 				A56C2E012819C33500995421 /* BackendPostAdServicesTokenTests.swift in Sources */,
 				5766AAD5283E9B7400FA6091 /* PurchasesRestoreTests.swift in Sources */,
 				57E4A52128BD8F610095C793 /* ErrorMatcher.swift in Sources */,

--- a/Sources/Misc/Deprecations.swift
+++ b/Sources/Misc/Deprecations.swift
@@ -403,7 +403,7 @@ extension CustomerInfo {
             self.quantity = 1
         }
 
-        func finish(_ wrapper: StoreKitWrapper) {
+        func finish(_ wrapper: StoreKit1Wrapper) {
             // Nothing to do
         }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -137,15 +137,15 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
      */
     @available(iOS 8.0, macOS 10.14, watchOS 6.2, macCatalyst 13.0, *)
     @objc public static var simulatesAskToBuyInSandbox: Bool {
-        get { StoreKitWrapper.simulatesAskToBuyInSandbox }
-        set { StoreKitWrapper.simulatesAskToBuyInSandbox = newValue }
+        get { StoreKit1Wrapper.simulatesAskToBuyInSandbox }
+        set { StoreKit1Wrapper.simulatesAskToBuyInSandbox = newValue }
     }
 
     /**
      * Indicates whether the user is allowed to make payments.
      * [More information on when this might be `false` here](https://rev.cat/can-make-payments-apple)
      */
-    @objc public static func canMakePayments() -> Bool { StoreKitWrapper.canMakePayments() }
+    @objc public static func canMakePayments() -> Bool { StoreKit1Wrapper.canMakePayments() }
 
     /**
      * Set a custom log handler for redirecting logs to your own logging system.
@@ -248,7 +248,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     private let purchasesOrchestrator: PurchasesOrchestrator
     private let receiptFetcher: ReceiptFetcher
     private let requestFetcher: StoreKitRequestFetcher
-    private let storeKitWrapper: StoreKitWrapper?
+    private let storeKit1Wrapper: StoreKit1Wrapper?
     private let paymentQueueWrapper: PaymentQueueWrapper
     private let systemInfo: SystemInfo
     private var customerInfoObservationDisposable: (() -> Void)?
@@ -288,10 +288,10 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                               eTagManager: eTagManager,
                               operationDispatcher: operationDispatcher,
                               attributionFetcher: attributionFetcher)
-        let storeKitWrapper: StoreKitWrapper? = systemInfo.storeKit2Setting.shouldOnlyUseStoreKit2
+        let storeKit1Wrapper: StoreKit1Wrapper? = systemInfo.storeKit2Setting.shouldOnlyUseStoreKit2
         ? nil
-        : StoreKitWrapper()
-        let paymentQueueWrapper = storeKitWrapper?.createPaymentQueueWrapper() ?? .init()
+        : StoreKit1Wrapper()
+        let paymentQueueWrapper = storeKit1Wrapper?.createPaymentQueueWrapper() ?? .init()
 
         let offeringsFactory = OfferingsFactory()
         let userDefaults = userDefaults ?? UserDefaults.standard
@@ -343,7 +343,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
                 return .init(
                     productsManager: productsManager,
-                    storeKitWrapper: storeKitWrapper,
+                    storeKit1Wrapper: storeKit1Wrapper,
                     systemInfo: systemInfo,
                     subscriberAttributes: subscriberAttributes,
                     operationDispatcher: operationDispatcher,
@@ -362,7 +362,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             } else {
                 return .init(
                     productsManager: productsManager,
-                    storeKitWrapper: storeKitWrapper,
+                    storeKit1Wrapper: storeKit1Wrapper,
                     systemInfo: systemInfo,
                     subscriberAttributes: subscriberAttributes,
                     operationDispatcher: operationDispatcher,
@@ -392,7 +392,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                   attributionFetcher: attributionFetcher,
                   attributionPoster: attributionPoster,
                   backend: backend,
-                  storeKitWrapper: storeKitWrapper,
+                  storeKit1Wrapper: storeKit1Wrapper,
                   paymentQueueWrapper: paymentQueueWrapper,
                   notificationCenter: NotificationCenter.default,
                   systemInfo: systemInfo,
@@ -415,7 +415,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
          attributionFetcher: AttributionFetcher,
          attributionPoster: AttributionPoster,
          backend: Backend,
-         storeKitWrapper: StoreKitWrapper?,
+         storeKit1Wrapper: StoreKit1Wrapper?,
          paymentQueueWrapper: PaymentQueueWrapper,
          notificationCenter: NotificationCenter,
          systemInfo: SystemInfo,
@@ -444,7 +444,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.attributionFetcher = attributionFetcher
         self.attributionPoster = attributionPoster
         self.backend = backend
-        self.storeKitWrapper = storeKitWrapper
+        self.storeKit1Wrapper = storeKit1Wrapper
         self.paymentQueueWrapper = paymentQueueWrapper
         self.offeringsFactory = offeringsFactory
         self.deviceCache = deviceCache
@@ -474,7 +474,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         }
 
         if self.systemInfo.dangerousSettings.autoSyncPurchases {
-            storeKitWrapper?.delegate = purchasesOrchestrator
+            storeKit1Wrapper?.delegate = purchasesOrchestrator
         } else {
             Logger.warn(Strings.configure.autoSyncPurchasesDisabled)
         }
@@ -492,7 +492,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
     deinit {
         self.notificationCenter.removeObserver(self)
-        self.storeKitWrapper?.delegate = nil
+        self.storeKit1Wrapper?.delegate = nil
         self.customerInfoObservationDisposable?()
         self.privateDelegate = nil
         Self.proxyURL = nil
@@ -1690,7 +1690,7 @@ internal extension Purchases {
 
     /// For testing purposes
     var isStoreKit1Configured: Bool {
-        return self.storeKitWrapper != nil
+        return self.storeKit1Wrapper != nil
     }
 
 }

--- a/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
@@ -7,36 +7,36 @@
 //
 //      https://opensource.org/licenses/MIT
 //
-//  RCStoreKitWrapper.swift
+//  RCStoreKit1Wrapper.swift
 //
 //  Created by RevenueCat.
 //
 
 import StoreKit
 
-protocol StoreKitWrapperDelegate: AnyObject {
+protocol StoreKit1WrapperDelegate: AnyObject {
 
-    func storeKitWrapper(_ storeKitWrapper: StoreKitWrapper, updatedTransaction transaction: SKPaymentTransaction)
+    func storeKit1Wrapper(_ storeKit1Wrapper: StoreKit1Wrapper, updatedTransaction transaction: SKPaymentTransaction)
 
-    func storeKitWrapper(_ storeKitWrapper: StoreKitWrapper, removedTransaction transaction: SKPaymentTransaction)
+    func storeKit1Wrapper(_ storeKit1Wrapper: StoreKit1Wrapper, removedTransaction transaction: SKPaymentTransaction)
 
-    func storeKitWrapper(_ storeKitWrapper: StoreKitWrapper,
-                         shouldAddStorePayment payment: SKPayment,
-                         for product: SK1Product) -> Bool
+    func storeKit1Wrapper(_ storeKit1Wrapper: StoreKit1Wrapper,
+                          shouldAddStorePayment payment: SKPayment,
+                          for product: SK1Product) -> Bool
 
-    func storeKitWrapper(_ storeKitWrapper: StoreKitWrapper,
-                         didRevokeEntitlementsForProductIdentifiers productIdentifiers: [String])
+    func storeKit1Wrapper(_ storeKit1Wrapper: StoreKit1Wrapper,
+                          didRevokeEntitlementsForProductIdentifiers productIdentifiers: [String])
 
     #if os(iOS) || targetEnvironment(macCatalyst)
     @available(iOS 13.4, macCatalyst 13.4, *)
-    var storeKitWrapperShouldShowPriceConsent: Bool { get }
+    var storeKit1WrapperShouldShowPriceConsent: Bool { get }
     #endif
 
-    func storeKitWrapperDidChangeStorefront(_ storeKitWrapper: StoreKitWrapper)
+    func storeKit1WrapperDidChangeStorefront(_ storeKit1Wrapper: StoreKit1Wrapper)
 
 }
 
-class StoreKitWrapper: NSObject, SKPaymentTransactionObserver {
+class StoreKit1Wrapper: NSObject, SKPaymentTransactionObserver {
 
     @available(iOS 8.0, macOS 10.14, watchOS 6.2, macCatalyst 13.0, *)
     static var simulatesAskToBuyInSandbox = false
@@ -50,7 +50,7 @@ class StoreKitWrapper: NSObject, SKPaymentTransactionObserver {
     }
 
     /// - Note: this is not thread-safe
-    weak var delegate: StoreKitWrapperDelegate? {
+    weak var delegate: StoreKit1WrapperDelegate? {
         didSet {
             if self.delegate != nil {
                 self.paymentQueue.add(self)
@@ -105,12 +105,12 @@ class StoreKitWrapper: NSObject, SKPaymentTransactionObserver {
 
 }
 
-extension StoreKitWrapper: SKPaymentQueueDelegate {
+extension StoreKit1Wrapper: SKPaymentQueueDelegate {
 
     func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
         for transaction in transactions {
             Logger.debug(Strings.purchase.paymentqueue_updatedtransaction(transaction: transaction))
-            self.delegate?.storeKitWrapper(self, updatedTransaction: transaction)
+            self.delegate?.storeKit1Wrapper(self, updatedTransaction: transaction)
         }
     }
 
@@ -118,7 +118,7 @@ extension StoreKitWrapper: SKPaymentQueueDelegate {
     func paymentQueue(_ queue: SKPaymentQueue, removedTransactions transactions: [SKPaymentTransaction]) {
         for transaction in transactions {
             Logger.debug(Strings.purchase.paymentqueue_removedtransaction(transaction: transaction))
-            self.delegate?.storeKitWrapper(self, removedTransaction: transaction)
+            self.delegate?.storeKit1Wrapper(self, removedTransaction: transaction)
         }
     }
 
@@ -127,7 +127,7 @@ extension StoreKitWrapper: SKPaymentQueueDelegate {
     func paymentQueue(_ queue: SKPaymentQueue,
                       shouldAddStorePayment payment: SKPayment,
                       for product: SK1Product) -> Bool {
-        return self.delegate?.storeKitWrapper(self, shouldAddStorePayment: payment, for: product) ?? false
+        return self.delegate?.storeKit1Wrapper(self, shouldAddStorePayment: payment, for: product) ?? false
     }
 
     // Sent when access to a family shared subscription is revoked from a family member or canceled the subscription.
@@ -139,24 +139,24 @@ extension StoreKitWrapper: SKPaymentQueueDelegate {
                 productIdentifiers: productIdentifiers
             )
         )
-        self.delegate?.storeKitWrapper(self, didRevokeEntitlementsForProductIdentifiers: productIdentifiers)
+        self.delegate?.storeKit1Wrapper(self, didRevokeEntitlementsForProductIdentifiers: productIdentifiers)
     }
 
     #if os(iOS) || targetEnvironment(macCatalyst)
     @available(iOS 13.4, macCatalyst 13.4, *)
     func paymentQueueShouldShowPriceConsent(_ paymentQueue: SKPaymentQueue) -> Bool {
-        return self.delegate?.storeKitWrapperShouldShowPriceConsent ?? true
+        return self.delegate?.storeKit1WrapperShouldShowPriceConsent ?? true
     }
     #endif
 
     // Sent when the storefront for the payment queue has changed.
     func paymentQueueDidChangeStorefront(_ queue: SKPaymentQueue) {
-        self.delegate?.storeKitWrapperDidChangeStorefront(self)
+        self.delegate?.storeKit1WrapperDidChangeStorefront(self)
     }
 
 }
 
-extension StoreKitWrapper {
+extension StoreKit1Wrapper {
 
     /// Creates a `PaymentQueueWrapper` backed by the same `SKPaymentQueue`.
     func createPaymentQueueWrapper() -> PaymentQueueWrapper {
@@ -167,4 +167,4 @@ extension StoreKitWrapper {
 
 // @unchecked because:
 // - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
-extension StoreKitWrapper: @unchecked Sendable {}
+extension StoreKit1Wrapper: @unchecked Sendable {}

--- a/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
@@ -31,7 +31,7 @@ internal struct SK1StoreTransaction: StoreTransactionType {
     let transactionIdentifier: String
     let quantity: Int
 
-    func finish(_ wrapper: StoreKitWrapper) {
+    func finish(_ wrapper: StoreKit1Wrapper) {
         wrapper.finishTransaction(self.underlyingSK1Transaction)
     }
 

--- a/Sources/Purchasing/StoreKitAbstractions/SK2StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK2StoreTransaction.swift
@@ -32,7 +32,7 @@ internal struct SK2StoreTransaction: StoreTransactionType {
     let transactionIdentifier: String
     let quantity: Int
 
-    func finish(_ wrapper: StoreKitWrapper) {
+    func finish(_ wrapper: StoreKit1Wrapper) {
         Task<Void, Never> {
             await self.underlyingSK2Transaction.finish()
         }

--- a/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
@@ -42,7 +42,7 @@ public typealias SK2Transaction = StoreKit.Transaction
     @objc public var transactionIdentifier: String { self.transaction.transactionIdentifier }
     @objc public var quantity: Int { self.transaction.quantity }
 
-    internal func finish(_ wrapper: StoreKitWrapper) { self.transaction.finish(wrapper) }
+    internal func finish(_ wrapper: StoreKit1Wrapper) { self.transaction.finish(wrapper) }
 
     // swiftlint:enable missing_docs
 
@@ -85,7 +85,7 @@ internal protocol StoreTransactionType: Sendable {
 
     /// Indicates to the App Store that the app delivered the purchased content
     /// or enabled the service to finish the transaction.
-    func finish(_ wrapper: StoreKitWrapper)
+    func finish(_ wrapper: StoreKit1Wrapper)
 
 }
 

--- a/Tests/UnitTests/Mocks/MockStoreKitWrapper.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKitWrapper.swift
@@ -6,7 +6,7 @@
 @testable import RevenueCat
 import StoreKit
 
-class MockStoreKitWrapper: StoreKitWrapper {
+class MockStoreKit1Wrapper: StoreKit1Wrapper {
     var payment: SKPayment?
     var addPaymentCallCount = 0
 
@@ -21,7 +21,7 @@ class MockStoreKitWrapper: StoreKitWrapper {
             let transaction = MockTransaction()
             transaction.mockPayment = newPayment
             transaction.mockState = mockAddPaymentTransactionState
-            delegate?.storeKitWrapper(self, updatedTransaction: transaction)
+            delegate?.storeKit1Wrapper(self, updatedTransaction: transaction)
         }
     }
 
@@ -31,8 +31,8 @@ class MockStoreKitWrapper: StoreKitWrapper {
         finishCalled = true
     }
 
-    weak var mockDelegate: StoreKitWrapperDelegate?
-    override var delegate: StoreKitWrapperDelegate? {
+    weak var mockDelegate: StoreKit1WrapperDelegate?
+    override var delegate: StoreKit1WrapperDelegate? {
         get {
             return mockDelegate
         }

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -101,7 +101,7 @@ class BasePurchasesTests: TestCase {
     var requestFetcher: MockRequestFetcher!
     var mockProductsManager: MockProductsManager!
     var backend: MockBackend!
-    let storeKitWrapper = MockStoreKitWrapper()
+    let storeKit1Wrapper = MockStoreKit1Wrapper()
     let notificationCenter = MockNotificationCenter()
     var userDefaults: UserDefaults! = nil
     let offeringsFactory = MockOfferingsFactory()
@@ -152,7 +152,7 @@ class BasePurchasesTests: TestCase {
     func initializePurchasesInstance(appUserId: String?, withDelegate: Bool = true) {
         self.purchasesOrchestrator = PurchasesOrchestrator(
             productsManager: self.mockProductsManager,
-            storeKitWrapper: self.storeKitWrapper,
+            storeKit1Wrapper: self.storeKit1Wrapper,
             systemInfo: self.systemInfo,
             subscriberAttributes: self.attribution,
             operationDispatcher: self.mockOperationDispatcher,
@@ -181,7 +181,7 @@ class BasePurchasesTests: TestCase {
                                    attributionFetcher: self.attributionFetcher,
                                    attributionPoster: self.attributionPoster,
                                    backend: self.backend,
-                                   storeKitWrapper: self.storeKitWrapper,
+                                   storeKit1Wrapper: self.storeKit1Wrapper,
                                    paymentQueueWrapper: .init(),
                                    notificationCenter: self.notificationCenter,
                                    systemInfo: self.systemInfo,
@@ -212,10 +212,10 @@ class BasePurchasesTests: TestCase {
         purchases.purchase(product: product) { _, _, _, _ in }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
         transaction.mockState = SKPaymentTransactionState.purchased
 
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
     }
 
 }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -230,13 +230,13 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expect(self.purchases.isAnonymous).to(beFalse())
     }
 
-    func testSetsSelfAsStoreKitWrapperDelegate() {
+    func testSetsSelfAsStoreKit1WrapperDelegate() {
         self.setupPurchases()
 
-        expect(self.storeKitWrapper.delegate) === self.purchasesOrchestrator
+        expect(self.storeKit1Wrapper.delegate) === self.purchasesOrchestrator
     }
 
-    func testSetsSelfAsStoreKitWrapperDelegateForSK1() {
+    func testSetsSelfAsStoreKit1WrapperDelegateForSK1() {
         let configurationBuilder = Configuration.Builder(withAPIKey: "")
             .with(usesStoreKit2IfAvailable: false)
         let purchases = Purchases.configure(with: configurationBuilder.build())

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDeferredPurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDeferredPurchasesTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 class PurchaseDeferredPurchasesTests: BasePurchasesTests {
 
-    private var storeKitWrapperDelegate: StoreKitWrapperDelegate!
+    private var storeKit1WrapperDelegate: StoreKit1WrapperDelegate!
     private var product: MockSK1Product!
 
     override func setUpWithError() throws {
@@ -28,35 +28,35 @@ class PurchaseDeferredPurchasesTests: BasePurchasesTests {
         self.setupPurchases()
 
         self.product = MockSK1Product(mockProductIdentifier: "mock_product")
-        self.storeKitWrapperDelegate = try XCTUnwrap(self.storeKitWrapper.delegate)
+        self.storeKit1WrapperDelegate = try XCTUnwrap(self.storeKit1Wrapper.delegate)
     }
 
     func testDeferBlockMakesPayment() throws {
         let payment = SKPayment(product: self.product)
 
-        _ = self.storeKitWrapperDelegate.storeKitWrapper(self.storeKitWrapper,
-                                                         shouldAddStorePayment: payment,
-                                                         for: self.product)
+        _ = self.storeKit1WrapperDelegate.storeKit1Wrapper(self.storeKit1Wrapper,
+                                                           shouldAddStorePayment: payment,
+                                                           for: self.product)
 
         expect(self.purchasesDelegate.makeDeferredPurchase).toNot(beNil())
-        expect(self.storeKitWrapper.payment).to(beNil())
+        expect(self.storeKit1Wrapper.payment).to(beNil())
 
         let makeDeferredPurchase = try XCTUnwrap(purchasesDelegate.makeDeferredPurchase)
 
         makeDeferredPurchase { (_, _, _, _) in }
 
-        expect(self.storeKitWrapper.payment) === payment
+        expect(self.storeKit1Wrapper.payment) === payment
     }
 
     func testDeferBlockCallsCompletionBlockAfterPurchaseCompletes() throws {
         let payment = SKPayment(product: self.product)
 
-        _ = self.storeKitWrapperDelegate.storeKitWrapper(storeKitWrapper,
-                                                         shouldAddStorePayment: payment,
-                                                         for: self.product)
+        _ = self.storeKit1WrapperDelegate.storeKit1Wrapper(storeKit1Wrapper,
+                                                           shouldAddStorePayment: payment,
+                                                           for: self.product)
 
         expect(self.purchasesDelegate.makeDeferredPurchase).toNot(beNil())
-        expect(self.storeKitWrapper.payment).to(beNil())
+        expect(self.storeKit1Wrapper.payment).to(beNil())
 
         var completionCalled = false
 
@@ -67,11 +67,11 @@ class PurchaseDeferredPurchasesTests: BasePurchasesTests {
         }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapperDelegate.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1WrapperDelegate.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
-        expect(self.storeKitWrapper.payment) === payment
+        expect(self.storeKit1Wrapper.payment) === payment
         expect(completionCalled).toEventually(beTrue())
     }
 
@@ -79,9 +79,9 @@ class PurchaseDeferredPurchasesTests: BasePurchasesTests {
         let payment = SKMutablePayment()
         payment.productIdentifier = "test"
 
-        _ = self.storeKitWrapperDelegate.storeKitWrapper(storeKitWrapper,
-                                                         shouldAddStorePayment: payment,
-                                                         for: self.product)
+        _ = self.storeKit1WrapperDelegate.storeKit1Wrapper(storeKit1Wrapper,
+                                                           shouldAddStorePayment: payment,
+                                                           for: self.product)
 
         expect(self.purchasesDelegate.promoProduct) == StoreProduct(sk1Product: self.product)
     }
@@ -90,9 +90,9 @@ class PurchaseDeferredPurchasesTests: BasePurchasesTests {
         let payment = SKMutablePayment()
         payment.productIdentifier = ""
 
-        let result = self.storeKitWrapperDelegate.storeKitWrapper(storeKitWrapper,
-                                                                  shouldAddStorePayment: payment,
-                                                                  for: self.product)
+        let result = self.storeKit1WrapperDelegate.storeKit1Wrapper(storeKit1Wrapper,
+                                                                    shouldAddStorePayment: payment,
+                                                                    for: self.product)
 
         expect(result) == false
         expect(self.purchasesDelegate.promoProduct).to(beNil())
@@ -101,18 +101,18 @@ class PurchaseDeferredPurchasesTests: BasePurchasesTests {
     func testPromoPaymentDelegateMethodMakesRightCalls() {
         let payment = SKPayment(product: self.product)
 
-        _ = self.storeKitWrapperDelegate.storeKitWrapper(storeKitWrapper,
-                                                         shouldAddStorePayment: payment,
-                                                         for: self.product)
+        _ = self.storeKit1WrapperDelegate.storeKit1Wrapper(storeKit1Wrapper,
+                                                           shouldAddStorePayment: payment,
+                                                           for: self.product)
 
         let transaction = MockTransaction()
         transaction.mockPayment = payment
 
         transaction.mockState = .purchasing
-        self.storeKitWrapperDelegate.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1WrapperDelegate.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         transaction.mockState = .purchased
-        self.storeKitWrapperDelegate.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1WrapperDelegate.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
         expect(self.backend.postedProductID) == self.product.productIdentifier
@@ -122,18 +122,18 @@ class PurchaseDeferredPurchasesTests: BasePurchasesTests {
     func testPromoPaymentDelegateMethodCachesProduct() {
         let payment = SKPayment(product: product)
 
-        _ = self.storeKitWrapperDelegate.storeKitWrapper(storeKitWrapper,
-                                                         shouldAddStorePayment: payment,
-                                                         for: self.product)
+        _ = self.storeKit1WrapperDelegate.storeKit1Wrapper(storeKit1Wrapper,
+                                                           shouldAddStorePayment: payment,
+                                                           for: self.product)
 
         let transaction = MockTransaction()
         transaction.mockPayment = payment
 
         transaction.mockState = .purchasing
-        self.storeKitWrapperDelegate.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1WrapperDelegate.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         transaction.mockState = .purchased
-        self.storeKitWrapperDelegate.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1WrapperDelegate.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.mockProductsManager.invokedCacheProduct) == true
         expect(self.mockProductsManager.invokedCacheProductParameter) == self.product

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDelegateTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDelegateTests.swift
@@ -28,11 +28,11 @@ class PurchasesDelegateTests: BasePurchasesTests {
     func testDoesntSetWrapperDelegateToNilIfDelegateNil() {
         self.purchases.delegate = nil
 
-        expect(self.storeKitWrapper.delegate).toNot(beNil())
+        expect(self.storeKit1Wrapper.delegate).toNot(beNil())
 
         self.purchases.delegate = self.purchasesDelegate
 
-        expect(self.storeKitWrapper.delegate).toNot(beNil())
+        expect(self.storeKit1Wrapper.delegate).toNot(beNil())
     }
 
     func testSubscribesToUIApplicationDidBecomeActive() throws {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
@@ -49,15 +49,15 @@ class PurchasesGetOfferingsTests: BasePurchasesTests {
             self.purchases.purchase(product: storeProduct) { (_, _, _, _) in }
 
             let transaction = MockTransaction()
-            transaction.mockPayment = self.storeKitWrapper.payment!
+            transaction.mockPayment = self.storeKit1Wrapper.payment!
 
             transaction.mockState = SKPaymentTransactionState.purchasing
-            self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+            self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
             self.backend.postReceiptResult = .success(CustomerInfo(testData: Self.emptyCustomerInfoData)!)
 
             transaction.mockState = SKPaymentTransactionState.purchased
-            self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+            self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
         }
 
         expect(product).toEventuallyNot(beNil())
@@ -68,7 +68,7 @@ class PurchasesGetOfferingsTests: BasePurchasesTests {
         expect(self.backend.postedPrice) == product.price as Decimal
         expect(self.backend.postedCurrencyCode) == product.priceLocale.currencyCode
 
-        expect(self.storeKitWrapper.finishCalled).toEventually(beTrue())
+        expect(self.storeKit1Wrapper.finishCalled).toEventually(beTrue())
     }
 
     func testInvalidateCustomerInfoCacheDoesntClearOfferingsCache() {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetProductsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetProductsTests.swift
@@ -74,16 +74,16 @@ class PurchasesGetProductsBackgroundTests: BasePurchasesTests {
         let product = StoreProduct(sk1Product: sk1Product)
 
         let transaction = MockTransaction()
-        self.storeKitWrapper.payment = SKPayment(product: sk1Product)
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        self.storeKit1Wrapper.payment = SKPayment(product: sk1Product)
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
         transaction.mockState = SKPaymentTransactionState.purchasing
 
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         self.backend.postReceiptResult = .success(try CustomerInfo(data: Self.emptyCustomerInfoData))
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.mockProductsManager.invokedProductsParameters).toEventually(contain([product.productIdentifier]))
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
@@ -30,13 +30,13 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
 
         transaction.mockState = SKPaymentTransactionState.purchasing
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
         expect(self.backend.postedIsRestore) == false
@@ -47,8 +47,8 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 
-        expect(self.storeKitWrapper.payment).toNot(beNil())
-        expect(self.storeKitWrapper.payment?.productIdentifier).to(equal(product.productIdentifier))
+        expect(self.storeKit1Wrapper.payment).toNot(beNil())
+        expect(self.storeKit1Wrapper.payment?.productIdentifier).to(equal(product.productIdentifier))
     }
 
     func testPurchaseProductCachesProduct() {
@@ -65,13 +65,13 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
 
         transaction.mockState = SKPaymentTransactionState.purchasing
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
         expect(self.backend.postedIsRestore) == false
@@ -84,13 +84,13 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
 
         transaction.mockState = SKPaymentTransactionState.purchasing
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
         expect(self.backend.postedIsRestore) == true
@@ -101,18 +101,18 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
 
         transaction.mockState = SKPaymentTransactionState.purchasing
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         self.backend.postReceiptResult = .success(try CustomerInfo(data: Self.emptyCustomerInfoData))
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
-        expect(self.storeKitWrapper.finishCalled).toEventually(beTrue())
+        expect(self.storeKit1Wrapper.finishCalled).toEventually(beTrue())
     }
 
     func testDoesntFinishTransactionsIfFinishingDisabled() throws {
@@ -121,18 +121,18 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
 
         transaction.mockState = SKPaymentTransactionState.purchasing
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         self.backend.postReceiptResult = .success(try CustomerInfo(data: Self.emptyCustomerInfoData))
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
-        expect(self.storeKitWrapper.finishCalled).toEventually(beFalse())
+        expect(self.storeKit1Wrapper.finishCalled).toEventually(beFalse())
     }
 
     func testAfterSendingDoesntFinishTransactionIfBackendError() {
@@ -140,7 +140,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
         self.backend.postReceiptResult = .failure(
             .networkError(.errorResponse(
                 .init(code: .unknownBackendError, message: nil),
@@ -149,10 +149,10 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         )
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
-        expect(self.storeKitWrapper.finishCalled) == false
+        expect(self.storeKit1Wrapper.finishCalled) == false
     }
 
     func testAfterSendingFinishesFromBackendErrorIfAppropriate() {
@@ -160,7 +160,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
 
         self.backend.postReceiptResult = .failure(
             .networkError(.errorResponse(
@@ -170,17 +170,17 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         )
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
-        expect(self.storeKitWrapper.finishCalled).toEventually(beTrue())
+        expect(self.storeKit1Wrapper.finishCalled).toEventually(beTrue())
     }
 
     func testNotifiesIfTransactionFailsFromBackend() {
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases.purchase(product: product) { (_, _, _, _) in }
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
 
         self.backend.postReceiptResult = .failure(
             .networkError(.errorResponse(
@@ -190,10 +190,10 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         )
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
-        expect(self.storeKitWrapper.finishCalled) == false
+        expect(self.storeKit1Wrapper.finishCalled) == false
     }
 
     func testNotifiesIfTransactionFailsFromStoreKit() {
@@ -205,15 +205,15 @@ class PurchasesPurchasingTests: BasePurchasesTests {
 
         let transaction = MockTransaction()
         transaction.mockError = NSError.init(domain: SKErrorDomain, code: 2, userInfo: nil)
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
 
         self.backend.postReceiptResult = .failure(.missingTransactionProductIdentifier())
 
         transaction.mockState = SKPaymentTransactionState.failed
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == false
-        expect(self.storeKitWrapper.finishCalled) == true
+        expect(self.storeKit1Wrapper.finishCalled) == true
         expect(receivedError).toEventuallyNot(beNil())
     }
 
@@ -227,14 +227,14 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
 
         self.backend.postReceiptResult = .success(try CustomerInfo(data: Self.emptyCustomerInfoData))
 
         transaction.mockState = SKPaymentTransactionState.purchased
 
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(callCount).toEventually(equal(1))
     }
@@ -248,9 +248,9 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(receivedUserCancelled).toEventually(beFalse())
     }
@@ -281,10 +281,10 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
         transaction.mockState = .failed
         transaction.mockError = unknownError
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(receivedUserCancelled).toEventually(beFalse())
         expect(receivedError).toEventuallyNot(beNil())
@@ -312,10 +312,10 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = try XCTUnwrap(self.storeKitWrapper.payment)
+        transaction.mockPayment = try XCTUnwrap(self.storeKit1Wrapper.payment)
         transaction.mockState = .failed
         transaction.mockError = NSError(domain: SKErrorDomain, code: SKError.Code.paymentCancelled.rawValue)
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(receivedUserCancelled).toEventuallyNot(beNil())
 
@@ -346,13 +346,13 @@ class PurchasesPurchasingTests: BasePurchasesTests {
             }
         }
 
-        expect(self.storeKitWrapper.payment).toEventuallyNot(beNil())
+        expect(self.storeKit1Wrapper.payment).toEventuallyNot(beNil())
 
         let transaction = MockTransaction()
-        transaction.mockPayment = try XCTUnwrap(self.storeKitWrapper.payment)
+        transaction.mockPayment = try XCTUnwrap(self.storeKit1Wrapper.payment)
         transaction.mockState = .failed
         transaction.mockError = NSError(domain: SKErrorDomain, code: SKError.Code.paymentCancelled.rawValue)
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(receivedError).toEventuallyNot(beNil())
         expect(receivedError).to(matchError(ErrorCode.purchaseCancelledError))
@@ -371,9 +371,9 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(receivedUserCancelled).toEventually(beFalse())
         expect(receivedError).toEventuallyNot(beNil())
@@ -388,18 +388,18 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
 
         transaction.mockState = SKPaymentTransactionState.purchasing
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         self.backend.postReceiptResult = .success(try CustomerInfo(data: Self.emptyCustomerInfoData))
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
-        expect(self.storeKitWrapper.finishCalled).toEventually(beTrue())
+        expect(self.storeKit1Wrapper.finishCalled).toEventually(beTrue())
     }
 
     func testNoCrashIfPaymentIsMissing() {
@@ -408,10 +408,10 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         let transaction = SKPaymentTransaction()
 
         transaction.setValue(SKPaymentTransactionState.purchasing.rawValue, forKey: "transactionState")
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         transaction.setValue(SKPaymentTransactionState.purchased.rawValue, forKey: "transactionState")
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
     }
 
     func testNoCrashIfPaymentDoesNotHaveProductIdenfier() {
@@ -419,10 +419,10 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         transaction.mockPayment = SKPayment()
 
         transaction.setValue(SKPaymentTransactionState.purchasing.rawValue, forKey: "transactionState")
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         transaction.setValue(SKPaymentTransactionState.purchased.rawValue, forKey: "transactionState")
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
     }
 
     func testReceiptsSendsObserverModeOffWhenObserverModeOff() {
@@ -430,13 +430,13 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
 
         transaction.mockState = SKPaymentTransactionState.purchasing
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
         expect(self.backend.postedObserverMode) == false
@@ -450,13 +450,13 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
 
         transaction.mockState = SKPaymentTransactionState.deferred
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == false
-        expect(self.storeKitWrapper.finishCalled) == false
+        expect(self.storeKit1Wrapper.finishCalled) == false
         expect(receivedError).toEventuallyNot(beNil())
         expect(receivedError?.domain).toEventually(equal(RCPurchasesErrorCodeDomain))
         expect(receivedError?.code).toEventually(equal(ErrorCode.paymentPendingError.rawValue))
@@ -485,15 +485,15 @@ class PurchasesPurchasingTests: BasePurchasesTests {
             self.purchases.purchase(package: package) { (_, _, _, _) in }
 
             let transaction = MockTransaction()
-            transaction.mockPayment = self.storeKitWrapper.payment!
+            transaction.mockPayment = self.storeKit1Wrapper.payment!
 
             transaction.mockState = SKPaymentTransactionState.purchasing
-            self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+            self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
             self.backend.postReceiptResult = .success(CustomerInfo(testData: Self.emptyCustomerInfoData)!)
 
             transaction.mockState = SKPaymentTransactionState.purchased
-            self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+            self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
         }
 
         expect(package).toEventuallyNot(beNil())
@@ -504,7 +504,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(self.backend.postedProductID).to(equal(package.storeProduct.productIdentifier))
         expect(self.backend.postedPrice) == package.storeProduct.price
         expect(self.backend.postedOfferingIdentifier).to(equal("base"))
-        expect(self.storeKitWrapper.finishCalled).toEventually(beTrue())
+        expect(self.storeKit1Wrapper.finishCalled).toEventually(beTrue())
     }
 
     func testPurchasingPackageDoesntThrowPurchaseAlreadyInProgressIfCallbackMakesANewPurchase() throws {
@@ -564,10 +564,10 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(customerInfo).toEventually(equal(customerInfoAfterPurchase))
         expect(receivedError).toEventually(beNil())
@@ -592,7 +592,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
 
         transaction.mockState = SKPaymentTransactionState.purchased
 
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(callCount).toEventually(equal(0))
     }
@@ -618,7 +618,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(receivedInfo).to(beNil())
         expect(receivedError?.domain) == RCPurchasesErrorCodeDomain
         expect(receivedError?.code) == ErrorCode.operationAlreadyInProgressForProductError.rawValue
-        expect(self.storeKitWrapper.addPaymentCallCount) == 1
+        expect(self.storeKit1Wrapper.addPaymentCallCount) == 1
         expect(receivedUserCancelled) == false
     }
 
@@ -627,10 +627,10 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
         transaction.mockState = SKPaymentTransactionState.purchasing
 
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled).to(beFalse())
     }
@@ -659,13 +659,13 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = try XCTUnwrap(self.storeKitWrapper.payment)
+        transaction.mockPayment = try XCTUnwrap(self.storeKit1Wrapper.payment)
 
         transaction.mockState = .purchasing
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
         expect(self.deviceCache.cacheCustomerInfoCount).toEventually(equal(2))
@@ -704,10 +704,10 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
         transaction.mockState = .failed
         transaction.mockError = unknownError
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(receivedUserCancelled).toEventuallyNot(beNil())
         expect(receivedUserCancelled) == true
@@ -722,15 +722,15 @@ class PurchasesPurchasingTests: BasePurchasesTests {
             self.purchases.purchase(product: newProducts[0]) { (_, _, _, _) in }
 
             let transaction = MockTransaction()
-            transaction.mockPayment = self.storeKitWrapper.payment!
+            transaction.mockPayment = self.storeKit1Wrapper.payment!
 
             transaction.mockState = SKPaymentTransactionState.purchasing
-            self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+            self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
             self.backend.postReceiptResult = .success(CustomerInfo(testData: Self.emptyCustomerInfoData)!)
 
             transaction.mockState = SKPaymentTransactionState.purchased
-            self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+            self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
             expect(self.backend.postReceiptDataCalled).to(beTrue())
             expect(self.backend.postedReceiptData).toNot(beNil())
@@ -761,7 +761,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
 
             expect(self.backend.postedCurrencyCode) == product.priceFormatter!.currencyCode
 
-            expect(self.storeKitWrapper.finishCalled).toEventually(beTrue())
+            expect(self.storeKit1Wrapper.finishCalled).toEventually(beTrue())
         }
     }
 
@@ -769,13 +769,13 @@ class PurchasesPurchasingTests: BasePurchasesTests {
 
     private func performTransaction() {
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
 
         transaction.mockState = SKPaymentTransactionState.purchasing
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
         self.backend.postReceiptResult = .success(CustomerInfo(testData: Self.emptyCustomerInfoData)!)
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
     }
 
 }
@@ -789,13 +789,13 @@ class PurchasesPurchasingCustomSetupTests: BasePurchasesTests {
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
 
         transaction.mockState = SKPaymentTransactionState.purchasing
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
         expect(self.backend.postedIsRestore) == true
@@ -810,13 +810,13 @@ class PurchasesPurchasingCustomSetupTests: BasePurchasesTests {
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
 
         transaction.mockState = SKPaymentTransactionState.purchasing
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
         expect(self.backend.postedIsRestore) == false
@@ -832,19 +832,19 @@ class PurchasesPurchasingCustomSetupTests: BasePurchasesTests {
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
 
         transaction.mockState = SKPaymentTransactionState.purchasing
-        self.storeKitWrapper.delegate?.storeKitWrapper(
-            self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(
+            self.storeKit1Wrapper, updatedTransaction: transaction)
 
         self.backend.postReceiptResult = .success(try CustomerInfo(data: Self.emptyCustomerInfoData))
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == false
-        expect(self.storeKitWrapper.finishCalled).toEventually(beFalse())
+        expect(self.storeKit1Wrapper.finishCalled).toEventually(beFalse())
     }
 
     func testDoesntPostTransactionsIfAutoSyncPurchasesSettingIsOff() throws {
@@ -857,19 +857,19 @@ class PurchasesPurchasingCustomSetupTests: BasePurchasesTests {
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
 
         transaction.mockState = SKPaymentTransactionState.purchasing
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         self.backend.postReceiptResult = .success(try CustomerInfo(data: Self.emptyCustomerInfoData))
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == false
         // Sync purchases never finishes transactions
-        expect(self.storeKitWrapper.finishCalled).toEventually(beFalse())
+        expect(self.storeKit1Wrapper.finishCalled).toEventually(beFalse())
     }
 
     func testDoesntFinishTransactionsIfObserverModeIsSet() throws {
@@ -879,18 +879,18 @@ class PurchasesPurchasingCustomSetupTests: BasePurchasesTests {
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
 
         transaction.mockState = SKPaymentTransactionState.purchasing
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         self.backend.postReceiptResult = .success(try CustomerInfo(data: Self.emptyCustomerInfoData))
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
-        expect(self.storeKitWrapper.finishCalled).toEventually(beFalse())
+        expect(self.storeKit1Wrapper.finishCalled).toEventually(beFalse())
     }
 
     func testReceiptsSendsObserverModeWhenObserverMode() throws {
@@ -900,13 +900,13 @@ class PurchasesPurchasingCustomSetupTests: BasePurchasesTests {
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
 
         transaction.mockState = SKPaymentTransactionState.purchasing
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
         expect(self.backend.postedObserverMode) == true
@@ -919,13 +919,13 @@ class PurchasesPurchasingCustomSetupTests: BasePurchasesTests {
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.storeKitWrapper.payment!
+        transaction.mockPayment = self.storeKit1Wrapper.payment!
 
         transaction.mockState = SKPaymentTransactionState.restored
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
-        expect(self.storeKitWrapper.finishCalled).toEventually(beFalse())
+        expect(self.storeKit1Wrapper.finishCalled).toEventually(beFalse())
     }
 
 }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncPurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncPurchasesTests.swift
@@ -162,8 +162,8 @@ class PurchasesSyncPurchasesTests: BasePurchasesTests {
         try AvailabilityChecks.iOS14APIAvailableOrSkipTest()
 
         expect(self.backend.postReceiptDataCalled) == false
-        (self.purchasesOrchestrator as StoreKitWrapperDelegate)
-            .storeKitWrapper(self.storeKitWrapper, didRevokeEntitlementsForProductIdentifiers: ["a", "b"])
+        (self.purchasesOrchestrator as StoreKit1WrapperDelegate)
+            .storeKit1Wrapper(self.storeKit1Wrapper, didRevokeEntitlementsForProductIdentifiers: ["a", "b"])
 
         expect(self.backend.postReceiptDataCalled) == true
     }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesTransactionHandlingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesTransactionHandlingTests.swift
@@ -29,9 +29,9 @@ class PurchasesTransactionHandlingTests: BasePurchasesTests {
         self.setupPurchases()
     }
 
-    private var delegate: StoreKitWrapperDelegate {
+    private var delegate: StoreKit1WrapperDelegate {
         get throws {
-            return try XCTUnwrap(self.storeKitWrapper.delegate)
+            return try XCTUnwrap(self.storeKit1Wrapper.delegate)
         }
     }
 
@@ -65,10 +65,10 @@ class PurchasesTransactionHandlingTests: BasePurchasesTests {
         transaction.mockPayment = payment
 
         transaction.mockState = .purchasing
-        try self.delegate.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        try self.delegate.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         transaction.mockState = .purchased
-        try self.delegate.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        try self.delegate.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
         expect(self.purchasesDelegate.customerInfoReceivedCount).toEventually(equal(2))
@@ -94,15 +94,15 @@ class PurchasesTransactionHandlingTests: BasePurchasesTests {
         transaction.mockPayment = payment
         transaction.mockState = .purchasing
 
-        self.storeKitWrapper.delegate?.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         self.backend.postReceiptResult = .success(customerInfo1)
         transaction.mockState = .purchased
-        try self.delegate.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        try self.delegate.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         self.backend.postReceiptResult = .success(customerInfo2)
         transaction.mockState = .purchased
-        try self.delegate.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        try self.delegate.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
         expect(self.purchasesDelegate.customerInfoReceivedCount).toEventually(equal(2))
@@ -137,15 +137,15 @@ class PurchasesTransactionHandlingTests: BasePurchasesTests {
         transaction.mockPayment = payment
         transaction.mockState = .purchasing
 
-        try self.delegate.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        try self.delegate.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         self.backend.postReceiptResult = .success(customerInfo1)
         transaction.mockState = .purchased
-        try self.delegate.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        try self.delegate.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         self.backend.postReceiptResult = .success(customerInfo2)
         transaction.mockState = .purchased
-        try self.delegate.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        try self.delegate.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
         expect(self.purchasesDelegate.customerInfoReceivedCount).toEventually(equal(3))
@@ -161,7 +161,7 @@ class PurchasesTransactionHandlingTests: BasePurchasesTests {
         transaction.mockPayment = payment
         transaction.mockState = .purchased
 
-        try self.delegate.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        try self.delegate.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled).to(beTrue())
     }
@@ -194,10 +194,10 @@ class PurchasesTransactionHandlingTests: BasePurchasesTests {
         transaction.mockPayment = payment
 
         transaction.mockState = .purchasing
-        try self.delegate.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        try self.delegate.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         transaction.mockState = .purchased
-        try self.delegate.storeKitWrapper(self.storeKitWrapper, updatedTransaction: transaction)
+        try self.delegate.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled).to(beTrue())
         expect(self.purchasesDelegate.customerInfoReceivedCount).toEventually(equal(2))

--- a/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
@@ -1,5 +1,5 @@
 //
-//  StoreKitWrapperTests.swift
+//  StoreKit1WrapperTests.swift
 //  PurchasesTests
 //
 //  Created by RevenueCat.
@@ -46,51 +46,51 @@ class MockPaymentQueue: SKPaymentQueue {
 
 }
 
-class StoreKitWrapperTests: TestCase, StoreKitWrapperDelegate {
+class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
     let paymentQueue = MockPaymentQueue()
 
-    var wrapper: StoreKitWrapper?
+    var wrapper: StoreKit1Wrapper?
 
     override func setUp() {
         super.setUp()
-        wrapper = StoreKitWrapper.init(paymentQueue: paymentQueue)
+        wrapper = StoreKit1Wrapper.init(paymentQueue: paymentQueue)
         wrapper?.delegate = self
     }
 
     var updatedTransactions: [SKPaymentTransaction] = []
 
-    func storeKitWrapper(_ storeKitWrapper: StoreKitWrapper, updatedTransaction transaction: SKPaymentTransaction) {
+    func storeKit1Wrapper(_ storeKit1Wrapper: StoreKit1Wrapper, updatedTransaction transaction: SKPaymentTransaction) {
         updatedTransactions.append(transaction)
     }
 
     var removedTransactions: [SKPaymentTransaction] = []
 
-    func storeKitWrapper(_ storeKitWrapper: StoreKitWrapper, removedTransaction transaction: SKPaymentTransaction) {
+    func storeKit1Wrapper(_ storeKit1Wrapper: StoreKit1Wrapper, removedTransaction transaction: SKPaymentTransaction) {
         removedTransactions.append(transaction)
     }
 
     var promoPayment: SKPayment?
     var promoProduct: SK1Product?
     var shouldAddPromo = false
-    func storeKitWrapper(_ storeKitWrapper: StoreKitWrapper,
-                         shouldAddStorePayment payment: SKPayment,
-                         for product: SK1Product) -> Bool {
+    func storeKit1Wrapper(_ storeKit1Wrapper: StoreKit1Wrapper,
+                          shouldAddStorePayment payment: SKPayment,
+                          for product: SK1Product) -> Bool {
         promoPayment = payment
         promoProduct = product
         return shouldAddPromo
     }
 
     var storefrontChangesCount: Int = 0
-    func storeKitWrapperDidChangeStorefront(_ storeKitWrapper: StoreKitWrapper) {
+    func storeKit1WrapperDidChangeStorefront(_ storeKit1Wrapper: StoreKit1Wrapper) {
         storefrontChangesCount += 1
     }
 
-    var storeKitWrapperShouldShowPriceConsent = true
+    var storeKit1WrapperShouldShowPriceConsent = true
 
     var productIdentifiersWithRevokedEntitlements: [String]?
 
-    func storeKitWrapper(
-        _ storeKitWrapper: StoreKitWrapper,
+    func storeKit1Wrapper(
+        _ storeKit1Wrapper: StoreKit1Wrapper,
         didRevokeEntitlementsForProductIdentifiers productIdentifiers: [String]
     ) {
         productIdentifiersWithRevokedEntitlements = productIdentifiers
@@ -228,11 +228,11 @@ class StoreKitWrapperTests: TestCase, StoreKitWrapperDelegate {
 
         let mockProduct = MockSK1Product(mockProductIdentifier: "mySuperProduct")
 
-        StoreKitWrapper.simulatesAskToBuyInSandbox = false
+        StoreKit1Wrapper.simulatesAskToBuyInSandbox = false
         let payment1 = wrapper.payment(with: mockProduct)
         expect(payment1.simulatesAskToBuyInSandbox) == false
 
-        StoreKitWrapper.simulatesAskToBuyInSandbox = true
+        StoreKit1Wrapper.simulatesAskToBuyInSandbox = true
         let payment2 = wrapper.payment(with: mockProduct)
         expect(payment2.simulatesAskToBuyInSandbox) == true
     }
@@ -262,11 +262,11 @@ class StoreKitWrapperTests: TestCase, StoreKitWrapperDelegate {
         let mockProduct = MockSK1Product(mockProductIdentifier: "mySuperProduct")
         let mockDiscount = MockPaymentDiscount(mockIdentifier: "mySuperDiscount")
 
-        StoreKitWrapper.simulatesAskToBuyInSandbox = false
+        StoreKit1Wrapper.simulatesAskToBuyInSandbox = false
         let payment1 = wrapper.payment(with: mockProduct, discount: mockDiscount)
         expect(payment1.simulatesAskToBuyInSandbox) == false
 
-        StoreKitWrapper.simulatesAskToBuyInSandbox = true
+        StoreKit1Wrapper.simulatesAskToBuyInSandbox = true
         let payment2 = wrapper.payment(with: mockProduct)
         expect(payment2.simulatesAskToBuyInSandbox) == true
     }
@@ -276,9 +276,9 @@ class StoreKitWrapperTests: TestCase, StoreKitWrapperDelegate {
         guard #available(iOS 13.4, macCatalyst 13.4, *) else {
             throw XCTSkip()
         }
-        expect(self.storeKitWrapperShouldShowPriceConsent) == true
+        expect(self.storeKit1WrapperShouldShowPriceConsent) == true
 
-        self.storeKitWrapperShouldShowPriceConsent = false
+        self.storeKit1WrapperShouldShowPriceConsent = false
 
         let consentStatuses = self.paymentQueue.simulatePaymentQueueShouldShowPriceConsent()
         expect(consentStatuses) == [false]

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -22,7 +22,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
     let mockRequestFetcher = MockRequestFetcher()
     var mockProductsManager: MockProductsManager!
     let mockBackend = MockBackend()
-    let mockStoreKitWrapper = MockStoreKitWrapper()
+    let mockStoreKit1Wrapper = MockStoreKit1Wrapper()
     let mockNotificationCenter = MockNotificationCenter()
     var userDefaults: UserDefaults! = nil
     let mockOfferingsFactory = MockOfferingsFactory()
@@ -139,7 +139,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
 
         self.mockIdentityManager.mockIsAnonymous = false
         let purchasesOrchestrator = PurchasesOrchestrator(productsManager: mockProductsManager,
-                                                          storeKitWrapper: mockStoreKitWrapper,
+                                                          storeKit1Wrapper: mockStoreKit1Wrapper,
                                                           systemInfo: systemInfo,
                                                           subscriberAttributes: attribution,
                                                           operationDispatcher: mockOperationDispatcher,
@@ -167,7 +167,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
                               attributionFetcher: mockAttributionFetcher,
                               attributionPoster: mockAttributionPoster,
                               backend: mockBackend,
-                              storeKitWrapper: mockStoreKitWrapper,
+                              storeKit1Wrapper: mockStoreKit1Wrapper,
                               paymentQueueWrapper: .init(),
                               notificationCenter: mockNotificationCenter,
                               systemInfo: systemInfo,
@@ -688,18 +688,18 @@ class PurchasesSubscriberAttributesTests: TestCase {
         mockSubscriberAttributesManager.stubbedUnsyncedAttributesByKeyResult = mockAttributes
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.mockStoreKitWrapper.payment!
+        transaction.mockPayment = self.mockStoreKit1Wrapper.payment!
 
         transaction.mockState = SKPaymentTransactionState.purchasing
-        self.mockStoreKitWrapper.delegate?.storeKitWrapper(self.mockStoreKitWrapper, updatedTransaction: transaction)
+        self.mockStoreKit1Wrapper.delegate?.storeKit1Wrapper(self.mockStoreKit1Wrapper, updatedTransaction: transaction)
 
         self.mockBackend.stubbedPostReceiptResult = .success(CustomerInfo(testData: emptyCustomerInfoData)!)
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.mockStoreKitWrapper.delegate?.storeKitWrapper(self.mockStoreKitWrapper, updatedTransaction: transaction)
+        self.mockStoreKit1Wrapper.delegate?.storeKit1Wrapper(self.mockStoreKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.mockBackend.invokedPostReceiptData).to(beTrue())
-        expect(self.mockStoreKitWrapper.finishCalled).toEventually(beTrue())
+        expect(self.mockStoreKit1Wrapper.finishCalled).toEventually(beTrue())
         expect(self.mockSubscriberAttributesManager.invokedMarkAttributes) == true
         expect(self.mockSubscriberAttributesManager.invokedMarkAttributesParameters!.syncedAttributes) == mockAttributes
         expect(self.mockSubscriberAttributesManager.invokedMarkAttributesParameters!.appUserID) ==
@@ -714,10 +714,10 @@ class PurchasesSubscriberAttributesTests: TestCase {
         mockSubscriberAttributesManager.stubbedUnsyncedAttributesByKeyResult = mockAttributes
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.mockStoreKitWrapper.payment!
+        transaction.mockPayment = self.mockStoreKit1Wrapper.payment!
 
         transaction.mockState = SKPaymentTransactionState.purchasing
-        self.mockStoreKitWrapper.delegate?.storeKitWrapper(self.mockStoreKitWrapper, updatedTransaction: transaction)
+        self.mockStoreKit1Wrapper.delegate?.storeKit1Wrapper(self.mockStoreKit1Wrapper, updatedTransaction: transaction)
 
         self.mockBackend.stubbedPostReceiptResult = .failure(
             .networkError(.errorResponse(
@@ -727,7 +727,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
         )
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.mockStoreKitWrapper.delegate?.storeKitWrapper(self.mockStoreKitWrapper, updatedTransaction: transaction)
+        self.mockStoreKit1Wrapper.delegate?.storeKit1Wrapper(self.mockStoreKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.mockBackend.invokedPostReceiptData).toEventually(equal(true))
         expect(self.mockSubscriberAttributesManager.invokedMarkAttributes).toEventually(equal(true))
@@ -744,10 +744,10 @@ class PurchasesSubscriberAttributesTests: TestCase {
         mockSubscriberAttributesManager.stubbedUnsyncedAttributesByKeyResult = mockAttributes
 
         let transaction = MockTransaction()
-        transaction.mockPayment = self.mockStoreKitWrapper.payment!
+        transaction.mockPayment = self.mockStoreKit1Wrapper.payment!
 
         transaction.mockState = SKPaymentTransactionState.purchasing
-        self.mockStoreKitWrapper.delegate?.storeKitWrapper(self.mockStoreKitWrapper, updatedTransaction: transaction)
+        self.mockStoreKit1Wrapper.delegate?.storeKit1Wrapper(self.mockStoreKit1Wrapper, updatedTransaction: transaction)
 
         self.mockBackend.stubbedPostReceiptResult = .failure(
             .networkError(.errorResponse(
@@ -757,7 +757,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
         )
 
         transaction.mockState = SKPaymentTransactionState.purchased
-        self.mockStoreKitWrapper.delegate?.storeKitWrapper(self.mockStoreKitWrapper, updatedTransaction: transaction)
+        self.mockStoreKit1Wrapper.delegate?.storeKit1Wrapper(self.mockStoreKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.mockBackend.invokedPostReceiptData).to(beTrue())
         expect(self.mockSubscriberAttributesManager.invokedMarkAttributes) == false


### PR DESCRIPTION
Follow up to #1882. Now that `StoreKit1Wrapper` is not initialized for SK2, it makes sense to clarify that this class is only for SK1.
This is just a simple find-replace.