### PR TITLE
Created `TimingUtil` to measure and log methods that are too slow

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -210,6 +210,8 @@
 		57069A5428E3918400B86355 /* AsyncExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57069A5328E3918400B86355 /* AsyncExtensions.swift */; };
 		57069A5E28E398E100B86355 /* AsyncExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57069A5D28E398E100B86355 /* AsyncExtensionsTests.swift */; };
 		570FAF4B2864EC2300D3C769 /* NonSubscriptionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570FAF4A2864EC2300D3C769 /* NonSubscriptionTransaction.swift */; };
+		5712BE9029241EB500A83F15 /* TimingUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5712BE8F29241EB500A83F15 /* TimingUtil.swift */; };
+		5712BE9229241F7900A83F15 /* TimingUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5712BE9129241F7900A83F15 /* TimingUtilTests.swift */; };
 		571E7AD4279F2D0C003B3606 /* StoreKitTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571E7AD3279F2D0C003B3606 /* StoreKitTestHelpers.swift */; };
 		5721360F28B4602C006C46BE /* Purchases+nonasync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5721360E28B4602C006C46BE /* Purchases+nonasync.swift */; };
 		572247D127BEC28E00C524A7 /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572247D027BEC28E00C524A7 /* Array+Extensions.swift */; };
@@ -743,6 +745,8 @@
 		570896B727596E8800296F1C /* SwiftAPITester.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SwiftAPITester.xcodeproj; path = Tests/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj; sourceTree = "<group>"; };
 		570896BD27596E8800296F1C /* ObjCAPITester.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ObjCAPITester.xcodeproj; path = Tests/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj; sourceTree = "<group>"; };
 		570FAF4A2864EC2300D3C769 /* NonSubscriptionTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonSubscriptionTransaction.swift; sourceTree = "<group>"; };
+		5712BE8F29241EB500A83F15 /* TimingUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingUtil.swift; sourceTree = "<group>"; };
+		5712BE9129241F7900A83F15 /* TimingUtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingUtilTests.swift; sourceTree = "<group>"; };
 		571E7AD3279F2D0C003B3606 /* StoreKitTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitTestHelpers.swift; sourceTree = "<group>"; };
 		5721360E28B4602C006C46BE /* Purchases+nonasync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Purchases+nonasync.swift"; sourceTree = "<group>"; };
 		572247D027BEC28E00C524A7 /* Array+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extensions.swift"; sourceTree = "<group>"; };
@@ -1318,6 +1322,7 @@
 				B3AA6237268B926F00894871 /* SystemInfo.swift */,
 				57FDAAB9284937A0009A48F1 /* SandboxEnvironmentDetector.swift */,
 				57ABA76C28F08DDA003D9181 /* Either.swift */,
+				5712BE8F29241EB500A83F15 /* TimingUtil.swift */,
 			);
 			path = Misc;
 			sourceTree = "<group>";
@@ -1533,6 +1538,7 @@
 				57FDAABD28493A29009A48F1 /* SandboxEnvironmentDetectorTests.swift */,
 				579189E828F47E8D00BF4963 /* PurchasesDiagnosticsTests.swift */,
 				57032ABE28C13CE4004FF47A /* StoreKit2SettingTests.swift */,
+				5712BE9129241F7900A83F15 /* TimingUtilTests.swift */,
 			);
 			path = Misc;
 			sourceTree = "<group>";
@@ -2527,6 +2533,7 @@
 				80E80EF226970E04008F245A /* ReceiptFetcher.swift in Sources */,
 				2DDF41AB24F6F37C005BC22D /* AppleReceipt.swift in Sources */,
 				2DDF41BB24F6F392005BC22D /* UInt8+Extensions.swift in Sources */,
+				5712BE9029241EB500A83F15 /* TimingUtil.swift in Sources */,
 				B3B5FBC1269E17CE00104A0C /* DeviceCache.swift in Sources */,
 				F5BE424226965F9F00254A30 /* ProductRequestData+Initialization.swift in Sources */,
 				2DDF41AD24F6F37C005BC22D /* ASN1ObjectIdentifier.swift in Sources */,
@@ -2767,6 +2774,7 @@
 				57FDAAC028493C13009A48F1 /* MockSandboxEnvironmentDetector.swift in Sources */,
 				5766AAD1283E981700FA6091 /* PurchasesPurchasingTests.swift in Sources */,
 				351B515E26D44B9900BD2BD7 /* MockPurchasesDelegate.swift in Sources */,
+				5712BE9229241F7900A83F15 /* TimingUtilTests.swift in Sources */,
 				57554CC1282AE1E3009A7E58 /* TestCase.swift in Sources */,
 				57A1772B276A726C0052D3A8 /* SetExtensionsTests.swift in Sources */,
 				351B515A26D44B6200BD2BD7 /* MockAttributionFetcher.swift in Sources */,

--- a/Sources/Logging/LogIntent.swift
+++ b/Sources/Logging/LogIntent.swift
@@ -17,6 +17,7 @@ import Foundation
 enum LogIntent {
 
     case appleError
+    case appleWarning
     case info
     case purchase
     case rcError
@@ -28,6 +29,7 @@ enum LogIntent {
     var prefix: String {
         switch self {
         case .appleError: return "🍎‼️"
+        case .appleWarning: return "🍎⚠️"
         case .info: return "ℹ️"
         case .purchase: return "💰"
         case .rcError: return "😿‼️"

--- a/Sources/Misc/TimingUtil.swift
+++ b/Sources/Misc/TimingUtil.swift
@@ -1,0 +1,168 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  TimingUtil.swift
+//
+//  Created by Nacho Soto on 11/15/22.
+
+import Foundation
+
+internal enum TimingUtil {
+
+    typealias Duration = TimeInterval
+
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+extension TimingUtil {
+
+    /// Measures the time to execute `work` and returns the result and the duration.
+    /// Example:
+    /// ```swift
+    /// let (result, duration) = try await TimingUtil.measure {
+    ///    return try await asyncMethod()
+    /// }
+    /// ```
+    static func measure<Value>(
+        _ work: () async throws -> Value
+    ) async rethrows  -> (result: Value, duration: Duration) {
+        let start: DispatchTime = .now()
+        let result = try await work()
+
+        return (
+            result: result,
+            duration: start.durationUntilNow
+        )
+    }
+
+    /// Measures the time to execute `work`, returns the result,
+    /// and logs `message` if duration exceeded `threshold`.
+    /// Example:
+    /// ```swift
+    /// let result = try await TimingUtil.measureAndLogIfTooSlow(
+    ///     threshold: 2,
+    ///     message: "Computation too slow",
+    ///     level: .warn,
+    ///     intent: .appleWarning
+    /// ) {
+    ///    try await asyncMethod()
+    /// }
+    /// ```
+    static func measureAndLogIfTooSlow<Value>(
+        threshold: Duration,
+        message: CustomStringConvertible,
+        level: LogLevel = .warn,
+        intent: LogIntent = .appleWarning,
+        work: () async throws -> Value
+    ) async rethrows  -> Value {
+        precondition(threshold > 0, "Invalid threshold: \(threshold)")
+
+        let (result, duration) = try await self.measure(work)
+
+        Self.logIfRequired(duration: duration,
+                           threshold: threshold,
+                           message: message,
+                           level: level,
+                           intent: intent)
+
+        return result
+    }
+
+}
+
+extension TimingUtil {
+
+    /// Measures the time to execute `work` and returns the `Result` and the duration.
+    /// Example:
+    /// ```swift
+    /// TimingUtil.measure { completion in
+    ///     work { completion($0) }
+    /// } result: { result, duration in
+    ///     print("Result: \(result) calculated in \(duration) seconds")
+    /// }
+    /// ```
+    static func measure<Value>(
+        _ work: (@escaping @Sendable (Value) -> Void) -> Void,
+        result: @escaping (Value, Duration) -> Void
+    ) {
+        let start: DispatchTime = .now()
+
+        work { value in
+            result(value, start.durationUntilNow)
+        }
+    }
+
+    /// Measures the time to execute `work`, returns the result,
+    /// and logs `message` if duration exceeded `threshold`.
+    /// Example:
+    /// ```swift
+    /// TimingUtil.measureAndLogIfTooSlow(
+    ///     threshold: 2,
+    ///     message: "Computation too slow",
+    ///     level: .warn,
+    ///     intent: .appleWarning
+    /// ) { completion in
+    ///     work { completion($0) }
+    /// } result: { result in
+    ///     print("Finished computing: \(result)")
+    /// }
+    /// ```
+    static func measureAndLogIfTooSlow<Value>(
+        threshold: Duration,
+        message: CustomStringConvertible,
+        level: LogLevel = .warn,
+        intent: LogIntent = .appleWarning,
+        work: (@escaping @Sendable (Value) -> Void) -> Void,
+        result: @escaping (Value) -> Void
+    ) {
+        Self.measure(work) { value, duration in
+            Self.logIfRequired(duration: duration,
+                               threshold: threshold,
+                               message: message,
+                               level: level,
+                               intent: intent)
+
+            result(value)
+        }
+    }
+
+}
+
+// MARK: - Private
+
+private extension TimingUtil {
+
+    static func logIfRequired(
+        duration: Duration,
+        threshold: Duration,
+        message: CustomStringConvertible,
+        level: LogLevel,
+        intent: LogIntent
+    ) {
+        if duration >= threshold {
+            let roundedDuration = (duration * 100).rounded(.down) / 100
+            let message = String(format: "%@ (%.2f seconds)", message.description, roundedDuration)
+
+            Logger.log(level: level, intent: intent, message: message)
+        }
+    }
+
+}
+
+private extension DispatchTime {
+
+    var durationUntilNow: TimingUtil.Duration {
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
+            return self.distance(to: .now()).seconds
+        } else {
+            return TimingUtil.Duration(DispatchTime.now().uptimeNanoseconds - self.uptimeNanoseconds) / 1_000_000_000
+        }
+    }
+
+}

--- a/Sources/Misc/TimingUtil.swift
+++ b/Sources/Misc/TimingUtil.swift
@@ -31,7 +31,7 @@ extension TimingUtil {
     /// ```
     static func measure<Value>(
         _ work: () async throws -> Value
-    ) async rethrows  -> (result: Value, duration: Duration) {
+    ) async rethrows -> (result: Value, duration: Duration) {
         let start: DispatchTime = .now()
         let result = try await work()
 
@@ -60,7 +60,7 @@ extension TimingUtil {
         level: LogLevel = .warn,
         intent: LogIntent = .appleWarning,
         work: () async throws -> Value
-    ) async rethrows  -> Value {
+    ) async rethrows -> Value {
         precondition(threshold > 0, "Invalid threshold: \(threshold)")
 
         let (result, duration) = try await self.measure(work)

--- a/Tests/UnitTests/Misc/TimingUtilTests.swift
+++ b/Tests/UnitTests/Misc/TimingUtilTests.swift
@@ -29,7 +29,7 @@ class TimingUtilAsyncTests: TestCase {
         let expectedResult = Int.random(in: 0..<1000)
         let sleepDuration: DispatchTimeInterval = .milliseconds(10)
 
-        let (result, time) = await TimingUtil.measure {
+        let (result, time) = await TimingUtil.measure { () -> Int in
             try? await Task.sleep(nanoseconds: UInt64(sleepDuration.nanoseconds))
 
             return expectedResult
@@ -62,7 +62,7 @@ class TimingUtilAsyncTests: TestCase {
         let sleepDuration = threshold + .milliseconds(-5)
 
         let result = await TimingUtil.measureAndLogIfTooSlow(threshold: threshold.seconds,
-                                                             message: "Too slow") {
+                                                             message: "Too slow") { () -> Int in
             try? await Task.sleep(nanoseconds: UInt64(sleepDuration.nanoseconds))
 
             return expectedResult
@@ -84,7 +84,7 @@ class TimingUtilAsyncTests: TestCase {
 
         let result = await TimingUtil.measureAndLogIfTooSlow(threshold: threshold.seconds,
                                                              message: message,
-                                                             level: level) {
+                                                             level: level) { () -> Int in
             try? await Task.sleep(nanoseconds: UInt64(sleepDuration.nanoseconds))
 
             return expectedResult

--- a/Tests/UnitTests/Misc/TimingUtilTests.swift
+++ b/Tests/UnitTests/Misc/TimingUtilTests.swift
@@ -1,0 +1,211 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  TimingUtilTests.swift
+//
+//  Created by Nacho Soto on 11/15/22.
+
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+class TimingUtilAsyncTests: TestCase {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+    }
+
+    func testMeasureNonThrowingBlockReturnsValueAndDuration() async {
+        let expectedResult = Int.random(in: 0..<1000)
+        let sleepDuration: DispatchTimeInterval = .milliseconds(10)
+
+        let (result, time) = await TimingUtil.measure {
+            try? await Task.sleep(nanoseconds: UInt64(sleepDuration.nanoseconds))
+
+            return expectedResult
+        }
+
+        expect(result) == expectedResult
+        expect(time) > 0
+        expect(time).to(beCloseTo(sleepDuration.seconds, within: 0.01))
+    }
+
+    func testMeasureThrowsError() async {
+        let expectedError: ErrorCode = .storeProblemError
+
+        do {
+            _ = try await TimingUtil.measure {
+                throw expectedError
+            }
+
+            fail("Expected error")
+        } catch {
+            expect(error).to(matchError(expectedError))
+        }
+    }
+
+    func testMeasureAndLogWithResultDoesNotLogIfLowerThanThreshold() async {
+        let logger = TestLogHandler()
+
+        let expectedResult = Int.random(in: 0..<1000)
+        let threshold: DispatchTimeInterval = .milliseconds(10)
+        let sleepDuration = threshold + .milliseconds(-5)
+
+        let result = await TimingUtil.measureAndLogIfTooSlow(threshold: threshold.seconds,
+                                                             message: "Too slow") {
+            try? await Task.sleep(nanoseconds: UInt64(sleepDuration.nanoseconds))
+
+            return expectedResult
+        }
+
+        expect(result) == expectedResult
+        expect(logger.messages).to(beEmpty())
+    }
+
+    func testMeasureAndLogWithResult() async {
+        let logger = TestLogHandler()
+
+        let expectedResult = Int.random(in: 0..<1000)
+        let threshold: DispatchTimeInterval = .milliseconds(10)
+        let sleepDuration = threshold + .milliseconds(10)
+
+        let message = "Computation took too long"
+        let level: LogLevel = .info
+
+        let result = await TimingUtil.measureAndLogIfTooSlow(threshold: threshold.seconds,
+                                                             message: message,
+                                                             level: level) {
+            try? await Task.sleep(nanoseconds: UInt64(sleepDuration.nanoseconds))
+
+            return expectedResult
+        }
+
+        expect(result) == expectedResult
+
+        // Expected: 🍎⚠️ Computation took too long (0.02 seconds)
+        logger.verifyMessageWasLogged(
+            String(format: "%@ %@ (%.2f seconds)",
+                   LogIntent.appleWarning.prefix,
+                   message,
+                   sleepDuration.seconds),
+            level: level
+        )
+    }
+
+    func testMeasureAndLogThrowsError() async {
+        let logger = TestLogHandler()
+
+        let expectedError: ErrorCode = .storeProblemError
+
+        do {
+            _ = try await TimingUtil.measureAndLogIfTooSlow(threshold: 0.001,
+                                                            message: "Too slow") {
+                throw expectedError
+            }
+
+            fail("Expected error")
+        } catch {
+            expect(error).to(matchError(expectedError))
+        }
+
+        expect(logger.messages).to(beEmpty())
+    }
+
+}
+
+class TimingUtilCompletionBlockTests: TestCase {
+
+    func testMeasureWithCompletionBlock() {
+        let expectedResult: Int = .random(in: 0..<1000)
+        let sleepDuration: DispatchTimeInterval = .milliseconds(10)
+
+        var result: Int?
+        var duration: TimingUtil.Duration?
+
+        TimingUtil.measure { completion in
+            DispatchQueue.main.asyncAfter(deadline: .now() + sleepDuration) {
+                Self.asynchronousWork(expectedResult, completion)
+            }
+        } result: { value, time in
+            result = value
+            duration = time
+        }
+
+        expect(result).toEventuallyNot(beNil())
+        expect(result) == expectedResult
+        expect(duration) > 0
+        expect(duration).to(beCloseTo(sleepDuration.seconds, within: 0.01))
+    }
+
+    func testMeasureAndLogDoesNotLogIfLowerThanThreshold() {
+        let logger = TestLogHandler()
+
+        let expectedResult = Int.random(in: 0..<1000)
+        let threshold: DispatchTimeInterval = .milliseconds(10)
+        let sleepDuration = threshold + .milliseconds(-5)
+
+        var result: Int?
+
+        TimingUtil.measureAndLogIfTooSlow(threshold: threshold.seconds,
+                                          message: "Too slow") { completion in
+            DispatchQueue.main.asyncAfter(deadline: .now() + sleepDuration) {
+                Self.asynchronousWork(expectedResult, completion)
+            }
+        } result: { value in
+            result = value
+        }
+
+        expect(result).toEventuallyNot(beNil())
+        expect(result) == expectedResult
+        expect(logger.messages).to(beEmpty())
+    }
+
+    func testMeasureAndLogWithResult() {
+        let logger = TestLogHandler()
+
+        let expectedResult = Int.random(in: 0..<1000)
+        let threshold: DispatchTimeInterval = .milliseconds(10)
+        let sleepDuration = threshold + .milliseconds(10)
+
+        let message = "Computation took too long"
+        let level: LogLevel = .info
+
+        var result: Int?
+
+        TimingUtil.measureAndLogIfTooSlow(threshold: threshold.seconds,
+                                          message: message,
+                                          level: level) { completion in
+            DispatchQueue.main.asyncAfter(deadline: .now() + sleepDuration) {
+                Self.asynchronousWork(expectedResult, completion)
+            }
+        } result: { value in
+            result = value
+        }
+
+        expect(result).toEventuallyNot(beNil())
+        expect(result) == expectedResult
+
+        logger.verifyMessageWasLogged(
+            String(format: "%@ %@ (%.2f seconds)",
+                   LogIntent.appleWarning.prefix,
+                   message,
+                   sleepDuration.seconds),
+            level: level
+        )
+    }
+
+    private static func asynchronousWork(_ value: Int, _ completion: (Int) -> Void) {
+        completion(value)
+    }
+
+}

--- a/Tests/UnitTests/TestHelpers/TestLogHandler.swift
+++ b/Tests/UnitTests/TestHelpers/TestLogHandler.swift
@@ -89,7 +89,7 @@ extension TestLogHandler {
         )
         .to(
             containElementSatisfying(Self.entryCondition(message: message, level: level)),
-            description: "Message not found. Logged messages: \(self.messages)"
+            description: "Message '\(message)' not found. Logged messages: \(self.messages)"
         )
     }
 


### PR DESCRIPTION
For [CSDK-512].

This will print messages like:
> 🍎⚠️ Computation took too long (2.13 seconds)

### Examples:

#### `async` methods:

```swift
let (result, duration) = try await TimingUtil.measure {
   return try await asyncMethod()
}
```

```swift
let result = try await TimingUtil.measureAndLogIfTooSlow(
    threshold: 2,
    message: "Computation too slow",
    level: .warn,
    intent: .appleWarning
) {
   try await asyncMethod()
}
```

#### Completion-block methods:

```swift
TimingUtil.measure { completion in
    work { completion($0) }
} result: { result, duration in
    print("Result: \(result) calculated in \(duration) seconds")
}
```

```swift
TimingUtil.measureAndLogIfTooSlow(
    threshold: 2,
    message: "Computation too slow",
    level: .warn,
    intent: .appleWarning
) { completion in
    work { completion($0) }
} result: { result in
    print("Finished computing: \(result)")
}
```


[CSDK-512]: https://revenuecats.atlassian.net/browse/CSDK-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ