### PR TITLE
`BasePurchasesTests`: added assertion to ensure `Purchases` does not leak

### DIFF
--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -94,7 +94,7 @@ class BasePurchasesTests: TestCase {
         // - They run in LIFO order.
 
         self.addTeardownBlock { [weak purchases = self.purchases] in
-            expect(purchases).toEventually(beNil(), timeout: .seconds(1), description: "Purchases has leaked")
+            expect(purchases).to(beNil(), description: "Purchases has leaked")
         }
 
         self.addTeardownBlock {

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -88,14 +88,24 @@ class BasePurchasesTests: TestCase {
         // Because unit tests can run in parallel, if a test needs to modify
         // this level it should be moved to `StoreKitUnitTests`, which runs serially.
         Purchases.logLevel = .verbose
+
+        // See `addTeardownBlock` docs:
+        // - These run *before* `tearDown`.
+        // - They run in LIFO order.
+
+        self.addTeardownBlock { [weak purchases = self.purchases] in
+            expect(purchases).toEventually(beNil(), timeout: .seconds(1), description: "Purchases has leaked")
+        }
+
+        self.addTeardownBlock {
+            Purchases.clearSingleton()
+
+            self.deviceCache = nil
+            self.purchases = nil
+        }
     }
 
     override func tearDown() {
-        self.deviceCache = nil
-        self.purchases = nil
-
-        Purchases.clearSingleton()
-
         self.userDefaults.removePersistentDomain(forName: Self.userDefaultsSuiteName)
 
         super.tearDown()


### PR DESCRIPTION
To continue debugging [CSDK-517], this adds an assertion to make sure that we don't leak `Purchases`, either because of a retain cycle, or due to any `XCTest` issue.

[CSDK-517]: https://revenuecats.atlassian.net/browse/CSDK-517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ