### PR TITLE
Fixed `SwiftLint` installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
             - vendor/bundle
       - restore_cache:
           keys:
-            - homebrew-tap-cache
+            - homebrew-tap-cache-0.46.5
       - run:
           name: Install swiftlint 0.46.5
           command: |
@@ -51,7 +51,7 @@ commands:
               brew extract --version=0.46.5 swiftlint $USER/local-tap
               brew install swiftlint@0.46.5
       - save_cache:
-          key: homebrew-tap-cache
+          key: homebrew-tap-cache-0.46.5
           paths:
             - /usr/local/Homebrew/Library/Taps/$USER/homebrew-local-tap/
             - /Users/$USER/Library/Caches/Homebrew/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,21 @@ commands:
           key: v1-gem-cache-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
+      - restore_cache:
+          keys:
+            - homebrew-tap-cache
       - run:
-          name: Install swiftlint
-          command: brew install swiftlint
+          name: Install swiftlint 0.46.5
+          command: |
+              brew update --preinstall
+              brew tap-new $USER/local-tap
+              brew extract --version=0.46.5 swiftlint $USER/local-tap
+              brew install swiftlint@0.46.5
+      - save_cache:
+          key: homebrew-tap-cache
+          paths:
+            - /usr/local/Homebrew/Library/Taps/$USER/homebrew-local-tap/
+            - /Users/$USER/Library/Caches/Homebrew/
 
   scan-and-archive:
     parameters:


### PR DESCRIPTION
We need an older version compatible with `macOS 11`.