### PR TITLE
`Logging`: added log when configuring SDK in observer mode

### DIFF
--- a/Sources/Logging/Strings/ConfigureStrings.swift
+++ b/Sources/Logging/Strings/ConfigureStrings.swift
@@ -27,6 +27,8 @@ enum ConfigureStrings {
 
     case store_kit_2_enabled
 
+    case observer_mode_enabled
+
     case delegate_set
 
     case purchase_instance_already_set
@@ -62,6 +64,8 @@ extension ConfigureStrings: CustomStringConvertible {
             return "Debug logging enabled"
         case .store_kit_2_enabled:
             return "StoreKit 2 support enabled"
+        case .observer_mode_enabled:
+            return "Purchases is configured in observer mode"
         case .delegate_set:
             return "Delegate set"
         case .purchase_instance_already_set:

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -40,6 +40,8 @@ class SystemInfo {
         set { self._finishTransactions.value = newValue }
     }
 
+    var observerMode: Bool { return !self.finishTransactions }
+
     private let sandboxEnvironmentDetector: SandboxEnvironmentDetector
     private let _finishTransactions: Atomic<Bool>
 

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -138,8 +138,6 @@ private extension HTTPClient {
 private extension HTTPClient {
 
     var defaultHeaders: [String: String] {
-        let observerMode = !self.systemInfo.finishTransactions
-
         var headers: [String: String] = [
             "content-type": "application/json",
             "X-Version": SystemInfo.frameworkVersion,
@@ -150,7 +148,7 @@ private extension HTTPClient {
             "X-Client-Build-Version": SystemInfo.buildVersion,
             "X-Client-Bundle-ID": SystemInfo.bundleIdentifier,
             "X-StoreKit2-Setting": "\(self.systemInfo.storeKit2Setting.debugDescription)",
-            "X-Observer-Mode-Enabled": "\(observerMode)",
+            "X-Observer-Mode-Enabled": "\(self.systemInfo.observerMode)",
             "X-Is-Sandbox": "\(self.systemInfo.isSandbox)"
         ]
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -412,6 +412,9 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         if systemInfo.storeKit2Setting == .enabledForCompatibleDevices {
             Logger.info(Strings.configure.store_kit_2_enabled, fileName: nil)
         }
+        if systemInfo.observerMode {
+            Logger.debug(Strings.configure.observer_mode_enabled, fileName: nil)
+        }
         Logger.debug(Strings.configure.sdk_version(Self.frameworkVersion), fileName: nil)
         Logger.debug(Strings.configure.bundle_id(SystemInfo.bundleIdentifier), fileName: nil)
         Logger.user(Strings.configure.initial_app_user_id(isSet: appUserID != nil), fileName: nil)

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -31,6 +31,8 @@ import StoreKit
 final class PurchasesOrchestrator {
 
     var finishTransactions: Bool { self.systemInfo.finishTransactions }
+    var observerMode: Bool { self.systemInfo.observerMode }
+
     var allowSharingAppStoreAccount: Bool {
         get { self._allowSharingAppStoreAccount.value ?? self.currentUserProvider.currentUserIsAnonymous }
         set { self._allowSharingAppStoreAccount.value = newValue }
@@ -779,8 +781,7 @@ extension PurchasesOrchestrator: StoreKit2TransactionListenerDelegate {
             }
         }
 
-        // Need to restore if using observer mode (which is inverse of finishTransactions)
-        let isRestore = !self.systemInfo.finishTransactions
+        let isRestore = self.systemInfo.observerMode
 
         _ = try await self.syncPurchases(receiptRefreshPolicy: .always,
                                          isRestore: isRestore,
@@ -889,7 +890,7 @@ private extension PurchasesOrchestrator {
                           isRestore: allowSharingAppStoreAccount,
                           productData: productData,
                           presentedOfferingIdentifier: presentedOfferingID,
-                          observerMode: !self.finishTransactions,
+                          observerMode: self.observerMode,
                           initiationSource: initiationSource,
                           subscriberAttributes: unsyncedAttributes) { result in
             self.handleReceiptPost(withTransaction: transaction,
@@ -1013,7 +1014,7 @@ private extension PurchasesOrchestrator {
                               isRestore: isRestore,
                               productData: nil,
                               presentedOfferingIdentifier: nil,
-                              observerMode: !self.finishTransactions,
+                              observerMode: self.observerMode,
                               initiationSource: initiationSource,
                               subscriberAttributes: unsyncedAttributes) { result in
                 self.handleReceiptPost(result: result,

--- a/Tests/UnitTests/Misc/SystemInfoTests.swift
+++ b/Tests/UnitTests/Misc/SystemInfoTests.swift
@@ -47,12 +47,14 @@ class SystemInfoTests: TestCase {
         var systemInfo = try SystemInfo(platformInfo: nil,
                                         finishTransactions: finishTransactions)
         expect(systemInfo.finishTransactions) == finishTransactions
+        expect(systemInfo.observerMode) == !finishTransactions
 
         finishTransactions = true
 
         systemInfo = try SystemInfo(platformInfo: nil,
                                     finishTransactions: finishTransactions)
         expect(systemInfo.finishTransactions) == finishTransactions
+        expect(systemInfo.observerMode) == !finishTransactions
     }
 
     func testIsSandbox() throws {


### PR DESCRIPTION
This is an important detail to log when initializing the SDK.