### PR TITLE
`CircleCI`: changed iOS 12/13 to use Xcode 13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -573,10 +573,10 @@ workflows:
       - run-test-ios-14:
           xcode_version: '14.0.0'
       - run-test-ios-13:
-          xcode_version: '14.0.0'
+          xcode_version: '13.4.1'
           <<: *release-branches-and-main
       - run-test-ios-12:
-          xcode_version: '14.0.0'
+          xcode_version: '13.4.1'
           <<: *release-branches-and-main
       - build-tv-watch-and-macos:
           # This is the only job not using Xcode 14 yet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -573,9 +573,11 @@ workflows:
       - run-test-ios-14:
           xcode_version: '14.0.0'
       - run-test-ios-13:
+          # Simulator fails to install on Xcode 14
           xcode_version: '13.4.1'
           <<: *release-branches-and-main
       - run-test-ios-12:
+          # Simulator fails to install on Xcode 14
           xcode_version: '13.4.1'
           <<: *release-branches-and-main
       - build-tv-watch-and-macos:


### PR DESCRIPTION
Looks like this broke in #1909. Not sure why it's not finding those simulators, but we can just run those old versions with an older Xcode for now.