### PR TITLE
`Integration Tests`: fixed `testPurchaseWithAskToBuyPostsReceipt`

### DIFF
--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -204,8 +204,8 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
 
         try self.testSession.approveAskToBuyTransaction(identifier: transaction.identifier)
 
-        // This shouldn't throw error anymore
-        try await self.purchaseMonthlyOffering()
+        let customerInfo = try await Purchases.shared.restorePurchases()
+        try await self.verifyEntitlementWentThrough(customerInfo)
     }
 
     func testLogInReturnsCreatedTrueWhenNewAndFalseWhenExisting() async throws {


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/8800/workflows/15003c88-3322-4c55-8cc4-e44d4494b9c3/jobs/43446/tests

This was failing with `StoreKit 2` (probably a recent `SKTestSession`/`StoreKit` change since it used to pass):
```
[00:51:46]: ▸ 2022-11-09 00:51:46.820614+0000 BackendIntegrationTestsHostApp[4240:21475] [Default] [StoreKit] Received error that does not have a corresponding StoreKit Error:
[00:51:46]: ▸ Error Domain=ASDServerErrorDomain Code=3532 "You’re currently subscribed to this." UserInfo={storefront-country-code=USA, client-environment-type=XcodeTest(/Users/distiller/Library/Developer/CoreSimulator/Devices/E616C409-03A4-4A07-B2DC-FFF7544CBCCD/data/Containers/Shared/App ... tTestApp), AMSServerErrorCode=3532, NSLocalizedDescription=You’re currently subscribed to this.}
[00:51:46]: ▸ 2022-11-09 00:51:46.820780+0000 BackendIntegrationTestsHostApp[4240:21475] [Default] [StoreKit] Purchase did not return a transaction: Error Domain=ASDServerErrorDomain Code=3532 "You’re currently subscribed to this." UserInfo={storefront-country-code=USA, client-environment-type=XcodeTest(/Users/distiller/Library/Developer/CoreSimulator/Devices/E616C409-03A4-4A07-B2DC-FFF7544CBCCD/data/Containers/Shared/App ... tTestApp), AMSServerErrorCode=3532, NSLocalizedDescription=You’re currently subscribed to this.}
[00:51:46]: ▸ 2022-11-09 00:51:46.821036+0000 BackendIntegrationTestsHostApp[4240:21475] [Purchases] - ERROR: 🍎‼️ There was a problem with the App Store.
[00:51:46]: ▸ 2022-11-09 00:51:46.821236+0000 BackendIntegrationTestsHostApp[4240:21475] [Purchases] - ERROR: 💰 Product purchase for 'com.revenuecat.monthly_4.99.1_week_intro' failed with error: PurchasesError(error: There was a problem with the App Store., userInfo: ["readable_error_code": "STORE_PROBLEM", "NSLocalizedDescription": "There was a problem with the App Store.", "source_file": "RevenueCat/StoreKitError+Extensions.swift:43", "source_function": "asPurchasesError", "NSUnderlyingError": StoreKit.StoreKitError.unknown])
[00:51:46]: ▸ <unknown>:0: error: -[BackendIntegrationTests.StoreKit2IntegrationTests testPurchaseWithAskToBuyPostsReceipt] : failed: caught error: "There was a problem with the App Store."
[00:51:46]: ▸ Test Case '-[BackendIntegrationTests.StoreKit2IntegrationTests testPurchaseWithAskToBuyPostsReceipt]' failed (0.827 seconds).
```

With this change, instead of trying to purchase it again, we simply restore purchases to confirm that the purchase went through after approving it.