### PR TITLE
`StoreKitRequestFetcher`: removed unnecessary dispatch

### DIFF
--- a/Sources/Purchasing/StoreKit1/StoreKitRequestFetcher.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKitRequestFetcher.swift
@@ -90,11 +90,9 @@ private extension StoreKitRequestFetcher {
             let completionHandlers = self.receiptRefreshCompletionHandlers
             self.receiptRefreshCompletionHandlers = []
 
-            self.operationDispatcher.dispatchOnWorkerThread {
-                for handler in completionHandlers {
-                    self.operationDispatcher.dispatchOnMainActor {
-                        handler()
-                    }
+            for handler in completionHandlers {
+                self.operationDispatcher.dispatchOnMainActor {
+                    handler()
                 }
             }
         }

--- a/Tests/UnitTests/Purchasing/StoreKitRequestFetcherTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKitRequestFetcherTests.swift
@@ -15,62 +15,13 @@ import XCTest
 @MainActor
 class StoreKitRequestFetcherTests: TestCase {
 
-    final class MockReceiptRequest: SKReceiptRefreshRequest {
-        // swiftlint:disable:next nesting
-        enum Error: Swift.Error {
-            case unknown
-        }
+    private var fetcher: StoreKitRequestFetcher!
+    private var factory: MockRequestsFactory!
+    private var operationDispatcher = MockOperationDispatcher()
+    private var receiptFetched = false
+    private var receiptFetchedCallbackCount = 0
 
-        private let _startCalled: Atomic<Bool> = false
-        private let _fails: Atomic<Bool> = false
-
-        var startCalled: Bool {
-            get { self._startCalled.value }
-            set { self._startCalled.value = newValue }
-        }
-
-        var fails: Bool {
-            get { self._fails.value }
-            set { self._fails.value = newValue }
-        }
-
-        override func start() {
-            self.startCalled = true
-
-            DispatchQueue.main.async {
-                if self.fails {
-                    self.delegate?.request!(self, didFailWithError: Error.unknown)
-                } else {
-                    self.delegate?.requestDidFinish!(self)
-                }
-            }
-        }
-    }
-
-    class MockRequestsFactory: ReceiptRefreshRequestFactory {
-        let fails: Bool
-
-        init(fails: Bool) {
-            self.fails = fails
-        }
-
-        var requests: [SKRequest] = []
-
-        override func receiptRefreshRequest() -> SKReceiptRefreshRequest {
-            let request = MockReceiptRequest()
-            requests.append(request)
-            request.fails = self.fails
-            return request
-        }
-    }
-
-    var fetcher: StoreKitRequestFetcher!
-    var factory: MockRequestsFactory!
-    var operationDispatcher = MockOperationDispatcher()
-    var receiptFetched = false
-    var receiptFetchedCallbackCount = 0
-
-    func setupFetcher(fails: Bool) {
+    private func setupFetcher(fails: Bool) {
         self.operationDispatcher = MockOperationDispatcher()
         self.factory = MockRequestsFactory(fails: fails)
         self.fetcher = StoreKitRequestFetcher(requestFactory: self.factory, operationDispatcher: operationDispatcher)
@@ -91,12 +42,12 @@ class StoreKitRequestFetcherTests: TestCase {
 
     func testCreatesARequest() {
         self.setupFetcher(fails: false)
-        expect(self.factory!.requests.count).toEventually(equal(1))
+        expect(self.factory.requests.count).toEventually(equal(1))
     }
 
     func testSetsTheRequestDelegate() {
         self.setupFetcher(fails: false)
-        expect(self.factory!.requests[0].delegate).toEventually(be(self.fetcher), timeout: .seconds(1))
+        expect(self.factory.requests[0].delegate).toEventually(be(self.fetcher), timeout: .seconds(1))
     }
 
     func testCallsStartOnRequest() throws {
@@ -127,13 +78,10 @@ class StoreKitRequestFetcherTests: TestCase {
     func testFetchesReceiptMultipleTimes() {
         setupFetcher(fails: false)
         expect(self.receiptFetched).toEventually(beTrue())
-        var fetchedAgain = false
 
-        self.fetcher.fetchReceiptData {
-            fetchedAgain = true
+        waitUntil { completion in
+            self.fetcher.fetchReceiptData { completion() }
         }
-
-        expect(fetchedAgain).toEventually(beTrue())
 
         expect(self.factory.requests).to(haveCount(2))
     }
@@ -143,3 +91,61 @@ class StoreKitRequestFetcherTests: TestCase {
 // `@unchecked` because:
 // - It inherits `SKReceiptRefreshRequest`, which may not be `Sendable`
 extension StoreKitRequestFetcherTests.MockReceiptRequest: @unchecked Sendable {}
+
+// MARK: - Private
+
+private extension StoreKitRequestFetcherTests {
+
+    final class MockReceiptRequest: SKReceiptRefreshRequest {
+
+        // swiftlint:disable:next nesting
+        enum Error: Swift.Error {
+            case unknown
+        }
+
+        private let _startCalled: Atomic<Bool> = false
+        private let _fails: Atomic<Bool> = false
+
+        var startCalled: Bool {
+            get { self._startCalled.value }
+            set { self._startCalled.value = newValue }
+        }
+
+        var fails: Bool {
+            get { self._fails.value }
+            set { self._fails.value = newValue }
+        }
+
+        override func start() {
+            self.startCalled = true
+
+            DispatchQueue.main.async {
+                if self.fails {
+                    self.delegate?.request!(self, didFailWithError: Error.unknown)
+                } else {
+                    self.delegate?.requestDidFinish!(self)
+                }
+            }
+        }
+
+    }
+
+    final class MockRequestsFactory: ReceiptRefreshRequestFactory {
+
+        private let fails: Bool
+
+        init(fails: Bool) {
+            self.fails = fails
+        }
+
+        var requests: [SKRequest] = []
+
+        override func receiptRefreshRequest() -> SKReceiptRefreshRequest {
+            let request = MockReceiptRequest()
+            requests.append(request)
+            request.fails = self.fails
+            return request
+        }
+    }
+
+}


### PR DESCRIPTION
`finishReceiptRequest` is already running on the worker thread, so there's no need for the double dispatch.

Also refactored tests.