### PR TITLE
`TimingUtil`: fixed Xcode 13.2 compilation

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -425,7 +425,7 @@ final class PurchasesOrchestrator {
         do {
             result = try await TimingUtil.measureAndLogIfTooSlow(
                 threshold: .purchase,
-                message: Strings.purchase.sk2_purchase_too_slow) {
+                message: Strings.purchase.sk2_purchase_too_slow.description) {
                     var options: Set<Product.PurchaseOption> = [
                         .simulatesAskToBuyInSandbox(Purchases.simulatesAskToBuyInSandbox)
                     ]


### PR DESCRIPTION
This compiles fine in Xcode 14 and Xcode 13.4, but produces the following error in Xcode 13.2:
```
static method 'measureAndLogIfTooSlow(threshold:message:level:intent:_:)' requires that 'PurchaseStrings' conform to 'Sendable'
```

To fix that, we can pass the `String` directly instead of a `CustomStringConvertible`.

See https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/9028/workflows/fdd6cb34-a28f-4f1c-9e56-
abecc4eab8c0/jobs/45630