### PR TITLE
Some updates on notify-on-non-patch-release-branches:

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -641,10 +641,6 @@ jobs:
                       {
                         "type": "mrkdwn",
                         "text": "*Branch*: $CIRCLE_BRANCH"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": "*Author*: $CIRCLE_USERNAME"
                       }
                     ]
                   }
@@ -734,6 +730,8 @@ workflows:
           xcode_version: '14.1.0'
           <<: *release-tags
       - notify-on-non-patch-release-branches:
+          requires:
+            - make-release
           <<: *non-patch-release-branches
           context: slack-secrets
   snapshot-bump:


### PR DESCRIPTION
- I noticed the `author` part was useless
- I also noticed this would run on every commit to the branch instead of after the release is successful so I moved it to after `make-release`