### PR TITLE
Added `LogLevel.verbose`

### DIFF
--- a/Sources/Logging/LogIntent.swift
+++ b/Sources/Logging/LogIntent.swift
@@ -16,10 +16,11 @@ import Foundation
 
 enum LogIntent {
 
-    case appleError
-    case appleWarning
+    case verbose
     case info
     case purchase
+    case appleWarning
+    case appleError
     case rcError
     case rcPurchaseSuccess
     case rcSuccess
@@ -28,10 +29,11 @@ enum LogIntent {
 
     var prefix: String {
         switch self {
-        case .appleError: return "🍎‼️"
-        case .appleWarning: return "🍎⚠️"
+        case .verbose: return ""
         case .info: return "ℹ️"
         case .purchase: return "💰"
+        case .appleWarning: return "🍎⚠️"
+        case .appleError: return "🍎‼️"
         case .rcError: return "😿‼️"
         case .rcPurchaseSuccess: return "😻💰"
         case .rcSuccess: return "😻"

--- a/Sources/Logging/Logger.swift
+++ b/Sources/Logging/Logger.swift
@@ -21,11 +21,12 @@ import Foundation
 @objc(RCLogLevel) public enum LogLevel: Int, CustomStringConvertible {
 
     // swiftlint:disable:next missing_docs
-    case debug, info, warn, error
+    case verbose, debug, info, warn, error
 
     // swiftlint:disable:next missing_docs
     public var description: String {
         switch self {
+        case .verbose: return "VERBOSE"
         case .debug: return "DEBUG"
         case .info: return "INFO"
         case .warn: return "WARN"
@@ -78,6 +79,14 @@ enum Logger {
     }()
 
     internal static let frameworkDescription = "Purchases"
+
+    static func verbose(_ message: @autoclosure () -> CustomStringConvertible,
+                        fileName: String? = #fileID,
+                        functionName: String? = #function,
+                        line: UInt = #line) {
+        log(level: .verbose, intent: .verbose, message: message().description,
+            fileName: fileName, functionName: functionName, line: line)
+    }
 
     static func debug(_ message: @autoclosure () -> CustomStringConvertible,
                       fileName: String? = #fileID,
@@ -178,7 +187,9 @@ extension Logger {
                     functionName: String? = #function,
                     line: UInt = #line) {
         Self.log(level: level,
-                 message: "\(intent.prefix) \(message())",
+                 message: [intent.prefix.notEmpty, message()]
+                    .compactMap { $0 }
+                    .joined(separator: " "),
                  fileName: fileName,
                  functionName: functionName,
                  line: line)

--- a/Sources/Logging/Logger.swift
+++ b/Sources/Logging/Logger.swift
@@ -20,10 +20,14 @@ import Foundation
 /// - ``Purchases/logLevel``
 @objc(RCLogLevel) public enum LogLevel: Int, CustomStringConvertible {
 
-    // swiftlint:disable:next missing_docs
-    case verbose, debug, info, warn, error
+    // swiftlint:disable missing_docs
 
-    // swiftlint:disable:next missing_docs
+    case verbose = 4
+    case debug = 0
+    case info = 1
+    case warn = 2
+    case error = 3
+
     public var description: String {
         switch self {
         case .verbose: return "VERBOSE"
@@ -34,6 +38,7 @@ import Foundation
         }
     }
 
+    // swiftlint:enable missing_docs
 }
 
 /// A function that can handle a log message including file and method information.

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -214,9 +214,10 @@ BOOL isAnonymous;
 
     RCLogLevel l = RCLogLevelInfo;
     switch(l) {
+        case RCLogLevelVerbose:
+        case RCLogLevelDebug:
         case RCLogLevelInfo:
         case RCLogLevelWarn:
-        case RCLogLevelDebug:
         case RCLogLevelError:
             NSLog(@"%ld", (long)o);
     }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -65,9 +65,10 @@ func checkPurchasesEnums() {
     }
 
     switch logLevel! {
-    case .info,
-         .warn,
+    case .verbose,
          .debug,
+         .info,
+         .warn,
          .error:
         print(logLevel!)
     @unknown default:

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -96,6 +96,8 @@ private extension BaseBackendIntegrationTests {
     func configurePurchases() {
         self.purchasesDelegate = TestPurchaseDelegate()
 
+        Purchases.logLevel = .verbose
+
         Purchases.configure(withAPIKey: Constants.apiKey,
                             appUserID: nil,
                             observerMode: false,
@@ -105,7 +107,6 @@ private extension BaseBackendIntegrationTests {
                             storeKitTimeout: Configuration.storeKitRequestTimeoutDefault,
                             networkTimeout: Configuration.networkTimeoutDefault,
                             dangerousSettings: self.dangerousSettings)
-        Purchases.logLevel = .verbose
         Purchases.shared.delegate = self.purchasesDelegate
     }
 

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -105,7 +105,7 @@ private extension BaseBackendIntegrationTests {
                             storeKitTimeout: Configuration.storeKitRequestTimeoutDefault,
                             networkTimeout: Configuration.networkTimeoutDefault,
                             dangerousSettings: self.dangerousSettings)
-        Purchases.logLevel = .debug
+        Purchases.logLevel = .verbose
         Purchases.shared.delegate = self.purchasesDelegate
     }
 


### PR DESCRIPTION
I want to add some extra logs to figure out [CSDK-517] which would be too verbose (no pun intended) for `debug`, so this will allow us to have some additional logging that wouldn't be enabled by default.

[CSDK-517]: https://revenuecats.atlassian.net/browse/CSDK-517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ