### PR TITLE
`StoreKit1Wrapper`: process transactions in a background thread

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -274,7 +274,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
         let paymentQueueWrapper: EitherPaymentQueueWrapper = systemInfo.storeKit2Setting.shouldOnlyUseStoreKit2
             ? .right(.init())
-            : .left(.init())
+            : .left(.init(operationDispatcher: operationDispatcher))
 
         let offeringsFactory = OfferingsFactory()
         let userDefaults = userDefaults ?? UserDefaults.computeDefault()

--- a/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
@@ -63,17 +63,14 @@ class StoreKit1Wrapper: NSObject {
     private let paymentQueue: SKPaymentQueue
     private let operationDispatcher: OperationDispatcher
 
-    init(paymentQueue: SKPaymentQueue, operationDispatcher: OperationDispatcher) {
+    init(paymentQueue: SKPaymentQueue = .default(),
+         operationDispatcher: OperationDispatcher = .default) {
         self.paymentQueue = paymentQueue
         self.operationDispatcher = operationDispatcher
 
         super.init()
 
         Logger.verbose(Strings.purchase.storekit1_wrapper_init(self))
-    }
-
-    override convenience init() {
-        self.init(paymentQueue: .default(), operationDispatcher: .default)
     }
 
     deinit {

--- a/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
@@ -134,20 +134,24 @@ extension StoreKit1Wrapper: PaymentQueueWrapperType {
 extension StoreKit1Wrapper: SKPaymentTransactionObserver {
 
     func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
+        guard let delegate = self.delegate else { return }
+
         self.operationDispatcher.dispatchOnWorkerThread {
             for transaction in transactions {
                 Logger.debug(Strings.purchase.paymentqueue_updated_transaction(self, transaction))
-                self.delegate?.storeKit1Wrapper(self, updatedTransaction: transaction)
+                delegate.storeKit1Wrapper(self, updatedTransaction: transaction)
             }
         }
     }
 
     // Sent when transactions are removed from the queue (via finishTransaction:).
     func paymentQueue(_ queue: SKPaymentQueue, removedTransactions transactions: [SKPaymentTransaction]) {
+        guard let delegate = self.delegate else { return }
+
         self.operationDispatcher.dispatchOnWorkerThread {
             for transaction in transactions {
                 Logger.debug(Strings.purchase.paymentqueue_removed_transaction(self, transaction))
-                self.delegate?.storeKit1Wrapper(self, removedTransaction: transaction)
+                delegate.storeKit1Wrapper(self, removedTransaction: transaction)
             }
         }
     }

--- a/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
@@ -14,14 +14,20 @@ import XCTest
 @testable import RevenueCat
 
 class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
-    let paymentQueue = MockPaymentQueue()
+    private var operationDispatcher: MockOperationDispatcher!
+    private var paymentQueue: MockPaymentQueue!
 
-    var wrapper: StoreKit1Wrapper?
+    private var wrapper: StoreKit1Wrapper?
 
     override func setUp() {
         super.setUp()
-        wrapper = StoreKit1Wrapper.init(paymentQueue: paymentQueue)
-        wrapper?.delegate = self
+
+        self.operationDispatcher = .init()
+        self.paymentQueue = .init()
+
+        self.wrapper = StoreKit1Wrapper.init(paymentQueue: self.paymentQueue,
+                                             operationDispatcher: self.operationDispatcher)
+        self.wrapper?.delegate = self
     }
 
     var updatedTransactions: [SKPaymentTransaction] = []
@@ -85,6 +91,20 @@ class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
         wrapper?.paymentQueue(paymentQueue, updatedTransactions: [transaction])
 
         expect(self.updatedTransactions).to(contain(transaction))
+    }
+
+    func testCallsDelegateToProcessTransactionsOnWorkerThread() {
+        let payment = SKPayment(product: SK1Product())
+        self.wrapper?.add(payment)
+
+        let transactions = [
+            Self.transaction(with: payment),
+            Self.transaction(with: payment)
+        ]
+
+        self.wrapper?.paymentQueue(paymentQueue, updatedTransactions: transactions)
+        expect(self.operationDispatcher.invokedDispatchOnWorkerThread) == true
+        expect(self.operationDispatcher.invokedDispatchOnWorkerThreadCount) == 1
     }
 
     func testCallsDelegateWhenPromoPurchaseIsAvailable() {
@@ -251,5 +271,16 @@ class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
         expect(consentStatuses) == [false]
     }
 #endif
+
+}
+
+private extension StoreKit1WrapperTests {
+
+    static func transaction(with: SKPayment) -> MockTransaction {
+        let transaction = MockTransaction()
+        transaction.mockPayment = SKPayment.init(product: SK1Product())
+
+        return transaction
+    }
 
 }

--- a/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
@@ -17,7 +17,7 @@ class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
     private var operationDispatcher: MockOperationDispatcher!
     private var paymentQueue: MockPaymentQueue!
 
-    private var wrapper: StoreKit1Wrapper?
+    private var wrapper: StoreKit1Wrapper!
 
     override func setUp() {
         super.setUp()
@@ -25,9 +25,9 @@ class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
         self.operationDispatcher = .init()
         self.paymentQueue = .init()
 
-        self.wrapper = StoreKit1Wrapper.init(paymentQueue: self.paymentQueue,
-                                             operationDispatcher: self.operationDispatcher)
-        self.wrapper?.delegate = self
+        self.wrapper = StoreKit1Wrapper(paymentQueue: self.paymentQueue,
+                                        operationDispatcher: self.operationDispatcher)
+        self.wrapper.delegate = self
     }
 
     var updatedTransactions: [SKPaymentTransaction] = []
@@ -95,14 +95,14 @@ class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
 
     func testCallsDelegateToProcessTransactionsOnWorkerThread() {
         let payment = SKPayment(product: SK1Product())
-        self.wrapper?.add(payment)
+        self.wrapper.add(payment)
 
         let transactions = [
             Self.transaction(with: payment),
             Self.transaction(with: payment)
         ]
 
-        self.wrapper?.paymentQueue(paymentQueue, updatedTransactions: transactions)
+        self.wrapper.paymentQueue(self.paymentQueue, updatedTransactions: transactions)
         expect(self.operationDispatcher.invokedDispatchOnWorkerThread) == true
         expect(self.operationDispatcher.invokedDispatchOnWorkerThreadCount) == 1
     }
@@ -278,7 +278,7 @@ private extension StoreKit1WrapperTests {
 
     static func transaction(with: SKPayment) -> MockTransaction {
         let transaction = MockTransaction()
-        transaction.mockPayment = SKPayment.init(product: SK1Product())
+        transaction.mockPayment = SKPayment(product: SK1Product())
 
         return transaction
     }


### PR DESCRIPTION
Fixes #2107 and [SDKONCALL-180]. That's a rare issue where a user ends up with thousands of transactions.
That exposed the fact that we're processing all of these transactions on the main thread. This fixes that.

[SDKONCALL-180]: https://revenuecats.atlassian.net/browse/SDKONCALL-180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ