### PR TITLE
CI: speed up `docs-deploy` by only installing `bundle` dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,7 +457,7 @@ jobs:
     steps:
       - setup-git-credentials
       - checkout
-      - install-dependencies
+      - install-bundle-dependencies
       - run:
           name: Build docs
           command: bundle exec fastlane generate_docs


### PR DESCRIPTION
Installing `swiftlint` can be slow, and it's not required.

This makes `docs_deploy` go from [6 minutes](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/9047/workflows/fabf7808-37cb-4d38-b1b2-27347da3554d/jobs/45800) to [2 minutes](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/9048/workflows/8b2aeb3d-a256-44e4-9a1d-92a5544fd82b/jobs/45802).