### PR TITLE
`IntegrationTests`: simplified `testExpireSubscription` to fix flaky test

### DIFF
--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -284,10 +284,9 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
         let (_, created) = try await Purchases.shared.logIn(UUID().uuidString)
         expect(created) == true
 
-        try await self.purchaseWeeklyOffering()
-        var customerInfo = try await Purchases.shared.syncPurchases()
+        var customerInfo = try await self.purchaseWeeklyOffering().customerInfo
+        let entitlement = try XCTUnwrap(customerInfo.entitlements.all[Self.entitlementIdentifier])
 
-        let entitlement = try self.verifyEntitlementWentThrough(customerInfo)
         try await self.expireSubscription(entitlement)
 
         customerInfo = try await Purchases.shared.syncPurchases()


### PR DESCRIPTION
Follow up to #1880. The duplicated and unnecessary `verifyEntitlementWentThrough` (that's already done by `purchaseWeeklyOffering`) didn't pass the new `verifyEntitlementIsActive`, which lead to false negatives due to the short expiration rate in weekly subscriptions.