### PR TITLE
`Integration Tests`: changed log output to `raw`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -347,6 +347,7 @@ platform :ios do
       scheme: "BackendIntegrationTests",
       derived_data_path: "scan_derived_data",
       output_types: 'junit',
+      output_style: 'raw',
       number_of_retries: 3,
       result_bundle: true,
       testplan: "CI-BackendIntegration",


### PR DESCRIPTION
This will help figure out failures more easily. Right now we only see the title of the error because that's all that `Xcode` generates (see https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/8749/workflows/f4994fe6-6ea3-4165-aaf0-4c5ee481260c/jobs/43011/tests for example).