### PR TITLE
`CachingProductsManager`: use partial cached products

### DIFF
--- a/Sources/Logging/Strings/OfferingStrings.swift
+++ b/Sources/Logging/Strings/OfferingStrings.swift
@@ -79,9 +79,9 @@ extension OfferingStrings: CustomStringConvertible {
             return "Offerings cache is stale, updating from " +
                 "network in foreground"
 
-        case .products_already_cached(let identifiers):
-            return "Skipping products request because products were already " +
-                "cached. products: \(identifiers)"
+        case let .products_already_cached(identifiers):
+            return "Skipping products request for these products because they were already " +
+                "cached: \(identifiers)"
 
         case .product_cache_invalid_for_storefront_change:
             return "Storefront change detected. Invalidating and re-fetching product cache."

--- a/Tests/StoreKitUnitTests/StoreKit2CachingProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2CachingProductsManagerTests.swift
@@ -67,7 +67,7 @@ class StoreKit2CachingProductsManagerTests: StoreKitConfigTestCase {
         expect(self.mockManager.invokedSk2StoreProductsCount) == 2
         expect(self.mockManager.invokedSk2StoreProductsParameterList) == [
             Set([product1.productIdentifier]), // First product fetched
-            Set([product1.productIdentifier, product2.productIdentifier]) // Both products fetched
+            Set([product2.productIdentifier]) // Second product fetched
         ]
     }
 

--- a/Tests/UnitTests/Purchasing/CachingProductsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/CachingProductsManagerTests.swift
@@ -49,7 +49,7 @@ class CachingProductsManagerTests: TestCase {
         self.expectProductsWereFetched(times: 1, for: Self.productID)
     }
 
-    func testFetchesNotCachedProductIfOneOfTheRequestedProductsIsNotCached() async throws {
+    func testFetchesNotCachedProductsIfOneOfTheRequestedProductsIsNotCached() async throws {
         let product1 = self.createMockProduct(identifier: "product1")
         let product2 = self.createMockProduct(identifier: "product2")
 
@@ -67,7 +67,7 @@ class CachingProductsManagerTests: TestCase {
         expect(self.mockManager.invokedProductsCount) == 2
         expect(self.mockManager.invokedProductsParametersList) == [
             Set([product1.productIdentifier]), // First product fetched
-            Set([product1.productIdentifier, product2.productIdentifier]) // Both products fetched
+            Set([product2.productIdentifier]) // Only second product fetched
         ]
     }
 


### PR DESCRIPTION
#1907 introduced this `CachingProductsManager` abstraction, but simply copied the existing caching mechanism, which was very limited. This expands on it by not ignoring cached products when not _all_ requested products are found. Instead, it uses the partial cache hit, and requests the rest of products.

This performance optimization is illustrated in the test change, as the second request only fetches the missing product now.