### PR TITLE
`PostReceiptDataOperation`: log Apple error when purchase equals expiration date

### DIFF
--- a/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
@@ -67,7 +67,7 @@ extension AppleReceipt {
     func containsActivePurchase(forProductIdentifier identifier: String) -> Bool {
         return (
             self.inAppPurchases.contains { $0.isActiveSubscription } ||
-            self.inAppPurchases.contains { $0.productType?.isSubscription != true && $0.productId == identifier }
+            self.inAppPurchases.contains { !$0.isSubscription && $0.productId == identifier }
         )
     }
 

--- a/Sources/LocalReceiptParsing/BasicTypes/InAppPurchase.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/InAppPurchase.swift
@@ -45,6 +45,16 @@ extension AppleReceipt.InAppPurchase {
         return expiration > Date()
     }
 
+    var purchaseDateEqualsExpiration: Bool {
+        guard self.productType?.isSubscription == true else { return false }
+        guard let expiration = self.expiresDate else { return false }
+
+        return abs(self.purchaseDate.timeIntervalSince(expiration)) <= Self.purchaseAndExpirationEqualThreshold
+    }
+
+    /// Seconds between purchase and expiration to consider both equal.
+    private static let purchaseAndExpirationEqualThreshold: TimeInterval = 5
+
 }
 
 extension AppleReceipt.InAppPurchase {

--- a/Sources/LocalReceiptParsing/BasicTypes/InAppPurchase.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/InAppPurchase.swift
@@ -22,7 +22,7 @@ extension AppleReceipt {
         let productId: String
         let transactionId: String
         let originalTransactionId: String?
-        let productType: ProductType?
+        let productType: ProductType
         let purchaseDate: Date
         let originalPurchaseDate: Date?
         let expiresDate: Date?
@@ -39,20 +39,20 @@ extension AppleReceipt {
 extension AppleReceipt.InAppPurchase {
 
     var isActiveSubscription: Bool {
-        guard self.productType?.isSubscription == true else { return false }
-        guard let expiration = self.expiresDate else { return true }
+        guard self.isSubscription, let expiration = self.expiresDate else { return false }
 
         return expiration > Date()
     }
 
     var purchaseDateEqualsExpiration: Bool {
-        guard self.productType?.isSubscription == true else { return false }
-        guard let expiration = self.expiresDate else { return false }
+        guard self.isSubscription, let expiration = self.expiresDate else { return false }
 
         return abs(self.purchaseDate.timeIntervalSince(expiration)) <= Self.purchaseAndExpirationEqualThreshold
     }
 
     /// Seconds between purchase and expiration to consider both equal.
+    /// 5 provides some margin for error, while still covering the shortest possible
+    /// subscription length (weekly subscriptions with `TimeRate.monthlyRenewalEveryThirtySeconds`.
     private static let purchaseAndExpirationEqualThreshold: TimeInterval = 5
 
 }
@@ -71,16 +71,14 @@ extension AppleReceipt.InAppPurchase {
 
 }
 
-extension AppleReceipt.InAppPurchase.ProductType {
-
+extension AppleReceipt.InAppPurchase {
     var isSubscription: Bool {
-        switch self {
-        case .unknown: return false
+        switch self.productType {
+        case .unknown: return self.expiresDate != nil
         case .nonConsumable, .consumable: return false
         case .nonRenewingSubscription, .autoRenewableSubscription: return true
         }
     }
-
 }
 
 // MARK: -

--- a/Sources/LocalReceiptParsing/Builders/InAppPurchaseBuilder.swift
+++ b/Sources/LocalReceiptParsing/Builders/InAppPurchaseBuilder.swift
@@ -45,7 +45,7 @@ class InAppPurchaseBuilder {
         var productId: String?
         var transactionId: String?
         var originalTransactionId: String?
-        var productType: InAppPurchase.ProductType?
+        var productType: InAppPurchase.ProductType = .unknown
         var purchaseDate: Date?
         var originalPurchaseDate: Date?
         var expiresDate: Date?
@@ -74,7 +74,7 @@ class InAppPurchaseBuilder {
             case .webOrderLineItemId:
                 webOrderLineItemId = internalContainer.internalPayload.toInt64()
             case .productType:
-                productType = .init(rawValue: internalContainer.internalPayload.toInt())
+                productType = .init(rawValue: internalContainer.internalPayload.toInt()) ?? .unknown
             case .isInIntroOfferPeriod:
                 isInIntroOfferPeriod = internalContainer.internalPayload.toBool()
             case .isInTrialPeriod:

--- a/Sources/Logging/Strings/ReceiptStrings.swift
+++ b/Sources/Logging/Strings/ReceiptStrings.swift
@@ -29,6 +29,11 @@ enum ReceiptStrings {
     case refreshing_empty_receipt
     case unable_to_load_receipt
     case posting_receipt(AppleReceipt)
+    case receipt_subscription_purchase_equals_expiration(
+        productIdentifier: String,
+        purchase: Date,
+        expiration: Date?
+    )
     case receipt_retrying_mechanism_not_available
     case local_receipt_missing_purchase(AppleReceipt, forProductIdentifier: String)
     case retrying_receipt_fetch_after(sleepDuration: DispatchTimeInterval)
@@ -80,6 +85,14 @@ extension ReceiptStrings: CustomStringConvertible {
 
         case let .posting_receipt(receipt):
             return "Posting receipt: \(receipt.debugDescription)"
+
+        case let .receipt_subscription_purchase_equals_expiration(
+            productIdentifier,
+            purchase,
+            expiration
+        ):
+            return "Receipt for product '\(productIdentifier)' has the same purchase (\(purchase)) " +
+            "and expiration (\(expiration?.description ?? "")) dates. This is likely a StoreKit bug."
 
         case .receipt_retrying_mechanism_not_available:
             return "Receipt retrying mechanism is not available in iOS 12. Will only attempt to fetch once."

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -82,9 +82,17 @@ private extension PostReceiptDataOperation {
 
     func printReceiptData() {
         do {
-            self.log(Strings.receipt.posting_receipt(
-                try ReceiptParser.default.parse(from: self.postData.receiptData)
-            ))
+            let receipt = try ReceiptParser.default.parse(from: self.postData.receiptData)
+            self.log(Strings.receipt.posting_receipt(receipt))
+
+            for purchase in receipt.inAppPurchases where purchase.purchaseDateEqualsExpiration {
+                Logger.appleError(Strings.receipt.receipt_subscription_purchase_equals_expiration(
+                    productIdentifier: purchase.productId,
+                    purchase: purchase.purchaseDate,
+                    expiration: purchase.expiresDate
+                ))
+            }
+
         } catch {
             Logger.appleError(Strings.receipt.parse_receipt_locally_error(error: error))
         }

--- a/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
@@ -74,13 +74,15 @@ class LocalReceiptParserStoreKitTests: StoreKitConfigTestCase {
         expect(firstPurchase.productId) == product.id
         expect(firstPurchase.transactionId).toNot(beNil())
         expect(firstPurchase.originalTransactionId).to(beNil())
-        expect(firstPurchase.productType).to(beNil())
+        expect(firstPurchase.productType) == .unknown
 
         expect(firstPurchase.purchaseDate).to(beCloseTo(Date(), within: 5))
         expect(firstPurchase.originalPurchaseDate).to(beNil())
 
         expect(firstPurchase.expiresDate).toNot(beNil())
         expect(firstPurchase.expiresDate).toNot(beCloseTo(Date(), within: 1))
+
+        expect(firstPurchase.isSubscription) == true
 
         expect(firstPurchase.cancellationDate).to(beNil())
         expect(firstPurchase.isInTrialPeriod).to(beNil())

--- a/Tests/UnitTests/LocalReceiptParsing/AppleReceiptTests.swift
+++ b/Tests/UnitTests/LocalReceiptParsing/AppleReceiptTests.swift
@@ -18,6 +18,8 @@ import XCTest
 
 final class AppleReceiptTests: TestCase {
 
+    // MARK: - containsActivePurchase
+
     func testReceiptWithNoPurchasesDoesNotContainActivePurchase() {
         let receipt = Self.create(with: [:])
         expect(receipt.containsActivePurchase(forProductIdentifier: Self.productIdentifier)) == false
@@ -63,6 +65,62 @@ final class AppleReceiptTests: TestCase {
             "different_product": nil
         ])
         expect(receipt.containsActivePurchase(forProductIdentifier: Self.productIdentifier)) == false
+    }
+
+    // MARK: - purchaseDateEqualsExpiration
+
+    func testPurchaseDateEqualsExpirationWithNoSubscription() {
+        expect(
+            Self.create(with: [ Self.productIdentifier: nil ])
+                .inAppPurchases
+                .first!
+                .purchaseDateEqualsExpiration
+        ) == false
+    }
+
+    func testExpirationDate10SecondsAfterPurchase() {
+        expect(
+            Self.create(with: [ Self.productIdentifier: Date().addingTimeInterval(10) ])
+                .inAppPurchases
+                .first!
+                .purchaseDateEqualsExpiration
+        ) == false
+    }
+
+    func testExpirationDate5SecondsAfterPurchase() {
+        expect(
+            Self.create(with: [ Self.productIdentifier: Date().addingTimeInterval(5) ])
+                .inAppPurchases
+                .first!
+                .purchaseDateEqualsExpiration
+        ) == true
+    }
+
+    func testExpirationDateSameAsPurchase() {
+        expect(
+            Self.create(with: [ Self.productIdentifier: Date() ])
+                .inAppPurchases
+                .first!
+                .purchaseDateEqualsExpiration
+        ) == true
+    }
+
+    func testExpirationDate4SecondsBeforePurchase() {
+        expect(
+            Self.create(with: [ Self.productIdentifier: Date().addingTimeInterval(-4) ])
+                .inAppPurchases
+                .first!
+                .purchaseDateEqualsExpiration
+        ) == true
+    }
+
+    func testExpirationDate10SecondsBeforePurchaseIsNotTheSame() {
+        expect(
+            Self.create(with: [ Self.productIdentifier: Date().addingTimeInterval(-10) ])
+                .inAppPurchases
+                .first!
+                .purchaseDateEqualsExpiration
+        ) == false
     }
 
     // MARK: -

--- a/Tests/UnitTests/Purchasing/ReceiptFetcherTests.swift
+++ b/Tests/UnitTests/Purchasing/ReceiptFetcherTests.swift
@@ -327,7 +327,7 @@ final class RetryingReceiptFetcherTests: BaseReceiptFetcherTests {
                 productType: .autoRenewableSubscription,
                 purchaseDate: Date(),
                 originalPurchaseDate: nil,
-                expiresDate: nil,
+                expiresDate: Date().addingTimeInterval(100),
                 cancellationDate: nil,
                 isInTrialPeriod: false,
                 isInIntroOfferPeriod: false,


### PR DESCRIPTION
A large amount of flaky integration tests are due to this bug, so detecting it early in the logs will help debug this.
Radar: `FB11767559`.

`productType` is missing in `StoreKitTest` purchases, so I changed `isSubscription` to default to checking if there is an expiration when the type is `.unknown`.
To simplify the code, I changed `ProductType?` to be non-optional, since we already have `.unknown` as a case.

### Example:
```
[00:27:56]: ▸ 2022-11-09 00:27:56.000533+0000 BackendIntegrationTestsHostApp[3942:17000] [Purchases] - DEBUG: ℹ️ PostReceiptDataOperation: Posting receipt: {
[00:27:56]: ▸   "opaque_value" : "1n+XXw8AAAA=",
[00:27:56]: ▸   "sha1_hash" : "unR7vAzPaUlB0TtZ09z5jMyqqAs=",
[00:27:56]: ▸   "bundle_id" : "com.revenuecat.StoreKitTestApp",
[00:27:56]: ▸   "in_app_purchases" : [
[00:27:56]: ▸     {
[00:27:56]: ▸       "quantity" : 1,
[00:27:56]: ▸       "product_id" : "com.revenuecat.weekly_1.99.3_day_intro",
[00:27:56]: ▸       "purchase_date" : "2022-11-09T00:27:50Z",
[00:27:56]: ▸       "transaction_id" : "0",
[00:27:56]: ▸       "is_in_intro_offer_period" : true,
[00:27:56]: ▸       "expires_date" : "2022-11-09T00:27:50Z"
[00:27:56]: ▸     },
[00:27:56]: ▸     {
[00:27:56]: ▸       "product_id" : "com.revenuecat.weekly_1.99.3_day_intro",
[00:27:56]: ▸       "quantity" : 1,
[00:27:56]: ▸       "transaction_id" : "1",
[00:27:56]: ▸       "is_in_intro_offer_period" : false,
[00:27:56]: ▸       "expires_date" : "2022-11-09T00:28:00Z",
[00:27:56]: ▸       "original_purchase_date" : "2022-11-09T00:27:50Z",
[00:27:56]: ▸       "original_transaction_id" : "0",
[00:27:56]: ▸       "purchase_date" : "2022-11-09T00:27:50Z"
[00:27:56]: ▸     }
[00:27:56]: ▸   ],
[00:27:56]: ▸   "application_version" : "1",
[00:27:56]: ▸   "creation_date" : "2022-11-09T00:27:55Z",
[00:27:56]: ▸   "expiration_date" : "4001-01-01T00:00:00Z"
[00:27:56]: ▸ }
[00:27:56]: ▸ 2022-11-09 00:27:56.000710+0000 BackendIntegrationTestsHostApp[3942:17000] [Purchases] - ERROR: 🍎‼️ Receipt for product 'com.revenuecat.weekly_1.99.3_day_intro' has the same purchase (2022-11-09 00:27:50 +0000) and expiration (2022-11-09 00:27:50 +0000) dates. This is likely a StoreKit bug.
```