### PR TITLE
`SKTestSession`: finish all unfinished transactions before starting each test

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -336,6 +336,8 @@
 		57DBFA5D28AADA43002D18CA /* PurchasesLogInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DBFA5C28AADA43002D18CA /* PurchasesLogInTests.swift */; };
 		57DC9F4627CC2E4900DA6AF9 /* HTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DC9F4527CC2E4900DA6AF9 /* HTTPRequest.swift */; };
 		57DC9F4A27CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DC9F4927CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift */; };
+		57DD426D2926B9620026DF09 /* StoreKitConfigTestCase+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DD426C2926B9620026DF09 /* StoreKitConfigTestCase+Extensions.swift */; };
+		57DD426E2926B9A50026DF09 /* StoreKitTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571E7AD3279F2D0C003B3606 /* StoreKitTestHelpers.swift */; };
 		57DE806D28074976008D6C6F /* Storefront.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DE806C28074976008D6C6F /* Storefront.swift */; };
 		57DE807128074C23008D6C6F /* SK1Storefront.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DE807028074C23008D6C6F /* SK1Storefront.swift */; };
 		57DE807328074C76008D6C6F /* SK2Storefront.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DE807228074C76008D6C6F /* SK2Storefront.swift */; };
@@ -860,6 +862,7 @@
 		57DBFA5C28AADA43002D18CA /* PurchasesLogInTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchasesLogInTests.swift; sourceTree = "<group>"; };
 		57DC9F4527CC2E4900DA6AF9 /* HTTPRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequest.swift; sourceTree = "<group>"; };
 		57DC9F4927CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCodeTests.swift; sourceTree = "<group>"; };
+		57DD426C2926B9620026DF09 /* StoreKitConfigTestCase+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoreKitConfigTestCase+Extensions.swift"; sourceTree = "<group>"; };
 		57DE806C28074976008D6C6F /* Storefront.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storefront.swift; sourceTree = "<group>"; };
 		57DE807028074C23008D6C6F /* SK1Storefront.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1Storefront.swift; sourceTree = "<group>"; };
 		57DE807228074C76008D6C6F /* SK2Storefront.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SK2Storefront.swift; sourceTree = "<group>"; };
@@ -1776,6 +1779,7 @@
 			children = (
 				B3BE0263275942D500915B4C /* AvailabilityChecks.swift */,
 				571E7AD3279F2D0C003B3606 /* StoreKitTestHelpers.swift */,
+				57DD426C2926B9620026DF09 /* StoreKitConfigTestCase+Extensions.swift */,
 			);
 			path = TestHelpers;
 			sourceTree = "<group>";
@@ -2354,6 +2358,7 @@
 				2D90F8C726FD221D009B9142 /* MockASN1ContainerBuilder.swift in Sources */,
 				F535515F286B5BE5009CA47A /* MockOfferingsManager.swift in Sources */,
 				F52CFAFC28290AE500E8ABC5 /* StoreKit2StorefrontListenerTests.swift in Sources */,
+				57DD426D2926B9620026DF09 /* StoreKitConfigTestCase+Extensions.swift in Sources */,
 				57ACB12528174B9F000DCC9F /* CustomerInfo+TestExtensions.swift in Sources */,
 				2D90F8C326FD214F009B9142 /* MockAttributionTypeFactory.swift in Sources */,
 				A55D083427235DED00D919E0 /* BeginRefundRequestHelperTests.swift in Sources */,
@@ -2805,6 +2810,7 @@
 				579234E327F7788900B39C68 /* BaseBackendIntegrationTests.swift in Sources */,
 				2DE20B6F264087FB004C597D /* StoreKitIntegrationTests.swift in Sources */,
 				2D3BFAD126DEA45C00370B11 /* MockSK1Product.swift in Sources */,
+				57DD426E2926B9A50026DF09 /* StoreKitTestHelpers.swift in Sources */,
 				57C2932A28BFF89D0054EDFC /* ErrorMatcher.swift in Sources */,
 				2DE61A84264190830021CEA0 /* Constants.swift in Sources */,
 				579234E527F779FE00B39C68 /* SubscriberAttributesManagerIntegrationTests.swift in Sources */,

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -53,6 +53,9 @@ class BaseBackendIntegrationTests: XCTestCase {
         }
 
         if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            // Despite calling `SKTestSession.clearTransactions` tests sometimes
+            // begin with leftover transactions. This ensures that we remove them
+            // to always start with a clean state.
             await self.finishAllUnfinishedTransactions()
         }
 

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -52,6 +52,10 @@ class BaseBackendIntegrationTests: XCTestCase {
             throw ErrorUtils.configurationError(message: "Must set configuration in `Constants.swift`")
         }
 
+        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            await self.finishAllUnfinishedTransactions()
+        }
+
         self.userDefaults = UserDefaults(suiteName: Constants.userDefaultsSuiteName)
         self.userDefaults?.removePersistentDomain(forName: Constants.userDefaultsSuiteName)
         if !Constants.proxyURL.isEmpty {

--- a/Tests/StoreKitUnitTests/StoreKit2TransactionListenerTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2TransactionListenerTests.swift
@@ -182,12 +182,6 @@ private extension StoreKit2TransactionListenerTests {
 
     private enum Error: Swift.Error {
         case invalidResult(Product.PurchaseResult)
-        case invalidTransactions([VerificationResult<Transaction>])
-    }
-
-    func verifyNoUnfinishedTransactions(line: UInt = #line) async {
-        let unfinished = await StoreKit.Transaction.unfinished.extractValues()
-        expect(line: line, unfinished).to(beEmpty())
     }
 
     func purchase() async throws -> (
@@ -205,22 +199,4 @@ private extension StoreKit2TransactionListenerTests {
 
         return (result, verificationResult, transaction)
     }
-
-    func verifyUnfinishedTransaction(
-        withId identifier: Transaction.ID,
-        line: UInt = #line
-    ) async throws {
-        let unfinishedTransactions = await StoreKit.Transaction.unfinished.extractValues()
-
-        expect(line: line, unfinishedTransactions).to(haveCount(1))
-
-        guard let transaction = unfinishedTransactions.onlyElement,
-              case let .verified(verified) = transaction else {
-            throw Error.invalidTransactions(unfinishedTransactions)
-        }
-
-        expect(line: line, verified.id) == identifier
-
-    }
-
 }

--- a/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -36,8 +36,9 @@ class StoreKitConfigTestCase: TestCase {
     var testSession: SKTestSession!
     var userDefaults: UserDefaults!
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    @MainActor
+    override func setUp() async throws {
+        try await super.setUp()
 
         try AvailabilityChecks.iOS14APIAvailableOrSkipTest()
 
@@ -45,6 +46,10 @@ class StoreKitConfigTestCase: TestCase {
         self.testSession.resetToDefaultState()
         self.testSession.disableDialogs = true
         self.testSession.clearTransactions()
+
+        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            await self.finishAllUnfinishedTransactions()
+        }
 
         self.waitForStoreKitTestIfNeeded()
 

--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitConfigTestCase+Extensions.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitConfigTestCase+Extensions.swift
@@ -1,0 +1,151 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  StoreKitConfigTestCase+Extensions.swift
+//
+//  Created by Nacho Soto on 11/17/22.
+
+import Nimble
+@testable import RevenueCat
+@preconcurrency import StoreKit
+import XCTest
+
+@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+extension StoreKitConfigTestCase {
+
+    @MainActor
+    @discardableResult
+    func simulateAnyPurchase() async throws -> SK2Product {
+        let product = try await fetchSk2Product()
+        _ = try await product.purchase()
+
+        return product
+    }
+
+    @MainActor
+    func createTransactionWithPurchase() async throws -> Transaction {
+        let product = try await self.simulateAnyPurchase()
+
+        let transaction = try await XCTAsyncUnwrap(await product.latestTransaction)
+
+        switch transaction {
+        case let .verified(transaction):
+            return transaction
+        default:
+            XCTFail("Invalid transaction: \(transaction)")
+            fatalError("Unreachable")
+        }
+    }
+
+    @MainActor
+    func fetchSk2Product(_ productID: String = StoreKitConfigTestCase.productID) async throws -> SK2Product {
+        let products: [SK2Product] = try await StoreKit.Product.products(for: [productID])
+        return try XCTUnwrap(products.first)
+    }
+
+    @MainActor
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func fetchSk2StoreProduct(_ productID: String = StoreKitConfigTestCase.productID) async throws -> SK2StoreProduct {
+        return SK2StoreProduct(sk2Product: try await self.fetchSk2Product(productID))
+    }
+
+}
+
+@available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 6.2, *)
+extension StoreKitConfigTestCase {
+
+    /// Updates `SKTestSession.storefront` and waits for `Storefront.current` to reflect the change
+    /// This is necessary because the change is aynchronous within `StoreKit`, and otherwise code that depends
+    /// on the change might not see it in time, resulting in race conditions and flaky tests.
+    func changeStorefront(
+        _ new: String,
+        file: FileString = #fileID,
+        line: UInt = #line
+    ) async {
+        self.testSession.storefront = new
+
+        // Note: a better approach would be using `XCTestExpectation` and `self.wait(for:timeout:)`
+        // but it doesn't seem to play well with async-await.
+        // Also `toEventually` (Quick nor Nimble) don't support `async`.
+
+        var storefrontUpdateDetected: Bool {
+            get async { await Storefront.currentStorefront?.countryCode == new }
+        }
+
+        var numberOfChecksLeft = 10
+
+        repeat {
+            if await !storefrontUpdateDetected {
+                numberOfChecksLeft -= 1
+                try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
+            } else {
+                break
+            }
+        } while numberOfChecksLeft > 0
+
+        let detected = await storefrontUpdateDetected
+        expect(
+            file: file,
+            line: line,
+            detected
+        ).to(beTrue(), description: "Storefront change not detected")
+    }
+
+}
+
+@available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 6.2, *)
+extension StoreKitConfigTestCase {
+
+    static let productID = "com.revenuecat.monthly_4.99.1_week_intro"
+    static let lifetimeProductID = "lifetime"
+
+}
+
+@available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 6.2, *)
+fileprivate extension StoreKitConfigTestCase {
+
+    enum Error: Swift.Error {
+
+        case noProductsFound
+        case multipleProductsFound
+
+    }
+
+}
+
+@available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 6.2, *)
+extension ProductsFetcherSK1 {
+
+    func product(withIdentifier identifier: String) async throws -> StoreProduct {
+        let products = try await self.products(withIdentifiers: Set([identifier]))
+
+        switch products.count {
+        case 0: throw StoreKitConfigTestCase.Error.noProductsFound
+        case 1: return StoreProduct.from(product: products.first!)
+        default: throw StoreKitConfigTestCase.Error.multipleProductsFound
+        }
+    }
+
+}
+
+@MainActor
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+extension ProductsFetcherSK2 {
+
+    func product(withIdentifier identifier: String) async throws -> StoreProduct {
+        let products = try await self.products(identifiers: Set([identifier]))
+
+        switch products.count {
+        case 0: throw StoreKitConfigTestCase.Error.noProductsFound
+        case 1: return StoreProduct.from(product: products.first!)
+        default: throw StoreKitConfigTestCase.Error.multipleProductsFound
+        }
+    }
+
+}


### PR DESCRIPTION
Filed this as `FB11799675`. I noticed some tests began with prior transactions (despite using `SKTestSession.clearTransactions`), so this workaround ensures each test begins in a clean state.