### PR TITLE
`ErrorUtils`: added test to verify that `PublicError`s can be `catch`'d as `ErrorCode`

### DIFF
--- a/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
+++ b/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
@@ -41,6 +41,37 @@ class ErrorUtilsTests: TestCase {
         expect(errorCode).to(matchError(error as Error))
     }
 
+    func testPublicErrorsCanBeCaughtAsErrorCode() throws {
+        func throwing() throws {
+            throw ErrorUtils.customerInfoError().asPublicError
+        }
+
+        do {
+            try throwing()
+            fail("Expected error")
+        } catch let error as ErrorCode {
+            expect(error).to(matchError(ErrorCode.customerInfoError))
+        } catch let error {
+            fail("Invalid error: \(error)")
+        }
+    }
+
+    func testPublicErrorsContainUnderlyingError() throws {
+        let underlyingError = ErrorUtils.offlineConnectionError().asPublicError
+
+        func throwing() throws {
+            throw ErrorUtils.customerInfoError(error: underlyingError).asPublicError
+        }
+
+        do {
+            try throwing()
+            fail("Expected error")
+        } catch let error as NSError {
+            expect(error).to(matchError(ErrorCode.customerInfoError))
+            expect(error.userInfo[NSUnderlyingErrorKey] as? NSError) == underlyingError
+        }
+    }
+
     func testPurchaseErrorsAreLoggedAsApppleErrors() {
         let underlyingError = NSError(domain: SKErrorDomain, code: SKError.Code.paymentInvalid.rawValue)
         let error = ErrorUtils.purchaseNotAllowedError(error: underlyingError)


### PR DESCRIPTION
This is a key part of how we document error handling in the SDK, so it's important that it's covered in a test.
The second test also verifies that this same error contains all the metadata.

This is a follow up to #1879.