### PR TITLE
`StoreKit1Wrapper`: added instance address when detecting transactions

### DIFF
--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -22,9 +22,11 @@ enum PurchaseStrings {
     case entitlements_revoked_syncing_purchases(productIdentifiers: [String])
     case finishing_transaction(StoreTransaction)
     case purchasing_with_observer_mode_and_finish_transactions_false_warning
-    case paymentqueue_removedtransaction(transaction: SKPaymentTransaction)
     case paymentqueue_revoked_entitlements_for_product_identifiers(productIdentifiers: [String])
-    case paymentqueue_updatedtransaction(transaction: SKPaymentTransaction)
+    case paymentqueue_removed_transaction(_ observer: SKPaymentTransactionObserver,
+                                          _ transaction: SKPaymentTransaction)
+    case paymentqueue_updated_transaction(_ observer: SKPaymentTransactionObserver,
+                                          _ transaction: SKPaymentTransaction)
     case presenting_code_redemption_sheet
     case unable_to_present_redemption_sheet
     case purchases_synced
@@ -89,9 +91,13 @@ extension PurchaseStrings: CustomStringConvertible {
             "purchase has been initiated. RevenueCat will not finish the " +
             "transaction, are you sure you want to do this?"
 
-        case .paymentqueue_removedtransaction(let transaction):
+        case .paymentqueue_revoked_entitlements_for_product_identifiers(let productIdentifiers):
+            return "PaymentQueue didRevokeEntitlementsForProductIdentifiers: \(productIdentifiers)"
+
+        case let .paymentqueue_removed_transaction(observer, transaction):
             let errorUserInfo = (transaction.error as NSError?)?.userInfo ?? [:]
-            return "PaymentQueue removedTransaction: \(transaction.payment.productIdentifier) " +
+
+            return "\(observer.debugName) removedTransaction: \(transaction.payment.productIdentifier) " +
             [
                 transaction.transactionIdentifier,
                 transaction.original?.transactionIdentifier,
@@ -102,12 +108,8 @@ extension PurchaseStrings: CustomStringConvertible {
                 .compactMap { $0 }
                 .joined(separator: " ")
 
-        case .paymentqueue_revoked_entitlements_for_product_identifiers(let productIdentifiers):
-            return "PaymentQueue " +
-            "didRevokeEntitlementsForProductIdentifiers: \(productIdentifiers)"
-
-        case .paymentqueue_updatedtransaction(let transaction):
-            return "PaymentQueue updatedTransaction: \(transaction.payment.productIdentifier) " +
+        case let .paymentqueue_updated_transaction(observer, transaction):
+            return "\(observer.debugName) updatedTransaction: \(transaction.payment.productIdentifier) " +
             [
                 transaction.transactionIdentifier,
                 (transaction.error?.localizedDescription).map { "(\($0))" },
@@ -247,6 +249,17 @@ extension PurchaseStrings: CustomStringConvertible {
         case .missing_cached_customer_info:
             return "Requested a cached CustomerInfo but it's not available."
         }
+    }
+
+}
+
+private extension SKPaymentTransactionObserver {
+
+    var debugName: String {
+        // Example: PaymentTransactionObserver (0x0000600000e36480)
+        // Used to debug which observer is detecting changes
+        // to ensure only one is in memory at a time.
+        return "PaymentTransactionObserver (\(Unmanaged.passUnretained(self).toOpaque()))"
     }
 
 }

--- a/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
@@ -127,7 +127,7 @@ extension StoreKit1Wrapper: SKPaymentTransactionObserver {
 
     func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
         for transaction in transactions {
-            Logger.debug(Strings.purchase.paymentqueue_updatedtransaction(transaction: transaction))
+            Logger.debug(Strings.purchase.paymentqueue_updated_transaction(self, transaction))
             self.delegate?.storeKit1Wrapper(self, updatedTransaction: transaction)
         }
     }
@@ -135,7 +135,7 @@ extension StoreKit1Wrapper: SKPaymentTransactionObserver {
     // Sent when transactions are removed from the queue (via finishTransaction:).
     func paymentQueue(_ queue: SKPaymentQueue, removedTransactions transactions: [SKPaymentTransaction]) {
         for transaction in transactions {
-            Logger.debug(Strings.purchase.paymentqueue_removedtransaction(transaction: transaction))
+            Logger.debug(Strings.purchase.paymentqueue_removed_transaction(self, transaction))
             self.delegate?.storeKit1Wrapper(self, removedTransaction: transaction)
         }
     }


### PR DESCRIPTION
My current theory for what's causing [CSDK-517] is that we have a leaking `StoreKit1Wrapper` when running integration tests, and that's why we're posting multiple receipts concurrently.

### Example:
```
PaymentTransactionObserver (0x0000600000e36480) updatedTransaction: com.revenuecat.monthly_4.99.1_week_intro 0
```

[CSDK-517]: https://revenuecats.atlassian.net/browse/CSDK-517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ