### PR TITLE
Changed `StoreKit2Setting.default` back to `.enabledOnlyForOptimizations`

### DIFF
--- a/Sources/Misc/StoreKit2Setting.swift
+++ b/Sources/Misc/StoreKit2Setting.swift
@@ -34,7 +34,7 @@ extension StoreKit2Setting {
             : .enabledOnlyForOptimizations
     }
 
-    static let `default`: Self = .enabledForCompatibleDevices
+    static let `default`: Self = .enabledOnlyForOptimizations
 
 }
 

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -135,8 +135,8 @@ import Foundation
 
         /**
          * Set `usesStoreKit2IfAvailable`.
-         * - Parameter usesStoreKit2IfAvailable: opt out of using StoreKit 2 on devices that support it.
-         * Defaults to  `true`.
+         * - Parameter usesStoreKit2IfAvailable: opt in using StoreKit 2 on devices that support it.
+         * Defaults to  `false`.
          */
         @objc public func with(usesStoreKit2IfAvailable: Bool) -> Builder {
             self.storeKit2Setting = .init(useStoreKit2IfAvailable: usesStoreKit2IfAvailable)


### PR DESCRIPTION
This changes the default back to `StoreKit 1`. We decided to do this for the following reasons:
- Purchasing with `PromotionalOffer`s does not work with StoreKit 2 due to an Apple bug (see https://github.com/RevenueCat/purchases-ios/pull/2020#discussion_r1012278099)
- `checkTrialOrIntroDiscountEligibility` is significantly slower with `StoreKit 2` (#1893). We're adding optimizations to help with that (#2007), but the underlying logic will still be slow.
- A rare race-condition where `StoreKit 2` does not have transactions after a purchase ([TRIAGE-82]). We have some workarounds (#1945), but it's still being investigated.

 _Note: This effectively reverts 0ee540aa. That commit made it easier to only change the default in one place which is why this PR is basically just one line._

[TRIAGE-82]: https://revenuecats.atlassian.net/browse/TRIAGE-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ