### PR TITLE
`ErrorResponse.asBackendError`: serialize attribute errors as `NSDictionary`

### DIFF
--- a/Sources/Networking/HTTPClient/HTTPResponse.swift
+++ b/Sources/Networking/HTTPClient/HTTPResponse.swift
@@ -81,7 +81,7 @@ extension ErrorResponse {
         ]
 
         if !self.attributeErrors.isEmpty {
-            userInfo[.attributeErrors] = self.attributeErrors
+            userInfo[.attributeErrors] = self.attributeErrors as NSDictionary
         }
 
         return ErrorUtils.backendError(


### PR DESCRIPTION
I noticed this error in an integration test failure:
> BackendIntegrationTestsHostApp[3972:15171] Exception attempting to serialize sanitized error of issue. All userInfo with be discarded except localized description: NSInvalidUnarchiveOperationException: The data couldn’t be read because it isn’t in the correct format.

This was the only instance I could see that might potentially fail to serialize (it's `[String: String]`.
This should be a safe conversion anyway, so it's worth trying.