### PR TITLE
`DeviceCache`: removed `fatalError` for users not overriding `UserDefaults`

### DIFF
--- a/Tests/UnitTests/Caching/DeviceCacheTests.swift
+++ b/Tests/UnitTests/Caching/DeviceCacheTests.swift
@@ -252,6 +252,22 @@ class DeviceCacheTests: TestCase {
         expectNoFatalError { mockNotificationCenter.fireNotifications() }
     }
 
+    func testNoAssertionIfModifyingRevenueCatUserDefaultsSuite() {
+        let userDefaults: UserDefaults = .revenueCatSuite
+        let mockNotificationCenter = MockNotificationCenter()
+
+        userDefaults.set("User", forKey: "com.revenuecat.userdefaults.appUserID.new")
+
+        self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
+                                       userDefaults: userDefaults,
+                                       offeringsCachedObject: nil,
+                                       notificationCenter: mockNotificationCenter)
+
+        userDefaults.set(nil, forKey: "com.revenuecat.userdefaults.appUserID.new")
+
+        expectNoFatalError { mockNotificationCenter.fireNotifications() }
+    }
+
     func testNewDeviceCacheInstanceWithExistingValidCustomerInfoCacheIsntStale() {
         let mockNotificationCenter = MockNotificationCenter()
         let appUserID = "myUser"


### PR DESCRIPTION
We can do this now thanks to #2046. Solves #1906.
We no longer need to do this check if we're using our own `UserDefaults`, which simplifies the code, avoids a dangerous `fatalError`, and makes [CSDK-519] less likely.

[CSDK-519]: https://revenuecats.atlassian.net/browse/CSDK-519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ