### PR TITLE
`NetworkOperation`: workaround for iOS 12 crashes

### DIFF
--- a/Sources/Networking/Operations/NetworkOperation.swift
+++ b/Sources/Networking/Operations/NetworkOperation.swift
@@ -36,15 +36,19 @@ class NetworkOperation: Operation {
 
     let httpClient: HTTPClient
 
+    // Note: implementing asynchronousy `Operations` needs KVO.
+    // We're not using Swift's `KeyPath` verison (`willChangeValue(for:)`)
+    // due to it crashing on iOS 12. See https://github.com/RevenueCat/purchases-ios/pull/2008.
+
     private var _isExecuting: Atomic<Bool> = false
     private(set) override final var isExecuting: Bool {
         get {
             return self._isExecuting.value
         }
         set {
-            self.willChangeValue(for: \.isExecuting)
+            self.willChangeValue(forKey: #keyPath(NetworkOperation.isExecuting))
             self._isExecuting.value = newValue
-            self.didChangeValue(for: \.isExecuting)
+            self.didChangeValue(forKey: #keyPath(NetworkOperation.isExecuting))
         }
     }
 
@@ -54,9 +58,9 @@ class NetworkOperation: Operation {
             return self._isFinished.value
         }
         set {
-            self.willChangeValue(for: \.isFinished)
+            self.willChangeValue(forKey: #keyPath(NetworkOperation.isFinished))
             self._isFinished.value = newValue
-            self.didChangeValue(for: \.isFinished)
+            self.didChangeValue(forKey: #keyPath(NetworkOperation.isFinished))
         }
     }
 
@@ -66,9 +70,10 @@ class NetworkOperation: Operation {
             return self._isCancelled.value
         }
         set {
-            self.willChangeValue(for: \.isCancelled)
+            self.willChangeValue(forKey: #keyPath(NetworkOperation.isCancelled))
             self._isCancelled.value = newValue
-            self.didChangeValue(for: \.isCancelled)
+            self.didChangeValue(forKey: #keyPath(NetworkOperation.isCancelled))
+
         }
     }
 


### PR DESCRIPTION
This _might_ fix [CSDK-503].

The latest stacktrace provided gave me a clue:
```
Fatal error: Should never be reached: file /BuildRoot/Library/Caches/com.apple.xbs/Sources/swiftlang_overlay_Foundation_Device/swiftlang-1001.2.63.13/swift/stdlib/public/SDK/Foundation/NSObject.swift, line 46
0xa3d10 @objc static NSObject.__old_unswizzled_keyPathsForValuesAffectingValue(forKey:) + 84
53  libswiftFoundation.dylib       0xa436c static __KVOKeyPathBridgeMachinery.keyPathsForValuesAffectingValue(forKey:) + 272
64  libswiftFoundation.dylib       0xa4864 @objc static __KVOKeyPathBridgeMachinery.keyPathsForValuesAffectingValue(forKey:) + 88
```

That crash is coming from [here](https://github.com/apple/swift-corelibs-foundation/blob/swift-DEVELOPMENT-SNAPSHOT-2022-10-24-a/Darwin/Foundation-swiftoverlay/NSObject.swift#L47).
KVO shipped broken on Swift at least throughout iOS 12.x (see https://github.com/apple/swift-corelibs-foundation/issues/3742)

Thanks to @jckarter for [suggesting this workaround](https://twitter.com/jckarter/status/1586029206646898688?s=61&t=LJyPWVeXcT9TfIL2zMjFng).

[CSDK-503]: https://revenuecats.atlassian.net/browse/CSDK-503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ