### PR TITLE
`Async.call` method to convert completion-block call to `async`

### DIFF
--- a/Sources/FoundationExtensions/AsyncExtensions.swift
+++ b/Sources/FoundationExtensions/AsyncExtensions.swift
@@ -56,4 +56,17 @@ internal enum Async {
         }
     }
 
+    static func call<Value, Error: Swift.Error>(
+        method: (@escaping @Sendable (Result<Value, Error>) -> Void) -> Void
+    ) async throws -> Value {
+        return try await withCheckedThrowingContinuation { continuation in
+            @Sendable
+            func complete(_ result: Result<Value, Error>) {
+                continuation.resume(with: result)
+            }
+
+            method(complete)
+        }
+    }
+
 }

--- a/Sources/Purchasing/ProductsManager.swift
+++ b/Sources/Purchasing/ProductsManager.swift
@@ -139,20 +139,16 @@ extension ProductsManagerType {
     /// `async` overload for `products(withIdentifiers:)`
     @available(iOS 13.0, tvOS 13.0, watchOS 6.2, macOS 10.15, *)
     func products(withIdentifiers identifiers: Set<String>) async throws -> Set<StoreProduct> {
-        return try await withCheckedThrowingContinuation { continuation in
-            self.products(withIdentifiers: identifiers) { result in
-                continuation.resume(with: result)
-            }
+        return try await Async.call { completion in
+            self.products(withIdentifiers: identifiers, completion: completion)
         }
     }
 
     /// `async` overload for `sk2Products(withIdentifiers:)`
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func sk2Products(withIdentifiers identifiers: Set<String>) async throws -> Set<SK2StoreProduct> {
-        return try await withCheckedThrowingContinuation { continuation in
-            self.sk2Products(withIdentifiers: identifiers) { result in
-                continuation.resume(with: result)
-            }
+        return try await Async.call { completion in
+            self.sk2Products(withIdentifiers: identifiers, completion: completion)
         }
     }
 

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -466,11 +466,10 @@ final class PurchasesOrchestrator {
         forProductDiscount discount: StoreProductDiscountType,
         product: StoreProductType
     ) async throws -> PromotionalOffer {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await Async.call { completion in
             self.promotionalOffer(forProductDiscount: discount,
-                                  product: product) { result in
-                continuation.resume(with: result)
-            }
+                                  product: product,
+                                  completion: completion)
         }
     }
 
@@ -1095,12 +1094,11 @@ extension PurchasesOrchestrator {
     func syncPurchases(receiptRefreshPolicy: ReceiptRefreshPolicy,
                        isRestore: Bool,
                        initiationSource: ProductRequestData.InitiationSource) async throws -> CustomerInfo {
-        return try await withCheckedThrowingContinuation { continuation in
+        return try await Async.call { completion in
             self.syncPurchases(receiptRefreshPolicy: receiptRefreshPolicy,
                                isRestore: isRestore,
-                               initiationSource: initiationSource) { result in
-                continuation.resume(with: result)
-            }
+                               initiationSource: initiationSource,
+                               completion: completion)
         }
     }
 

--- a/Sources/Purchasing/StoreKit1/ProductsFetcherSK1.swift
+++ b/Sources/Purchasing/StoreKit1/ProductsFetcherSK1.swift
@@ -96,10 +96,8 @@ final class ProductsFetcherSK1: NSObject {
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func products(withIdentifiers identifiers: Set<String>) async throws -> Set<SK1StoreProduct> {
-        return try await withCheckedThrowingContinuation { continuation in
-            self.products(withIdentifiers: identifiers) { result in
-                continuation.resume(with: result)
-            }
+        return try await Async.call { completion in
+            self.products(withIdentifiers: identifiers, completion: completion)
         }
     }
 

--- a/Tests/StoreKitUnitTests/OfferingsManagerStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/OfferingsManagerStoreKitTests.swift
@@ -106,10 +106,8 @@ private extension OfferingsManager {
 
     @available(iOS 13.0, tvOS 13.0, watchOS 6.2, macOS 10.15, *)
     func offerings(appUserID: String) async throws -> Offerings {
-        return try await withCheckedThrowingContinuation { continuation in
-            self.offerings(appUserID: appUserID) { result in
-                continuation.resume(with: result)
-            }
+        return try await Async.call { completion in
+            self.offerings(appUserID: appUserID, completion: completion)
         }
     }
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -211,11 +211,10 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                                                             numberOfPeriods: 2,
                                                             type: .promotional)
 
-        _ = try await withCheckedThrowingContinuation { continuation in
+        _ = try await Async.call { completion in
             orchestrator.promotionalOffer(forProductDiscount: storeProductDiscount,
-                                          product: StoreProduct(sk1Product: product)) { result in
-                continuation.resume(with: result)
-            }
+                                          product: StoreProduct(sk1Product: product),
+                                          completion: completion)
         }
 
         expect(self.offerings.invokedPostOfferCount) == 1

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
@@ -144,7 +144,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
         let storeProduct = try await self.fetchSk2StoreProduct()
 
-        let status: IntroEligibilityStatus = try await withCheckedThrowingContinuation { continuation in
+        let status: IntroEligibilityStatus = await withCheckedContinuation { continuation in
             self.trialOrIntroPriceEligibilityChecker.checkEligibility(product: storeProduct) { status in
                 continuation.resume(returning: status)
             }
@@ -159,7 +159,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
         let storeProduct = try await self.fetchSk2StoreProduct("lifetime")
 
-        let status: IntroEligibilityStatus = try await withCheckedThrowingContinuation { continuation in
+        let status: IntroEligibilityStatus = await withCheckedContinuation { continuation in
             self.trialOrIntroPriceEligibilityChecker.checkEligibility(product: storeProduct) { status in
                 continuation.resume(returning: status)
             }
@@ -175,7 +175,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
         let sk2Product = try await self.fetchSk2Product()
         let storeProduct = StoreProduct(sk2Product: sk2Product)
 
-        let prePurchaseStatus: IntroEligibilityStatus = try await withCheckedThrowingContinuation { continuation in
+        let prePurchaseStatus: IntroEligibilityStatus = await withCheckedContinuation { continuation in
             self.trialOrIntroPriceEligibilityChecker.checkEligibility(product: storeProduct) { status in
                 continuation.resume(returning: status)
             }
@@ -185,7 +185,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
         _ = try await sk2Product.purchase()
 
-        let postPurchaseStatus: IntroEligibilityStatus = try await withCheckedThrowingContinuation { continuation in
+        let postPurchaseStatus: IntroEligibilityStatus = await withCheckedContinuation { continuation in
             self.trialOrIntroPriceEligibilityChecker.checkEligibility(product: storeProduct) { status in
                 continuation.resume(returning: status)
             }
@@ -203,7 +203,7 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
         // We can't fetch an invalid StoreProduct to pass into the
         // eligibility checker so this just fakes an unknown response,
         // regardless of the real status from the checker
-        let fakeStatus: IntroEligibilityStatus = try await withCheckedThrowingContinuation { continuation in
+        let fakeStatus: IntroEligibilityStatus = await withCheckedContinuation { continuation in
             self.trialOrIntroPriceEligibilityChecker.checkEligibility(product: storeProduct) { _ in
                 continuation.resume(returning: .unknown)
             }

--- a/Tests/UnitTests/FoundationExtensions/AsyncExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/AsyncExtensionsTests.swift
@@ -95,4 +95,29 @@ class AsyncExtensionsTests: TestCase {
         expect(result).toEventually(equal(expected))
     }
 
+    func testConversionToAsyncWithValue() async throws {
+        let expected = Int.random(in: 0..<100)
+
+        let result = try await Async.call { (completion: (Result<Int, NSError>) -> Void) in
+            completion(.success(expected))
+        }
+
+        expect(result) == expected
+    }
+
+    func testConversionToAsyncWithError() async throws {
+        enum Error: Swift.Error {
+            case error1
+        }
+
+        do {
+            let _: Int = try await Async.call { completion in
+                completion(.failure(Error.error1))
+            }
+            fail("Expected error")
+        } catch {
+            expect(error).to(matchError(Error.error1))
+        }
+    }
+
 }


### PR DESCRIPTION
This simplifies calling completion-block APIs as `async`. The opposite of what #1943 introduced.