### PR TITLE
`eligiblePromotionalOffers`: don't log error if response is ineligible

### DIFF
--- a/Sources/Misc/Purchases+async.swift
+++ b/Sources/Misc/Purchases+async.swift
@@ -150,6 +150,8 @@ extension Purchases {
                             forProductDiscount: discount,
                             product: product
                         )
+                    } catch RevenueCat.ErrorCode.ineligibleError {
+                        return nil
                     } catch {
                         Logger.error(
                             Strings.purchase.check_eligibility_failed(


### PR DESCRIPTION
When calling this method, we were logging a message saying that determining eligibility failed, when in fact it didn't. It successfully detected that it's not eligible.

I've also added a small test for this scenario.