### PR TITLE
`PostReceiptDataOperation`: also print receipt data with `verbose` logs

### DIFF
--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -54,7 +54,7 @@ class PostReceiptDataOperation: CacheableNetworkOperation {
     }
 
     override func begin(completion: @escaping () -> Void) {
-        if Logger.logLevel == .debug {
+        if Logger.logLevel <= .debug {
             self.printReceiptData()
         }
 


### PR DESCRIPTION
This was fine when we only had `debug` logs, but since #2080 we need to check for `verbose` too.
Thanks to #2102 we can just use `<=`, because `LogLevel` conforms to `Comparable`.