### PR TITLE
Renamed `CallbackCache.add(callback:)`

### DIFF
--- a/Sources/Networking/Caching/CallbackCache.swift
+++ b/Sources/Networking/Caching/CallbackCache.swift
@@ -25,7 +25,7 @@ final class CallbackCache<T> where T: CacheKeyProviding {
 
     let cachedCallbacksByKey: Atomic<[String: [T]]> = .init([:])
 
-    func add(callback: T) -> CallbackCacheStatus {
+    func add(_ callback: T) -> CallbackCacheStatus {
         return self.cachedCallbacksByKey.modify { cachedCallbacksByKey in
             var values = cachedCallbacksByKey[callback.cacheKey] ?? []
             let cacheStatus: CallbackCacheStatus = !values.isEmpty ?

--- a/Sources/Networking/Caching/CustomerInfoCallback.swift
+++ b/Sources/Networking/Caching/CustomerInfoCallback.swift
@@ -35,9 +35,9 @@ extension CallbackCache where T == CustomerInfoCallback {
 
     func addOrAppendToPostReceiptDataOperation(callback: CustomerInfoCallback) -> CallbackCacheStatus {
         if let existing = self.callbacks(ofType: PostReceiptDataOperation.self).last {
-            return self.add(callback: callback.withNewCacheKey(existing.cacheKey))
+            return self.add(callback.withNewCacheKey(existing.cacheKey))
         } else {
-            return self.add(callback: callback)
+            return self.add(callback)
         }
     }
 

--- a/Sources/Networking/CustomerAPI.swift
+++ b/Sources/Networking/CustomerAPI.swift
@@ -113,7 +113,7 @@ final class CustomerAPI {
 
         let callbackObject = CustomerInfoCallback(operation: postReceiptOperation, completion: completion)
 
-        let cacheStatus = customerInfoCallbackCache.add(callback: callbackObject)
+        let cacheStatus = customerInfoCallbackCache.add(callbackObject)
 
         self.backendConfig.operationQueue.addCacheableOperation(postReceiptOperation, cacheStatus: cacheStatus)
     }

--- a/Sources/Networking/IdentityAPI.swift
+++ b/Sources/Networking/IdentityAPI.swift
@@ -36,7 +36,7 @@ class IdentityAPI {
                                             loginCallbackCache: self.logInCallbacksCache)
 
         let loginCallback = LogInCallback(cacheKey: loginOperation.cacheKey, completion: completion)
-        let cacheStatus = self.logInCallbacksCache.add(callback: loginCallback)
+        let cacheStatus = self.logInCallbacksCache.add(loginCallback)
 
         self.backendConfig.operationQueue.addCacheableOperation(loginOperation, cacheStatus: cacheStatus)
     }

--- a/Sources/Networking/OfferingsAPI.swift
+++ b/Sources/Networking/OfferingsAPI.swift
@@ -36,7 +36,7 @@ class OfferingsAPI {
                                                           offeringsCallbackCache: self.offeringsCallbacksCache)
 
         let offeringsCallback = OfferingsCallback(cacheKey: getOfferingsOperation.cacheKey, completion: completion)
-        let cacheStatus = self.offeringsCallbacksCache.add(callback: offeringsCallback)
+        let cacheStatus = self.offeringsCallbacksCache.add(offeringsCallback)
 
         self.backendConfig.addCacheableOperation(getOfferingsOperation,
                                                  withRandomDelay: randomDelay,


### PR DESCRIPTION
This is the Swifty way to avoid the duplication in `cache.add(callback: callback)`.