### PR TITLE
`spm build` CI job: changed to release build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: SPM Build
+          name: SPM Release Build
           command: swift build -c release
           no_output_timeout: 30m
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
       - checkout
       - run:
           name: SPM Build
-          command: swift build
+          command: swift build -c release
           no_output_timeout: 30m
 
   run-test-ios-16:


### PR DESCRIPTION
See #1860.

We want to ensure that the framework can be correctly compiled with SPM, so I think it makes sense to ensure that the _RELEASE_ version of it can be compiled specifically.
We have a lot of coverage of `DEBUG` builds basically by most other CI jobs, so this provides coverage of the release build as well.

See #1902 for example for the type of change that could break release builds if not covered in CI.