### PR TITLE
`PurchaseTesterSwiftUI`: allow configuring API key at runtime

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Constants.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Constants.swift
@@ -15,8 +15,8 @@ struct Constants {
 
     /*
      The API key for your app from the RevenueCat dashboard: https://app.revenuecat.com
+     This is the default used by `ConfigurationView`
      */
-    #error("Modify this property to reflect your app's API key, then comment this line out.")
     static let apiKey = "REVENUECAT_API_KEY"
 
 }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Constants.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Constants.swift
@@ -19,7 +19,4 @@ struct Constants {
     #error("Modify this property to reflect your app's API key, then comment this line out.")
     static let apiKey = "REVENUECAT_API_KEY"
 
-    // Server URL. Can be set to something else to use a proxy.
-    static let proxyURL: String? = nil
-    
 }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
@@ -24,6 +24,10 @@
 		2CF4286428637559007E6A78 /* RevenueCat.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2CF4286328637559007E6A78 /* RevenueCat.framework */; };
 		2CF4286528637559007E6A78 /* RevenueCat.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2CF4286328637559007E6A78 /* RevenueCat.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2CF428692863EEAC007E6A78 /* Package+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF428682863EEAC007E6A78 /* Package+Extensions.swift */; };
+		57ED6A80290886B6009580C6 /* ConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ED6A7F290886B6009580C6 /* ConfigurationView.swift */; };
+		57ED6A8229089111009580C6 /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ED6A8129089111009580C6 /* Identifiable.swift */; };
+		57ED6A84290891AF009580C6 /* ConfiguredPurchases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ED6A83290891AF009580C6 /* ConfiguredPurchases.swift */; };
+		57ED6A86290893B6009580C6 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ED6A85290893B6009580C6 /* Extensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -59,6 +63,10 @@
 		2CD2C4F5278C9B02005D1CC2 /* PurchaseTester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PurchaseTester.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CF4286328637559007E6A78 /* RevenueCat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RevenueCat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CF428682863EEAC007E6A78 /* Package+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Package+Extensions.swift"; sourceTree = "<group>"; };
+		57ED6A7F290886B6009580C6 /* ConfigurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationView.swift; sourceTree = "<group>"; };
+		57ED6A8129089111009580C6 /* Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
+		57ED6A83290891AF009580C6 /* ConfiguredPurchases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfiguredPurchases.swift; sourceTree = "<group>"; };
+		57ED6A85290893B6009580C6 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		57FA0F7C2908503B00E9EA1B /* PurchaseTester.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PurchaseTester.entitlements; sourceTree = "<group>"; };
 		57FD7B2628DA6A44009CA4E4 /* RevenueCat.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RevenueCat.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -79,6 +87,7 @@
 			isa = PBXGroup;
 			children = (
 				2CD2C4EF278C9B01005D1CC2 /* ContentView.swift */,
+				57ED6A7F290886B6009580C6 /* ConfigurationView.swift */,
 				2C10F18427A995150078444D /* HomeView.swift */,
 				2C10F18927A996F10078444D /* Customer */,
 				2C10F18827A996B80078444D /* Offerings */,
@@ -136,6 +145,7 @@
 				2CF428672863EE9D007E6A78 /* Extensions */,
 				2C10F18727A9952B0078444D /* Views */,
 				2CD2C4F0278C9B02005D1CC2 /* Assets.xcassets */,
+				57ED6A83290891AF009580C6 /* ConfiguredPurchases.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -161,6 +171,8 @@
 			isa = PBXGroup;
 			children = (
 				2CF428682863EEAC007E6A78 /* Package+Extensions.swift */,
+				57ED6A8129089111009580C6 /* Identifiable.swift */,
+				57ED6A85290893B6009580C6 /* Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -241,17 +253,21 @@
 			buildActionMask = 2147483647;
 			files = (
 				2C10F19427AC319A0078444D /* EntitlementsView.swift in Sources */,
+				57ED6A80290886B6009580C6 /* ConfigurationView.swift in Sources */,
 				2C10F18E27AAD1F00078444D /* TextFieldAlert.swift in Sources */,
 				2CD2C518278C9B02005D1CC2 /* ContentView.swift in Sources */,
 				2CF428692863EEAC007E6A78 /* Package+Extensions.swift in Sources */,
 				2C10F17F27A993EA0078444D /* OfferingDetailView.swift in Sources */,
 				2C10F18527A995150078444D /* HomeView.swift in Sources */,
 				2C10F19127AC31610078444D /* TransactionsView.swift in Sources */,
+				57ED6A84290891AF009580C6 /* ConfiguredPurchases.swift in Sources */,
 				2C10F18B27A997570078444D /* CustomerView.swift in Sources */,
 				2C10F19A27AC32840078444D /* SubscriberAttributesView.swift in Sources */,
 				2CD2C516278C9B02005D1CC2 /* PurchaseTesterApp.swift in Sources */,
 				2C10F18227A9943D0078444D /* PromoOfferDetailsView.swift in Sources */,
 				2C10F19727AC31B80078444D /* CustomerInfoView.swift in Sources */,
+				57ED6A86290893B6009580C6 /* Extensions.swift in Sources */,
+				57ED6A8229089111009580C6 /* Identifiable.swift in Sources */,
 				2CCAF2AC2862330F0004E2CA /* Constants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ConfiguredPurchases.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ConfiguredPurchases.swift
@@ -1,0 +1,52 @@
+//
+//  ConfiguredPurchases.swift
+//  PurchaseTester
+//
+//  Created by Nacho Soto on 10/25/22.
+//
+
+import RevenueCat
+
+final class ConfiguredPurchases {
+
+    let purchases: Purchases
+    private let delegate: Delegate
+
+    init(purchases: Purchases) {
+        self.purchases = purchases
+        self.delegate = Delegate()
+
+        self.purchases.delegate = self.delegate
+    }
+
+    convenience init(
+        apiKey: String,
+        proxyURL: String?,
+        useStoreKit2: Bool
+    ) {
+        Purchases.logLevel = .debug
+
+        if let proxyURL {
+            Purchases.proxyURL = URL(string: proxyURL)!
+        }
+
+        let purchases = Purchases.configure(
+            with: .builder(withAPIKey: apiKey)
+                .with(usesStoreKit2IfAvailable: useStoreKit2)
+                .build()
+        )
+
+        self.init(purchases: purchases)
+    }
+
+}
+
+private final class Delegate: NSObject, PurchasesDelegate {
+
+    func purchases(_ purchases: Purchases, readyForPromotedProduct product: StoreProduct, purchase makeDeferredPurchase: @escaping StartPurchaseBlock) {
+        makeDeferredPurchase { (transaction, customerInfo, error, success) in
+            print("Yay")
+        }
+    }
+
+}

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Extensions/Extensions.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Extensions/Extensions.swift
@@ -1,0 +1,20 @@
+//
+//  Extensions.swift
+//  PurchaseTester
+//
+//  Created by Nacho Soto on 10/25/22.
+//
+
+import Foundation
+
+extension String {
+
+    var nonEmpty: String? {
+        let trimmed = self.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return trimmed.isEmpty
+            ? nil
+            : trimmed
+    }
+
+}

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Extensions/Identifiable.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Extensions/Identifiable.swift
@@ -1,0 +1,24 @@
+//
+//  Identifiable.swift
+//  PurchaseTester
+//
+//  Created by Nacho Soto on 10/25/22.
+//
+
+import RevenueCat
+
+extension StoreProduct: Identifiable {
+
+    public var id: String {
+        return self.productIdentifier
+    }
+
+}
+
+extension NonSubscriptionTransaction: Identifiable {
+
+    public var id: String {
+        return self.productIdentifier
+    }
+
+}

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
@@ -20,6 +20,15 @@ struct PurchaseTesterApp: App {
             NavigationView {
                 if let configuration {
                     ContentView(configuration: configuration)
+                        .toolbar {
+                            ToolbarItem(placement: .navigationBarLeading) {
+                                Button {
+                                    self.configuration = nil
+                                } label: {
+                                    Text("Reconfigure")
+                                }
+                            }
+                        }
                 } else {
                     ConfigurationView { data in
                         self.configuration = .init(
@@ -30,7 +39,14 @@ struct PurchaseTesterApp: App {
                     }
                 }
             }
+            .navigationViewStyle(.stack)
+            .animation(.default, value: self.isConfigured)
+            .transition(.opacity)
         }
+    }
+
+    private var isConfigured: Bool {
+        return self.configuration != nil
     }
 
 }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/ConfigurationView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/ConfigurationView.swift
@@ -1,0 +1,86 @@
+//
+//  ConfigurationView.swift
+//  PurchaseTester
+//
+//  Created by Nacho Soto on 10/25/22.
+//
+
+import SwiftUI
+
+import RevenueCat
+
+struct ConfigurationView: View {
+
+    struct Data {
+        var apiKey: String = Constants.apiKey.replacingOccurrences(of: "REVENUECAT_API_KEY",
+                                                                   with: "")
+        var proxy: String = ""
+        var storeKit2Enabled: Bool = true
+    }
+
+    @State
+    private var data: Data = .init()
+
+    let onContinue: (Data) -> Void
+
+    var body: some View {
+        Form {
+            Section(header: Text("Configuration")) {
+                TextField("API Key (required)", text: self.$data.apiKey)
+
+                TextField("Proxy URL (optional)", text: self.$data.proxy)
+            }
+
+            Section {
+                Toggle(isOn: self.$data.storeKit2Enabled) {
+                    Text("StoreKit2 enabled")
+                }
+            }
+
+            Section(header: Text("About")) {
+                HStack {
+                    Text("Version")
+                    Spacer()
+                    Text(Purchases.frameworkVersion)
+                }
+            }
+        }
+
+        .textInputAutocapitalization(.never)
+        .autocorrectionDisabled(true)
+        .navigationTitle("Purchase Tester")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    self.onContinue(self.data)
+                } label: {
+                    Text("Continue")
+                }
+                .disabled(!self.contentIsValid)
+            }
+        }
+    }
+
+    private var contentIsValid: Bool {
+        let apiKeyIsValid = !self.data.apiKey
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty
+        let proxyIsValid = self.data.proxy
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty
+        || URL(string: self.data.proxy) != nil
+
+        return apiKeyIsValid && proxyIsValid
+    }
+
+}
+
+// MARK: -
+
+struct ConfigurationView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            ConfigurationView { _ in }
+        }
+    }
+}

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/ContentView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/ContentView.swift
@@ -10,9 +10,28 @@ import SwiftUI
 import RevenueCat
 
 struct ContentView: View {
+
+    let configuration: ConfiguredPurchases
+
+    @StateObject
+    private var revenueCatCustomerData = RevenueCatCustomerData()
+
     var body: some View {
-        NavigationView {
-            HomeView()
-        }
+        HomeView()
+            .environmentObject(self.revenueCatCustomerData)
+            .task {
+                for await customerInfo in self.configuration.purchases.customerInfoStream {
+                    self.revenueCatCustomerData.customerInfo = customerInfo
+                    self.revenueCatCustomerData.appUserID = self.configuration.purchases.appUserID
+                }
+            }
     }
+
+}
+
+final class RevenueCatCustomerData: ObservableObject {
+
+    @Published var appUserID: String? = nil
+    @Published var customerInfo: CustomerInfo? = nil
+
 }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
@@ -16,6 +16,8 @@ struct HomeView: View {
     
     @State private var showingAlert = false
     @State private var newAppUserID: String = ""
+
+    @State private var error: Error?
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -103,6 +105,18 @@ struct HomeView: View {
                 }
 
         }
+        .alert(
+            isPresented: .constant(self.error != nil),
+            error: LocalizedAlertError(self.error),
+            actions: { _ in
+                Button("OK") {
+                    self.error = nil
+                }
+            },
+            message: { error in
+                Text((error.underlyingError as NSError).debugDescription)
+            }
+        )
         .navigationTitle("PurchaseTester")
         .textFieldAlert(isShowing: self.$showingAlert, title: "App User ID", fields: [("User ID", "ID of your user", self.$newAppUserID)]) {
             guard !self.newAppUserID.isEmpty else {
@@ -116,6 +130,7 @@ struct HomeView: View {
                     print("🚀 Info 💁‍♂️ - Created: \(created)")
                 } catch {
                     print("🚀 Info 💁‍♂️ - Error: \(error)")
+                    self.error = error
                 }
             }
         }
@@ -129,6 +144,7 @@ struct HomeView: View {
             })
         } catch {
             print("🚀 Info 💁‍♂️ - Error: \(error)")
+            self.error = error
         }
     }
     
@@ -143,6 +159,7 @@ struct HomeView: View {
             print("🚀 Info 💁‍♂️ - Customer Info: \(customerInfo)")
         } catch {
             print("🚀 Failed logging out 💁‍♂️ - Error: \(error)")
+            self.error = error
         }
     }
 }
@@ -231,4 +248,18 @@ private struct OfferingItemView: View {
             Text("\(offering.availablePackages.count) package(s)")
         }
     }
+}
+
+private struct LocalizedAlertError: LocalizedError {
+
+    let underlyingError: Error
+
+    var errorDescription: String? { (self.underlyingError as NSError).localizedDescription }
+    var recoverySuggestion: String? { (self.underlyingError as NSError).localizedRecoverySuggestion }
+
+    init?(_ error: Error?) {
+        guard let error else { return nil }
+        self.underlyingError = error
+    }
+
 }


### PR DESCRIPTION
Fixes [CSDK-456].

### Configuration screen:
![Simulator Screen Shot - iPhone 13 Pro Max - 2022-10-25 at 15 02 26](https://user-images.githubusercontent.com/685609/197890837-3160d9cd-72e0-45d7-8e9e-f248b0dd93c5.png)

### Displaying errors:
_Note that if you enter an invalid API key and there's a credentials issue, you can tap on "reconfigure" to start over:

![Simulator Screen Shot - iPhone 13 Pro - 2022-10-26 at 13 35 42](https://user-images.githubusercontent.com/685609/198134117-d80f7c28-922b-4c48-be83-9b8ec03de299.png)

[CSDK-456]: https://revenuecats.atlassian.net/browse/CSDK-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ