### PR TITLE
`Integration Tests`: relaunch tests when retrying failures

### DIFF
--- a/Tests/TestPlans/CI-BackendIntegration.xctestplan
+++ b/Tests/TestPlans/CI-BackendIntegration.xctestplan
@@ -11,6 +11,7 @@
   "defaultOptions" : {
     "codeCoverage" : false,
     "maximumTestExecutionTimeAllowance" : 180,
+    "repeatInNewRunnerProcess" : true,
     "targetForVariableExpansion" : {
       "containerPath" : "container:RevenueCat.xcodeproj",
       "identifier" : "2DEAC2D926EFE46E006914ED",


### PR DESCRIPTION
I've observed that a lot of the time flaky tests still don't pass after a retry.
This change can probably decrease the likelyhood that a retry will still fail, by ensuring that we create a brand new `SKTestSession` in a new simulator session.