### PR TITLE
Runs push-pods after make-release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -466,6 +466,16 @@ jobs:
           command: bundle exec fastlane release
           no_output_timeout: 30m
 
+  push-pods:
+    <<: *base-job
+    steps:
+      - checkout
+      - trust-github-key
+      - run:
+          name: Deploy new version
+          command: bundle exec fastlane push_pods
+          no_output_timeout: 30m
+
   prepare-next-version:
     <<: *base-job
     steps:
@@ -724,8 +734,14 @@ workflows:
             - hold
           <<: *release-branches
       - make-release:
+          xcode_version: '14.1.0'
+          <<: *release-tags
+      - push-pods:
           # Xcode 14 not supported until https://github.com/CocoaPods/CocoaPods/issues/11558 is fixed.
+          # This runs as its own job until https://github.com/CocoaPods/CocoaPods/issues/11621 is fixed.
           xcode_version: '13.4.1'
+          requires:
+            - make-release
           <<: *release-tags
       - docs-deploy:
           xcode_version: '14.1.0'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -237,13 +237,20 @@ platform :ios do
     )
   end
 
-  desc "Release to CocoaPods, create Carthage archive, export XCFramework, and create GitHub release"
+  desc "Create Carthage archive, export XCFramework, and create GitHub release"
   lane :release do |options|
     version_number = current_version_number
-    push_pods
+    # making it its own lane until https://github.com/CocoaPods/CocoaPods/issues/11621 is fixed.
+    # push_pods 
     carthage_archive
     export_xcframework
     github_release(version: version_number)
+  end
+
+  desc "Release to CocoaPods"
+  lane :push_pods do |options|
+    version_number = current_version_number
+    push_pods
   end
 
   desc "Tag current branch with current version number"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -249,7 +249,6 @@ platform :ios do
 
   desc "Release to CocoaPods"
   lane :push_pods do |options|
-    version_number = current_version_number
     push_pods
   end
 


### PR DESCRIPTION
Pushes the pod in its own job until https://github.com/CocoaPods/CocoaPods/issues/11621 is fixed. Otherwise make-release always fails