### PR TITLE
`CallbackCache`: added assertion for tests to ensure we don't leak callbacks

### DIFF
--- a/Sources/Networking/Caching/CallbackCache.swift
+++ b/Sources/Networking/Caching/CallbackCache.swift
@@ -48,6 +48,17 @@ final class CallbackCache<T> where T: CacheKeyProviding {
         }
     }
 
+    deinit {
+        #if DEBUG
+        if ProcessInfo.isRunningRevenueCatTests {
+            precondition(
+                self.cachedCallbacksByKey.value.isEmpty,
+                "\(type(of: self)) was deallocated with callbacks still stored."
+            )
+        }
+        #endif
+    }
+
 }
 
 extension CallbackCache: Sendable where T: Sendable {}


### PR DESCRIPTION
See also #2135.
I'm looking into the leak in #2105, and I have a theory that it's due to callbacks being stored in this cache, but sometimes not being dequeued, so leaking all references in them.

This assertion will only run in RC tests, and will ensure that this doesn't happen.