### PR TITLE
`PurchaseTesterSwiftUI`: added observer mode setting

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ConfiguredPurchases.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ConfiguredPurchases.swift
@@ -24,7 +24,8 @@ final class ConfiguredPurchases {
     convenience init(
         apiKey: String,
         proxyURL: String?,
-        useStoreKit2: Bool
+        useStoreKit2: Bool,
+        observerMode: Bool
     ) {
         Purchases.logLevel = .debug
         Purchases.logHandler = Self.logger.logHandler
@@ -36,6 +37,7 @@ final class ConfiguredPurchases {
         let purchases = Purchases.configure(
             with: .builder(withAPIKey: apiKey)
                 .with(usesStoreKit2IfAvailable: useStoreKit2)
+                .with(observerMode: observerMode)
                 .build()
         )
 

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
@@ -35,7 +35,8 @@ struct PurchaseTesterApp: App {
                         self.configuration = .init(
                             apiKey: data.apiKey,
                             proxyURL: data.proxy.nonEmpty,
-                            useStoreKit2: data.storeKit2Enabled
+                            useStoreKit2: data.storeKit2Enabled,
+                            observerMode: data.observerMode
                         )
                     }
                 }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/ConfigurationView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/ConfigurationView.swift
@@ -16,6 +16,7 @@ struct ConfigurationView: View {
                                                                    with: "")
         var proxy: String = ""
         var storeKit2Enabled: Bool = true
+        var observerMode: Bool = false
     }
 
     let onContinue: (Data) -> Void
@@ -40,6 +41,10 @@ struct ConfigurationView: View {
             Section {
                 Toggle(isOn: self.$data.storeKit2Enabled) {
                     Text("StoreKit2 enabled")
+                }
+
+                Toggle(isOn: self.$data.observerMode) {
+                    Text("Observer mode")
                 }
             }
 


### PR DESCRIPTION
Can be useful when debugging observer mode.

<img width="734" alt="Screenshot 2022-11-14 at 09 48 21" src="https://user-images.githubusercontent.com/685609/201731589-e412865d-d6e9-4032-afae-1ae191196c51.png">
