### PR TITLE
`ErrorCode.unknownBackendError`: include original error code

### DIFF
--- a/Sources/Error Handling/ErrorDetails.swift
+++ b/Sources/Error Handling/ErrorDetails.swift
@@ -21,6 +21,7 @@ extension NSError.UserInfoKey {
     static let statusCode: NSError.UserInfoKey = "rc_response_status_code"
 
     static let readableErrorCode: NSError.UserInfoKey = "readable_error_code"
+    static let backendErrorCode: NSError.UserInfoKey = "rc_backend_error_code"
     static let extraContext: NSError.UserInfoKey = "extra_context"
     static let file: NSError.UserInfoKey = "source_file"
     static let function: NSError.UserInfoKey = "source_function"

--- a/Tests/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
+++ b/Tests/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
@@ -70,7 +70,10 @@ class ManageSubscriptionsHelperTests: TestCase {
 
     func testShowManageSubscriptionsFailsIfCouldntGetCustomerInfo() throws {
         let error: BackendError = .networkError(.errorResponse(
-            .init(code: BackendErrorCode.badRequest, message: nil, attributeErrors: [:]),
+            .init(code: .badRequest,
+                  originalCode: BackendErrorCode.badRequest.rawValue,
+                  message: nil,
+                  attributeErrors: [:]),
             400)
         )
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -226,7 +226,8 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         self.offerings.stubbedPostOfferCompletionResult = .failure(
             .networkError(
                 .errorResponse(
-                    .init(code: .userIneligibleForPromoOffer),
+                    .init(code: .userIneligibleForPromoOffer,
+                          originalCode: BackendErrorCode.userIneligibleForPromoOffer.rawValue),
                     .success
                 )
             )

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
@@ -177,7 +177,9 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
         let productId = "product_id"
 
         let stubbedError: BackendError = .networkError(
-            .errorResponse(.init(code: .invalidAPIKey, message: nil),
+            .errorResponse(.init(code: .invalidAPIKey,
+                                 originalCode: BackendErrorCode.invalidAPIKey.rawValue,
+                                 message: nil),
                            400)
         )
         mockIntroEligibilityCalculator.stubbedCheckTrialOrIntroDiscountEligibilityResult = ([:], stubbedError)

--- a/Tests/UnitTests/Attribution/AttributionPosterTests.swift
+++ b/Tests/UnitTests/Attribution/AttributionPosterTests.swift
@@ -328,7 +328,9 @@ class AdServicesAttributionPosterTests: BaseAttributionPosterTests {
 
     func testPostAdServicesTokenIfNeededDoesNotCacheOnAPIError() throws {
         let stubbedError: BackendError = .networkError(
-            .errorResponse(.init(code: .invalidAPIKey, message: nil),
+            .errorResponse(.init(code: .invalidAPIKey,
+                                 originalCode: BackendErrorCode.invalidAPIKey.rawValue,
+                                 message: nil),
                            400)
         )
 

--- a/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
+++ b/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
@@ -60,7 +60,9 @@ class PurchasesDiagnosticsTests: TestCase {
 
     func testFailingAuthenticatedRequest() async throws {
         let error = ErrorUtils
-            .backendError(withBackendCode: .invalidAPIKey, backendMessage: "Invalid API key")
+            .backendError(withBackendCode: .invalidAPIKey,
+                          originalBackendErrorCode: BackendErrorCode.invalidAPIKey.rawValue,
+                          backendMessage: "Invalid API key")
             .asPublicError
         self.purchases.mockedCustomerInfoResponse = .failure(error)
 

--- a/Tests/UnitTests/Networking/Backend/BackendPostOfferForSigningTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostOfferForSigningTests.swift
@@ -122,7 +122,9 @@ class BackendPostOfferForSigningTests: BaseBackendTests {
     }
 
     func testOfferForSigningSignatureErrorResponse() {
-        let errorResponse = ErrorResponse(code: 7234, message: "Ineligible for some reason")
+        let errorResponse = ErrorResponse(code: .invalidAppleSubscriptionKey,
+                                          originalCode: 7234,
+                                          message: "Ineligible for some reason")
 
         let validSigningResponse: [String: Any] = [
             "offers": [

--- a/Tests/UnitTests/Networking/BackendErrorTests.swift
+++ b/Tests/UnitTests/Networking/BackendErrorTests.swift
@@ -58,6 +58,7 @@ class BackendErrorTests: BaseErrorTests {
 
         let response = ErrorResponse(
             code: .subscriptionNotFoundForCustomer,
+            originalCode: BackendErrorCode.subscriptionNotFoundForCustomer.rawValue,
             message: "Subscription not found for subscriber",
             attributeErrors: [:]
         )

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -269,7 +269,9 @@ class HTTPClientTests: TestCase {
 
         let error = try XCTUnwrap(result.value?.error)
         expect(error) == .errorResponse(
-            .init(code: .storeProblem, message: "something is broken up in the cloud"),
+            .init(code: .storeProblem,
+                  originalCode: 7101,
+                  message: "something is broken up in the cloud"),
             HTTPStatusCode(rawValue: errorCode)
         )
     }
@@ -281,7 +283,7 @@ class HTTPClientTests: TestCase {
         let result: Atomic<HTTPResponse<Data>.Result?> = nil
 
         stub(condition: isPath(request.path)) { _ in
-            let json = "{\"message\": \"something is broken up in the cloud\"}"
+            let json = "{\"code\": 5000,\"message\": \"something is broken up in the cloud\"}"
             return HTTPStubsResponse(
                 data: json.data(using: String.Encoding.utf8)!,
                 statusCode: Int32(errorCode),
@@ -298,7 +300,9 @@ class HTTPClientTests: TestCase {
 
         let error = try XCTUnwrap(result.value?.error)
         expect(error) == .errorResponse(
-            .init(code: .unknownBackendError, message: "something is broken up in the cloud"),
+            .init(code: .unknownBackendError,
+                  originalCode: 5000,
+                  message: "something is broken up in the cloud"),
             HTTPStatusCode(rawValue: errorCode)
         )
     }

--- a/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
+++ b/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
@@ -116,7 +116,10 @@ class ErrorUtilsTests: TestCase {
     }
 
     func testNetworkErrorsAreLoggedWithUnderlyingError() throws {
+        let originalErrorCode = 6000
+
         let response = ErrorResponse(code: .unknownBackendError,
+                                     originalCode: originalErrorCode,
                                      message: "Page not found",
                                      attributeErrors: [:])
         let purchasesError = response.asBackendError(with: .notFoundError)
@@ -127,7 +130,8 @@ class ErrorUtilsTests: TestCase {
         expect(loggedMessage.message) == [
             LogIntent.rcError.prefix,
             purchasesError.error.description,
-            response.message!
+            response.message!,
+            "(\(originalErrorCode))"
         ].joined(separator: " ")
     }
 
@@ -159,6 +163,7 @@ class ErrorUtilsTests: TestCase {
 
     func testLoggedErrorResponseWithAttributeErrors() throws {
         let errorResponse = ErrorResponse(code: .invalidSubscriberAttributes,
+                                          originalCode: BackendErrorCode.invalidSubscriberAttributes.rawValue,
                                           message: "Invalid Attributes",
                                           attributeErrors: [
                                             "$email": "invalid"
@@ -180,6 +185,7 @@ class ErrorUtilsTests: TestCase {
 
     func testLoggedErrorResponseWithNoAttributeErrors() throws {
         let errorResponse = ErrorResponse(code: .invalidAPIKey,
+                                          originalCode: BackendErrorCode.invalidAPIKey.rawValue,
                                           message: "Invalid API key",
                                           attributeErrors: [:])
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
@@ -154,7 +154,9 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         transaction.mockPayment = try XCTUnwrap(self.storeKit1Wrapper.payment)
         self.backend.postReceiptResult = .failure(
             .networkError(.errorResponse(
-                .init(code: .unknownBackendError, message: nil),
+                .init(code: .unknownBackendError,
+                      originalCode: BackendErrorCode.unknownBackendError.rawValue,
+                      message: nil),
                 .internalServerError
             ))
         )
@@ -186,7 +188,9 @@ class PurchasesPurchasingTests: BasePurchasesTests {
 
         self.backend.postReceiptResult = .failure(
             .networkError(.errorResponse(
-                .init(code: .unknownBackendError, message: nil),
+                .init(code: .unknownBackendError,
+                      originalCode: BackendErrorCode.unknownBackendError.rawValue,
+                      message: nil),
                 .invalidRequest
             ))
         )
@@ -205,7 +209,9 @@ class PurchasesPurchasingTests: BasePurchasesTests {
 
         self.backend.postReceiptResult = .failure(
             .networkError(.errorResponse(
-                .init(code: .unknownBackendError, message: nil),
+                .init(code: .unknownBackendError,
+                      originalCode: BackendErrorCode.unknownBackendError.rawValue,
+                      message: nil),
                 .internalServerError
             ))
         )

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -206,7 +206,8 @@ class BackendSubscriberAttributesTests: TestCase {
 
     func testPostReceiptWithSubscriberAttributesPassesErrorIfStatusCodeIsNotSuccess() throws {
         let errorResponse: ErrorResponse = .init(
-            code: BackendErrorCode.invalidSubscriberAttributes,
+            code: .invalidSubscriberAttributes,
+            originalCode: BackendErrorCode.invalidSubscriberAttributes.rawValue,
             message: "Some subscriber attributes keys were unable to be saved.",
             attributeErrors: [ "$email": "email is not in valid format"]
         )

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -719,7 +719,9 @@ class PurchasesSubscriberAttributesTests: TestCase {
 
         self.mockBackend.stubbedPostReceiptResult = .failure(
             .networkError(.errorResponse(
-                .init(code: .invalidAPIKey, message: "Invalid credentials"),
+                .init(code: .invalidAPIKey,
+                      originalCode: BackendErrorCode.invalidAPIKey.rawValue,
+                      message: "Invalid credentials"),
                 400
             ))
         )
@@ -749,7 +751,10 @@ class PurchasesSubscriberAttributesTests: TestCase {
 
         self.mockBackend.stubbedPostReceiptResult = .failure(
             .networkError(.errorResponse(
-                .init(code: .internalServerError, message: "Error", attributeErrors: [:]),
+                .init(code: .internalServerError,
+                      originalCode: BackendErrorCode.internalServerError.rawValue,
+                      message: "Error",
+                      attributeErrors: [:]),
                 .internalServerError)
             )
         )


### PR DESCRIPTION
Currently we only include the message and not the error code. So when these unknown errors are returned, unless the message is clear, we might not known which code the backend actually sent.
Example:
> There was an unknown backend error. The purchased product was missing in the receipt. This is typically due to a bug in StoreKit.

In this case it's clear, but nowhere in the logs we can find the error code.

This adds the error code to those messages (only when the code is unknown), as well as to `userInfo`.

### Examples from the tests

#### Before:
> There was an unknown backend error. This is a future unknown error
#### After:
> There was an unknown backend error. This is a future unknown error (1234)

#### Before:
> 😿‼️ There was an unknown backend error. Page not found
#### After:
> 😿‼️ There was an unknown backend error. Page not found (6000)