### PR TITLE
use `transactions.all` to observe transactions in observer mode with SK2

### DIFF
--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -40,6 +40,8 @@ class SystemInfo {
         set { self._finishTransactions.value = newValue }
     }
 
+    var observerMode: Bool { return !self.finishTransactions }
+
     private let sandboxEnvironmentDetector: SandboxEnvironmentDetector
     private let _finishTransactions: Atomic<Bool>
 

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -138,8 +138,6 @@ private extension HTTPClient {
 private extension HTTPClient {
 
     var defaultHeaders: [String: String] {
-        let observerMode = !self.systemInfo.finishTransactions
-
         var headers: [String: String] = [
             "content-type": "application/json",
             "X-Version": SystemInfo.frameworkVersion,
@@ -150,7 +148,7 @@ private extension HTTPClient {
             "X-Client-Build-Version": SystemInfo.buildVersion,
             "X-Client-Bundle-ID": SystemInfo.bundleIdentifier,
             "X-StoreKit2-Setting": "\(self.systemInfo.storeKit2Setting.debugDescription)",
-            "X-Observer-Mode-Enabled": "\(observerMode)",
+            "X-Observer-Mode-Enabled": "\(self.systemInfo.observerMode)",
             "X-Is-Sandbox": "\(self.systemInfo.isSandbox)"
         ]
 

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -31,6 +31,8 @@ import StoreKit
 final class PurchasesOrchestrator {
 
     var finishTransactions: Bool { self.systemInfo.finishTransactions }
+    var observerMode: Bool { self.systemInfo.observerMode }
+
     var allowSharingAppStoreAccount: Bool {
         get { self._allowSharingAppStoreAccount.value ?? self.currentUserProvider.currentUserIsAnonymous }
         set { self._allowSharingAppStoreAccount.value = newValue }
@@ -779,8 +781,7 @@ extension PurchasesOrchestrator: StoreKit2TransactionListenerDelegate {
             }
         }
 
-        // Need to restore if using observer mode (which is inverse of finishTransactions)
-        let isRestore = !self.systemInfo.finishTransactions
+        let isRestore = self.systemInfo.observerMode
 
         _ = try await self.syncPurchases(receiptRefreshPolicy: .always,
                                          isRestore: isRestore,
@@ -889,7 +890,7 @@ private extension PurchasesOrchestrator {
                           isRestore: allowSharingAppStoreAccount,
                           productData: productData,
                           presentedOfferingIdentifier: presentedOfferingID,
-                          observerMode: !self.finishTransactions,
+                          observerMode: self.observerMode,
                           initiationSource: initiationSource,
                           subscriberAttributes: unsyncedAttributes) { result in
             self.handleReceiptPost(withTransaction: transaction,
@@ -1013,7 +1014,7 @@ private extension PurchasesOrchestrator {
                               isRestore: isRestore,
                               productData: nil,
                               presentedOfferingIdentifier: nil,
-                              observerMode: !self.finishTransactions,
+                              observerMode: self.observerMode,
                               initiationSource: initiationSource,
                               subscriberAttributes: unsyncedAttributes) { result in
                 self.handleReceiptPost(result: result,

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -128,7 +128,7 @@ final class PurchasesOrchestrator {
         storeKit2StorefrontListener.delegate = self
 
         if systemInfo.storeKit2Setting == .enabledForCompatibleDevices {
-            storeKit2TransactionListener.listenForTransactions()
+            storeKit2TransactionListener.listenForTransactions(observerMode: systemInfo.observerMode)
             storeKit2StorefrontListener.listenForStorefrontChanges()
         }
     }

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -8,31 +8,21 @@
 
 import Nimble
 @testable import RevenueCat
+@preconcurrency import StoreKit // `PurchaseResult` is not `Sendable`
 import StoreKitTest
 import UniformTypeIdentifiers
 import XCTest
 
-// swiftlint:disable file_length type_body_length
+// swiftlint:disable file_length type_body_length type_name
 
-class StoreKit2IntegrationTests: StoreKit1IntegrationTests {
+@MainActor
+class BaseStoreKitIntegrationTests: BaseBackendIntegrationTests {
 
-    override class var storeKit2Setting: StoreKit2Setting { return .enabledForCompatibleDevices }
-
-}
-
-class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
-
-    private var testSession: SKTestSession!
+    fileprivate var testSession: SKTestSession!
 
     override func setUp() async throws {
-        self.testSession = try SKTestSession(configurationFileNamed: Constants.storeKitConfigFileName)
-        self.testSession.resetToDefaultState()
-        self.testSession.disableDialogs = true
-        self.testSession.clearTransactions()
-        if #available(iOS 15.2, *) {
-            self.testSession.timeRate = .monthlyRenewalEveryThirtySeconds
-        } else {
-            self.testSession.timeRate = .oneSecondIsOneDay
+        if self.testSession == nil {
+            try self.configureTestSession()
         }
 
         // Initialize `Purchases` *after* the fresh new session has been created
@@ -46,6 +36,36 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
         // this waits for that request to finish.
         _ = try await Purchases.shared.offerings()
     }
+
+    override func tearDown() {
+        self.testSession = nil
+
+        super.tearDown()
+    }
+
+    func configureTestSession() throws {
+        assert(self.testSession == nil, "Attempted to configure session multiple times")
+
+        self.testSession = try SKTestSession(configurationFileNamed: Constants.storeKitConfigFileName)
+        self.testSession.resetToDefaultState()
+        self.testSession.disableDialogs = true
+        self.testSession.clearTransactions()
+        if #available(iOS 15.2, *) {
+            self.testSession.timeRate = .monthlyRenewalEveryThirtySeconds
+        } else {
+            self.testSession.timeRate = .oneSecondIsOneDay
+        }
+    }
+
+}
+
+class StoreKit2IntegrationTests: StoreKit1IntegrationTests {
+
+    override class var storeKit2Setting: StoreKit2Setting { return .enabledForCompatibleDevices }
+
+}
+
+class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
     override class var storeKit2Setting: StoreKit2Setting {
         return .disabled
@@ -433,10 +453,99 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
 
 }
 
-private extension StoreKit1IntegrationTests {
+// MARK: - Observer Mode tests
+
+class BaseStoreKitObserverModeIntegrationTests: BaseStoreKitIntegrationTests {
+
+    override class var observerMode: Bool { return true }
+
+}
+
+class StoreKit2ObserverModeIntegrationTests: StoreKit1ObserverModeIntegrationTests {
+
+    override class var storeKit2Setting: StoreKit2Setting { return .enabledForCompatibleDevices }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testPurchaseInDevicePostsReceipt() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        let products = try await StoreKit.Product.products(for: [Self.monthlyNoIntroProductID])
+        let product = try XCTUnwrap(products.onlyElement)
+
+        _ = try await product.purchase()
+
+        let info = try await Purchases.shared.restorePurchases()
+        try await self.verifyEntitlementWentThrough(info)
+    }
+
+}
+
+class StoreKit1ObserverModeIntegrationTests: BaseStoreKitObserverModeIntegrationTests {
+
+    func testPurchaseOutsideTheAppPostsReceipt() async throws {
+        try self.testSession.buyProduct(productIdentifier: Self.monthlyNoIntroProductID)
+
+        let info = try await Purchases.shared.restorePurchases()
+        try await self.verifyEntitlementWentThrough(info)
+    }
+
+}
+
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+class StoreKit2ObserverModeWithExistingPurchasesTests: StoreKit1ObserverModeWithExistingPurchasesTests {
+
+    override class var storeKit2Setting: StoreKit2Setting { return .enabledForCompatibleDevices }
+
+}
+
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+class StoreKit1ObserverModeWithExistingPurchasesTests: BaseStoreKitObserverModeIntegrationTests {
+
+    // MARK: - Transactions observation
+
+    private static var transactionsObservation: Task<Void, Never>?
+
+    override class func setUp() {
+        Self.transactionsObservation?.cancel()
+        Self.transactionsObservation = Task {
+            // Silence warning in tests:
+            // "Making a purchase without listening for transaction updates risks missing successful purchases.
+            for await _ in Transaction.updates {}
+        }
+    }
+
+    override class func tearDown() {
+        Self.transactionsObservation?.cancel()
+        Self.transactionsObservation = nil
+    }
+
+    override func setUp() async throws {
+        try self.configureTestSession()
+
+        let products = try await StoreKit.Product.products(for: [Self.monthlyNoIntroProductID])
+        let product = try XCTUnwrap(products.onlyElement)
+
+        _ = try await product.purchase()
+
+        try await super.setUp()
+    }
+
+    func testPostsExistingTransaction() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        let info = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
+        try await self.verifyEntitlementWentThrough(info)
+    }
+
+}
+
+// MARK: - Private
+
+private extension BaseStoreKitIntegrationTests {
 
     static let entitlementIdentifier = "premium"
     static let consumable10Coins = "consumable.10_coins"
+    static let monthlyNoIntroProductID = "com.revenuecat.monthly_4.99.no_intro"
 
     private var currentOffering: Offering {
         get async throws {
@@ -458,7 +567,7 @@ private extension StoreKit1IntegrationTests {
 
     var monthlyNoIntroProduct: StoreProduct {
         get async throws {
-            let products = await Purchases.shared.products(["com.revenuecat.monthly_4.99.no_intro"])
+            let products = await Purchases.shared.products([Self.monthlyNoIntroProductID])
             return try XCTUnwrap(products.onlyElement)
         }
     }
@@ -614,7 +723,7 @@ private extension StoreKit1IntegrationTests {
 
 // MARK: - Private
 
-private extension StoreKit1IntegrationTests {
+private extension BaseStoreKitIntegrationTests {
 
     func printReceiptContent() async {
         do {

--- a/Tests/UnitTests/Misc/SystemInfoTests.swift
+++ b/Tests/UnitTests/Misc/SystemInfoTests.swift
@@ -47,12 +47,14 @@ class SystemInfoTests: TestCase {
         var systemInfo = try SystemInfo(platformInfo: nil,
                                         finishTransactions: finishTransactions)
         expect(systemInfo.finishTransactions) == finishTransactions
+        expect(systemInfo.observerMode) == !finishTransactions
 
         finishTransactions = true
 
         systemInfo = try SystemInfo(platformInfo: nil,
                                     finishTransactions: finishTransactions)
         expect(systemInfo.finishTransactions) == finishTransactions
+        expect(systemInfo.observerMode) == !finishTransactions
     }
 
     func testIsSandbox() throws {

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionListener.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionListener.swift
@@ -49,11 +49,13 @@ class MockStoreKit2TransactionListener: StoreKit2TransactionListener {
     }
 
     var invokedListenForTransactions = false
+    var invokedListenForTransactionObserverMode: Bool?
     var invokedListenForTransactionsCount = 0
 
-    override func listenForTransactions() {
-        invokedListenForTransactions = true
-        invokedListenForTransactionsCount += 1
+    override func listenForTransactions(observerMode: Bool) {
+        self.invokedListenForTransactions = true
+        self.invokedListenForTransactionObserverMode = observerMode
+        self.invokedListenForTransactionsCount += 1
     }
 
     var invokedHandle = false

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionListenerDelegate.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionListenerDelegate.swift
@@ -16,15 +16,18 @@
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
 final class MockStoreKit2TransactionListenerDelegate: StoreKit2TransactionListenerDelegate {
 
-    var invokedTransactionUpdated = false
-    var updatedTransactions: [StoreTransactionType] = []
+    var invokedTransactionUpdated: Bool { return self._invokedTransactionUpdated.value }
+    var updatedTransactions: [StoreTransactionType] { return self._updatedTransactions.value }
+
+    private var _invokedTransactionUpdated: Atomic<Bool> = false
+    private var _updatedTransactions: Atomic<[StoreTransactionType]> = .init([])
 
     func storeKit2TransactionListener(
         _ listener: StoreKit2TransactionListener,
         updatedTransaction transaction: StoreTransactionType
     ) async throws {
-        self.invokedTransactionUpdated = true
-        self.updatedTransactions.append(transaction)
+        self._invokedTransactionUpdated.value = true
+        self._updatedTransactions.value.append(transaction)
     }
 
 }


### PR DESCRIPTION
While it's not documented, `Transaction.updates` will only send updates for purchases being made on other devices or renewed. Purchases made on the same device will not receive an update through `.updates`. Instead, those get them through `.all`. 

This draft PR updates the logic so that in observer mode we don't miss transactions made on the same device. 