### PR TITLE
Added `BackendErrorCode.purchasedProductMissingInAppleReceipt`

### DIFF
--- a/Sources/Error Handling/BackendErrorCode.swift
+++ b/Sources/Error Handling/BackendErrorCode.swift
@@ -90,7 +90,8 @@ extension BackendErrorCode {
             return .storeProblemError
         case .cannotTransferPurchase:
             return .receiptAlreadyInUseError
-        case .invalidReceiptToken, .purchasedProductMissingInAppleReceipt:
+        case .invalidReceiptToken,
+                .purchasedProductMissingInAppleReceipt:
             return .invalidReceiptError
         case .invalidAppStoreSharedSecret,
              .invalidAuthToken,

--- a/Sources/Error Handling/BackendErrorCode.swift
+++ b/Sources/Error Handling/BackendErrorCode.swift
@@ -42,6 +42,7 @@ enum BackendErrorCode: Int, Error {
     case subscriptionNotFoundForCustomer = 7259
     case invalidSubscriberAttributes = 7263
     case invalidSubscriberAttributesBody = 7264
+    case purchasedProductMissingInAppleReceipt = 7712
 
     /**
      * - Parameter code: Generally comes from the backend in json. This may be a String, or an Int, or nothing.
@@ -89,7 +90,7 @@ extension BackendErrorCode {
             return .storeProblemError
         case .cannotTransferPurchase:
             return .receiptAlreadyInUseError
-        case .invalidReceiptToken:
+        case .invalidReceiptToken, .purchasedProductMissingInAppleReceipt:
             return .invalidReceiptError
         case .invalidAppStoreSharedSecret,
              .invalidAuthToken,


### PR DESCRIPTION
See https://github.com/RevenueCat/khepri/pull/4716
This makes that error `ErrorCode.invalidReceiptError` instead of `.unknownBackendError`.

I've also added #2032 to improve error messages when these errors are unknown in the future.