### PR TITLE
`OfferingsManager`: added ability to fail if any product is not found

### DIFF
--- a/Sources/Logging/Strings/OfferingStrings.swift
+++ b/Sources/Logging/Strings/OfferingStrings.swift
@@ -34,7 +34,7 @@ enum OfferingStrings {
     case fetching_products_finished
     case fetching_products(identifiers: Set<String>)
     case completion_handlers_waiting_on_products(handlersCount: Int)
-    case configuration_error_skproducts_not_found
+    case configuration_error_products_not_found
     case configuration_error_no_products_for_offering
     case offering_empty(offeringIdentifier: String)
     case product_details_empty_title(productIdentifier: String)
@@ -48,7 +48,7 @@ extension OfferingStrings: CustomStringConvertible {
     var description: String {
         switch self {
         case .cannot_find_product_configuration_error(let identifiers):
-            return "Could not find SKProduct for \(identifiers) " +
+            return "Could not find products with identifiers: \(identifiers)." +
                 "\nThere is a problem with your configuration in App Store Connect. " +
                 "\nMore info here: https://errors.rev.cat/configuring-products"
 
@@ -107,7 +107,7 @@ extension OfferingStrings: CustomStringConvertible {
         case .completion_handlers_waiting_on_products(let handlersCount):
             return "\(handlersCount) completion handlers waiting on products"
 
-        case .configuration_error_skproducts_not_found:
+        case .configuration_error_products_not_found:
             return "There's a problem with your configuration. None of the products registered in the RevenueCat " +
             "dashboard could be fetched from App Store Connect (or the StoreKit Configuration file " +
             "if one is being used). \nMore information: https://rev.cat/why-are-offerings-empty"

--- a/Sources/Misc/Purchases+async.swift
+++ b/Sources/Misc/Purchases+async.swift
@@ -34,9 +34,9 @@ extension Purchases {
         }
     }
 
-    func offeringsAsync() async throws -> Offerings {
+    func offeringsAsync(fetchPolicy: OfferingsManager.FetchPolicy) async throws -> Offerings {
         return try await withCheckedThrowingContinuation { continuation in
-            getOfferings { offerings, error in
+            self.getOfferings(fetchPolicy: fetchPolicy) { offerings, error in
                 continuation.resume(with: Result(offerings, error))
             }
         }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -570,15 +570,28 @@ public extension Purchases {
     func logOut() async throws -> CustomerInfo {
         return try await logOutAsync()
     }
+
     @objc func getOfferings(completion: @escaping (Offerings?, PublicError?) -> Void) {
-        self.offeringsManager.offerings(appUserID: appUserID) { result in
+        self.getOfferings(fetchPolicy: .default, completion: completion)
+    }
+
+    internal func getOfferings(
+        fetchPolicy: OfferingsManager.FetchPolicy,
+        completion: @escaping (Offerings?, PublicError?) -> Void
+    ) {
+        self.offeringsManager.offerings(appUserID: self.appUserID, fetchPolicy: fetchPolicy) { result in
             completion(result.value, result.error?.asPublicError)
         }
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func offerings() async throws -> Offerings {
-        return try await offeringsAsync()
+        return try await self.offerings(fetchPolicy: .default)
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    internal func offerings(fetchPolicy: OfferingsManager.FetchPolicy) async throws -> Offerings {
+        return try await self.offeringsAsync(fetchPolicy: fetchPolicy)
     }
 
 }

--- a/Tests/UnitTests/Mocks/MockOfferingsManager.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsManager.swift
@@ -14,24 +14,31 @@
 import Foundation
 @testable import RevenueCat
 
+// swiftlint:disable identifier_name large_tuple
+
 // Note: this class is implicitly `@unchecked Sendable` through its parent
 // even though it's not actually thread safe.
-// swiftlint:disable identifier_name
 class MockOfferingsManager: OfferingsManager {
 
 typealias OfferingsCompletion = @MainActor @Sendable (Result<Offerings, Error>) -> Void
 
     var invokedOfferings = false
     var invokedOfferingsCount = 0
-    var invokedOfferingsParameters: (appUserID: String, completion: OfferingsCompletion?)?
-    var invokedOfferingsParametersList = [(appUserID: String, completion: OfferingsCompletion??)]()
+    var invokedOfferingsParameters: (appUserID: String,
+                                     fetchPolicy: FetchPolicy,
+                                     completion: OfferingsCompletion?)?
+    var invokedOfferingsParametersList = [(appUserID: String,
+                                           fetchPolicy: FetchPolicy,
+                                           completion: OfferingsCompletion??)]()
     var stubbedOfferingsCompletionResult: Result<Offerings, Error>?
 
-    override func offerings(appUserID: String, completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?) {
+    override func offerings(appUserID: String,
+                            fetchPolicy: FetchPolicy,
+                            completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?) {
         self.invokedOfferings = true
         self.invokedOfferingsCount += 1
-        self.invokedOfferingsParameters = (appUserID, completion)
-        self.invokedOfferingsParametersList.append((appUserID, completion))
+        self.invokedOfferingsParameters = (appUserID, fetchPolicy, completion)
+        self.invokedOfferingsParametersList.append((appUserID, fetchPolicy, completion))
 
         OperationDispatcher.dispatchOnMainActor { [result = self.stubbedOfferingsCompletionResult] in
             completion?(result!)
@@ -41,6 +48,7 @@ typealias OfferingsCompletion = @MainActor @Sendable (Result<Offerings, Error>) 
     struct InvokedUpdateOfferingsCacheParameters {
         let appUserID: String
         let isAppBackgrounded: Bool
+        let fetchPolicy: OfferingsManager.FetchPolicy
         let completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
     }
 
@@ -53,6 +61,7 @@ typealias OfferingsCompletion = @MainActor @Sendable (Result<Offerings, Error>) 
     override func updateOfferingsCache(
         appUserID: String,
         isAppBackgrounded: Bool,
+        fetchPolicy: OfferingsManager.FetchPolicy,
         completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
     ) {
         self.invokedUpdateOfferingsCache = true
@@ -61,6 +70,7 @@ typealias OfferingsCompletion = @MainActor @Sendable (Result<Offerings, Error>) 
         let parameters = InvokedUpdateOfferingsCacheParameters(
             appUserID: appUserID,
             isAppBackgrounded: isAppBackgrounded,
+            fetchPolicy: fetchPolicy,
             completion: completion
         )
 


### PR DESCRIPTION
The default behavior is unchanged: if any products aren't found, those are logged, but an `Offerings` value is returned with the found products.

This introduces a new `OfferingsManager.FetchPolicy` that allows receiving an error if any product is not found. For the time being, this is `internal` only, and will be used for [CSDK-451], since we don't want to ignore those errors when using this new SDK tester.

[CSDK-451]: https://revenuecats.atlassian.net/browse/CSDK-451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ