### PR TITLE
`APITester`: fixed warning in `SubscriptionPeriodAPI`

### DIFF
--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/SubscriptionPeriodAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/SubscriptionPeriodAPI.swift
@@ -18,9 +18,7 @@ func checkSubscriptionPeriodAPI() {
     print(value, unit)
 }
 
-func checkSubscriptionPeriodUnit() {
-    let unit: SubscriptionPeriod.Unit = .day
-
+func checkSubscriptionPeriodUnit(_ unit: SubscriptionPeriod.Unit = .day) {
     switch unit {
     case
             .day,


### PR DESCRIPTION
For some reason this wasn't compiling when compiling with test coverage on because the `switch` value was known at compile time.