### PR TITLE
`CircleCI`: lowered `no_output_timeout` to 5 minutes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,7 @@ jobs:
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios
-          no_output_timeout: 30m
+          no_output_timeout: 5m
           environment:
             SCAN_DEVICE: iPhone 14 (16.1)
       - compress_result_bundle:
@@ -270,7 +270,7 @@ jobs:
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios
-          no_output_timeout: 30m
+          no_output_timeout: 5m
           environment:
             SCAN_DEVICE: iPhone 13 (15.5)
       - compress_result_bundle:
@@ -307,7 +307,7 @@ jobs:
           name: SPM Build
           # Not using `pod lib lint` because that fails on this old Xcode
           command: swift build
-          no_output_timeout: 30m
+          no_output_timeout: 5m
 
   run-test-tvos:
     <<: *base-job
@@ -317,7 +317,7 @@ jobs:
       - run:
           name: Run tests
           command: bundle exec fastlane test_tvos
-          no_output_timeout: 30m
+          no_output_timeout: 5m
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/tvos
           bundle_name: RevenueCat
@@ -335,7 +335,7 @@ jobs:
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios
-          no_output_timeout: 30m
+          no_output_timeout: 5m
           environment:
             SCAN_DEVICE: iPhone 8 (14.5)
       - compress_result_bundle:
@@ -359,7 +359,7 @@ jobs:
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios
-          no_output_timeout: 30m
+          no_output_timeout: 5m
           environment:
             SCAN_DEVICE: iPhone 8 (13.7)
       - compress_result_bundle:
@@ -384,7 +384,7 @@ jobs:
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios
-          no_output_timeout: 30m
+          no_output_timeout: 5m
           environment:
             SCAN_DEVICE: iPhone 6 (12.4)
       - compress_result_bundle:
@@ -414,7 +414,7 @@ jobs:
       - run:
           name: Run backend_integration Tests
           command: bundle exec fastlane backend_integration_tests
-          no_output_timeout: 30m
+          no_output_timeout: 5m
           environment:
             SCAN_DEVICE: iPhone 14 (16.1)
       - compress_result_bundle:


### PR DESCRIPTION
We see [some instances](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/8977/workflows/2eefe06e-29bc-465c-827b-059cd899c6dc/jobs/45088) where the simulator gets stuck (probably because of a system dialog) and the build ends up taking about 1 hour total.

CircleCI doesn't have [an easy way](https://support.circleci.com/hc/en-us/articles/4411204604059-Automatically-cancel-build-after-set-amount-of-time) to set an overall timeout, but lowering the `no_output_timeout` would help.
30 minutes is very excessive. It's useful for things like making a release, where CocoaPods might be slow, but shouldn't lead to false negatives in test execution.