### PR TITLE
Fixed lint issues with `SwiftLint 0.5.0`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,6 +16,9 @@ opt_in_rules:
   - vertical_parameter_alignment
   - vertical_parameter_alignment_on_call
 
+disabled_rules:
+  - orphaned_doc_comment
+
 custom_rules:
   xctestcase_superclass:
     included: ".*\\.swift"
@@ -28,6 +31,10 @@ identifier_name:
   max_length: 
     warning: 60 
     error: 80
+
+large_tuple:
+  warning: 4
+  error: 5
 
 missing_docs:
   excludes_inherited_types: false

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -386,7 +386,6 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                   trialOrIntroPriceEligibilityChecker: trialOrIntroPriceChecker)
     }
 
-    // swiftlint:disable:next function_body_length
     init(appUserID: String?,
          requestFetcher: StoreKitRequestFetcher,
          receiptFetcher: ReceiptFetcher,

--- a/Tests/StoreKitUnitTests/StoreKit2TransactionListenerTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2TransactionListenerTests.swift
@@ -190,7 +190,6 @@ private extension StoreKit2TransactionListenerTests {
         expect(line: line, unfinished).to(beEmpty())
     }
 
-    // swiftlint:disable:next large_tuple
     func purchase() async throws -> (
         result: Product.PurchaseResult,
         verificationResult: VerificationResult<Transaction>,

--- a/Tests/UnitTests/Mocks/MockCustomerInfoManager.swift
+++ b/Tests/UnitTests/Mocks/MockCustomerInfoManager.swift
@@ -6,7 +6,6 @@
 import Foundation
 @testable import RevenueCat
 
-// swiftlint:disable large_tuple
 // swiftlint:disable line_length
 // Note: this class is implicitly `@unchecked Sendable` through its parent
 // even though it's not actually thread safe.

--- a/Tests/UnitTests/Mocks/MockOfferingsManager.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsManager.swift
@@ -14,7 +14,7 @@
 import Foundation
 @testable import RevenueCat
 
-// swiftlint:disable identifier_name large_tuple
+// swiftlint:disable identifier_name
 
 // Note: this class is implicitly `@unchecked Sendable` through its parent
 // even though it's not actually thread safe.

--- a/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
+++ b/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
@@ -6,7 +6,6 @@
 @testable import RevenueCat
 
 // swiftlint:disable identifier_name
-// swiftlint:disable large_tuple
 // swiftlint:disable line_length
 class MockSubscriberAttributesManager: SubscriberAttributesManager {
 

--- a/Tests/UnitTests/Networking/NetworkErrorTests.swift
+++ b/Tests/UnitTests/Networking/NetworkErrorTests.swift
@@ -11,7 +11,7 @@
 //
 //  Created by Nacho Soto on 4/7/22.
 
-// swiftlint:disable multiline_parameters large_tuple
+// swiftlint:disable multiline_parameters
 
 import Nimble
 @testable import RevenueCat

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -387,7 +387,6 @@ extension BasePurchasesTests {
 
         var invokedPostAttributionData = false
         var invokedPostAttributionDataCount = 0
-        // swiftlint:disable:next large_tuple
         var invokedPostAttributionDataParameters: (
             data: [String: Any]?,
             network: AttributionNetwork,


### PR DESCRIPTION
[The new release](https://github.com/realm/SwiftLint/releases/tag/0.50.0) is much faster as [it uses](https://github.com/realm/SwiftLint/pull/4216) the [new SwiftParser](https://github.com/apple/swift-syntax).

### Changes:
- Disabled `orphaned_doc_comment`: it provides warnings for non-public declarations (see https://github.com/realm/SwiftLint/issues/4573#issuecomment-1322502917), but those are still useful for us.
- `function_body_length` has a new logic
- `large_tuple` seems to have new default thresholds, so I've specified them in `.swiftlint` to relax them. Tuples will most likely even become `Equatable` soon in Swift 6.0 so they're here to stay.