### PR TITLE
`Atomic`: added new test to verify each instance gets its own `Lock`

### DIFF
--- a/Tests/UnitTests/Misc/AtomicTests.swift
+++ b/Tests/UnitTests/Misc/AtomicTests.swift
@@ -58,13 +58,14 @@ class AtomicTests: TestCase {
 
     func testRecursiveUnrelatedAtomics() {
         let atomic1: Atomic<Bool> = false
-        let atomic2: Atomic<Bool> = true
+        let atomic2: Atomic<Bool> = false
 
         atomic1.modify {
-            $0 = atomic2.value
+            $0 = !atomic2.value
         }
 
         expect(atomic1.value) == true
+        expect(atomic2.value) == false
     }
 
 }

--- a/Tests/UnitTests/Misc/AtomicTests.swift
+++ b/Tests/UnitTests/Misc/AtomicTests.swift
@@ -56,4 +56,15 @@ class AtomicTests: TestCase {
         expect(atomic.value) == ["0": 0, "1": 1, "2": 2]
     }
 
+    func testRecursiveUnrelatedAtomics() {
+        let atomic1: Atomic<Bool> = false
+        let atomic2: Atomic<Bool> = true
+
+        atomic1.modify {
+            $0 = atomic2.value
+        }
+
+        expect(atomic1.value) == true
+    }
+
 }


### PR DESCRIPTION
Looking into [CSDK-519], a key part of that potential deadlock comes down to this use of `Atomic`.
This is a useful test to have to verify that this obvious usage is valid.

[CSDK-519]: https://revenuecats.atlassian.net/browse/CSDK-519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ