### PR TITLE
`ReceiptFetcher`: throttle receipt refreshing to avoid `StoreKit` throttle errors

### DIFF
--- a/Sources/FoundationExtensions/DispatchTimeInterval+Extensions.swift
+++ b/Sources/FoundationExtensions/DispatchTimeInterval+Extensions.swift
@@ -55,6 +55,10 @@ func + (lhs: DispatchTimeInterval, rhs: DispatchTimeInterval) -> DispatchTimeInt
     return .nanoseconds(lhs.nanoseconds + rhs.nanoseconds)
 }
 
+func - (lhs: DispatchTimeInterval, rhs: DispatchTimeInterval) -> DispatchTimeInterval {
+    return .nanoseconds(lhs.nanoseconds - rhs.nanoseconds)
+}
+
 extension DispatchTimeInterval: Comparable {
 
     // swiftlint:disable:next missing_docs

--- a/Sources/Logging/Strings/ReceiptStrings.swift
+++ b/Sources/Logging/Strings/ReceiptStrings.swift
@@ -19,6 +19,7 @@ enum ReceiptStrings {
 
     case data_object_identifer_not_found_receipt
     case force_refreshing_receipt
+    case throttling_force_refreshing_receipt
     case loaded_receipt(url: URL)
     case no_sandbox_receipt_intro_eligibility
     case no_sandbox_receipt_restore
@@ -50,6 +51,9 @@ extension ReceiptStrings: CustomStringConvertible {
 
         case .force_refreshing_receipt:
             return "Force refreshing the receipt to get latest transactions from Apple."
+
+        case .throttling_force_refreshing_receipt:
+            return "Throttled request to refresh receipt."
 
         case .loaded_receipt(let url):
             return "Loaded receipt from url \(url.absoluteString)"

--- a/Sources/Purchasing/ReceiptRefreshPolicy.swift
+++ b/Sources/Purchasing/ReceiptRefreshPolicy.swift
@@ -26,4 +26,14 @@ enum ReceiptRefreshPolicy {
 
 }
 
+extension ReceiptRefreshPolicy {
+
+    /// See `ReceiptFetcher`.
+    /// `ReceiptRefreshPolicy.always` won't refresh receipts faster than this interval
+    /// to avoid StoreKit errors:
+    /// "Finished refreshing receipt with error: Error Domain=ASDErrorDomain Code=603 "Request throttled"
+    static let alwaysRefreshThrottleDuration: DispatchTimeInterval = .seconds(2)
+
+}
+
 extension ReceiptRefreshPolicy: Equatable {}


### PR DESCRIPTION
Fixes #2116.

Depends on #2134, #2144, #2145.

We've known that, especially for sandbox accounts with lots of purchases, the SDK can get flooded with a lot of transactions to process at once.
I've been making some improvements for this (like #2115).

Another consequence of this behavior, is that we can end up failing due to `StoreKit` throttling us (see #2116):

> 2022-12-03 12:31:58.670892+0100 app[673:61074] <SKReceiptRefreshRequest: 0x283edc860>: Finished refreshing receipt with error: Error Domain=ASDErrorDomain Code=603 "Request throttled" UserInfo={NSLocalizedFailureReason=Unified receipt is valid and current, NSLocalizedDescription=Request throttled, AMSServerErrorCode=0}

This change avoids that by skipping the refresh if less than 2 seconds have elapsed. I chose 2 to make this a low-ish risk change, with a huge benefit for multiple semi-concurrent requests coming from a big transaction queue.