### PR TITLE
`TrialOrIntroPriceEligibilityChecker`: only use SK2 implementation if enabled

### DIFF
--- a/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -54,8 +54,8 @@ class TrialOrIntroPriceEligibilityChecker {
             return
         }
 
-        // Note: this uses SK2 (unless it's explicitly disabled) because its implementation is more accurate.
-        if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *), self.systemInfo.storeKit2Setting != .disabled {
+        if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *),
+            self.systemInfo.storeKit2Setting.usesStoreKit2IfAvailable {
             Async.call(with: completion) {
                 do {
                     return try await self.sk2CheckEligibility(productIdentifiers)


### PR DESCRIPTION
This is similar to #1894, but as a permanent change.

This used to always default to the SK2 implementation if it was available because it was much more reliable.
However, as we've learned (#1893), it can be significantly slow.

Until we implement caching for it ([CSDK-493]), this for now allows users to disable it if it's too slow.

For users that don't specify `useSk2IfAvailable`, SK2 is now the new default, so this class will continue to use the "better" implementation for them too.

[CSDK-493]: https://revenuecats.atlassian.net/browse/CSDK-493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ