### PR TITLE
`StoreKit 2`: enabled by default

### DIFF
--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -161,16 +161,16 @@ extension PurchaseStrings: CustomStringConvertible {
             "a transaction date - this is an issue with the App Store. Unix Epoch will be used instead. \n" +
             "Transactions in the backend and in webhooks are unaffected and will have the correct timestamps. " +
             "This is a bug in StoreKit 1. To prevent running into this issue on devices running " +
-            "iOS 15+, watchOS 8+, macOS 12+, and tvOS 15+, " +
-            "you can set `usesStoreKit2IfAvailable` to true when calling `configure`."
+            "iOS 15+, watchOS 8+, macOS 12+, and tvOS 15+, make sure " +
+            "`usesStoreKit2IfAvailable` is set to true when calling `configure`."
 
         case .sktransaction_missing_transaction_identifier:
             return "There is a problem with the SKPaymentTransaction missing " +
             "a transaction identifier - this is an issue with the App Store." +
             "Transactions in the backend and in webhooks are unaffected and will have the correct identifier. " +
             "This is a bug in StoreKit 1. To prevent running into this issue on devices running " +
-            "iOS 15+, watchOS 8+, macOS 12+, and tvOS 15+, " +
-            "you can set `usesStoreKit2IfAvailable` to true when calling `configure`."
+            "iOS 15+, watchOS 8+, macOS 12+, and tvOS 15+, make sure " +
+            "`usesStoreKit2IfAvailable` is set to true when calling `configure`."
 
         case .could_not_purchase_product_id_not_found:
             return "makePurchase - Could not purchase SKProduct. " +

--- a/Sources/Misc/Deprecations.swift
+++ b/Sources/Misc/Deprecations.swift
@@ -93,7 +93,7 @@ public extension Purchases {
             appUserID: appUserID,
             observerMode: observerMode,
             userDefaults: userDefaults,
-            useStoreKit2IfAvailable: false
+            useStoreKit2IfAvailable: StoreKit2Setting.default.usesStoreKit2IfAvailable
         )
     }
 

--- a/Sources/Misc/StoreKit2Setting.swift
+++ b/Sources/Misc/StoreKit2Setting.swift
@@ -34,7 +34,7 @@ extension StoreKit2Setting {
             : .enabledOnlyForOptimizations
     }
 
-    static let `default`: Self = .enabledOnlyForOptimizations
+    static let `default`: Self = .enabledForCompatibleDevices
 
 }
 
@@ -46,6 +46,15 @@ extension StoreKit2Setting {
             return true
         } else {
             return false
+        }
+    }
+
+    /// Returns: `true` if SK2 is enabled.
+    var usesStoreKit2IfAvailable: Bool {
+        switch self {
+        case .disabled: return false
+        case .enabledOnlyForOptimizations: return false
+        case .enabledForCompatibleDevices: return true
         }
     }
 

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -79,7 +79,7 @@ import Foundation
         private(set) var appUserID: String?
         private(set) var observerMode: Bool = false
         private(set) var userDefaults: UserDefaults?
-        private(set) var storeKit2Setting: StoreKit2Setting = .init(useStoreKit2IfAvailable: false)
+        private(set) var storeKit2Setting: StoreKit2Setting = .default
         private(set) var dangerousSettings: DangerousSettings?
         private(set) var networkTimeout = Configuration.networkTimeoutDefault
         private(set) var storeKit1Timeout = Configuration.storeKitRequestTimeoutDefault
@@ -135,8 +135,8 @@ import Foundation
 
         /**
          * Set `usesStoreKit2IfAvailable`.
-         * - Parameter usesStoreKit2IfAvailable: opt in to using StoreKit 2 on devices that support it.
-         * Purchases will be made using StoreKit 2 under the hood automatically.
+         * - Parameter usesStoreKit2IfAvailable: opt out of using StoreKit 2 on devices that support it.
+         * Defaults to  `true`.
          */
         @objc public func with(usesStoreKit2IfAvailable: Bool) -> Builder {
             self.storeKit2Setting = .init(useStoreKit2IfAvailable: usesStoreKit2IfAvailable)

--- a/Tests/UnitTests/Misc/StoreKit2SettingTests.swift
+++ b/Tests/UnitTests/Misc/StoreKit2SettingTests.swift
@@ -18,6 +18,16 @@ import XCTest
 
 class StoreKit2SettingTests: TestCase {
 
+    func testInitWithTrue() {
+        expect(StoreKit2Setting(useStoreKit2IfAvailable: true)) == .enabledForCompatibleDevices
+        expect(StoreKit2Setting(useStoreKit2IfAvailable: true).usesStoreKit2IfAvailable) == true
+    }
+
+    func testInitWithFalse() {
+        expect(StoreKit2Setting(useStoreKit2IfAvailable: false)) == .enabledOnlyForOptimizations
+        expect(StoreKit2Setting(useStoreKit2IfAvailable: false).usesStoreKit2IfAvailable) == false
+    }
+
     func testStoreKit2NotAvailableWhenDisabled() {
         expect(StoreKit2Setting.disabled.shouldOnlyUseStoreKit2) == false
     }


### PR DESCRIPTION
The main change is `StoreKit2Setting.default` is now `enabledForCompatibleDevices`, but I've also made sure that all places in the codebase are derived from this value.