### PR TITLE
Added integration and unit tests to verify observer mode behavior

### DIFF
--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -34,9 +34,8 @@ class BaseBackendIntegrationTests: XCTestCase {
     // swiftlint:disable:next weak_delegate
     private(set) var purchasesDelegate: TestPurchaseDelegate!
 
-    class var storeKit2Setting: StoreKit2Setting {
-        return .default
-    }
+    class var storeKit2Setting: StoreKit2Setting { return .default }
+    class var observerMode: Bool { return false }
 
     override class func setUp() {
         BundleSandboxEnvironmentDetector.default = MockSandboxEnvironmentDetector()
@@ -95,7 +94,7 @@ private extension BaseBackendIntegrationTests {
 
         Purchases.configure(withAPIKey: Constants.apiKey,
                             appUserID: nil,
-                            observerMode: false,
+                            observerMode: Self.observerMode,
                             userDefaults: self.userDefaults,
                             platformInfo: nil,
                             storeKit2Setting: Self.storeKit2Setting,

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -423,7 +423,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
         // 4. Verify purchase went through
 
-        let entitlement = try await self.verifyEntitlementWentThrough(customerInfo)
+        try await self.verifyEntitlementWentThrough(customerInfo)
     }
 
     @available(iOS 15.2, tvOS 15.2, macOS 12.1, watchOS 8.3, *)

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -8,31 +8,21 @@
 
 import Nimble
 @testable import RevenueCat
+@preconcurrency import StoreKit // `PurchaseResult` is not `Sendable`
 import StoreKitTest
 import UniformTypeIdentifiers
 import XCTest
 
-// swiftlint:disable file_length type_body_length
+// swiftlint:disable file_length type_body_length type_name
 
-class StoreKit2IntegrationTests: StoreKit1IntegrationTests {
+@MainActor
+class BaseStoreKitIntegrationTests: BaseBackendIntegrationTests {
 
-    override class var storeKit2Setting: StoreKit2Setting { return .enabledForCompatibleDevices }
-
-}
-
-class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
-
-    private var testSession: SKTestSession!
+    fileprivate var testSession: SKTestSession!
 
     override func setUp() async throws {
-        self.testSession = try SKTestSession(configurationFileNamed: Constants.storeKitConfigFileName)
-        self.testSession.resetToDefaultState()
-        self.testSession.disableDialogs = true
-        self.testSession.clearTransactions()
-        if #available(iOS 15.2, *) {
-            self.testSession.timeRate = .monthlyRenewalEveryThirtySeconds
-        } else {
-            self.testSession.timeRate = .oneSecondIsOneDay
+        if self.testSession == nil {
+            try self.configureTestSession()
         }
 
         // Initialize `Purchases` *after* the fresh new session has been created
@@ -46,6 +36,36 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
         // this waits for that request to finish.
         _ = try await Purchases.shared.offerings()
     }
+
+    override func tearDown() {
+        self.testSession = nil
+
+        super.tearDown()
+    }
+
+    func configureTestSession() throws {
+        assert(self.testSession == nil, "Attempted to configure session multiple times")
+
+        self.testSession = try SKTestSession(configurationFileNamed: Constants.storeKitConfigFileName)
+        self.testSession.resetToDefaultState()
+        self.testSession.disableDialogs = true
+        self.testSession.clearTransactions()
+        if #available(iOS 15.2, *) {
+            self.testSession.timeRate = .monthlyRenewalEveryThirtySeconds
+        } else {
+            self.testSession.timeRate = .oneSecondIsOneDay
+        }
+    }
+
+}
+
+class StoreKit2IntegrationTests: StoreKit1IntegrationTests {
+
+    override class var storeKit2Setting: StoreKit2Setting { return .enabledForCompatibleDevices }
+
+}
+
+class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
     override class var storeKit2Setting: StoreKit2Setting {
         return .disabled
@@ -449,10 +469,97 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
 
 }
 
-private extension StoreKit1IntegrationTests {
+// MARK: - Observer Mode tests
+
+class BaseStoreKitObserverModeIntegrationTests: BaseStoreKitIntegrationTests {
+
+    override class var observerMode: Bool { return true }
+
+}
+
+class StoreKit2ObserverModeIntegrationTests: StoreKit1ObserverModeIntegrationTests {
+
+    override class var storeKit2Setting: StoreKit2Setting { return .enabledForCompatibleDevices }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testPurchaseInDevicePostsReceipt() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        try await self.purchaseProductFromStoreKit()
+
+        let info = try await Purchases.shared.restorePurchases()
+        try await self.verifyEntitlementWentThrough(info)
+    }
+
+}
+
+class StoreKit1ObserverModeIntegrationTests: BaseStoreKitObserverModeIntegrationTests {
+
+    func testPurchaseOutsideTheAppPostsReceipt() async throws {
+        try self.testSession.buyProduct(productIdentifier: Self.monthlyNoIntroProductID)
+
+        let info = try await Purchases.shared.restorePurchases()
+        try await self.verifyEntitlementWentThrough(info)
+    }
+
+}
+
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+class StoreKit2ObserverModeWithExistingPurchasesTests: StoreKit1ObserverModeWithExistingPurchasesTests {
+
+    override class var storeKit2Setting: StoreKit2Setting { return .enabledForCompatibleDevices }
+
+}
+
+/// Purchases a product before configuring `Purchases` to verify behavior upon initialization in observer mode.
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+class StoreKit1ObserverModeWithExistingPurchasesTests: BaseStoreKitObserverModeIntegrationTests {
+
+    // MARK: - Transactions observation
+
+    private static var transactionsObservation: Task<Void, Never>?
+
+    override class func setUp() {
+        Self.transactionsObservation?.cancel()
+        Self.transactionsObservation = Task {
+            // Silence warning in tests:
+            // "Making a purchase without listening for transaction updates risks missing successful purchases.
+            for await _ in Transaction.updates {}
+        }
+    }
+
+    override class func tearDown() {
+        Self.transactionsObservation?.cancel()
+        Self.transactionsObservation = nil
+    }
+
+    override func setUp() async throws {
+        // 1. Create `SKTestSession`
+        try self.configureTestSession()
+
+        // 2. Purchase product directly from StoreKit
+        try await self.purchaseProductFromStoreKit()
+
+        // 3. Configure SDK
+        try await super.setUp()
+    }
+
+    func testDoesNotSyncExistingPurchase() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        let info = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
+        self.assertNoPurchases(info)
+    }
+
+}
+
+// MARK: - Private
+
+private extension BaseStoreKitIntegrationTests {
 
     static let entitlementIdentifier = "premium"
     static let consumable10Coins = "consumable.10_coins"
+    static let monthlyNoIntroProductID = "com.revenuecat.monthly_4.99.no_intro"
 
     private var currentOffering: Offering {
         get async throws {
@@ -474,7 +581,7 @@ private extension StoreKit1IntegrationTests {
 
     var monthlyNoIntroProduct: StoreProduct {
         get async throws {
-            let products = await Purchases.shared.products(["com.revenuecat.monthly_4.99.no_intro"])
+            let products = await Purchases.shared.products([Self.monthlyNoIntroProductID])
             return try XCTUnwrap(products.onlyElement)
         }
     }
@@ -647,7 +754,7 @@ private extension StoreKit1IntegrationTests {
 
 // MARK: - Private
 
-private extension StoreKit1IntegrationTests {
+private extension BaseStoreKitIntegrationTests {
 
     func printReceiptContent() async {
         do {
@@ -666,6 +773,15 @@ private extension StoreKit1IntegrationTests {
         } catch {
             Logger.error("Error parsing local receipt: \(error)")
         }
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    @discardableResult
+    func purchaseProductFromStoreKit() async throws -> Product.PurchaseResult {
+        let products = try await StoreKit.Product.products(for: [Self.monthlyNoIntroProductID])
+        let product = try XCTUnwrap(products.onlyElement)
+
+        return try await product.purchase()
     }
 
 }

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -499,8 +499,8 @@ class StoreKit2ObserverModeIntegrationTests: StoreKit1ObserverModeIntegrationTes
 
                 return entitlement?.isActive == true
             },
-            timeout: .seconds(30),
-            pollInterval: .seconds(1),
+            timeout: .seconds(60),
+            pollInterval: .seconds(2),
             description: "Entitlement didn't become active"
         )
     }

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionListener.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionListener.swift
@@ -52,8 +52,8 @@ class MockStoreKit2TransactionListener: StoreKit2TransactionListener {
     var invokedListenForTransactionsCount = 0
 
     override func listenForTransactions() {
-        invokedListenForTransactions = true
-        invokedListenForTransactionsCount += 1
+        self.invokedListenForTransactions = true
+        self.invokedListenForTransactionsCount += 1
     }
 
     var invokedHandle = false

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionListenerDelegate.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionListenerDelegate.swift
@@ -16,15 +16,18 @@
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
 final class MockStoreKit2TransactionListenerDelegate: StoreKit2TransactionListenerDelegate {
 
-    var invokedTransactionUpdated = false
-    var updatedTransactions: [StoreTransactionType] = []
+    var invokedTransactionUpdated: Bool { return self._invokedTransactionUpdated.value }
+    var updatedTransactions: [StoreTransactionType] { return self._updatedTransactions.value }
+
+    private var _invokedTransactionUpdated: Atomic<Bool> = false
+    private var _updatedTransactions: Atomic<[StoreTransactionType]> = .init([])
 
     func storeKit2TransactionListener(
         _ listener: StoreKit2TransactionListener,
         updatedTransaction transaction: StoreTransactionType
     ) async throws {
-        self.invokedTransactionUpdated = true
-        self.updatedTransactions.append(transaction)
+        self._invokedTransactionUpdated.value = true
+        self._updatedTransactions.value.append(transaction)
     }
 
 }


### PR DESCRIPTION
See [TRIAGE-179].

I wrote all these to cover the change in #2063. I wrote a failing test that only passed with the change in #2063. However, when running that in SK1, that would fail.
With the change as suggested in #2063, the SK2 behavior would differ from SK1.

From the `Transaction.all` docs:
> This sequence returns the user’s transaction history current to the moment you access the sequence. The sequence emits a finite number of transactions. If the App Store processes new transactions for the user while you’re accessing this sequence, the new transactions appear in the transaction listener, updates.

These new tests verify the behavior of the SDK when encountering transactions created prior to initializing the SDK, and some made after initialization.

Integration tests now are as follows:
- `BaseStoreKitIntegrationTests`
  - `StoreKit1IntegrationTests`
  - `StoreKit2IntegrationTests`
  - `BaseStoreKitObserverModeIntegrationTests`:
    - `StoreKit1ObserverModeIntegrationTests`
    - `StoreKit2ObserverModeIntegrationTests`
    - `StoreKit1ObserverModeWithExistingPurchasesTests`
    - `StoreKit2ObserverModeWithExistingPurchasesTests`

Depends on #2064, #2066, and #2134.

[TRIAGE-179]: https://revenuecats.atlassian.net/browse/TRIAGE-179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ