### PR TITLE
Remind about updating docs and parity spreadsheet on minor releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -562,6 +562,57 @@ jobs:
           name: Create automatic PR
           command: bundle exec fastlane automatic_bump github_rate_limit:10
 
+  notify-on-non-patch-release-branches:
+    docker:
+      - image: 'cimg/base:stable'
+    steps:
+      - slack/notify:
+          custom: |
+              {
+                "text": "Public facing changes detected",
+                "blocks": [
+                  {
+                    "type": "header",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "REMINDER :raised_hand:",
+                      "emoji": true
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "Do *public docs* need to be updated?"
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "Does the *SDK parity spreadsheet* need to be updated?"
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Project*: $CIRCLE_PROJECT_REPONAME"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Branch*: $CIRCLE_BRANCH"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Author*: $CIRCLE_USERNAME"
+                      }
+                    ]
+                  }
+                ]
+              }
+
 workflows:
   version: 2
   build-test:
@@ -636,54 +687,9 @@ workflows:
           # Not using Xcode 14 yet because it does not contain the new macOS SDK until Ventura is released.
           xcode_version: '13.4.1'
           <<: *release-tags
-      - slack/notify:
+      - notify-on-non-patch-release-branches:
           <<: *non-patch-release-branches
           context: slack-secrets
-          custom: |
-              {
-                "text": "Public facing changes detected",
-                "blocks": [
-                  {
-                    "type": "header",
-                    "text": {
-                      "type": "plain_text",
-                      "text": "REMINDER :raised_hand:",
-                      "emoji": true
-                    }
-                  },
-                  {
-                    "type": "section",
-                    "text": {
-                      "type": "mrkdwn",
-                      "text": "Do *public docs* need to be updated?"
-                    }
-                  },
-                  {
-                    "type": "section",
-                    "text": {
-                      "type": "mrkdwn",
-                      "text": "Does the *SDK parity spreadsheet* need to be updated?"
-                    }
-                  },
-                  {
-                    "type": "section",
-                    "fields": [
-                      {
-                        "type": "mrkdwn",
-                        "text": "*Project*: $CIRCLE_PROJECT_REPONAME"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": "*Branch*: $CIRCLE_BRANCH"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": "*Author*: $CIRCLE_USERNAME"
-                      }
-                    ]
-                  }
-                ]
-              }
   snapshot-bump:
     when:
       not:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ aliases:
         ignore: /.*/
       branches:
         only: main
-  non-patch-branches: &non-patch-branches
+  non-patch-release-branches: &non-patch-release-branches
     filters: 
       tags:
         ignore: /.*/
@@ -637,7 +637,7 @@ workflows:
           xcode_version: '13.4.1'
           <<: *release-tags
       - slack/notify:
-          <<: *non-patch-branches
+          <<: *non-patch-release-branches
           context: slack-secrets
           custom: |
               {

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 orbs:
-   macos: circleci/macos@2.0.1
+  macos: circleci/macos@2.0.1
+  slack: circleci/slack@4.10.1
 
 version: 2.1
 
@@ -45,6 +46,12 @@ aliases:
         ignore: /.*/
       branches:
         only: main
+  non-patch-branches: &non-patch-branches
+    filters: 
+      tags:
+        ignore: /.*/
+      branches:
+        only: /^release\/.*\.0$/
 
 commands:
   install-and-create-sim:
@@ -629,6 +636,81 @@ workflows:
           # Not using Xcode 14 yet because it does not contain the new macOS SDK until Ventura is released.
           xcode_version: '13.4.1'
           <<: *release-tags
+      - slack/on-hold:
+          <<: *non-patch-branches
+          context: slack-secrets
+          custom: |
+              {
+                "text": "CircleCI job on hold, waiting for approval.",
+                "blocks": [
+                  {
+                    "type": "header",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "AWAITING APPROVAL - Public facing changes detected :raised_hand:",
+                      "emoji": true
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "Approve `docs-have-been-updated` if *public docs* have been updated"
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "Approve `sdk-parity-sheet-has-been-updated` if the *SDK parity spreadsheet* has been updated"
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Project*: $CIRCLE_PROJECT_REPONAME"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Branch*: $CIRCLE_BRANCH"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Author*: $CIRCLE_USERNAME"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "actions",
+                    "elements": [
+                      {
+                        "type": "button",
+                        "text": {
+                          "type": "plain_text",
+                          "text": "View Workflow"
+                        },
+                        "url": "${SLACK_PARAM_CIRCLECI_HOST}/workflow-run/${CIRCLE_WORKFLOW_ID}"
+                      }
+                    ]
+                  }
+                ]
+              }
+          requires:
+            - docs-deploy
+      - docs-have-been-updated:
+          <<: *non-patch-branches
+          type: approval
+          requires:
+            - docs-deploy
+            - slack/on-hold
+      - sdk-parity-sheet-has-been-updated:
+          <<: *non-patch-branches
+          type: approval
+          requires:
+            - docs-deploy
+            - slack/on-hold
   snapshot-bump:
     when:
       not:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -636,18 +636,18 @@ workflows:
           # Not using Xcode 14 yet because it does not contain the new macOS SDK until Ventura is released.
           xcode_version: '13.4.1'
           <<: *release-tags
-      - slack/on-hold:
+      - slack/notify:
           <<: *non-patch-branches
           context: slack-secrets
           custom: |
               {
-                "text": "CircleCI job on hold, waiting for approval.",
+                "text": "Public facing changes detected",
                 "blocks": [
                   {
                     "type": "header",
                     "text": {
                       "type": "plain_text",
-                      "text": "AWAITING APPROVAL - Public facing changes detected :raised_hand:",
+                      "text": "REMINDER :raised_hand:",
                       "emoji": true
                     }
                   },
@@ -655,14 +655,14 @@ workflows:
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": "Approve `docs-have-been-updated` if *public docs* have been updated"
+                      "text": "Do *public docs* need to be updated?"
                     }
                   },
                   {
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": "Approve `sdk-parity-sheet-has-been-updated` if the *SDK parity spreadsheet* has been updated"
+                      "text": "Does the *SDK parity spreadsheet* need to be updated?"
                     }
                   },
                   {
@@ -681,36 +681,9 @@ workflows:
                         "text": "*Author*: $CIRCLE_USERNAME"
                       }
                     ]
-                  },
-                  {
-                    "type": "actions",
-                    "elements": [
-                      {
-                        "type": "button",
-                        "text": {
-                          "type": "plain_text",
-                          "text": "View Workflow"
-                        },
-                        "url": "${SLACK_PARAM_CIRCLECI_HOST}/workflow-run/${CIRCLE_WORKFLOW_ID}"
-                      }
-                    ]
                   }
                 ]
               }
-          requires:
-            - docs-deploy
-      - docs-have-been-updated:
-          <<: *non-patch-branches
-          type: approval
-          requires:
-            - docs-deploy
-            - slack/on-hold
-      - sdk-parity-sheet-has-been-updated:
-          <<: *non-patch-branches
-          type: approval
-          requires:
-            - docs-deploy
-            - slack/on-hold
   snapshot-bump:
     when:
       not:


### PR DESCRIPTION
Adds two approval jobs and a Slack notification posted to the `#sdk-prs` channel. After this is merged, it can be moved to the orb so it can be shared across all repos

<img width="617" alt="Screen Shot 2022-09-29 at 1 40 59 PM" src="https://user-images.githubusercontent.com/664544/193022122-33c1d2e8-ec1d-4c87-9f29-e368ef266f12.png">

[CSDK-420]


[CSDK-420]: https://revenuecats.atlassian.net/browse/CSDK-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ