### PR TITLE
`ReceiptFetcher`: added retry mechanism

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -227,6 +227,7 @@
 		573A10D92800ADCD00F976E5 /* StoreKitErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573A10D82800ADCD00F976E5 /* StoreKitErrorTests.swift */; };
 		573A10DB2800AF4700F976E5 /* PurchaseErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573A10DA2800AF4700F976E5 /* PurchaseErrorTests.swift */; };
 		573E7F092819B989007C9128 /* StoreKitWorkarounds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 573E7F082819B989007C9128 /* StoreKitWorkarounds.swift */; };
+		5744D8AB28E3B86600646735 /* AppleReceiptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5744D8AA28E3B86600646735 /* AppleReceiptTests.swift */; };
 		5746508C27586B2E0053AB09 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5746508B27586B2E0053AB09 /* Result+Extensions.swift */; };
 		5746508E275949F20053AB09 /* DispatchTimeInterval+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5746508D275949F20053AB09 /* DispatchTimeInterval+Extensions.swift */; };
 		574A2EE7282C3F0800150D40 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574A2EE6282C3F0800150D40 /* AnyDecodable.swift */; };
@@ -740,6 +741,7 @@
 		573A10D82800ADCD00F976E5 /* StoreKitErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitErrorTests.swift; sourceTree = "<group>"; };
 		573A10DA2800AF4700F976E5 /* PurchaseErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseErrorTests.swift; sourceTree = "<group>"; };
 		573E7F082819B989007C9128 /* StoreKitWorkarounds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitWorkarounds.swift; sourceTree = "<group>"; };
+		5744D8AA28E3B86600646735 /* AppleReceiptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleReceiptTests.swift; sourceTree = "<group>"; };
 		5746508B27586B2E0053AB09 /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
 		5746508D275949F20053AB09 /* DispatchTimeInterval+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchTimeInterval+Extensions.swift"; sourceTree = "<group>"; };
 		574A2EE6282C3F0800150D40 /* AnyDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyDecodable.swift; sourceTree = "<group>"; };
@@ -1242,6 +1244,7 @@
 				2DDF41BD24F6F4C3005BC22D /* DataConverters */,
 				2DDF41C624F6F4C3005BC22D /* TestsAgainstRealReceipts */,
 				37E351D0EBC4698E1D3585A6 /* ReceiptParserTests.swift */,
+				5744D8AA28E3B86600646735 /* AppleReceiptTests.swift */,
 			);
 			path = LocalReceiptParsing;
 			sourceTree = "<group>";
@@ -2593,6 +2596,7 @@
 				578FB10E27ADDA8000F70709 /* AvailabilityChecks.swift in Sources */,
 				57E415EF284697A300EA5460 /* PurchasesDeferredPurchasesTests.swift in Sources */,
 				35F82BB226A98EC50051DF03 /* AttributionDataMigratorTests.swift in Sources */,
+				5744D8AB28E3B86600646735 /* AppleReceiptTests.swift in Sources */,
 				B3CAFF10285CE8E30048A994 /* MockOfferingsAPI.swift in Sources */,
 				351B51BF26D450E800BD2BD7 /* StoreKitRequestFetcherTests.swift in Sources */,
 				2DDF41E224F6F527005BC22D /* MockProductsRequest.swift in Sources */,

--- a/Sources/FoundationExtensions/Data+Extensions.swift
+++ b/Sources/FoundationExtensions/Data+Extensions.swift
@@ -54,3 +54,20 @@ extension Data {
     }
 
 }
+
+/// A type that can read data from disk
+/// Useful for mocking.
+protocol FileReader {
+
+    func contents(of url: URL) -> Data?
+
+}
+
+/// Default implementation of `FileReader` that simply uses `Data`'s implementation.
+final class DefaultFileReader: FileReader {
+
+    func contents(of url: URL) -> Data? {
+        return try? Data(contentsOf: url)
+    }
+
+}

--- a/Sources/FoundationExtensions/DispatchTimeInterval+Extensions.swift
+++ b/Sources/FoundationExtensions/DispatchTimeInterval+Extensions.swift
@@ -17,6 +17,19 @@ import Foundation
 extension DispatchTimeInterval {
 
     /// `DispatchTimeInterval` can only be used by specifying a unit of time.
+    /// This allows us to easily convert any `DispatchTimeInterval` into nanoseconds.
+    var nanoseconds: Int {
+        switch self {
+        case let .seconds(s): return s * 1_000_000_000
+        case let .milliseconds(ms): return ms * 1_000_000
+        case let .microseconds(ms): return ms * 1000
+        case let .nanoseconds(ns): return ns
+        case .never: return 0
+        @unknown default: fatalError("Unknown value: \(self)")
+        }
+    }
+
+    /// `DispatchTimeInterval` can only be used by specifying a unit of time.
     /// This allows us to easily convert any `DispatchTimeInterval` into seconds.
     var seconds: Double {
         switch self {
@@ -29,21 +42,16 @@ extension DispatchTimeInterval {
         }
     }
 
-    fileprivate var milliseconds: Double {
-        switch self {
-        case let .seconds(seconds): return Double(seconds * 1000)
-        case let .milliseconds(ms): return Double(ms)
-        case let .microseconds(ms): return Double(ms) / 1_000
-        case let .nanoseconds(ns): return Double(ns) / 1_000_000
-        case .never: return 0
-        @unknown default: fatalError("Unknown value: \(self)")
-        }
-    }
-
 }
 
 // swiftlint:enable identifier_name
 
 func + (lhs: DispatchTimeInterval, rhs: DispatchTimeInterval) -> DispatchTimeInterval {
-    return .milliseconds(Int(lhs.milliseconds + rhs.milliseconds))
+    return .nanoseconds(lhs.nanoseconds + rhs.nanoseconds)
 }
+
+#if swift(<5.8)
+// `DispatchTimeInterval` is not `Sendable` as of Swift 5.7.
+// Its conformance is safe since it only represents data
+extension DispatchTimeInterval: @unchecked Sendable {}
+#endif

--- a/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
@@ -60,6 +60,19 @@ struct AppleReceipt: Equatable {
 
 }
 
+// MARK: - Extensions
+
+extension AppleReceipt {
+
+    func containsActivePurchase(forProductIdentifier identifier: String) -> Bool {
+        return self.inAppPurchases
+            .contains { $0.isActivePurchase(forProductIdentifier: identifier) }
+    }
+
+}
+
+// MARK: - Conformances
+
 extension AppleReceipt: Codable {}
 
 extension AppleReceipt: CustomDebugStringConvertible {

--- a/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
@@ -52,7 +52,7 @@ struct AppleReceipt: Equatable {
     let inAppPurchases: [InAppPurchase]
 
     func purchasedIntroOfferOrFreeTrialProductIdentifiers() -> Set<String> {
-        let productIdentifiers = inAppPurchases
+        let productIdentifiers = self.inAppPurchases
             .filter { $0.isInIntroOfferPeriod == true || $0.isInTrialPeriod == true }
             .map { $0.productId }
         return Set(productIdentifiers)
@@ -65,8 +65,10 @@ struct AppleReceipt: Equatable {
 extension AppleReceipt {
 
     func containsActivePurchase(forProductIdentifier identifier: String) -> Bool {
-        return (self.inAppPurchases.contains { $0.isActiveSubscription } ||
-                self.inAppPurchases.contains { $0.productId == identifier })
+        return (
+            self.inAppPurchases.contains { $0.isActiveSubscription } ||
+            self.inAppPurchases.contains { $0.productType?.isSubscription != true && $0.productId == identifier }
+        )
     }
 
 }

--- a/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
@@ -65,8 +65,8 @@ struct AppleReceipt: Equatable {
 extension AppleReceipt {
 
     func containsActivePurchase(forProductIdentifier identifier: String) -> Bool {
-        return self.inAppPurchases
-            .contains { $0.isActivePurchase(forProductIdentifier: identifier) }
+        return (self.inAppPurchases.contains { $0.isActiveSubscription } ||
+                self.inAppPurchases.contains { $0.productId == identifier })
     }
 
 }

--- a/Sources/LocalReceiptParsing/BasicTypes/InAppPurchase.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/InAppPurchase.swift
@@ -38,6 +38,22 @@ extension AppleReceipt {
 
 extension AppleReceipt.InAppPurchase {
 
+    func isActivePurchase(forProductIdentifier identifier: String) -> Bool {
+        return self.productId == identifier && self.isActive
+    }
+
+    private var isActive: Bool {
+        guard let expiration = self.expiresDate else {
+            return true
+        }
+
+        return expiration > Date()
+    }
+
+}
+
+extension AppleReceipt.InAppPurchase {
+
     enum ProductType: Int {
 
         case unknown = -1,

--- a/Sources/LocalReceiptParsing/BasicTypes/InAppPurchase.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/InAppPurchase.swift
@@ -38,14 +38,9 @@ extension AppleReceipt {
 
 extension AppleReceipt.InAppPurchase {
 
-    func isActivePurchase(forProductIdentifier identifier: String) -> Bool {
-        return self.productId == identifier && self.isActive
-    }
-
-    private var isActive: Bool {
-        guard let expiration = self.expiresDate else {
-            return true
-        }
+    var isActiveSubscription: Bool {
+        guard self.productType?.isSubscription == true else { return false }
+        guard let expiration = self.expiresDate else { return true }
 
         return expiration > Date()
     }
@@ -62,6 +57,18 @@ extension AppleReceipt.InAppPurchase {
         nonRenewingSubscription,
         autoRenewableSubscription
 
+    }
+
+}
+
+private extension AppleReceipt.InAppPurchase.ProductType {
+
+    var isSubscription: Bool {
+        switch self {
+        case .unknown: return false
+        case .nonConsumable, .consumable: return false
+        case .nonRenewingSubscription, .autoRenewableSubscription: return true
+        }
     }
 
 }

--- a/Sources/LocalReceiptParsing/BasicTypes/InAppPurchase.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/InAppPurchase.swift
@@ -61,7 +61,7 @@ extension AppleReceipt.InAppPurchase {
 
 }
 
-private extension AppleReceipt.InAppPurchase.ProductType {
+extension AppleReceipt.InAppPurchase.ProductType {
 
     var isSubscription: Bool {
         switch self {

--- a/Sources/Logging/Strings/ReceiptStrings.swift
+++ b/Sources/Logging/Strings/ReceiptStrings.swift
@@ -89,7 +89,7 @@ extension ReceiptStrings: CustomStringConvertible {
             "\((try? receipt.prettyPrintedJSON) ?? "<null>")"
 
         case let .retrying_receipt_fetch_after(sleepDuration):
-            return String(format: "Retrying Receipt fetch after %2.f seconds", sleepDuration.seconds)
+            return String(format: "Retrying receipt fetch after %2.f seconds", sleepDuration.seconds)
 
         }
     }

--- a/Sources/Logging/Strings/ReceiptStrings.swift
+++ b/Sources/Logging/Strings/ReceiptStrings.swift
@@ -29,7 +29,7 @@ enum ReceiptStrings {
     case refreshing_empty_receipt
     case unable_to_load_receipt
     case posting_receipt(AppleReceipt)
-    case recepit_retrying_mechanism_not_available
+    case receipt_retrying_mechanism_not_available
     case local_receipt_missing_purchase(AppleReceipt, forProductIdentifier: String)
     case retrying_receipt_fetch_after(sleepDuration: DispatchTimeInterval)
 
@@ -81,7 +81,7 @@ extension ReceiptStrings: CustomStringConvertible {
         case let .posting_receipt(receipt):
             return "Posting receipt: \(receipt.debugDescription)"
 
-        case .recepit_retrying_mechanism_not_available:
+        case .receipt_retrying_mechanism_not_available:
             return "Receipt retrying mechanism is not available in iOS 12. Will only attempt to fetch once."
 
         case let .local_receipt_missing_purchase(receipt, productIdentifier):

--- a/Sources/Logging/Strings/ReceiptStrings.swift
+++ b/Sources/Logging/Strings/ReceiptStrings.swift
@@ -29,6 +29,8 @@ enum ReceiptStrings {
     case refreshing_empty_receipt
     case unable_to_load_receipt
     case posting_receipt(AppleReceipt)
+    case recepit_retrying_mechanism_not_available
+    case retrying_receipt_fetch_after(sleepDuration: DispatchTimeInterval)
 
 }
 
@@ -77,6 +79,12 @@ extension ReceiptStrings: CustomStringConvertible {
 
         case let .posting_receipt(receipt):
             return "Posting receipt: \(receipt.debugDescription)"
+
+        case .recepit_retrying_mechanism_not_available:
+            return "Receipt retrying mechanism is not available in iOS 12. Will only attempt to fetch once."
+
+        case let .retrying_receipt_fetch_after(sleepDuration):
+            return String(format: "Retrying Receipt fetch after %2.f seconds", sleepDuration.seconds)
 
         }
     }

--- a/Sources/Logging/Strings/ReceiptStrings.swift
+++ b/Sources/Logging/Strings/ReceiptStrings.swift
@@ -30,6 +30,7 @@ enum ReceiptStrings {
     case unable_to_load_receipt
     case posting_receipt(AppleReceipt)
     case recepit_retrying_mechanism_not_available
+    case local_receipt_missing_purchase(AppleReceipt, forProductIdentifier: String)
     case retrying_receipt_fetch_after(sleepDuration: DispatchTimeInterval)
 
 }
@@ -82,6 +83,10 @@ extension ReceiptStrings: CustomStringConvertible {
 
         case .recepit_retrying_mechanism_not_available:
             return "Receipt retrying mechanism is not available in iOS 12. Will only attempt to fetch once."
+
+        case let .local_receipt_missing_purchase(receipt, productIdentifier):
+            return "Local receipt is still missing purchase for '\(productIdentifier)': \n" +
+            "\((try? receipt.prettyPrintedJSON) ?? "<null>")"
 
         case let .retrying_receipt_fetch_after(sleepDuration):
             return String(format: "Retrying Receipt fetch after %2.f seconds", sleepDuration.seconds)

--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -13,6 +13,15 @@ import Foundation
  */
 @objc(RCDangerousSettings) public final class DangerousSettings: NSObject {
 
+    /// Dangerous settings not exposed outside of the SDK.
+    internal struct InternalSettings {
+
+        /// Whether `ReceiptFetcher` can retry fetching receipts.
+        let enableReceiptFetchRetry: Bool
+
+        static let `default`: Self = .init(enableReceiptFetchRetry: false)
+    }
+
     /**
      * Disable or enable subscribing to the StoreKit queue. If this is disabled, RevenueCat won't observe
      * the StoreKit queue, and it will not sync any purchase automatically.
@@ -22,6 +31,8 @@ import Foundation
      * Auto syncing of purchases is enabled by default.
      */
     @objc public let autoSyncPurchases: Bool
+
+    internal let internalSettings: InternalSettings
 
     @objc public override convenience init() {
         self.init(autoSyncPurchases: true)
@@ -34,8 +45,14 @@ import Foundation
      * If this is disabled, RevenueCat won't observe the StoreKit queue, and it will not sync any purchase
      * automatically.
      */
-    @objc public init(autoSyncPurchases: Bool) {
+    @objc public convenience init(autoSyncPurchases: Bool) {
+        self.init(autoSyncPurchases: autoSyncPurchases, internalSettings: .default)
+    }
+
+    /// Designated initializer
+    internal init(autoSyncPurchases: Bool, internalSettings: InternalSettings) {
         self.autoSyncPurchases = autoSyncPurchases
+        self.internalSettings = internalSettings
     }
 
 }

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -48,6 +48,9 @@ final class PurchasesOrchestrator {
         self.attribution.unsyncedAttributesByKey(appUserID: self.appUserID)
     }
 
+    static let receiptRetryCount: Int = 3
+    static let receiptRetrySleepDuration: DispatchTimeInterval = .seconds(5)
+
     private let productsManager: ProductsManagerType
     private let storeKit1Wrapper: StoreKit1Wrapper?
     private let systemInfo: SystemInfo
@@ -744,8 +747,8 @@ private extension PurchasesOrchestrator {
     private func refreshRequestPolicy(forProductIdentifier productIdentifier: String) -> ReceiptRefreshPolicy {
         if self.systemInfo.isSandbox {
             return .retryUntilProductIsFound(productIdentifier: productIdentifier,
-                                             maximumRetries: 3,
-                                             sleepDuration: .seconds(5))
+                                             maximumRetries: Self.receiptRetryCount,
+                                             sleepDuration: Self.receiptRetrySleepDuration)
         } else {
             return .always
         }

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -745,7 +745,7 @@ private extension PurchasesOrchestrator {
     }
 
     private func refreshRequestPolicy(forProductIdentifier productIdentifier: String) -> ReceiptRefreshPolicy {
-        if self.systemInfo.isSandbox {
+        if self.systemInfo.dangerousSettings.internalSettings.enableReceiptFetchRetry {
             return .retryUntilProductIsFound(productIdentifier: productIdentifier,
                                              maximumRetries: Self.receiptRetryCount,
                                              sleepDuration: Self.receiptRetrySleepDuration)

--- a/Sources/Purchasing/ReceiptFetcher.swift
+++ b/Sources/Purchasing/ReceiptFetcher.swift
@@ -59,7 +59,7 @@ class ReceiptFetcher {
                                               sleepDuration: sleepDuration)
                 }
             } else {
-                Logger.warn(Strings.receipt.recepit_retrying_mechanism_not_available)
+                Logger.warn(Strings.receipt.receipt_retrying_mechanism_not_available)
                 self.receiptData(refreshPolicy: .always, completion: completion)
             }
 

--- a/Sources/Purchasing/ReceiptFetcher.swift
+++ b/Sources/Purchasing/ReceiptFetcher.swift
@@ -17,11 +17,21 @@ import Foundation
 class ReceiptFetcher {
 
     private let requestFetcher: StoreKitRequestFetcher
+    private let receiptParser: ReceiptParser
+    private let fileReader: FileReader
+
     let systemInfo: SystemInfo
 
-    init(requestFetcher: StoreKitRequestFetcher, systemInfo: SystemInfo) {
+    init(
+        requestFetcher: StoreKitRequestFetcher,
+        systemInfo: SystemInfo,
+        receiptParser: ReceiptParser = .default,
+        fileReader: FileReader = DefaultFileReader()
+    ) {
         self.requestFetcher = requestFetcher
         self.systemInfo = systemInfo
+        self.receiptParser = receiptParser
+        self.fileReader = fileReader
     }
 
     func receiptData(refreshPolicy: ReceiptRefreshPolicy, completion: @escaping (Data?) -> Void) {
@@ -41,6 +51,18 @@ class ReceiptFetcher {
                 completion(receiptData)
             }
 
+        case let .retryUntilProductIsFound(productIdentifier, maximumRetries, sleepDuration):
+            if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
+                Async.call(with: completion) {
+                    await self.refreshReceipt(untilProductIsFound: productIdentifier,
+                                              maximumRetries: maximumRetries,
+                                              sleepDuration: sleepDuration)
+                }
+            } else {
+                Logger.warn(Strings.receipt.recepit_retrying_mechanism_not_available)
+                self.receiptData(refreshPolicy: .always, completion: completion)
+            }
+
         case .never:
             completion(self.receiptData())
         }
@@ -49,7 +71,7 @@ class ReceiptFetcher {
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func receiptData(refreshPolicy: ReceiptRefreshPolicy) async -> Data? {
         return await withCheckedContinuation { continuation in
-            receiptData(refreshPolicy: refreshPolicy) { result in
+            self.receiptData(refreshPolicy: refreshPolicy) { result in
                 continuation.resume(returning: result)
             }
         }
@@ -87,7 +109,7 @@ private extension ReceiptFetcher {
             return nil
         }
 
-        guard let data: Data = try? Data(contentsOf: receiptURL) else {
+        guard let data = self.fileReader.contents(of: receiptURL) else {
             Logger.debug(Strings.receipt.unable_to_load_receipt)
             return nil
         }
@@ -98,7 +120,7 @@ private extension ReceiptFetcher {
     }
 
     func refreshReceipt(_ completion: @escaping (Data) -> Void) {
-        requestFetcher.fetchReceiptData {
+        self.requestFetcher.fetchReceiptData {
             let data = self.receiptData()
             guard let receiptData = data,
                   !receiptData.isEmpty else {
@@ -109,6 +131,49 @@ private extension ReceiptFetcher {
 
             completion(receiptData)
         }
+    }
+
+    /// `async` version of `refreshReceipt(_:)`
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func refreshReceipt() async -> Data {
+        await withCheckedContinuation { continuation in
+            self.refreshReceipt {
+                continuation.resume(returning: $0)
+            }
+        }
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    @MainActor
+    private func refreshReceipt(
+        untilProductIsFound productIdentifier: String,
+        maximumRetries: Int,
+        sleepDuration: DispatchTimeInterval
+    ) async -> Data {
+        var retries = 0
+        var result: Data = .init()
+
+        repeat {
+            retries += 1
+            result = await self.refreshReceipt()
+
+            if !result.isEmpty {
+                do {
+                    let receipt = try self.receiptParser.parse(from: result)
+                    if receipt.containsActivePurchase(forProductIdentifier: productIdentifier) {
+                        break // Valid receipt found
+                    }
+                } catch {
+                    Logger.error(Strings.receipt.parse_receipt_locally_error(error: error))
+                }
+            }
+
+            Logger.debug(Strings.receipt.retrying_receipt_fetch_after(sleepDuration: sleepDuration))
+            try? await Task.sleep(nanoseconds: UInt64(sleepDuration.nanoseconds))
+
+        } while retries <= maximumRetries && !Task.isCancelled
+
+        return result
     }
 
 }

--- a/Sources/Purchasing/ReceiptFetcher.swift
+++ b/Sources/Purchasing/ReceiptFetcher.swift
@@ -161,6 +161,11 @@ private extension ReceiptFetcher {
                     let receipt = try self.receiptParser.parse(from: data)
                     if receipt.containsActivePurchase(forProductIdentifier: productIdentifier) {
                         return data
+                    } else {
+                        Logger.appleWarning(Strings.receipt.local_receipt_missing_purchase(
+                            receipt,
+                            forProductIdentifier: productIdentifier
+                        ))
                     }
                 } catch {
                     Logger.error(Strings.receipt.parse_receipt_locally_error(error: error))

--- a/Sources/Purchasing/ReceiptRefreshPolicy.swift
+++ b/Sources/Purchasing/ReceiptRefreshPolicy.swift
@@ -14,10 +14,16 @@
 
 import Foundation
 
-enum ReceiptRefreshPolicy: Int {
+/// Determines the behavior when fetching receipts with `ReceiptFetcher`.
+enum ReceiptRefreshPolicy {
 
-    case always = 0
+    case always
     case onlyIfEmpty
+    case retryUntilProductIsFound(productIdentifier: String,
+                                  maximumRetries: Int,
+                                  sleepDuration: DispatchTimeInterval = .never)
     case never
 
 }
+
+extension ReceiptRefreshPolicy: Equatable {}

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -97,9 +97,14 @@ private extension BaseBackendIntegrationTests {
                             storeKit2Setting: Self.storeKit2Setting,
                             storeKitTimeout: Configuration.storeKitRequestTimeoutDefault,
                             networkTimeout: Configuration.networkTimeoutDefault,
-                            dangerousSettings: nil)
+                            dangerousSettings: self.dangerousSettings)
         Purchases.logLevel = .debug
         Purchases.shared.delegate = self.purchasesDelegate
+    }
+
+    private var dangerousSettings: DangerousSettings {
+        return .init(autoSyncPurchases: true,
+                     internalSettings: .init(enableReceiptFetchRetry: true))
     }
 
 }

--- a/Tests/UnitTests/LocalReceiptParsing/AppleReceiptTests.swift
+++ b/Tests/UnitTests/LocalReceiptParsing/AppleReceiptTests.swift
@@ -1,0 +1,92 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  AppleReceiptTests.swift
+//
+//  Created by Nacho Soto on 9/27/22.
+
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+final class AppleReceiptTests: TestCase {
+
+    func testReceiptWithNoPurchasesDoesNotContainActivePurchase() {
+        let receipt = Self.create(with: [:])
+        expect(receipt.containsActivePurchase(forProductIdentifier: Self.productIdentifier)) == false
+    }
+
+    func testReceiptWithPurchaseDoesNotContainActivePurchaseForDifferentIdentifier() {
+        let receipt = Self.create(with: [
+            "different_product": Date()
+        ])
+        expect(receipt.containsActivePurchase(forProductIdentifier: Self.productIdentifier)) == false
+    }
+
+    func testReceiptWithExpiredPurchaseDoesNotContainActivePurchase() {
+        let receipt = Self.create(with: [
+            Self.productIdentifier: Date().addingTimeInterval(-1000)
+        ])
+        expect(receipt.containsActivePurchase(forProductIdentifier: Self.productIdentifier)) == false
+    }
+
+    func testReceiptWithNonExpiringPurchaseContainsActivePurchase() {
+        let receipt = Self.create(with: [
+            Self.productIdentifier: nil
+        ])
+        expect(receipt.containsActivePurchase(forProductIdentifier: Self.productIdentifier)) == true
+    }
+
+    func testReceiptWithNotExpiredPurchaseContainsActivePurchase() {
+        let receipt = Self.create(with: [
+            Self.productIdentifier: Date().addingTimeInterval(1000)
+        ])
+        expect(receipt.containsActivePurchase(forProductIdentifier: Self.productIdentifier)) == true
+    }
+
+    // MARK: -
+
+    private static let productIdentifier = "com.revenuecat.product_a"
+}
+
+// MARK: -
+
+private extension AppleReceiptTests {
+
+    static func create(with expirationDatesByProductIdentifier: [String: Date?]) -> AppleReceipt {
+        return .init(
+            bundleId: "com.revenuecat.test_app",
+            applicationVersion: "1.0",
+            originalApplicationVersion: nil,
+            opaqueValue: Data(),
+            sha1Hash: Data(),
+            creationDate: Date(),
+            expirationDate: nil,
+            inAppPurchases: expirationDatesByProductIdentifier.map { identifier, expiration in
+                .init(
+                    quantity: 1,
+                    productId: identifier,
+                    transactionId: "transaction-\(identifier)",
+                    originalTransactionId: nil,
+                    productType: .autoRenewableSubscription,
+                    purchaseDate: Date(),
+                    originalPurchaseDate: nil,
+                    expiresDate: expiration,
+                    cancellationDate: nil,
+                    isInTrialPeriod: nil,
+                    isInIntroOfferPeriod: nil,
+                    webOrderLineItemId: nil,
+                    promotionalOfferIdentifier: nil
+                )
+            }
+        )
+    }
+
+}

--- a/Tests/UnitTests/LocalReceiptParsing/AppleReceiptTests.swift
+++ b/Tests/UnitTests/LocalReceiptParsing/AppleReceiptTests.swift
@@ -30,11 +30,11 @@ final class AppleReceiptTests: TestCase {
         expect(receipt.containsActivePurchase(forProductIdentifier: Self.productIdentifier)) == true
     }
 
-    func testReceiptWithExpiredPurchaseContainsActivePurchase() {
+    func testReceiptWithExpiredPurchaseDoesNotContainActivePurchase() {
         let receipt = Self.create(with: [
             Self.productIdentifier: Date().addingTimeInterval(-1000)
         ])
-        expect(receipt.containsActivePurchase(forProductIdentifier: Self.productIdentifier)) == true
+        expect(receipt.containsActivePurchase(forProductIdentifier: Self.productIdentifier)) == false
     }
 
     func testReceiptWithNonExpiringPurchaseContainsActivePurchase() {

--- a/Tests/UnitTests/LocalReceiptParsing/AppleReceiptTests.swift
+++ b/Tests/UnitTests/LocalReceiptParsing/AppleReceiptTests.swift
@@ -23,18 +23,18 @@ final class AppleReceiptTests: TestCase {
         expect(receipt.containsActivePurchase(forProductIdentifier: Self.productIdentifier)) == false
     }
 
-    func testReceiptWithPurchaseDoesNotContainActivePurchaseForDifferentIdentifier() {
+    func testReceiptWithPurchaseContainsActivePurchaseWithDifferentProductIdentifier() {
         let receipt = Self.create(with: [
-            "different_product": Date()
+            "different_product": Date().addingTimeInterval(1000)
         ])
-        expect(receipt.containsActivePurchase(forProductIdentifier: Self.productIdentifier)) == false
+        expect(receipt.containsActivePurchase(forProductIdentifier: Self.productIdentifier)) == true
     }
 
-    func testReceiptWithExpiredPurchaseDoesNotContainActivePurchase() {
+    func testReceiptWithExpiredPurchaseContainsActivePurchase() {
         let receipt = Self.create(with: [
             Self.productIdentifier: Date().addingTimeInterval(-1000)
         ])
-        expect(receipt.containsActivePurchase(forProductIdentifier: Self.productIdentifier)) == false
+        expect(receipt.containsActivePurchase(forProductIdentifier: Self.productIdentifier)) == true
     }
 
     func testReceiptWithNonExpiringPurchaseContainsActivePurchase() {
@@ -49,6 +49,20 @@ final class AppleReceiptTests: TestCase {
             Self.productIdentifier: Date().addingTimeInterval(1000)
         ])
         expect(receipt.containsActivePurchase(forProductIdentifier: Self.productIdentifier)) == true
+    }
+
+    func testReceiptWithSubscriptionActiveForDifferentProductContainsActivePurchase() {
+        let receipt = Self.create(with: [
+            "different_product": Date().addingTimeInterval(1000)
+        ])
+        expect(receipt.containsActivePurchase(forProductIdentifier: Self.productIdentifier)) == true
+    }
+
+    func testReceiptWithNonConsumablePurchaseForDifferentProductDoesNotContainActivePurchase() {
+        let receipt = Self.create(with: [
+            "different_product": nil
+        ])
+        expect(receipt.containsActivePurchase(forProductIdentifier: Self.productIdentifier)) == false
     }
 
     // MARK: -
@@ -75,7 +89,9 @@ private extension AppleReceiptTests {
                     productId: identifier,
                     transactionId: "transaction-\(identifier)",
                     originalTransactionId: nil,
-                    productType: .autoRenewableSubscription,
+                    productType: expiration == nil
+                        ? .nonConsumable
+                        : .autoRenewableSubscription,
                     purchaseDate: Date(),
                     originalPurchaseDate: nil,
                     expiresDate: expiration,

--- a/Tests/UnitTests/Misc/SystemInfoTests.swift
+++ b/Tests/UnitTests/Misc/SystemInfoTests.swift
@@ -81,6 +81,13 @@ class SystemInfoTests: TestCase {
         )) == false
     }
 
+    func testReceiptFetchRetryIsDisabledByDefault() throws {
+        let systemInfo = try SystemInfo(platformInfo: nil, finishTransactions: false)
+        let settings = systemInfo.dangerousSettings.internalSettings
+
+        expect(settings.enableReceiptFetchRetry) == false
+    }
+
 }
 
 private extension SystemInfo {

--- a/Tests/UnitTests/Mocks/MockReceiptParser.swift
+++ b/Tests/UnitTests/Mocks/MockReceiptParser.swift
@@ -6,6 +6,8 @@
 import Foundation
 @testable import RevenueCat
 
+import XCTest
+
 class MockReceiptParser: ReceiptParser {
 
     var invokedParse = false
@@ -13,14 +15,24 @@ class MockReceiptParser: ReceiptParser {
     var invokedParseParameters: Data?
     var invokedParseParametersList = [Data]()
     var stubbedParseError: Error?
-    var stubbedParseResult = AppleReceipt(bundleId: "com.revenuecat.test",
-                                          applicationVersion: "5.6.7",
-                                          originalApplicationVersion: "3.4.5",
-                                          opaqueValue: Data(),
-                                          sha1Hash: Data(),
-                                          creationDate: Date(),
-                                          expirationDate: nil,
-                                          inAppPurchases: [])
+
+    var stubbedParseResult: AppleReceipt {
+        get { return self.stubbedParseResults.onlyElement!.value! }
+        set { self.stubbedParseResults = [.success(newValue)] }
+    }
+
+    var stubbedParseResults: [Result<AppleReceipt, Error>] = [
+        .success(
+            .init(bundleId: "com.revenuecat.test",
+                  applicationVersion: "5.6.7",
+                  originalApplicationVersion: "3.4.5",
+                  opaqueValue: Data(),
+                  sha1Hash: Data(),
+                  creationDate: Date(),
+                  expirationDate: nil,
+                  inAppPurchases: [])
+        )
+    ]
 
     convenience init() {
         self.init(containerBuilder: MockASN1ContainerBuilder(),
@@ -28,14 +40,22 @@ class MockReceiptParser: ReceiptParser {
     }
 
     override func parse(from receiptData: Data) throws -> AppleReceipt {
-        invokedParse = true
-        invokedParseCount += 1
-        invokedParseParameters = receiptData
-        invokedParseParametersList.append(receiptData)
-        if let error = stubbedParseError {
+        self.invokedParse = true
+        self.invokedParseCount += 1
+        self.invokedParseParameters = receiptData
+        self.invokedParseParametersList.append(receiptData)
+        if let error = self.stubbedParseError {
             throw error
         }
-        return stubbedParseResult
+
+        if self.stubbedParseResults.count > 1 {
+            // If `stubbedParseResults` contains multiple elements
+            // this returns a different result every time.
+            // This is used to mock changing receipts over time.
+            return try self.stubbedParseResults[self.invokedParseCount - 1].get()
+        } else {
+            return try XCTUnwrap(self.stubbedParseResults.first?.get())
+        }
     }
 
     var invokedReceiptHasTransactions = false

--- a/Tests/UnitTests/Mocks/MockRequestFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockRequestFetcher.swift
@@ -6,10 +6,13 @@
 @testable import RevenueCat
 
 class MockRequestFetcher: StoreKitRequestFetcher {
+    var refreshReceiptCalledCount = 0
     var refreshReceiptCalled = false
 
     override func fetchReceiptData(_ completion: @MainActor @Sendable @escaping () -> Void) {
-        refreshReceiptCalled = true
+        self.refreshReceiptCalledCount += 1
+        self.refreshReceiptCalled = true
+
         OperationDispatcher.dispatchOnMainActor {
             completion()
         }

--- a/Tests/UnitTests/Mocks/MockSystemInfo.swift
+++ b/Tests/UnitTests/Mocks/MockSystemInfo.swift
@@ -15,7 +15,8 @@ class MockSystemInfo: SystemInfo {
     var stubbedIsApplicationBackgrounded: Bool?
     var stubbedIsSandbox: Bool?
 
-    convenience init(finishTransactions: Bool, storeKit2Setting: StoreKit2Setting = .default) {
+    convenience init(finishTransactions: Bool,
+                     storeKit2Setting: StoreKit2Setting = .default) {
         // swiftlint:disable:next force_try
         try! self.init(platformInfo: nil,
                        finishTransactions: finishTransactions,

--- a/Tests/UnitTests/Mocks/MockSystemInfo.swift
+++ b/Tests/UnitTests/Mocks/MockSystemInfo.swift
@@ -41,7 +41,7 @@ class MockSystemInfo: SystemInfo {
     }
 
     override var isSandbox: Bool {
-        return stubbedIsSandbox ?? super.isSandbox
+        return self.stubbedIsSandbox ?? super.isSandbox
     }
 
 }

--- a/Tests/UnitTests/Purchasing/ReceiptFetcherTests.swift
+++ b/Tests/UnitTests/Purchasing/ReceiptFetcherTests.swift
@@ -190,7 +190,7 @@ final class RetryingReceiptFetcherTests: BaseReceiptFetcherTests {
         self.mock(receipt: Self.receiptWithoutPurchases)
 
         let data = await self.fetch(productIdentifier: Self.productID, retries: 0)
-        expect(data) == Self.receiptWithoutPurchases.asData
+        expect(data) == Data()
 
         expect(self.mockReceiptParser.invokedParseParametersList) == [
             Self.receiptWithoutPurchases.asData
@@ -203,7 +203,7 @@ final class RetryingReceiptFetcherTests: BaseReceiptFetcherTests {
         let invalidData = Self.receiptWithoutPurchases.asData
 
         let data = await self.fetch(productIdentifier: Self.productID, retries: 2)
-        expect(data) == invalidData
+        expect(data) == Data()
 
         expect(self.mockReceiptParser.invokedParseParametersList) == [
             invalidData,
@@ -235,6 +235,7 @@ final class RetryingReceiptFetcherTests: BaseReceiptFetcherTests {
 
         expect(self.mockRequestFetcher.refreshReceiptCalledCount) == 2
         expect(self.mockReceiptParser.invokedParseParametersList) == [
+            Self.validReceipt.asData,
             Self.validReceipt.asData
         ]
     }
@@ -277,8 +278,9 @@ final class RetryingReceiptFetcherTests: BaseReceiptFetcherTests {
         precondition(!receipts.isEmpty)
 
         self.mockBundle.receiptURLResult = .receiptWithData
+        self.mockFileReader.mockedURLContents[self.mockBundle.appStoreReceiptURL!] = receipts
+            .compactMap { $0.value?.asData }
         self.mockReceiptParser.stubbedParseResults = receipts
-        self.mockFileReader.mockedURLContents[self.mockBundle.appStoreReceiptURL!] = receipts.map { $0.value?.asData }
     }
 
     private static let productID = "com.revenuecat.test_product"

--- a/Tests/UnitTests/Purchasing/ReceiptFetcherTests.swift
+++ b/Tests/UnitTests/Purchasing/ReceiptFetcherTests.swift
@@ -17,23 +17,37 @@ import XCTest
 import Nimble
 @testable import RevenueCat
 
-class ReceiptFetcherTests: TestCase {
+class BaseReceiptFetcherTests: TestCase {
 
-    private var receiptFetcher: ReceiptFetcher!
-    private var mockRequestFetcher: MockRequestFetcher!
-    private var mockBundle: MockBundle!
-    private var mockSystemInfo: MockSystemInfo!
+    fileprivate var receiptFetcher: ReceiptFetcher!
+    fileprivate var mockRequestFetcher: MockRequestFetcher!
+    fileprivate var mockBundle: MockBundle!
+    fileprivate var mockSystemInfo: MockSystemInfo!
+    fileprivate var mockReceiptParser: MockReceiptParser!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
 
         self.mockBundle = MockBundle()
         self.mockRequestFetcher = MockRequestFetcher()
+        self.mockReceiptParser = MockReceiptParser()
         self.mockSystemInfo = try MockSystemInfo(platformInfo: nil,
                                                  finishTransactions: false,
                                                  bundle: self.mockBundle)
-        self.receiptFetcher = ReceiptFetcher(requestFetcher: self.mockRequestFetcher, systemInfo: self.mockSystemInfo)
+
+        self.receiptFetcher = ReceiptFetcher(requestFetcher: self.mockRequestFetcher,
+                                             systemInfo: self.mockSystemInfo,
+                                             receiptParser: self.mockReceiptParser,
+                                             fileReader: self.createFileReader())
     }
+
+    func createFileReader() -> FileReader {
+        return DefaultFileReader()
+    }
+
+}
+
+final class ReceiptFetcherTests: BaseReceiptFetcherTests {
 
     func testReceiptDataWithRefreshPolicyNeverReturnsReceiptData() {
         var receivedData: Data?
@@ -127,6 +141,196 @@ class ReceiptFetcherTests: TestCase {
         expect(receivedData).toEventuallyNot(beNil())
         expect(receivedData).toNot(beEmpty())
         expect(receivedData).toNot(beNil())
+    }
+
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+final class RetryingReceiptFetcherTests: BaseReceiptFetcherTests {
+
+    private var mockFileReader: MockFileReader!
+
+    override func setUpWithError() throws {
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
+        self.mockFileReader = MockFileReader()
+
+        try super.setUpWithError()
+    }
+
+    override func createFileReader() -> FileReader {
+        return self.mockFileReader
+    }
+
+    func testSampleDataIsCorrect() {
+        // Tests rely on these conditions
+        expect(Self.validReceipt.containsActivePurchase(forProductIdentifier: Self.productID)) == true
+        expect(Self.receiptWithoutPurchases.containsActivePurchase(forProductIdentifier: Self.productID)) == false
+    }
+
+    func testReturnsAfterFirstTryIfNoReceiptURL() async {
+        self.mockBundle.receiptURLResult = .nilURL
+
+        let data = await self.fetch(productIdentifier: "", retries: 1)
+        expect(data) == Data()
+    }
+
+    func testReturnsAfterFirstTryIfDataIsCorrect() async {
+        self.mock(receipt: Self.validReceipt)
+
+        let data = await self.fetch(productIdentifier: Self.productID, retries: 1)
+        expect(data) == Self.validReceipt.asData
+
+        expect(self.mockReceiptParser.invokedParseParametersList) == [
+            Self.validReceipt.asData
+        ]
+    }
+
+    func testDoesNotRetryIfMaximumIsZeroEvenIfDataIsInvalid() async {
+        self.mock(receipt: Self.receiptWithoutPurchases)
+
+        let data = await self.fetch(productIdentifier: Self.productID, retries: 0)
+        expect(data) == Self.receiptWithoutPurchases.asData
+
+        expect(self.mockReceiptParser.invokedParseParametersList) == [
+            Self.receiptWithoutPurchases.asData
+        ]
+    }
+
+    func testStopsRetryingEvenIfDataIsInvalid() async {
+        self.mock(receipt: Self.receiptWithoutPurchases)
+
+        let invalidData = Self.receiptWithoutPurchases.asData
+
+        let data = await self.fetch(productIdentifier: Self.productID, retries: 2)
+        expect(data) == invalidData
+
+        expect(self.mockReceiptParser.invokedParseParametersList) == [
+            invalidData,
+            invalidData,
+            invalidData
+        ]
+        expect(self.mockRequestFetcher.refreshReceiptCalledCount) == 3
+    }
+
+    func testRetriesIfFirstReceiptIsInvalid() async {
+        self.mock(receipts: [Self.receiptWithoutPurchases, Self.validReceipt])
+
+        let data = await self.fetch(productIdentifier: Self.productID, retries: 1)
+        expect(data) == Self.validReceipt.asData
+
+        expect(self.mockRequestFetcher.refreshReceiptCalledCount) == 2
+        expect(self.mockReceiptParser.invokedParseParametersList) == [
+            Self.receiptWithoutPurchases.asData,
+            Self.validReceipt.asData
+        ]
+    }
+
+    func testRetriesIfFirstReceiptThrowsError() async {
+        self.mock(receipts: [.failure(ErrorUtils.missingReceiptFileError()),
+                             .success(Self.validReceipt)])
+
+        let data = await self.fetch(productIdentifier: Self.productID, retries: 1)
+        expect(data) == Self.validReceipt.asData
+
+        expect(self.mockRequestFetcher.refreshReceiptCalledCount) == 2
+        expect(self.mockReceiptParser.invokedParseParametersList) == [
+            Self.validReceipt.asData
+        ]
+    }
+
+    func testStopsRetryingIfFindsValidReceipt() async {
+        self.mock(receipts: [Self.receiptWithoutPurchases, Self.validReceipt])
+
+        let data = await self.fetch(productIdentifier: Self.productID, retries: 2)
+        expect(data) == Self.validReceipt.asData
+
+        expect(self.mockRequestFetcher.refreshReceiptCalledCount) == 2
+        expect(self.mockReceiptParser.invokedParseParametersList) == [
+            Self.receiptWithoutPurchases.asData,
+            Self.validReceipt.asData
+        ]
+    }
+
+    // MARK: -
+
+    private func fetch(productIdentifier: String, retries: Int) async -> Data {
+        return await withCheckedContinuation { continuation in
+            self.receiptFetcher.receiptData(refreshPolicy: .retryUntilProductIsFound(
+                productIdentifier: productIdentifier,
+                maximumRetries: retries
+            )) {
+                continuation.resume(returning: $0 ?? Data())
+            }
+        }
+    }
+
+    private func mock(receipt: AppleReceipt) {
+        self.mock(receipts: [receipt])
+    }
+
+    private func mock(receipts: [AppleReceipt]) {
+        self.mock(receipts: receipts.map(Result.success))
+    }
+
+    private func mock(receipts: [Result<AppleReceipt, Error>]) {
+        precondition(!receipts.isEmpty)
+
+        self.mockBundle.receiptURLResult = .receiptWithData
+        self.mockReceiptParser.stubbedParseResults = receipts
+        self.mockFileReader.mockedURLContents[self.mockBundle.appStoreReceiptURL!] = receipts.map { $0.value?.asData }
+    }
+
+    private static let productID = "com.revenuecat.test_product"
+
+    private static let validReceipt = AppleReceipt(
+        bundleId: "bundle",
+        applicationVersion: "1.0",
+        originalApplicationVersion: nil,
+        opaqueValue: Data(),
+        sha1Hash: Data(),
+        creationDate: Date(),
+        expirationDate: nil,
+        inAppPurchases: [
+            .init(
+                quantity: 1,
+                productId: RetryingReceiptFetcherTests.productID,
+                transactionId: "transaction",
+                originalTransactionId: nil,
+                productType: .autoRenewableSubscription,
+                purchaseDate: Date(),
+                originalPurchaseDate: nil,
+                expiresDate: nil,
+                cancellationDate: nil,
+                isInTrialPeriod: false,
+                isInIntroOfferPeriod: false,
+                webOrderLineItemId: nil,
+                promotionalOfferIdentifier: nil
+            )
+        ]
+    )
+
+    private static let receiptWithoutPurchases = AppleReceipt(
+        bundleId: "bundle",
+        applicationVersion: "1.0",
+        originalApplicationVersion: nil,
+        opaqueValue: Data(),
+        sha1Hash: Data(),
+        creationDate: Date(),
+        expirationDate: nil,
+        inAppPurchases: []
+    )
+}
+
+// MARK: -
+
+private extension AppleReceipt {
+
+    var asData: Data {
+        // Note: this is not how receipts are serialized as `Data`
+        // but it's used as a way to mock its deserialization.
+        // swiftlint:disable:next force_try
+        return try! self.prettyPrintedData
     }
 
 }


### PR DESCRIPTION
Fixes [CSDK-478]

~~Depends on #1941, #1942, and #1943.~~

### Example:

Log of a successful purchase after retrying 🎉 

> INFO: 💰 Purchasing Product 'com.revenuecat.monthly_4.99.1_week_intro'
DEBUG: ℹ️ Loaded receipt from url file:///Users/nachosoto/Library/Developer/CoreSimulator/Devices/A3576DC2-355E-45BA-B32C-D2C0A3811BB4/data/Containers/Data/Application/7ACD12DA-2A12-4CF1-8A76-8295E40B64EF/StoreKit/receipt
INFO: ℹ️ Receipt parsed successfully
WARN: 🍎‼️ Local receipt is still missing purchase for 'com.revenuecat.monthly_4.99.1_week_intro': 
{
  "opaque_value" : "79v2XwwAAAA=",
  "sha1_hash" : "GhOmfuioo2Z4R3zX8K60l4b0qgs=",
  "bundle_id" : "com.revenuecat.StoreKitTestApp",
  "in_app_purchases" : [
    {
      "quantity" : 1,
      "product_id" : "com.revenuecat.monthly_4.99.1_week_intro",
      "purchase_date" : "2022-09-28T01:14:24Z",
      "transaction_id" : "0",
      "is_in_intro_offer_period" : true,
      "expires_date" : "2022-09-28T01:14:34Z"
    }
  ],
  "application_version" : "1",
  "creation_date" : "2022-09-28T01:14:24Z",
  "expiration_date" : "4001-01-01T00:00:00Z"
}
DEBUG: ℹ️ Retrying Receipt fetch after  5 seconds
DEBUG: ℹ️ API request completed: POST /v1/receipts 200
DEBUG: ℹ️ PostReceiptDataOperation: Finished
DEBUG: ℹ️ Serial request done: POST receipts, 0 requests left in the queue
DEBUG: ℹ️ Sending updated CustomerInfo to delegate.
DEBUG: ℹ️ Found 0 unsynced attributes for App User ID: $RCAnonymousID:ec326c1613c14b489980eace90dceabb
DEBUG: ℹ️ Force refreshing the receipt to get latest transactions from Apple.
DEBUG: ℹ️ Loaded receipt from url file:///Users/nachosoto/Library/Developer/CoreSimulator/Devices/A3576DC2-355E-45BA-B32C-D2C0A3811BB4/data/Containers/Data/Application/7ACD12DA-2A12-4CF1-8A76-8295E40B64EF/StoreKit/receipt
DEBUG: ℹ️ PostReceiptDataOperation: Started
INFO: ℹ️ Receipt parsed successfully
DEBUG: ℹ️ PostReceiptDataOperation: Posting receipt: {
  "opaque_value" : "0nf1uwEAAAA=",
  "sha1_hash" : "lfxVVsBuSkQLtrGJseZ8zlpXc5A=",
  "bundle_id" : "com.revenuecat.StoreKitTestApp",
  "in_app_purchases" : [
    {
      "quantity" : 1,
      "product_id" : "com.revenuecat.monthly_4.99.1_week_intro",
      "purchase_date" : "2022-09-28T01:14:24Z",
      "transaction_id" : "0",
      "is_in_intro_offer_period" : true,
      "expires_date" : "2022-09-28T01:14:34Z"
    },
    {
      "product_id" : "com.revenuecat.monthly_4.99.1_week_intro",
      "quantity" : 1,
      "transaction_id" : "1",
      "is_in_intro_offer_period" : false,
      "expires_date" : "2022-09-28T01:15:04Z",
      "original_purchase_date" : "2022-09-28T01:14:24Z",
      "original_transaction_id" : "0",
      "purchase_date" : "2022-09-28T01:14:34Z"
    }
  ],
  "application_version" : "1",
  "creation_date" : "2022-09-28T01:14:35Z",
  "expiration_date" : "4001-01-01T00:00:00Z"
}
DEBUG: ℹ️ There are no requests currently running, starting request POST receipts
DEBUG: ℹ️ API request started: POST /v1/receipts
DEBUG: ℹ️ API request completed: POST /v1/receipts 200
DEBUG: ℹ️ PostReceiptDataOperation: Finished
DEBUG: ℹ️ Serial request done: POST receipts, 0 requests left in the queue
DEBUG: ℹ️ Sending updated CustomerInfo to delegate.
DEBUG: ℹ️ Loaded receipt from url file:///Users/nachosoto/Library/Developer/CoreSimulator/Devices/A3576DC2-355E-45BA-B32C-D2C0A3811BB4/data/Containers/Data/Application/7ACD12DA-2A12-4CF1-8A76-8295E40B64EF/StoreKit/receipt
INFO: ℹ️ Receipt parsed successfully
DEBUG: ℹ️ Skipping products request because products were already cached. products: ["com.revenuecat.monthly_4.99.1_week_intro"]
DEBUG: ℹ️ Skipping products request because products were already cached. products: ["com.revenuecat.monthly_4.99.1_week_intro"]
DEBUG: ℹ️ Store products request finished
DEBUG: ℹ️ Found 0 unsynced attributes for App User ID: $RCAnonymousID:ec326c1613c14b489980eace90dceabb
DEBUG: ℹ️ PostReceiptDataOperation: Started
INFO: ℹ️ Receipt parsed successfully
DEBUG: ℹ️ PostReceiptDataOperation: Posting receipt: {
  "opaque_value" : "tv4\/2gcAAAA=",
  "sha1_hash" : "0rh1naTc3JyfM16M\/1f6fw4ezAY=",
  "bundle_id" : "com.revenuecat.StoreKitTestApp",
  "in_app_purchases" : [
    {
      "quantity" : 1,
      "product_id" : "com.revenuecat.monthly_4.99.1_week_intro",
      "purchase_date" : "2022-09-28T01:14:24Z",
      "transaction_id" : "0",
      "is_in_intro_offer_period" : true,
      "expires_date" : "2022-09-28T01:14:34Z"
    },
    {
      "product_id" : "com.revenuecat.monthly_4.99.1_week_intro",
      "quantity" : 1,
      "transaction_id" : "1",
      "is_in_intro_offer_period" : false,
      "expires_date" : "2022-09-28T01:15:04Z",
      "original_purchase_date" : "2022-09-28T01:14:24Z",
      "original_transaction_id" : "0",
      "purchase_date" : "2022-09-28T01:14:34Z"
    }
  ],
  "application_version" : "1",
  "creation_date" : "2022-09-28T01:14:40Z",
  "expiration_date" : "4001-01-01T00:00:00Z"
}
DEBUG: ℹ️ There are no requests currently running, starting request POST receipts
DEBUG: ℹ️ API request started: POST /v1/receipts
DEBUG: ℹ️ API request completed: POST /v1/receipts 200
DEBUG: ℹ️ PostReceiptDataOperation: Finished
DEBUG: ℹ️ Serial request done: POST receipts, 0 requests left in the queue
INFO: 😻💰 Purchased product - 'com.revenuecat.monthly_4.99.1_week_intro'

[CSDK-478]: https://revenuecats.atlassian.net/browse/CSDK-478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ