### PR TITLE
`StoreKitIntegrationTests`: print `AppleReceipt` data whenever `verifyEntitlementWentThrough` fails

### DIFF
--- a/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
@@ -72,3 +72,5 @@ struct AppleReceipt: Equatable {
     }
 
 }
+
+extension AppleReceipt: Codable {}

--- a/Sources/LocalReceiptParsing/BasicTypes/InAppPurchase.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/InAppPurchase.swift
@@ -82,3 +82,6 @@ struct InAppPurchase: Equatable {
     }
 
 }
+
+extension InAppPurchaseProductType: Codable {}
+extension InAppPurchase: Codable {}

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1051,6 +1051,20 @@ internal extension Purchases {
         return self.storeKit1Wrapper != nil
     }
 
+    #if DEBUG
+
+    /// Returns the parsed `AppleReceipt`
+    ///
+    /// - Warning: this is only meant for integration tests, as a way to debug purchase failures.
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func fetchReceipt(_ policy: ReceiptRefreshPolicy) async throws -> AppleReceipt? {
+        let receipt = await self.receiptFetcher.receiptData(refreshPolicy: policy)
+
+        return try receipt.map { try ReceiptParser().parse(from: $0) }
+    }
+
+    #endif
+
     /// - Parameter syncedAttribute: will be called for every attribute that is updated
     /// - Parameter completion: will be called once all attributes have completed syncing
     /// - Returns: the number of attributes that will be synced

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1053,7 +1053,7 @@ internal extension Purchases {
 
     #if DEBUG
 
-    /// Returns the parsed `AppleReceipt`
+    /// - Returns: the parsed `AppleReceipt`
     ///
     /// - Warning: this is only meant for integration tests, as a way to debug purchase failures.
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -498,12 +498,12 @@ private extension StoreKit1IntegrationTests {
         }
 
         if verifyEntitlementIsActive {
-            expect(file: file, line: line, entitlement.isActive)
-                .to(beTrue(), description: "Entitlement is not active")
-
             if !entitlement.isActive {
                 await self.printReceiptContent()
             }
+
+            expect(file: file, line: line, entitlement.isActive)
+                .to(beTrue(), description: "Entitlement is not active")
         }
 
         return entitlement


### PR DESCRIPTION
This will help us debug flaky tests.

Example:
> INFO: 😻💰 Purchased product - 'com.revenuecat.monthly_4.99.1_week_intro'
DEBUG: ℹ️ Force refreshing the receipt to get latest transactions from Apple.
DEBUG: ℹ️ Loaded receipt from url file:///Users/nachosoto/Library/Developer/CoreSimulator/Devices/A3576DC2-355E-45BA-B32C-D2C0A3811BB4/data/Containers/Data/Application/EDF3B7C8-A4BD-4629-813E-0934528AF02E/StoreKit/receipt
INFO: ℹ️ Receipt parsed successfully
INFO: ℹ️ Receipt content:
["inAppPurchases": [], "creationDate": 2022-09-21 21:00:07 +0000, "opaqueValue": 8 bytes, "applicationVersion": "1", "originalApplicationVersion": "<unknown>", "bundleId": "com.revenuecat.StoreKitTestApp", "expirationDate": 4001-01-01 00:00:00 +0000, "sha1Hash": 20 bytes]
/Users/nachosoto/dev/purchases-ios/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift:64: error: -[BackendIntegrationTests.StoreKit2IntegrationTests testCanPurchaseProduct] : failed - Expected Entitlement. Got: [:]
expected to have Dictionary<String, EntitlementInfo> with count 1, got 0
Actual Value: [:]

I've also added the receipt as a test attachment so we can download it from `CircleCI`:

![Screenshot 2022-09-21 at 14 33 01](https://user-images.githubusercontent.com/685609/191614494-c1b1b24e-133d-45f2-83b5-f4cd1f491294.png)