### PR TITLE
`Integration Tests`: fixed `Purchases` leak through `PurchasesDiagnostics`

### DIFF
--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -56,7 +56,8 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
     }
 
     func testPurchasesDiagnostics() async throws {
-        let diagnostics = PurchasesDiagnostics.default
+        let diagnostics = PurchasesDiagnostics(purchases: Purchases.shared)
+
         try await diagnostics.testSDKHealth()
     }
 


### PR DESCRIPTION
Calling `PurchasesDiagnostics.default` was lazily initializing it:
```swift
public static let `default`: PurchasesDiagnostics = .init(purchases: Purchases.shared)
```

Which was keeping a reference to `Purchases.shared` around.
For most cases this is fine, since `Purchases` would only be initialized once, but for tests it meant that it was leaking, which is now detected by #2106.