### PR TITLE
`ReceiptParser`: ensure parsing never happens in the main thread

### DIFF
--- a/Sources/LocalReceiptParsing/ReceiptParser.swift
+++ b/Sources/LocalReceiptParsing/ReceiptParser.swift
@@ -38,6 +38,10 @@ class ReceiptParser {
     }
 
     func parse(from receiptData: Data) throws -> AppleReceipt {
+        #if DEBUG
+        Self.ensureRunningOutsideOfMainThread()
+        #endif
+
         let intData = [UInt8](receiptData)
 
         let asn1Container = try self.containerBuilder.build(fromPayload: ArraySlice(intData))
@@ -81,5 +85,16 @@ private extension ReceiptParser {
         }
         return nil
     }
+
+    #if DEBUG
+    static func ensureRunningOutsideOfMainThread() {
+        if ProcessInfo.isRunningIntegrationTests {
+            precondition(
+                !Thread.isMainThread,
+                "Receipt parsing should not run on the main thread."
+            )
+        }
+    }
+    #endif
 
 }

--- a/Sources/LocalReceiptParsing/ReceiptParser.swift
+++ b/Sources/LocalReceiptParsing/ReceiptParser.swift
@@ -88,6 +88,8 @@ private extension ReceiptParser {
 
     #if DEBUG
     static func ensureRunningOutsideOfMainThread() {
+        // Only checking on integration tests.
+        // Unit tests might run on the main thread when testing this class directly.
         if ProcessInfo.isRunningIntegrationTests {
             precondition(
                 !Thread.isMainThread,

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -999,33 +999,35 @@ private extension PurchasesOrchestrator {
                       return
                   }
 
-            let hasTransactions = self.transactionsManager.customerHasTransactions(receiptData: receiptData)
-            let cachedCustomerInfo = self.customerInfoManager.cachedCustomerInfo(appUserID: currentAppUserID)
-            let hasOriginalPurchaseDate = cachedCustomerInfo?.originalPurchaseDate != nil
+            self.operationDispatcher.dispatchOnWorkerThread {
+                let hasTransactions = self.transactionsManager.customerHasTransactions(receiptData: receiptData)
+                let cachedCustomerInfo = self.customerInfoManager.cachedCustomerInfo(appUserID: currentAppUserID)
+                let hasOriginalPurchaseDate = cachedCustomerInfo?.originalPurchaseDate != nil
 
-            if !hasTransactions && hasOriginalPurchaseDate {
-                if let completion = completion {
-                    self.operationDispatcher.dispatchOnMainThread {
-                        completion(
-                            Result(cachedCustomerInfo,
-                                   ErrorUtils.customerInfoError(withMessage: "No cached customer info"))
-                        )
+                if !hasTransactions && hasOriginalPurchaseDate {
+                    if let completion = completion {
+                        self.operationDispatcher.dispatchOnMainThread {
+                            completion(
+                                Result(cachedCustomerInfo,
+                                       ErrorUtils.customerInfoError(withMessage: "No cached customer info"))
+                            )
+                        }
                     }
+                    return
                 }
-                return
-            }
 
-            self.backend.post(receiptData: receiptData,
-                              appUserID: currentAppUserID,
-                              isRestore: isRestore,
-                              productData: nil,
-                              presentedOfferingIdentifier: nil,
-                              observerMode: self.observerMode,
-                              initiationSource: initiationSource,
-                              subscriberAttributes: unsyncedAttributes) { result in
-                self.handleReceiptPost(result: result,
-                                       subscriberAttributes: unsyncedAttributes,
-                                       completion: completion)
+                self.backend.post(receiptData: receiptData,
+                                  appUserID: currentAppUserID,
+                                  isRestore: isRestore,
+                                  productData: nil,
+                                  presentedOfferingIdentifier: nil,
+                                  observerMode: self.observerMode,
+                                  initiationSource: initiationSource,
+                                  subscriberAttributes: unsyncedAttributes) { result in
+                    self.handleReceiptPost(result: result,
+                                           subscriberAttributes: unsyncedAttributes,
+                                           completion: completion)
+                }
             }
         }
     }

--- a/Sources/Purchasing/ReceiptFetcher.swift
+++ b/Sources/Purchasing/ReceiptFetcher.swift
@@ -159,7 +159,11 @@ private extension ReceiptFetcher {
 
             if !data.isEmpty {
                 do {
-                    let receipt = try self.receiptParser.parse(from: data)
+                    // Parse receipt in a background thread
+                    let receipt = try await Task.detached { [currentData = data] in
+                        try self.receiptParser.parse(from: currentData)
+                    }.value
+
                     if receipt.containsActivePurchase(forProductIdentifier: productIdentifier) {
                         return data
                     } else {


### PR DESCRIPTION
Fixes #2107 and [SDKONCALL-180].

[This comment](https://github.com/RevenueCat/purchases-ios/issues/2107#issuecomment-1342846583) pointed out that parsing a long receipt can freeze the UI for almost a second.

⚠️ This new assertion (running only in integration tests using the code added in #2100) has exposed a couple of code paths where we parse receipts from the main thread!

[SDKONCALL-180]: https://revenuecats.atlassian.net/browse/SDKONCALL-180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ