### PR TITLE
`CI`: run tests on iOS 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -697,46 +697,46 @@ workflows:
       not:
         equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
-      - lint:
-          xcode_version: '14.1.0'
-      - run-test-ios-16:
-          xcode_version: '14.1.0'
-      - spm-release-build:
-          xcode_version: '14.1.0'
-      - run-test-ios-15:
-          xcode_version: '14.1.0'
-      - run-test-tvos:
-          xcode_version: '14.1.0'
-      - run-test-ios-14:
-          xcode_version: '14.1.1'
-      - run-test-ios-13:
-          # Simulator fails to install on Xcode 14
-          xcode_version: '13.4.1'
-          <<: *release-branches-and-main
-      - run-test-ios-12:
-          # Simulator fails to install on Xcode 14
-          xcode_version: '13.4.1'
-          <<: *release-branches-and-main
+      # - lint:
+      #     xcode_version: '14.1.0'
+      # - run-test-ios-16:
+      #     xcode_version: '14.1.0'
+      # - spm-release-build:
+      #     xcode_version: '14.1.0'
+      # - run-test-ios-15:
+      #     xcode_version: '14.1.0'
+      # - run-test-tvos:
+      #     xcode_version: '14.1.0'
+      # - run-test-ios-14:
+      #     xcode_version: '14.1.1'
+      # - run-test-ios-13:
+      #     # Simulator fails to install on Xcode 14
+      #     xcode_version: '13.4.1'
+      #     <<: *release-branches-and-main
+      # - run-test-ios-12:
+      #     # Simulator fails to install on Xcode 14
+      #     xcode_version: '13.4.1'
+      #     <<: *release-branches-and-main
       - run-test-ios-11:
           xcode_version: '13.1.0'
           # TODO: add this
           #<<: *release-branches-and-main
-      - build-tv-watch-and-macos:
-          xcode_version: '14.1.0'
-      # To ensure we don't break compilation with Xcode 13.2.1
-      - compile-xcode-13-2:
-          name: xcode-13.2.1
-          xcode_version: '13.2.1'
-          <<: *release-branches-and-main
-      - release-checks:
-          xcode_version: '14.1.0'
-          <<: *release-branches
-      - backend-integration-tests:
-          xcode_version: '14.1.0'
-          filters:
-              branches:
-                # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-                ignore: /pull\/[0-9]+/
+      # - build-tv-watch-and-macos:
+      #     xcode_version: '14.1.0'
+      # # To ensure we don't break compilation with Xcode 13.2.1
+      # - compile-xcode-13-2:
+      #     name: xcode-13.2.1
+      #     xcode_version: '13.2.1'
+      #     <<: *release-branches-and-main
+      # - release-checks:
+      #     xcode_version: '14.1.0'
+      #     <<: *release-branches
+      # - backend-integration-tests:
+      #     xcode_version: '14.1.0'
+      #     filters:
+      #         branches:
+      #           # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+      #           ignore: /pull\/[0-9]+/
   deploy:
     when:
       not:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,8 +398,6 @@ jobs:
   run-test-ios-11:
     <<: *base-job
     steps:
-      - setup-git-credentials
-      - install-swiftlint-0-48
       - checkout
       - install-bundle-dependencies
       - install-and-create-sim:
@@ -407,6 +405,8 @@ jobs:
           sim-device-type: iPhone-6
           sim-device-runtime: iOS-11-4-1
           sim-name: iPhone 6 (11.4.1)
+      - setup-git-credentials
+      - install-swiftlint-0-48
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios
@@ -718,7 +718,7 @@ workflows:
       #     xcode_version: '13.4.1'
       #     <<: *release-branches-and-main
       - run-test-ios-11:
-          xcode_version: '13.1.0'
+          xcode_version: '13.0.0'
           # TODO: add this
           #<<: *release-branches-and-main
       # - build-tv-watch-and-macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,25 @@ commands:
           name: Install xcbeautify
           command: brew install xcbeautify
 
+  # Required to be installed manually for Xcode < 13.3
+  install-swiftlint-0-48:
+    steps:
+      - restore_cache:
+          keys:
+            - homebrew-tap-cache-3
+      - run:
+          name: Install swiftlint 0.48.0
+          command: |
+              brew update --preinstall
+              brew tap-new $USER/local-tap
+              brew extract --version=0.48.0 swiftlint $USER/local-tap
+              brew install swiftlint@0.48.0
+      - save_cache:
+          key: homebrew-tap-cache-3
+          paths:
+            - /usr/local/Homebrew/Library/Taps/$USER/homebrew-local-tap/
+            - /Users/$USER/Library/Caches/Homebrew/
+
   install-rubydocker-dependencies:
     steps:
       - restore_cache:
@@ -280,21 +299,7 @@ jobs:
     <<: *base-job
     steps:
       - setup-git-credentials
-      - restore_cache:
-          keys:
-            - homebrew-tap-cache-3
-      - run:
-          name: Install swiftlint 0.48.0
-          command: |
-              brew update --preinstall
-              brew tap-new $USER/local-tap
-              brew extract --version=0.48.0 swiftlint $USER/local-tap
-              brew install swiftlint@0.48.0
-      - save_cache:
-          key: homebrew-tap-cache-3
-          paths:
-            - /usr/local/Homebrew/Library/Taps/$USER/homebrew-local-tap/
-            - /Users/$USER/Library/Caches/Homebrew/
+      - install-swiftlint-0-48
       - checkout
       - install-bundle-dependencies
       - run:
@@ -389,6 +394,34 @@ jobs:
       - store_artifacts:
           path: fastlane/test_output/xctest
           destination: scan-test-output
+
+  run-test-ios-11:
+    <<: *base-job
+    steps:
+      - setup-git-credentials
+      - install-swiftlint-0-48
+      - checkout
+      - install-bundle-dependencies
+      - install-and-create-sim:
+          install-name: iOS 11.4.1 Simulator
+          sim-device-type: iPhone-6
+          sim-device-runtime: iOS-11-4-1
+          sim-name: iPhone 6 (11.4.1)
+      - run:
+          name: Run tests
+          command: bundle exec fastlane test_ios
+          no_output_timeout: 30m
+          environment:
+            SCAN_DEVICE: iPhone 6 (11.4.1)
+      - compress_result_bundle:
+          directory: fastlane/test_output/xctest/ios
+          bundle_name: RevenueCat
+      - store_test_results:
+          path: fastlane/test_output
+      - store_artifacts:
+          path: fastlane/test_output/xctest
+          destination: scan-test-output
+
 
   build-tv-watch-and-macos:
     <<: *base-job
@@ -684,6 +717,10 @@ workflows:
           # Simulator fails to install on Xcode 14
           xcode_version: '13.4.1'
           <<: *release-branches-and-main
+      - run-test-ios-11:
+          xcode_version: '13.1.0'
+          # TODO: add this
+          #<<: *release-branches-and-main
       - build-tv-watch-and-macos:
           xcode_version: '14.1.0'
       # To ensure we don't break compilation with Xcode 13.2.1


### PR DESCRIPTION
We support iOS 11, so we should make sure tests pass there too.