### PR TITLE
`Integration Tests`: always run them in random order locally

### DIFF
--- a/Tests/TestPlans/BackendIntegrationTests.xctestplan
+++ b/Tests/TestPlans/BackendIntegrationTests.xctestplan
@@ -14,7 +14,8 @@
       "containerPath" : "container:RevenueCat.xcodeproj",
       "identifier" : "2DE20B7E26409EB7004C597D",
       "name" : "BackendIntegrationTestsHostApp"
-    }
+    },
+    "testExecutionOrdering" : "random"
   },
   "testTargets" : [
     {


### PR DESCRIPTION
This is already set to random in `CI-BackendIntegration.xctestplan`, but it's useful to default to random when running them locally too, to potentially catch any state issues.