### PR TITLE
`SnapshotTesting`: require version 1.9.0 to keep supporting iOS 12/13 tests

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -3364,8 +3364,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pointfreeco/swift-snapshot-testing";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.9.0;
+				kind = exactVersion;
+				version = 1.9.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
[The new 1.10.0 version](https://github.com/pointfreeco/swift-snapshot-testing/releases/tag/1.10.0) requires iOS 13+, which is making CI builds all fail.

We'll be able to upgrade when we drop support for those version, but for now we're stuck with `1.9.0`