### PR TITLE
Generate documentation for `iOS` instead of `macOS`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,6 +461,8 @@ jobs:
       - run:
           name: Build docs
           command: bundle exec fastlane generate_docs
+          environment:
+            DOCS_IOS_VERSION: "16.1"
 
   make-release:
     <<: *base-job

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -384,9 +384,14 @@ platform :ios do
   end
 
   private_lane :build_symbols_for_docs do
+    ios_version = ENV['DOCS_IOS_VERSION'] || "16.1"
+
     sh("swift",
        "build",
        "--target", "RevenueCat",
+       # Build for iOS instead of the default macOS. This ensures that iOS-only symbols are included in the docs.
+       "-Xswiftc", "-sdk", "-Xswiftc", sh("xcrun", "--sdk", "iphonesimulator", "--show-sdk-path").strip!,
+       "-Xswiftc", "-target", "-Xswiftc", "x86_64-apple-ios#{ios_version}-simulator",
        "-Xswiftc", "-emit-symbol-graph",
        "-Xswiftc", "-emit-symbol-graph-dir",
        "-Xswiftc", ".build")
@@ -394,6 +399,8 @@ platform :ios do
 
   desc "Preview docs"
   lane :preview_docs do
+    ios_version = ENV['DOCS_IOS_VERSION'] || "16.1"
+
     ENV["INCLUDE_DOCC_PLUGIN"] = "true"
     Dir.chdir("..") do
       build_symbols_for_docs
@@ -404,6 +411,8 @@ platform :ios do
          "preview-documentation",
          "--target",
          "RevenueCat",
+         "--platform",
+         "name=iOS,version=#{ios_version}",
          "--transform-for-static-hosting",
          "--enable-inherited-docs",
          "--additional-symbol-graph-dir", ".build")
@@ -417,6 +426,8 @@ platform :ios do
     version_number = current_version_number
     docs_repo_base_url = ENV["DOCS_REPO_BASE_URL"]
     docs_repo_name = ENV["DOCS_REPO_NAME"]
+    ios_version = ENV['DOCS_IOS_VERSION'] || "16.1"
+    
     UI.user_error!("Missing environment variable: DOCS_REPO_BASE_URL") unless docs_repo_base_url
     UI.user_error!("Missing environment variable: DOCS_REPO_NAME") unless docs_repo_name
 
@@ -437,7 +448,9 @@ platform :ios do
            "generate-documentation",
            "--target",
            "RevenueCat",
-           "--disable-indexing",
+           "--disable-indexing", # Produces a DocC archive that is best-suited for hosting online but incompatible with Xcode.
+           "--platform",
+           "name=iOS,version=#{ios_version}",
            "--output-path",
            docs_generation_folder,
            "--hosting-base-path",


### PR DESCRIPTION
`iOS` is sort of the "canonical" version of this SDK. There are more methods available for iOS than the default `macOS`. For that reason, there were several referfences in the index that weren't found.

See [doc generation log](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/9001/workflows/c5786e9e-d40a-4c06-b380-011a1d66a547/jobs/45354/parallel-runs/0/steps/0-107):
```
[18:28:52]: ▸ /Users/distiller/purchases-ios/Sources/DocCDocumentation/DocCDocumentation.docc/V4_API_Migration_guide.md:281:3: warning: Topic reference 'Purchases/beginRefundRequestForActiveEntitlement()' couldn't be resolved. No local documentation matches this reference.
[18:28:52]: ▸ /Users/distiller/purchases-ios/Sources/DocCDocumentation/DocCDocumentation.docc/V4_API_Migration_guide.md:282:3: warning: Topic reference 'Purchases/beginRefundRequest(forProduct:)' couldn't be resolved. No local documentation matches this reference.
[18:28:52]: ▸ /Users/distiller/purchases-ios/Sources/DocCDocumentation/DocCDocumentation.docc/V4_API_Migration_guide.md:283:3: warning: Topic reference 'Purchases/beginRefundRequest(forEntitlement:)' couldn't be resolved. No local documentation matches this reference.
[18:28:52]: ▸ /Users/distiller/purchases-ios/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md:54:3: warning: Topic reference 'Purchases/presentCodeRedemptionSheet()' couldn't be resolved. No local documentation matches this reference.
[18:28:52]: ▸ /Users/distiller/purchases-ios/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md:74:3: warning: Topic reference 'Purchases/beginRefundRequestForActiveEntitlement()' couldn't be resolved. No local documentation matches this reference.
[18:28:52]: ▸ /Users/distiller/purchases-ios/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md:75:3: warning: Topic reference 'Purchases/beginRefundRequest(forEntitlement:)' couldn't be resolved. No local documentation matches this reference.
[18:28:52]: ▸ /Users/distiller/purchases-ios/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md:76:3: warning: Topic reference 'Purchases/beginRefundRequest(forProduct:)' couldn't be resolved. No local documentation matches this reference.
[18:28:52]: ▸ /Users/distiller/purchases-ios/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md:118:3: warning: Topic reference 'Purchases/beginRefundRequestForActiveEntitlement()' couldn't be resolved. No local documentation matches this reference.
[18:28:52]: ▸ /Users/distiller/purchases-ios/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md:119:3: warning: Topic reference 'Purchases/beginRefundRequest(forEntitlement:)' couldn't be resolved. No local documentation matches this reference.
[18:28:52]: ▸ /Users/distiller/purchases-ios/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md:120:3: warning: Topic reference 'Purchases/beginRefundRequest(forProduct:)' couldn't be resolved. No local documentation matches this reference.
```

This builds symbols for `iOS` instead, which allows us to provide docs for all those methods.

Also inherited symbols seem to be working again, see https://revenuecat.github.io/purchases-ios-docs/4.15.0-SNAPSHOT/documentation/revenuecat/purchases/purchase(package:)/
So I'm going to call [CSDK-532] fixed. Once this is merged I'll manually generate docs for the versions that are missing those docs.

[CSDK-532]: https://revenuecats.atlassian.net/browse/CSDK-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ