### PR TITLE
`pre-commit` hook: also verify leftover API keys in `PurchaseTester`

### DIFF
--- a/Tests/TestingApps/PurchaseTester/PurchaseTester/Constants.swift
+++ b/Tests/TestingApps/PurchaseTester/PurchaseTester/Constants.swift
@@ -9,6 +9,6 @@
 enum Constants {
     
     #error("Must define your Public SDK key here")
-    static let apiKey = "<your_public_sdk_key_here>"
-    
+    static let apiKey = "REVENUECAT_API_KEY"
+
 }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Constants.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Constants.swift
@@ -17,5 +17,6 @@ struct Constants {
      The API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
      */
     #error("Modify this property to reflect your app's API key, then comment this line out.")
-    static let apiKey = "api_key"
+    static let apiKey = "REVENUECAT_API_KEY"
+
 }

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -37,6 +37,8 @@ verify_no_included_apikeys() {
     "${SCRIPT_DIR}/../Tests/BackendIntegrationTests/Constants.swift"
     "${SCRIPT_DIR}/../Examples/MagicWeather/MagicWeather/Constants.swift"
     "${SCRIPT_DIR}/../Examples/MagicWeatherSwiftUI/Shared/Constants.swift"
+    "${SCRIPT_DIR}/../Tests/TestingApps/PurchaseTesterSwiftUI/Constants.swift"
+    "${SCRIPT_DIR}/../Tests/TestingApps/PurchaseTester/PurchaseTester/Constants.swift"
   )
   PATTERN="\"REVENUECAT_API_KEY\""
 


### PR DESCRIPTION
See #1756.