### PR TITLE
`HTTPClient`: added log for failed requests

### DIFF
--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -17,8 +17,9 @@ import Foundation
 // swiftlint:disable identifier_name
 enum NetworkStrings {
 
-    case api_request_completed(_ request: HTTPRequest, httpCode: HTTPStatusCode)
     case api_request_started(HTTPRequest)
+    case api_request_completed(_ request: HTTPRequest, httpCode: HTTPStatusCode)
+    case api_request_failed(_ request: HTTPRequest, error: NetworkError)
     case reusing_existing_request_for_operation(CacheableNetworkOperation)
     case creating_json_error(error: String)
     case json_data_received(dataString: String)
@@ -38,13 +39,14 @@ extension NetworkStrings: CustomStringConvertible {
 
     var description: String {
         switch self {
+        case let .api_request_started(request):
+            return "API request started: \(request.description)"
 
         case let .api_request_completed(request, httpCode):
-            return "API request completed: \(request.method.httpMethod) \(request.path.url?.path ?? "")" +
-            " \(httpCode.rawValue)"
+            return "API request completed: \(request.description) (\(httpCode.rawValue))"
 
-        case let .api_request_started(request):
-            return "API request started: \(request.method.httpMethod) \(request.path.url?.path ?? "")"
+        case let .api_request_failed(request, error):
+            return "API request failed: \(request.description): \(error.description)"
 
         case let .reusing_existing_request_for_operation(operation):
             return "Network operation '\(type(of: operation))' found with the same cache key " +
@@ -89,6 +91,14 @@ extension NetworkStrings: CustomStringConvertible {
             "to \(url.absoluteString) host: (\(newHost ?? "<unable to resolve>")), " +
             "see: https://rev.cat/dnsBlocking for more info."
         }
+    }
+
+}
+
+private extension HTTPRequest {
+
+    var description: String {
+        return "\(self.method.httpMethod) \(self.path.url?.path ?? "")"
     }
 
 }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -214,9 +214,6 @@ private extension HTTPClient {
 
         let statusCode = HTTPStatusCode(rawValue: httpURLResponse.statusCode)
 
-        Logger.debug(Strings.network.api_request_completed(request.httpRequest,
-                                                           httpCode: statusCode))
-
         return Result
             .success(dataIfAvailable(statusCode))
             .mapSuccessToOptionalHTTPResult(statusCode)
@@ -244,6 +241,13 @@ private extension HTTPClient {
         )
 
         if let response = response {
+            switch response {
+            case let .success(response):
+                Logger.debug(Strings.network.api_request_completed(request.httpRequest, httpCode: response.statusCode))
+            case let .failure(error):
+                Logger.debug(Strings.network.api_request_failed(request.httpRequest, error: error))
+            }
+
             request.completionHandler?(response)
         } else {
             Logger.debug(Strings.network.retrying_request(httpMethod: request.method.httpMethod,


### PR DESCRIPTION
I'm looking into [CSDK-517], and it's hard to tell why we ended up with concurrent requests. It appears that a second request begins before the last one started.
That's seemingly impossible, and the only explanation for the logs missing "request completed" is that the first request failed.

This extra log will help us understand what's happening.

[CSDK-517]: https://revenuecats.atlassian.net/browse/CSDK-517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ