### PR TITLE
Created `CachingProductsManager` to provide consistent caching logic when fetching products

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -298,6 +298,8 @@
 		57ACB12528174B9F000DCC9F /* CustomerInfo+TestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ACB12328174B9F000DCC9F /* CustomerInfo+TestExtensions.swift */; };
 		57ACB13728184CF1000DCC9F /* DecoderExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ACB13628184CF1000DCC9F /* DecoderExtensionTests.swift */; };
 		57BA943128330ACA00CD5FC5 /* ConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BA943028330ACA00CD5FC5 /* ConfigurationTests.swift */; };
+		57BB070E28D27A2B007F5DF0 /* CachingProductsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BB070D28D27A2B007F5DF0 /* CachingProductsManager.swift */; };
+		57BB071628D282A4007F5DF0 /* CachingProductsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BB071528D282A4007F5DF0 /* CachingProductsManagerTests.swift */; };
 		57BD50AA27692B7500211D6D /* StoreKitError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */; };
 		57C2931528BFEF4F0054EDFC /* PurchasesError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C2931428BFEF4F0054EDFC /* PurchasesError.swift */; };
 		57C2932A28BFF89D0054EDFC /* ErrorMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E4A52028BD8F610095C793 /* ErrorMatcher.swift */; };
@@ -334,6 +336,7 @@
 		57E415FF28469EAB00EA5460 /* PurchasesGetProductsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E415FE28469EAB00EA5460 /* PurchasesGetProductsTests.swift */; };
 		57E4A52128BD8F610095C793 /* ErrorMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E4A52028BD8F610095C793 /* ErrorMatcher.swift */; };
 		57E4A52228BD8F610095C793 /* ErrorMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E4A52028BD8F610095C793 /* ErrorMatcher.swift */; };
+		57E6195028D291DC0093170C /* StoreKit2CachingProductsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E6194F28D291DC0093170C /* StoreKit2CachingProductsManagerTests.swift */; };
 		57EAE527274324C60060EB74 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE526274324C60060EB74 /* Lock.swift */; };
 		57EAE52B274332830060EB74 /* Obsoletions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE52A274332830060EB74 /* Obsoletions.swift */; };
 		57EAE52D274468900060EB74 /* RawDataContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE52C274468900060EB74 /* RawDataContainer.swift */; };
@@ -805,6 +808,8 @@
 		57ACB13628184CF1000DCC9F /* DecoderExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecoderExtensionTests.swift; sourceTree = "<group>"; };
 		57B530E52858F3FD00FA4E37 /* SwiftStyleGuide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SwiftStyleGuide.swift; path = Contributing/SwiftStyleGuide.swift; sourceTree = "<group>"; };
 		57BA943028330ACA00CD5FC5 /* ConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationTests.swift; sourceTree = "<group>"; };
+		57BB070D28D27A2B007F5DF0 /* CachingProductsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachingProductsManager.swift; sourceTree = "<group>"; };
+		57BB071528D282A4007F5DF0 /* CachingProductsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachingProductsManagerTests.swift; sourceTree = "<group>"; };
 		57BD50A927692B7500211D6D /* StoreKitError+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoreKitError+Extensions.swift"; sourceTree = "<group>"; };
 		57C2931428BFEF4F0054EDFC /* PurchasesError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesError.swift; sourceTree = "<group>"; };
 		57C381B62791E593009E3940 /* StoreKit2TransactionListenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2TransactionListenerTests.swift; sourceTree = "<group>"; };
@@ -834,6 +839,7 @@
 		57E415F02846997B00EA5460 /* PurchasesAttributionDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesAttributionDataTests.swift; sourceTree = "<group>"; };
 		57E415FE28469EAB00EA5460 /* PurchasesGetProductsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesGetProductsTests.swift; sourceTree = "<group>"; };
 		57E4A52028BD8F610095C793 /* ErrorMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMatcher.swift; sourceTree = "<group>"; };
+		57E6194F28D291DC0093170C /* StoreKit2CachingProductsManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2CachingProductsManagerTests.swift; sourceTree = "<group>"; };
 		57EAE526274324C60060EB74 /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		57EAE52A274332830060EB74 /* Obsoletions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Obsoletions.swift; sourceTree = "<group>"; };
 		57EAE52C274468900060EB74 /* RawDataContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawDataContainer.swift; sourceTree = "<group>"; };
@@ -1180,6 +1186,7 @@
 				57DE80882807540D008D6C6F /* StorefrontTests.swift */,
 				F5E5E2E82847953000216ECD /* ProductsFetcherSK2Tests.swift */,
 				F5355162286B70E0009CA47A /* OfferingsManagerStoreKitTests.swift */,
+				57E6194F28D291DC0093170C /* StoreKit2CachingProductsManagerTests.swift */,
 			);
 			path = StoreKitUnitTests;
 			sourceTree = "<group>";
@@ -1532,6 +1539,7 @@
 				3597020F24BF6A710010506E /* TransactionsFactory.swift */,
 				F56E2E7627622B5E009FED5B /* TransactionsManager.swift */,
 				359E8E3E26DEBEEB00B869F9 /* TrialOrIntroPriceEligibilityChecker.swift */,
+				57BB070D28D27A2B007F5DF0 /* CachingProductsManager.swift */,
 			);
 			path = Purchasing;
 			sourceTree = "<group>";
@@ -1562,6 +1570,7 @@
 				57554C83282AC273009A7E58 /* PeriodTypeTests.swift */,
 				57554C87282AC293009A7E58 /* PurchaseOwnershipTypeTests.swift */,
 				57BA943028330ACA00CD5FC5 /* ConfigurationTests.swift */,
+				57BB071528D282A4007F5DF0 /* CachingProductsManagerTests.swift */,
 			);
 			path = Purchasing;
 			sourceTree = "<group>";
@@ -2307,6 +2316,7 @@
 				2D90F8C226FD20F7009B9142 /* MockETagManager.swift in Sources */,
 				2D90F8B526FD2093009B9142 /* MockSystemInfo.swift in Sources */,
 				2D90F8C126FD20F2009B9142 /* MockHTTPClient.swift in Sources */,
+				57E6195028D291DC0093170C /* StoreKit2CachingProductsManagerTests.swift in Sources */,
 				F5847431278D00C1001B1CE6 /* MockDNSChecker.swift in Sources */,
 				B3CAFF1F285CEAAA0048A994 /* MockOfferingsAPI.swift in Sources */,
 				F55FFA632763F60700995146 /* TransactionsManagerSK1Tests.swift in Sources */,
@@ -2425,6 +2435,7 @@
 				B3A55B7D26C452A7007EFC56 /* AttributionPoster.swift in Sources */,
 				2DC19195255F36D10039389A /* Logger.swift in Sources */,
 				2DDF419F24F6F331005BC22D /* ReceiptParsingError.swift in Sources */,
+				57BB070E28D27A2B007F5DF0 /* CachingProductsManager.swift in Sources */,
 				2DDF419D24F6F331005BC22D /* IntroEligibilityCalculator.swift in Sources */,
 				57536A2627851FFE00E2AE7F /* SK1StoreTransaction.swift in Sources */,
 				57DE807128074C23008D6C6F /* SK1Storefront.swift in Sources */,
@@ -2680,6 +2691,7 @@
 				2DDF41EA24F6F844005BC22D /* SKProductSubscriptionDurationExtensions.swift in Sources */,
 				351B517A26D44FF000BD2BD7 /* MockRequestFetcher.swift in Sources */,
 				351B514E26D44ACE00BD2BD7 /* SubscriberAttributesManagerTests.swift in Sources */,
+				57BB071628D282A4007F5DF0 /* CachingProductsManagerTests.swift in Sources */,
 				574A2F4F282D7B9E00150D40 /* PostOfferDecodingTests.swift in Sources */,
 				2DDF41CE24F6F4C3005BC22D /* InAppPurchaseBuilderTests.swift in Sources */,
 				573A10DB2800AF4700F976E5 /* PurchaseErrorTests.swift in Sources */,

--- a/Sources/Purchasing/CachingProductsManager.swift
+++ b/Sources/Purchasing/CachingProductsManager.swift
@@ -1,0 +1,188 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CachingProductsManager.swift
+//
+//  Created by Nacho Soto on 9/14/22.
+
+import Foundation
+
+/// `ProductsManagerType` decorator that adds caching behavior on each request.
+/// The product results are cached, and it avoids performing concurrent duplicate requests for the same products.
+final class CachingProductsManager {
+
+    private let manager: ProductsManagerType
+
+    private let productCache: Atomic<[String: StoreProduct]> = .init([:])
+    private let requestCache: Atomic<[Set<String>: [Completion]]> = .init([:])
+
+    #if swift(>=5.7)
+    private let _sk2ProductCache: (any Sendable)?
+    private let _sk2RequestCache: (any Sendable)?
+    #else
+    private let _sk2ProductCache: any
+    private let _sk2RequestCache: any
+    #endif
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    private var sk2ProductCache: Atomic<[String: SK2StoreProduct]> {
+        // swiftlint:disable:next force_cast
+        return self._sk2ProductCache as! Atomic<[String: SK2StoreProduct]>
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    private var sk2RequestCache: Atomic<[Set<String>: [SK2Completion]]> {
+        // swiftlint:disable:next force_cast
+        return self._sk2RequestCache as! Atomic<[Set<String>: [SK2Completion]]>
+    }
+
+    init(manager: ProductsManagerType) {
+        assert(!(manager is CachingProductsManager), "Decorating CachingProductsManager with itself")
+
+        self.manager = manager
+
+        if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
+            self._sk2ProductCache = Atomic<[String: SK2StoreProduct]>([:])
+            self._sk2RequestCache = Atomic<[Set<String>: [SK2Completion]]>([:])
+        } else {
+            self._sk2ProductCache = nil
+            self._sk2RequestCache = nil
+        }
+    }
+
+    func clearCache() {
+        self.productCache.value.removeAll(keepingCapacity: true)
+        if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
+            self.sk2ProductCache.value.removeAll(keepingCapacity: true)
+        }
+
+        self.manager.clearCache()
+    }
+
+}
+
+extension CachingProductsManager: ProductsManagerType {
+
+    func products(withIdentifiers identifiers: Set<String>, completion: @escaping Completion) {
+        Self.products(with: identifiers,
+                      completion: completion,
+                      productCache: self.productCache,
+                      requestCache: self.requestCache) { identifiers, completion in
+            self.manager.products(withIdentifiers: identifiers, completion: completion)
+        }
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func sk2Products(withIdentifiers identifiers: Set<String>, completion: @escaping SK2Completion) {
+        Self.products(with: identifiers,
+                      completion: completion,
+                      productCache: self.sk2ProductCache,
+                      requestCache: self.sk2RequestCache) { identifiers, completion in
+            self.manager.sk2Products(withIdentifiers: identifiers, completion: completion)
+        }
+    }
+
+    func cache(_ product: StoreProductType) {
+        Self.cache([StoreProduct.from(product: product)], container: self.productCache)
+    }
+
+    var requestTimeout: TimeInterval { return self.manager.requestTimeout }
+
+}
+
+#if swift(>=5.7)
+extension CachingProductsManager: Sendable {}
+#else
+// @unchecked because:
+// - It contains `any`
+extension CachingProductsManager: @unchecked Sendable {}
+#endif
+
+// MARK: - Private
+
+private extension CachingProductsManager {
+
+    static func products<T: StoreProductType>(
+        with identifiers: Set<String>,
+        completion: @escaping (Result<Set<T>, PurchasesError>) -> Void,
+        productCache: Atomic<[String: T]>,
+        requestCache: Atomic<[Set<String>: [(Result<Set<T>, PurchasesError>) -> Void]]>,
+        fetcher: (Set<String>, @escaping (Result<Set<T>, PurchasesError>) -> Void) -> Void
+    ) {
+        if let cachedProducts = Self.cachedProducts(with: identifiers, productCache: productCache) {
+            Logger.debug(
+                Strings.offering.products_already_cached(
+                    identifiers: Set(cachedProducts.map { $0.productIdentifier})
+                )
+            )
+
+            completion(.success(cachedProducts))
+        } else {
+            let requestInProgress = Self.save(completion, for: identifiers, requestCache: requestCache)
+            guard !requestInProgress else { return }
+
+            Logger.debug(
+                Strings.storeKit.no_cached_products_starting_store_products_request(identifiers: identifiers)
+            )
+
+            fetcher(identifiers) { result in
+                if let products = result.value {
+                    Self.cache(products, container: productCache)
+                }
+
+                for completion in Self.getAndClearRequestCompletion(for: identifiers, requestCache: requestCache) {
+                    completion(result)
+                }
+            }
+        }
+    }
+
+    static func cachedProducts<T: StoreProductType>(
+        with identifiers: Set<String>,
+        productCache: Atomic<[String: T]>
+    ) -> Set<T>? {
+        let productsAlreadyCached = productCache.value.filter { identifiers.contains($0.key) }
+
+        if productsAlreadyCached.count == identifiers.count {
+            Logger.debug(Strings.offering.products_already_cached(identifiers: identifiers))
+            return Set(productsAlreadyCached.values)
+        } else {
+            return nil
+        }
+    }
+
+    static func cache<T: StoreProductType>(_ products: Set<T>, container: Atomic<[String: T]>) {
+        container.value += products.dictionaryWithKeys { $0.productIdentifier }
+    }
+
+    /// - Returns: true if there is already a request in progress for these products.
+    static func save<T: StoreProductType>(
+        _ completion: @escaping (Result<Set<T>, PurchasesError>) -> Void,
+        for identifiers: Set<String>,
+        requestCache: Atomic<[Set<String>: [(Result<Set<T>, PurchasesError>) -> Void]]>
+    ) -> Bool {
+        return requestCache.modify { cache in
+            let existingRequest = cache[identifiers]?.isEmpty == false
+
+            cache[identifiers, default: []].append(completion)
+            return existingRequest
+        }
+    }
+
+    /// - Returns: completion blocks for requests for the given identifiers.
+    static func getAndClearRequestCompletion<T: StoreProductType>(
+        for identifiers: Set<String>,
+        requestCache: Atomic<[Set<String>: [(Result<Set<T>, PurchasesError>) -> Void]]>
+    ) -> [(Result<Set<T>, PurchasesError>) -> Void] {
+        return requestCache.modify {
+            return $0.removeValue(forKey: identifiers) ?? []
+        }
+    }
+
+}

--- a/Sources/Purchasing/CachingProductsManager.swift
+++ b/Sources/Purchasing/CachingProductsManager.swift
@@ -26,8 +26,8 @@ final class CachingProductsManager {
     private let _sk2ProductCache: (any Sendable)?
     private let _sk2RequestCache: (any Sendable)?
     #else
-    private let _sk2ProductCache: any
-    private let _sk2RequestCache: any
+    private let _sk2ProductCache: Any?
+    private let _sk2RequestCache: Any?
     #endif
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)

--- a/Sources/Purchasing/CachingProductsManager.swift
+++ b/Sources/Purchasing/CachingProductsManager.swift
@@ -125,7 +125,10 @@ private extension CachingProductsManager {
             completion(.success(cachedProducts))
         } else {
             let requestInProgress = Self.save(completion, for: identifiers, requestCache: requestCache)
-            guard !requestInProgress else { return }
+            guard !requestInProgress else {
+                Logger.debug(Strings.offering.found_existing_product_request(identifiers: identifiers))
+                return
+            }
 
             Logger.debug(
                 Strings.storeKit.no_cached_products_starting_store_products_request(identifiers: identifiers)

--- a/Sources/Purchasing/IntroEligibilityCalculator.swift
+++ b/Sources/Purchasing/IntroEligibilityCalculator.swift
@@ -17,10 +17,10 @@ import StoreKit
 
 class IntroEligibilityCalculator {
 
-    private let productsManager: ProductsManager
+    private let productsManager: ProductsManagerType
     private let receiptParser: ReceiptParser
 
-    init(productsManager: ProductsManager,
+    init(productsManager: ProductsManagerType,
          receiptParser: ReceiptParser) {
         self.productsManager = productsManager
         self.receiptParser = receiptParser

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -21,14 +21,14 @@ class OfferingsManager {
     private let systemInfo: SystemInfo
     private let backend: Backend
     private let offeringsFactory: OfferingsFactory
-    private let productsManager: ProductsManager
+    private let productsManager: ProductsManagerType
 
     init(deviceCache: DeviceCache,
          operationDispatcher: OperationDispatcher,
          systemInfo: SystemInfo,
          backend: Backend,
          offeringsFactory: OfferingsFactory,
-         productsManager: ProductsManager) {
+         productsManager: ProductsManagerType) {
         self.deviceCache = deviceCache
         self.operationDispatcher = operationDispatcher
         self.systemInfo = systemInfo

--- a/Sources/Purchasing/ProductsManager.swift
+++ b/Sources/Purchasing/ProductsManager.swift
@@ -15,20 +15,48 @@
 import Foundation
 import StoreKit
 
-class ProductsManager: NSObject {
+/// Protocol for a type that can fetch and cache ``StoreProduct``s.
+/// The basic interface only has a completion-blocked based API, but default `async` overloads are provided.
+protocol ProductsManagerType: Sendable {
 
-    let productsFetcherSK1: ProductsFetcherSK1
-    var requestTimeout: TimeInterval {
-        return productsFetcherSK1.requestTimeout
-    }
+    typealias Completion = (Result<Set<StoreProduct>, PurchasesError>) -> Void
 
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    typealias SK2Completion = (Result<Set<SK2StoreProduct>, PurchasesError>) -> Void
+
+    /// Fetches the ``StoreProduct``s with the given identifiers
+    /// The returned products will be SK1 or SK2 backed depending on the implementation and configuration.
+    func products(withIdentifiers identifiers: Set<String>, completion: @escaping Completion)
+
+    /// Fetches the `SK2StoreProduct`s with the given identifiers.
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func sk2Products(withIdentifiers identifiers: Set<String>, completion: @escaping SK2Completion)
+
+    /// Adds the products to the internal cache
+    /// If the type implementing this protocol doesn't have a caching mechanism then this method does nothing.
+    func cache(_ product: StoreProductType)
+
+    /// Removes all elements from its internal cache
+    /// If the type implementing this protocol doesn't have a caching mechanism then this method does nothing.
+    func clearCache()
+
+    var requestTimeout: TimeInterval { get }
+
+}
+
+// MARK: -
+
+/// Basic implemenation of a `ProductsManagerType`
+class ProductsManager: NSObject, ProductsManagerType {
+
+    private let productsFetcherSK1: ProductsFetcherSK1
     private let systemInfo: SystemInfo
 
-    #if swift(>=5.7)
+#if swift(>=5.7)
     private let _productsFetcherSK2: (any Sendable)?
-    #else
+#else
     private let _productsFetcherSK2: Any?
-    #endif
+#endif
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     private var productsFetcherSK2: ProductsFetcherSK2 {
@@ -52,8 +80,7 @@ class ProductsManager: NSObject {
         }
     }
 
-    func products(withIdentifiers identifiers: Set<String>,
-                  completion: @escaping (Result<Set<StoreProduct>, PurchasesError>) -> Void) {
+    func products(withIdentifiers identifiers: Set<String>, completion: @escaping Completion) {
         if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *),
            self.systemInfo.storeKit2Setting == .enabledForCompatibleDevices {
             self.sk2Products(withIdentifiers: identifiers) { result in
@@ -66,28 +93,40 @@ class ProductsManager: NSObject {
         }
     }
 
-    @available(iOS 13.0, tvOS 13.0, watchOS 6.2, macOS 10.15, *)
-    func products(withIdentifiers identifiers: Set<String>) async throws -> Set<StoreProduct> {
-        return try await withCheckedThrowingContinuation { continuation in
-            self.products(withIdentifiers: identifiers) { result in
-                continuation.resume(with: result)
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func sk2Products(withIdentifiers identifiers: Set<String>, completion: @escaping SK2Completion) {
+        Async.call(with: completion) {
+            do {
+                let products = try await self.productsFetcherSK2.products(identifiers: identifiers)
+
+                Logger.debug(Strings.storeKit.store_product_request_finished)
+                return Set(products)
+            } catch {
+                Logger.debug(Strings.storeKit.store_products_request_failed(error: error))
+                throw ErrorUtils.storeProblemError(error: error)
             }
         }
     }
 
-    /// - Throws: `ProductsFetcherSK2.Error`
-    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    func sk2StoreProducts(withIdentifiers identifiers: Set<String>) async throws -> Set<SK2StoreProduct> {
-        let products = try await self.productsFetcherSK2.products(identifiers: identifiers)
+    func cache(_ product: StoreProductType) {
+        switch product {
+        case let sk1Product as SK1Product:
+            self.productsFetcherSK1.cacheProduct(sk1Product)
 
-        return Set(products)
+        case let product as StoreProduct:
+            if let sk1Product = product.sk1Product {
+                self.productsFetcherSK1.cacheProduct(sk1Product)
+            }
+
+        default:
+            // Ignoring otherwise.
+            // This is temporary, as the caching logic is going away from here
+            // in favor of the new `CachingProductsManager`
+            break
+        }
     }
 
-    func cacheProduct(_ product: SK1Product) {
-        self.productsFetcherSK1.cacheProduct(product)
-    }
-
-    func invalidateAndReFetchCachedProductsIfAppropiate() {
+    func clearCache() {
         if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *),
            self.systemInfo.storeKit2Setting == .enabledForCompatibleDevices {
             self.invalidateAndReFetchCachedSK2Products()
@@ -96,28 +135,19 @@ class ProductsManager: NSObject {
         }
     }
 
+    var requestTimeout: TimeInterval {
+        return self.productsFetcherSK1.requestTimeout
+    }
+
 }
+
+// MARK: - private
 
 private extension ProductsManager {
 
     func sk1Products(withIdentifiers identifiers: Set<String>,
                      completion: @escaping (Result<Set<SK1Product>, PurchasesError>) -> Void) {
         return self.productsFetcherSK1.sk1Products(withIdentifiers: identifiers, completion: completion)
-    }
-
-    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    func sk2Products(withIdentifiers identifiers: Set<String>,
-                     completion: @escaping (Result<Set<SK2StoreProduct>, PurchasesError>) -> Void) {
-        Async.call(with: completion) {
-            do {
-                let products = try await self.sk2StoreProducts(withIdentifiers: identifiers)
-                Logger.debug(Strings.storeKit.store_product_request_finished)
-                return Set(products)
-            } catch {
-                Logger.debug(Strings.storeKit.store_products_request_failed(error: error))
-                throw ErrorUtils.storeProblemError(error: error)
-            }
-        }
     }
 
     func invalidateAndReFetchCachedSK1Products() {
@@ -144,6 +174,34 @@ private extension ProductsManager {
     }
 
 }
+
+// MARK: - ProductsManagerType async
+
+extension ProductsManagerType {
+
+    /// `async` overload for `products(withIdentifiers:)`
+    @available(iOS 13.0, tvOS 13.0, watchOS 6.2, macOS 10.15, *)
+    func products(withIdentifiers identifiers: Set<String>) async throws -> Set<StoreProduct> {
+        return try await withCheckedThrowingContinuation { continuation in
+            self.products(withIdentifiers: identifiers) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+
+    /// `async` overload for `sk2Products(withIdentifiers:)`
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func sk2Products(withIdentifiers identifiers: Set<String>) async throws -> Set<SK2StoreProduct> {
+        return try await withCheckedThrowingContinuation { continuation in
+            self.sk2Products(withIdentifiers: identifiers) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+
+}
+
+// MARK: -
 
 // @unchecked because:
 // - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -221,7 +221,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     private let notificationCenter: NotificationCenter
     private let offeringsFactory: OfferingsFactory
     private let offeringsManager: OfferingsManager
-    private let productsManager: ProductsManager
+    private let productsManager: ProductsManagerType
     private let customerInfoManager: CustomerInfoManager
     private let trialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityChecker
     private let purchasesOrchestrator: PurchasesOrchestrator
@@ -302,9 +302,11 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                                                currentUserProvider: identityManager,
                                                attributionPoster: attributionPoster)
         let productsRequestFactory = ProductsRequestFactory()
-        let productsManager = ProductsManager(productsRequestFactory: productsRequestFactory,
-                                              systemInfo: systemInfo,
-                                              requestTimeout: storeKitTimeout)
+        let productsManager = CachingProductsManager(
+            manager: ProductsManager(productsRequestFactory: productsRequestFactory,
+                                     systemInfo: systemInfo,
+                                     requestTimeout: storeKitTimeout)
+        )
         let introCalculator = IntroEligibilityCalculator(productsManager: productsManager, receiptParser: receiptParser)
         let offeringsManager = OfferingsManager(deviceCache: deviceCache,
                                                 operationDispatcher: operationDispatcher,
@@ -404,7 +406,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
          subscriberAttributes: Attribution,
          operationDispatcher: OperationDispatcher,
          customerInfoManager: CustomerInfoManager,
-         productsManager: ProductsManager,
+         productsManager: ProductsManagerType,
          offeringsManager: OfferingsManager,
          purchasesOrchestrator: PurchasesOrchestrator,
          trialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityChecker

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -48,7 +48,7 @@ final class PurchasesOrchestrator {
         self.attribution.unsyncedAttributesByKey(appUserID: self.appUserID)
     }
 
-    private let productsManager: ProductsManager
+    private let productsManager: ProductsManagerType
     private let storeKit1Wrapper: StoreKit1Wrapper?
     private let systemInfo: SystemInfo
     private let attribution: Attribution
@@ -82,7 +82,7 @@ final class PurchasesOrchestrator {
     }
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    convenience init(productsManager: ProductsManager,
+    convenience init(productsManager: ProductsManagerType,
                      storeKit1Wrapper: StoreKit1Wrapper?,
                      systemInfo: SystemInfo,
                      subscriberAttributes: Attribution,
@@ -128,7 +128,7 @@ final class PurchasesOrchestrator {
         }
     }
 
-    init(productsManager: ProductsManager,
+    init(productsManager: ProductsManagerType,
          storeKit1Wrapper: StoreKit1Wrapper?,
          systemInfo: SystemInfo,
          subscriberAttributes: Attribution,
@@ -175,7 +175,7 @@ final class PurchasesOrchestrator {
             return
         }
 
-        productsManager.products(withIdentifiers: productIdentifiersSet) { products in
+        self.productsManager.products(withIdentifiers: productIdentifiersSet) { products in
             self.operationDispatcher.dispatchOnMainThread {
                 completion(Array(products.value ?? []))
             }
@@ -344,7 +344,7 @@ final class PurchasesOrchestrator {
 
         }
 
-        self.productsManager.cacheProduct(sk1Product)
+        self.productsManager.cache(StoreProduct(sk1Product: sk1Product))
 
         let addPayment: Bool = self.addPurchaseCompletedCallback(
             productIdentifier: productIdentifier,
@@ -566,7 +566,7 @@ extension PurchasesOrchestrator: StoreKit1WrapperDelegate {
     func storeKit1Wrapper(_ storeKit1Wrapper: StoreKit1Wrapper,
                           shouldAddStorePayment payment: SKPayment,
                           for product: SK1Product) -> Bool {
-        self.productsManager.cacheProduct(product)
+        self.productsManager.cache(StoreProduct(sk1Product: product))
         guard let delegate = self.delegate else { return false }
 
         guard let productIdentifier = payment.extractProductIdentifier() else {
@@ -1007,7 +1007,7 @@ private extension PurchasesOrchestrator {
     }
 
     func handleStorefrontChange() {
-        self.productsManager.invalidateAndReFetchCachedProductsIfAppropiate()
+        self.productsManager.clearCache()
         self.offeringsManager.invalidateAndReFetchCachedOfferingsIfAppropiate(appUserID: self.appUserID)
     }
 

--- a/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -26,7 +26,7 @@ class TrialOrIntroPriceEligibilityChecker {
     private let backend: Backend
     private let currentUserProvider: CurrentUserProvider
     private let operationDispatcher: OperationDispatcher
-    private let productsManager: ProductsManager
+    private let productsManager: ProductsManagerType
 
     init(
         systemInfo: SystemInfo,
@@ -35,7 +35,7 @@ class TrialOrIntroPriceEligibilityChecker {
         backend: Backend,
         currentUserProvider: CurrentUserProvider,
         operationDispatcher: OperationDispatcher,
-        productsManager: ProductsManager
+        productsManager: ProductsManagerType
     ) {
         self.systemInfo = systemInfo
         self.receiptFetcher = receiptFetcher
@@ -104,7 +104,7 @@ class TrialOrIntroPriceEligibilityChecker {
                 .init(eligibilityStatus: .unknown)
         }
 
-        let products = try await self.productsManager.sk2StoreProducts(withIdentifiers: identifiers)
+        let products = try await self.productsManager.sk2Products(withIdentifiers: identifiers)
         for sk2StoreProduct in products {
             let sk2Product = sk2StoreProduct.underlyingSK2Product
 

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -61,7 +61,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         expect(product.productIdentifier) == identifier
     }
 
-    func testInvalidateAndReFetchCachedProductsAfterStorefrontChangesSK1() async throws {
+    func testClearCacheAfterStorefrontChangesSK1() async throws {
         let manager = try createManager(storeKit2Setting: .disabled)
 
         let identifier = "com.revenuecat.monthly_4.99.1_week_intro"
@@ -76,10 +76,10 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         testSession.locale = Locale(identifier: "es_ES")
         await changeStorefront("ESP")
 
-        // Note: this test passes only because the method `invalidateAndReFetchCachedProductsIfAppropiate`
+        // Note: this test passes only because the method `clearCache`
         // is manually executed. `ProductsManager` does not detect Storefront changes to invalidate the
         // cache. The changes are now managed by `StoreKit2StorefrontListenerDelegate`.
-        manager.invalidateAndReFetchCachedProductsIfAppropiate()
+        manager.clearCache()
 
         receivedProducts = try await manager.products(withIdentifiers: Set([identifier]))
 
@@ -106,10 +106,10 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         testSession.locale = Locale(identifier: "es_ES")
         await changeStorefront("ESP")
 
-        // Note: this test passes only because the method `invalidateAndReFetchCachedProductsIfAppropiate`
+        // Note: this test passes only because the method `clearCache`
         // is manually executed. `ProductsManager` does not detect Storefront changes to invalidate the
         // cache. The changes are now managed by `StoreKit2StorefrontListenerDelegate`.
-        manager.invalidateAndReFetchCachedProductsIfAppropiate()
+        manager.clearCache()
 
         receivedProducts = try await manager.products(withIdentifiers: Set([identifier]))
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -492,14 +492,14 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         self.orchestrator.storefrontDidUpdate()
 
         expect(self.mockOfferingsManager.invokedInvalidateAndReFetchCachedOfferingsIfAppropiateCount) == 1
-        expect(self.productsManager.invokedInvalidateAndReFetchCachedProductsIfAppropiateCount) == 1
+        expect(self.productsManager.invokedClearCacheCount) == 1
     }
 
     func testClearCachedProductsAndOfferingsAfterStorefrontChangesWithSK1() async throws {
         self.orchestrator.storeKit1WrapperDidChangeStorefront(storeKit1Wrapper)
 
         expect(self.mockOfferingsManager.invokedInvalidateAndReFetchCachedOfferingsIfAppropiateCount) == 1
-        expect(self.productsManager.invokedInvalidateAndReFetchCachedProductsIfAppropiateCount) == 1
+        expect(self.productsManager.invokedClearCacheCount) == 1
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)

--- a/Tests/StoreKitUnitTests/StoreKit2CachingProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2CachingProductsManagerTests.swift
@@ -1,0 +1,153 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  StoreKit2CachingProductsManagerTests.swift
+//
+//  Created by Nacho Soto on 9/14/22.
+
+import Nimble
+@testable import RevenueCat
+import StoreKitTest
+import XCTest
+
+/// Addition to `CachingProductsManagerTests` but for SK2 requests
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+@MainActor
+class StoreKit2CachingProductsManagerTests: StoreKitConfigTestCase {
+
+    private var mockManager: MockProductsManager!
+    private var cachingManager: CachingProductsManager!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        // `CachingProductsManager` is available on iOS 12, but tests
+        // make use of `async` APIs for simplicity.
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
+        let systemInfo = MockSystemInfo(finishTransactions: false)
+
+        self.mockManager = MockProductsManager(
+            systemInfo: systemInfo,
+            requestTimeout: Configuration.storeKitRequestTimeoutDefault
+        )
+        self.cachingManager = CachingProductsManager(manager: self.mockManager)
+    }
+
+    func testFetchesNotCachedProduct() async throws {
+        let product = try await self.fetchSk2StoreProduct()
+        self.mockManager.stubbedSk2StoreProductsResult = .success([product])
+
+        let result = try await self.cachingManager.sk2Products(withIdentifiers: [Self.productID])
+        expect(result.onlyElement) == product
+
+        self.expectProductsWereFetched(times: 1, for: Self.productID)
+    }
+
+    func testFetchesNotCachedProductIfOneOfTheRequestedProductsIsNotCached() async throws {
+        let product1 = try await self.fetchSk2StoreProduct()
+        let product2 = try await self.fetchSk2StoreProduct("lifetime")
+
+        // Cache 1 product
+        self.mockManager.stubbedSk2StoreProductsResult = .success([product1])
+        _ = try await self.cachingManager.sk2Products(withIdentifiers: [product1.productIdentifier])
+
+        // Request 2 products
+        self.mockManager.stubbedSk2StoreProductsResult = .success([product1, product2])
+
+        let result = try await self.cachingManager.sk2Products(withIdentifiers: [product1.productIdentifier,
+                                                                                 product2.productIdentifier])
+        expect(result) == [product1, product2]
+
+        expect(self.mockManager.invokedSk2StoreProductsCount) == 2
+        expect(self.mockManager.invokedSk2StoreProductsParameterList) == [
+            Set([product1.productIdentifier]), // First product fetched
+            Set([product1.productIdentifier, product2.productIdentifier]) // Both products fetched
+        ]
+    }
+
+    func testRefetchesProductIfItFailedTheFirstTime() async throws {
+        self.mockManager.stubbedSk2StoreProductsResult = .failure(ErrorUtils.productRequestTimedOutError())
+
+        // This will fail
+        let failedResult = try? await self.cachingManager.sk2Products(withIdentifiers: [Self.productID])
+        expect(failedResult).to(beNil())
+
+        let product = try await self.fetchSk2StoreProduct()
+        self.mockManager.stubbedSk2StoreProductsResult = .success([product])
+
+        let result = try await self.cachingManager.sk2Products(withIdentifiers: [Self.productID])
+
+        expect(result.onlyElement) == product
+        self.expectProductsWereFetched(times: 2, for: Self.productID)
+    }
+
+    func testReturnsCachedProduct() async throws {
+        let product = try await self.fetchSk2StoreProduct()
+        self.mockManager.stubbedSk2StoreProductsResult = .success([product])
+
+        _ = try await self.cachingManager.sk2Products(withIdentifiers: [Self.productID])
+        let result = try await self.cachingManager.sk2Products(withIdentifiers: [Self.productID])
+
+        expect(result.onlyElement) == product
+        self.expectProductsWereFetched(times: 1, for: Self.productID)
+    }
+
+    func testRefetchesAfterClearingCache() async throws {
+        let product = try await self.fetchSk2StoreProduct()
+        self.mockManager.stubbedSk2StoreProductsResult = .success([product])
+
+        _ = try await self.cachingManager.sk2Products(withIdentifiers: [Self.productID])
+        self.cachingManager.clearCache()
+
+        let result = try await self.cachingManager.sk2Products(withIdentifiers: [Self.productID])
+
+        expect(result.onlyElement) == product
+        self.expectProductsWereFetched(times: 2, for: Self.productID)
+    }
+
+    func testReusesProductRequestsIfAlreadyInProgress() async throws {
+        let product = try await self.fetchSk2StoreProduct()
+
+        self.mockManager.productResultDelay = 0.01
+        self.mockManager.stubbedSk2StoreProductsResult = .success([product])
+
+        var tasks: [Task<Set<SK2StoreProduct>, Error>] = []
+
+        for _ in 0..<5 {
+            tasks.append(Task { try await self.cachingManager.sk2Products(withIdentifiers: [Self.productID]) })
+        }
+
+        for task in tasks {
+            let result = try await task.value
+            expect(result.onlyElement) == product
+        }
+
+        self.expectProductsWereFetched(times: 1, for: Self.productID)
+    }
+
+}
+
+// MARK: - Private
+
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+private extension StoreKit2CachingProductsManagerTests {
+
+    func expectProductsWereFetched(
+        times: Int,
+        for identifiers: String...,
+        file: FileString = #file,
+        line: UInt = #line
+    ) {
+        expect(file: file, line: line, self.mockManager.invokedSk2StoreProductsCount)
+            .to(equal(times), description: "Products fetched an unexpected number of times")
+        expect(file: file, line: line, self.mockManager.invokedSk2StoreProductsParameter) == Set(identifiers)
+    }
+
+}

--- a/Tests/StoreKitUnitTests/StoreKit2CachingProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2CachingProductsManagerTests.swift
@@ -24,12 +24,11 @@ class StoreKit2CachingProductsManagerTests: StoreKitConfigTestCase {
     private var mockManager: MockProductsManager!
     private var cachingManager: CachingProductsManager!
 
+    @MainActor
     override func setUp() async throws {
         try await super.setUp()
 
-        // `CachingProductsManager` is available on iOS 12, but tests
-        // make use of `async` APIs for simplicity.
-        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         let systemInfo = MockSystemInfo(finishTransactions: false)
 

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
@@ -121,7 +121,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
                         "com.revenuecat.annual_39.99.2_week_intro": IntroEligibilityStatus.unknown,
                         "lifetime": IntroEligibilityStatus.unknown]
 
-        mockProductsManager?.stubbedSk2StoreProductsThrowsError = true
+        self.mockProductsManager?.stubbedSk2StoreProductsResult = .failure(ErrorUtils.productRequestTimedOutError())
 
         var eligibilities: [String: IntroEligibility]?
         trialOrIntroPriceEligibilityChecker.checkEligibility(productIdentifiers: products) { receivedEligibilities in

--- a/Tests/UnitTests/Purchasing/CachingProductsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/CachingProductsManagerTests.swift
@@ -22,6 +22,7 @@ class CachingProductsManagerTests: TestCase {
     private var mockManager: MockProductsManager!
     private var cachingManager: CachingProductsManager!
 
+    @MainActor
     override func setUp() async throws {
         try await super.setUp()
 

--- a/Tests/UnitTests/Purchasing/CachingProductsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/CachingProductsManagerTests.swift
@@ -1,0 +1,159 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CachingProductsManagerTests.swift
+//
+//  Created by Nacho Soto on 9/14/22.
+
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+@available(iOS 13.0, tvOS 13.0, watchOS 6.2, macOS 10.15, *)
+@MainActor
+class CachingProductsManagerTests: TestCase {
+
+    private var mockManager: MockProductsManager!
+    private var cachingManager: CachingProductsManager!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        // `CachingProductsManager` is available on iOS 12, but tests
+        // make use of `async` APIs for simplicity.
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
+        let systemInfo = MockSystemInfo(finishTransactions: false)
+
+        self.mockManager = MockProductsManager(
+            systemInfo: systemInfo,
+            requestTimeout: Configuration.storeKitRequestTimeoutDefault
+        )
+        self.cachingManager = CachingProductsManager(manager: self.mockManager)
+    }
+
+    func testFetchesNotCachedProduct() async throws {
+        let product = self.createMockProduct()
+        self.mockManager.stubbedProductsCompletionResult = .success([product])
+
+        let result = try await self.cachingManager.products(withIdentifiers: [Self.productID])
+        expect(result.onlyElement) === product
+
+        self.expectProductsWereFetched(times: 1, for: Self.productID)
+    }
+
+    func testFetchesNotCachedProductIfOneOfTheRequestedProductsIsNotCached() async throws {
+        let product1 = self.createMockProduct(identifier: "product1")
+        let product2 = self.createMockProduct(identifier: "product2")
+
+        // Cache 1 product
+        self.mockManager.stubbedProductsCompletionResult = .success([product1])
+        _ = try await self.cachingManager.products(withIdentifiers: [product1.productIdentifier])
+
+        // Request 2 products
+        self.mockManager.stubbedProductsCompletionResult = .success([product1, product2])
+
+        let result = try await self.cachingManager.products(withIdentifiers: [product1.productIdentifier,
+                                                                              product2.productIdentifier])
+        expect(result) == [product1, product2]
+
+        expect(self.mockManager.invokedProductsCount) == 2
+        expect(self.mockManager.invokedProductsParametersList) == [
+            Set([product1.productIdentifier]), // First product fetched
+            Set([product1.productIdentifier, product2.productIdentifier]) // Both products fetched
+        ]
+    }
+
+    func testRefetchesProductIfItFailedTheFirstTime() async throws {
+        self.mockManager.stubbedProductsCompletionResult = .failure(ErrorUtils.productRequestTimedOutError())
+
+        // This will fail
+        let failedResult = try? await self.cachingManager.products(withIdentifiers: [Self.productID])
+        expect(failedResult).to(beNil())
+
+        let product = self.createMockProduct()
+        self.mockManager.stubbedProductsCompletionResult = .success([product])
+
+        let result = try await self.cachingManager.products(withIdentifiers: [Self.productID])
+
+        expect(result.onlyElement) === product
+        self.expectProductsWereFetched(times: 2, for: Self.productID)
+    }
+
+    func testReturnsCachedProduct() async throws {
+        let product = self.createMockProduct()
+        self.mockManager.stubbedProductsCompletionResult = .success([product])
+
+        _ = try await self.cachingManager.products(withIdentifiers: [Self.productID])
+        let result = try await self.cachingManager.products(withIdentifiers: [Self.productID])
+
+        expect(result.onlyElement) === product
+        self.expectProductsWereFetched(times: 1, for: Self.productID)
+    }
+
+    func testRefetchesAfterClearingCache() async throws {
+        let product = self.createMockProduct()
+        self.mockManager.stubbedProductsCompletionResult = .success([product])
+
+        _ = try await self.cachingManager.products(withIdentifiers: [Self.productID])
+        self.cachingManager.clearCache()
+
+        let result = try await self.cachingManager.products(withIdentifiers: [Self.productID])
+
+        expect(result.onlyElement) === product
+        self.expectProductsWereFetched(times: 2, for: Self.productID)
+    }
+
+    func testReusesProductRequestsIfAlreadyInProgress() async throws {
+        let product = self.createMockProduct()
+
+        self.mockManager.productResultDelay = 0.01
+        self.mockManager.stubbedProductsCompletionResult = .success([product])
+
+        var tasks: [Task<Set<StoreProduct>, Error>] = []
+
+        for _ in 0..<5 {
+            tasks.append(Task { try await self.cachingManager.products(withIdentifiers: [Self.productID]) })
+        }
+
+        for task in tasks {
+            let result = try await task.value
+            expect(result.onlyElement) === product
+        }
+
+        self.expectProductsWereFetched(times: 1, for: Self.productID)
+    }
+
+}
+
+// MARK: - Private
+
+@available(iOS 13.0, tvOS 13.0, watchOS 6.2, macOS 10.15, *)
+private extension CachingProductsManagerTests {
+
+    static let productID = "com.revenuecat.product_id"
+
+    func expectProductsWereFetched(
+        times: Int,
+        for identifiers: String...,
+        file: FileString = #file,
+        line: UInt = #line
+    ) {
+        expect(file: file, line: line, self.mockManager.invokedProductsCount)
+            .to(equal(times), description: "Products fetched an unexpected number of times")
+        expect(file: file, line: line, self.mockManager.invokedProductsParameters) == Set(identifiers)
+    }
+
+    func createMockProduct(identifier: String = CachingProductsManagerTests.productID) -> StoreProduct {
+        // Using SK1 products because they can be mocked, but `CachingProductsManager
+        // works with generic `StoreProduct`s regardless of what they contain
+        return StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: identifier))
+    }
+
+}

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDeferredPurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDeferredPurchasesTests.swift
@@ -136,7 +136,8 @@ class PurchaseDeferredPurchasesTests: BasePurchasesTests {
         self.storeKit1WrapperDelegate.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.mockProductsManager.invokedCacheProduct) == true
-        expect(self.mockProductsManager.invokedCacheProductParameter) == self.product
+        expect(self.mockProductsManager.invokedCacheProductParameter.map(StoreProduct.from(product:)))
+        == StoreProduct(sk1Product: self.product)
     }
 
 }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
@@ -57,7 +57,8 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         self.purchases.purchase(product: product) { (_, _, _, _) in }
 
         expect(self.mockProductsManager.invokedCacheProduct) == true
-        expect(self.mockProductsManager.invokedCacheProductParameter) == sk1Product
+        expect(self.mockProductsManager.invokedCacheProductParameter.map(StoreProduct.from(product:)))
+        == StoreProduct(sk1Product: sk1Product)
     }
 
     func testTransitioningToPurchasedSendsToBackend() throws {


### PR DESCRIPTION
Fixes [SDKONCALL-129].

### Goal

The main feature that this change introduces is providing a _request_ cache to `ProductsFetcherSK2` (like `ProductsFetcherSK1` has).
It already implements a _product_ cache, but concurrent requests for the same products result in fetching those multiple times. It does not cache products until they're done being fetched.

This was observed in the logs when doing something simple like purchasing a product. This is running `testCanPurchaseProduct` integration test:
> DEBUG: ℹ️ No existing products cached, starting store products request for: ["com.revenuecat.monthly_4.99.1_week_intro", "com.revenuecat.annual_39.99.2_week_intro", "com.revenuecat.weekly_1.99.3_day_intro"]
DEBUG: ℹ️ No existing products cached, starting store products request for: ["com.revenuecat.monthly_4.99.1_week_intro", "com.revenuecat.annual_39.99.2_week_intro", "com.revenuecat.weekly_1.99.3_day_intro"]
DEBUG: 😻 Store products request request received response
DEBUG: ℹ️ Store products request finished
DEBUG: 😻 Store products request request received response
DEBUG: ℹ️ Store products request finished

With this PR, we avoid the double request due to that race condition:

> DEBUG: ℹ️ No existing products cached, starting store products request for: ["com.revenuecat.annual_39.99.2_week_intro", "com.revenuecat.weekly_1.99.3_day_intro", "com.revenuecat.monthly_4.99.1_week_intro"]
DEBUG: 😻 Store products request request received response
DEBUG: ℹ️ Store products request finished

### How

Instead of implementing that logic _only_ on `ProductsFetcherSK2` or in `ProductsManager`, this aims to keep the implementation simple in `ProductsManager` and each of the fetchers, and instead uses the [decorator pattern](https://en.wikipedia.org/wiki/Decorator_pattern) to provide that new functionality in a way that's simple to test and maintain, independent of the logic for actually fetching products.

To accomplish that, this adds a new `protocol`: `ProductsManagerType`, with 2 main methods (more about why the need for an SK2 special method below):
```swift
/// Fetches the ``StoreProduct``s with the given identifiers
/// The returned products will be SK1 or SK2 backed depending on the implementation and configuration.
func products(withIdentifiers identifiers: Set<String>, completion: @escaping Completion)

/// Fetches the `SK2StoreProduct`s with the given identifiers.
@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
func sk2Products(withIdentifiers identifiers: Set<String>, completion: @escaping SK2Completion)
```

Those are only completion-block APIs. To avoid repetition, an `extension` on the `protocol` itself provides an `async` API, wrapping on top of these 2 methods, regardless of which `ProductsManagerType` they're being used on.

The hierarchy is now as follows:
- `CachingProductsManager`
    - `ProductsManager`
        - `ProductsFetcherSK1`
        - `ProductsFetcherSK2`

#1908 gets rid of the now duplicate caching logic in `ProductsManager` and the fetchers.

### Other notes

What makes the implementation a bit more convoluted is the need for a special SK2 method.
This is necessary specifically for `TrialOrIntroPriceEligibilityChecker` which requires fetching only SK2 products regardless of `StoreKit2Setting`. In order to guarantee this invariant at compile time through types, a separate cache is maintained with `SK2StoreProduct`s. However, the main caching logic is *not* duplicated and instead shared for both.

The main tests for `CachingProductsManager` are simple unit tests that don't make use of `StoreKitConfigTestCase`.
Because creating SK2 products does require that, I added a separate test class for those.

### Future changes

The caching logic is very simple, just like what we had for the fetchers. One missing piece is that if products A and B are requested, and only A is in the cache, this is treated as a complete cache miss.

The fetchers had the same problem, but now that this caching logic is isolated and much easier to test, we can evolve and solve that feature in a more maintainable way.

[SDKONCALL-129]: https://revenuecats.atlassian.net/browse/SDKONCALL-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ