### PR TITLE
`Tests`: replaced `toEventually` with new `waitUntilValue` to simplify tests

### DIFF
--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -23,13 +23,10 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         let manager = try createManager(storeKit2Setting: .disabled)
 
         let identifier = "com.revenuecat.monthly_4.99.1_week_intro"
-        var receivedProducts: Result<Set<StoreProduct>, PurchasesError>?
-
-        manager.products(withIdentifiers: Set([identifier])) { products in
-            receivedProducts = products
+        let receivedProducts = waitUntilValue(timeout: Self.requestDispatchTimeout) { completed in
+            manager.products(withIdentifiers: Set([identifier]), completion: completed)
         }
 
-        expect(receivedProducts).toEventuallyNot(beNil(), timeout: Self.requestDispatchTimeout)
         let unwrappedProducts = try XCTUnwrap(receivedProducts?.get())
 
         let product = try XCTUnwrap(unwrappedProducts.onlyElement).product
@@ -46,13 +43,10 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         let manager = try createManager(storeKit2Setting: .enabledForCompatibleDevices)
 
         let identifier = "com.revenuecat.monthly_4.99.1_week_intro"
-        var receivedProducts: Result<Set<StoreProduct>, PurchasesError>?
-
-        manager.products(withIdentifiers: Set([identifier])) { products in
-            receivedProducts = products
+        let receivedProducts = waitUntilValue(timeout: Self.requestDispatchTimeout) { completed in
+            manager.products(withIdentifiers: Set([identifier]), completion: completed)
         }
 
-        expect(receivedProducts).toEventuallyNot(beNil(), timeout: Self.requestDispatchTimeout)
         let unwrappedProducts = try XCTUnwrap(receivedProducts?.get())
 
         let product = try XCTUnwrap(unwrappedProducts.onlyElement).product

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -646,12 +646,12 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         let message = "Failed to get managementURL from CustomerInfo. Details: customerInfo is nil."
         mockManageSubsHelper.mockError = ErrorUtils.customerInfoError(withMessage: message)
 
-        var receivedError: Error?
-        orchestrator.showManageSubscription { error in
-            receivedError = error
+        let receivedError: Error? = waitUntilValue { completed in
+            self.orchestrator.showManageSubscription { error in
+                completed(error)
+            }
         }
 
-        expect(receivedError).toEventuallyNot(beNil())
         expect(receivedError).to(matchError(ErrorCode.customerInfoError))
     }
 

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
@@ -76,15 +76,11 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
         let stubbedEligibility = ["product_id": IntroEligibilityStatus.eligible]
         mockIntroEligibilityCalculator.stubbedCheckTrialOrIntroDiscountEligibilityResult = (stubbedEligibility, nil)
 
-        var eligibilities: [String: IntroEligibility]?
-        trialOrIntroPriceEligibilityChecker!.sk1CheckEligibility([]) { (receivedEligibilities) in
-            eligibilities = receivedEligibilities
+        let eligibilities = waitUntilValue { completed in
+            self.trialOrIntroPriceEligibilityChecker.sk1CheckEligibility([], completion: completed)
         }
 
-        expect(eligibilities).toEventuallyNot(beNil())
-
-        let receivedEligibilities = try XCTUnwrap(eligibilities)
-        expect(receivedEligibilities).to(haveCount(1))
+        expect(eligibilities).to(haveCount(1))
     }
 
     func testSK1EligibilityProductsWithKnownIntroEligibilityStatus() throws {
@@ -126,12 +122,9 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
         let stubbedEligibility = [productId: IntroEligibility(eligibilityStatus: IntroEligibilityStatus.eligible)]
         mockOfferingsAPI.stubbedGetIntroEligibilityCompletionResult = (stubbedEligibility, nil)
 
-        var eligibilities: [String: IntroEligibility]?
-        trialOrIntroPriceEligibilityChecker!.sk1CheckEligibility([productId]) { (receivedEligibilities) in
-            eligibilities = receivedEligibilities
+        let eligibilities = waitUntilValue { completed in
+            self.trialOrIntroPriceEligibilityChecker.sk1CheckEligibility([productId], completion: completed)
         }
-
-        expect(eligibilities).toEventuallyNot(beNil())
 
         let receivedEligibilities = try XCTUnwrap(eligibilities)
         expect(receivedEligibilities).to(haveCount(1))
@@ -158,12 +151,9 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
         let stubbedEligibility = [productId: IntroEligibility(eligibilityStatus: IntroEligibilityStatus.eligible)]
         mockOfferingsAPI.stubbedGetIntroEligibilityCompletionResult = (stubbedEligibility, nil)
 
-        var eligibilities: [String: IntroEligibility]?
-        trialOrIntroPriceEligibilityChecker!.sk1CheckEligibility([productId]) { (receivedEligibilities) in
-            eligibilities = receivedEligibilities
+        let eligibilities = waitUntilValue { completed in
+            self.trialOrIntroPriceEligibilityChecker.sk1CheckEligibility([productId], completion: completed)
         }
-
-        expect(eligibilities).toEventuallyNot(beNil())
 
         let receivedEligibilities = try XCTUnwrap(eligibilities)
         expect(receivedEligibilities).to(haveCount(1))
@@ -186,9 +176,8 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
 
         mockOfferingsAPI.stubbedGetIntroEligibilityCompletionResult = ([:], stubbedError)
 
-        var eligibilities: [String: IntroEligibility]?
-        trialOrIntroPriceEligibilityChecker!.sk1CheckEligibility([productId]) { (receivedEligibilities) in
-            eligibilities = receivedEligibilities
+        let eligibilities = waitUntilValue { completed in
+            self.trialOrIntroPriceEligibilityChecker.sk1CheckEligibility([productId], completion: completed)
         }
 
         expect(eligibilities).toEventuallyNot(beNil())

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
@@ -93,12 +93,13 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
                         "com.revenuecat.annual_39.99.2_week_intro": IntroEligibilityStatus.eligible,
                         "lifetime": IntroEligibilityStatus.noIntroOfferExists]
 
-        var eligibilities: [String: IntroEligibility]?
-        trialOrIntroPriceEligibilityChecker.checkEligibility(productIdentifiers: products) { receivedEligibilities in
-            eligibilities = receivedEligibilities
+        let eligibilities = waitUntilValue { completed in
+            self.trialOrIntroPriceEligibilityChecker.checkEligibility(
+                productIdentifiers: products
+            ) {
+                completed($0)
+            }
         }
-
-        expect(eligibilities).toEventuallyNot(beNil())
 
         let receivedEligibilities = try XCTUnwrap(eligibilities)
         expect(receivedEligibilities).to(haveCount(expected.count))
@@ -123,12 +124,13 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
 
         self.mockProductsManager?.stubbedSk2StoreProductsResult = .failure(ErrorUtils.productRequestTimedOutError())
 
-        var eligibilities: [String: IntroEligibility]?
-        trialOrIntroPriceEligibilityChecker.checkEligibility(productIdentifiers: products) { receivedEligibilities in
-            eligibilities = receivedEligibilities
+        let eligibilities = waitUntilValue { completed in
+            self.trialOrIntroPriceEligibilityChecker.checkEligibility(
+                productIdentifiers: products
+            ) {
+                completed($0)
+            }
         }
-
-        expect(eligibilities).toEventuallyNot(beNil())
 
         let receivedEligibilities = try XCTUnwrap(eligibilities)
         expect(receivedEligibilities).to(haveCount(expected.count))

--- a/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
@@ -63,14 +63,11 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
             response: .init(statusCode: .success, response: Self.validCustomerResponse)
         )
 
-        var customerInfo: Result<CustomerInfo, BackendError>?
-
-        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) { result in
-            customerInfo = result
+        let customerInfo = waitUntilValue { completed in
+            self.backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false, completion: completed)
         }
 
-        expect(customerInfo).toEventuallyNot(beNil())
-        expect(customerInfo?.value).toNot(beNil())
+        expect(customerInfo).to(beSuccess())
     }
 
     func testEncodesCustomerUserID() {
@@ -82,14 +79,11 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         httpClient.mock(requestPath: .getCustomerInfo(appUserID: encodeableUserID),
                         response: .init(error: .unexpectedResponse(nil)))
 
-        var customerInfo: Result<CustomerInfo, BackendError>?
-
-        backend.getCustomerInfo(appUserID: encodeableUserID, withRandomDelay: false) { result in
-            customerInfo = result
+        let customerInfo = waitUntilValue { completed in
+            self.backend.getCustomerInfo(appUserID: encodeableUserID, withRandomDelay: false, completion: completed)
         }
 
-        expect(customerInfo).toEventuallyNot(beNil())
-        expect(customerInfo?.value).toNot(beNil())
+        expect(customerInfo).to(beSuccess())
     }
 
     func testHandlesGetCustomerInfoErrors() throws {
@@ -100,13 +94,10 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
             response: .init(error: mockedError)
         )
 
-        var result: Result<CustomerInfo, BackendError>?
-
-        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) {
-            result = $0
+        let result = waitUntilValue { completed in
+            self.backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false, completion: completed)
         }
 
-        expect(result).toEventuallyNot(beNil())
         expect(result).to(beFailure())
         expect(result?.error) == .networkError(mockedError)
     }
@@ -117,13 +108,9 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
             response: .init(statusCode: .success, response: ["sjkaljdklsjadkjs": ""])
         )
 
-        var result: Result<CustomerInfo, BackendError>?
-
-        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) {
-            result = $0
+        let result = waitUntilValue { completed in
+            self.backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false, completion: completed)
         }
-
-        expect(result).toEventuallyNot(beNil())
 
         guard case .failure(.networkError(.decoding)) = result else {
             fail("Unexpected result: \(result!)")

--- a/Tests/UnitTests/Networking/Backend/BackendGetIntroEligibilityTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetIntroEligibilityTests.swift
@@ -45,7 +45,7 @@ class BackendGetIntroEligibilityTests: BaseBackendTests {
 
         let products = ["producta", "productb", "productc", "productd"]
 
-        let eligibility = waitUntilValue { completed in
+        let eligibility: [String: IntroEligibility]? = waitUntilValue { completed in
             self.offerings.getIntroEligibility(appUserID: Self.userID,
                                                receiptData: Data(1...3),
                                                productIdentifiers: products,
@@ -70,7 +70,7 @@ class BackendGetIntroEligibilityTests: BaseBackendTests {
             response: .init(statusCode: .invalidRequest, response: Self.serverErrorResponse)
         )
 
-        let eligibility = waitUntilValue { completed in
+        let eligibility: [String: IntroEligibility]? = waitUntilValue { completed in
             let products = ["producta", "productb", "productc"]
             self.offerings.getIntroEligibility(appUserID: Self.userID,
                                                receiptData: Data.init(1...2),
@@ -132,7 +132,7 @@ class BackendGetIntroEligibilityTests: BaseBackendTests {
 
         let products = ["producta", "productb", "productc"]
 
-        let eligibility = waitUntilValue { completed in
+        let eligibility: [String: IntroEligibility]? = waitUntilValue { completed in
 
             self.offerings.getIntroEligibility(appUserID: Self.userID,
                                                receiptData: Data.init(1...2),
@@ -150,7 +150,7 @@ class BackendGetIntroEligibilityTests: BaseBackendTests {
 
     func testEligibilityUnknownIfNoReceipt() {
         let products = ["producta", "productb", "productc"]
-        let eligibility = waitUntilValue { completed in
+        let eligibility: [String: IntroEligibility]? = waitUntilValue { completed in
             self.offerings.getIntroEligibility(appUserID: Self.userID,
                                                receiptData: Data(),
                                                productIdentifiers: products,

--- a/Tests/UnitTests/Networking/Backend/BackendPostAdServicesTokenTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostAdServicesTokenTests.swift
@@ -30,13 +30,12 @@ class BackendPostAdServicesTokenTests: BaseBackendTests {
             response: .init(statusCode: .success)
         )
 
-        var completionCalled = false
-        backend.post(adServicesToken: "asdf",
-                     appUserID: "asdf") { _ in
-            completionCalled = true
+        waitUntil { completed in
+            self.backend.post(adServicesToken: "asdf", appUserID: "asdf") { _ in
+                completed()
+            }
         }
-        expect(self.httpClient.calls).toEventually(haveCount(1))
-        expect(completionCalled).toEventually(beTrue())
+        expect(self.httpClient.calls).to(haveCount(1))
     }
 
 }

--- a/Tests/UnitTests/Networking/Backend/BackendPostAttributionDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostAttributionDataTests.swift
@@ -31,12 +31,15 @@ class BackendPostAttributionDataTests: BaseBackendTests {
 
         let data: [String: AnyObject] = ["a": "b" as NSString, "c": "d" as NSString]
 
-        backend.post(attributionData: data,
-                     network: .adjust,
-                     appUserID: Self.userID,
-                     completion: nil)
+        waitUntil { completed in
+            self.backend.post(attributionData: data,
+                              network: .adjust,
+                              appUserID: Self.userID) { _ in
+                completed()
+            }
+        }
 
-        expect(self.httpClient.calls).toEventually(haveCount(1))
+        expect(self.httpClient.calls).to(haveCount(1))
     }
 
 }

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -31,25 +31,24 @@ class BackendPostReceiptDataTests: BaseBackendTests {
             response: .init(statusCode: .success, response: Self.validCustomerResponse)
         )
 
-        var completionCalled = false
-
         let isRestore = false
         let observerMode = true
 
-        backend.post(receiptData: Self.receiptData,
-                     appUserID: Self.userID,
-                     isRestore: isRestore,
-                     productData: nil,
-                     presentedOfferingIdentifier: nil,
-                     observerMode: observerMode,
-                     initiationSource: .queue,
-                     subscriberAttributes: nil,
-                     completion: { _ in
-            completionCalled = true
-        })
+        waitUntil { completed in
+            self.backend.post(receiptData: Self.receiptData,
+                              appUserID: Self.userID,
+                              isRestore: isRestore,
+                              productData: nil,
+                              presentedOfferingIdentifier: nil,
+                              observerMode: observerMode,
+                              initiationSource: .queue,
+                              subscriberAttributes: nil,
+                              completion: { _ in
+                completed()
+            })
+        }
 
-        expect(self.httpClient.calls).toEventually(haveCount(1))
-        expect(completionCalled).toEventually(beTrue())
+        expect(self.httpClient.calls).to(haveCount(1))
     }
 
     func testPostsReceiptDataWithProductDataCorrectly() throws {
@@ -60,25 +59,24 @@ class BackendPostReceiptDataTests: BaseBackendTests {
             response: .init(statusCode: .success, response: Self.validCustomerResponse)
         )
 
-        var completionCalled = false
-
         let isRestore = false
         let observerMode = true
         let productData: ProductRequestData = .createMockProductData(currencyCode: "USD")
 
-        backend.post(receiptData: Self.receiptData,
-                     appUserID: Self.userID,
-                     isRestore: isRestore,
-                     productData: productData,
-                     presentedOfferingIdentifier: nil,
-                     observerMode: observerMode,
-                     initiationSource: .purchase,
-                     subscriberAttributes: nil,
-                     completion: { _ in
-            completionCalled = true
-        })
+        waitUntil { completed in
+            self.backend.post(receiptData: Self.receiptData,
+                              appUserID: Self.userID,
+                              isRestore: isRestore,
+                              productData: productData,
+                              presentedOfferingIdentifier: nil,
+                              observerMode: observerMode,
+                              initiationSource: .purchase,
+                              subscriberAttributes: nil,
+                              completion: { _ in
+                completed()
+            })
+        }
 
-        expect(completionCalled).toEventually(beTrue())
         expect(self.httpClient.calls).to(haveCount(1))
     }
 
@@ -293,27 +291,27 @@ class BackendPostReceiptDataTests: BaseBackendTests {
 
         let paymentMode: StoreProductDiscount.PaymentMode? = nil
 
-        var completionCalled = false
         let productData: ProductRequestData = .createMockProductData(productIdentifier: productIdentifier,
                                                                      paymentMode: paymentMode,
                                                                      currencyCode: currencyCode,
                                                                      price: price,
                                                                      subscriptionGroup: group)
 
-        backend.post(receiptData: Self.receiptData,
-                     appUserID: Self.userID,
-                     isRestore: false,
-                     productData: productData,
-                     presentedOfferingIdentifier: offeringIdentifier,
-                     observerMode: false,
-                     initiationSource: .purchase,
-                     subscriberAttributes: nil,
-                     completion: { _ in
-            completionCalled = true
-        })
+        waitUntil { completed in
+            self.backend.post(receiptData: Self.receiptData,
+                              appUserID: Self.userID,
+                              isRestore: false,
+                              productData: productData,
+                              presentedOfferingIdentifier: offeringIdentifier,
+                              observerMode: false,
+                              initiationSource: .purchase,
+                              subscriberAttributes: nil,
+                              completion: { _ in
+                completed()
+            })
+        }
 
-        expect(self.httpClient.calls).toEventually(haveCount(1))
-        expect(completionCalled).toEventually(beTrue())
+        expect(self.httpClient.calls).to(haveCount(1))
     }
 
     func testIndividualParamsCanBeNil() {
@@ -323,23 +321,23 @@ class BackendPostReceiptDataTests: BaseBackendTests {
                             response: Self.validCustomerResponse)
         )
 
-        var completionCalled = false
-
         let productData: ProductRequestData = .createMockProductData()
-        backend.post(receiptData: Self.receiptData,
-                     appUserID: Self.userID,
-                     isRestore: false,
-                     productData: productData,
-                     presentedOfferingIdentifier: nil,
-                     observerMode: false,
-                     initiationSource: .queue,
-                     subscriberAttributes: nil,
-                     completion: { _ in
-            completionCalled = true
-        })
 
-        expect(self.httpClient.calls).toEventually(haveCount(1))
-        expect(completionCalled).toEventually(beTrue())
+        waitUntil { completed in
+            self.backend.post(receiptData: Self.receiptData,
+                              appUserID: Self.userID,
+                              isRestore: false,
+                              productData: productData,
+                              presentedOfferingIdentifier: nil,
+                              observerMode: false,
+                              initiationSource: .queue,
+                              subscriberAttributes: nil,
+                              completion: { _ in
+                completed()
+            })
+        }
+
+        expect(self.httpClient.calls).to(haveCount(1))
     }
 
     func testPayAsYouGoPostsCorrectly() throws {
@@ -457,25 +455,21 @@ class BackendPostReceiptDataTests: BaseBackendTests {
             response: .init(statusCode: .success, response: Self.validCustomerResponse)
         )
 
-        var customerInfo: CustomerInfo?
-
-        backend.post(receiptData: Self.receiptData,
-                     appUserID: Self.userID,
-                     isRestore: false,
-                     productData: nil,
-                     presentedOfferingIdentifier: nil,
-                     observerMode: false,
-                     initiationSource: .purchase,
-                     subscriberAttributes: nil,
-                     completion: { result in
-            customerInfo = result.value
-        })
-
-        expect(customerInfo).toEventuallyNot(beNil())
-        if customerInfo != nil {
-            let expiration = customerInfo!.expirationDate(forProductIdentifier: "onemonth_freetrial")
-            expect(expiration).toNot(beNil())
+        let customerInfo = waitUntilValue { completed in
+            self.backend.post(receiptData: Self.receiptData,
+                              appUserID: Self.userID,
+                              isRestore: false,
+                              productData: nil,
+                              presentedOfferingIdentifier: nil,
+                              observerMode: false,
+                              initiationSource: .purchase,
+                              subscriberAttributes: nil,
+                              completion: { result in
+                completed(result.value)
+            })
         }
+
+        expect(customerInfo?.expirationDate(forProductIdentifier: "onemonth_freetrial")).toNot(beNil())
     }
 
     func testErrorIsForwardedForCustomerInfoCalls() throws {
@@ -486,20 +480,20 @@ class BackendPostReceiptDataTests: BaseBackendTests {
             response: .init(error: error)
         )
 
-        var receivedError: BackendError?
-        backend.post(receiptData: Self.receiptData,
-                     appUserID: Self.userID,
-                     isRestore: true,
-                     productData: nil,
-                     presentedOfferingIdentifier: nil,
-                     observerMode: false,
-                     initiationSource: .queue,
-                     subscriberAttributes: nil,
-                     completion: { result in
-            receivedError = result.error
-        })
+        let receivedError = waitUntilValue { completed in
+            self.backend.post(receiptData: Self.receiptData,
+                              appUserID: Self.userID,
+                              isRestore: true,
+                              productData: nil,
+                              presentedOfferingIdentifier: nil,
+                              observerMode: false,
+                              initiationSource: .queue,
+                              subscriberAttributes: nil,
+                              completion: { result in
+                completed(result.error)
+            })
+        }
 
-        expect(receivedError).toEventuallyNot(beNil())
         expect(receivedError) == .networkError(error)
     }
 
@@ -563,7 +557,6 @@ class BackendPostReceiptDataTests: BaseBackendTests {
         let group = "sub_group"
         let currencyCode = "BFD"
         let paymentMode: StoreProductDiscount.PaymentMode? = nil
-        var completionCalled = false
         let discount = MockStoreProductDiscount(offerIdentifier: "offerid",
                                                 currencyCode: currencyCode,
                                                 price: 12.1,
@@ -579,20 +572,21 @@ class BackendPostReceiptDataTests: BaseBackendTests {
                                                                      subscriptionGroup: group,
                                                                      discounts: [discount])
 
-        backend.post(receiptData: Self.receiptData,
-                     appUserID: Self.userID,
-                     isRestore: false,
-                     productData: productData,
-                     presentedOfferingIdentifier: nil,
-                     observerMode: false,
-                     initiationSource: .queue,
-                     subscriberAttributes: nil,
-                     completion: { _ in
-            completionCalled = true
-        })
+        waitUntil { completed in
+            self.backend.post(receiptData: Self.receiptData,
+                              appUserID: Self.userID,
+                              isRestore: false,
+                              productData: productData,
+                              presentedOfferingIdentifier: nil,
+                              observerMode: false,
+                              initiationSource: .queue,
+                              subscriberAttributes: nil,
+                              completion: { _ in
+                completed()
+            })
+        }
 
-        expect(self.httpClient.calls).toEventually(haveCount(1))
-        expect(completionCalled).toEventually(beTrue())
+        expect(self.httpClient.calls).to(haveCount(1))
     }
 
     func testDoesntCacheForDifferentOfferings() {
@@ -641,23 +635,21 @@ private extension BackendPostReceiptDataTests {
     static let receiptData2 = "an awesomeer receipt".data(using: String.Encoding.utf8)!
 
     func postPaymentMode(paymentMode: StoreProductDiscount.PaymentMode) {
-        var completionCalled = false
-
         let productData: ProductRequestData = .createMockProductData(paymentMode: paymentMode)
 
-        backend.post(receiptData: Self.receiptData,
-                     appUserID: Self.userID,
-                     isRestore: false,
-                     productData: productData,
-                     presentedOfferingIdentifier: nil,
-                     observerMode: false,
-                     initiationSource: .queue,
-                     subscriberAttributes: nil,
-                     completion: { _ in
-            completionCalled = true
-        })
-
-        expect(completionCalled).toEventually(beTrue())
+        waitUntil { completed in
+            self.backend.post(receiptData: Self.receiptData,
+                              appUserID: Self.userID,
+                              isRestore: false,
+                              productData: productData,
+                              presentedOfferingIdentifier: nil,
+                              observerMode: false,
+                              initiationSource: .queue,
+                              subscriberAttributes: nil,
+                              completion: { _ in
+                completed()
+            })
+        }
     }
 
 }

--- a/Tests/UnitTests/Networking/Backend/BackendPostSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostSubscriberAttributesTests.swift
@@ -24,13 +24,11 @@ class BackendPostSubscriberAttributesTests: BaseBackendTests {
     }
 
     func testPostingWithNoSubscriberAttributesProducesAnError() {
-        var eventuallyError: BackendError?
-        backend.post(subscriberAttributes: [:], appUserID: "testUserID") { error in
-            eventuallyError = error
+        let error = waitUntilValue { completed in
+            self.backend.post(subscriberAttributes: [:], appUserID: "testUserID", completion: completed)
         }
 
-        expect(eventuallyError).toEventuallyNot(beNil())
-        expect(eventuallyError) == .emptySubscriberAttributes()
+        expect(error) == .emptySubscriberAttributes()
     }
 
 }

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -50,41 +50,38 @@ extension OfferingsManagerTests {
 
     func testOfferingsForAppUserIDReturnsNilIfMissingStoreProduct() throws {
         // given
-        mockOfferingsFactory.emptyOfferings = true
-        mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsResponse)
+        self.mockOfferingsFactory.emptyOfferings = true
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsResponse)
 
         // when
-        var result: Result<Offerings, OfferingsManager.Error>?
-        offeringsManager.offerings(appUserID: MockData.anyAppUserID) {
-            result = $0
+        let result = waitUntilValue { completed in
+            self.offeringsManager.offerings(appUserID: MockData.anyAppUserID) {
+                completed($0)
+            }
         }
 
         // then
-        expect(result).toEventuallyNot(beNil())
         expect(result).to(beSuccess())
-
-        let unwrappedOfferings = try XCTUnwrap(result?.value)
-        expect(unwrappedOfferings.all).to(beEmpty())
-        expect(unwrappedOfferings["base"]).to(beNil())
+        expect(result?.value?.all).to(beEmpty())
+        expect(result?.value?["base"]).to(beNil())
     }
 
     func testOfferingsForAppUserIDReturnsOfferingsIfSuccessBackendRequest() throws {
         // given
-        mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsResponse)
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsResponse)
 
         // when
-        var result: Result<Offerings, OfferingsManager.Error>?
-        offeringsManager.offerings(appUserID: MockData.anyAppUserID) {
-            result = $0
+        let result = waitUntilValue { completed in
+            self.offeringsManager.offerings(appUserID: MockData.anyAppUserID) {
+                completed($0)
+            }
         }
 
         // then
-        expect(result).toEventuallyNot(beNil())
-
-        let unwrappedOfferings = try XCTUnwrap(result?.value)
-        expect(unwrappedOfferings["base"]).toNot(beNil())
-        expect(unwrappedOfferings["base"]!.monthly).toNot(beNil())
-        expect(unwrappedOfferings["base"]!.monthly?.storeProduct).toNot(beNil())
+        expect(result).to(beSuccess())
+        expect(result?.value?["base"]).toNot(beNil())
+        expect(result?.value?["base"]!.monthly).toNot(beNil())
+        expect(result?.value?["base"]!.monthly?.storeProduct).toNot(beNil())
     }
 
     func testOfferingsIgnoresProductsNotFoundAndLogsWarning() throws {
@@ -99,14 +96,13 @@ extension OfferingsManagerTests {
         ])
 
         // when
-        var result: Result<Offerings, OfferingsManager.Error>?
-        self.offeringsManager.offerings(appUserID: MockData.anyAppUserID) {
-            result = $0
+        let result = waitUntilValue { completed in
+            self.offeringsManager.offerings(appUserID: MockData.anyAppUserID) {
+                completed($0)
+            }
         }
 
         // then
-        expect(result).toEventuallyNot(beNil())
-
         let offerings = try XCTUnwrap(result?.value)
         expect(offerings.all).to(haveCount(1))
         expect(offerings["base"]).toNot(beNil())
@@ -129,13 +125,13 @@ extension OfferingsManagerTests {
         ])
 
         // when
-        var result: Result<Offerings, OfferingsManager.Error>?
-        self.offeringsManager.offerings(appUserID: MockData.anyAppUserID, fetchPolicy: .failIfProductsAreMissing) {
-            result = $0
+        let result = waitUntilValue { completed in
+            self.offeringsManager.offerings(appUserID: MockData.anyAppUserID, fetchPolicy: .failIfProductsAreMissing) {
+                completed($0)
+            }
         }
 
         // then
-        expect(result).toEventuallyNot(beNil())
         expect(result).to(beFailure { error in
             expect(error).to(matchError(OfferingsManager.Error.missingProducts(identifiers: ["yearly_freetrial"])))
         })
@@ -143,36 +139,36 @@ extension OfferingsManagerTests {
 
     func testOfferingsForAppUserIDReturnsNilIfFailBackendRequest() {
         // given
-        mockOfferings.stubbedGetOfferingsCompletionResult = .failure(MockData.unexpectedBackendResponseError)
-        mockOfferingsFactory.emptyOfferings = true
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .failure(MockData.unexpectedBackendResponseError)
+        self.mockOfferingsFactory.emptyOfferings = true
 
         // when
-        var result: Result<Offerings, OfferingsManager.Error>?
-        offeringsManager.offerings(appUserID: MockData.anyAppUserID) {
-            result = $0
+        let result = waitUntilValue { completed in
+            self.offeringsManager.offerings(appUserID: MockData.anyAppUserID) {
+                completed($0)
+            }
         }
 
         // then
-        expect(result).toEventuallyNot(beNil())
         expect(result).to(beFailure())
         expect(result?.error) == .backendError(.unexpectedBackendResponse(.customerInfoNil))
     }
 
     func testOfferingsForAppUserIDReturnsConfigurationErrorIfBackendReturnsEmpty() throws {
         // given
-        mockOfferings.stubbedGetOfferingsCompletionResult = .success(
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(
             .init(currentOfferingId: "", offerings: [])
         )
-        mockOfferingsFactory.emptyOfferings = true
+        self.mockOfferingsFactory.emptyOfferings = true
 
         // when
-        var result: Result<Offerings, OfferingsManager.Error>?
-        offeringsManager.offerings(appUserID: MockData.anyAppUserID) {
-            result = $0
+        let result = waitUntilValue { completed in
+            self.offeringsManager.offerings(appUserID: MockData.anyAppUserID) {
+                completed($0)
+            }
         }
 
         // then
-        expect(result).toEventuallyNot(beNil())
         expect(result).to(beFailure())
 
         switch result?.error {
@@ -186,17 +182,17 @@ extension OfferingsManagerTests {
 
     func testOfferingsForAppUserIDReturnsConfigurationErrorIfProductsRequestsReturnsEmpty() throws {
         // given
-        mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsResponse)
-        mockProductsManager.stubbedProductsCompletionResult = .success(Set())
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsResponse)
+        self.mockProductsManager.stubbedProductsCompletionResult = .success(Set())
 
         // when
-        var result: Result<Offerings, OfferingsManager.Error>?
-        offeringsManager.offerings(appUserID: MockData.anyAppUserID) {
-            result = $0
+        let result = waitUntilValue { completed in
+            self.offeringsManager.offerings(appUserID: MockData.anyAppUserID) {
+                completed($0)
+            }
         }
 
         // then
-        expect(result).toEventuallyNot(beNil())
         expect(result).to(beFailure())
 
         switch result?.error {
@@ -212,17 +208,17 @@ extension OfferingsManagerTests {
         let error = ErrorUtils.unknownError()
 
         // given
-        mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsResponse)
-        mockProductsManager.stubbedProductsCompletionResult = .failure(error)
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsResponse)
+        self.mockProductsManager.stubbedProductsCompletionResult = .failure(error)
 
         // when
-        var result: Result<Offerings, OfferingsManager.Error>?
-        offeringsManager.offerings(appUserID: MockData.anyAppUserID) {
-            result = $0
+        let result = waitUntilValue { completed in
+            self.offeringsManager.offerings(appUserID: MockData.anyAppUserID) {
+                completed($0)
+            }
         }
 
         // then
-        expect(result).toEventuallyNot(beNil())
         expect(result).to(beFailure())
 
         switch result?.error {
@@ -236,68 +232,76 @@ extension OfferingsManagerTests {
 
     func testOfferingsForAppUserIDReturnsUnexpectedBackendResponseIfOfferingsFactoryCantCreateOfferings() throws {
         // given
-        mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsResponse)
-        mockOfferingsFactory.nilOfferings = true
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsResponse)
+        self.mockOfferingsFactory.nilOfferings = true
 
         // when
-        var result: Result<Offerings, OfferingsManager.Error>?
-        offeringsManager.offerings(appUserID: MockData.anyAppUserID) {
-            result = $0
+        let result = waitUntilValue { completed in
+            self.offeringsManager.offerings(appUserID: MockData.anyAppUserID) {
+                completed($0)
+            }
         }
 
         // then
-        expect(result).toEventuallyNot(beNil())
         expect(result).to(beFailure())
         expect(result?.error) == .noOfferingsFound()
     }
 
     func testOfferingsForAppUserIDReturnsUnexpectedBackendErrorIfBadBackendRequest() throws {
         // given
-        mockOfferings.stubbedGetOfferingsCompletionResult = .failure(MockData.unexpectedBackendResponseError)
-        mockOfferingsFactory.nilOfferings = true
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .failure(MockData.unexpectedBackendResponseError)
+        self.mockOfferingsFactory.nilOfferings = true
 
         // when
-        var result: Result<Offerings, OfferingsManager.Error>?
-        offeringsManager.offerings(appUserID: MockData.anyAppUserID) {
-            result = $0
+        let result = waitUntilValue { completed in
+            self.offeringsManager.offerings(appUserID: MockData.anyAppUserID) {
+                completed($0)
+            }
         }
 
         // then
-        expect(result).toEventuallyNot(beNil())
         expect(result).to(beFailure())
         expect(result?.error) == .backendError(MockData.unexpectedBackendResponseError)
     }
 
     func testFailBackendDeviceCacheClearsOfferingsCache() {
         // given
-        mockOfferings.stubbedGetOfferingsCompletionResult = .failure(MockData.unexpectedBackendResponseError)
-        mockOfferingsFactory.emptyOfferings = true
-        mockSystemInfo.stubbedIsApplicationBackgrounded = false
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .failure(MockData.unexpectedBackendResponseError)
+        self.mockOfferingsFactory.emptyOfferings = true
+        self.mockSystemInfo.stubbedIsApplicationBackgrounded = false
 
         let expectedCallCount = 1
 
         // when
-        offeringsManager.offerings(appUserID: MockData.anyAppUserID, completion: nil)
+        waitUntil { completed in
+            self.offeringsManager.offerings(appUserID: MockData.anyAppUserID) { _ in
+                completed()
+            }
+        }
 
         // then
-        expect(self.mockOfferings.invokedGetOfferingsForAppUserIDCount).toEventually(equal(expectedCallCount))
-        expect(self.mockDeviceCache.clearOfferingsCacheTimestampCount).toEventually(equal(expectedCallCount))
+        expect(self.mockOfferings.invokedGetOfferingsForAppUserIDCount) == expectedCallCount
+        expect(self.mockDeviceCache.clearOfferingsCacheTimestampCount) == expectedCallCount
         expect(self.mockOfferings.invokedGetOfferingsForAppUserIDParameters?.randomDelay) == false
     }
 
     func testUpdateOfferingsCacheOK() {
         // given
-        mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsResponse)
-        mockSystemInfo.stubbedIsApplicationBackgrounded = true
+        self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(MockData.anyBackendOfferingsResponse)
+        self.mockSystemInfo.stubbedIsApplicationBackgrounded = true
 
         let expectedCallCount = 1
 
         // when
-        offeringsManager.offerings(appUserID: MockData.anyAppUserID, completion: nil)
+        waitUntil { completed in
+            self.offeringsManager.offerings(appUserID: MockData.anyAppUserID) { _ in
+                completed()
+            }
+        }
 
         // then
-        expect(self.mockOfferings.invokedGetOfferingsForAppUserIDCount).toEventually(equal(expectedCallCount))
-        expect(self.mockDeviceCache.cacheOfferingsCount).toEventually(equal(expectedCallCount))
+        expect(self.mockOfferings.invokedGetOfferingsForAppUserIDCount) == expectedCallCount
+        expect(self.mockDeviceCache.cacheOfferingsCount) == expectedCallCount
         expect(self.mockOfferings.invokedGetOfferingsForAppUserIDParameters?.randomDelay) == true
     }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetCustomerInfoTests.swift
@@ -37,13 +37,12 @@ class PurchasesGetCustomerInfoTests: BasePurchasesTests {
 
         self.setupPurchases()
 
-        var receivedInfo: CustomerInfo?
-
-        purchases.getCustomerInfo { (info, _) in
-            receivedInfo = info
+        let receivedInfo = waitUntilValue { completed in
+            self.purchases.getCustomerInfo { info, _ in
+                completed(info)
+            }
         }
 
-        expect(receivedInfo).toEventuallyNot(beNil())
         expect(receivedInfo?.schemaVersion).toNot(beNil())
     }
 
@@ -57,13 +56,13 @@ class PurchasesGetCustomerInfoTests: BasePurchasesTests {
 
         self.setupPurchases()
 
-        var receivedInfo: CustomerInfo?
-
-        self.purchases.getCustomerInfo { (info, _) in
-            receivedInfo = info
+        let receivedInfo = waitUntilValue { completed in
+            self.purchases.getCustomerInfo { info, _ in
+                completed(info)
+            }
         }
 
-        expect(receivedInfo).toEventually(equal(fetchedInfo))
+        expect(receivedInfo) == fetchedInfo
     }
 
     func testSendsCachedCustomerInfoToGetter() throws {
@@ -73,13 +72,12 @@ class PurchasesGetCustomerInfoTests: BasePurchasesTests {
 
         self.setupPurchases()
 
-        var receivedInfo: CustomerInfo?
-
-        self.purchases.getCustomerInfo { (info, _) in
-            receivedInfo = info
+        let receivedInfo = waitUntilValue { completed in
+            self.purchases.getCustomerInfo { info, _ in
+                completed(info)
+            }
         }
-
-        expect(receivedInfo).toEventuallyNot(beNil())
+        expect(receivedInfo).toNot(beNil())
     }
 
     func testCustomerInfoCompletionBlockCalledExactlyOnceWhenInfoCached() throws {
@@ -109,13 +107,13 @@ class PurchasesGetCustomerInfoTests: BasePurchasesTests {
 
         self.setupPurchases()
 
-        var receivedInfo: CustomerInfo?
-
-        self.purchases.getCustomerInfo { (info, _) in
-            receivedInfo = info
+        let receivedInfo = waitUntilValue { completed in
+            self.purchases.getCustomerInfo { info, _ in
+                completed(info)
+            }
         }
 
-        expect(receivedInfo).toEventually(equal(fetchedInfo))
+        expect(receivedInfo) == fetchedInfo
     }
 
     func testDoesntSendsCachedCustomerInfoToGetterIfNoSchemaVersionInCached() throws {
@@ -128,13 +126,12 @@ class PurchasesGetCustomerInfoTests: BasePurchasesTests {
 
         self.setupPurchases()
 
-        var receivedInfo: CustomerInfo?
-
-        self.purchases.getCustomerInfo { (info, _) in
-            receivedInfo = info
+        let receivedInfo = waitUntilValue { completed in
+            self.purchases.getCustomerInfo { info, _ in
+                completed(info)
+            }
         }
-
-        expect(receivedInfo).toEventually(equal(fetchedInfo))
+        expect(receivedInfo) == fetchedInfo
     }
 
     func testDoesntSendCacheIfNoCacheAndCallsBackendAgain() {
@@ -154,9 +151,11 @@ class PurchasesGetCustomerInfoTests: BasePurchasesTests {
 
         self.deviceCache.stubbedIsCustomerInfoCacheStale = true
 
-        self.purchases.getCustomerInfo { (_, _) in }
+        waitUntil { completed in
+            self.purchases.getCustomerInfo { (_, _) in completed() }
+        }
 
-        expect(self.backend.getSubscriberCallCount).toEventually(equal(2))
+        expect(self.backend.getSubscriberCallCount) == 2
     }
 
     func testGetCustomerInfoAfterInvalidatingDoesntReturnCachedVersion() throws {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
@@ -40,27 +40,29 @@ class PurchasesGetOfferingsTests: BasePurchasesTests {
             try XCTUnwrap(self.offeringsFactory.createOfferings(from: [:], data: .mockResponse))
         )
 
-        var product: SK1Product!
+        let result = waitUntilValue { completed in
+            self.purchases.getOfferings { (newOfferings, _) in
+                let storeProduct = newOfferings!["base"]!.monthly!.storeProduct
 
-        self.purchases.getOfferings { (newOfferings, _) in
-            let storeProduct = newOfferings!["base"]!.monthly!.storeProduct
-            product = storeProduct.sk1Product!
+                self.purchases.purchase(product: storeProduct) { (_, _, _, _) in }
 
-            self.purchases.purchase(product: storeProduct) { (_, _, _, _) in }
+                let transaction = MockTransaction()
+                transaction.mockPayment = self.storeKit1Wrapper.payment!
 
-            let transaction = MockTransaction()
-            transaction.mockPayment = self.storeKit1Wrapper.payment!
+                transaction.mockState = SKPaymentTransactionState.purchasing
+                self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
-            transaction.mockState = SKPaymentTransactionState.purchasing
-            self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
+                self.backend.postReceiptResult = .success(CustomerInfo(testData: Self.emptyCustomerInfoData)!)
 
-            self.backend.postReceiptResult = .success(CustomerInfo(testData: Self.emptyCustomerInfoData)!)
+                transaction.mockState = SKPaymentTransactionState.purchased
+                self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
-            transaction.mockState = SKPaymentTransactionState.purchased
-            self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
+                completed(storeProduct.sk1Product!)
+            }
         }
 
-        expect(product).toEventuallyNot(beNil())
+        let product = try XCTUnwrap(result)
+
         expect(self.backend.postReceiptDataCalled).to(beTrue())
         expect(self.backend.postedReceiptData).toNot(beNil())
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
@@ -40,7 +40,7 @@ class PurchasesGetOfferingsTests: BasePurchasesTests {
             try XCTUnwrap(self.offeringsFactory.createOfferings(from: [:], data: .mockResponse))
         )
 
-        let result = waitUntilValue { completed in
+        let result: SK1Product? = waitUntilValue { completed in
             self.purchases.getOfferings { (newOfferings, _) in
                 let storeProduct = newOfferings!["base"]!.monthly!.storeProduct
 
@@ -57,7 +57,7 @@ class PurchasesGetOfferingsTests: BasePurchasesTests {
                 transaction.mockState = SKPaymentTransactionState.purchased
                 self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
-                completed(storeProduct.sk1Product!)
+                completed(storeProduct.sk1Product)
             }
         }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetProductsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetProductsTests.swift
@@ -28,25 +28,22 @@ class PurchasesGetProductsTests: BasePurchasesTests {
     func testDoesntFetchProductDataIfEmptyList() {
         self.mockProductsManager.resetMock()
 
-        var completionCalled = false
-
-        self.purchases.getProducts([]) { _ in
-            completionCalled = true
+        waitUntil { completed in
+            self.purchases.getProducts([]) { _ in
+                completed()
+            }
         }
 
-        expect(completionCalled).toEventually(beTrue())
         expect(self.mockProductsManager.invokedProducts) == false
     }
 
     func testIsAbleToFetchProducts() {
         let productIdentifiers = ["com.product.id1", "com.product.id2"]
 
-        var products: [StoreProduct]?
-        self.purchases.getProducts(productIdentifiers) { (newProducts) in
-            products = newProducts
+        let products = waitUntilValue { completed in
+            self.purchases.getProducts(productIdentifiers, completion: completed)
         }
 
-        expect(products).toEventuallyNot(beNil())
         expect(products).to(haveCount(productIdentifiers.count))
     }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesRestoreTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesRestoreTests.swift
@@ -39,7 +39,7 @@ class PurchasesRestoreTests: BasePurchasesTests {
 
     func testRestorePurchasesCallsCompletionOnMainThreadWhenMissingReceipts() {
         self.receiptFetcher.shouldReturnReceipt = false
-        let receivedError = waitUntilValue { completed in
+        let receivedError: NSError? = waitUntilValue { completed in
             self.purchases.restorePurchases { (_, error) in
                 expect(Thread.isMainThread) == true
                 completed(error as NSError?)

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesRestoreTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesRestoreTests.swift
@@ -45,7 +45,7 @@ class PurchasesRestoreTests: BasePurchasesTests {
             }
         }
 
-        expect(self.mockOperationDispatcher.invokedDispatchOnMainThreadCount) == 3
+        expect(self.mockOperationDispatcher.invokedDispatchOnMainThreadCount) >= 1
         expect(receivedError).to(matchError(ErrorCode.missingReceiptFileError))
     }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesRestoreTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesRestoreTests.swift
@@ -41,6 +41,7 @@ class PurchasesRestoreTests: BasePurchasesTests {
         self.receiptFetcher.shouldReturnReceipt = false
         let receivedError = waitUntilValue { completed in
             self.purchases.restorePurchases { (_, error) in
+                expect(Thread.isMainThread) == true
                 completed(error as NSError?)
             }
         }

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -1637,6 +1637,7 @@ class SubscriberAttributesManagerTests: TestCase {
 }
 
 private extension SubscriberAttributesManagerTests {
+
     func assertMockAttributesSynced() {
         expect(self.mockDeviceCache.invokedStoreSubscriberAttributesCount).toEventually(equal(1))
 

--- a/Tests/UnitTests/TestHelpers/AsyncTestHelpers.swift
+++ b/Tests/UnitTests/TestHelpers/AsyncTestHelpers.swift
@@ -13,6 +13,8 @@
 
 import Foundation
 
+import Nimble
+
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 internal extension AsyncSequence {
 
@@ -23,4 +25,31 @@ internal extension AsyncSequence {
         }
     }
 
+}
+
+/// Waits for `action` to be invoked, and returns the provided value, or `nil` on timeout.
+/// Usage:
+/// ```swift
+/// let value: T? = waitUntilValue { completed in
+///    asyncMethod { value in
+///         completed(value)
+///    }
+/// }
+/// ```
+func waitUntilValue<Value>(
+    timeout: DispatchTimeInterval = AsyncDefaults.timeout,
+    file: FileString = #file,
+    line: UInt = #line,
+    action: @escaping (@escaping (Value?) -> Void) -> Void
+) -> Value? {
+    var value: Value?
+
+    waitUntil(timeout: timeout, file: file, line: line) { completed in
+        action {
+            value = $0
+            completed()
+        }
+    }
+
+    return value
 }


### PR DESCRIPTION
Example:
```diff
-        var result: Result<Offerings, OfferingsManager.Error>?
-        offeringsManager.offerings(appUserID: MockData.anyAppUserID) {
-            result = $0
+        let result = waitUntilValue { completed in
+            self.offeringsManager.offerings(appUserID: MockData.anyAppUserID) {
+                completed($0)
+            }
         }
-        expect(result).toEventuallyNot(beNil())
```

This removes the need to _poll_ for when the value is returned, and instead it gets detected immediately, potentially providing a significant boost in test execution speed.

I've also used `Nimble`'s own `waitUntil` for cases where we don't need to return a value.

 #### `toEventually` usage:
- Before this PR: 353
- After: 229

There's still a lot of legitimate usage of `toEventually`, but I'm sure I missed other places where this can also simplify the code. This is a good start for now.