### PR TITLE
`PostReceiptDataOperation`: clarified receipt debug log

### DIFF
--- a/Sources/Logging/Strings/ReceiptStrings.swift
+++ b/Sources/Logging/Strings/ReceiptStrings.swift
@@ -84,7 +84,8 @@ extension ReceiptStrings: CustomStringConvertible {
             return "Unable to load receipt, ensure you are logged in to a valid Apple account."
 
         case let .posting_receipt(receipt):
-            return "Posting receipt: \(receipt.debugDescription)"
+            return "Posting receipt (note: the contents might not be up-to-date, " +
+            "but it will be refreshed with Apple's servers):\n\(receipt.debugDescription)"
 
         case let .receipt_subscription_purchase_equals_expiration(
             productIdentifier,


### PR DESCRIPTION
Fixes [CSDK-543].
See https://github.com/RevenueCat/purchases-flutter/issues/540.

Users might be confused and think that if data is missing from the receipt, something is wrong.
This new log should clarify that.

[CSDK-543]: https://revenuecats.atlassian.net/browse/CSDK-543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ