### PR TITLE
`Integration Tests`: run on iOS 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -410,7 +410,7 @@ jobs:
           command: bundle exec fastlane backend_integration_tests
           no_output_timeout: 30m
           environment:
-            SCAN_DEVICE: iPhone 11 Pro (15.5)
+            SCAN_DEVICE: iPhone 14 (16.1)
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: BackendIntegrationTests


### PR DESCRIPTION
iOS 16 is here to stay, so we should make sure our tests run there too.

One could make the case for running integration tests in all versions of iOS, but I think for now running on the latest is a good default.