### PR TITLE
CI: fixed `iOS 14` tests Xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,6 +326,11 @@ jobs:
     steps:
       - checkout
       - install-dependencies
+      - install-and-create-sim:
+          install-name: iOS 14.5 Simulator
+          sim-device-type: iPhone-8
+          sim-device-runtime: iOS-14-5
+          sim-name: iPhone 8 (14.5)
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -675,7 +675,7 @@ workflows:
       - run-test-tvos:
           xcode_version: '14.1.0'
       - run-test-ios-14:
-          xcode_version: '14.1.1'
+          xcode_version: '14.1.0'
       - run-test-ios-13:
           # Simulator fails to install on Xcode 14
           xcode_version: '13.4.1'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,11 +326,6 @@ jobs:
     steps:
       - checkout
       - install-dependencies
-      - install-and-create-sim:
-          install-name: iOS 14.5 Simulator
-          sim-device-type: iPhone-8
-          sim-device-runtime: iOS-14-5
-          sim-name: iPhone 8 (14.5)
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios
@@ -680,7 +675,8 @@ workflows:
       - run-test-tvos:
           xcode_version: '14.1.0'
       - run-test-ios-14:
-          xcode_version: '14.1.0'
+          # Simulator fails to install on Xcode 14
+          xcode_version: '13.4.1'
       - run-test-ios-13:
           # Simulator fails to install on Xcode 14
           xcode_version: '13.4.1'


### PR DESCRIPTION
See https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/8749/workflows/f4994fe6-6ea3-4165-aaf0-4c5ee481260c/jobs/43015

We can't run these tests on Xcode 14 without first installing the runtime (see https://circle-macos-docs.s3.amazonaws.com/image-manifest/v8973/index.html).
Not sure if there's an API for that, and even if there was, it would be way too slow to bother instead of using an image that has the runtime already installed.