### PR TITLE
Fixed race condition finishing `SK1` transactions

### DIFF
--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -184,7 +184,7 @@ extension PurchaseStrings: CustomStringConvertible {
 
         case .sktransaction_missing_transaction_identifier:
             return "There is a problem with the SKPaymentTransaction missing " +
-            "a transaction identifier - this is an issue with the App Store." +
+            "a transaction identifier - this is an issue with the App Store. " +
             "Transactions in the backend and in webhooks are unaffected and will have the correct identifier. " +
             "This is a bug in StoreKit 1. To prevent running into this issue on devices running " +
             "iOS 15+, watchOS 8+, macOS 12+, and tvOS 15+, make sure " +

--- a/Sources/Purchasing/StoreKit1/PaymentQueueWrapper.swift
+++ b/Sources/Purchasing/StoreKit1/PaymentQueueWrapper.swift
@@ -31,7 +31,7 @@ protocol PaymentQueueWrapperDelegate: AnyObject, Sendable {
 @objc
 protocol PaymentQueueWrapperType: AnyObject {
 
-    func finishTransaction(_ transaction: SKPaymentTransaction)
+    func finishTransaction(_ transaction: SKPaymentTransaction, completion: @escaping () -> Void)
 
     #if os(iOS) || targetEnvironment(macCatalyst)
     @available(iOS 13.4, macCatalyst 13.4, *)
@@ -77,8 +77,14 @@ class PaymentQueueWrapper: NSObject, PaymentQueueWrapperType {
         super.init()
     }
 
-    func finishTransaction(_ transaction: SKPaymentTransaction) {
+    func finishTransaction(_ transaction: SKPaymentTransaction, completion: @escaping () -> Void) {
+        // See `StoreKit1Wrapper.finishTransaction(:completion:)`.
+        // Technically this is a race condition, because `SKPaymentQueue.finishTransaction` is asynchronous
+        // In practice this method won't be used, because this class is only used in SK2 mode,
+        // and those transactions are finished through `SK2StoreTransaction`.
+
         self.paymentQueue.finishTransaction(transaction)
+        completion()
     }
 
     #if os(iOS) || targetEnvironment(macCatalyst)

--- a/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
@@ -60,6 +60,8 @@ class StoreKit1Wrapper: NSObject {
         }
     }
 
+    private let finishedTransactionCallbacks: Atomic<[SKPaymentTransaction: [() -> Void]]> = .init([:])
+
     private let paymentQueue: SKPaymentQueue
     private let operationDispatcher: OperationDispatcher
 
@@ -108,8 +110,18 @@ class StoreKit1Wrapper: NSObject {
 extension StoreKit1Wrapper: PaymentQueueWrapperType {
 
     @objc
-    func finishTransaction(_ transaction: SKPaymentTransaction) {
-        self.paymentQueue.finishTransaction(transaction)
+    func finishTransaction(_ transaction: SKPaymentTransaction, completion: @escaping () -> Void) {
+        let existingCompletion: Bool = self.finishedTransactionCallbacks.modify { callbacks in
+            let existingCompletion = callbacks[transaction] != nil
+
+            callbacks[transaction, default: []].append(completion)
+
+            return existingCompletion
+        }
+
+        if !existingCompletion {
+            self.paymentQueue.finishTransaction(transaction)
+        }
     }
 
     #if os(iOS) || targetEnvironment(macCatalyst)
@@ -149,6 +161,10 @@ extension StoreKit1Wrapper: SKPaymentTransactionObserver {
             for transaction in transactions {
                 Logger.debug(Strings.purchase.paymentqueue_removed_transaction(self, transaction))
                 delegate.storeKit1Wrapper(self, removedTransaction: transaction)
+
+                if let callbacks = self.finishedTransactionCallbacks.value.removeValue(forKey: transaction) {
+                    callbacks.forEach { $0() }
+                }
             }
         }
     }

--- a/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
@@ -32,8 +32,7 @@ internal struct SK1StoreTransaction: StoreTransactionType {
     let quantity: Int
 
     func finish(_ wrapper: PaymentQueueWrapperType, completion: @escaping @Sendable () -> Void) {
-        wrapper.finishTransaction(self.underlyingSK1Transaction)
-        completion()
+        wrapper.finishTransaction(self.underlyingSK1Transaction, completion: completion)
     }
 
 }

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -81,9 +81,6 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
     }
 
     func testCanPurchaseConsumableMultipleTimes() async throws {
-        // See https://revenuecats.atlassian.net/browse/TRIAGE-134
-        try XCTSkipIf(Self.storeKit2Setting == .disabled, "This test is not currently passing on SK1")
-
         let count = 2
 
         for _ in 0..<count {
@@ -92,10 +89,8 @@ class StoreKit1IntegrationTests: BaseBackendIntegrationTests {
 
         let info = try await Purchases.shared.customerInfo()
         expect(info.nonSubscriptions).to(haveCount(count))
-        expect(info.nonSubscriptions.map(\.productIdentifier)) == [
-            Self.consumable10Coins,
-            Self.consumable10Coins
-        ]
+        expect(info.nonSubscriptions.map(\.productIdentifier)) == Array(repeating: Self.consumable10Coins,
+                                                                        count: count)
     }
 
     func testCanPurchaseConsumableWithMultipleUsers() async throws {

--- a/Tests/UnitTests/Mocks/MockStoreKit1Wrapper.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit1Wrapper.swift
@@ -28,9 +28,11 @@ class MockStoreKit1Wrapper: StoreKit1Wrapper {
     var finishCalled = false
     var finishProductIdentifier: String?
 
-    override func finishTransaction(_ transaction: SKPaymentTransaction) {
+    override func finishTransaction(_ transaction: SKPaymentTransaction, completion: @escaping () -> Void) {
         self.finishCalled = true
         self.finishProductIdentifier = transaction.productIdentifier
+
+        completion()
     }
 
     weak var mockDelegate: StoreKit1WrapperDelegate?

--- a/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
@@ -146,17 +146,53 @@ class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
     }
 
     func testFinishesTransactions() {
-        let payment = SKPayment.init(product: SK1Product())
-        wrapper?.add(payment)
+        let payment = SKPayment(product: SK1Product())
+        self.wrapper.add(payment)
 
-        let transaction = MockTransaction()
-        transaction.mockPayment = payment
+        let transaction = Self.transaction(with: payment)
 
-        wrapper?.paymentQueue(paymentQueue, updatedTransactions: [transaction])
+        self.wrapper.paymentQueue(self.paymentQueue, updatedTransactions: [transaction])
 
-        wrapper?.finishTransaction(transaction)
+        waitUntil { completion in
+            self.wrapper.finishTransaction(transaction, completion: completion)
+
+            // `SKPaymentQueue.finishTransaction` is asynchronous, and this is how
+            // it notifies of finished transactions.
+            self.wrapper.paymentQueue(self.paymentQueue, removedTransactions: [transaction])
+        }
 
         expect(self.paymentQueue.finishedTransactions).to(contain(transaction))
+    }
+
+    func testFinishesTransactionOnlyOnceWhenRequestedMultipleTimesConcurrently() {
+        let payment = SKPayment(product: SK1Product())
+        self.wrapper.add(payment)
+
+        let transaction = Self.transaction(with: payment)
+
+        self.wrapper.paymentQueue(self.paymentQueue, updatedTransactions: [transaction])
+
+        var firstTransactionCompletionBlockedInvoked = false
+
+        // 1. Finish transaction
+        self.wrapper.finishTransaction(transaction) {
+            firstTransactionCompletionBlockedInvoked = true
+        }
+
+        waitUntil { completion in
+            // 2. Finish transaction again
+            self.wrapper.finishTransaction(transaction, completion: completion)
+
+            // 3. Notify of removed transaction
+            self.wrapper.paymentQueue(self.paymentQueue, removedTransactions: [transaction])
+        }
+
+        // 4. Verify transaction is only finished once
+        expect(self.paymentQueue.finishedTransactions).to(haveCount(1))
+        expect(self.paymentQueue.finishedTransactions).to(contain(transaction))
+
+        // 5. But both callbacks were invoked
+        expect(firstTransactionCompletionBlockedInvoked) == true
     }
 
     func testCallsRemovedTransactionDelegateMethod() {


### PR DESCRIPTION
Fixes [CSDK-504].

`SKPaymentQueue.finishTransaction` is asynchronous, but we were assuming it wasn't.
This meant that when performing multiple purchases (like consumables) in quick succession, before the first transaction was finished, the second purchase was reusing the first transaction.

Example log:
```
[Purchases] - INFO: :moneybag: Finishing transaction ‘0’ for product ‘consumable.10_coins’
[Purchases] - INFO: :heart_eyes_cat::moneybag: Purchased product - ‘consumable.10_coins’
[Purchases] - INFO: :moneybag: Purchasing Product ‘consumable.10_coins’ from package in Offering ‘coins’
[Purchases] - DEBUG: :information_source: StoreKit1Wrapper (0x00006000008a9530) removedTransaction: consumable.10_coins 0 1
```

Notice how the "removed transaction" was notified _after_ we had already started the second purchase.

See also #2148 for an earlier fix for finishing transactions.

[CSDK-504]: https://revenuecats.atlassian.net/browse/CSDK-504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ