### PR TITLE
Abstracted conversion from `async` to completion-block APIs

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -207,6 +207,8 @@
 		57057FF928B0048900995F21 /* TestLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57057FF728B0048900995F21 /* TestLogHandler.swift */; };
 		5705800328B0085200995F21 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5705800228B0085200995F21 /* Box.swift */; };
 		5705800428B0085200995F21 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5705800228B0085200995F21 /* Box.swift */; };
+		57069A5428E3918400B86355 /* AsyncExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57069A5328E3918400B86355 /* AsyncExtensions.swift */; };
+		57069A5E28E398E100B86355 /* AsyncExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57069A5D28E398E100B86355 /* AsyncExtensionsTests.swift */; };
 		570FAF4B2864EC2300D3C769 /* NonSubscriptionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570FAF4A2864EC2300D3C769 /* NonSubscriptionTransaction.swift */; };
 		571E7AD4279F2D0C003B3606 /* StoreKitTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571E7AD3279F2D0C003B3606 /* StoreKitTestHelpers.swift */; };
 		5721360F28B4602C006C46BE /* Purchases+nonasync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5721360E28B4602C006C46BE /* Purchases+nonasync.swift */; };
@@ -709,6 +711,8 @@
 		57032ABE28C13CE4004FF47A /* StoreKit2SettingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2SettingTests.swift; sourceTree = "<group>"; };
 		57057FF728B0048900995F21 /* TestLogHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestLogHandler.swift; sourceTree = "<group>"; };
 		5705800228B0085200995F21 /* Box.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
+		57069A5328E3918400B86355 /* AsyncExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncExtensions.swift; sourceTree = "<group>"; };
+		57069A5D28E398E100B86355 /* AsyncExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncExtensionsTests.swift; sourceTree = "<group>"; };
 		570814C128A308050018BAE3 /* BackendIntegrationTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = BackendIntegrationTests.xctestplan; path = Tests/TestPlans/BackendIntegrationTests.xctestplan; sourceTree = "<group>"; };
 		570896B227595C8100296F1C /* AllTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = AllTests.xctestplan; path = Tests/TestPlans/AllTests.xctestplan; sourceTree = "<group>"; };
 		570896B327595C8100296F1C /* RevenueCat.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = RevenueCat.xctestplan; path = Tests/TestPlans/RevenueCat.xctestplan; sourceTree = "<group>"; };
@@ -1030,6 +1034,7 @@
 			isa = PBXGroup;
 			children = (
 				572247D027BEC28E00C524A7 /* Array+Extensions.swift */,
+				57069A5328E3918400B86355 /* AsyncExtensions.swift */,
 				2CD72941268A823900BFC976 /* Data+Extensions.swift */,
 				2CD72943268A826F00BFC976 /* Date+Extensions.swift */,
 				37E353FD94A8FD5CD8796530 /* DateFormatter+Extensions.swift */,
@@ -1620,6 +1625,7 @@
 			isa = PBXGroup;
 			children = (
 				572247F627BF1ADF00C524A7 /* ArrayExtensionsTests.swift */,
+				57069A5D28E398E100B86355 /* AsyncExtensionsTests.swift */,
 				37E35FDA0A44EA03EA12DAA2 /* DateFormatter+ExtensionsTests.swift */,
 				57ACB13628184CF1000DCC9F /* DecoderExtensionTests.swift */,
 				2DD269162522A20A006AC4BC /* DictionaryExtensionsTests.swift */,
@@ -2391,6 +2397,7 @@
 				570FAF4B2864EC2300D3C769 /* NonSubscriptionTransaction.swift in Sources */,
 				2D11F5E1250FF886005A70E8 /* AttributionStrings.swift in Sources */,
 				2CD72944268A826F00BFC976 /* Date+Extensions.swift in Sources */,
+				57069A5428E3918400B86355 /* AsyncExtensions.swift in Sources */,
 				B34605C5279A6E380031CA74 /* CustomerInfoResponseHandler.swift in Sources */,
 				5796A3A927D7C43500653165 /* Deprecations.swift in Sources */,
 				B3AA6238268B926F00894871 /* SystemInfo.swift in Sources */,
@@ -2542,6 +2549,7 @@
 				5766C620282DA3D50067D886 /* GetIntroEligibilityDecodingTests.swift in Sources */,
 				57C381E2279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */,
 				2DDF41E824F6F61B005BC22D /* MockSKProductDiscount.swift in Sources */,
+				57069A5E28E398E100B86355 /* AsyncExtensionsTests.swift in Sources */,
 				35272E2226D0048D00F22C3B /* HTTPClientTests.swift in Sources */,
 				2DDF41CB24F6F4C3005BC22D /* ASN1ObjectIdentifierBuilderTests.swift in Sources */,
 				5766AA5A283D4CAB00FA6091 /* IgnoreHashableTests.swift in Sources */,

--- a/Sources/FoundationExtensions/AsyncExtensions.swift
+++ b/Sources/FoundationExtensions/AsyncExtensions.swift
@@ -32,7 +32,7 @@ internal enum Async {
     }
 
     /// Invokes an `async throws` method and calls `completion` with the result.
-    /// /// Ensures that the returned error is `PurchasesError`.
+    /// Ensures that the returned error is `PurchasesError`.
     static func call<T>(
         with completion: @escaping (Result<T, PurchasesError>) -> Void,
         asyncMethod method: @escaping () async throws -> T

--- a/Sources/FoundationExtensions/AsyncExtensions.swift
+++ b/Sources/FoundationExtensions/AsyncExtensions.swift
@@ -1,0 +1,59 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  AsyncExtensions.swift
+//
+//  Created by Nacho Soto on 9/27/22.
+
+import Foundation
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+internal enum Async {
+
+    /// Invokes an `async throws` method and calls `completion` with the result.
+    /// Ensures that the returned error is `PublicError`.
+    static func call<T>(
+        with completion: @escaping (Result<T, PublicError>) -> Void,
+        asyncMethod method: @escaping () async throws -> T
+    ) {
+        _ = Task<Void, Never> {
+            do {
+                completion(.success(try await method()))
+            } catch {
+                completion(.failure(ErrorUtils.purchasesError(withUntypedError: error).asPublicError))
+            }
+        }
+    }
+
+    /// Invokes an `async throws` method and calls `completion` with the result.
+    /// /// Ensures that the returned error is `PurchasesError`.
+    static func call<T>(
+        with completion: @escaping (Result<T, PurchasesError>) -> Void,
+        asyncMethod method: @escaping () async throws -> T
+    ) {
+        _ = Task<Void, Never> {
+            do {
+                completion(.success(try await method()))
+            } catch {
+                completion(.failure(ErrorUtils.purchasesError(withUntypedError: error)))
+            }
+        }
+    }
+
+    /// Invokes an `async` non-throwing method and calls `completion` with the result.
+    static func call<T>(
+        with completion: @escaping (T) -> Void,
+        asyncMethod method: @escaping () async -> T
+    ) {
+        _ = Task<Void, Never> {
+            completion(await method())
+        }
+    }
+
+}

--- a/Sources/Misc/Purchases+nonasync.swift
+++ b/Sources/Misc/Purchases+nonasync.swift
@@ -30,7 +30,7 @@ public extension Purchases {
         forProduct productID: String,
         completion: @escaping (Result<RefundRequestStatus, PublicError>) -> Void
     ) {
-        call(with: completion) {
+        Async.call(with: completion) {
             try await self.beginRefundRequest(forProduct: productID)
         }
     }
@@ -43,7 +43,7 @@ public extension Purchases {
         forEntitlement entitlementID: String,
         completion: @escaping (Result<RefundRequestStatus, PublicError>) -> Void
     ) {
-        call(with: completion) {
+        Async.call(with: completion) {
             try await self.beginRefundRequest(forEntitlement: entitlementID)
         }
     }
@@ -55,26 +55,11 @@ public extension Purchases {
     func beginRefundRequestForActiveEntitlement(
         completion: @escaping (Result<RefundRequestStatus, PublicError>) -> Void
     ) {
-        call(with: completion) {
+        Async.call(with: completion) {
             try await self.beginRefundRequestForActiveEntitlement()
         }
     }
 
     #endif
 
-}
-
-/// Invokes an `async throws` method and calls `completion` with the result.
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-private func call<T>(
-    with completion: @escaping (Result<T, PublicError>) -> Void,
-    asyncMethod method: @escaping () async throws -> T
-) {
-    _ = Task {
-        do {
-            completion(.success(try await method()))
-        } catch {
-            completion(.failure(ErrorUtils.purchasesError(withUntypedError: error).asPublicError))
-        }
-    }
 }

--- a/Sources/Purchasing/ProductsManager.swift
+++ b/Sources/Purchasing/ProductsManager.swift
@@ -108,14 +108,14 @@ private extension ProductsManager {
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func sk2Products(withIdentifiers identifiers: Set<String>,
                      completion: @escaping (Result<Set<SK2StoreProduct>, PurchasesError>) -> Void) {
-        _ = Task<Void, Never> {
+        Async.call(with: completion) {
             do {
                 let products = try await self.sk2StoreProducts(withIdentifiers: identifiers)
                 Logger.debug(Strings.storeKit.store_product_request_finished)
-                completion(.success(Set(products)))
+                return Set(products)
             } catch {
                 Logger.debug(Strings.storeKit.store_products_request_failed(error: error))
-                completion(.failure(ErrorUtils.storeProblemError(error: error)))
+                throw ErrorUtils.storeProblemError(error: error)
             }
         }
     }

--- a/Sources/Purchasing/TransactionsManager.swift
+++ b/Sources/Purchasing/TransactionsManager.swift
@@ -27,11 +27,11 @@ class TransactionsManager {
     func customerHasTransactions(receiptData: Data, completion: @escaping (Bool) -> Void) {
         // Note: this uses SK2 (unless it's explicitly disabled) because its implementation is more accurate.
         if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *), self.storeKit2Setting != .disabled {
-            _ = Task<Void, Never> {
-                completion(await sk2CheckCustomerHasTransactions())
+            Async.call(with: completion) {
+                return await self.sk2CheckCustomerHasTransactions()
             }
         } else {
-            completion(sk1CheckCustomerHasTransactions(receiptData: receiptData))
+            completion(self.sk1CheckCustomerHasTransactions(receiptData: receiptData))
         }
     }
 

--- a/Sources/Support/ManageSubscriptionsHelper.swift
+++ b/Sources/Support/ManageSubscriptionsHelper.swift
@@ -85,9 +85,8 @@ private extension ManageSubscriptionsHelper {
            // showManageSubscriptions doesn't work on iOS apps running on Apple Silicon
            // https://developer.apple.com/documentation/storekit/appstore/3803198-showmanagesubscriptions#
            !ProcessInfo().isiOSAppOnMac {
-            _ = Task<Void, Never> {
-                let result = await self.showSK2ManageSubscriptions()
-                completion(result)
+            Async.call(with: completion) {
+                return await self.showSK2ManageSubscriptions()
             }
             return
         }
@@ -134,7 +133,7 @@ private extension ManageSubscriptionsHelper {
 #if os(iOS)
         // Note: we're ignoring the result of AppStore.showManageSubscriptions(in:) because as of
         // iOS 15.2, it only returns after the sheet is dismissed, which isn't desired.
-        _ = Task.init {
+        _ = Task<Void, Never> {
             do {
                 try await AppStore.showManageSubscriptions(in: windowScene)
                 Logger.info(Strings.susbscription_management_sheet_dismissed)

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -34,7 +34,7 @@ func checkPurchasesAPI() {
     let _: Attribution = purch.attribution
 
     if #available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *) {
-        _ = Task.init {
+        _ = Task<Void, Never> {
             await checkAsyncMethods(purchases: purch)
         }
 

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
@@ -33,7 +33,7 @@ func checkStoreProductAPI() {
     let sk2Product: SK2Product? = product.sk2Product
 
     if #available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *) {
-        _ = Task.init {
+        _ = Task<Void, Never> {
             await checkStoreProductAsyncAPI()
         }
     }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/StorefrontAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/StorefrontAPI.swift
@@ -17,7 +17,7 @@ func checkStorefrontAPI() {
     let sk1Storefront: SKStorefront? = storefront.sk1Storefront
     let sk2Storefront: StoreKit.Storefront? = storefront.sk2Storefront
 
-    _ = Task {
+    _ = Task<Void, Never> {
         let _: RevenueCat.Storefront? = await Storefront.currentStorefront
     }
 

--- a/Tests/UnitTests/FoundationExtensions/AsyncExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/AsyncExtensionsTests.swift
@@ -1,0 +1,98 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  AsyncExtensionsTests.swift
+//
+//  Created by Nacho Soto on 9/27/22.
+
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+class AsyncExtensionsTests: TestCase {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+    }
+
+    func testPublicErrorResultReturningSuccess() {
+        var result: Result<Int, PublicError>?
+        let expected = Int.random(in: 0..<100)
+
+        let completion: (Result<Int, PublicError>) -> Void = { result = $0 }
+
+        Async.call(with: completion) {
+            return expected
+        }
+
+        expect(result).toEventually(beSuccess())
+        expect(result?.value) == expected
+    }
+
+    func testPublicErrorResultReturningError() {
+        var result: Result<Int, PublicError>?
+        let error = ErrorUtils.configurationError()
+        let expected = error.asPublicError
+
+        let completion: (Result<Int, PublicError>) -> Void = { result = $0 }
+
+        Async.call(with: completion) {
+            throw error
+        }
+
+        expect(result).toEventually(beFailure())
+        expect(result?.error).to(matchError(expected))
+    }
+
+    func testPurchasesErrorResultReturningSuccess() {
+        var result: Result<Int, PurchasesError>?
+        let expected = Int.random(in: 0..<100)
+
+        let completion: (Result<Int, PurchasesError>) -> Void = { result = $0 }
+
+        Async.call(with: completion) {
+            return expected
+        }
+
+        expect(result).toEventually(beSuccess())
+        expect(result?.value) == expected
+    }
+
+    func testPurchasesErrorResultReturningError() {
+        var result: Result<Int, PurchasesError>?
+        let expected = ErrorUtils.configurationError()
+
+        let completion: (Result<Int, PurchasesError>) -> Void = { result = $0 }
+
+        Async.call(with: completion) {
+            throw expected
+        }
+
+        expect(result).toEventually(beFailure())
+        expect(result?.error).to(matchError(expected))
+    }
+
+    func testCallWithNoError() {
+        var result: Int?
+        let expected = Int.random(in: 0..<100)
+
+        let completion: (Int) -> Void = { result = $0 }
+
+        Async.call(with: completion) {
+            return expected
+        }
+
+        expect(result).toEventually(equal(expected))
+    }
+
+}


### PR DESCRIPTION
Created `Async` with some shared methods that make this conversion simpler in a type-safe way.

Helps turn this:
```swift
_ = Task<Void, Never> {
    do {
        completion(.success(try await f()))
    } catch {
        completion(.failure(ErrorUtils.error())
    }
}
```

Into this:
```swift
Async.call(with: completion) {
    try await f()
}
```