### PR TITLE
`CallbackCache`: avoid exposing internal mutable cache

### DIFF
--- a/Sources/Networking/Caching/CallbackCache.swift
+++ b/Sources/Networking/Caching/CallbackCache.swift
@@ -23,10 +23,12 @@ import Foundation
  */
 final class CallbackCache<T> where T: CacheKeyProviding {
 
-    let cachedCallbacksByKey: Atomic<[String: [T]]> = .init([:])
+    private let _cachedCallbacksByKey: Atomic<[String: [T]]> = .init([:])
+
+    var cachedCallbacksByKey: [String: [T]] { return self._cachedCallbacksByKey.value }
 
     func add(_ callback: T) -> CallbackCacheStatus {
-        return self.cachedCallbacksByKey.modify { cachedCallbacksByKey in
+        return self._cachedCallbacksByKey.modify { cachedCallbacksByKey in
             var values = cachedCallbacksByKey[callback.cacheKey] ?? []
             let cacheStatus: CallbackCacheStatus = !values.isEmpty ?
                 .addedToExistingInFlightList :
@@ -39,7 +41,7 @@ final class CallbackCache<T> where T: CacheKeyProviding {
     }
 
     func performOnAllItemsAndRemoveFromCache(withCacheable cacheable: CacheKeyProviding, _ block: (T) -> Void) {
-        self.cachedCallbacksByKey.modify { cachedCallbacksByKey in
+        self._cachedCallbacksByKey.modify { cachedCallbacksByKey in
             guard let items = cachedCallbacksByKey.removeValue(forKey: cacheable.cacheKey) else {
                 return
             }

--- a/Sources/Networking/Caching/CustomerInfoCallback.swift
+++ b/Sources/Networking/Caching/CustomerInfoCallback.swift
@@ -44,7 +44,6 @@ extension CallbackCache where T == CustomerInfoCallback {
     private func callbacks(ofType type: NetworkOperation.Type) -> [T] {
         return self
             .cachedCallbacksByKey
-            .value
             .lazy
             .flatMap(\.value)
             .filter { $0.source == type }


### PR DESCRIPTION
Small refactor to avoid users of this `class` change the content of the cache without using the methods.