### PR TITLE
`StoreKit2` listeners: set `Task` `priority` to `.utility`

### DIFF
--- a/Sources/Purchasing/StoreKit2/StoreKit2StorefrontListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2StorefrontListener.swift
@@ -38,7 +38,7 @@ class StoreKit2StorefrontListener {
     }
 
     func listenForStorefrontChanges() {
-        self.taskHandle = Task(priority: .background) { [weak self] in
+        self.taskHandle = Task(priority: .utility) { [weak self] in
             for await _ in StoreKit.Storefront.updates {
                 guard let delegate = self?.delegate else { break }
                 await MainActor.run { @Sendable in
@@ -49,8 +49,8 @@ class StoreKit2StorefrontListener {
     }
 
     deinit {
-        taskHandle?.cancel()
-        taskHandle = nil
+        self.taskHandle?.cancel()
+        self.taskHandle = nil
     }
 
 }

--- a/Sources/Purchasing/StoreKit2/StoreKit2StorefrontListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2StorefrontListener.swift
@@ -38,7 +38,7 @@ class StoreKit2StorefrontListener {
     }
 
     func listenForStorefrontChanges() {
-        self.taskHandle = Task { [weak self] in
+        self.taskHandle = Task(priority: .background) { [weak self] in
             for await _ in StoreKit.Storefront.updates {
                 guard let delegate = self?.delegate else { break }
                 await MainActor.run { @Sendable in

--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
@@ -39,7 +39,7 @@ class StoreKit2TransactionListener {
 
     func listenForTransactions() {
         self.taskHandle?.cancel()
-        self.taskHandle = Task(priority: .background) { [weak self] in
+        self.taskHandle = Task(priority: .utility) { [weak self] in
             for await result in StoreKit.Transaction.updates {
                 guard let self = self else { break }
 

--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
@@ -39,7 +39,7 @@ class StoreKit2TransactionListener {
 
     func listenForTransactions() {
         self.taskHandle?.cancel()
-        self.taskHandle = Task { [weak self] in
+        self.taskHandle = Task(priority: .background) { [weak self] in
             for await result in StoreKit.Transaction.updates {
                 guard let self = self else { break }
 


### PR DESCRIPTION
A small performance improvement, since technically these don't need higher priorities.