### PR TITLE
`CacheableNetworkOperation`: fixed race condition in new test

### DIFF
--- a/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
@@ -60,7 +60,9 @@ class BackendGetOfferingsTests: BaseBackendTests {
     func testGetOfferingsCachesForSameUserID() {
         self.httpClient.mock(
             requestPath: .getOfferings(appUserID: Self.userID),
-            response: .init(statusCode: .success, response: Self.noOfferingsResponse as [String: Any])
+            response: .init(statusCode: .success,
+                            response: Self.noOfferingsResponse as [String: Any],
+                            delay: .seconds(2))
         )
         self.offerings.getOfferings(appUserID: Self.userID, withRandomDelay: false) { _ in }
         self.offerings.getOfferings(appUserID: Self.userID, withRandomDelay: false) { _ in }
@@ -73,7 +75,9 @@ class BackendGetOfferingsTests: BaseBackendTests {
 
         self.httpClient.mock(
             requestPath: .getOfferings(appUserID: Self.userID),
-            response: .init(statusCode: .success, response: Self.noOfferingsResponse as [String: Any])
+            response: .init(statusCode: .success,
+                            response: Self.noOfferingsResponse as [String: Any],
+                            delay: .seconds(2))
         )
         self.offerings.getOfferings(appUserID: Self.userID, withRandomDelay: false) { _ in }
         self.offerings.getOfferings(appUserID: Self.userID, withRandomDelay: false) { _ in }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -209,17 +209,6 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expect(SystemInfo.serverHostURL) == defaultHostURL
     }
 
-    @available(*, deprecated) // Ignore deprecation warnings
-    func testSetDebugLogsEnabledSetsTheCorrectValue() {
-        Logger.logLevel = .warn
-
-        Purchases.debugLogsEnabled = true
-        expect(Logger.logLevel) == .debug
-
-        Purchases.debugLogsEnabled = false
-        expect(Logger.logLevel) == .info
-    }
-
     func testIsAnonymous() {
         setupAnonPurchases()
         expect(self.purchases.isAnonymous).to(beTrue())

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -128,6 +128,7 @@ platform :ios do
       number_of_retries: 5,
       result_bundle: true,
       testplan: "CI-AllTests",
+      configuration: 'Debug',
       output_directory: "fastlane/test_output/xctest/ios"
     )
   end
@@ -144,6 +145,7 @@ platform :ios do
       number_of_retries: 5,
       result_bundle: true,
       testplan: "CI-AllTests",
+      configuration: 'Debug',
       output_directory: "fastlane/test_output/xctest/tvos"
     )
   end
@@ -342,6 +344,7 @@ platform :ios do
       number_of_retries: 3,
       result_bundle: true,
       testplan: "CI-BackendIntegration",
+      configuration: 'Debug',
       output_directory: "fastlane/test_output/xctest/ios"
     )
   end


### PR DESCRIPTION
The test introduced by #1926 passed locally, but sometimes failed in CI due to a race condition.

What we're testing is that the second request reuses the callback of the first one, **if called while the first one is still in progress**. However, nothing in the test ensures that's the case.
This introduces an optional delay in `MockHTTPClient` so we can ensure that.

Another reason that test was failing randomly is because we had another test modifying global state, which interferes with every other test. We run tests in parallel, so it was making the new test that requires `debug` logs to fail randomly, if this test happened to run before.

_Note: because of the nature of these 2 tests, they don't actually wait for the whole response to finish, so they still pass in ~0.006s_