### PR TITLE
fix the link to StoreKit Config file from watchOS purchaseTester

### DIFF
--- a/Tests/TestingApps/PurchaseTester/PurchaseTester.xcodeproj/xcshareddata/xcschemes/WatchPurchaseTester - StoreKit Config Files (Xcode 12+).xcscheme
+++ b/Tests/TestingApps/PurchaseTester/PurchaseTester.xcodeproj/xcshareddata/xcschemes/WatchPurchaseTester - StoreKit Config Files (Xcode 12+).xcscheme
@@ -66,7 +66,7 @@
          </BuildableReference>
       </BuildableProductRunnable>
       <StoreKitConfigurationFileReference
-         identifier = "../Configuration.storekit">
+         identifier = "../RevenueCat_IntegrationPurchaseTesterConfiguration.storekit">
       </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction


### PR DESCRIPTION
It was pointing to an old file that's been since renamed