### PR TITLE
Version 3.x: increased output timeout for `make-release`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,6 +230,7 @@ jobs:
       - run:
           name: Deploy new version
           command: bundle exec fastlane deploy
+          no_output_timeout: 30m
 
   prepare-next-version:
     macos:


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/9137/workflows/28969b50-feae-4f06-b271-f38dc91b62c0/jobs/46576