### PR TITLE
`StoreKit`: added logs when purchasing and product requests are too slow

### DIFF
--- a/Sources/Logging/Logger.swift
+++ b/Sources/Logging/Logger.swift
@@ -18,7 +18,7 @@ import Foundation
 ///
 /// #### Related Symbols
 /// - ``Purchases/logLevel``
-@objc(RCLogLevel) public enum LogLevel: Int, CustomStringConvertible {
+@objc(RCLogLevel) public enum LogLevel: Int, CustomStringConvertible, Sendable {
 
     // swiftlint:disable:next missing_docs
     case debug, info, warn, error

--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -65,6 +65,8 @@ enum PurchaseStrings {
     case check_eligibility_no_identifiers
     case check_eligibility_failed(productIdentifier: String, error: Error)
     case missing_cached_customer_info
+    case sk1_purchase_too_slow
+    case sk2_purchase_too_slow
 
 }
 
@@ -248,6 +250,12 @@ extension PurchaseStrings: CustomStringConvertible {
 
         case .missing_cached_customer_info:
             return "Requested a cached CustomerInfo but it's not available."
+
+        case .sk1_purchase_too_slow:
+            return "StoreKit 1 purchase took longer than expected"
+
+        case .sk2_purchase_too_slow:
+            return "StoreKit 2 purchase took longer than expected"
         }
     }
 

--- a/Sources/Logging/Strings/StoreKitStrings.swift
+++ b/Sources/Logging/Strings/StoreKitStrings.swift
@@ -42,6 +42,10 @@ enum StoreKitStrings {
 
     case no_cached_products_starting_store_products_request(identifiers: Set<String>)
 
+    case sk1_product_request_too_slow
+
+    case sk2_product_request_too_slow
+
 }
 
 extension StoreKitStrings: CustomStringConvertible {
@@ -92,6 +96,12 @@ extension StoreKitStrings: CustomStringConvertible {
 
         case .no_cached_products_starting_store_products_request(let identifiers):
             return "No existing products cached, starting store products request for: \(identifiers)"
+
+        case .sk1_product_request_too_slow:
+            return "StoreKit 1 product request took longer than expected"
+
+        case .sk2_product_request_too_slow:
+            return "StoreKit 2 product request took longer than expected"
         }
     }
 

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -36,7 +36,7 @@ import Foundation
  *  Purchases.configure(with: configuration)
  * ```
  */
-@objc(RCConfiguration) public class Configuration: NSObject {
+@objc(RCConfiguration) public final class Configuration: NSObject {
 
     static let storeKitRequestTimeoutDefault: TimeInterval = 30
     static let networkTimeoutDefault: TimeInterval = 60
@@ -226,5 +226,19 @@ extension Configuration {
     }
 
     private static let applePlatformKeyPrefix: String = "appl_"
+
+}
+
+// MARK: - Slow Operation Thresholds
+
+extension Configuration {
+
+    /// Thresholds that determine when `TimingUtil` log warnings for slow operations.
+    internal enum TimingThreshold: TimingUtil.Duration {
+
+        case productRequest = 3
+        case purchase = 7
+
+    }
 
 }

--- a/Sources/Purchasing/StoreKit1/ProductsFetcherSK1.swift
+++ b/Sources/Purchasing/StoreKit1/ProductsFetcherSK1.swift
@@ -86,12 +86,16 @@ final class ProductsFetcherSK1: NSObject {
 
     func products(withIdentifiers identifiers: Set<String>,
                   completion: @escaping (Result<Set<SK1StoreProduct>, PurchasesError>) -> Void) {
-        self.sk1Products(withIdentifiers: identifiers) { skProducts in
-            let result = skProducts
-                .map { Set($0.map(SK1StoreProduct.init)) }
-
-            completion(result)
-        }
+        TimingUtil.measureAndLogIfTooSlow(
+            threshold: .productRequest,
+            message: Strings.storeKit.sk1_product_request_too_slow,
+            work: { completion in
+                self.sk1Products(withIdentifiers: identifiers) { skProducts in
+                    completion(skProducts.map { Set($0.map(SK1StoreProduct.init)) })
+                }
+            },
+            result: completion
+        )
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)

--- a/Sources/Purchasing/StoreKit2/ProductsFetcherSK2.swift
+++ b/Sources/Purchasing/StoreKit2/ProductsFetcherSK2.swift
@@ -26,7 +26,13 @@ actor ProductsFetcherSK2 {
     /// - Throws: `ProductsFetcherSK2.Error`
     func products(identifiers: Set<String>) async throws -> Set<SK2StoreProduct> {
         do {
-            let storeKitProducts = try await StoreKit.Product.products(for: identifiers)
+            let storeKitProducts = try await TimingUtil.measureAndLogIfTooSlow(
+                threshold: .productRequest,
+                message: Strings.storeKit.sk2_product_request_too_slow
+            ) {
+                try await StoreKit.Product.products(for: identifiers)
+            }
+
             Logger.rcSuccess(Strings.storeKit.store_product_request_received_response)
             return Set(storeKitProducts.map { SK2StoreProduct(sk2Product: $0) })
         } catch {


### PR DESCRIPTION
Using #2059 in a few places for now.
We can add this to more places, and tweak the thresholds.

Fixes [CSDK-512].

[CSDK-512]: https://revenuecats.atlassian.net/browse/CSDK-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ