### PR TITLE
Documentation: fixed missing docs from inherited symbols

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -722,8 +722,7 @@ workflows:
           xcode_version: '13.4.1'
           <<: *release-tags
       - docs-deploy:
-          # Not using Xcode 14 yet because it does not contain the new macOS SDK until Ventura is released.
-          xcode_version: '13.4.1'
+          xcode_version: '14.1.0'
           <<: *release-tags
       - notify-on-non-patch-release-branches:
           <<: *non-patch-release-branches

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -376,23 +376,37 @@ platform :ios do
     )
   end
 
+  private_lane :build_symbols_for_docs do
+    sh("swift",
+       "build",
+       "--target", "RevenueCat",
+       "-Xswiftc", "-emit-symbol-graph",
+       "-Xswiftc", "-emit-symbol-graph-dir",
+       "-Xswiftc", ".build")
+  end
+
   desc "Preview docs"
   lane :preview_docs do
     ENV["INCLUDE_DOCC_PLUGIN"] = "true"
     Dir.chdir("..") do
+      build_symbols_for_docs
+
       sh("swift",
          "package",
          "--disable-sandbox",
          "preview-documentation",
          "--target",
          "RevenueCat",
-         "--transform-for-static-hosting")
+         "--transform-for-static-hosting",
+         "--enable-inherited-docs",
+         "--additional-symbol-graph-dir", ".build")
     end
   end
 
   desc "Generate docs"
   lane :generate_docs do
     ENV["INCLUDE_DOCC_PLUGIN"] = "true"
+
     version_number = current_version_number
     docs_repo_base_url = ENV["DOCS_REPO_BASE_URL"]
     docs_repo_name = ENV["DOCS_REPO_NAME"]
@@ -406,6 +420,8 @@ platform :ios do
       # swift package must be run from the dir that contains the Package.swift
       # output is generated in docs_generation_folder
       Dir.chdir("..") do
+        build_symbols_for_docs
+
         sh("swift",
            "package",
            "--disable-sandbox",
@@ -419,7 +435,10 @@ platform :ios do
            docs_generation_folder,
            "--hosting-base-path",
            hosting_base_path,
-           "--transform-for-static-hosting")
+           "--transform-for-static-hosting",
+           "--enable-inherited-docs",
+           "--additional-symbol-graph-dir", ".build")
+           
         docs_index_path = File.join(Dir.pwd, "scripts/docs/index.html")
         # clone docs repo
         Dir.mktmpdir do |docs_repo_clone_dir|
@@ -430,7 +449,7 @@ platform :ios do
               # and push the changes
               docs_destination_folder = "docs/#{version_number}"
               index_destination_path = "docs/index.html"
-              FileUtils.cp_r docs_generation_folder, docs_destination_folder
+              FileUtils.cp_r docs_generation_folder + "/.", docs_destination_folder
               FileUtils.cp docs_index_path, index_destination_path
 
               # using sh instead of fastlane commands because fastlane would run


### PR DESCRIPTION
Fixes [CSDK-508].

#1912 moved all the docs to the `protocol`. The generated docs locally were correct, so I didn't notice that [the online docs](https://revenuecat.github.io/purchases-ios-docs/4.13.2/documentation/revenuecat/purchases/offerings()) were wrong.

I checked and Xcode was generating them with an extra parameter:
<img width="1000" alt="Screenshot 2022-10-25 at 12 04 38" src="https://user-images.githubusercontent.com/685609/197862253-2afc66a3-bfcf-40af-a0c2-32e2d793c759.png">

This is also [documented](https://www.swift.org/documentation/docc/documenting-a-swift-framework-or-package), and it works like magic.

`--enable-inherited-docs` doesn't seem to be needed to fix this, but it doesn't hurt to be explicit.

[CSDK-508]: https://revenuecats.atlassian.net/browse/CSDK-508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ