### PR TITLE
`CircleCI`: changed all jobs to use Xcode 14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -579,6 +579,8 @@ workflows:
           xcode_version: '14.0.0'
           <<: *release-branches-and-main
       - build-tv-watch-and-macos:
+          # This is the only job not using Xcode 14 yet
+          # because it does not contain the new macOS SDK until Ventura is release.
           xcode_version: '13.4.1'
       - release-checks:
           xcode_version: '14.0.0'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -561,43 +561,45 @@ workflows:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - lint:
-          xcode_version: '13.4.1'
+          xcode_version: '14.0.0'
       - run-test-ios-16:
           xcode_version: '14.0.0'
       - spm-build:
-          xcode_version: '13.4.1'
+          xcode_version: '14.0.0'
       - run-test-ios-15:
-          xcode_version: '13.4.1'
+          xcode_version: '14.0.0'
       - run-test-tvos:
-          xcode_version: '13.4.1'
+          xcode_version: '14.0.0'
       - run-test-ios-14:
-          xcode_version: '13.4.1'
+          xcode_version: '14.0.0'
       - run-test-ios-13:
-          xcode_version: '13.4.1'
+          xcode_version: '14.0.0'
+          <<: *release-branches-and-main
       - run-test-ios-12:
-          xcode_version: '13.4.1'
+          xcode_version: '14.0.0'
+          <<: *release-branches-and-main
       - build-tv-watch-and-macos:
           xcode_version: '13.4.1'
       - release-checks:
-          xcode_version: '13.4.1'
+          xcode_version: '14.0.0'
           <<: *release-branches
       - backend-integration-tests:
-          xcode_version: '13.4.1'
+          xcode_version: '14.0.0'
           filters:
               branches:
                 # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
                 ignore: /pull\/[0-9]+/
       - installation-tests-cocoapods:
-          xcode_version: '13.4.1'
+          xcode_version: '14.0.0'
           <<: *release-tags-and-branches
       - installation-tests-swift-package-manager:
-          xcode_version: '13.4.1'
+          xcode_version: '14.0.0'
           <<: *release-tags-and-branches
       - installation-tests-carthage:
-          xcode_version: '13.4.1'
+          xcode_version: '14.0.0'
           <<: *release-tags-and-branches
       - installation-tests-xcode-direct-integration:
-          xcode_version: '13.4.1'
+          xcode_version: '14.0.0'
           <<: *release-tags-and-branches
   deploy:
     when:
@@ -612,7 +614,7 @@ workflows:
             - hold
           <<: *release-branches
       - make-release:
-          xcode_version: '13.4.1'
+          xcode_version: '14.0.0'
           <<: *release-tags
       - docs-deploy:
           xcode_version: '14.0.0'
@@ -623,7 +625,7 @@ workflows:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - prepare-next-version:
-          xcode_version: '13.4.1'
+          xcode_version: '14.0.0'
           <<: *only-main-branch
   danger:
     jobs:
@@ -635,4 +637,4 @@ workflows:
         - equal: [ "release-train", << pipeline.schedule.name >> ]
     jobs:
       - release-train:
-          xcode_version: '13.4.1'
+          xcode_version: '14.0.0'


### PR DESCRIPTION
Now that [Xcode 14 RC](https://discuss.circleci.com/t/xcode-14-rc-released/45334) is out, we should make it the default for all the jobs moving forward.