### PR TITLE
`Purchases.logIn`: log warning if attempting to use a static `appUserID`

### DIFF
--- a/Sources/Logging/Strings/IdentityStrings.swift
+++ b/Sources/Logging/Strings/IdentityStrings.swift
@@ -20,6 +20,8 @@ enum IdentityStrings {
 
     case logging_in_with_same_appuserid
 
+    case logging_in_with_static_string
+
     case login_success
 
     case log_out_called_for_user
@@ -44,6 +46,10 @@ extension IdentityStrings: CustomStringConvertible {
         case .logging_in_with_same_appuserid:
             return "The appUserID passed to logIn is the same as the one " +
                 "already cached. No action will be taken."
+        case .logging_in_with_static_string:
+            return "The appUserID passed to logIn is a constant string known at compile time. " +
+            "This is likely a programmer error. This ID is used to identify the current user. " +
+            "See https://docs.revenuecat.com/docs/user-ids for more information."
         case .login_success:
             return "Log in successful"
         case .log_out_called_for_user:

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -524,6 +524,13 @@ public extension Purchases {
 
     @objc var isAnonymous: Bool { self.identityManager.currentUserIsAnonymous }
 
+    func logIn(_ appUserID: StaticString, completion: @escaping (CustomerInfo?, Bool, PublicError?) -> Void) {
+        Logger.warn(Strings.identity.logging_in_with_static_string)
+
+        self.logIn("\(appUserID)", completion: completion)
+    }
+
+    @_disfavoredOverload // Favor `StaticString` overload (`String` is not convertible to `StaticString`).
     @objc(logIn:completion:)
     func logIn(_ appUserID: String, completion: @escaping (CustomerInfo?, Bool, PublicError?) -> Void) {
         self.identityManager.logIn(appUserID: appUserID) { result in
@@ -545,8 +552,16 @@ public extension Purchases {
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func logIn(_ appUserID: StaticString) async throws -> (customerInfo: CustomerInfo, created: Bool) {
+        Logger.warn(Strings.identity.logging_in_with_static_string)
+
+        return try await self.logIn("\(appUserID)")
+    }
+
+    @_disfavoredOverload // Favor `StaticString` overload (`String` is not convertible to `StaticString`).
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func logIn(_ appUserID: String) async throws -> (customerInfo: CustomerInfo, created: Bool) {
-        return try await logInAsync(appUserID)
+        return try await self.logInAsync(appUserID)
     }
 
     @objc func logOut(completion: ((CustomerInfo?, PublicError?) -> Void)?) {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -155,7 +155,7 @@ class PurchasesLogInTests: BasePurchasesTests {
 
         _ = try await self.purchases.logIn(appUserID)
 
-        logger.verifyMessageWasNotLogged(Strings.identity.logging_in_with_static_string, level: .warn)
+        logger.verifyMessageWasNotLogged(Strings.identity.logging_in_with_static_string)
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
@@ -184,7 +184,7 @@ class PurchasesLogInTests: BasePurchasesTests {
         }
 
         expect(finished).toEventually(beTrue())
-        logger.verifyMessageWasNotLogged(Strings.identity.logging_in_with_static_string, level: .warn)
+        logger.verifyMessageWasNotLogged(Strings.identity.logging_in_with_static_string)
     }
 
     func testCompletionBlockLogInWithStaticStringLogsMessage() {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -159,7 +159,7 @@ class PurchasesLogInTests: BasePurchasesTests {
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func testLogInWithStringLogsMessage() async throws {
+    func testLogInWithStaticStringLogsMessage() async throws {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
         let logger = TestLogHandler()
@@ -171,7 +171,7 @@ class PurchasesLogInTests: BasePurchasesTests {
         logger.verifyMessageWasLogged(Strings.identity.logging_in_with_static_string, level: .warn)
     }
 
-    func testLogInWithCompletionBlockWithStringDoesNotLogMessage() throws {
+    func testCompletionBlockLogInWithStringDoesNotLogMessage() throws {
         let appUserID = "user ID"
         let logger = TestLogHandler()
 
@@ -187,7 +187,7 @@ class PurchasesLogInTests: BasePurchasesTests {
         logger.verifyMessageWasNotLogged(Strings.identity.logging_in_with_static_string, level: .warn)
     }
 
-    func testLogInWithCompletionBlockStringLogsMessage() throws {
+    func testCompletionBlockLogInWithStaticStringLogsMessage() throws {
         let logger = TestLogHandler()
 
         self.identityManager.mockLogInResult = .success((Self.mockLoggedInInfo, true))

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -142,6 +142,66 @@ class PurchasesLogInTests: BasePurchasesTests {
         expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount) == 1
     }
 
+    // MARK: - StaticString appUserID
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func testLogInWithStringDoesNotLogMessage() async throws {
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
+        let appUserID = "user ID"
+        let logger = TestLogHandler()
+
+        self.identityManager.mockLogInResult = .success((Self.mockLoggedInInfo, true))
+
+        _ = try await self.purchases.logIn(appUserID)
+
+        logger.verifyMessageWasNotLogged(Strings.identity.logging_in_with_static_string, level: .warn)
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func testLogInWithStringLogsMessage() async throws {
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
+        let logger = TestLogHandler()
+
+        self.identityManager.mockLogInResult = .success((Self.mockLoggedInInfo, true))
+
+        _ = try await self.purchases.logIn("Static string")
+
+        logger.verifyMessageWasLogged(Strings.identity.logging_in_with_static_string, level: .warn)
+    }
+
+    func testLogInWithCompletionBlockWithStringDoesNotLogMessage() throws {
+        let appUserID = "user ID"
+        let logger = TestLogHandler()
+
+        self.identityManager.mockLogInResult = .success((Self.mockLoggedInInfo, true))
+
+        var finished = false
+
+        self.purchases.logIn(appUserID) { _, _, _ in
+            finished = true
+        }
+
+        expect(finished).toEventually(beTrue())
+        logger.verifyMessageWasNotLogged(Strings.identity.logging_in_with_static_string, level: .warn)
+    }
+
+    func testLogInWithCompletionBlockStringLogsMessage() throws {
+        let logger = TestLogHandler()
+
+        self.identityManager.mockLogInResult = .success((Self.mockLoggedInInfo, true))
+
+        var finished = false
+
+        self.purchases.logIn("Static string") { _, _, _ in
+            finished = true
+        }
+
+        expect(finished).toEventually(beTrue())
+        logger.verifyMessageWasLogged(Strings.identity.logging_in_with_static_string, level: .warn)
+    }
+
 }
 
 // MARK: -

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -171,7 +171,7 @@ class PurchasesLogInTests: BasePurchasesTests {
         logger.verifyMessageWasLogged(Strings.identity.logging_in_with_static_string, level: .warn)
     }
 
-    func testCompletionBlockLogInWithStringDoesNotLogMessage() throws {
+    func testCompletionBlockLogInWithStringDoesNotLogMessage() {
         let appUserID = "user ID"
         let logger = TestLogHandler()
 
@@ -187,7 +187,7 @@ class PurchasesLogInTests: BasePurchasesTests {
         logger.verifyMessageWasNotLogged(Strings.identity.logging_in_with_static_string, level: .warn)
     }
 
-    func testCompletionBlockLogInWithStaticStringLogsMessage() throws {
+    func testCompletionBlockLogInWithStaticStringLogsMessage() {
         let logger = TestLogHandler()
 
         self.identityManager.mockLogInResult = .success((Self.mockLoggedInInfo, true))


### PR DESCRIPTION
This only works in `Swift`, but it can be useful to catch incorrect usages of `logIn`, where a user might accidentally pass the api key, or some other key known at compile time.