### PR TITLE
`DeviceCache`: added verbose logs for `init`/`deinit`

### DIFF
--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -50,12 +50,13 @@ class DeviceCache {
          userDefaults: UserDefaults,
          offeringsCachedObject: InMemoryCachedObject<Offerings>? = InMemoryCachedObject(),
          notificationCenter: NotificationCenter? = NotificationCenter.default) {
-
         self.sandboxEnvironmentDetector = sandboxEnvironmentDetector
         self.offeringsCachedObject = offeringsCachedObject ?? InMemoryCachedObject()
         self.notificationCenter = notificationCenter ?? NotificationCenter.default
         self.userDefaults = .init(userDefaults: userDefaults)
         self.appUserIDHasBeenSet.value = userDefaults.string(forKey: .appUserDefaults) != nil
+
+        Logger.verbose(Strings.purchase.device_cache_init(self))
 
         // Observe `UserDefaults` changes through `handleUserDefaultsChanged`
         // to ensure that users don't remove the data from the SDK, which would
@@ -87,6 +88,8 @@ class DeviceCache {
     }
 
     deinit {
+        Logger.verbose(Strings.purchase.device_cache_deinit(self))
+
         if let observer = self.userDefaultsObserver {
             self.notificationCenter.removeObserver(observer)
         }

--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -20,6 +20,8 @@ enum PurchaseStrings {
 
     case storekit1_wrapper_init(StoreKit1Wrapper)
     case storekit1_wrapper_deinit(StoreKit1Wrapper)
+    case device_cache_init(DeviceCache)
+    case device_cache_deinit(DeviceCache)
     case cannot_purchase_product_appstore_configuration_error
     case entitlements_revoked_syncing_purchases(productIdentifiers: [String])
     case finishing_transaction(StoreTransactionType)
@@ -77,12 +79,16 @@ extension PurchaseStrings: CustomStringConvertible {
     var description: String {
         switch self {
         case let .storekit1_wrapper_init(instance):
-            return "StoreKit1Wrapper.init: " +
-            "\(Strings.objectDescription(instance))"
+            return "StoreKit1Wrapper.init: \(Strings.objectDescription(instance))"
 
         case let .storekit1_wrapper_deinit(instance):
-            return "StoreKit1Wrapper.deinit: " +
-            "\(Strings.objectDescription(instance))"
+            return "StoreKit1Wrapper.deinit: \(Strings.objectDescription(instance))"
+
+        case let .device_cache_init(instance):
+            return "DeviceCache.init: \(Strings.objectDescription(instance))"
+
+        case let .device_cache_deinit(instance):
+            return "DeviceCache.deinit: \(Strings.objectDescription(instance))"
 
         case .cannot_purchase_product_appstore_configuration_error:
             return "Could not purchase SKProduct. " +


### PR DESCRIPTION
Equivalent to #2082.
This change will help continue debugging [CSDK-517].

While debugging locally I ran into this crash:
```
Test Case '-[StoreKitUnitTests.UserDefaultsDefaultTests testDefaultIsRevenueCatSuiteIfStandardDoesNotContainUserID]' started.
RevenueCat/DeviceCache.swift:85: Fatal error: [Purchases] - Cached appUserID has been deleted from user defaults.
This leaves the SDK in an undetermined state. Please make sure that RevenueCat
entries in user defaults don't get deleted by anything other than the SDK.
More info: https://rev.cat/userdefaults-crash
```

But that should have been impossible because the current test had not initialized `Purchases` or `DeviceCache`, which showed that there was a leaking `DeviceCache` from another test.

[CSDK-517]: https://revenuecats.atlassian.net/browse/CSDK-517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ