### PR TITLE
`HTTPClient`: replaced `X-StoreKit2-Setting` with `X-StoreKit2-Enabled`

### DIFF
--- a/Sources/Misc/StoreKit2Setting.swift
+++ b/Sources/Misc/StoreKit2Setting.swift
@@ -60,6 +60,11 @@ extension StoreKit2Setting {
 
     /// - Returns: `true` iff SK2 is enabled and it's available.
     var shouldOnlyUseStoreKit2: Bool {
+        return self.isEnabledAndAvailable
+    }
+
+    /// - Returns: `true` iff SK2 is enabled and it's available.
+    var isEnabledAndAvailable: Bool {
         switch self {
         case .disabled, .enabledOnlyForOptimizations: return false
         case .enabledForCompatibleDevices: return Self.isStoreKit2Available

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -148,6 +148,7 @@ private extension HTTPClient {
             "X-Client-Build-Version": SystemInfo.buildVersion,
             "X-Client-Bundle-ID": SystemInfo.bundleIdentifier,
             "X-StoreKit2-Setting": "\(self.systemInfo.storeKit2Setting.debugDescription)",
+            "X-StoreKit2-Enabled": "\(self.systemInfo.storeKit2Setting.isEnabledAndAvailable)",
             "X-Observer-Mode-Enabled": "\(self.systemInfo.observerMode)",
             "X-Is-Sandbox": "\(self.systemInfo.isSandbox)"
         ]

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -147,7 +147,6 @@ private extension HTTPClient {
             "X-Client-Version": SystemInfo.appVersion,
             "X-Client-Build-Version": SystemInfo.buildVersion,
             "X-Client-Bundle-ID": SystemInfo.bundleIdentifier,
-            "X-StoreKit2-Setting": "\(self.systemInfo.storeKit2Setting.debugDescription)",
             "X-StoreKit2-Enabled": "\(self.systemInfo.storeKit2Setting.isEnabledAndAvailable)",
             "X-Observer-Mode-Enabled": "\(self.systemInfo.observerMode)",
             "X-Is-Sandbox": "\(self.systemInfo.isSandbox)"

--- a/Tests/UnitTests/Misc/StoreKit2SettingTests.swift
+++ b/Tests/UnitTests/Misc/StoreKit2SettingTests.swift
@@ -48,6 +48,22 @@ class StoreKit2SettingTests: TestCase {
         expect(StoreKit2Setting.enabledForCompatibleDevices.shouldOnlyUseStoreKit2) == true
     }
 
+    func testIsEnabledAndAvailableFalseWhenOnlyEnabledForOptimizations() {
+        expect(StoreKit2Setting.enabledOnlyForOptimizations.isEnabledAndAvailable) == false
+    }
+
+    func testIsEnabledAndAvailableFalseIfNotAvailable() throws {
+        try AvailabilityChecks.iOS15APINotAvailableOrSkipTest()
+
+        expect(StoreKit2Setting.enabledForCompatibleDevices.isEnabledAndAvailable) == false
+    }
+
+    func testIsEnabledAndAvailableTrueIfAvailable() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        expect(StoreKit2Setting.enabledForCompatibleDevices.isEnabledAndAvailable) == true
+    }
+
     func testStoreKit2NotAvailableOnOlderDevices() throws {
         try AvailabilityChecks.iOS15APINotAvailableOrSkipTest()
 

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -469,6 +469,24 @@ class HTTPClientTests: TestCase {
         expect(headerPresent.value).toEventually(equal(true))
     }
 
+    func testPassesStoreKit2EnabledHeader() {
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
+
+        let headerPresent: Atomic<Bool> = false
+
+        let enabled = self.systemInfo.storeKit2Setting.isEnabledAndAvailable.description
+
+        stub(condition: hasHeaderNamed("X-StoreKit2-Enabled",
+                                       value: enabled)) { _ in
+            headerPresent.value = true
+            return .emptySuccessResponse
+        }
+
+        self.client.perform(request) { (_: HTTPResponse<Data>.Result) in }
+
+        expect(headerPresent.value).toEventually(equal(true))
+    }
+
     #if os(macOS) || targetEnvironment(macCatalyst)
     func testAlwaysPassesAppleDeviceIdentifierWhenIsSandbox() {
         let request = HTTPRequest(method: .get, path: .mockPath)


### PR DESCRIPTION
This will be used for https://github.com/RevenueCat/khepri/pull/4843, to fix [SDKONCALL-160] and #2020.

`X-StoreKit2-Setting` only told us if the apps had that setting enabled. However, when running on an older device, `SK2` would still be disabled.

[SDKONCALL-160]: https://revenuecats.atlassian.net/browse/SDKONCALL-160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ