### PR TITLE
Fixed iOS 12 tests

### DIFF
--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testRepeatedRequestsLogDebugMessage.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetOfferingsTests/iOS12-testRepeatedRequestsLogDebugMessage.1.json
@@ -5,6 +5,6 @@
   "request" : {
     "body" : null,
     "method" : "GET",
-    "url" : "https://api.revenuecat.com/v1/subscribers/user/offerings"
+    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user\/offerings"
   }
 }


### PR DESCRIPTION
I blindly copy-pasted this snapshot and forgot that iOS 12 has different formatting. This was wrong in #1926.

It wasn't caught originally because we hadn't been running tests on iOS 12 until #1928.