### PR TITLE
`PurchaseTesterSwiftUI`: removed unnecessary `UIApplicationDelegate`

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
@@ -11,7 +11,18 @@ import RevenueCat
 
 @main
 struct PurchaseTesterApp: App {
-    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    private let delegate = Delegate()
+
+    init() {
+        Purchases.logLevel = .debug
+        Purchases.configure(with: Configuration
+            .builder(withAPIKey: Constants.apiKey)
+            .with(usesStoreKit2IfAvailable: true)
+            .build())
+        Purchases.shared.delegate = self.delegate
+    }
+
     @State private var revenueCatCustomerData = RevenueCatCustomerData()
     
     var body: some Scene {
@@ -26,29 +37,17 @@ struct PurchaseTesterApp: App {
                 }
         }
     }
+
 }
 
-class AppDelegate: NSObject, UIApplicationDelegate {
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+final class Delegate: NSObject, PurchasesDelegate {
 
-        Purchases.logLevel = .debug
-        Purchases.configure(with: Configuration
-            .builder(withAPIKey: Constants.apiKey)
-            .with(usesStoreKit2IfAvailable: true)
-            .build())
-        Purchases.shared.delegate = self
-
-        return true
-    }
-}
-
-extension AppDelegate: PurchasesDelegate {
     func purchases(_ purchases: Purchases, readyForPromotedProduct product: StoreProduct, purchase makeDeferredPurchase: @escaping StartPurchaseBlock) {
-        
         makeDeferredPurchase { (transaction, customerInfo, error, success) in
             print("Yay")
         }
     }
+
 }
 
 class RevenueCatCustomerData: ObservableObject {

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
@@ -15,11 +15,13 @@ struct PurchaseTesterApp: App {
     private let delegate = Delegate()
 
     init() {
-        Purchases.logLevel = .debug
-        Purchases.configure(with: Configuration
+        let configuration: Configuration =
             .builder(withAPIKey: Constants.apiKey)
             .with(usesStoreKit2IfAvailable: true)
-            .build())
+            .build()
+
+        Purchases.logLevel = .debug
+        Purchases.configure(with: configuration)
         Purchases.shared.delegate = self.delegate
     }
 


### PR DESCRIPTION
Using `init` in the `@main` app is the `SwiftUI` way of setting up `Purchases`