### PR TITLE
`Purchases.beginRefundRequest`: ensured errors are `PublicError`

### DIFF
--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -286,7 +286,6 @@ enum ErrorUtils {
      * If the error is already a `PurchasesError`, this simply returns the same value,
      * otherwise it wraps it into a ``ErrorCode/unknownError``.
      */
-    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     static func purchasesError(
         withUntypedError error: Error,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line

--- a/Sources/Misc/Purchases+nonasync.swift
+++ b/Sources/Misc/Purchases+nonasync.swift
@@ -34,7 +34,7 @@ public extension Purchases {
     @available(tvOS, unavailable)
     func beginRefundRequest(
         forProduct productID: String,
-        completion: @escaping (Result<RefundRequestStatus, Error>) -> Void
+        completion: @escaping (Result<RefundRequestStatus, PublicError>) -> Void
     ) {
         call(with: completion) {
             try await self.beginRefundRequest(forProduct: productID)
@@ -57,7 +57,7 @@ public extension Purchases {
     @available(tvOS, unavailable)
     func beginRefundRequest(
         forEntitlement entitlementID: String,
-        completion: @escaping (Result<RefundRequestStatus, Error>) -> Void
+        completion: @escaping (Result<RefundRequestStatus, PublicError>) -> Void
     ) {
         call(with: completion) {
             try await self.beginRefundRequest(forEntitlement: entitlementID)
@@ -82,7 +82,7 @@ public extension Purchases {
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
     func beginRefundRequestForActiveEntitlement(
-        completion: @escaping (Result<RefundRequestStatus, Error>) -> Void
+        completion: @escaping (Result<RefundRequestStatus, PublicError>) -> Void
     ) {
         call(with: completion) {
             try await self.beginRefundRequestForActiveEntitlement()
@@ -96,14 +96,14 @@ public extension Purchases {
 /// Invokes an `async throws` method and calls `completion` with the result.
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 private func call<T>(
-    with completion: @escaping (Result<T, Error>) -> Void,
+    with completion: @escaping (Result<T, PublicError>) -> Void,
     asyncMethod method: @escaping () async throws -> T
 ) {
     _ = Task {
         do {
             completion(.success(try await method()))
         } catch {
-            completion(.failure(error))
+            completion(.failure(ErrorUtils.purchasesError(withUntypedError: error).asPublicError))
         }
     }
 }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -241,9 +241,9 @@ private func checkAsyncMethods(purchases: Purchases) async {
 
 func checkNonAsyncMethods(_ purchases: Purchases) {
     #if os(iOS)
-    purchases.beginRefundRequest(forProduct: "") { (_: Result<RefundRequestStatus, Error>) in }
-    purchases.beginRefundRequest(forEntitlement: "") { (_: Result<RefundRequestStatus, Error>) in }
-    purchases.beginRefundRequestForActiveEntitlement { (_: Result<RefundRequestStatus, Error>) in }
+    purchases.beginRefundRequest(forProduct: "") { (_: Result<RefundRequestStatus, PublicError>) in }
+    purchases.beginRefundRequest(forEntitlement: "") { (_: Result<RefundRequestStatus, PublicError>) in }
+    purchases.beginRefundRequestForActiveEntitlement { (_: Result<RefundRequestStatus, PublicError>) in }
     #endif
 }
 


### PR DESCRIPTION
This was missed in #1879. Without this, we might have been forwarding some private errors instead of ensuring that we only sent `CodeError`s