### PR TITLE
`BasePurchasesTests`: detecting and fixing many `DeviceCache` leaks

### DIFF
--- a/Tests/UnitTests/Mocks/MockNotificationCenter.swift
+++ b/Tests/UnitTests/Mocks/MockNotificationCenter.swift
@@ -6,7 +6,7 @@ import Foundation
 
 class MockNotificationCenter: NotificationCenter {
 
-    typealias ObserversWithSelector = (observer: AnyObject,
+    typealias ObserversWithSelector = (observer: WeakBox<AnyObject>,
                                        selector: Selector,
                                        notificationName: NSNotification.Name?,
                                        object: Any?)
@@ -18,7 +18,7 @@ class MockNotificationCenter: NotificationCenter {
         name aName: NSNotification.Name?,
         object anObject: Any?
     ) {
-        self.observers.append((observer as AnyObject, aSelector, aName, anObject))
+        self.observers.append((.init(observer as AnyObject), aSelector, aName, anObject))
     }
 
     typealias ObserversWithBlock = (block: (Notification) -> Void,
@@ -39,7 +39,7 @@ class MockNotificationCenter: NotificationCenter {
 
     override func removeObserver(_ anObserver: Any, name aName: NSNotification.Name?, object anObject: Any?) {
         self.observers = self.observers.filter {
-            $0.0 !== anObserver as AnyObject || $0.2 != aName
+            $0.0.value !== anObserver as AnyObject || $0.2 != aName
         }
     }
 
@@ -49,7 +49,7 @@ class MockNotificationCenter: NotificationCenter {
             if let name = name {
                 notification = NSNotification(name: name, object: object)
             }
-            _ = observer.perform(selector, with: notification)
+            _ = observer.value?.perform(selector, with: notification)
         }
 
         for (block, name, object) in self.observersWithBlock {

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -25,6 +25,12 @@ class BasePurchasesTests: TestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
+        self.storeKit1Wrapper = MockStoreKit1Wrapper()
+        self.notificationCenter = MockNotificationCenter()
+        self.purchasesDelegate = MockPurchasesDelegate()
+
+        self.paymentQueueWrapper = MockPaymentQueueWrapper()
+
         self.userDefaults = UserDefaults(suiteName: Self.userDefaultsSuiteName)
         self.systemInfo = MockSystemInfo(finishTransactions: true, storeKit2Setting: self.storeKit2Setting)
         self.deviceCache = MockDeviceCache(sandboxEnvironmentDetector: self.systemInfo,
@@ -87,14 +93,44 @@ class BasePurchasesTests: TestCase {
         // See `addTeardownBlock` docs:
         // - These run *before* `tearDown`.
         // - They run in LIFO order.
-
         self.addTeardownBlock { [weak purchases = self.purchases] in
-            expect(purchases).to(beNil(), description: "Purchases has leaked")
+            expect(purchases).toEventually(beNil(), description: "Purchases has leaked")
+        }
+        self.addTeardownBlock { [weak orchestrator = self.purchasesOrchestrator] in
+            expect(orchestrator).toEventually(beNil(), description: "PurchasesOrchestrator has leaked")
+        }
+        self.addTeardownBlock { [weak deviceCache = self.deviceCache] in
+            expect(deviceCache).toEventually(beNil(), description: "DeviceCache has leaked: \(self)")
         }
 
         self.addTeardownBlock {
             Purchases.clearSingleton()
 
+            self.mockOperationDispatcher = nil
+            self.paymentQueueWrapper = nil
+            self.requestFetcher = nil
+            self.receiptFetcher = nil
+            self.mockProductsManager = nil
+            self.mockIntroEligibilityCalculator = nil
+            self.mockTransactionsManager = nil
+            self.backend = nil
+            self.attributionFetcher = nil
+            self.purchasesDelegate.makeDeferredPurchase = nil
+            self.purchasesDelegate = nil
+            self.storeKit1Wrapper.delegate = nil
+            self.storeKit1Wrapper = nil
+            self.systemInfo = nil
+            self.notificationCenter = nil
+            self.subscriberAttributesManager = nil
+            self.trialOrIntroPriceEligibilityChecker = nil
+            self.attributionPoster = nil
+            self.attribution = nil
+            self.customerInfoManager = nil
+            self.identityManager = nil
+            self.mockOfferingsManager = nil
+            self.mockManageSubsHelper = nil
+            self.mockBeginRefundRequestHelper = nil
+            self.purchasesOrchestrator = nil
             self.deviceCache = nil
             self.purchases = nil
         }
@@ -110,9 +146,9 @@ class BasePurchasesTests: TestCase {
     var requestFetcher: MockRequestFetcher!
     var mockProductsManager: MockProductsManager!
     var backend: MockBackend!
-    let storeKit1Wrapper = MockStoreKit1Wrapper()
-    let paymentQueueWrapper = MockPaymentQueueWrapper()
-    let notificationCenter = MockNotificationCenter()
+    var storeKit1Wrapper: MockStoreKit1Wrapper!
+    var paymentQueueWrapper: MockPaymentQueueWrapper!
+    var notificationCenter: MockNotificationCenter!
     var userDefaults: UserDefaults! = nil
     let offeringsFactory = MockOfferingsFactory()
     var deviceCache: MockDeviceCache!
@@ -134,7 +170,7 @@ class BasePurchasesTests: TestCase {
     var mockBeginRefundRequestHelper: MockBeginRefundRequestHelper!
 
     // swiftlint:disable:next weak_delegate
-    var purchasesDelegate = MockPurchasesDelegate()
+    var purchasesDelegate: MockPurchasesDelegate!
 
     var purchases: Purchases!
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
@@ -98,7 +98,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
     }
 
     func testFinishesTransactionsIfSentToBackendCorrectly() throws {
-        var finished = true
+        var finished = false
 
         let productID = "com.product.id1"
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: productID))


### PR DESCRIPTION
Follow up to #2100. This has uncovered a huge source of leaks across many tests. Fixing this will provide many benefits:

- Faster test runs
- Lower memory overhead
- Isolated state across each test run
- Ensure that these types don't leak outside of tests too
