### PR TITLE
`PaymentQueueWrapper`: also implement `shouldShowPriceConsent`

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -598,7 +598,7 @@ extension PurchasesOrchestrator: StoreKit1WrapperDelegate {
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     var storeKit1WrapperShouldShowPriceConsent: Bool {
-        return delegate?.shouldShowPriceConsent ?? true
+        return self.delegate?.shouldShowPriceConsent ?? true
     }
 
     func storeKit1WrapperDidChangeStorefront(_ storeKit1Wrapper: StoreKit1Wrapper) {
@@ -608,6 +608,13 @@ extension PurchasesOrchestrator: StoreKit1WrapperDelegate {
 }
 
 extension PurchasesOrchestrator: PaymentQueueWrapperDelegate {
+
+    #if os(iOS) || targetEnvironment(macCatalyst)
+    @available(iOS 13.4, macCatalyst 13.4, *)
+    var paymentQueueWrapperShouldShowPriceConsent: Bool {
+        return self.storeKit1WrapperShouldShowPriceConsent
+    }
+    #endif
 
     func paymentQueueWrapper(
         _ wrapper: PaymentQueueWrapper,

--- a/Sources/Purchasing/StoreKit1/PaymentQueueWrapper.swift
+++ b/Sources/Purchasing/StoreKit1/PaymentQueueWrapper.swift
@@ -19,6 +19,12 @@ protocol PaymentQueueWrapperDelegate: AnyObject, Sendable {
     func paymentQueueWrapper(_ wrapper: PaymentQueueWrapper,
                              shouldAddStorePayment payment: SKPayment,
                              for product: SK1Product) -> Bool
+
+    #if os(iOS) || targetEnvironment(macCatalyst)
+    @available(iOS 13.4, macCatalyst 13.4, *)
+    var paymentQueueWrapperShouldShowPriceConsent: Bool { get }
+    #endif
+
 }
 
 class PaymentQueueWrapper: NSObject {
@@ -72,6 +78,13 @@ class PaymentQueueWrapper: NSObject {
 }
 
 extension PaymentQueueWrapper: SKPaymentQueueDelegate {
+
+    #if os(iOS) || targetEnvironment(macCatalyst)
+    @available(iOS 13.4, macCatalyst 13.4, *)
+    func paymentQueueShouldShowPriceConsent(_ paymentQueue: SKPaymentQueue) -> Bool {
+        return self.delegate?.paymentQueueWrapperShouldShowPriceConsent ?? true
+    }
+    #endif
 
 }
 


### PR DESCRIPTION
Follow up to #1962. This is also needed when `StoreKit1Wrapper` is not setup (see #1882).