### PR TITLE
Changed default `UserDefaults` from `.standard` to our own Suite

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -325,7 +325,7 @@
 		57C381E2279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */; };
 		57C381E3279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */; };
 		57CD86DA291C1E2300768DE1 /* UserDefaults+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CD86D9291C1E2300768DE1 /* UserDefaults+Extensions.swift */; };
-		57CD86DC291C1E3E00768DE1 /* UserDefaultsExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CD86DB291C1E3E00768DE1 /* UserDefaultsExtensionsTests.swift */; };
+		57CD86E6291C344000768DE1 /* UserDefaultsDefaultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CD86E5291C344000768DE1 /* UserDefaultsDefaultTests.swift */; };
 		57CFB96C27FE0E79002A6730 /* MockCurrentUserProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CFB96B27FE0E79002A6730 /* MockCurrentUserProvider.swift */; };
 		57CFB96D27FE0E79002A6730 /* MockCurrentUserProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CFB96B27FE0E79002A6730 /* MockCurrentUserProvider.swift */; };
 		57CFB98427FE2258002A6730 /* StoreKit2Setting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CFB98327FE2258002A6730 /* StoreKit2Setting.swift */; };
@@ -849,7 +849,7 @@
 		57C381DB27961547009E3940 /* SK2StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreProductDiscount.swift; sourceTree = "<group>"; };
 		57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreProductDiscount.swift; sourceTree = "<group>"; };
 		57CD86D9291C1E2300768DE1 /* UserDefaults+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Extensions.swift"; sourceTree = "<group>"; };
-		57CD86DB291C1E3E00768DE1 /* UserDefaultsExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsExtensionsTests.swift; sourceTree = "<group>"; };
+		57CD86E5291C344000768DE1 /* UserDefaultsDefaultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsDefaultTests.swift; sourceTree = "<group>"; };
 		57CFB96B27FE0E79002A6730 /* MockCurrentUserProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCurrentUserProvider.swift; sourceTree = "<group>"; };
 		57CFB98327FE2258002A6730 /* StoreKit2Setting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2Setting.swift; sourceTree = "<group>"; };
 		57D04BB727D947C6006DAC06 /* HTTPResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponseTests.swift; sourceTree = "<group>"; };
@@ -1221,6 +1221,7 @@
 				F5E5E2E82847953000216ECD /* ProductsFetcherSK2Tests.swift */,
 				F5355162286B70E0009CA47A /* OfferingsManagerStoreKitTests.swift */,
 				57E6194F28D291DC0093170C /* StoreKit2CachingProductsManagerTests.swift */,
+				57CD86E5291C344000768DE1 /* UserDefaultsDefaultTests.swift */,
 			);
 			path = StoreKitUnitTests;
 			sourceTree = "<group>";
@@ -1691,7 +1692,6 @@
 				5796A3BF27D7D64500653165 /* ResultExtensionsTests.swift */,
 				57A1772A276A726C0052D3A8 /* SetExtensionsTests.swift */,
 				57D56FC92853C005009E8E1E /* StringExtensionsTests.swift */,
-				57CD86DB291C1E3E00768DE1 /* UserDefaultsExtensionsTests.swift */,
 			);
 			path = FoundationExtensions;
 			sourceTree = "<group>";
@@ -2379,6 +2379,7 @@
 				5738F489278CC2500096D623 /* MockTransaction.swift in Sources */,
 				576C8ABC27D2997C0058FA6E /* SnapshotTesting+Extensions.swift in Sources */,
 				F5355164286B7125009CA47A /* MockOfferingsFactory.swift in Sources */,
+				57CD86E6291C344000768DE1 /* UserDefaultsDefaultTests.swift in Sources */,
 				57CFB96D27FE0E79002A6730 /* MockCurrentUserProvider.swift in Sources */,
 				2D90F8C826FD2225009B9142 /* MockAppleReceiptBuilder.swift in Sources */,
 				57C381B72791E593009E3940 /* StoreKit2TransactionListenerTests.swift in Sources */,
@@ -2759,7 +2760,6 @@
 				573A10DB2800AF4700F976E5 /* PurchaseErrorTests.swift in Sources */,
 				B300E4BF26D436F900B22262 /* LogIntent.swift in Sources */,
 				351B513F26D4496000BD2BD7 /* MockIdentityManager.swift in Sources */,
-				57CD86DC291C1E3E00768DE1 /* UserDefaultsExtensionsTests.swift in Sources */,
 				B319514926C19856002CA9AC /* NSData+RCExtensionsTests.swift in Sources */,
 				5733B1A427FF9F8300EC2045 /* NetworkErrorTests.swift in Sources */,
 				351B517026D44E8D00BD2BD7 /* MockDateProvider.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -324,6 +324,8 @@
 		57C381DC27961547009E3940 /* SK2StoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381DB27961547009E3940 /* SK2StoreProductDiscount.swift */; };
 		57C381E2279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */; };
 		57C381E3279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */; };
+		57CD86DA291C1E2300768DE1 /* UserDefaults+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CD86D9291C1E2300768DE1 /* UserDefaults+Extensions.swift */; };
+		57CD86DC291C1E3E00768DE1 /* UserDefaultsExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CD86DB291C1E3E00768DE1 /* UserDefaultsExtensionsTests.swift */; };
 		57CFB96C27FE0E79002A6730 /* MockCurrentUserProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CFB96B27FE0E79002A6730 /* MockCurrentUserProvider.swift */; };
 		57CFB96D27FE0E79002A6730 /* MockCurrentUserProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CFB96B27FE0E79002A6730 /* MockCurrentUserProvider.swift */; };
 		57CFB98427FE2258002A6730 /* StoreKit2Setting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CFB98327FE2258002A6730 /* StoreKit2Setting.swift */; };
@@ -846,6 +848,8 @@
 		57C381D92796153D009E3940 /* SK1StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1StoreProductDiscount.swift; sourceTree = "<group>"; };
 		57C381DB27961547009E3940 /* SK2StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreProductDiscount.swift; sourceTree = "<group>"; };
 		57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreProductDiscount.swift; sourceTree = "<group>"; };
+		57CD86D9291C1E2300768DE1 /* UserDefaults+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Extensions.swift"; sourceTree = "<group>"; };
+		57CD86DB291C1E3E00768DE1 /* UserDefaultsExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsExtensionsTests.swift; sourceTree = "<group>"; };
 		57CFB96B27FE0E79002A6730 /* MockCurrentUserProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCurrentUserProvider.swift; sourceTree = "<group>"; };
 		57CFB98327FE2258002A6730 /* StoreKit2Setting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2Setting.swift; sourceTree = "<group>"; };
 		57D04BB727D947C6006DAC06 /* HTTPResponseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponseTests.swift; sourceTree = "<group>"; };
@@ -1086,6 +1090,7 @@
 				57A17726276A721D0052D3A8 /* Set+Extensions.swift */,
 				B35F9E0826B4BEED00095C3F /* String+Extensions.swift */,
 				2D9C7BB226D838FC006838BE /* UIApplication+RCExtensions.swift */,
+				57CD86D9291C1E2300768DE1 /* UserDefaults+Extensions.swift */,
 			);
 			path = FoundationExtensions;
 			sourceTree = "<group>";
@@ -1686,6 +1691,7 @@
 				5796A3BF27D7D64500653165 /* ResultExtensionsTests.swift */,
 				57A1772A276A726C0052D3A8 /* SetExtensionsTests.swift */,
 				57D56FC92853C005009E8E1E /* StringExtensionsTests.swift */,
+				57CD86DB291C1E3E00768DE1 /* UserDefaultsExtensionsTests.swift */,
 			);
 			path = FoundationExtensions;
 			sourceTree = "<group>";
@@ -2512,6 +2518,7 @@
 				9A65E07B2591977500DE00B0 /* NetworkStrings.swift in Sources */,
 				F530E4FF275646EF001AF6BD /* MacDevice.swift in Sources */,
 				F5714EAC26D7A87B00635477 /* PurchaseOwnershipType+Extensions.swift in Sources */,
+				57CD86DA291C1E2300768DE1 /* UserDefaults+Extensions.swift in Sources */,
 				F5BE424026962ACF00254A30 /* ReceiptRefreshPolicy.swift in Sources */,
 				9A65E0762591977200DE00B0 /* IdentityStrings.swift in Sources */,
 				F5714EAA26D7A85D00635477 /* PeriodType+Extensions.swift in Sources */,
@@ -2752,6 +2759,7 @@
 				573A10DB2800AF4700F976E5 /* PurchaseErrorTests.swift in Sources */,
 				B300E4BF26D436F900B22262 /* LogIntent.swift in Sources */,
 				351B513F26D4496000BD2BD7 /* MockIdentityManager.swift in Sources */,
+				57CD86DC291C1E3E00768DE1 /* UserDefaultsExtensionsTests.swift in Sources */,
 				B319514926C19856002CA9AC /* NSData+RCExtensionsTests.swift in Sources */,
 				5733B1A427FF9F8300EC2045 /* NetworkErrorTests.swift in Sources */,
 				351B517026D44E8D00BD2BD7 /* MockDateProvider.swift in Sources */,

--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -37,7 +37,7 @@ class DeviceCache {
     private let appUserIDHasBeenSet: Atomic<Bool> = false
 
     convenience init(sandboxEnvironmentDetector: SandboxEnvironmentDetector,
-                     userDefaults: UserDefaults = UserDefaults.standard) {
+                     userDefaults: UserDefaults) {
         self.init(sandboxEnvironmentDetector: sandboxEnvironmentDetector,
                   userDefaults: userDefaults,
                   offeringsCachedObject: nil,
@@ -45,7 +45,7 @@ class DeviceCache {
     }
 
     init(sandboxEnvironmentDetector: SandboxEnvironmentDetector,
-         userDefaults: UserDefaults = UserDefaults.standard,
+         userDefaults: UserDefaults,
          offeringsCachedObject: InMemoryCachedObject<Offerings>? = InMemoryCachedObject(),
          notificationCenter: NotificationCenter? = NotificationCenter.default) {
 

--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -268,7 +268,7 @@ class DeviceCache {
                 Logger.warn(Strings.identity.deleting_synced_attributes_none_found)
                 return
             }
-            $0.setValue(groupedAttributes, forKey: CacheKeys.subscriberAttributes)
+            $0.setValue(groupedAttributes, forKey: .subscriberAttributes)
         }
     }
 
@@ -318,7 +318,7 @@ class DeviceCache {
 
     // MARK: - Helper functions
 
-    fileprivate enum CacheKeys: String {
+    internal enum CacheKeys: String {
 
         case legacyGeneratedAppUserDefaults = "com.revenuecat.userdefaults.appUserID"
         case appUserDefaults = "com.revenuecat.userdefaults.appUserID.new"

--- a/Sources/FoundationExtensions/UserDefaults+Extensions.swift
+++ b/Sources/FoundationExtensions/UserDefaults+Extensions.swift
@@ -15,20 +15,6 @@ import Foundation
 
 extension UserDefaults {
 
-    #if DEBUG
-    /// The "default" `UserDefaults` to use for the SDK.
-    ///
-    /// Moving foward, this default is `UserDefaults.revenueCatSuite`,
-    /// but existing users will continue using `UserDefaults.standard` for compatibility.
-    /// This is determined by the presence of an app user ID in `UserDefaults.standard`.
-    ///
-    /// Computed property only in `DEBUG` to be able to test it under different conditions.
-    /// In release mode, it gets cached.
-    static var `default`: UserDefaults { .computeDefault() }
-    #else
-    static let `default`: UserDefaults = .computeDefault()
-    #endif
-
     // These are the only 2 documented reasons why `.init(suiteName:)` might return `nil`:
     // - "Because a suite manages the defaults of a specified app group, a suite name
     // must be distinct from your app’s main bundle identifier.
@@ -37,12 +23,17 @@ extension UserDefaults {
     // Because we know at compile time that it's neither of those, this is a safe force-unwrap.
     static let revenueCatSuite: UserDefaults = .init(suiteName: UserDefaults.revenueCatSuiteName)!
 
+    private static let revenueCatSuiteName = "com.revenuecat.user_defaults"
+
 }
 
-private extension UserDefaults {
+extension UserDefaults {
 
-    static let revenueCatSuiteName = "com.revenuecat.user_defaults"
-
+    /// Determines the "default" `UserDefaults` to use for the SDK.
+    ///
+    /// Moving foward, this default is `UserDefaults.revenueCatSuite`,
+    /// but existing users will continue using `UserDefaults.standard` for compatibility.
+    /// This is determined by the presence of an app user ID in `UserDefaults.standard`.
     static func computeDefault() -> UserDefaults {
         let standard: UserDefaults = .standard
 

--- a/Sources/FoundationExtensions/UserDefaults+Extensions.swift
+++ b/Sources/FoundationExtensions/UserDefaults+Extensions.swift
@@ -47,8 +47,10 @@ private extension UserDefaults {
         let standard: UserDefaults = .standard
 
         if standard.value(forKey: DeviceCache.CacheKeys.appUserDefaults.rawValue) != nil {
+            Logger.debug(Strings.configure.using_user_defaults_standard)
             return standard
         } else {
+            Logger.debug(Strings.configure.using_user_defaults_suite_name)
             return .revenueCatSuite
         }
     }

--- a/Sources/FoundationExtensions/UserDefaults+Extensions.swift
+++ b/Sources/FoundationExtensions/UserDefaults+Extensions.swift
@@ -15,12 +15,19 @@ import Foundation
 
 extension UserDefaults {
 
+    #if DEBUG
     /// The "default" `UserDefaults` to use for the SDK.
     ///
     /// Moving foward, this default is `UserDefaults.revenueCatSuite`, for for compatibility with existing users
     /// `UserDefaults.standard` is used.
     /// This is determined by the presence of an app user ID in `UserDefaults.standard`.
-    static let `default`: UserDefaults = UserDefaults.computeDefault()
+    ///
+    /// Computed property only in `DEBUG` to be able to test it under different conditions.
+    /// In release mode, it gets cached.
+    static var `default`: UserDefaults { .computeDefault() }
+    #else
+    static let `default`: UserDefaults = .computeDefault()
+    #endif
 
     // These are the only 2 documented reasons why `.init(suiteName:)` might return `nil`:
     // - "Because a suite manages the defaults of a specified app group, a suite name
@@ -30,7 +37,12 @@ extension UserDefaults {
     // Because we know at compile time that it's neither of those, this is a safe force-unwrap.
     static let revenueCatSuite: UserDefaults = .init(suiteName: UserDefaults.revenueCatSuiteName)!
 
-    /// - Warning: this is only visible for tests, `.default` must be used instead.
+}
+
+private extension UserDefaults {
+
+    static let revenueCatSuiteName = "com.revenuecat.user_defaults"
+
     static func computeDefault() -> UserDefaults {
         let standard: UserDefaults = .standard
 
@@ -40,11 +52,5 @@ extension UserDefaults {
             return .revenueCatSuite
         }
     }
-
-}
-
-private extension UserDefaults {
-
-    static let revenueCatSuiteName = "com.revenuecat.user_defaults"
 
 }

--- a/Sources/FoundationExtensions/UserDefaults+Extensions.swift
+++ b/Sources/FoundationExtensions/UserDefaults+Extensions.swift
@@ -18,8 +18,8 @@ extension UserDefaults {
     #if DEBUG
     /// The "default" `UserDefaults` to use for the SDK.
     ///
-    /// Moving foward, this default is `UserDefaults.revenueCatSuite`, for for compatibility with existing users
-    /// `UserDefaults.standard` is used.
+    /// Moving foward, this default is `UserDefaults.revenueCatSuite`,
+    /// but existing users will continue using `UserDefaults.standard` for compatibility.
     /// This is determined by the presence of an app user ID in `UserDefaults.standard`.
     ///
     /// Computed property only in `DEBUG` to be able to test it under different conditions.

--- a/Sources/FoundationExtensions/UserDefaults+Extensions.swift
+++ b/Sources/FoundationExtensions/UserDefaults+Extensions.swift
@@ -1,0 +1,50 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  UserDefaults+Extensions.swift
+//
+//  Created by Nacho Soto on 11/9/22.
+
+import Foundation
+
+extension UserDefaults {
+
+    /// The "default" `UserDefaults` to use for the SDK.
+    ///
+    /// Moving foward, this default is `UserDefaults.revenueCatSuite`, for for compatibility with existing users
+    /// `UserDefaults.standard` is used.
+    /// This is determined by the presence of an app user ID in `UserDefaults.standard`.
+    static let `default`: UserDefaults = UserDefaults.computeDefault()
+
+    // These are the only 2 documented reasons why `.init(suiteName:)` might return `nil`:
+    // - "Because a suite manages the defaults of a specified app group, a suite name
+    // must be distinct from your app’s main bundle identifier.
+    // - The globalDomain is also an invalid suite name, because it isn't writeable by apps.
+    //
+    // Because we know at compile time that it's neither of those, this is a safe force-unwrap.
+    static let revenueCatSuite: UserDefaults = .init(suiteName: UserDefaults.revenueCatSuiteName)!
+
+    /// - Warning: this is only visible for tests, `.default` must be used instead.
+    static func computeDefault() -> UserDefaults {
+        let standard: UserDefaults = .standard
+
+        if standard.value(forKey: DeviceCache.CacheKeys.appUserDefaults.rawValue) != nil {
+            return standard
+        } else {
+            return .revenueCatSuite
+        }
+    }
+
+}
+
+private extension UserDefaults {
+
+    static let revenueCatSuiteName = "com.revenuecat.user_defaults"
+
+}

--- a/Sources/Logging/Strings/ConfigureStrings.swift
+++ b/Sources/Logging/Strings/ConfigureStrings.swift
@@ -108,7 +108,7 @@ extension ConfigureStrings: CustomStringConvertible {
             return "Configuring SDK using provided UserDefaults."
 
         case .using_user_defaults_standard:
-            return "Configuring SDK using UserDefaults.standard."
+            return "Configuring SDK using UserDefaults.standard because we found existing data in it."
 
         case .using_user_defaults_suite_name:
             return "Configuring SDK using RevenueCat's UserDefaults suite."

--- a/Sources/Logging/Strings/ConfigureStrings.swift
+++ b/Sources/Logging/Strings/ConfigureStrings.swift
@@ -45,6 +45,12 @@ enum ConfigureStrings {
 
     case autoSyncPurchasesDisabled
 
+    case using_custom_user_defaults
+
+    case using_user_defaults_standard
+
+    case using_user_defaults_suite_name
+
 }
 
 extension ConfigureStrings: CustomStringConvertible {
@@ -97,6 +103,16 @@ extension ConfigureStrings: CustomStringConvertible {
             "after the transaction is finished, so make sure purchases are synced before \n" +
             "finishing any consumable transaction, otherwise RevenueCat won’t register the \n" +
             "purchase."
+
+        case .using_custom_user_defaults:
+            return "Configuring SDK using provided UserDefaults."
+
+        case .using_user_defaults_standard:
+            return "Configuring SDK using UserDefaults.standard."
+
+        case .using_user_defaults_suite_name:
+            return "Configuring SDK using RevenueCat's UserDefaults suite."
+
         }
     }
 

--- a/Sources/Networking/HTTPClient/ETagManager.swift
+++ b/Sources/Networking/HTTPClient/ETagManager.swift
@@ -22,7 +22,10 @@ class ETagManager {
 
     convenience init() {
         self.init(
-            userDefaults: UserDefaults(suiteName: ETagManager.suiteName) ?? UserDefaults.standard
+            userDefaults: UserDefaults(suiteName: Self.suiteName)
+            // This should never return `nil` for this known `suiteName`,
+            // but `.standard` is a good fallback anyway.
+            ?? UserDefaults.standard
         )
     }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -218,6 +218,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     private let backend: Backend
     private let deviceCache: DeviceCache
     private let identityManager: IdentityManager
+    private let userDefaults: UserDefaults
     private let notificationCenter: NotificationCenter
     private let offeringsFactory: OfferingsFactory
     private let offeringsManager: OfferingsManager
@@ -272,7 +273,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             : .left(.init())
 
         let offeringsFactory = OfferingsFactory()
-        let userDefaults = userDefaults ?? UserDefaults.standard
+        let userDefaults = userDefaults ?? UserDefaults.default
         let deviceCache = DeviceCache(sandboxEnvironmentDetector: systemInfo, userDefaults: userDefaults)
         let receiptParser = ReceiptParser.default
         let transactionsManager = TransactionsManager(receiptParser: receiptParser)
@@ -372,7 +373,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                   attributionPoster: attributionPoster,
                   backend: backend,
                   paymentQueueWrapper: paymentQueueWrapper,
-                  notificationCenter: NotificationCenter.default,
+                  userDefaults: userDefaults,
+                  notificationCenter: .default,
                   systemInfo: systemInfo,
                   offeringsFactory: offeringsFactory,
                   deviceCache: deviceCache,
@@ -393,6 +395,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
          attributionPoster: AttributionPoster,
          backend: Backend,
          paymentQueueWrapper: EitherPaymentQueueWrapper,
+         userDefaults: UserDefaults,
          notificationCenter: NotificationCenter,
          systemInfo: SystemInfo,
          offeringsFactory: OfferingsFactory,
@@ -424,6 +427,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.offeringsFactory = offeringsFactory
         self.deviceCache = deviceCache
         self.identityManager = identityManager
+        self.userDefaults = userDefaults
         self.notificationCenter = notificationCenter
         self.systemInfo = systemInfo
         self.attribution = subscriberAttributes
@@ -1122,7 +1126,7 @@ internal extension Purchases {
 
 #if DEBUG
 
-// MARK: - Exposed data for testing
+// MARK: - Exposed data for testing only
 
 internal extension Purchases {
 
@@ -1136,6 +1140,10 @@ internal extension Purchases {
 
     var isSandbox: Bool {
         return self.systemInfo.isSandbox
+    }
+
+    var configuredUserDefaults: UserDefaults {
+        return self.userDefaults
     }
 
 }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -242,6 +242,10 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                      storeKitTimeout: TimeInterval = Configuration.storeKitRequestTimeoutDefault,
                      networkTimeout: TimeInterval = Configuration.networkTimeoutDefault,
                      dangerousSettings: DangerousSettings? = nil) {
+        if userDefaults != nil {
+            Logger.debug(Strings.configure.using_custom_user_defaults)
+        }
+
         let operationDispatcher: OperationDispatcher = .default
         let receiptRefreshRequestFactory = ReceiptRefreshRequestFactory()
         let fetcher = StoreKitRequestFetcher(requestFactory: receiptRefreshRequestFactory,

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -277,7 +277,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             : .left(.init())
 
         let offeringsFactory = OfferingsFactory()
-        let userDefaults = userDefaults ?? UserDefaults.default
+        let userDefaults = userDefaults ?? UserDefaults.computeDefault()
         let deviceCache = DeviceCache(sandboxEnvironmentDetector: systemInfo, userDefaults: userDefaults)
         let receiptParser = ReceiptParser.default
         let transactionsManager = TransactionsManager(receiptParser: receiptParser)

--- a/Tests/StoreKitUnitTests/UserDefaultsDefaultTests.swift
+++ b/Tests/StoreKitUnitTests/UserDefaultsDefaultTests.swift
@@ -35,18 +35,18 @@ final class UserDefaultsDefaultTests: TestCase {
     func testDefaultIsStandardIfStandardContainsUserID() {
         UserDefaults.standard.set("user", forKey: Self.appUserKey)
 
-        expect(UserDefaults.default) === UserDefaults.standard
+        expect(UserDefaults.computeDefault()) === UserDefaults.standard
     }
 
     func testDefaultIsRevenueCatSuiteIfStandardDoesNotContainUserID() {
-        expect(UserDefaults.default) === UserDefaults.revenueCatSuite
+        expect(UserDefaults.computeDefault()) === UserDefaults.revenueCatSuite
     }
 
     /// Ensures that the logic only checks `UserDefaults.standard`.
     func testDefaultIsRevenueCatSuiteEvenIfItContainsAppUserID() {
         UserDefaults.revenueCatSuite.set("user", forKey: Self.appUserKey)
 
-        expect(UserDefaults.default) === UserDefaults.revenueCatSuite
+        expect(UserDefaults.computeDefault()) === UserDefaults.revenueCatSuite
     }
 
 }

--- a/Tests/StoreKitUnitTests/UserDefaultsDefaultTests.swift
+++ b/Tests/StoreKitUnitTests/UserDefaultsDefaultTests.swift
@@ -7,7 +7,7 @@
 //
 //      https://opensource.org/licenses/MIT
 //
-//  UserDefaultsExtensionsTests.swift
+//  UserDefaultsDefaultTests.swift
 //
 //  Created by Nacho Soto on 11/9/22.
 
@@ -17,7 +17,10 @@ import XCTest
 
 @testable import RevenueCat
 
-final class UserDefaultsExtensionsTests: TestCase {
+// Note: these are in `StoreKitUnitTests` because they can't run in parallel.
+// We run them serially to avoid race conditions while modifying `UserDefaults`.
+
+final class UserDefaultsDefaultTests: TestCase {
 
     override func setUp() {
         super.setUp()
@@ -32,23 +35,23 @@ final class UserDefaultsExtensionsTests: TestCase {
     func testDefaultIsStandardIfStandardContainsUserID() {
         UserDefaults.standard.set("user", forKey: Self.appUserKey)
 
-        expect(UserDefaults.computeDefault()) === UserDefaults.standard
+        expect(UserDefaults.default) === UserDefaults.standard
     }
 
     func testDefaultIsRevenueCatSuiteIfStandardDoesNotContainUserID() {
-        expect(UserDefaults.computeDefault()) === UserDefaults.revenueCatSuite
+        expect(UserDefaults.default) === UserDefaults.revenueCatSuite
     }
 
     /// Ensures that the logic only checks `UserDefaults.standard`.
     func testDefaultIsRevenueCatSuiteEvenIfItContainsAppUserID() {
         UserDefaults.revenueCatSuite.set("user", forKey: Self.appUserKey)
 
-        expect(UserDefaults.computeDefault()) === UserDefaults.revenueCatSuite
+        expect(UserDefaults.default) === UserDefaults.revenueCatSuite
     }
 
 }
 
-private extension UserDefaultsExtensionsTests {
+private extension UserDefaultsDefaultTests {
 
     static let appUserKey: String = DeviceCache.CacheKeys.appUserDefaults.rawValue
 

--- a/Tests/UnitTests/FoundationExtensions/UserDefaultsExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/UserDefaultsExtensionsTests.swift
@@ -1,0 +1,55 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  UserDefaultsExtensionsTests.swift
+//
+//  Created by Nacho Soto on 11/9/22.
+
+import Foundation
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+final class UserDefaultsExtensionsTests: TestCase {
+
+    override func setUp() {
+        super.setUp()
+
+        UserDefaults.standard.removeObject(forKey: Self.appUserKey)
+    }
+
+    func testRevenueCatSuiteIsNotStandard() {
+        expect(UserDefaults.revenueCatSuite) !== UserDefaults.standard
+    }
+
+    func testDefaultIsStandardIfStandardContainsUserID() {
+        UserDefaults.standard.set("user", forKey: Self.appUserKey)
+
+        expect(UserDefaults.computeDefault()) === UserDefaults.standard
+    }
+
+    func testDefaultIsRevenueCatSuiteIfStandardDoesNotContainUserID() {
+        expect(UserDefaults.computeDefault()) === UserDefaults.revenueCatSuite
+    }
+
+    /// Ensures that the logic only checks `UserDefaults.standard`.
+    func testDefaultIsRevenueCatSuiteEvenIfItContainsAppUserID() {
+        UserDefaults.revenueCatSuite.set("user", forKey: Self.appUserKey)
+
+        expect(UserDefaults.computeDefault()) === UserDefaults.revenueCatSuite
+    }
+
+}
+
+private extension UserDefaultsExtensionsTests {
+
+    static let appUserKey: String = DeviceCache.CacheKeys.appUserDefaults.rawValue
+
+}

--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -9,7 +9,7 @@ class MockDeviceCache: DeviceCache {
 
     convenience init(sandboxEnvironmentDetector: SandboxEnvironmentDetector) {
         self.init(sandboxEnvironmentDetector: sandboxEnvironmentDetector,
-                  userDefaults: .default)
+                  userDefaults: .computeDefault())
     }
 
     // MARK: appUserID

--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -9,7 +9,7 @@ class MockDeviceCache: DeviceCache {
 
     convenience init(sandboxEnvironmentDetector: SandboxEnvironmentDetector) {
         self.init(sandboxEnvironmentDetector: sandboxEnvironmentDetector,
-                  userDefaults: .standard)
+                  userDefaults: .default)
     }
 
     // MARK: appUserID

--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -7,6 +7,11 @@
 
 class MockDeviceCache: DeviceCache {
 
+    convenience init(sandboxEnvironmentDetector: SandboxEnvironmentDetector) {
+        self.init(sandboxEnvironmentDetector: sandboxEnvironmentDetector,
+                  userDefaults: .standard)
+    }
+
     // MARK: appUserID
 
     var stubbedAppUserID: String?

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -190,6 +190,7 @@ class BasePurchasesTests: TestCase {
                                    attributionPoster: self.attributionPoster,
                                    backend: self.backend,
                                    paymentQueueWrapper: paymentQueueWrapper,
+                                   userDefaults: .default,
                                    notificationCenter: self.notificationCenter,
                                    systemInfo: self.systemInfo,
                                    offeringsFactory: self.offeringsFactory,

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -91,7 +91,7 @@ class BasePurchasesTests: TestCase {
 
         Purchases.clearSingleton()
 
-        UserDefaults.standard.removePersistentDomain(forName: Self.userDefaultsSuiteName)
+        self.userDefaults.removePersistentDomain(forName: Self.userDefaultsSuiteName)
 
         super.tearDown()
     }
@@ -190,7 +190,7 @@ class BasePurchasesTests: TestCase {
                                    attributionPoster: self.attributionPoster,
                                    backend: self.backend,
                                    paymentQueueWrapper: paymentQueueWrapper,
-                                   userDefaults: .default,
+                                   userDefaults: self.userDefaults,
                                    notificationCenter: self.notificationCenter,
                                    systemInfo: self.systemInfo,
                                    offeringsFactory: self.offeringsFactory,

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -270,7 +270,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
     }
 
     func testDefaultUserDefaultsIsUsedByDefault() {
-        expect(Self.create(userDefaults: nil).configuredUserDefaults) === UserDefaults.default
+        expect(Self.create(userDefaults: nil).configuredUserDefaults) === UserDefaults.computeDefault()
     }
 
     private static func create(userDefaults: UserDefaults?) -> Purchases {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -263,4 +263,38 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expect(self.paymentQueueWrapper.delegate) === self.purchasesOrchestrator
     }
 
+    // MARK: - UserDefaults
+
+    func testCustomUserDefaultsIsUsedIfNoUserIDIsStored() {
+        expect(Self.create(userDefaults: Self.customUserDefaults).configuredUserDefaults) === Self.customUserDefaults
+    }
+
+    func testCustomUserDefaultsIsUsedEvenIfUserIDIsStored() {
+        UserDefaults.standard.set("user", forKey: DeviceCache.CacheKeys.appUserDefaults.rawValue)
+
+        expect(Self.create(userDefaults: Self.customUserDefaults).configuredUserDefaults) === Self.customUserDefaults
+    }
+
+    func testRevenueCatSuiteIsUsedByDefault() {
+        expect(Self.create(userDefaults: nil).configuredUserDefaults) === UserDefaults.revenueCatSuite
+    }
+
+    func testStandardUserDefaultsIsUsedByDefaultIfItContainedUserID() {
+        UserDefaults.standard.set("user", forKey: DeviceCache.CacheKeys.appUserDefaults.rawValue)
+
+        expect(Self.create(userDefaults: nil).configuredUserDefaults) === UserDefaults.standard
+    }
+
+    private static func create(userDefaults: UserDefaults?) -> Purchases {
+        var configurationBuilder: Configuration.Builder = .init(withAPIKey: "")
+
+        if let userDefaults = userDefaults {
+            configurationBuilder = configurationBuilder.with(userDefaults: userDefaults)
+        }
+
+        return Purchases.configure(with: configurationBuilder.build())
+    }
+
+    private static let customUserDefaults: UserDefaults = .init(suiteName: "com.revenuecat.testing_user_defaults")!
+
 }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -265,24 +265,12 @@ class PurchasesConfiguringTests: BasePurchasesTests {
 
     // MARK: - UserDefaults
 
-    func testCustomUserDefaultsIsUsedIfNoUserIDIsStored() {
+    func testCustomUserDefaultsIsUsed() {
         expect(Self.create(userDefaults: Self.customUserDefaults).configuredUserDefaults) === Self.customUserDefaults
     }
 
-    func testCustomUserDefaultsIsUsedEvenIfUserIDIsStored() {
-        UserDefaults.standard.set("user", forKey: DeviceCache.CacheKeys.appUserDefaults.rawValue)
-
-        expect(Self.create(userDefaults: Self.customUserDefaults).configuredUserDefaults) === Self.customUserDefaults
-    }
-
-    func testRevenueCatSuiteIsUsedByDefault() {
-        expect(Self.create(userDefaults: nil).configuredUserDefaults) === UserDefaults.revenueCatSuite
-    }
-
-    func testStandardUserDefaultsIsUsedByDefaultIfItContainedUserID() {
-        UserDefaults.standard.set("user", forKey: DeviceCache.CacheKeys.appUserDefaults.rawValue)
-
-        expect(Self.create(userDefaults: nil).configuredUserDefaults) === UserDefaults.standard
+    func testDefaultUserDefaultsIsUsedByDefault() {
+        expect(Self.create(userDefaults: nil).configuredUserDefaults) === UserDefaults.default
     }
 
     private static func create(userDefaults: UserDefaults?) -> Purchases {

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -167,7 +167,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
                               attributionPoster: mockAttributionPoster,
                               backend: mockBackend,
                               paymentQueueWrapper: .left(self.mockStoreKit1Wrapper),
-                              userDefaults: .default,
+                              userDefaults: .computeDefault(),
                               notificationCenter: mockNotificationCenter,
                               systemInfo: systemInfo,
                               offeringsFactory: mockOfferingsFactory,

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -167,6 +167,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
                               attributionPoster: mockAttributionPoster,
                               backend: mockBackend,
                               paymentQueueWrapper: .left(self.mockStoreKit1Wrapper),
+                              userDefaults: .default,
                               notificationCenter: mockNotificationCenter,
                               systemInfo: systemInfo,
                               offeringsFactory: mockOfferingsFactory,


### PR DESCRIPTION
Fixes [CSDK-16].
See https://docs.google.com/document/d/1DDyed98RFpIvUwUPJcetc7X4fBhDzf-r1trC4g3zf4c/edit# for reasoning and documentation.

### Motivation

The RevenueCat SDK has always used `UserDefaults.standard` as the default value. The advantage of this was simplicity, however, this brings a few challenges.

### Issues

- While `UserDefaults` is itself thread-safe, our users might be observing `UserDefaults.defaults` changes via `KVO`, `NotificationCenter`, or `@AppStorage` (see https://github.com/RevenueCat/purchases-ios/issues/1527). We update `UserDefaults` from background threads, and users might be getting updates on those threads without handling thread-safety correctly.
- Users can accidentally delete data from the shared `UserDefaults` (see https://rev.cat/userdefaults-crash).

Using a custom `UserDefaults` solves all these issues.

### Change

The new `UserDefaults.revenueCatSuite` is used when:
- Only if users aren’t overriding the `UserDefaults` parameter
- Only if `UserDefaults.standard` has no value for `com.revenuecat.userdefaults.appUserID.new` (the user hasn't used the SDK in that app before).

#### Logged during app start:

> PurchaseTester[35110:6323140] DEBUG: ℹ️ Configuring SDK using RevenueCat's UserDefaults suite.

### Alternatives Considered
See https://docs.google.com/document/d/1c2B4MNAFKs_DcFJ3OE_KnmryHCArBkjlZbAD9_kSXu0/edit#

We considered also migrating data for everyone into the new `UserDefaults`.
This new approach is much simpler, less error prone, easier to implement, and maintain.
The only downside is that existing users won’t benefit from this change, but @aboedo correctly pointed out: if the app is working for them, no reason to change anything.

So in this way, this becomes a purely forward-looking improvement.

[CSDK-16]: https://revenuecats.atlassian.net/browse/CSDK-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ