### PR TITLE
`Configuration.with(appUserID:)`: allow passing `nil` and added new tests

### DIFF
--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -70,11 +70,8 @@ class IdentityManager: CurrentUserProvider {
     }
 
     var currentUserIsAnonymous: Bool {
-
-        let anonymousFoundRange = currentAppUserID.range(of: IdentityManager.anonymousRegex,
-                                                         options: .regularExpression)
-        let currentAppUserIDLooksAnonymous = anonymousFoundRange != nil
-        let isLegacyAnonymousAppUserID = currentAppUserID == deviceCache.cachedLegacyAppUserID
+        let currentAppUserIDLooksAnonymous = Self.userIsAnonymous(self.currentAppUserID)
+        let isLegacyAnonymousAppUserID = self.currentAppUserID == deviceCache.cachedLegacyAppUserID
 
         return currentAppUserIDLooksAnonymous || isLegacyAnonymousAppUserID
     }
@@ -93,6 +90,16 @@ class IdentityManager: CurrentUserProvider {
 
     static func generateRandomID() -> String {
         "$RCAnonymousID:\(UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased())"
+    }
+
+}
+
+extension IdentityManager {
+
+    static func userIsAnonymous(_ appUserId: String) -> Bool {
+        let anonymousFoundRange = appUserId.range(of: IdentityManager.anonymousRegex,
+                                                  options: .regularExpression)
+        return anonymousFoundRange != nil
     }
 
 }

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -32,7 +32,7 @@ class IdentityManager: CurrentUserProvider {
     private let customerInfoManager: CustomerInfoManager
     private let attributeSyncing: AttributeSyncing
 
-    internal static let anonymousRegex = #"\$RCAnonymousID:([a-z0-9]{32})$"#
+    private static let anonymousRegex = #"\$RCAnonymousID:([a-z0-9]{32})$"#
 
     init(
         deviceCache: DeviceCache,

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -109,7 +109,7 @@ import Foundation
          *
          * - Important: Set this property if you have your own user identifiers that you manage.
          */
-        @objc public func with(appUserID: String) -> Builder {
+        @objc public func with(appUserID: String?) -> Builder {
             self.appUserID = appUserID
             return self
         }

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCConfigurationAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCConfigurationAPI.m
@@ -13,10 +13,11 @@
 
 + (void)checkAPI {
     RCConfigurationBuilder *builder = [RCConfiguration builderWithAPIKey:@""];
-    RCConfiguration *config = [[[[[[[[[[builder withApiKey:@""]
+    RCConfiguration *config = [[[[[[[[[[[builder withApiKey:@""]
                                        withObserverMode:false]
                                       withUserDefaults:NSUserDefaults.standardUserDefaults]
                                      withAppUserID:@""]
+                                    withAppUserID:nil]
                                     withDangerousSettings:[[RCDangerousSettings alloc] init]]
                                    withNetworkTimeout:1]
                                   withStoreKit1Timeout: 1]

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
@@ -13,6 +13,7 @@ func checkConfigurationAPI() {
         .builder(withAPIKey: "")
         .with(apiKey: "")
         .with(appUserID: "")
+        .with(appUserID: nil)
         .with(observerMode: false)
         .with(userDefaults: UserDefaults.standard)
         .with(dangerousSettings: DangerousSettings())

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -298,26 +298,17 @@ class IdentityManagerTests: TestCase {
 private extension IdentityManagerTests {
 
     func assertCorrectlyIdentified(_ manager: IdentityManager, expectedAppUserID: String) {
-        expect(manager.currentAppUserID).to(equal(expectedAppUserID))
-        expect(self.mockDeviceCache.userIDStoredInCache!).to(equal(expectedAppUserID))
-        expect(manager.currentUserIsAnonymous).to(beFalse())
+        expect(manager.currentAppUserID) == expectedAppUserID
+        expect(self.mockDeviceCache.userIDStoredInCache!) == expectedAppUserID
+        expect(manager.currentUserIsAnonymous) == false
     }
 
     func assertCorrectlyIdentifiedWithAnonymous(_ manager: IdentityManager, usingOldID: Bool = false) {
         if !usingOldID {
-            var obtainedRange = manager.currentAppUserID.range(
-                of: IdentityManager.anonymousRegex,
-                options: .regularExpression
-            )
-            expect(obtainedRange).toNot(beNil())
-
-            obtainedRange = self.mockDeviceCache.userIDStoredInCache!.range(
-                of: IdentityManager.anonymousRegex,
-                options: .regularExpression
-            )
-            expect(obtainedRange).toNot(beNil())
+            expect(IdentityManager.userIsAnonymous(manager.currentAppUserID)) == true
+            expect(IdentityManager.userIsAnonymous(self.mockDeviceCache.userIDStoredInCache!)) == true
         }
-        expect(manager.currentUserIsAnonymous).to(beTrue())
+        expect(manager.currentUserIsAnonymous) == true
     }
 
 }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -92,6 +92,34 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expect(Purchases.shared.finishTransactions) == true
     }
 
+    func testUserIdIsSetWhenConfiguringWithUserID() {
+        let purchases = Purchases.configure(
+            with: .init(withAPIKey: "")
+                .with(appUserID: Self.appUserID)
+        )
+        expect(purchases.appUserID) == Self.appUserID
+    }
+
+    func testUserIdIsSetToAnonymousWhenConfiguringWithEmptyUserID() {
+        let purchases = Purchases.configure(
+            with: .init(withAPIKey: "")
+                .with(appUserID: "")
+        )
+        expect(purchases.appUserID).toNot(beEmpty())
+        expect(IdentityManager.userIsAnonymous(purchases.appUserID))
+            .to(beTrue(), description: "User '\(purchases.appUserID)' should be anonymous")
+    }
+
+    func testUserIdIsSetToAnonymousWhenConfiguringWithNilUserID() {
+        let purchases = Purchases.configure(
+            with: .init(withAPIKey: "")
+                .with(appUserID: nil)
+        )
+        expect(purchases.appUserID).toNot(beEmpty())
+        expect(IdentityManager.userIsAnonymous(purchases.appUserID))
+            .to(beTrue(), description: "User '\(purchases.appUserID)' should be anonymous")
+    }
+
     func testFirstInitializationCallDelegate() {
         self.setupPurchases()
         expect(self.purchasesDelegate.customerInfoReceivedCount).toEventually(equal(1))

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -101,8 +101,12 @@ class PurchasesConfiguringTests: BasePurchasesTests {
     }
 
     func testUserIdIsSetToAnonymousWhenConfiguringWithEmptyUserID() {
+        self.deviceCache.userIDStoredInCache = nil
+
         let purchases = Purchases.configure(
             with: .init(withAPIKey: "")
+                // This test requires no previously stored user
+                .with(userDefaults: .init(suiteName: UUID().uuidString)!)
                 .with(appUserID: "")
         )
         expect(purchases.appUserID).toNot(beEmpty())
@@ -113,6 +117,8 @@ class PurchasesConfiguringTests: BasePurchasesTests {
     func testUserIdIsSetToAnonymousWhenConfiguringWithNilUserID() {
         let purchases = Purchases.configure(
             with: .init(withAPIKey: "")
+                // This test requires no previously stored user
+                .with(userDefaults: .init(suiteName: UUID().uuidString)!)
                 .with(appUserID: nil)
         )
         expect(purchases.appUserID).toNot(beEmpty())

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -114,16 +114,44 @@ class PurchasesConfiguringTests: BasePurchasesTests {
             .to(beTrue(), description: "User '\(purchases.appUserID)' should be anonymous")
     }
 
-    func testUserIdIsSetToAnonymousWhenConfiguringWithNilUserID() {
+    func testUserIdOverridesPreviouslyConfiguredUser() {
+        // This test requires no previously stored user
+        let userDefaults: UserDefaults = .init(suiteName: UUID().uuidString)!
+
+        let newUserID = Self.appUserID + "_new"
+
+        _ = Purchases.configure(
+            with: .init(withAPIKey: "")
+                .with(userDefaults: userDefaults)
+                .with(appUserID: Self.appUserID)
+        )
+        Purchases.clearSingleton()
         let purchases = Purchases.configure(
             with: .init(withAPIKey: "")
-                // This test requires no previously stored user
-                .with(userDefaults: .init(suiteName: UUID().uuidString)!)
+                .with(userDefaults: userDefaults)
+                .with(appUserID: newUserID)
+        )
+
+        expect(purchases.appUserID) == newUserID
+    }
+
+    func testNilUserIdIsIgnoredIfPreviousUserExists() {
+        // This test requires no previously stored user
+        let userDefaults: UserDefaults = .init(suiteName: UUID().uuidString)!
+
+        _ = Purchases.configure(
+            with: .init(withAPIKey: "")
+                .with(userDefaults: userDefaults)
+                .with(appUserID: Self.appUserID)
+        )
+        Purchases.clearSingleton()
+        let purchases = Purchases.configure(
+            with: .init(withAPIKey: "")
+                .with(userDefaults: userDefaults)
                 .with(appUserID: nil)
         )
-        expect(purchases.appUserID).toNot(beEmpty())
-        expect(IdentityManager.userIsAnonymous(purchases.appUserID))
-            .to(beTrue(), description: "User '\(purchases.appUserID)' should be anonymous")
+
+        expect(purchases.appUserID) == Self.appUserID
     }
 
     func testFirstInitializationCallDelegate() {


### PR DESCRIPTION
The docs had this:
> Pass `nil` or an empty string if you want ``Purchases`` to generate this for you.

But `nil` wasn't a valid input.
I noticed [this reported issue](https://github.com/RevenueCat/purchases-ios/issues/2107#issuecomment-1332007011) where the user was doing this:
```swift
.with(appUserID: userUID ?? "")
```

Which technically would have the same semantics, since we allow empty and convert it to anonymous, but now this is more clear and it matches the docstring.