### PR TITLE
Fixed `CarthageInstallation` tests

### DIFF
--- a/Tests/InstallationTests/CarthageInstallation/CarthageInstallation.xcodeproj/project.pbxproj
+++ b/Tests/InstallationTests/CarthageInstallation/CarthageInstallation.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		2D6C03212549FF4F0039CB92 /* RCInstallationRunner.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D6C02F02549FE2C0039CB92 /* RCInstallationRunner.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2D6C0393254A04300039CB92 /* Dummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D6C0392254A04300039CB92 /* Dummy.swift */; };
 		2DC19168255F1D100039389A /* InstallationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC19167255F1D0F0039389A /* InstallationTests.swift */; };
+		57CFCF3028CA6DD400B4BF4D /* RCInstallationRunner.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D6C02E72549FE2C0039CB92 /* RCInstallationRunner.m */; };
 		B33EDF7326E2D53F00F379EA /* RevenueCat.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = B33EDF7226E2D53F00F379EA /* RevenueCat.xcframework */; };
 /* End PBXBuildFile section */
 
@@ -209,7 +210,6 @@
 					2D6C02972549F7700039CB92 = {
 						CreatedOnToolsVersion = 12.1;
 						LastSwiftMigration = 1210;
-						TestTargetID = 2D6C027C2549F76E0039CB92;
 					};
 				};
 			};
@@ -270,6 +270,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				57CFCF3028CA6DD400B4BF4D /* RCInstallationRunner.m in Sources */,
 				2DC19168255F1D100039389A /* InstallationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -473,7 +474,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 8SXR2327BM;
@@ -491,7 +491,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CarthageInstallation.app/CarthageInstallation";
 			};
 			name = Debug;
 		};
@@ -499,7 +498,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 8SXR2327BM;
@@ -516,7 +514,6 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "CarthageInstallationTests/CarthageInstallationTests-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CarthageInstallation.app/CarthageInstallation";
 			};
 			name = Release;
 		};

--- a/Tests/InstallationTests/CarthageInstallation/CarthageInstallation.xcodeproj/project.pbxproj
+++ b/Tests/InstallationTests/CarthageInstallation/CarthageInstallation.xcodeproj/project.pbxproj
@@ -426,10 +426,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 8SXR2327BM;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/RevenueCat.xcframework/ios-arm64_armv7",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/../CommonFiles/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -456,10 +453,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 8SXR2327BM;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/RevenueCat.xcframework/ios-arm64_armv7",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/../CommonFiles/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Tests/InstallationTests/CarthageInstallation/CarthageInstallation.xcodeproj/xcshareddata/xcschemes/CarthageInstallation.xcscheme
+++ b/Tests/InstallationTests/CarthageInstallation/CarthageInstallation.xcodeproj/xcshareddata/xcschemes/CarthageInstallation.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2D6C027C2549F76E0039CB92"
+               BuildableName = "CarthageInstallation.app"
+               BlueprintName = "CarthageInstallation"
+               ReferencedContainer = "container:CarthageInstallation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2D6C02972549F7700039CB92"
+               BuildableName = "CarthageInstallationTests.xctest"
+               BlueprintName = "CarthageInstallationTests"
+               ReferencedContainer = "container:CarthageInstallation.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2D6C027C2549F76E0039CB92"
+            BuildableName = "CarthageInstallation.app"
+            BlueprintName = "CarthageInstallation"
+            ReferencedContainer = "container:CarthageInstallation.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2D6C027C2549F76E0039CB92"
+            BuildableName = "CarthageInstallation.app"
+            BlueprintName = "CarthageInstallation"
+            ReferencedContainer = "container:CarthageInstallation.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
For #1890.

The failure was likely because the simulators had a dialog which was blocking the tests from continuing. In order to fix that, I removed the test host from the target, which was never necessary and will make running these tests a bit faster.

### Changes:
- `CarthageInstallation`: removed unnecessary `FRAMEWORK_SEARCH_PATHS`
- Removed test host
- Added single scheme with `test` action