### PR TITLE
CI: removed redundant `swiftlint` installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,9 +365,6 @@ jobs:
     <<: *base-job
     steps:
       - checkout
-      - run:
-          name: Install swiftlint
-          command: brew install swiftlint
       - install-dependencies
       - run:
           name: Build tvOS, watchOS and macOS


### PR DESCRIPTION
That's already part of `install-dependencies`.