### PR TITLE
`Logger`: refactored default `LogLevel` definition

### DIFF
--- a/Sources/Logging/Logger.swift
+++ b/Sources/Logging/Logger.swift
@@ -48,7 +48,7 @@ public typealias LogHandler = (_ level: LogLevel,
 
 enum Logger {
 
-    static var logLevel: LogLevel = Self.debugLogLevel
+    static var logLevel: LogLevel = Self.defaultLogLevel
     static var logHandler: VerboseLogHandler = Self.defaultLogHandler
 
     static let defaultLogHandler: VerboseLogHandler = { level, message, file, functionName, line in
@@ -69,7 +69,7 @@ enum Logger {
 
     static var verbose: Bool = false
 
-    private static let debugLogLevel: LogLevel = {
+    private static let defaultLogLevel: LogLevel = {
         #if DEBUG
         return .debug
         #else

--- a/Sources/Logging/Logger.swift
+++ b/Sources/Logging/Logger.swift
@@ -47,11 +47,8 @@ public typealias LogHandler = (_ level: LogLevel,
                                _ message: String) -> Void
 
 enum Logger {
-    #if DEBUG
-    static var logLevel: LogLevel = .debug
-    #else
-    static var logLevel: LogLevel = .info
-    #endif
+
+    static var logLevel: LogLevel = Self.debugLogLevel
     static var logHandler: VerboseLogHandler = Self.defaultLogHandler
 
     static let defaultLogHandler: VerboseLogHandler = { level, message, file, functionName, line in
@@ -71,6 +68,14 @@ enum Logger {
     }
 
     static var verbose: Bool = false
+
+    private static let debugLogLevel: LogLevel = {
+        #if DEBUG
+        return .debug
+        #else
+        return .info
+        #endif
+    }()
 
     internal static let frameworkDescription = "Purchases"
 


### PR DESCRIPTION
Defining the property "twice" was a big weird and hard to read. Now `logLevel` is only defined once, with the default value extracted into a separate method.