### PR TITLE
`ReceiptParser.parse` always throws `ReceiptParser.Error`

### DIFF
--- a/Sources/LocalReceiptParsing/Builders/ASN1ContainerBuilder.swift
+++ b/Sources/LocalReceiptParsing/Builders/ASN1ContainerBuilder.swift
@@ -19,7 +19,7 @@ class ASN1ContainerBuilder {
     func build(fromPayload payload: ArraySlice<UInt8>) throws -> ASN1Container {
         guard payload.count >= 2,
             let firstByte = payload.first else {
-            throw ReceiptReadingError.asn1ParsingError(description: "payload needs to be at least 2 bytes long")
+            throw ReceiptParser.Error.asn1ParsingError(description: "payload needs to be at least 2 bytes long")
         }
         let containerClass = try extractClass(byte: firstByte)
         let encodingType = try extractEncodingType(byte: firstByte)
@@ -31,7 +31,7 @@ class ASN1ContainerBuilder {
         let bytesUsedForMetadata = bytesUsedForIdentifier + length.bytesUsedForLength
 
         guard payload.count - bytesUsedForMetadata >= length.value else {
-            throw ReceiptReadingError.asn1ParsingError(description: "payload is shorter than length value")
+            throw ReceiptParser.Error.asn1ParsingError(description: "payload is shorter than length value")
         }
         let internalPayload = payload.dropFirst(bytesUsedForMetadata).prefix(length.value)
 
@@ -64,40 +64,70 @@ private extension ASN1ContainerBuilder {
         return internalContainers
     }
 
+    /// - Throws `ReceiptParser.Error`
     func extractClass(byte: UInt8) throws -> ASN1Class {
-        let firstTwoBits = try byte.valueInRange(from: 0, to: 1)
+        let firstTwoBits: UInt8
+        do {
+            firstTwoBits = try byte.valueInRange(from: 0, to: 1)
+        } catch {
+            throw ReceiptParser.Error.asn1ParsingError(description: error.localizedDescription)
+        }
+
         guard let asn1Class = ASN1Class(rawValue: firstTwoBits) else {
-            throw ReceiptReadingError.asn1ParsingError(description: "couldn't determine asn1 class")
+            throw ReceiptParser.Error.asn1ParsingError(description: "couldn't determine asn1 class")
         }
         return asn1Class
     }
 
+    /// - Throws `ReceiptParser.Error`
     func extractEncodingType(byte: UInt8) throws -> ASN1EncodingType {
-        let thirdBit = try byte.bitAtIndex(2)
+        let thirdBit: UInt8
+
+        do {
+            thirdBit = try byte.bitAtIndex(2)
+        } catch {
+            throw ReceiptParser.Error.asn1ParsingError(description: error.localizedDescription)
+        }
+
         guard let encodingType = ASN1EncodingType(rawValue: thirdBit) else {
-            throw ReceiptReadingError.asn1ParsingError(description: "couldn't determine encoding type")
+            throw ReceiptParser.Error.asn1ParsingError(description: "couldn't determine encoding type")
         }
         return encodingType
     }
 
+    /// - Throws `ReceiptParser.Error`
     func extractIdentifier(byte: UInt8) throws -> ASN1Identifier {
-        let lastFiveBits = try byte.valueInRange(from: 3, to: 7)
+        let lastFiveBits: UInt8
+        do {
+            lastFiveBits = try byte.valueInRange(from: 3, to: 7)
+        } catch {
+            throw ReceiptParser.Error.asn1ParsingError(description: error.localizedDescription)
+        }
+
         guard let asn1Identifier = ASN1Identifier(rawValue: lastFiveBits) else {
-            throw ReceiptReadingError.asn1ParsingError(description: "couldn't determine identifier")
+            throw ReceiptParser.Error.asn1ParsingError(description: "couldn't determine identifier")
         }
         return asn1Identifier
     }
 
+    /// - Throws `ReceiptParser.Error`
     func extractLengthAndInternalContainers(data: ArraySlice<UInt8>,
                                             isConstructed: Bool) throws -> (ASN1Length, [ASN1Container]) {
         guard let firstByte = data.first else {
-            throw ReceiptReadingError.asn1ParsingError(description: "length needs to be at least one byte")
+            throw ReceiptParser.Error.asn1ParsingError(description: "length needs to be at least one byte")
         }
 
-        let lengthBit = try firstByte.bitAtIndex(0)
-        let isShortLength = lengthBit == 0
+        let isShortLength: Bool
+        let firstByteValue: Int
 
-        let firstByteValue = Int(try firstByte.valueInRange(from: 1, to: 7))
+        do {
+            let lengthBit = try firstByte.bitAtIndex(0)
+
+            isShortLength = lengthBit == 0
+            firstByteValue = Int(try firstByte.valueInRange(from: 1, to: 7))
+        } catch {
+            throw ReceiptParser.Error.asn1ParsingError(description: error.localizedDescription)
+        }
 
         var bytesUsedForLength = 1
 

--- a/Sources/LocalReceiptParsing/Builders/AppleReceiptBuilder.swift
+++ b/Sources/LocalReceiptParsing/Builders/AppleReceiptBuilder.swift
@@ -30,6 +30,7 @@ class AppleReceiptBuilder {
         self.inAppPurchaseBuilder = inAppPurchaseBuilder
     }
 
+    /// - Throws: `ReceiptParser.Error`
     // swiftlint:disable:next cyclomatic_complexity function_body_length
     func build(fromContainer container: ASN1Container) throws -> AppleReceipt {
         var bundleId: String?
@@ -42,7 +43,7 @@ class AppleReceiptBuilder {
         var inAppPurchases: [AppleReceipt.InAppPurchase] = []
 
         guard let internalContainer = container.internalContainers.first else {
-            throw ReceiptReadingError.receiptParsingError
+            throw ReceiptParser.Error.receiptParsingError
         }
         var receiptContainer = try containerBuilder.build(fromPayload: internalContainer.internalPayload)
 
@@ -57,7 +58,7 @@ class AppleReceiptBuilder {
 
         for receiptAttribute in receiptContainer.internalContainers {
             guard receiptAttribute.internalContainers.count == expectedInternalContainersCount else {
-                throw ReceiptReadingError.receiptParsingError
+                throw ReceiptParser.Error.receiptParsingError
             }
             let typeContainer = receiptAttribute.internalContainers[typeContainerIndex]
             let valueContainer = receiptAttribute.internalContainers[attributeTypeContainerIndex]
@@ -99,7 +100,7 @@ class AppleReceiptBuilder {
             let nonOptionalOpaqueValue = opaqueValue,
             let nonOptionalSha1Hash = sha1Hash,
             let nonOptionalCreationDate = creationDate else {
-            throw ReceiptReadingError.receiptParsingError
+            throw ReceiptParser.Error.receiptParsingError
         }
 
         let receipt = AppleReceipt(bundleId: nonOptionalBundleId,

--- a/Sources/LocalReceiptParsing/Builders/InAppPurchaseBuilder.swift
+++ b/Sources/LocalReceiptParsing/Builders/InAppPurchaseBuilder.swift
@@ -57,7 +57,7 @@ class InAppPurchaseBuilder {
 
         for internalContainer in container.internalContainers {
             guard internalContainer.internalContainers.count == expectedInternalContainersCount else {
-                throw ReceiptReadingError.inAppPurchaseParsingError
+                throw ReceiptParser.Error.inAppPurchaseParsingError
             }
             let typeContainer = internalContainer.internalContainers[typeContainerIndex]
             let valueContainer = internalContainer.internalContainers[attributeTypeContainerIndex]
@@ -102,7 +102,7 @@ class InAppPurchaseBuilder {
             let nonOptionalProductId = productId,
             let nonOptionalTransactionId = transactionId,
             let nonOptionalPurchaseDate = purchaseDate else {
-            throw ReceiptReadingError.inAppPurchaseParsingError
+            throw ReceiptParser.Error.inAppPurchaseParsingError
         }
 
         return InAppPurchase(quantity: nonOptionalQuantity,

--- a/Sources/LocalReceiptParsing/DataConverters/UInt8+Extensions.swift
+++ b/Sources/LocalReceiptParsing/DataConverters/UInt8+Extensions.swift
@@ -43,19 +43,21 @@ extension BitShiftError: CustomStringConvertible {
 
 extension UInt8 {
 
+    /// - Throws: `BitShiftError`
     func bitAtIndex(_ index: UInt8) throws -> UInt8 {
         guard index <= 7 else { throw BitShiftError.invalidIndex(index) }
         let shifted = self >> (7 - index)
         return shifted & 0b1
     }
 
+    /// - Throws: `BitShiftError`
     func valueInRange(from: UInt8, to: UInt8) throws -> UInt8 {
         guard to <= 7 else { throw BitShiftError.invalidIndex(to) }
         guard from <= to else { throw BitShiftError.rangeFlipped(from: from, to: to) }
 
         let range: UInt8 = to - from + 1
         let shifted = self >> (7 - to)
-        let mask = try maskForRange(range)
+        let mask = try self.maskForRange(range)
         return shifted & mask
     }
 
@@ -63,6 +65,7 @@ extension UInt8 {
 
 private extension UInt8 {
 
+    /// - Throws: `BitShiftError`
     func maskForRange(_ range: UInt8) throws -> UInt8 {
         guard 0 <= range && range <= 8 else { throw BitShiftError.rangeLargerThanByte }
         switch range {

--- a/Sources/LocalReceiptParsing/ReceiptParser.swift
+++ b/Sources/LocalReceiptParsing/ReceiptParser.swift
@@ -40,11 +40,11 @@ class ReceiptParser {
     func parse(from receiptData: Data) throws -> AppleReceipt {
         let intData = [UInt8](receiptData)
 
-        let asn1Container = try containerBuilder.build(fromPayload: ArraySlice(intData))
-        guard let receiptASN1Container = try findASN1Container(withObjectId: ASN1ObjectIdentifier.data,
-                                                               inContainer: asn1Container) else {
+        let asn1Container = try self.containerBuilder.build(fromPayload: ArraySlice(intData))
+        guard let receiptASN1Container = try self.findASN1Container(withObjectId: ASN1ObjectIdentifier.data,
+                                                                    inContainer: asn1Container) else {
             Logger.error(Strings.receipt.data_object_identifer_not_found_receipt)
-            throw ReceiptReadingError.dataObjectIdentifierMissing
+            throw Error.dataObjectIdentifierMissing
         }
         let receipt = try receiptBuilder.build(fromContainer: receiptASN1Container)
         Logger.info(Strings.receipt.parsing_receipt_success)
@@ -72,7 +72,7 @@ private extension ReceiptParser {
                         return container.internalContainers[index + 1]
                     }
                 } else {
-                    let receipt = try findASN1Container(withObjectId: objectId, inContainer: internalContainer)
+                    let receipt = try self.findASN1Container(withObjectId: objectId, inContainer: internalContainer)
                     if receipt != nil {
                         return receipt
                     }

--- a/Sources/LocalReceiptParsing/ReceiptParsingError.swift
+++ b/Sources/LocalReceiptParsing/ReceiptParsingError.swift
@@ -15,28 +15,28 @@
 
 import Foundation
 
-enum ReceiptReadingError: Error, Equatable {
+extension ReceiptParser {
 
-    case missingReceipt,
-         emptyReceipt,
-         dataObjectIdentifierMissing,
-         asn1ParsingError(description: String),
-         receiptParsingError,
-         inAppPurchaseParsingError
+    enum Error: Swift.Error, Equatable {
 
+        case emptyReceipt,
+             dataObjectIdentifierMissing,
+             asn1ParsingError(description: String),
+             receiptParsingError,
+             inAppPurchaseParsingError
+
+    }
 }
 
-extension ReceiptReadingError: LocalizedError {
+extension ReceiptParser.Error: LocalizedError {
 
     var errorDescription: String? {
         switch self {
-        case .missingReceipt:
-            return "The receipt couldn't be found"
         case .emptyReceipt:
             return "The receipt is empty"
         case .dataObjectIdentifierMissing:
             return "Couldn't find an object identifier of type data in the receipt"
-        case .asn1ParsingError(let description):
+        case let .asn1ParsingError(description):
             return "Error while parsing, payload can't be interpreted as ASN1. details: \(description)"
         case .receiptParsingError:
             return "Error while parsing the receipt. One or more attributes are missing."

--- a/Tests/UnitTests/LocalReceiptParsing/ReceiptParserTests.swift
+++ b/Tests/UnitTests/LocalReceiptParsing/ReceiptParserTests.swift
@@ -77,9 +77,9 @@ class ReceiptParserTests: TestCase {
         let container = containerWithDataObjectIdentifier()
 
         mockASN1ContainerBuilder.stubbedBuildResult = container
-        mockAppleReceiptBuilder.stubbedBuildError = ReceiptReadingError.receiptParsingError
+        mockAppleReceiptBuilder.stubbedBuildError = ReceiptParser.Error.receiptParsingError
 
-        expect { try self.receiptParser.parse(from: Data()) }.to(throwError(ReceiptReadingError.receiptParsingError))
+        expect { try self.receiptParser.parse(from: Data()) }.to(throwError(ReceiptParser.Error.receiptParsingError))
     }
 
     func testParseFromReceiptThrowsIfNoDataObjectIdentifierFound() {
@@ -91,7 +91,7 @@ class ReceiptParserTests: TestCase {
         mockASN1ContainerBuilder.stubbedBuildResult = container
 
         expect { try self.receiptParser.parse(from: Data()) }
-            .to(throwError(ReceiptReadingError.dataObjectIdentifierMissing))
+            .to(throwError(ReceiptParser.Error.dataObjectIdentifierMissing))
     }
 
     func testParseFromReceiptThrowsIfReceiptPayloadIsntLocatedAfterDataObjectIdentifierContainer() {
@@ -103,7 +103,7 @@ class ReceiptParserTests: TestCase {
         mockASN1ContainerBuilder.stubbedBuildResult = container
 
         expect { try self.receiptParser.parse(from: Data()) }
-            .to(throwError(ReceiptReadingError.dataObjectIdentifierMissing))
+            .to(throwError(ReceiptParser.Error.dataObjectIdentifierMissing))
     }
 
     func testReceiptHasTransactionsTrueIfReceiptHasTransactions() {
@@ -119,7 +119,7 @@ class ReceiptParserTests: TestCase {
     }
 
     func testReceiptHasTransactionsTrueIfReceiptCantBeParsed() {
-        mockASN1ContainerBuilder.stubbedBuildError = ReceiptReadingError.receiptParsingError
+        mockASN1ContainerBuilder.stubbedBuildError = ReceiptParser.Error.receiptParsingError
         expect(self.receiptParser.receiptHasTransactions(receiptData: Data())) == true
     }
 }

--- a/Tests/UnitTests/Purchasing/IntroEligibilityCalculatorTests.swift
+++ b/Tests/UnitTests/Purchasing/IntroEligibilityCalculatorTests.swift
@@ -37,7 +37,7 @@ class IntroEligibilityCalculatorTests: TestCase {
     func testCheckTrialOrIntroDiscountEligibilityReturnsErrorIfReceiptParserThrows() {
         let productIdentifiers = Set(["com.revenuecat.test"])
 
-        self.mockReceiptParser.stubbedParseError = ReceiptReadingError.receiptParsingError
+        self.mockReceiptParser.stubbedParseError = ReceiptParser.Error.receiptParsingError
 
         let result: (eligibility: [String: IntroEligibilityStatus], error: Error?)? = waitUntilValue { completed in
             self.calculator.checkEligibility(with: Data(),
@@ -46,7 +46,7 @@ class IntroEligibilityCalculatorTests: TestCase {
             }
         }
 
-        expect(result?.error).to(matchError(ReceiptReadingError.receiptParsingError))
+        expect(result?.error).to(matchError(ReceiptParser.Error.receiptParsingError))
         expect(result?.eligibility).toNot(beNil())
         expect(result?.eligibility).to(beEmpty())
     }

--- a/Tests/UnitTests/Purchasing/ReceiptFetcherTests.swift
+++ b/Tests/UnitTests/Purchasing/ReceiptFetcherTests.swift
@@ -227,7 +227,7 @@ final class RetryingReceiptFetcherTests: BaseReceiptFetcherTests {
     }
 
     func testRetriesIfFirstReceiptThrowsError() async {
-        self.mock(receipts: [.failure(ErrorUtils.missingReceiptFileError()),
+        self.mock(receipts: [.failure(.receiptParsingError),
                              .success(Self.validReceipt)])
 
         let data = await self.fetch(productIdentifier: Self.productID, retries: 1)
@@ -287,7 +287,7 @@ final class RetryingReceiptFetcherTests: BaseReceiptFetcherTests {
         self.mock(receipts: receipts.map(Result.success))
     }
 
-    private func mock(receipts: [Result<AppleReceipt, Error>]) {
+    private func mock(receipts: [Result<AppleReceipt, ReceiptParser.Error>]) {
         precondition(!receipts.isEmpty)
 
         self.mockBundle.receiptURLResult = .receiptWithData
@@ -302,7 +302,7 @@ final class RetryingReceiptFetcherTests: BaseReceiptFetcherTests {
         self.mockBundle.receiptURLResult = .receiptWithData
         self.mockFileReader.mockedURLContents[self.mockBundle.appStoreReceiptURL!] = [invalidData]
         self.mockReceiptParser.stubbedParseResults = [
-            .failure(ErrorUtils.missingReceiptFileError())
+            .failure(.emptyReceipt)
         ]
 
         return invalidData

--- a/Tests/UnitTests/TestHelpers/ContainerFactory.swift
+++ b/Tests/UnitTests/TestHelpers/ContainerFactory.swift
@@ -209,7 +209,9 @@ private extension ContainerFactory {
 }
 
 protocol BuildableReceiptAttributeType {
+
     var rawValue: Int { get }
+
 }
 
 extension InAppPurchaseBuilder.AttributeType: BuildableReceiptAttributeType {}


### PR DESCRIPTION
This will be used for [CSDK-17]. 

Since this will be a public API, we want to make sure we provide consistent and documented errors.
This changes a few thrown `BitShiftError`s into `ReceiptParser.Error`.

[CSDK-17]: https://revenuecats.atlassian.net/browse/CSDK-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ