### PR TITLE
`Async.call`: added non-throwing overload

### DIFF
--- a/Sources/FoundationExtensions/AsyncExtensions.swift
+++ b/Sources/FoundationExtensions/AsyncExtensions.swift
@@ -18,6 +18,13 @@ internal enum Async {
 
     /// Invokes an `async throws` method and calls `completion` with the result.
     /// Ensures that the returned error is `PublicError`.
+    ///
+    /// Example:
+    /// ```swift
+    /// Async.call(with: completion) {
+    ///     return try await asynchronousMethod()
+    /// }
+    /// ```
     static func call<T>(
         with completion: @escaping (Result<T, PublicError>) -> Void,
         asyncMethod method: @escaping () async throws -> T
@@ -33,6 +40,13 @@ internal enum Async {
 
     /// Invokes an `async throws` method and calls `completion` with the result.
     /// Ensures that the returned error is `PurchasesError`.
+    ///
+    /// Example:
+    /// ```swift
+    /// Async.call(with: completion) {
+    ///     return try await asynchronousMethod()
+    /// }
+    /// ```
     static func call<T>(
         with completion: @escaping (Result<T, PurchasesError>) -> Void,
         asyncMethod method: @escaping () async throws -> T
@@ -57,6 +71,13 @@ internal enum Async {
     }
 
     /// Invokes a completion-block based API and returns the `throw`ing method `async`hronously.
+    ///
+    /// Example:
+    /// ```swift
+    /// let result = try await Async.call { completion in
+    ///     completionBlockAPI(completion)
+    /// }
+    /// ```
     static func call<Value, Error: Swift.Error>(
         method: (@escaping @Sendable (Result<Value, Error>) -> Void) -> Void
     ) async throws -> Value {
@@ -70,7 +91,14 @@ internal enum Async {
         }
     }
 
-    /// Invokes a completion-block based API and returns the method `async`hronoiusly.
+    /// Invokes a completion-block based API and returns the method `async`hronously.
+    ///
+    /// Example:
+    /// ```swift
+    /// let result = await Async.call { completion in
+    ///     completionBlockAPI(completion)
+    /// }
+    /// ```
     static func call<Value>(
         method: (@escaping @Sendable (Value) -> Void) -> Void
     ) async -> Value {

--- a/Sources/FoundationExtensions/AsyncExtensions.swift
+++ b/Sources/FoundationExtensions/AsyncExtensions.swift
@@ -56,6 +56,7 @@ internal enum Async {
         }
     }
 
+    /// Invokes a completion-block based API and returns the `throw`ing method `async`hronously.
     static func call<Value, Error: Swift.Error>(
         method: (@escaping @Sendable (Result<Value, Error>) -> Void) -> Void
     ) async throws -> Value {
@@ -63,6 +64,20 @@ internal enum Async {
             @Sendable
             func complete(_ result: Result<Value, Error>) {
                 continuation.resume(with: result)
+            }
+
+            method(complete)
+        }
+    }
+
+    /// Invokes a completion-block based API and returns the method `async`hronoiusly.
+    static func call<Value>(
+        method: (@escaping @Sendable (Value) -> Void) -> Void
+    ) async -> Value {
+        return await withCheckedContinuation { continuation in
+            @Sendable
+            func complete(_ value: Value) {
+                continuation.resume(with: .success(value))
             }
 
             method(complete)

--- a/Tests/UnitTests/FoundationExtensions/AsyncExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/AsyncExtensionsTests.swift
@@ -95,7 +95,7 @@ class AsyncExtensionsTests: TestCase {
         expect(result).toEventually(equal(expected))
     }
 
-    func testConversionToAsyncWithValue() async throws {
+    func testConversionToAsyncWithResultSuccess() async throws {
         let expected = Int.random(in: 0..<100)
 
         let result = try await Async.call { (completion: (Result<Int, NSError>) -> Void) in
@@ -105,7 +105,7 @@ class AsyncExtensionsTests: TestCase {
         expect(result) == expected
     }
 
-    func testConversionToAsyncWithError() async throws {
+    func testConversionToAsyncWithResultFailure() async throws {
         enum Error: Swift.Error {
             case error1
         }
@@ -118,6 +118,16 @@ class AsyncExtensionsTests: TestCase {
         } catch {
             expect(error).to(matchError(Error.error1))
         }
+    }
+
+    func testConversionToAsyncWithValue() async {
+        let expected = Int.random(in: 0..<100)
+
+        let result = await Async.call { (completion: (Int) -> Void) in
+            completion(expected)
+        }
+
+        expect(result) == expected
     }
 
 }


### PR DESCRIPTION
This will be used by an upcoming PR.