### PR TITLE
`StoreKit 1`: changed result of cancelled purchases to be consistent with `StoreKit 2`

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -640,10 +640,10 @@ private extension PurchasesOrchestrator {
 
             if isCancelled {
                 self.customerInfoManager.customerInfo(appUserID: self.appUserID,
-                                                      fetchPolicy: .cachedOrFetched) { result in
+                                                      fetchPolicy: .cachedOrFetched) { customerInfo in
                     self.operationDispatcher.dispatchOnMainActor {
                         completion(storeTransaction,
-                                   result.value,
+                                   customerInfo.value,
                                    purchasesError.asPublicError,
                                    true)
                     }


### PR DESCRIPTION
Fixes [CSDK-464]. Follow up to #1869.

SK1 and SK2 had inconsistent behavior during cancelled purchases.

### Before this PR:
- SK1 / completion-block:  no `CustomerInfo` + cancelled + `ErrorCode.purchaseCancelledError`
- **SK1 / `async`: thrown `ErrorCode.purchaseCancelledError`** :warning:
- SK2 / completion-block: `CustomerInfo` + cancelled + `ErrorCode.purchaseCancelledError`
- SK2 / `async`: `CustomerInfo` + cancelled (not error)

### After this PR:

The output is now consistent across the board:

- SK1 / completion-block:  `CustomerInfo` + cancelled + `ErrorCode.purchaseCancelledError`
- SK1 / `async`: `CustomerInfo` + cancelled (not error)
- SK2 / completion-block: `CustomerInfo` + cancelled + `ErrorCode.purchaseCancelledError`
- SK2 / `async`: `CustomerInfo` + cancelled (not error)

## Notes

This is of course a somewhat backwards incompatible change, but this output is now what makes the most sense based on the types. **This would only break existing code if users are relying on the existence of `CustomerInfo` alone without checking `error` or `userCancelled`.**

- Completion-block API:

There's 2 ways of detecting cancellation, both valid and reasonable. Either checking that `cancelled` is `true`, or comparing `error` with `ErrorCode.purchaseCancelledError`

- `async` API:

A cancelled purchase no longer throws. This didn't make sense in SK1, because it meant that `userCancelled` was always `false` in the case that the purchase method returned. This also matches `StoreKit`'s  behavior in `Product.purchase()`

[CSDK-464]: https://revenuecats.atlassian.net/browse/CSDK-464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ