### PR TITLE
Docs: fixed `logIn` references

### DIFF
--- a/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
@@ -60,8 +60,8 @@ Most features require configuring the SDK before using it.
 ### Identifying Users
 - ``Purchases/appUserID``
 - ``Purchases/isAnonymous``
-- ``Purchases/logIn(_:)``
-- ``Purchases/logIn(_:completion:)``
+- ``Purchases/logIn(_:)-arja``
+- ``Purchases/logIn(_:completion:)-4km90``
 - ``Purchases/logOut()``
 - ``Purchases/logOut(completion:)``
 

--- a/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md
@@ -104,8 +104,8 @@ Or browse our iOS sample apps:
 - ``Purchases/customerInfoStream``
 
 ### Identifying Users
-- ``Purchases/logIn(_:)``
-- ``Purchases/logIn(_:completion:)``
+- ``Purchases/logIn(_:)-arja``
+- ``Purchases/logIn(_:completion:)-4km90``
 - ``Purchases/logOut()``
 - ``Purchases/logOut(completion:)``
 


### PR DESCRIPTION
These became ambiguous after #1958.