### PR TITLE
Added `verbose` logs for `Purchases` and `StoreKit1Wrapper` lifetime

### DIFF
--- a/Sources/Logging/Strings/ConfigureStrings.swift
+++ b/Sources/Logging/Strings/ConfigureStrings.swift
@@ -17,6 +17,10 @@ import Foundation
 // swiftlint:disable identifier_name
 enum ConfigureStrings {
 
+    case purchases_init(Purchases, EitherPaymentQueueWrapper)
+
+    case purchases_deinit(Purchases)
+
     case adsupport_not_imported
 
     case application_active
@@ -59,6 +63,12 @@ extension ConfigureStrings: CustomStringConvertible {
 
     var description: String {
         switch self {
+        case let .purchases_init(purchases, wrapper):
+            return "Purchases.init: created new Purchases instance: " +
+            "\(Strings.objectDescription(purchases))\nStoreKit Wrapper: \(wrapper)"
+        case let .purchases_deinit(purchases):
+            return "Purchases.deinit: " +
+            "\(Strings.objectDescription(purchases))"
         case .adsupport_not_imported:
             return "AdSupport framework not imported. Attribution data incomplete."
         case .application_active:

--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -18,6 +18,8 @@ import StoreKit
 // swiftlint:disable identifier_name
 enum PurchaseStrings {
 
+    case storekit1_wrapper_init(StoreKit1Wrapper)
+    case storekit1_wrapper_deinit(StoreKit1Wrapper)
     case cannot_purchase_product_appstore_configuration_error
     case entitlements_revoked_syncing_purchases(productIdentifiers: [String])
     case finishing_transaction(StoreTransactionType)
@@ -72,6 +74,13 @@ extension PurchaseStrings: CustomStringConvertible {
 
     var description: String {
         switch self {
+        case let .storekit1_wrapper_init(instance):
+            return "StoreKit1Wrapper.init: " +
+            "\(Strings.objectDescription(instance))"
+
+        case let .storekit1_wrapper_deinit(instance):
+            return "StoreKit1Wrapper.deinit: " +
+            "\(Strings.objectDescription(instance))"
 
         case .cannot_purchase_product_appstore_configuration_error:
             return "Could not purchase SKProduct. " +
@@ -256,10 +265,7 @@ extension PurchaseStrings: CustomStringConvertible {
 private extension SKPaymentTransactionObserver {
 
     var debugName: String {
-        // Example: PaymentTransactionObserver (0x0000600000e36480)
-        // Used to debug which observer is detecting changes
-        // to ensure only one is in memory at a time.
-        return "PaymentTransactionObserver (\(Unmanaged.passUnretained(self).toOpaque()))"
+        return Strings.objectDescription(self)
     }
 
 }

--- a/Sources/Logging/Strings/Strings.swift
+++ b/Sources/Logging/Strings/Strings.swift
@@ -28,3 +28,18 @@ enum Strings {
     static let storeKit = StoreKitStrings.self
 
 }
+
+extension Strings {
+
+    /// Returns the type and address of the given object, useful for debugging.
+    /// Example: StoreKit1Wrapper (0x0000600000e36480)
+    static func objectDescription(_ object: AnyObject) -> String {
+        return "\(type(of: object)) (\(Strings.address(for: object)))"
+    }
+
+    /// Returns the address of the given object, useful for debugging.
+    private static func address(for object: AnyObject) -> String {
+        return Unmanaged.passUnretained(object).toOpaque().debugDescription
+    }
+
+}

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -414,7 +414,6 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
          purchasesOrchestrator: PurchasesOrchestrator,
          trialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityCheckerType
     ) {
-
         Logger.debug(Strings.configure.debug_enabled, fileName: nil)
         if systemInfo.storeKit2Setting == .enabledForCompatibleDevices {
             Logger.info(Strings.configure.store_kit_2_enabled, fileName: nil)
@@ -447,6 +446,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.trialOrIntroPriceEligibilityChecker = trialOrIntroPriceEligibilityChecker
 
         super.init()
+
+        Logger.verbose(Strings.configure.purchases_init(self, paymentQueueWrapper))
 
         self.purchasesOrchestrator.delegate = self
 
@@ -482,6 +483,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     }
 
     deinit {
+        Logger.verbose(Strings.configure.purchases_deinit(self))
+
         self.notificationCenter.removeObserver(self)
         self.paymentQueueWrapper.sk1Wrapper?.delegate = nil
         self.paymentQueueWrapper.sk2Wrapper?.delegate = nil

--- a/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
@@ -64,6 +64,10 @@ class StoreKit1Wrapper: NSObject {
 
     init(paymentQueue: SKPaymentQueue) {
         self.paymentQueue = paymentQueue
+
+        super.init()
+
+        Logger.verbose(Strings.purchase.storekit1_wrapper_init(self))
     }
 
     override convenience init() {
@@ -71,6 +75,8 @@ class StoreKit1Wrapper: NSObject {
     }
 
     deinit {
+        Logger.verbose(Strings.purchase.storekit1_wrapper_deinit(self))
+
         self.paymentQueue.remove(self)
     }
 


### PR DESCRIPTION
Depends on #2080.
This will help debug [CSDK-517].

### Examples:
```
- VERBOSE: Purchases.init: created new Purchases instance: Purchases (0x00006000037af800)
StoreKit Wrapper: left(<RevenueCat.StoreKit1Wrapper: 0x600000b6d3a0>)
- VERBOSE: Purchases.deinit: Purchases (0x0000600003f82600)
```

[CSDK-517]: https://revenuecats.atlassian.net/browse/CSDK-517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ