### PR TITLE
`ErrorUtils`: improved logging and `localizedDescription` to include underlying errors

### DIFF
--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -293,6 +293,8 @@ enum ErrorUtils {
         switch error {
         case let purchasesError as PurchasesError:
             return purchasesError
+        case let convertible as PurchasesErrorConvertible:
+            return convertible.asPurchasesError
         default:
             return ErrorUtils.unknownError(
                 error: error,

--- a/Tests/UnitTests/Networking/NetworkErrorTests.swift
+++ b/Tests/UnitTests/Networking/NetworkErrorTests.swift
@@ -91,7 +91,12 @@ class NetworkErrorAsPurchasesErrorTests: BaseErrorTests {
         let nsError = error.asPurchasesError as NSError
 
         expect(nsError.subscriberAttributesErrors) == errorResponse.attributeErrors
-        expect(nsError.localizedDescription) == errorResponse.attributeErrors.description
+        expect(nsError.localizedDescription) == [
+            errorResponse.code.toPurchasesErrorCode().description,
+            errorResponse.attributeErrors.description
+
+        ]
+            .joined(separator: " ")
     }
 
     func testErrorResponseWithNoAttributeErrors() throws {
@@ -113,7 +118,12 @@ class NetworkErrorAsPurchasesErrorTests: BaseErrorTests {
         let nsError = error.asPurchasesError as NSError
 
         expect(nsError.subscriberAttributesErrors).to(beNil())
-        expect(nsError.localizedDescription) == errorResponse.code.toPurchasesErrorCode().description
+        expect(nsError.localizedDescription) == [
+            errorResponse.code.toPurchasesErrorCode().description,
+            errorResponse.message!
+
+        ]
+            .joined(separator: " ")
     }
 
 }

--- a/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
+++ b/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
@@ -72,6 +72,27 @@ class ErrorUtilsTests: TestCase {
         }
     }
 
+    func testPurchasesErrorWithUntypedPurchasesError() throws {
+        let error = ErrorUtils.offlineConnectionError()
+
+        expect(ErrorUtils.purchasesError(withUntypedError: error)).to(matchError(error))
+    }
+
+    func testPurchasesErrorWithUntypedBackendError() throws {
+        let error: BackendError = .missingAppUserID()
+        let expected = error.asPurchasesError
+
+        expect(ErrorUtils.purchasesError(withUntypedError: error)).to(matchError(expected))
+    }
+
+    func testPublicErrorFromUntypedBackendError() throws {
+        let error: BackendError = .missingAppUserID()
+        let expected = error.asPublicError
+
+        expect(ErrorUtils.purchasesError(withUntypedError: error).asPublicError)
+            .to(matchError(expected))
+    }
+
     func testPurchaseErrorsAreLoggedAsApppleErrors() {
         let underlyingError = NSError(domain: SKErrorDomain, code: SKError.Code.paymentInvalid.rawValue)
         let error = ErrorUtils.purchaseNotAllowedError(error: underlyingError)


### PR DESCRIPTION
## Changes:
- `Error.localizedDescription` now matches the message being logged. Improvements introduced in #1776, for example, now apply to the description too.
- Logged `BackendError` messages now include underlying error.

## Examples:

The following errors are improved:

### `BackendError`:
- Before:
>  😿‼️ There was an unknown backend error.

- After:
> 😿‼️ There was an unknown backend error. Page not found

### API key error:
- Before:
> 😿‼️ There was a credentials issue. Check the underlying error for more details.

- After:
> 😿‼️ There was a credentials issue. Check the underlying error for more details. Invalid API key

### Attribute errors:
- Before:
> ["$email": "invalid"]

- After:
> One or more of the attributes sent could not be saved. ["$email": "invalid"]