### PR TITLE
`PostReceiptDataOperation`: print receipt data if `debug` logs are enabled

### DIFF
--- a/Sources/FoundationExtensions/JSONDecoder+Extensions.swift
+++ b/Sources/FoundationExtensions/JSONDecoder+Extensions.swift
@@ -122,7 +122,23 @@ extension Encodable {
         return result
     }
 
+    /// - Throws: if encoding failed
+    /// - Returns: `nil` if the encoded `Data` can't be serialized into a `String`.
+    var prettyPrintedJSON: String? {
+        get throws {
+            return String(data: try self.prettyPrintedData, encoding: .utf8)
+        }
+    }
+
+    var prettyPrintedData: Data {
+        get throws {
+            return try JSONEncoder.prettyPrinted.encode(self)
+        }
+    }
+
 }
+
+// MARK: -
 
 extension JSONEncoder {
 

--- a/Sources/FoundationExtensions/JSONDecoder+Extensions.swift
+++ b/Sources/FoundationExtensions/JSONDecoder+Extensions.swift
@@ -134,6 +134,15 @@ extension JSONEncoder {
         return encoder
     }()
 
+    static let prettyPrinted: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = .prettyPrinted
+
+        return encoder
+    }()
+
 }
 
 extension JSONDecoder {

--- a/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
@@ -58,23 +58,14 @@ struct AppleReceipt: Equatable {
         return Set(productIdentifiers)
     }
 
-    var asDict: [String: Any] {
-        return [
-            "bundleId": bundleId,
-            "applicationVersion": applicationVersion,
-            "originalApplicationVersion": originalApplicationVersion ?? "<unknown>",
-            "opaqueValue": opaqueValue,
-            "sha1Hash": sha1Hash,
-            "creationDate": creationDate,
-            "expirationDate": expirationDate ?? "",
-            "inAppPurchases": inAppPurchases.map { $0.asDict }
-        ]
-    }
-
-    var description: String {
-        return String(describing: self.asDict)
-    }
-
 }
 
 extension AppleReceipt: Codable {}
+
+extension AppleReceipt: CustomDebugStringConvertible {
+
+    var debugDescription: String {
+        return (try? self.prettyPrintedJSON) ?? "<null>"
+    }
+
+}

--- a/Sources/LocalReceiptParsing/BasicTypes/InAppPurchase.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/InAppPurchase.swift
@@ -40,29 +40,15 @@ struct InAppPurchase: Equatable {
     let webOrderLineItemId: Int64?
     let promotionalOfferIdentifier: String?
 
-    var asDict: [String: Any] {
-        return [
-            "quantity": quantity,
-            "productId": productId,
-            "transactionId": transactionId,
-            "originalTransactionId": originalTransactionId ?? "<unknown>",
-            "promotionalOfferIdentifier": promotionalOfferIdentifier ?? "",
-            "purchaseDate": purchaseDate,
-            "productType": productType?.rawValue ?? "",
-            "originalPurchaseDate": originalPurchaseDate ?? "<unknown>",
-            "expiresDate": expiresDate ?? "",
-            "cancellationDate": cancellationDate ?? "",
-            "isInTrialPeriod": isInTrialPeriod ?? "",
-            "isInIntroOfferPeriod": isInIntroOfferPeriod ?? "<unknown>",
-            "webOrderLineItemId": webOrderLineItemId ?? "<unknown>"
-        ]
-    }
-
-    var description: String {
-        return String(describing: self.asDict)
-    }
-
 }
 
 extension InAppPurchase.ProductType: Codable {}
 extension InAppPurchase: Codable {}
+
+extension InAppPurchase: CustomDebugStringConvertible {
+
+    var debugDescription: String {
+        return (try? self.prettyPrintedJSON) ?? "<null>"
+    }
+
+}

--- a/Sources/LocalReceiptParsing/ReceiptParser.swift
+++ b/Sources/LocalReceiptParsing/ReceiptParser.swift
@@ -16,6 +16,8 @@ import Foundation
 
 class ReceiptParser {
 
+    static let `default`: ReceiptParser = .init()
+
     private let containerBuilder: ASN1ContainerBuilder
     private let receiptBuilder: AppleReceiptBuilder
 

--- a/Sources/Logging/Strings/ReceiptStrings.swift
+++ b/Sources/Logging/Strings/ReceiptStrings.swift
@@ -28,7 +28,7 @@ enum ReceiptStrings {
     case parsing_receipt
     case refreshing_empty_receipt
     case unable_to_load_receipt
-    case posting_receipt(content: String)
+    case posting_receipt(AppleReceipt)
 
 }
 
@@ -76,7 +76,7 @@ extension ReceiptStrings: CustomStringConvertible {
             return "Unable to load receipt, ensure you are logged in to a valid Apple account."
 
         case let .posting_receipt(content):
-            return "Posting receipt: \(content)"
+            return "Posting receipt: \(content.debugDescription)"
 
         }
     }

--- a/Sources/Logging/Strings/ReceiptStrings.swift
+++ b/Sources/Logging/Strings/ReceiptStrings.swift
@@ -28,6 +28,7 @@ enum ReceiptStrings {
     case parsing_receipt
     case refreshing_empty_receipt
     case unable_to_load_receipt
+    case posting_receipt(content: String)
 
 }
 
@@ -73,6 +74,9 @@ extension ReceiptStrings: CustomStringConvertible {
 
         case .unable_to_load_receipt:
             return "Unable to load receipt, ensure you are logged in to a valid Apple account."
+
+        case let .posting_receipt(content):
+            return "Posting receipt: \(content)"
 
         }
     }

--- a/Sources/Logging/Strings/ReceiptStrings.swift
+++ b/Sources/Logging/Strings/ReceiptStrings.swift
@@ -75,8 +75,8 @@ extension ReceiptStrings: CustomStringConvertible {
         case .unable_to_load_receipt:
             return "Unable to load receipt, ensure you are logged in to a valid Apple account."
 
-        case let .posting_receipt(content):
-            return "Posting receipt: \(content.debugDescription)"
+        case let .posting_receipt(receipt):
+            return "Posting receipt: \(receipt.debugDescription)"
 
         }
     }

--- a/Sources/Networking/Operations/NetworkOperation.swift
+++ b/Sources/Networking/Operations/NetworkOperation.swift
@@ -125,8 +125,8 @@ class NetworkOperation: Operation {
 
     // MARK: -
 
-    private func log(_ message: String) {
-        Logger.debug("\(type(of: self)): \(message)")
+    internal func log(_ message: CustomStringConvertible) {
+        Logger.debug("\(type(of: self)): \(message.description)")
     }
 
     // MARK: -

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -53,6 +53,10 @@ class PostReceiptDataOperation: CacheableNetworkOperation {
     }
 
     override func begin(completion: @escaping () -> Void) {
+        if Logger.logLevel == .debug {
+            self.printReceiptData()
+        }
+
         self.post(completion: completion)
     }
 
@@ -70,6 +74,27 @@ class PostReceiptDataOperation: CacheableNetworkOperation {
     }
 
 }
+
+// MARK: - Private
+
+private extension PostReceiptDataOperation {
+
+    func printReceiptData() {
+        do {
+            let receiptData = try JSONEncoder.prettyPrinted.encode(
+                try ReceiptParser.default.parse(from: self.postData.receiptData)
+            )
+            let receiptContent = String(data: receiptData, encoding: .utf8) ?? "<nil>"
+
+            self.log(Strings.receipt.posting_receipt(content: receiptContent))
+        } catch {
+            Logger.appleError(Strings.receipt.parse_receipt_locally_error(error: error))
+        }
+    }
+
+}
+
+// MARK: - Request Data
 
 extension PostReceiptDataOperation.PostData: Encodable {
 

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -81,12 +81,9 @@ private extension PostReceiptDataOperation {
 
     func printReceiptData() {
         do {
-            let receiptData = try JSONEncoder.prettyPrinted.encode(
+            self.log(Strings.receipt.posting_receipt(
                 try ReceiptParser.default.parse(from: self.postData.receiptData)
-            )
-            let receiptContent = String(data: receiptData, encoding: .utf8) ?? "<nil>"
-
-            self.log(Strings.receipt.posting_receipt(content: receiptContent))
+            ))
         } catch {
             Logger.appleError(Strings.receipt.parse_receipt_locally_error(error: error))
         }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -275,7 +275,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         let offeringsFactory = OfferingsFactory()
         let userDefaults = userDefaults ?? UserDefaults.standard
         let deviceCache = DeviceCache(sandboxEnvironmentDetector: systemInfo, userDefaults: userDefaults)
-        let receiptParser = ReceiptParser()
+        let receiptParser = ReceiptParser.default
         let transactionsManager = TransactionsManager(storeKit2Setting: systemInfo.storeKit2Setting,
                                                       receiptParser: receiptParser)
         let customerInfoManager = CustomerInfoManager(operationDispatcher: operationDispatcher,
@@ -1060,7 +1060,7 @@ internal extension Purchases {
     func fetchReceipt(_ policy: ReceiptRefreshPolicy) async throws -> AppleReceipt? {
         let receipt = await self.receiptFetcher.receiptData(refreshPolicy: policy)
 
-        return try receipt.map { try ReceiptParser().parse(from: $0) }
+        return try receipt.map { try ReceiptParser.default.parse(from: $0) }
     }
 
     #endif

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -610,16 +610,7 @@ private extension AppleReceipt {
 
     var prettyPrintedData: Data {
         get throws {
-            let encoder: JSONEncoder = {
-                let encoder = JSONEncoder()
-                encoder.keyEncodingStrategy = .convertToSnakeCase
-                encoder.outputFormatting = .prettyPrinted
-                encoder.dateEncodingStrategy = .iso8601
-
-                return encoder
-            }()
-
-            return try encoder.encode(self)
+            return try JSONEncoder.prettyPrinted.encode(self)
         }
     }
 }

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -578,7 +578,7 @@ private extension StoreKit1IntegrationTests {
     func printReceiptContent() async {
         do {
             let receipt = try await Purchases.shared.fetchReceipt(.always)
-            let description = receipt.map { $0.description } ?? "<null>"
+            let description = receipt.map { $0.debugDescription } ?? "<null>"
 
             Logger.appleWarning("Receipt content:\n\(description)")
 
@@ -604,13 +604,4 @@ private extension AsyncSequence {
         }
     }
 
-}
-
-private extension AppleReceipt {
-
-    var prettyPrintedData: Data {
-        get throws {
-            return try JSONEncoder.prettyPrinted.encode(self)
-        }
-    }
 }

--- a/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
@@ -37,7 +37,7 @@ class LocalReceiptParserStoreKitTests: StoreKitConfigTestCase {
                                          operationDispatcher: operationDispatcher,
                                          storeKit2Setting: .disabled)
         self.receiptFetcher = ReceiptFetcher(requestFetcher: self.requestFetcher, systemInfo: systemInfo)
-        self.parser = ReceiptParser()
+        self.parser = .default
     }
 
     @MainActor

--- a/Tests/UnitTests/LocalReceiptParsing/TestsAgainstRealReceipts/ReceiptParsing+TestsWithRealReceipts.swift
+++ b/Tests/UnitTests/LocalReceiptParsing/TestsAgainstRealReceipts/ReceiptParsing+TestsWithRealReceipts.swift
@@ -18,7 +18,7 @@ class ReceiptParsingRealReceiptTests: TestCase {
 
     func testBasicReceiptAttributesForSample1() throws {
         let receiptData = sampleReceiptData(receiptName: receipt1Name)
-        let receipt = try ReceiptParser().parse(from: receiptData)
+        let receipt = try ReceiptParser.default.parse(from: receiptData)
 
         expect(receipt.applicationVersion) == "4"
         expect(receipt.bundleId) == "com.revenuecat.sampleapp"
@@ -29,7 +29,7 @@ class ReceiptParsingRealReceiptTests: TestCase {
 
     func testInAppPurchasesAttributesForSample1() throws {
         let receiptData = sampleReceiptData(receiptName: receipt1Name)
-        let receipt = try ReceiptParser().parse(from: receiptData)
+        let receipt = try ReceiptParser.default.parse(from: receiptData)
         let inAppPurchases = receipt.inAppPurchases
 
         expect(inAppPurchases.count) == 9


### PR DESCRIPTION
For [CSDK-478].
Follow up to #1929.

### Example:
> DEBUG: ℹ️ PostReceiptDataOperation: Started
INFO: ℹ️ Receipt parsed successfully
DEBUG: ℹ️ PostReceiptDataOperation: Posting receipt: {
  "opaque_value" : "Rn\/39QYAAAA=",
  "sha1_hash" : "Ii8Z7ocZm524eJcWFOvVauNrNHs=",
  "bundle_id" : "com.revenuecat.StoreKitTestApp",
  "in_app_purchases" : [
    {
      "quantity" : 1,
      "product_id" : "com.revenuecat.monthly_4.99.1_week_intro",
      "purchase_date" : "2022-09-27T19:09:47Z",
      "transaction_id" : "0",
      "is_in_intro_offer_period" : true,
      "expires_date" : "2022-09-27T19:09:57Z"
    }
  ],
  "application_version" : "1",
  "creation_date" : "2022-09-27T19:09:47Z",
  "expiration_date" : "4001-01-01T00:00:00Z"
}
DEBUG: ℹ️ There are no requests currently running, starting request POST receipts
DEBUG: ℹ️ API request started: POST /v1/receipts
DEBUG: ℹ️ API request completed: POST /v1/receipts 200
DEBUG: ℹ️ PostReceiptDataOperation: Finished
DEBUG: ℹ️ Serial request done: POST receipts, 0 requests left in the queue
DEBUG: ℹ️ Sending updated CustomerInfo to delegate.
INFO: 😻💰 Purchased product - 'com.revenuecat.monthly_4.99.1_week_intro'
INFO: 💰 Finishing transaction com.revenuecat.monthly_4.99.1_week_intro 0 ()

[CSDK-478]: https://revenuecats.atlassian.net/browse/CSDK-478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ