### PR TITLE
`Integration Tests`: simplified `testIneligibleForIntroAfterPurchaseExpires` to fix flakiness

### DIFF
--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -252,15 +252,17 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
     func testIneligibleForIntroAfterPurchaseExpires() async throws {
         let product = try await self.weeklyPackage.storeProduct
 
+        // 1. Purchase weekly offering
         let customerInfo = try await self.purchaseWeeklyOffering().customerInfo
-        let entitlement = try await self.verifyEntitlementWentThrough(customerInfo)
 
+        // 2. Expire subscription
+        let entitlement = try XCTUnwrap(customerInfo.entitlements[Self.entitlementIdentifier])
         try await self.expireSubscription(entitlement)
 
-        let info = try await Purchases.shared.syncPurchases()
+        // 3. Sync purchases
+        _ = try await Purchases.shared.syncPurchases()
 
-        self.assertNoActiveSubscription(info)
-
+        // 4. Check eligibility
         let eligibility = await Purchases.shared.checkTrialOrIntroDiscountEligibility(product: product)
         expect(eligibility) == .ineligible
     }

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -259,10 +259,7 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
         let entitlement = try XCTUnwrap(customerInfo.entitlements[Self.entitlementIdentifier])
         try await self.expireSubscription(entitlement)
 
-        // 3. Sync purchases
-        _ = try await Purchases.shared.syncPurchases()
-
-        // 4. Check eligibility
+        // 3. Check eligibility
         let eligibility = await Purchases.shared.checkTrialOrIntroDiscountEligibility(product: product)
         expect(eligibility) == .ineligible
     }


### PR DESCRIPTION
Fixes [CSDK-479].

### Changes:
- Removed extra `verifyEntitlementWentThrough`. #1880 introduced a change so that weekly subscriptions aren't verified, because they expire within a second. This make the test flaky due to that race condition.
- Removed `assertNoActiveSubscription`: I tried calling `SKTestSession.disableAutoRenewForTransaction`, but sometimes the server still thinks the subscription has auto-renewed. This was making the test flaky. Turns out that even if it's not active, the eligibility test still passes as expected.
- Removed call to `syncPurchases`. It doesn't matter what state the server is in, as long as locally `SKTestSession` has an expired subscription.

This, together with #1945, should fix the last of the issues causing flaky integration tests 🤞🏻

[CSDK-479]: https://revenuecats.atlassian.net/browse/CSDK-479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ