### PR TITLE
`Result.init(catching:)` with `async` method

### DIFF
--- a/Sources/FoundationExtensions/Result+Extensions.swift
+++ b/Sources/FoundationExtensions/Result+Extensions.swift
@@ -71,3 +71,16 @@ extension Result where Success: OptionalType {
     }
 
 }
+
+extension Result where Failure == Swift.Error {
+
+    /// Equivalent to `Result.init(catching:)` but with an `async` closure.
+    init(catching block: () async throws -> Success) async {
+        do {
+            self = .success(try await block())
+        } catch {
+            self = .failure(error)
+        }
+    }
+
+}

--- a/Tests/UnitTests/FoundationExtensions/ResultExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/ResultExtensionsTests.swift
@@ -69,6 +69,30 @@ class ResultExtensionsTests: TestCase {
         })
     }
 
+    func testInitWithThrowingAsyncBlockReturningValue() async {
+        let expectedValue: Int = .random(in: 0..<100)
+
+        func asyncValue() async throws -> Int {
+            return expectedValue
+        }
+
+        let result: Result<Int, Swift.Error> = await .init(catching: { try await asyncValue() })
+        expect(result).to(beSuccess())
+        expect(result.value) == expectedValue
+    }
+
+    func testInitWithThrowingAsyncBlockThrowingError() async {
+        let expectedError: ErrorCode = .customerInfoError
+
+        func asyncValue() async throws -> Int {
+            throw expectedError
+        }
+
+        let result: Result<Int, Swift.Error> = await .init(catching: { try await asyncValue() })
+        expect(result).to(beFailure())
+        expect(result.error).to(matchError(expectedError))
+    }
+
 }
 
 class ResultAsOptionalResultTest: TestCase {


### PR DESCRIPTION
I ended up not using this in my recent PR but it's a useful overload.