### PR TITLE
`CircleCI`: fixed `docs-deploy` git credentials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -455,6 +455,7 @@ jobs:
   docs-deploy:
     <<: *base-job
     steps:
+      - setup-git-credentials
       - checkout
       - install-dependencies
       - run:


### PR DESCRIPTION
I found this while looking into [CSDK-532].

Fixes the following error:
```
[18:29:04]: ▸ Committer: Distiller <...>
[18:29:04]: ▸ Your name and email address were configured automatically based
[18:29:04]: ▸ on your username and hostname. Please check that they are accurate.
[18:29:04]: ▸ You can suppress this message by setting them explicitly:
[18:29:04]: ▸ git config --global user.name "Your Name"
[18:29:04]: ▸ git config --global user.email you@example.com
```

[CSDK-532]: https://revenuecats.atlassian.net/browse/CSDK-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ