### PR TITLE
Un-deprecate `Purchases.configure(withAPIKey:appUserID:)` and `Purchases.configure(withAPIKey:appUserID:observerMode:)`

### DIFF
--- a/Sources/Misc/Deprecations.swift
+++ b/Sources/Misc/Deprecations.swift
@@ -14,7 +14,7 @@
 import Foundation
 import StoreKit
 
-// swiftlint:disable file_length line_length missing_docs
+// swiftlint:disable line_length missing_docs
 
 public extension Purchases {
 
@@ -54,28 +54,6 @@ public extension Purchases {
     @available(macCatalyst, introduced: 13.0, deprecated, renamed: "eligiblePromotionalOffers(forProduct:)")
     func getEligiblePromotionalOffers(forProduct product: StoreProduct) async -> [PromotionalOffer] {
         return await eligiblePromotionalOffers(forProduct: product)
-    }
-
-    @available(iOS, deprecated: 1, renamed: "configure(with:)")
-    @available(tvOS, deprecated: 1, renamed: "configure(with:)")
-    @available(watchOS, deprecated: 1, renamed: "configure(with:)")
-    @available(macOS, deprecated: 1, renamed: "configure(with:)")
-    @available(macCatalyst, deprecated: 1, renamed: "configure(with:)")
-    @objc(configureWithAPIKey:appUserID:)
-    @discardableResult static func configure(withAPIKey apiKey: String, appUserID: String?) -> Purchases {
-        configure(withAPIKey: apiKey, appUserID: appUserID, observerMode: false)
-    }
-
-    @available(iOS, deprecated: 1, renamed: "configure(with:)")
-    @available(tvOS, deprecated: 1, renamed: "configure(with:)")
-    @available(watchOS, deprecated: 1, renamed: "configure(with:)")
-    @available(macOS, deprecated: 1, renamed: "configure(with:)")
-    @available(macCatalyst, deprecated: 1, renamed: "configure(with:)")
-    @objc(configureWithAPIKey:appUserID:observerMode:)
-    @discardableResult static func configure(withAPIKey apiKey: String,
-                                             appUserID: String?,
-                                             observerMode: Bool) -> Purchases {
-        configure(withAPIKey: apiKey, appUserID: appUserID, observerMode: observerMode, userDefaults: nil)
     }
 
     @available(iOS, deprecated: 1, renamed: "configure(with:)")

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -954,7 +954,62 @@ public extension Purchases {
      */
     @objc(configureWithAPIKey:)
     @discardableResult static func configure(withAPIKey apiKey: String) -> Purchases {
-        configure(with: Configuration.builder(withAPIKey: apiKey).build())
+        Self.configure(withAPIKey: apiKey, appUserID: nil)
+    }
+
+    /**
+     * Configures an instance of the Purchases SDK with a specified API key and app user ID.
+     *
+     * The instance will be set as a singleton.
+     * You should access the singleton instance using ``Purchases/shared``
+     *
+     * - Note: Best practice is to use a salted hash of your unique app user ids.
+     *
+     * - Warning: Use this initializer if you have your own user identifiers that you manage.
+     *
+     * - Parameter apiKey: The API Key generated for your app from https://app.revenuecat.com/
+     *
+     * - Parameter appUserID: The unique app user id for this user. This user id will allow users to share their
+     * purchases and subscriptions across devices. Pass `nil` or an empty string if you want ``Purchases``
+     * to generate this for you.
+     *
+     * - Returns: An instantiated ``Purchases`` object that has been set as a singleton.
+     */
+    @objc(configureWithAPIKey:appUserID:)
+    @discardableResult static func configure(withAPIKey apiKey: String, appUserID: String?) -> Purchases {
+        Self.configure(withAPIKey: apiKey, appUserID: appUserID, observerMode: false)
+    }
+
+    /**
+     * Configures an instance of the Purchases SDK with a custom `UserDefaults`.
+     *
+     * Use this constructor if you want to
+     * sync status across a shared container, such as between a host app and an extension. The instance of the
+     * Purchases SDK will be set as a singleton.
+     * You should access the singleton instance using ``Purchases/shared``
+     *
+     * - Parameter apiKey: The API Key generated for your app from https://app.revenuecat.com/
+     *
+     * - Parameter appUserID: The unique app user id for this user. This user id will allow users to share their
+     * purchases and subscriptions across devices. Pass `nil` or an empty string if you want ``Purchases``
+     * to generate this for you.
+     *
+     * - Parameter observerMode: Set this to `true` if you have your own IAP implementation and want to use only
+     * RevenueCat's backend. Default is `false`.
+     *
+     * - Returns: An instantiated ``Purchases`` object that has been set as a singleton.
+     */
+    @objc(configureWithAPIKey:appUserID:observerMode:)
+    @discardableResult static func configure(withAPIKey apiKey: String,
+                                             appUserID: String?,
+                                             observerMode: Bool) -> Purchases {
+        Self.configure(
+            with: Configuration
+                .builder(withAPIKey: apiKey)
+                .with(appUserID: appUserID)
+                .with(observerMode: observerMode)
+                .build()
+        )
     }
 
     // swiftlint:disable:next function_parameter_count

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -16,7 +16,7 @@ import RevenueCat
 import StoreKit
 
 func checkPurchasesAPI() {
-    let purch = checkConfigure()
+    let purch = checkConfigure()!
 
     // initializers
     let finishTransactions: Bool = purch.finishTransactions
@@ -248,11 +248,19 @@ func checkNonAsyncMethods(_ purchases: Purchases) {
     #endif
 }
 
-private func checkConfigure() -> Purchases {
+private func checkConfigure() -> Purchases! {
     Purchases.configure(with: Configuration.Builder(withAPIKey: ""))
     Purchases.configure(with: Configuration.Builder(withAPIKey: "").build())
 
-    return Purchases.configure(withAPIKey: "")
+    Purchases.configure(withAPIKey: "")
+
+    Purchases.configure(withAPIKey: "", appUserID: nil)
+    Purchases.configure(withAPIKey: "", appUserID: "")
+
+    Purchases.configure(withAPIKey: "", appUserID: "", observerMode: false)
+    Purchases.configure(withAPIKey: "", appUserID: nil, observerMode: true)
+
+    return nil
 }
 
 @available(*, deprecated) // Ignore deprecation warnings
@@ -276,12 +284,6 @@ private func checkDeprecatedMethods(_ purchases: Purchases) {
     Purchases.automaticAppleSearchAdsAttributionCollection = false
 
     purchases.checkTrialOrIntroDiscountEligibility([String]()) { (_: [String: IntroEligibility]) in }
-
-    Purchases.configure(withAPIKey: "", appUserID: nil)
-    Purchases.configure(withAPIKey: "", appUserID: "")
-
-    Purchases.configure(withAPIKey: "", appUserID: "", observerMode: false)
-    Purchases.configure(withAPIKey: "", appUserID: nil, observerMode: true)
 
     Purchases.configure(withAPIKey: "", appUserID: "", observerMode: true, userDefaults: nil)
     Purchases.configure(withAPIKey: "", appUserID: nil, observerMode: true, userDefaults: nil)

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -61,17 +61,21 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expect(Purchases.shared) === purchases
     }
 
-    @available(*, deprecated) // Ignore deprecation warnings
     func testSharedInstanceIsSetWhenConfiguringWithAppUserID() {
         let purchases = Purchases.configure(withAPIKey: "", appUserID: "")
         expect(Purchases.shared) === purchases
     }
 
-    @available(*, deprecated) // Ignore deprecation warnings
     func testSharedInstanceIsSetWhenConfiguringWithObserverMode() {
         let purchases = Purchases.configure(withAPIKey: "", appUserID: "", observerMode: true)
         expect(Purchases.shared) === purchases
         expect(Purchases.shared.finishTransactions) == false
+    }
+
+    func testSharedInstanceIsSetWhenConfiguringWithObserverModeDisabled() {
+        let purchases = Purchases.configure(withAPIKey: "", appUserID: "", observerMode: false)
+        expect(Purchases.shared) === purchases
+        expect(Purchases.shared.finishTransactions) == true
     }
 
     @available(*, deprecated) // Ignore deprecation warnings


### PR DESCRIPTION
Fixes [CSDK-544].

This makes these 2 common configuration patterns a bit simpler than using `Configuration.Builder`.
I've also updated the docs in https://docs-origin.revenuecat.com/docs/configuring-sdk

The documentation is the same as the old one (see https://github.com/RevenueCat/purchases-ios/blob/5679b2b954c9bfda0d7bddb3e43cdd4dcc489519/Sources/Purchasing/Purchases.swift).

[CSDK-544]: https://revenuecats.atlassian.net/browse/CSDK-544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ