### PR TITLE
Extracted `asyncWait` to poll `async` conditions in tests

### DIFF
--- a/Sources/FoundationExtensions/DispatchTimeInterval+Extensions.swift
+++ b/Sources/FoundationExtensions/DispatchTimeInterval+Extensions.swift
@@ -16,6 +16,11 @@ import Foundation
 
 extension DispatchTimeInterval {
 
+    /// Creates a `DispatchTimeInterval` from a `TimeInterval` with millisecond precision.
+    init(_ timeInterval: TimeInterval) {
+        self = .milliseconds(Int(timeInterval * 1000))
+    }
+
     /// `DispatchTimeInterval` can only be used by specifying a unit of time.
     /// This allows us to easily convert any `DispatchTimeInterval` into nanoseconds.
     var nanoseconds: Int {
@@ -48,6 +53,15 @@ extension DispatchTimeInterval {
 
 func + (lhs: DispatchTimeInterval, rhs: DispatchTimeInterval) -> DispatchTimeInterval {
     return .nanoseconds(lhs.nanoseconds + rhs.nanoseconds)
+}
+
+extension DispatchTimeInterval: Comparable {
+
+    // swiftlint:disable:next missing_docs
+    public static func < (lhs: DispatchTimeInterval, rhs: DispatchTimeInterval) -> Bool {
+        return lhs.nanoseconds < rhs.nanoseconds
+    }
+
 }
 
 #if swift(<5.8)

--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitConfigTestCase+Extensions.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitConfigTestCase+Extensions.swift
@@ -70,31 +70,12 @@ extension StoreKitConfigTestCase {
     ) async {
         self.testSession.storefront = new
 
-        // Note: a better approach would be using `XCTestExpectation` and `self.wait(for:timeout:)`
-        // but it doesn't seem to play well with async-await.
-        // Also `toEventually` (Quick nor Nimble) don't support `async`.
-
-        var storefrontUpdateDetected: Bool {
-            get async { await Storefront.currentStorefront?.countryCode == new }
-        }
-
-        var numberOfChecksLeft = 10
-
-        repeat {
-            if await !storefrontUpdateDetected {
-                numberOfChecksLeft -= 1
-                try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
-            } else {
-                break
-            }
-        } while numberOfChecksLeft > 0
-
-        let detected = await storefrontUpdateDetected
-        expect(
-            file: file,
-            line: line,
-            detected
-        ).to(beTrue(), description: "Storefront change not detected")
+        await asyncWait(
+            until: { await Storefront.currentStorefront?.countryCode == new },
+            timeout: .seconds(1),
+            pollInterval: .milliseconds(100),
+            description: "Storefront change not detected"
+        )
     }
 
 }

--- a/Tests/UnitTests/Purchasing/ProductsFetcherSK1Tests.swift
+++ b/Tests/UnitTests/Purchasing/ProductsFetcherSK1Tests.swift
@@ -9,7 +9,7 @@ class ProductsFetcherSK1Tests: TestCase {
     var productsFetcherSK1: ProductsFetcherSK1!
 
     private static let defaultTimeout: TimeInterval = 2
-    private static let defaultTimeoutInterval = DispatchTimeInterval.milliseconds(Int(defaultTimeout * 1000))
+    private static let defaultTimeoutInterval: DispatchTimeInterval = .init(ProductsFetcherSK1Tests.defaultTimeout)
 
     override func setUp() {
         super.setUp()

--- a/Tests/UnitTests/TestHelpers/AsyncTestHelpers.swift
+++ b/Tests/UnitTests/TestHelpers/AsyncTestHelpers.swift
@@ -15,6 +15,8 @@ import Foundation
 
 import Nimble
 
+@testable import RevenueCat
+
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 internal extension AsyncSequence {
 
@@ -52,4 +54,40 @@ func waitUntilValue<Value>(
     }
 
     return value
+}
+
+/// Verifies that the given `async` condition becomes true after `timeout`,
+/// checking every `pollInterval`.
+// Note: a better approach would be using `XCTestExpectation` and `self.wait(for:timeout:)`
+// but it doesn't seem to play well with async-await.
+// Also `toEventually` (Quick nor Nimble) don't support `async`.
+// Fix-me: remove once we can use Quick v6.x:
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+func asyncWait(
+    until condition: @Sendable () async -> Bool,
+    timeout: DispatchTimeInterval,
+    pollInterval: DispatchTimeInterval,
+    description: String? = nil,
+    file: FileString = #fileID,
+    line: UInt = #line
+) async {
+    let start = Date()
+    var foundCorrectValue = false
+
+    func timedOut() -> Bool {
+        return DispatchTimeInterval(Date().timeIntervalSince(start)) > timeout
+    }
+
+    repeat {
+        foundCorrectValue = await condition()
+        if !foundCorrectValue {
+            try? await Task.sleep(nanoseconds: UInt64(pollInterval.nanoseconds))
+        }
+    } while !(foundCorrectValue || timedOut())
+
+    expect(
+        file: file,
+        line: line,
+        foundCorrectValue
+    ).to(beTrue(), description: description)
 }


### PR DESCRIPTION
This is necessary because we can't use `Quick` v6.x yet.

Abstracting this out to use it in #2069.