### PR TITLE
`CI`: fixed `PurchaseTester` deployment

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,6 +35,10 @@ platform :ios do
   before_all do
     setup_circle_ci
     update_fastlane
+
+    if ENV['APP_STORE_CONNECT_API_KEY_ISSUER_ID']
+      app_store_connect_api_key # This will create a shared client that all the tools know how to use and will look for
+    end
   end
 
   desc "Bump version, update swift header, edit changelog, and create pull request"


### PR DESCRIPTION
Fixes [CSDK-527].

Thanks to @joshdholtz for the help.

Configured CircleCI environment variables to use an ASC API Key:
```
APP_STORE_CONNECT_API_KEY_ISSUER_ID=
APP_STORE_CONNECT_API_KEY_KEY_ID=
APP_STORE_CONNECT_API_KEY_KEY=
APP_STORE_CONNECT_API_KEY_IS_KEY_CONTENT_BASE64=true
```

[CSDK-527]: https://revenuecats.atlassian.net/browse/CSDK-527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ