### PR TITLE
`ErrorUtils.purchasesError(withUntypedError:)` handle `PurchasesErrorConvertible`

### DIFF
--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -293,6 +293,8 @@ enum ErrorUtils {
         switch error {
         case let purchasesError as PurchasesError:
             return purchasesError
+        case let convertible as PurchasesErrorConvertible:
+            return convertible.asPurchasesError
         default:
             return ErrorUtils.unknownError(
                 error: error,

--- a/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
+++ b/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
@@ -72,6 +72,27 @@ class ErrorUtilsTests: TestCase {
         }
     }
 
+    func testPurchasesErrorWithUntypedPurchasesError() throws {
+        let error = ErrorUtils.offlineConnectionError()
+
+        expect(ErrorUtils.purchasesError(withUntypedError: error)).to(matchError(error))
+    }
+
+    func testPurchasesErrorWithUntypedBackendError() throws {
+        let error: BackendError = .missingAppUserID()
+        let expected = error.asPurchasesError
+
+        expect(ErrorUtils.purchasesError(withUntypedError: error)).to(matchError(expected))
+    }
+
+    func testPublicErrorFromUntypedBackendError() throws {
+        let error: BackendError = .missingAppUserID()
+        let expected = error.asPublicError
+
+        expect(ErrorUtils.purchasesError(withUntypedError: error).asPublicError)
+            .to(matchError(expected))
+    }
+
     func testPurchaseErrorsAreLoggedAsApppleErrors() {
         let underlyingError = NSError(domain: SKErrorDomain, code: SKError.Code.paymentInvalid.rawValue)
         let error = ErrorUtils.purchaseNotAllowedError(error: underlyingError)


### PR DESCRIPTION
This allows methods throwing something like `BackendError` and converting it to `PurchasesError` automatically.