### PR TITLE
`NetworkOperation`: added assertion to ensure that subclasses call completion

### DIFF
--- a/Sources/FoundationExtensions/OperationQueue+Extensions.swift
+++ b/Sources/FoundationExtensions/OperationQueue+Extensions.swift
@@ -15,12 +15,15 @@ import Foundation
 
 extension OperationQueue {
 
-    func addCacheableOperation(_ operation: CacheableNetworkOperation, cacheStatus: CallbackCacheStatus) {
+    final func addCacheableOperation<T: CacheableNetworkOperation>(
+        with factory: CacheableNetworkOperationFactory<T>,
+        cacheStatus: CallbackCacheStatus
+    ) {
         switch cacheStatus {
         case .firstCallbackAddedToList:
-            self.addOperation(operation)
+            self.addOperation(factory.create())
         case .addedToExistingInFlightList:
-            Logger.debug(Strings.network.reusing_existing_request_for_operation(operation))
+            Logger.debug(Strings.network.reusing_existing_request_for_operation(T.self, factory.cacheKey))
             return
         }
     }

--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -20,7 +20,7 @@ enum NetworkStrings {
     case api_request_started(HTTPRequest)
     case api_request_completed(_ request: HTTPRequest, httpCode: HTTPStatusCode)
     case api_request_failed(_ request: HTTPRequest, error: NetworkError)
-    case reusing_existing_request_for_operation(CacheableNetworkOperation)
+    case reusing_existing_request_for_operation(CacheableNetworkOperation.Type, String)
     case creating_json_error(error: String)
     case json_data_received(dataString: String)
     case parsing_json_error(error: Error)
@@ -48,9 +48,9 @@ extension NetworkStrings: CustomStringConvertible {
         case let .api_request_failed(request, error):
             return "API request failed: \(request.description): \(error.description)"
 
-        case let .reusing_existing_request_for_operation(operation):
-            return "Network operation '\(type(of: operation))' found with the same cache key " +
-            "'\(operation.individualizedCacheKeyPart.prefix(15))...'. Skipping request."
+        case let .reusing_existing_request_for_operation(operationType, cacheKey):
+            return "Network operation '\(operationType)' found with the same cache key " +
+            "'\(cacheKey.prefix(15))...'. Skipping request."
 
         case let .creating_json_error(error):
             return "Error creating request with body: \(error)"

--- a/Sources/Networking/BackendConfiguration.swift
+++ b/Sources/Networking/BackendConfiguration.swift
@@ -40,13 +40,13 @@ final class BackendConfiguration {
 extension BackendConfiguration {
 
     /// Adds the `operation` to the `OperationQueue` (based on `CallbackCacheStatus`) potentially adding a random delay.
-    func addCacheableOperation(
-        _ operation: CacheableNetworkOperation,
+    func addCacheableOperation<T: CacheableNetworkOperation>(
+        with factory: CacheableNetworkOperationFactory<T>,
         withRandomDelay randomDelay: Bool,
         cacheStatus: CallbackCacheStatus
     ) {
         self.operationDispatcher.dispatchOnWorkerThread(withRandomDelay: randomDelay) {
-            self.operationQueue.addCacheableOperation(operation, cacheStatus: cacheStatus)
+            self.operationQueue.addCacheableOperation(with: factory, cacheStatus: cacheStatus)
         }
     }
 

--- a/Sources/Networking/Caching/CustomerInfoCallback.swift
+++ b/Sources/Networking/Caching/CustomerInfoCallback.swift
@@ -21,9 +21,11 @@ struct CustomerInfoCallback: CacheKeyProviding {
     var source: NetworkOperation.Type
     var completion: Completion
 
-    init(operation: CacheableNetworkOperation, completion: @escaping Completion) {
-        self.cacheKey = operation.cacheKey
-        self.source = type(of: operation)
+    init<T: CacheableNetworkOperation>(cacheKey: String,
+                                       source: T.Type,
+                                       completion: @escaping Completion) {
+        self.cacheKey = cacheKey
+        self.source = T.self
         self.completion = completion
     }
 

--- a/Sources/Networking/CustomerAPI.swift
+++ b/Sources/Networking/CustomerAPI.swift
@@ -34,12 +34,14 @@ final class CustomerAPI {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
                                                                 appUserID: appUserID)
 
-        let operation = GetCustomerInfoOperation(configuration: config,
-                                                 customerInfoCallbackCache: self.customerInfoCallbackCache)
+        let factory = GetCustomerInfoOperation.createFactory(configuration: config,
+                                                             customerInfoCallbackCache: self.customerInfoCallbackCache)
 
-        let callback = CustomerInfoCallback(operation: operation, completion: completion)
+        let callback = CustomerInfoCallback(cacheKey: factory.cacheKey,
+                                            source: factory.operationType,
+                                            completion: completion)
         let cacheStatus = self.customerInfoCallbackCache.addOrAppendToPostReceiptDataOperation(callback: callback)
-        self.backendConfig.addCacheableOperation(operation,
+        self.backendConfig.addCacheableOperation(with: factory,
                                                  withRandomDelay: randomDelay,
                                                  cacheStatus: cacheStatus)
     }
@@ -107,15 +109,17 @@ final class CustomerAPI {
                                                          observerMode: observerMode,
                                                          initiationSource: initiationSource,
                                                          subscriberAttributesByKey: subscriberAttributesByKey)
-        let postReceiptOperation = PostReceiptDataOperation(configuration: config,
-                                                            postData: postData,
-                                                            customerInfoCallbackCache: self.customerInfoCallbackCache)
+        let factory = PostReceiptDataOperation.createFactory(configuration: config,
+                                                             postData: postData,
+                                                             customerInfoCallbackCache: self.customerInfoCallbackCache)
 
-        let callbackObject = CustomerInfoCallback(operation: postReceiptOperation, completion: completion)
+        let callbackObject = CustomerInfoCallback(cacheKey: factory.cacheKey,
+                                                  source: PostReceiptDataOperation.self,
+                                                  completion: completion)
 
         let cacheStatus = customerInfoCallbackCache.add(callbackObject)
 
-        self.backendConfig.operationQueue.addCacheableOperation(postReceiptOperation, cacheStatus: cacheStatus)
+        self.backendConfig.operationQueue.addCacheableOperation(with: factory, cacheStatus: cacheStatus)
     }
 
 }

--- a/Sources/Networking/IdentityAPI.swift
+++ b/Sources/Networking/IdentityAPI.swift
@@ -31,14 +31,14 @@ class IdentityAPI {
                completion: @escaping LogInResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
                                                                 appUserID: currentAppUserID)
-        let loginOperation = LogInOperation(configuration: config,
-                                            newAppUserID: newAppUserID,
-                                            loginCallbackCache: self.logInCallbacksCache)
+        let factory = LogInOperation.createFactory(configuration: config,
+                                                   newAppUserID: newAppUserID,
+                                                   loginCallbackCache: self.logInCallbacksCache)
 
-        let loginCallback = LogInCallback(cacheKey: loginOperation.cacheKey, completion: completion)
+        let loginCallback = LogInCallback(cacheKey: factory.cacheKey, completion: completion)
         let cacheStatus = self.logInCallbacksCache.add(loginCallback)
 
-        self.backendConfig.operationQueue.addCacheableOperation(loginOperation, cacheStatus: cacheStatus)
+        self.backendConfig.operationQueue.addCacheableOperation(with: factory, cacheStatus: cacheStatus)
     }
 
 }

--- a/Sources/Networking/OfferingsAPI.swift
+++ b/Sources/Networking/OfferingsAPI.swift
@@ -32,15 +32,19 @@ class OfferingsAPI {
                       completion: @escaping OfferingsResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
                                                                 appUserID: appUserID)
-        let getOfferingsOperation = GetOfferingsOperation(configuration: config,
-                                                          offeringsCallbackCache: self.offeringsCallbacksCache)
+        let factory = GetOfferingsOperation.createFactory(
+            configuration: config,
+            offeringsCallbackCache: self.offeringsCallbacksCache
+        )
 
-        let offeringsCallback = OfferingsCallback(cacheKey: getOfferingsOperation.cacheKey, completion: completion)
+        let offeringsCallback = OfferingsCallback(cacheKey: factory.cacheKey, completion: completion)
         let cacheStatus = self.offeringsCallbacksCache.add(offeringsCallback)
 
-        self.backendConfig.addCacheableOperation(getOfferingsOperation,
-                                                 withRandomDelay: randomDelay,
-                                                 cacheStatus: cacheStatus)
+        self.backendConfig.addCacheableOperation(
+            with: factory,
+            withRandomDelay: randomDelay,
+            cacheStatus: cacheStatus
+        )
     }
 
     func getIntroEligibility(appUserID: String,

--- a/Sources/Networking/Operations/GetCustomerInfoOperation.swift
+++ b/Sources/Networking/Operations/GetCustomerInfoOperation.swift
@@ -13,21 +13,38 @@
 
 import Foundation
 
-class GetCustomerInfoOperation: CacheableNetworkOperation {
+final class GetCustomerInfoOperation: CacheableNetworkOperation {
 
     private let customerInfoResponseHandler: CustomerInfoResponseHandler
     private let customerInfoCallbackCache: CallbackCache<CustomerInfoCallback>
     private let configuration: UserSpecificConfiguration
 
-    init(configuration: UserSpecificConfiguration,
-         customerInfoResponseHandler: CustomerInfoResponseHandler = CustomerInfoResponseHandler(),
-         customerInfoCallbackCache: CallbackCache<CustomerInfoCallback>) {
+    static func createFactory(
+        configuration: UserSpecificConfiguration,
+        customerInfoResponseHandler: CustomerInfoResponseHandler = CustomerInfoResponseHandler(),
+        customerInfoCallbackCache: CallbackCache<CustomerInfoCallback>
+    ) -> CacheableNetworkOperationFactory<GetCustomerInfoOperation> {
+        return .init({
+            .init(configuration: configuration,
+                  customerInfoResponseHandler: customerInfoResponseHandler,
+                  customerInfoCallbackCache: customerInfoCallbackCache,
+                  cacheKey: $0) },
+            individualizedCacheKeyPart: configuration.appUserID
+        )
+    }
+
+    private init(
+        configuration: UserSpecificConfiguration,
+        customerInfoResponseHandler: CustomerInfoResponseHandler,
+        customerInfoCallbackCache: CallbackCache<CustomerInfoCallback>,
+        cacheKey: String
+    ) {
         self.configuration = configuration
         self.customerInfoResponseHandler = customerInfoResponseHandler
         self.customerInfoCallbackCache = customerInfoCallbackCache
 
         super.init(configuration: configuration,
-                   individualizedCacheKeyPart: configuration.appUserID)
+                   cacheKey: cacheKey)
     }
 
     override func begin(completion: @escaping () -> Void) {

--- a/Sources/Networking/Operations/GetOfferingsOperation.swift
+++ b/Sources/Networking/Operations/GetOfferingsOperation.swift
@@ -13,17 +13,32 @@
 
 import Foundation
 
-class GetOfferingsOperation: CacheableNetworkOperation {
+final class GetOfferingsOperation: CacheableNetworkOperation {
 
     private let offeringsCallbackCache: CallbackCache<OfferingsCallback>
     private let configuration: AppUserConfiguration
 
-    init(configuration: UserSpecificConfiguration,
-         offeringsCallbackCache: CallbackCache<OfferingsCallback>) {
+    static func createFactory(
+        configuration: UserSpecificConfiguration,
+        offeringsCallbackCache: CallbackCache<OfferingsCallback>
+    ) -> CacheableNetworkOperationFactory<GetOfferingsOperation> {
+        return .init({ cacheKey in
+                    .init(
+                        configuration: configuration,
+                        offeringsCallbackCache: offeringsCallbackCache,
+                        cacheKey: cacheKey
+                    )
+            },
+            individualizedCacheKeyPart: configuration.appUserID)
+    }
+
+    private init(configuration: UserSpecificConfiguration,
+                 offeringsCallbackCache: CallbackCache<OfferingsCallback>,
+                 cacheKey: String) {
         self.configuration = configuration
         self.offeringsCallbackCache = offeringsCallbackCache
 
-        super.init(configuration: configuration, individualizedCacheKeyPart: configuration.appUserID)
+        super.init(configuration: configuration, cacheKey: cacheKey)
     }
 
     override func begin(completion: @escaping () -> Void) {

--- a/Sources/Networking/Operations/LogInOperation.swift
+++ b/Sources/Networking/Operations/LogInOperation.swift
@@ -13,20 +13,38 @@
 
 import Foundation
 
-class LogInOperation: CacheableNetworkOperation {
+final class LogInOperation: CacheableNetworkOperation {
 
     private let loginCallbackCache: CallbackCache<LogInCallback>
     private let configuration: UserSpecificConfiguration
     private let newAppUserID: String
 
-    init(configuration: UserSpecificConfiguration,
-         newAppUserID: String,
-         loginCallbackCache: CallbackCache<LogInCallback>) {
+    static func createFactory(
+        configuration: UserSpecificConfiguration,
+        newAppUserID: String,
+        loginCallbackCache: CallbackCache<LogInCallback>
+    ) -> CacheableNetworkOperationFactory<LogInOperation> {
+        return .init({
+            .init(
+                configuration: configuration,
+                newAppUserID: newAppUserID,
+                loginCallbackCache: loginCallbackCache,
+                cacheKey: $0
+            ) },
+                     individualizedCacheKeyPart: configuration.appUserID + newAppUserID)
+    }
+
+    private init(
+        configuration: UserSpecificConfiguration,
+        newAppUserID: String,
+        loginCallbackCache: CallbackCache<LogInCallback>,
+        cacheKey: String
+    ) {
         self.configuration = configuration
         self.newAppUserID = newAppUserID
         self.loginCallbackCache = loginCallbackCache
 
-        super.init(configuration: configuration, individualizedCacheKeyPart: configuration.appUserID + newAppUserID)
+        super.init(configuration: configuration, cacheKey: cacheKey)
     }
 
     override func begin(completion: @escaping () -> Void) {


### PR DESCRIPTION
Looking into the leak in #2135, I realized that we have an operation which doesn't call `completion`, we would be leaking the completion block in the cache.
This ensures that it doesn't happen in tests. In production, we won't risk crashing.