### PR TITLE
`Logger`: exposed generic `log` method

### DIFF
--- a/Sources/Logging/Logger.swift
+++ b/Sources/Logging/Logger.swift
@@ -171,6 +171,19 @@ extension Logger {
                  fileName: fileName, functionName: functionName, line: line)
     }
 
+    static func log(level: LogLevel,
+                    intent: LogIntent,
+                    message: @autoclosure () -> String,
+                    fileName: String? = #fileID,
+                    functionName: String? = #function,
+                    line: UInt = #line) {
+        Self.log(level: level,
+                 message: "\(intent.prefix) \(message())",
+                 fileName: fileName,
+                 functionName: functionName,
+                 line: line)
+    }
+
 }
 
 private extension Logger {
@@ -183,19 +196,6 @@ private extension Logger {
         guard self.logLevel.rawValue <= level.rawValue else { return }
 
         Self.logHandler(level, message(), fileName, functionName, line)
-    }
-
-    static func log(level: LogLevel,
-                    intent: LogIntent,
-                    message: @autoclosure () -> String,
-                    fileName: String? = #fileID,
-                    functionName: String? = #function,
-                    line: UInt = #line) {
-        Self.log(level: level,
-                 message: "\(intent.prefix) \(message())",
-                 fileName: fileName,
-                 functionName: functionName,
-                 line: line)
     }
 
 }


### PR DESCRIPTION
This will be used for [CSDK-512] to be able to configure the log level.

[CSDK-512]: https://revenuecats.atlassian.net/browse/CSDK-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ