### PR TITLE
`CustomerInfoManager`/`OfferingsManager`: improved display of underlying errors

### DIFF
--- a/Sources/Error Handling/BackendError.swift
+++ b/Sources/Error Handling/BackendError.swift
@@ -153,6 +153,27 @@ extension BackendError {
 
 extension BackendError {
 
+    var underlyingError: Error? {
+        switch self {
+        case let .networkError(error):
+            return error
+
+        case .missingAppUserID,
+                .emptySubscriberAttributes,
+                .missingReceiptFile,
+                .missingTransactionProductIdentifier,
+                .missingCachedCustomerInfo:
+            return nil
+
+        case let .unexpectedBackendResponse(error, _, _):
+            return error
+        }
+    }
+
+}
+
+extension BackendError {
+
     enum UnexpectedBackendResponseError: Error, Equatable {
 
         /// Login call failed due to a problem with the response.

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -42,7 +42,7 @@ class CustomerInfoManager {
             switch result {
             case let .failure(error):
                 self.deviceCache.clearCustomerInfoCacheTimestamp(appUserID: appUserID)
-                Logger.warn(Strings.customerInfo.customerinfo_updated_from_network_error(error: error))
+                Logger.warn(Strings.customerInfo.customerinfo_updated_from_network_error(error))
 
             case let .success(info):
                 self.cache(customerInfo: info, appUserID: appUserID)

--- a/Sources/Logging/Strings/CustomerInfoStrings.swift
+++ b/Sources/Logging/Strings/CustomerInfoStrings.swift
@@ -25,7 +25,7 @@ enum CustomerInfoStrings {
     case customerinfo_stale_updating_in_background
     case customerinfo_stale_updating_in_foreground
     case customerinfo_updated_from_network
-    case customerinfo_updated_from_network_error(error: Error)
+    case customerinfo_updated_from_network_error(BackendError)
     case sending_latest_customerinfo_to_delegate
     case sending_updated_customerinfo_to_delegate
     case vending_cache
@@ -53,8 +53,14 @@ extension CustomerInfoStrings: CustomStringConvertible {
             return "CustomerInfo cache is stale, updating from network in foreground."
         case .customerinfo_updated_from_network:
             return "CustomerInfo updated from network."
-        case .customerinfo_updated_from_network_error(let error):
-            return "Attempt to update CustomerInfo from network failed.\n\(error.localizedDescription)"
+        case let .customerinfo_updated_from_network_error(error):
+            var result = "Attempt to update CustomerInfo from network failed.\n\(error.localizedDescription)"
+
+            if let underlyingError = error.underlyingError {
+                result += "\nUnderlying error: \(underlyingError.localizedDescription)"
+            }
+
+            return result
         case .sending_latest_customerinfo_to_delegate:
             return "Sending latest CustomerInfo to delegate."
         case .sending_updated_customerinfo_to_delegate:

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -240,6 +240,7 @@ extension OfferingsManager.Error: CustomNSError {
 
     fileprivate var underlyingError: Error? {
         switch self {
+        case let .backendError(.networkError(error)): return error
         case let .backendError(error): return error
         case let .configurationError(_, error, _): return error
         case .noOfferingsFound: return nil


### PR DESCRIPTION
Improved these 2 logs:

> 🍎‼️ Error fetching offerings - The operation couldn’t be completed. (RevenueCat.OfferingsManager.Error error 0.)
Underlying error: The operation couldn’t be completed. (RevenueCat.BackendError error 0.)

> ⚠️ Attempt to update CustomerInfo from network failed.
The operation couldn’t be completed. (RevenueCat.BackendError error 0.)

These 2 now will display the underlying `NetworkError` instead of the opaque "(RevenueCat.BackendError error 0.)".