### PR TITLE
`OperationQueue`: log debug message when requests are found in cache and skipped

### DIFF
--- a/Sources/FoundationExtensions/OperationQueue+Extensions.swift
+++ b/Sources/FoundationExtensions/OperationQueue+Extensions.swift
@@ -20,6 +20,7 @@ extension OperationQueue {
         case .firstCallbackAddedToList:
             self.addOperation(operation)
         case .addedToExistingInFlightList:
+            Logger.debug(Strings.network.reusing_existing_request_for_operation(operation))
             return
         }
     }

--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -19,6 +19,7 @@ enum NetworkStrings {
 
     case api_request_completed(_ request: HTTPRequest, httpCode: HTTPStatusCode)
     case api_request_started(HTTPRequest)
+    case reusing_existing_request_for_operation(CacheableNetworkOperation)
     case creating_json_error(error: String)
     case json_data_received(dataString: String)
     case parsing_json_error(error: Error)
@@ -44,6 +45,10 @@ extension NetworkStrings: CustomStringConvertible {
 
         case let .api_request_started(request):
             return "API request started: \(request.method.httpMethod) \(request.path.url?.path ?? "")"
+
+        case let .reusing_existing_request_for_operation(operation):
+            return "Network operation '\(type(of: operation))' found with the same cache key " +
+            "'\(operation.individualizedCacheKeyPart.prefix(15))...'. Skipping request."
 
         case let .creating_json_error(error):
             return "Error creating request with body: \(error)"

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testRepeatedRequestsLogDebugMessage.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS13-testRepeatedRequestsLogDebugMessage.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS14-testRepeatedRequestsLogDebugMessage.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS15-testRepeatedRequestsLogDebugMessage.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS16-testRepeatedRequestsLogDebugMessage.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
+  }
+}

--- a/Tests/UnitTests/TestHelpers/TestLogHandler.swift
+++ b/Tests/UnitTests/TestHelpers/TestLogHandler.swift
@@ -87,7 +87,10 @@ extension TestLogHandler {
             line: line,
             self.messages
         )
-        .to(containElementSatisfying(Self.entryCondition(message: message, level: level)))
+        .to(
+            containElementSatisfying(Self.entryCondition(message: message, level: level)),
+            description: "Message not found. Logged messages: \(self.messages)"
+        )
     }
 
     func verifyMessageWasNotLogged(


### PR DESCRIPTION
Right now there is no way to know when a request is being reused. If this were to lead to a hard to debug issue, at lease we'll now have evidence for this in the logs.