### PR TITLE
Refactored `ReceiptFetcher.receiptData`

### DIFF
--- a/Sources/Purchasing/ReceiptFetcher.swift
+++ b/Sources/Purchasing/ReceiptFetcher.swift
@@ -25,20 +25,24 @@ class ReceiptFetcher {
     }
 
     func receiptData(refreshPolicy: ReceiptRefreshPolicy, completion: @escaping (Data?) -> Void) {
-        if refreshPolicy == .always {
+        switch refreshPolicy {
+        case .always:
             Logger.debug(Strings.receipt.force_refreshing_receipt)
-            refreshReceipt(completion)
-            return
-        }
+            self.refreshReceipt(completion)
 
-        let receiptData = receiptData()
-        let isReceiptEmpty = receiptData?.isEmpty ?? true
+        case .onlyIfEmpty:
+            let receiptData = self.receiptData()
+            let isReceiptEmpty = receiptData?.isEmpty ?? true
 
-        if isReceiptEmpty && refreshPolicy == .onlyIfEmpty {
-            Logger.debug(Strings.receipt.refreshing_empty_receipt)
-            refreshReceipt(completion)
-        } else {
-            completion(receiptData)
+            if isReceiptEmpty {
+                Logger.debug(Strings.receipt.refreshing_empty_receipt)
+                self.refreshReceipt(completion)
+            } else {
+                completion(receiptData)
+            }
+
+        case .never:
+            completion(self.receiptData())
         }
     }
 


### PR DESCRIPTION
I'm considering adding a 4th `ReceiptRefreshPolicy` that re-fetches the receipt N-times until it finds a transaction for a recently purchased product ([CSDK-478]).
This will make it easier to implement.

[CSDK-478]: https://revenuecats.atlassian.net/browse/CSDK-478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ