### PR TITLE
`ProductsFetcherSK2`: removed now redundant caching logic

### DIFF
--- a/Sources/Purchasing/StoreKit2/ProductsFetcherSK2.swift
+++ b/Sources/Purchasing/StoreKit2/ProductsFetcherSK2.swift
@@ -23,67 +23,14 @@ actor ProductsFetcherSK2 {
 
     }
 
-    /// Getter is declared as `internal` for testing purposes only.
-    private(set) var cachedProductsByIdentifier: [String: SK2StoreProduct] = [:]
-
     /// - Throws: `ProductsFetcherSK2.Error`
     func products(identifiers: Set<String>) async throws -> Set<SK2StoreProduct> {
         do {
-            if let cachedProducts = await self.cachedProducts(withIdentifiers: identifiers) {
-                Logger.debug(
-                    Strings.offering.products_already_cached(
-                        identifiers: Set(cachedProducts.map { $0.productIdentifier})
-                    )
-                )
-                return cachedProducts
-            }
-
-            Logger.debug(
-                Strings.storeKit.no_cached_products_starting_store_products_request(identifiers: identifiers)
-            )
-
             let storeKitProducts = try await StoreKit.Product.products(for: identifiers)
             Logger.rcSuccess(Strings.storeKit.store_product_request_received_response)
-            let sk2StoreProducts = Set(storeKitProducts.map { SK2StoreProduct(sk2Product: $0) })
-
-            await self.cache(products: sk2StoreProducts)
-
-            return sk2StoreProducts
+            return Set(storeKitProducts.map { SK2StoreProduct(sk2Product: $0) })
         } catch {
             throw Error.productsRequestError(innerError: error)
-        }
-    }
-
-    /// - Returns: The product identifiers that were removed, or empty if there were not
-    ///   cached products.
-    @discardableResult
-    func clearCache() -> Set<String> {
-        let cachedProductIdentifiers = self.cachedProductsByIdentifier.keys
-        if !cachedProductIdentifiers.isEmpty {
-            Logger.debug(Strings.offering.product_cache_invalid_for_storefront_change)
-            self.cachedProductsByIdentifier.removeAll(keepingCapacity: false)
-        }
-        return Set(cachedProductIdentifiers)
-    }
-
-}
-
-@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-private extension ProductsFetcherSK2 {
-
-    func cachedProducts(withIdentifiers identifiers: Set<String>) async -> Set<SK2StoreProduct>? {
-        let productsAlreadyCached = self.cachedProductsByIdentifier.filter { key, _ in identifiers.contains(key) }
-        if productsAlreadyCached.count == identifiers.count {
-            Logger.debug(Strings.offering.products_already_cached(identifiers: identifiers))
-            return Set(productsAlreadyCached.values)
-        } else {
-            return nil
-        }
-    }
-
-    func cache(products: Set<SK2StoreProduct>) async {
-        self.cachedProductsByIdentifier += products.dictionaryWithKeys {
-            $0.productIdentifier
         }
     }
 

--- a/Tests/StoreKitUnitTests/PriceFormatterProviderTests.swift
+++ b/Tests/StoreKitUnitTests/PriceFormatterProviderTests.swift
@@ -92,12 +92,6 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
         self.testSession.locale = Locale(identifier: "en_EN")
         await self.changeStorefront("USA")
 
-        // Note: this test passes only because the cache is manually
-        // cleared. `ProductsFetcherSK2` does not detect Storefront
-        // changes to invalidate the cache. The changes are now managed by
-        // `StoreKit2StorefrontListenerDelegate`.
-        await sk2Fetcher.clearCache()
-
         storeProduct = try await sk2Fetcher.product(withIdentifier: Self.productID)
 
         priceFormatter = try XCTUnwrap(storeProduct.priceFormatter)

--- a/Tests/StoreKitUnitTests/ProductsFetcherSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/ProductsFetcherSK2Tests.swift
@@ -21,23 +21,18 @@ class ProductsFetcherSK2Tests: StoreKitConfigTestCase {
 
     private var productsFetcherSK2: ProductsFetcherSK2!
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
         self.productsFetcherSK2 = ProductsFetcherSK2()
     }
 
-    func testCachedProductsAreEmptyAfterClearingCachedProductCorrectly() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+    func testItFetchesProducts() async throws {
+        let result = try await self.productsFetcherSK2.product(withIdentifier: Self.productID)
+        expect(result.productIdentifier) == Self.productID
 
-        _ = try await productsFetcherSK2.product(withIdentifier: Self.productID)
-
-        var cachedProducts = await productsFetcherSK2.cachedProductsByIdentifier
-        expect(cachedProducts).notTo(beEmpty())
-
-        await productsFetcherSK2.clearCache()
-
-        cachedProducts = await productsFetcherSK2.cachedProductsByIdentifier
-        expect(cachedProducts).to(beEmpty())
     }
 
 }

--- a/Tests/StoreKitUnitTests/StoreProductTests.swift
+++ b/Tests/StoreKitUnitTests/StoreProductTests.swift
@@ -284,12 +284,6 @@ class StoreProductTests: StoreKitConfigTestCase {
         testSession.locale = Locale(identifier: "en_EN")
         await self.changeStorefront("USA")
 
-        // Note: this test passes only because the cache is manually
-        // cleared. `ProductsFetcherSK2` does not detect Storefront
-        // changes to invalidate the cache. The changes are now managed by
-        // `StoreKit2StorefrontListenerDelegate`.
-        await sk2Fetcher.clearCache()
-
         storeProduct = try await sk2Fetcher.product(withIdentifier: Self.productID)
 
         priceFormatter = try XCTUnwrap(storeProduct.priceFormatter)


### PR DESCRIPTION
Follow up to #1907.

This logic is now implemented and shared in `CachingProductsManager`.

I've decided to keep the logic in `ProductsFetcherSK1` because it's intertwined with the retry mechanism, and it wasn't trivial to remove caching while leaving that logic.