### PR TITLE
`PaymentQueueWrapper`: improved abstraction for active `SKPaymentQueue` wrapper

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -274,6 +274,7 @@
 		5774F9C12805EA3000997128 /* BaseHTTPResponseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5774F9C02805EA3000997128 /* BaseHTTPResponseTest.swift */; };
 		5774F9C22805EA6900997128 /* CustomerInfoDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5774F9B92805E6E200997128 /* CustomerInfoDecodingTests.swift */; };
 		578FB10E27ADDA8000F70709 /* AvailabilityChecks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3BE0263275942D500915B4C /* AvailabilityChecks.swift */; };
+		579189B728F4747700BF4963 /* EitherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579189B628F4747700BF4963 /* EitherTests.swift */; };
 		5791A1C82767FC9400C972AA /* ManageSubscriptionsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791A1C72767FC9400C972AA /* ManageSubscriptionsHelperTests.swift */; };
 		5791CE80273F26A000E50C4B /* base64encoded_sandboxReceipt.txt in Resources */ = {isa = PBXBuildFile; fileRef = 5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */; };
 		579234E327F7788900B39C68 /* BaseBackendIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579234E127F777EE00B39C68 /* BaseBackendIntegrationTests.swift */; };
@@ -787,6 +788,7 @@
 		5774F9B92805E6E200997128 /* CustomerInfoDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoDecodingTests.swift; sourceTree = "<group>"; };
 		5774F9BD2805E71100997128 /* Fixtures */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = folder; name = Fixtures; path = Tests/UnitTests/Networking/Responses/Fixtures; sourceTree = SOURCE_ROOT; };
 		5774F9C02805EA3000997128 /* BaseHTTPResponseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseHTTPResponseTest.swift; sourceTree = "<group>"; };
+		579189B628F4747700BF4963 /* EitherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EitherTests.swift; sourceTree = "<group>"; };
 		5791A1C72767FC9400C972AA /* ManageSubscriptionsHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionsHelperTests.swift; sourceTree = "<group>"; };
 		5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = base64encoded_sandboxReceipt.txt; sourceTree = "<group>"; };
 		579234E127F777EE00B39C68 /* BaseBackendIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBackendIntegrationTests.swift; sourceTree = "<group>"; };
@@ -1494,6 +1496,7 @@
 				5722482627C2BD3200C524A7 /* LockTests.swift */,
 				576C8A8E27CFCD110058FA6E /* AnyEncodableTests.swift */,
 				574A2EE8282C403800150D40 /* AnyDecodableTests.swift */,
+				579189B628F4747700BF4963 /* EitherTests.swift */,
 				57554CC0282AE1E3009A7E58 /* TestCase.swift */,
 				2D22BF6626F3CBFB001AE2F9 /* XCTestCase+Extensions.swift */,
 				5766AA59283D4CAB00FA6091 /* IgnoreHashableTests.swift */,
@@ -2573,6 +2576,7 @@
 				5766C620282DA3D50067D886 /* GetIntroEligibilityDecodingTests.swift in Sources */,
 				57C381E2279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */,
 				2DDF41E824F6F61B005BC22D /* MockSKProductDiscount.swift in Sources */,
+				579189B728F4747700BF4963 /* EitherTests.swift in Sources */,
 				57069A5E28E398E100B86355 /* AsyncExtensionsTests.swift in Sources */,
 				35272E2226D0048D00F22C3B /* HTTPClientTests.swift in Sources */,
 				2DDF41CB24F6F4C3005BC22D /* ASN1ObjectIdentifierBuilderTests.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -295,6 +295,7 @@
 		57A0FBF22749CF66009E2FC3 /* SynchronizedUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */; };
 		57A17727276A721D0052D3A8 /* Set+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A17726276A721D0052D3A8 /* Set+Extensions.swift */; };
 		57A1772B276A726C0052D3A8 /* SetExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A1772A276A726C0052D3A8 /* SetExtensionsTests.swift */; };
+		57ABA76D28F08DDA003D9181 /* Either.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ABA76C28F08DDA003D9181 /* Either.swift */; };
 		57AC4C182770F55C00DDE30F /* SK2StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AC4C172770F55C00DDE30F /* SK2StoreProduct.swift */; };
 		57AC4C1C2770F56200DDE30F /* SK1StoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AC4C1B2770F56200DDE30F /* SK1StoreProduct.swift */; };
 		57ACB12428174B9F000DCC9F /* CustomerInfo+TestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ACB12328174B9F000DCC9F /* CustomerInfo+TestExtensions.swift */; };
@@ -808,6 +809,7 @@
 		57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedUserDefaults.swift; sourceTree = "<group>"; };
 		57A17726276A721D0052D3A8 /* Set+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Set+Extensions.swift"; sourceTree = "<group>"; };
 		57A1772A276A726C0052D3A8 /* SetExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetExtensionsTests.swift; sourceTree = "<group>"; };
+		57ABA76C28F08DDA003D9181 /* Either.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Either.swift; sourceTree = "<group>"; };
 		57AC4C172770F55C00DDE30F /* SK2StoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreProduct.swift; sourceTree = "<group>"; };
 		57AC4C1B2770F56200DDE30F /* SK1StoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1StoreProduct.swift; sourceTree = "<group>"; };
 		57ACB12328174B9F000DCC9F /* CustomerInfo+TestExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerInfo+TestExtensions.swift"; sourceTree = "<group>"; };
@@ -1288,6 +1290,7 @@
 				57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */,
 				B3AA6237268B926F00894871 /* SystemInfo.swift */,
 				57FDAAB9284937A0009A48F1 /* SandboxEnvironmentDetector.swift */,
+				57ABA76C28F08DDA003D9181 /* Either.swift */,
 			);
 			path = Misc;
 			sourceTree = "<group>";
@@ -2440,6 +2443,7 @@
 				A56F9AB126990E9200AFC48F /* CustomerInfo.swift in Sources */,
 				2DDF41AE24F6F37C005BC22D /* InAppPurchase.swift in Sources */,
 				B32B750126868C1D005647BF /* EntitlementInfo.swift in Sources */,
+				57ABA76D28F08DDA003D9181 /* Either.swift in Sources */,
 				35F82BB426A9A74D0051DF03 /* HTTPClient.swift in Sources */,
 				B3A55B7D26C452A7007EFC56 /* AttributionPoster.swift in Sources */,
 				2DC19195255F36D10039389A /* Logger.swift in Sources */,

--- a/Sources/Misc/Deprecations.swift
+++ b/Sources/Misc/Deprecations.swift
@@ -403,7 +403,7 @@ extension CustomerInfo {
             self.quantity = 1
         }
 
-        func finish(_ wrapper: StoreKit1Wrapper) {
+        func finish(_ wrapper: PaymentQueueWrapperType) {
             // Nothing to do
         }
 

--- a/Sources/Misc/Either.swift
+++ b/Sources/Misc/Either.swift
@@ -1,0 +1,40 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Either.swift
+//
+//  Created by Nacho Soto on 10/7/22.
+
+import Foundation
+
+/// A type that may contain one of two possible values.
+internal enum Either<Left, Right> {
+
+    case left(Left)
+    case right(Right)
+
+}
+
+extension Either {
+
+    var left: Left? {
+        switch self {
+        case let .left(left): return left
+        case .right: return nil
+        }
+    }
+
+    var right: Right? {
+        switch self {
+        case .left: return nil
+        case let .right(right): return right
+        }
+    }
+
+}

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -227,8 +227,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     private let purchasesOrchestrator: PurchasesOrchestrator
     private let receiptFetcher: ReceiptFetcher
     private let requestFetcher: StoreKitRequestFetcher
-    private let storeKit1Wrapper: StoreKit1Wrapper?
-    private let paymentQueueWrapper: PaymentQueueWrapper
+    private let paymentQueueWrapper: EitherPaymentQueueWrapper
     private let systemInfo: SystemInfo
     private var customerInfoObservationDisposable: (() -> Void)?
 
@@ -267,10 +266,10 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                               eTagManager: eTagManager,
                               operationDispatcher: operationDispatcher,
                               attributionFetcher: attributionFetcher)
-        let storeKit1Wrapper: StoreKit1Wrapper? = systemInfo.storeKit2Setting.shouldOnlyUseStoreKit2
-        ? nil
-        : StoreKit1Wrapper()
-        let paymentQueueWrapper = storeKit1Wrapper?.createPaymentQueueWrapper() ?? .init()
+
+        let paymentQueueWrapper: EitherPaymentQueueWrapper = systemInfo.storeKit2Setting.shouldOnlyUseStoreKit2
+            ? .right(.init())
+            : .left(.init())
 
         let offeringsFactory = OfferingsFactory()
         let userDefaults = userDefaults ?? UserDefaults.standard
@@ -324,7 +323,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
                 return .init(
                     productsManager: productsManager,
-                    storeKit1Wrapper: storeKit1Wrapper,
+                    paymentQueueWrapper: paymentQueueWrapper,
                     systemInfo: systemInfo,
                     subscriberAttributes: subscriberAttributes,
                     operationDispatcher: operationDispatcher,
@@ -343,7 +342,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             } else {
                 return .init(
                     productsManager: productsManager,
-                    storeKit1Wrapper: storeKit1Wrapper,
+                    paymentQueueWrapper: paymentQueueWrapper,
                     systemInfo: systemInfo,
                     subscriberAttributes: subscriberAttributes,
                     operationDispatcher: operationDispatcher,
@@ -373,7 +372,6 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                   attributionFetcher: attributionFetcher,
                   attributionPoster: attributionPoster,
                   backend: backend,
-                  storeKit1Wrapper: storeKit1Wrapper,
                   paymentQueueWrapper: paymentQueueWrapper,
                   notificationCenter: NotificationCenter.default,
                   systemInfo: systemInfo,
@@ -396,8 +394,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
          attributionFetcher: AttributionFetcher,
          attributionPoster: AttributionPoster,
          backend: Backend,
-         storeKit1Wrapper: StoreKit1Wrapper?,
-         paymentQueueWrapper: PaymentQueueWrapper,
+         paymentQueueWrapper: EitherPaymentQueueWrapper,
          notificationCenter: NotificationCenter,
          systemInfo: SystemInfo,
          offeringsFactory: OfferingsFactory,
@@ -425,7 +422,6 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.attributionFetcher = attributionFetcher
         self.attributionPoster = attributionPoster
         self.backend = backend
-        self.storeKit1Wrapper = storeKit1Wrapper
         self.paymentQueueWrapper = paymentQueueWrapper
         self.offeringsFactory = offeringsFactory
         self.deviceCache = deviceCache
@@ -455,16 +451,14 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         }
 
         if self.systemInfo.dangerousSettings.autoSyncPurchases {
-            storeKit1Wrapper?.delegate = purchasesOrchestrator
+            self.paymentQueueWrapper.storeKit1Wrapper?.delegate = purchasesOrchestrator
         } else {
             Logger.warn(Strings.configure.autoSyncPurchasesDisabled)
         }
 
         /// If SK1 is not enabled, `PaymentQueueWrapper` needs to handle transactions
         /// for promotional offers to work.
-        if !self.isStoreKit1Configured {
-            self.paymentQueueWrapper.delegate = purchasesOrchestrator
-        }
+        self.paymentQueueWrapper.right?.delegate = purchasesOrchestrator
 
         self.subscribeToAppStateNotifications()
         self.attributionPoster.postPostponedAttributionDataIfNeeded()
@@ -479,8 +473,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
     deinit {
         self.notificationCenter.removeObserver(self)
-        self.storeKit1Wrapper?.delegate = nil
-        self.paymentQueueWrapper.delegate = nil
+        self.paymentQueueWrapper.left?.delegate = nil
+        self.paymentQueueWrapper.right?.delegate = nil
         self.customerInfoObservationDisposable?()
         self.privateDelegate = nil
         Self.proxyURL = nil
@@ -730,7 +724,7 @@ public extension Purchases {
 #if os(iOS) || targetEnvironment(macCatalyst)
     @available(iOS 13.4, macCatalyst 13.4, *)
     @objc func showPriceConsentIfNeeded() {
-        self.paymentQueueWrapper.showPriceConsentIfNeeded()
+        self.paymentQueueWrapper.paymentQueueWrapperType.showPriceConsentIfNeeded()
     }
 #endif
 
@@ -746,7 +740,7 @@ public extension Purchases {
     @available(macOS, unavailable)
     @available(macCatalyst, unavailable)
     @objc func presentCodeRedemptionSheet() {
-        self.paymentQueueWrapper.presentCodeRedemptionSheet()
+        self.paymentQueueWrapper.paymentQueueWrapperType.presentCodeRedemptionSheet()
     }
 #endif
 
@@ -1050,7 +1044,7 @@ extension Purchases: @unchecked Sendable {}
 internal extension Purchases {
 
     var isStoreKit1Configured: Bool {
-        return self.storeKit1Wrapper != nil
+        return self.paymentQueueWrapper.storeKit1Wrapper != nil
     }
 
     #if DEBUG

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -451,14 +451,14 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         }
 
         if self.systemInfo.dangerousSettings.autoSyncPurchases {
-            self.paymentQueueWrapper.storeKit1Wrapper?.delegate = purchasesOrchestrator
+            self.paymentQueueWrapper.sk1Wrapper?.delegate = purchasesOrchestrator
         } else {
             Logger.warn(Strings.configure.autoSyncPurchasesDisabled)
         }
 
         /// If SK1 is not enabled, `PaymentQueueWrapper` needs to handle transactions
         /// for promotional offers to work.
-        self.paymentQueueWrapper.right?.delegate = purchasesOrchestrator
+        self.paymentQueueWrapper.sk2Wrapper?.delegate = purchasesOrchestrator
 
         self.subscribeToAppStateNotifications()
         self.attributionPoster.postPostponedAttributionDataIfNeeded()
@@ -473,8 +473,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
     deinit {
         self.notificationCenter.removeObserver(self)
-        self.paymentQueueWrapper.left?.delegate = nil
-        self.paymentQueueWrapper.right?.delegate = nil
+        self.paymentQueueWrapper.sk1Wrapper?.delegate = nil
+        self.paymentQueueWrapper.sk2Wrapper?.delegate = nil
         self.customerInfoObservationDisposable?()
         self.privateDelegate = nil
         Self.proxyURL = nil
@@ -1044,7 +1044,7 @@ extension Purchases: @unchecked Sendable {}
 internal extension Purchases {
 
     var isStoreKit1Configured: Bool {
-        return self.paymentQueueWrapper.storeKit1Wrapper != nil
+        return self.paymentQueueWrapper.sk1Wrapper != nil
     }
 
     #if DEBUG

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -525,7 +525,7 @@ extension PurchasesOrchestrator {
 
     /// - Returns: `StoreKit1Wrapper` if it's set, otherwise forwards an error to `completion` and returns `nil`
     private func storeKit1Wrapper(orFailWith completion: @escaping PurchaseCompletedBlock) -> StoreKit1Wrapper? {
-        guard let storeKit1Wrapper = self.paymentQueueWrapper.storeKit1Wrapper else {
+        guard let storeKit1Wrapper = self.paymentQueueWrapper.sk1Wrapper else {
             self.operationDispatcher.dispatchOnMainActor {
                 completion(nil,
                            nil,
@@ -631,7 +631,7 @@ extension PurchasesOrchestrator: PaymentQueueWrapperDelegate {
         // when `StoreKit1Wrapper` is not initialized, which means that promoted purchases
         // need to be handled as a SK2 purchase.
         // This method converts the `SKPayment` into an SK2 purchase by fetching the product again.
-        if self.paymentQueueWrapper.storeKit1Wrapper != nil {
+        if self.paymentQueueWrapper.sk1Wrapper != nil {
             Logger.warn("Unexpectedly received PaymentQueueWrapperDelegate call with SK1 enabled")
             assertionFailure("This method should not be invoked if SK1 is enabled")
         }

--- a/Sources/Purchasing/StoreKit1/PaymentQueueWrapper.swift
+++ b/Sources/Purchasing/StoreKit1/PaymentQueueWrapper.swift
@@ -135,13 +135,14 @@ extension PaymentQueueWrapper: @unchecked Sendable {}
 
 extension EitherPaymentQueueWrapper {
 
-    var storeKit1Wrapper: StoreKit1Wrapper? { return self.left }
-
     var paymentQueueWrapperType: PaymentQueueWrapperType {
         switch self {
         case let .left(storeKit1Wrapper): return storeKit1Wrapper
         case let .right(paymentQueueWrapper): return paymentQueueWrapper
         }
     }
+
+    var sk1Wrapper: StoreKit1Wrapper? { return self.left }
+    var sk2Wrapper: PaymentQueueWrapper? { return self.right }
 
 }

--- a/Sources/Purchasing/StoreKit1/PaymentQueueWrapper.swift
+++ b/Sources/Purchasing/StoreKit1/PaymentQueueWrapper.swift
@@ -27,7 +27,33 @@ protocol PaymentQueueWrapperDelegate: AnyObject, Sendable {
 
 }
 
-class PaymentQueueWrapper: NSObject {
+/// A wrapper for `SKPaymentQueue`
+@objc
+protocol PaymentQueueWrapperType: AnyObject {
+
+    func finishTransaction(_ transaction: SKPaymentTransaction)
+
+    #if os(iOS) || targetEnvironment(macCatalyst)
+    @available(iOS 13.4, macCatalyst 13.4, *)
+    func showPriceConsentIfNeeded()
+    #endif
+
+    @available(iOS 14.0, *)
+    @available(macOS, unavailable)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    @available(macCatalyst, unavailable)
+    func presentCodeRedemptionSheet()
+
+}
+
+/// The choice between SK1's `StoreKit1Wrapper` or `PaymentQueueWrapper` when SK2 is enabled.
+typealias EitherPaymentQueueWrapper = Either<StoreKit1Wrapper, PaymentQueueWrapper>
+
+// MARK: -
+
+/// Implementation of `PaymentQueueWrapperType` used when SK1 is not enabled.
+class PaymentQueueWrapper: NSObject, PaymentQueueWrapperType {
 
     private let paymentQueue: SKPaymentQueue
 
@@ -51,6 +77,10 @@ class PaymentQueueWrapper: NSObject {
         super.init()
     }
 
+    func finishTransaction(_ transaction: SKPaymentTransaction) {
+        self.paymentQueue.finishTransaction(transaction)
+    }
+
     #if os(iOS) || targetEnvironment(macCatalyst)
     @available(iOS 13.4, macCatalyst 13.4, *)
     func showPriceConsentIfNeeded() {
@@ -58,14 +88,12 @@ class PaymentQueueWrapper: NSObject {
     }
     #endif
 
+    #if os(iOS)
     @available(iOS 14.0, *)
-    @available(macOS, unavailable)
-    @available(tvOS, unavailable)
-    @available(watchOS, unavailable)
-    @available(macCatalyst, unavailable)
     func presentCodeRedemptionSheet() {
         self.paymentQueue.presentCodeRedemptionSheetIfAvailable()
     }
+    #endif
 
 }
 
@@ -104,3 +132,16 @@ extension PaymentQueueWrapper: SKPaymentTransactionObserver {
 // `SKPaymentQueue` is not `Sendable` until Swift 5.7
 // - Not-final since it's mocked in tests.
 extension PaymentQueueWrapper: @unchecked Sendable {}
+
+extension EitherPaymentQueueWrapper {
+
+    var storeKit1Wrapper: StoreKit1Wrapper? { return self.left }
+
+    var paymentQueueWrapperType: PaymentQueueWrapperType {
+        switch self {
+        case let .left(storeKit1Wrapper): return storeKit1Wrapper
+        case let .right(paymentQueueWrapper): return paymentQueueWrapper
+        }
+    }
+
+}

--- a/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
@@ -78,11 +78,6 @@ class StoreKit1Wrapper: NSObject {
         self.paymentQueue.add(payment)
     }
 
-    func finishTransaction(_ transaction: SKPaymentTransaction) {
-        Logger.purchase(Strings.purchase.finishing_transaction(transaction: transaction))
-        self.paymentQueue.finishTransaction(transaction)
-    }
-
     static func canMakePayments() -> Bool {
         return SKPaymentQueue.canMakePayments()
     }
@@ -102,6 +97,29 @@ class StoreKit1Wrapper: NSObject {
         payment.paymentDiscount = discount
         return payment
     }
+
+}
+
+extension StoreKit1Wrapper: PaymentQueueWrapperType {
+
+    @objc
+    func finishTransaction(_ transaction: SKPaymentTransaction) {
+        self.paymentQueue.finishTransaction(transaction)
+    }
+
+    #if os(iOS) || targetEnvironment(macCatalyst)
+    @available(iOS 13.4, macCatalyst 13.4, *)
+    func showPriceConsentIfNeeded() {
+        self.paymentQueue.showPriceConsentIfNeeded()
+    }
+    #endif
+
+    #if os(iOS)
+    @available(iOS 14.0, *)
+    func presentCodeRedemptionSheet() {
+        self.paymentQueue.presentCodeRedemptionSheetIfAvailable()
+    }
+    #endif
 
 }
 
@@ -158,15 +176,6 @@ extension StoreKit1Wrapper: SKPaymentQueueDelegate {
         return self.delegate?.storeKit1WrapperShouldShowPriceConsent ?? true
     }
     #endif
-
-}
-
-extension StoreKit1Wrapper {
-
-    /// Creates a `PaymentQueueWrapper` backed by the same `SKPaymentQueue`.
-    func createPaymentQueueWrapper() -> PaymentQueueWrapper {
-        return .init(paymentQueue: self.paymentQueue)
-    }
 
 }
 

--- a/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
@@ -31,7 +31,7 @@ internal struct SK1StoreTransaction: StoreTransactionType {
     let transactionIdentifier: String
     let quantity: Int
 
-    func finish(_ wrapper: StoreKit1Wrapper) {
+    func finish(_ wrapper: PaymentQueueWrapperType) {
         wrapper.finishTransaction(self.underlyingSK1Transaction)
     }
 

--- a/Sources/Purchasing/StoreKitAbstractions/SK2StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK2StoreTransaction.swift
@@ -32,8 +32,8 @@ internal struct SK2StoreTransaction: StoreTransactionType {
     let transactionIdentifier: String
     let quantity: Int
 
-    func finish(_ wrapper: StoreKit1Wrapper) {
-        Task<Void, Never> {
+    func finish(_ wrapper: PaymentQueueWrapperType) {
+        _ = Task<Void, Never> {
             await self.underlyingSK2Transaction.finish()
         }
     }

--- a/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
@@ -42,7 +42,9 @@ public typealias SK2Transaction = StoreKit.Transaction
     @objc public var transactionIdentifier: String { self.transaction.transactionIdentifier }
     @objc public var quantity: Int { self.transaction.quantity }
 
-    internal func finish(_ wrapper: StoreKit1Wrapper) { self.transaction.finish(wrapper) }
+    func finish(_ wrapper: PaymentQueueWrapperType) {
+        self.transaction.finish(wrapper)
+    }
 
     // swiftlint:enable missing_docs
 
@@ -85,7 +87,7 @@ internal protocol StoreTransactionType: Sendable {
 
     /// Indicates to the App Store that the app delivered the purchased content
     /// or enabled the service to finish the transaction.
-    func finish(_ wrapper: StoreKit1Wrapper)
+    func finish(_ wrapper: PaymentQueueWrapperType)
 
 }
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -123,21 +123,21 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     }
 
     fileprivate func setUpOrchestrator() {
-        orchestrator = PurchasesOrchestrator(productsManager: productsManager,
-                                             storeKit1Wrapper: storeKit1Wrapper,
-                                             systemInfo: systemInfo,
-                                             subscriberAttributes: attribution,
-                                             operationDispatcher: operationDispatcher,
-                                             receiptFetcher: receiptFetcher,
-                                             customerInfoManager: customerInfoManager,
-                                             backend: backend,
-                                             currentUserProvider: currentUserProvider,
-                                             transactionsManager: transactionsManager,
-                                             deviceCache: deviceCache,
-                                             offeringsManager: mockOfferingsManager,
-                                             manageSubscriptionsHelper: mockManageSubsHelper,
-                                             beginRefundRequestHelper: mockBeginRefundRequestHelper)
-        storeKit1Wrapper.delegate = orchestrator
+        self.orchestrator = PurchasesOrchestrator(productsManager: self.productsManager,
+                                                  paymentQueueWrapper: .left(self.storeKit1Wrapper),
+                                                  systemInfo: self.systemInfo,
+                                                  subscriberAttributes: self.attribution,
+                                                  operationDispatcher: self.operationDispatcher,
+                                                  receiptFetcher: self.receiptFetcher,
+                                                  customerInfoManager: self.customerInfoManager,
+                                                  backend: self.backend,
+                                                  currentUserProvider: self.currentUserProvider,
+                                                  transactionsManager: self.transactionsManager,
+                                                  deviceCache: self.deviceCache,
+                                                  offeringsManager: self.mockOfferingsManager,
+                                                  manageSubscriptionsHelper: self.mockManageSubsHelper,
+                                                  beginRefundRequestHelper: self.mockBeginRefundRequestHelper)
+        self.storeKit1Wrapper.delegate = self.orchestrator
     }
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -146,7 +146,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         storeKit2StorefrontListener: StoreKit2StorefrontListener
     ) {
         self.orchestrator = PurchasesOrchestrator(productsManager: self.productsManager,
-                                                  storeKit1Wrapper: self.storeKit1Wrapper,
+                                                  paymentQueueWrapper: .left(self.storeKit1Wrapper),
                                                   systemInfo: self.systemInfo,
                                                   subscriberAttributes: self.attribution,
                                                   operationDispatcher: self.operationDispatcher,

--- a/Tests/UnitTests/Misc/EitherTests.swift
+++ b/Tests/UnitTests/Misc/EitherTests.swift
@@ -1,0 +1,33 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  EitherTests.swift
+//
+//  Created by Nacho Soto on 10/10/22.
+
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+class EitherTests: TestCase {
+
+    func testLeft() throws {
+        let either: Either<Int, String> = .left(1)
+        expect(either.left) == 1
+        expect(either.right).to(beNil())
+    }
+
+    func testRight() throws {
+        let either: Either<Int, String> = .right("a")
+        expect(either.left).to(beNil())
+        expect(either.right) == "a"
+    }
+
+}

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -154,13 +154,13 @@ class BasePurchasesTests: TestCase {
 
     func initializePurchasesInstance(appUserId: String?, withDelegate: Bool = true) {
         // Note: this logic must match `Purchases`.
-        let storeKit1Wrapper = self.systemInfo.storeKit2Setting.shouldOnlyUseStoreKit2
-        ? nil
-        : self.storeKit1Wrapper
+        let paymentQueueWrapper: EitherPaymentQueueWrapper = self.systemInfo.storeKit2Setting.shouldOnlyUseStoreKit2
+            ? .right(self.paymentQueueWrapper)
+            : .left(self.storeKit1Wrapper)
 
         self.purchasesOrchestrator = PurchasesOrchestrator(
             productsManager: self.mockProductsManager,
-            storeKit1Wrapper: storeKit1Wrapper,
+            paymentQueueWrapper: paymentQueueWrapper,
             systemInfo: self.systemInfo,
             subscriberAttributes: self.attribution,
             operationDispatcher: self.mockOperationDispatcher,
@@ -190,8 +190,7 @@ class BasePurchasesTests: TestCase {
                                    attributionFetcher: self.attributionFetcher,
                                    attributionPoster: self.attributionPoster,
                                    backend: self.backend,
-                                   storeKit1Wrapper: storeKit1Wrapper,
-                                   paymentQueueWrapper: self.paymentQueueWrapper,
+                                   paymentQueueWrapper: paymentQueueWrapper,
                                    notificationCenter: self.notificationCenter,
                                    systemInfo: self.systemInfo,
                                    offeringsFactory: self.offeringsFactory,

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDeferredPurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDeferredPurchasesTests.swift
@@ -160,7 +160,7 @@ class PurchaseDeferredPurchasesSK2Tests: BasePurchasesTests {
         self.setupPurchases()
 
         self.product = MockSK1Product(mockProductIdentifier: "mock_product")
-        self.paymentQueueWrapperDelegate = self.paymentQueueWrapper.delegate
+        self.paymentQueueWrapperDelegate = try XCTUnwrap(self.paymentQueueWrapper.delegate)
     }
 
     func testDeferBlockMakesPayment() throws {

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -139,7 +139,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
 
         self.mockIdentityManager.mockIsAnonymous = false
         let purchasesOrchestrator = PurchasesOrchestrator(productsManager: mockProductsManager,
-                                                          storeKit1Wrapper: mockStoreKit1Wrapper,
+                                                          paymentQueueWrapper: .left(self.mockStoreKit1Wrapper),
                                                           systemInfo: systemInfo,
                                                           subscriberAttributes: attribution,
                                                           operationDispatcher: mockOperationDispatcher,
@@ -167,8 +167,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
                               attributionFetcher: mockAttributionFetcher,
                               attributionPoster: mockAttributionPoster,
                               backend: mockBackend,
-                              storeKit1Wrapper: mockStoreKit1Wrapper,
-                              paymentQueueWrapper: .init(),
+                              paymentQueueWrapper: .left(self.mockStoreKit1Wrapper),
                               notificationCenter: mockNotificationCenter,
                               systemInfo: systemInfo,
                               offeringsFactory: mockOfferingsFactory,


### PR DESCRIPTION
This is a follow up to #1901 and #1882. Depends on #1967.
Essentially before this change, `Purchases` had both `StoreKit1Wrapper?` and a `PaymentQueueWrapper`. The later wasn't actually needed when the first was not-nil, so it was essentially storing `(a?, b?)`. What we really wanted to express is that it could have one OR the other.

This introduces `Either` to express this requirement in the type system, as well as `PaymentQueueWrapperType` that will be used to fix #1964.
