### PR TITLE
`GetCustomerInfoAPI`: avoid making a request if there's any `PostReceiptDataOperation` in progress

### DIFF
--- a/Sources/Networking/Caching/CustomerInfoCallback.swift
+++ b/Sources/Networking/Caching/CustomerInfoCallback.swift
@@ -17,14 +17,52 @@ struct CustomerInfoCallback: CacheKeyProviding {
 
     typealias Completion = (Result<CustomerInfo, BackendError>) -> Void
 
-    let cacheKey: String
-    let source: NetworkOperation.Type
-    let completion: Completion
+    var cacheKey: String
+    var source: NetworkOperation.Type
+    var completion: Completion
 
     init(operation: CacheableNetworkOperation, completion: @escaping Completion) {
         self.cacheKey = operation.cacheKey
         self.source = type(of: operation)
         self.completion = completion
+    }
+
+}
+
+extension CustomerInfoCallback {
+
+    func withNewCacheKey(_ newKey: String) -> Self {
+        var copy = self
+        copy.cacheKey = newKey
+
+        return copy
+    }
+
+}
+
+// MARK: - CallbackCache helpers
+
+extension CallbackCache where T == CustomerInfoCallback {
+
+    func addOrAppendToPostReceiptDataOperation(callback: CustomerInfoCallback) -> CallbackCacheStatus {
+        if let existing = self.callbacks(ofType: PostReceiptDataOperation.self).last {
+            return self.add(callback: callback.withNewCacheKey(existing.cacheKey))
+        } else {
+            return self.add(callback: callback)
+        }
+    }
+
+    private func callbacks(ofType type: NetworkOperation.Type) -> [T] {
+        return self
+            .cachedCallbacksByKey
+            .value
+            .lazy
+            .flatMap(\.value)
+            .filter { $0.source == type }
+    }
+
+    private func callbackCount(ofType type: NetworkOperation.Type) -> Int {
+        return self.callbacks(ofType: type).count
     }
 
 }

--- a/Sources/Networking/Caching/CustomerInfoCallback.swift
+++ b/Sources/Networking/Caching/CustomerInfoCallback.swift
@@ -29,17 +29,6 @@ struct CustomerInfoCallback: CacheKeyProviding {
 
 }
 
-extension CustomerInfoCallback {
-
-    func withNewCacheKey(_ newKey: String) -> Self {
-        var copy = self
-        copy.cacheKey = newKey
-
-        return copy
-    }
-
-}
-
 // MARK: - CallbackCache helpers
 
 extension CallbackCache where T == CustomerInfoCallback {
@@ -61,8 +50,15 @@ extension CallbackCache where T == CustomerInfoCallback {
             .filter { $0.source == type }
     }
 
-    private func callbackCount(ofType type: NetworkOperation.Type) -> Int {
-        return self.callbacks(ofType: type).count
+}
+
+private extension CustomerInfoCallback {
+
+    func withNewCacheKey(_ newKey: String) -> Self {
+        var copy = self
+        copy.cacheKey = newKey
+
+        return copy
     }
 
 }

--- a/Sources/Networking/CustomerAPI.swift
+++ b/Sources/Networking/CustomerAPI.swift
@@ -38,7 +38,7 @@ final class CustomerAPI {
                                                  customerInfoCallbackCache: self.customerInfoCallbackCache)
 
         let callback = CustomerInfoCallback(operation: operation, completion: completion)
-        let cacheStatus = self.customerInfoCallbackCache.add(callback: callback)
+        let cacheStatus = self.customerInfoCallbackCache.addOrAppendToPostReceiptDataOperation(callback: callback)
         self.backendConfig.addCacheableOperation(operation,
                                                  withRandomDelay: randomDelay,
                                                  cacheStatus: cacheStatus)

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -432,8 +432,7 @@ class BackendPostReceiptDataTests: BaseBackendTests {
 
         expect(self.httpClient.calls.map { $0.request.path }) == [
             getCustomerInfoPath,
-            .postReceiptData,
-            getCustomerInfoPath
+            .postReceiptData
         ]
     }
 


### PR DESCRIPTION
Fixes [CSDK-419].

This is an improvement over the fix in #1292. In there, we avoided appending on an existing `CustomerInfoOperation` if there were any `PostReceiptDataOperation`s in progress, because those might come back with outdated entitlements.
This fix removes that cache key hack, and instead *reuses* the entire response to that `PostReceiptDataOperation` by "stealing" that request's cache key.

This is perfectly captured by the existing test `BackendPostReceiptDataTests.testGetsUpdatedSubscriberInfoAfterPost`, added in #1292. Amazingly enough, that test still passes with one minor change: the entire process requires one fewer API call :tada: 🐼

[CSDK-419]: https://revenuecats.atlassian.net/browse/CSDK-419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ