### PR TITLE
`StoreKit1Wrapper`: added warning if receiving too many updated transactions

### DIFF
--- a/Sources/Logging/Strings/StoreKitStrings.swift
+++ b/Sources/Logging/Strings/StoreKitStrings.swift
@@ -42,6 +42,8 @@ enum StoreKitStrings {
 
     case no_cached_products_starting_store_products_request(identifiers: Set<String>)
 
+    case sk1_payment_queue_too_many_transactions(_ count: Int)
+
     case sk1_product_request_too_slow
 
     case sk2_product_request_too_slow
@@ -96,6 +98,10 @@ extension StoreKitStrings: CustomStringConvertible {
 
         case .no_cached_products_starting_store_products_request(let identifiers):
             return "No existing products cached, starting store products request for: \(identifiers)"
+
+        case let .sk1_payment_queue_too_many_transactions(count):
+            return "SKPaymentQueue sent \(count) updated transactions. " +
+            "This high number is unexpected and is likely due to bad state on your device."
 
         case .sk1_product_request_too_slow:
             return "StoreKit 1 product request took longer than expected"

--- a/Sources/Logging/Strings/StoreKitStrings.swift
+++ b/Sources/Logging/Strings/StoreKitStrings.swift
@@ -42,7 +42,7 @@ enum StoreKitStrings {
 
     case no_cached_products_starting_store_products_request(identifiers: Set<String>)
 
-    case sk1_payment_queue_too_many_transactions(_ count: Int)
+    case sk1_payment_queue_too_many_transactions(count: Int, isSandbox: Bool)
 
     case sk1_product_request_too_slow
 
@@ -99,10 +99,13 @@ extension StoreKitStrings: CustomStringConvertible {
         case .no_cached_products_starting_store_products_request(let identifiers):
             return "No existing products cached, starting store products request for: \(identifiers)"
 
-        case let .sk1_payment_queue_too_many_transactions(count):
-            return "SKPaymentQueue sent \(count) updated transactions. " +
-            "This high number is unexpected and is likely due to using an old sandbox account on a new device. " +
+        case let .sk1_payment_queue_too_many_transactions(count, isSandbox):
+            let messageSuffix = isSandbox
+            ? "This high number is unexpected and is likely due to using an old sandbox account on a new device. " +
             "If this is impacting performance, using a new sandbox account is recommended."
+            : "This is a very high number and might impact performance."
+
+            return "SKPaymentQueue sent \(count) updated transactions. " + messageSuffix
 
         case .sk1_product_request_too_slow:
             return "StoreKit 1 product request took longer than expected"

--- a/Sources/Logging/Strings/StoreKitStrings.swift
+++ b/Sources/Logging/Strings/StoreKitStrings.swift
@@ -101,7 +101,8 @@ extension StoreKitStrings: CustomStringConvertible {
 
         case let .sk1_payment_queue_too_many_transactions(count):
             return "SKPaymentQueue sent \(count) updated transactions. " +
-            "This high number is unexpected and is likely due to bad state on your device."
+            "This high number is unexpected and is likely due to using an old sandbox account on a new device. " +
+            "If this is impacting performance, using a new sandbox account is recommended."
 
         case .sk1_product_request_too_slow:
             return "StoreKit 1 product request took longer than expected"

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -274,7 +274,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
         let paymentQueueWrapper: EitherPaymentQueueWrapper = systemInfo.storeKit2Setting.shouldOnlyUseStoreKit2
             ? .right(.init())
-            : .left(.init(operationDispatcher: operationDispatcher))
+            : .left(.init(operationDispatcher: operationDispatcher, sandboxEnvironmentDetector: systemInfo))
 
         let offeringsFactory = OfferingsFactory()
         let userDefaults = userDefaults ?? UserDefaults.computeDefault()

--- a/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
@@ -133,6 +133,10 @@ extension StoreKit1Wrapper: SKPaymentTransactionObserver {
     func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
         guard let delegate = self.delegate else { return }
 
+        if transactions.count >= 100 {
+            Logger.appleWarning(Strings.storeKit.sk1_payment_queue_too_many_transactions(transactions.count))
+        }
+
         self.operationDispatcher.dispatchOnWorkerThread {
             for transaction in transactions {
                 Logger.debug(Strings.purchase.paymentqueue_updated_transaction(self, transaction))

--- a/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
@@ -133,7 +133,7 @@ extension StoreKit1Wrapper: SKPaymentTransactionObserver {
     func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
         guard let delegate = self.delegate else { return }
 
-        if transactions.count >= 100 {
+        if transactions.count >= Self.highTransactionCountThreshold {
             Logger.appleWarning(Strings.storeKit.sk1_payment_queue_too_many_transactions(transactions.count))
         }
 
@@ -182,6 +182,9 @@ extension StoreKit1Wrapper: SKPaymentTransactionObserver {
     func paymentQueueDidChangeStorefront(_ queue: SKPaymentQueue) {
         self.delegate?.storeKit1WrapperDidChangeStorefront(self)
     }
+
+    /// Receiving this many or more will produce a warning.
+    private static let highTransactionCountThreshold: Int = 100
 
 }
 

--- a/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
@@ -62,11 +62,14 @@ class StoreKit1Wrapper: NSObject {
 
     private let paymentQueue: SKPaymentQueue
     private let operationDispatcher: OperationDispatcher
+    private let sandboxEnvironmentDetector: SandboxEnvironmentDetector
 
     init(paymentQueue: SKPaymentQueue = .default(),
-         operationDispatcher: OperationDispatcher = .default) {
+         operationDispatcher: OperationDispatcher = .default,
+         sandboxEnvironmentDetector: SandboxEnvironmentDetector = BundleSandboxEnvironmentDetector.default) {
         self.paymentQueue = paymentQueue
         self.operationDispatcher = operationDispatcher
+        self.sandboxEnvironmentDetector = sandboxEnvironmentDetector
 
         super.init()
 
@@ -134,7 +137,10 @@ extension StoreKit1Wrapper: SKPaymentTransactionObserver {
         guard let delegate = self.delegate else { return }
 
         if transactions.count >= Self.highTransactionCountThreshold {
-            Logger.appleWarning(Strings.storeKit.sk1_payment_queue_too_many_transactions(transactions.count))
+            Logger.appleWarning(Strings.storeKit.sk1_payment_queue_too_many_transactions(
+                count: transactions.count,
+                isSandbox: self.sandboxEnvironmentDetector.isSandbox
+            ))
         }
 
         self.operationDispatcher.dispatchOnWorkerThread {

--- a/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
@@ -16,6 +16,7 @@ import XCTest
 class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
     private var operationDispatcher: MockOperationDispatcher!
     private var paymentQueue: MockPaymentQueue!
+    private var sandboxEnvironmentDetector: MockSandboxEnvironmentDetector!
 
     private var wrapper: StoreKit1Wrapper!
 
@@ -24,9 +25,11 @@ class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
 
         self.operationDispatcher = .init()
         self.paymentQueue = .init()
+        self.sandboxEnvironmentDetector = .init(isSandbox: .random())
 
         self.wrapper = StoreKit1Wrapper(paymentQueue: self.paymentQueue,
-                                        operationDispatcher: self.operationDispatcher)
+                                        operationDispatcher: self.operationDispatcher,
+                                        sandboxEnvironmentDetector: self.sandboxEnvironmentDetector)
         self.wrapper.delegate = self
     }
 
@@ -276,7 +279,10 @@ class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
 
         self.wrapper.paymentQueue(self.paymentQueue, updatedTransactions: transactions)
 
-        logger.verifyMessageWasLogged(Strings.storeKit.sk1_payment_queue_too_many_transactions(transactions.count),
+        logger.verifyMessageWasLogged(Strings.storeKit.sk1_payment_queue_too_many_transactions(
+            count: transactions.count,
+            isSandbox: self.sandboxEnvironmentDetector.isSandbox
+        ),
                                       level: .warn)
     }
 

--- a/Tests/UnitTests/TestHelpers/TestLogHandler.swift
+++ b/Tests/UnitTests/TestHelpers/TestLogHandler.swift
@@ -56,8 +56,14 @@ final class TestLogHandler {
     typealias MessageData = (level: LogLevel, message: String)
 
     var messages: [MessageData] { return self.loggedMessages.value }
+    private let capacity: Int
 
-    init(file: String = #fileID, line: UInt = #line) {
+    init(
+        capacity: Int = TestLogHandler.defaultMessageLimit,
+        file: String = #fileID,
+        line: UInt = #line
+    ) {
+        self.capacity = capacity
         self.creationContext = .init(file: file, line: line)
         Self.sharedHandler.add(observer: self)
     }
@@ -145,15 +151,15 @@ extension TestLogHandler: LogMessageObserver {
             $0.append((level, message))
 
             precondition(
-                $0.count < Self.messageLimit,
-                "\(Self.messageLimit) messages have been stored. " +
+                $0.count < self.capacity,
+                "\($0.count) messages have been stored. " +
                 "This is likely a programming error and \(self) " +
                 "(created in \(self.creationContext.file):\(self.creationContext.line) has leaked."
             )
         }
     }
 
-    private static let messageLimit = 100
+    private static let defaultMessageLimit = 100
 
 }
 


### PR DESCRIPTION
See #2107. We still don't know what caused that, but it leads to degraded performance (mildly reduced by #2115). To advice of that, in case users are wondering why the app might potentially take excessive CPU usage, I added this warning.