### PR TITLE
Fix sending presentedOfferingIdentifier in StoreKit2

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1105,7 +1105,7 @@ private extension PurchasesOrchestrator {
     }
 
     func cachePresentedOfferingIdentifier(package: Package?, productIdentifier: String) {
-        if let package {
+        if let package = package {
             self.presentedOfferingIDsByProductID.modify { $0[productIdentifier] = package.offeringIdentifier }
         }
     }

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -431,14 +431,18 @@ final class PurchasesOrchestrator {
                     var options: Set<Product.PurchaseOption> = [
                         .simulatesAskToBuyInSandbox(Purchases.simulatesAskToBuyInSandbox)
                     ]
+
                     let productIdentifier = sk2Product.id
+
                     if let signedData = promotionalOffer {
                         Logger.debug(
                             Strings.storeKit.sk2_purchasing_added_promotional_offer_option(signedData.identifier)
                         )
                         options.insert(try signedData.sk2PurchaseOption)
                     }
+
                     cachePresentedOfferingIdentifier(package: package, productIdentifier: productIdentifier)
+
                     return try await sk2Product.purchase(options: options)
                 }
         } catch StoreKitError.userCancelled {

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -350,7 +350,7 @@ final class PurchasesOrchestrator {
         payment.applicationUsername = self.appUserID
         self.preventPurchasePopupCallFromTriggeringCacheRefresh(appUserID: self.appUserID)
 
-        cachePresentedOfferingIdentifier(package: package, productIdentifier: productIdentifier)
+        self.cachePresentedOfferingIdentifier(package: package, productIdentifier: productIdentifier)
 
         self.productsManager.cache(StoreProduct(sk1Product: sk1Product))
 
@@ -432,8 +432,6 @@ final class PurchasesOrchestrator {
                         .simulatesAskToBuyInSandbox(Purchases.simulatesAskToBuyInSandbox)
                     ]
 
-                    let productIdentifier = sk2Product.id
-
                     if let signedData = promotionalOffer {
                         Logger.debug(
                             Strings.storeKit.sk2_purchasing_added_promotional_offer_option(signedData.identifier)
@@ -441,7 +439,7 @@ final class PurchasesOrchestrator {
                         options.insert(try signedData.sk2PurchaseOption)
                     }
 
-                    cachePresentedOfferingIdentifier(package: package, productIdentifier: productIdentifier)
+                    self.cachePresentedOfferingIdentifier(package: package, productIdentifier: sk2Product.id)
 
                     return try await sk2Product.purchase(options: options)
                 }

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -267,6 +267,7 @@ final class PurchasesOrchestrator {
         } else if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *),
                   let sk2Product = product.sk2Product {
             self.purchase(sk2Product: sk2Product,
+                          package: package,
                           promotionalOffer: nil,
                           completion: completion)
         } else {
@@ -292,6 +293,7 @@ final class PurchasesOrchestrator {
         } else if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *),
                   let sk2Product = product.sk2Product {
             self.purchase(sk2Product: sk2Product,
+                          package: package,
                           promotionalOffer: promotionalOffer,
                           completion: completion)
         } else {
@@ -348,10 +350,7 @@ final class PurchasesOrchestrator {
         payment.applicationUsername = self.appUserID
         self.preventPurchasePopupCallFromTriggeringCacheRefresh(appUserID: self.appUserID)
 
-        if let presentedOfferingIdentifier = package?.offeringIdentifier {
-            self.presentedOfferingIDsByProductID.modify { $0[productIdentifier] = presentedOfferingIdentifier }
-
-        }
+        cachePresentedOfferingIdentifier(package: package, productIdentifier: productIdentifier)
 
         self.productsManager.cache(StoreProduct(sk1Product: sk1Product))
 
@@ -382,11 +381,13 @@ final class PurchasesOrchestrator {
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func purchase(sk2Product product: SK2Product,
+                  package: Package?,
                   promotionalOffer: PromotionalOffer.SignedData?,
                   completion: @escaping PurchaseCompletedBlock) {
         _ = Task<Void, Never> {
             do {
                 let result: PurchaseResultData = try await self.purchase(sk2Product: product,
+                                                                         package: package,
                                                                          promotionalOffer: promotionalOffer)
 
                 if !result.userCancelled {
@@ -418,6 +419,7 @@ final class PurchasesOrchestrator {
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func purchase(
         sk2Product: SK2Product,
+        package: Package?,
         promotionalOffer: PromotionalOffer.SignedData?
     ) async throws -> PurchaseResultData {
         let result: Product.PurchaseResult
@@ -429,14 +431,14 @@ final class PurchasesOrchestrator {
                     var options: Set<Product.PurchaseOption> = [
                         .simulatesAskToBuyInSandbox(Purchases.simulatesAskToBuyInSandbox)
                     ]
-
+                    let productIdentifier = sk2Product.id
                     if let signedData = promotionalOffer {
                         Logger.debug(
                             Strings.storeKit.sk2_purchasing_added_promotional_offer_option(signedData.identifier)
                         )
                         options.insert(try signedData.sk2PurchaseOption)
                     }
-
+                    cachePresentedOfferingIdentifier(package: package, productIdentifier: productIdentifier)
                     return try await sk2Product.purchase(options: options)
                 }
         } catch StoreKitError.userCancelled {
@@ -1098,6 +1100,11 @@ private extension PurchasesOrchestrator {
         transaction.finish(self.paymentQueueWrapper.paymentQueueWrapperType, completion: complete)
     }
 
+    func cachePresentedOfferingIdentifier(package: Package?, productIdentifier: String) {
+        if let package {
+            self.presentedOfferingIDsByProductID.modify { $0[productIdentifier] = package.offeringIdentifier }
+        }
+    }
 }
 
 private extension PurchasesOrchestrator {

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -343,11 +343,11 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         let package = Package(identifier: "package",
                               packageType: .monthly,
-                              storeProduct: product,
+                              storeProduct: StoreProduct(sk2Product: product),
                               offeringIdentifier: "offering")
 
         let (transaction, customerInfo, userCancelled) = try await orchestrator.purchase(sk2Product: product,
-                                                                                         package: package
+                                                                                         package: package,
                                                                                          promotionalOffer: nil)
 
         expect(transaction?.sk2Transaction) == mockTransaction
@@ -400,7 +400,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         let product = try await fetchSk2Product()
 
-        _ = try await orchestrator.purchase(sk2Product: product, promotionalOffer: nil)
+        _ = try await orchestrator.purchase(sk2Product: product, package: nil, promotionalOffer: nil)
 
         expect(self.receiptFetcher.receiptDataCalled) == true
         expect(self.receiptFetcher.receiptDataReceivedRefreshPolicy) == .always
@@ -424,7 +424,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         let package = Package(identifier: "package",
                               packageType: .monthly,
-                              storeProduct: product,
+                              storeProduct: StoreProduct(sk2Product: product),
                               offeringIdentifier: "offering")
 
         _ = try await orchestrator.purchase(sk2Product: product, package: package, promotionalOffer: nil)
@@ -463,7 +463,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         let product = try await self.fetchSk2Product()
 
-        _ = try await orchestrator.purchase(sk2Product: product, promotionalOffer: nil)
+        _ = try await orchestrator.purchase(sk2Product: product, package: nil, promotionalOffer: nil)
 
         expect(self.receiptFetcher.receiptDataCalled) == true
         expect(self.receiptFetcher.receiptDataReceivedRefreshPolicy) == .retryUntilProductIsFound(
@@ -492,7 +492,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                                                 timestamp: 0)
 
         do {
-            _ = try await orchestrator.purchase(sk2Product: product, promotionalOffer: offer)
+            _ = try await orchestrator.purchase(sk2Product: product, package: nil, promotionalOffer: offer)
             XCTFail("Expected error")
         } catch {
             expect(self.backend.invokedPostReceiptData) == false
@@ -521,7 +521,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         )
 
         do {
-            _ = try await orchestrator.purchase(sk2Product: product, promotionalOffer: offer)
+            _ = try await orchestrator.purchase(sk2Product: product, package: nil, promotionalOffer: offer)
             XCTFail("Expected error")
         } catch {
             expect(error).to(matchError(ErrorCode.invalidPromotionalOfferError))
@@ -539,6 +539,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         let product = try await self.fetchSk2Product()
 
         let (transaction, customerInfo, cancelled) = try await self.orchestrator.purchase(sk2Product: product,
+                                                                                          package: nil,
                                                                                           promotionalOffer: nil)
 
         expect(transaction).to(beNil())
@@ -560,7 +561,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         mockListener.mockTransaction.value = try await self.createTransactionWithPurchase()
 
         do {
-            _ = try await self.orchestrator.purchase(sk2Product: product, promotionalOffer: nil)
+            _ = try await self.orchestrator.purchase(sk2Product: product, package: nil, promotionalOffer: nil)
 
             XCTFail("Expected error")
         } catch {

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -192,7 +192,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         expect(self.backend.invokedPostReceiptDataCount) == 1
         expect(self.backend.invokedPostReceiptDataParameters?.productData).toNot(beNil())
-        expect(self.backend.invokedPostReceiptDataParameters?.offeringIdentifier).to(equal("offering"))
+        expect(self.backend.invokedPostReceiptDataParameters?.offeringIdentifier) == "offering"
     }
 
     func testGetSK1PromotionalOffer() async throws {
@@ -289,7 +289,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         expect(self.backend.invokedPostReceiptDataCount) == 1
         expect(self.backend.invokedPostReceiptDataParameters?.productData).toNot(beNil())
-        expect(self.backend.invokedPostReceiptDataParameters?.offeringIdentifier).to(equal("offering"))
+        expect(self.backend.invokedPostReceiptDataParameters?.offeringIdentifier) == "offering"
     }
 
     func testPurchaseSK1PackageWithNoProductIdentifierDoesNotPostReceipt() async throws {
@@ -434,7 +434,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         expect(self.backend.invokedPostReceiptDataCount) == 1
         expect(self.backend.invokedPostReceiptDataParameters?.productData).toNot(beNil())
-        expect(self.backend.invokedPostReceiptDataParameters?.offeringIdentifier).to(equal("offering"))
+        expect(self.backend.invokedPostReceiptDataParameters?.offeringIdentifier) == "offering"
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)


### PR DESCRIPTION
### Description
Fixes [CSDK-546](https://revenuecats.atlassian.net/browse/CSDK-546)

Looks like we were not caching the offeringIdentifier for a productIdentifier when using store kit 2. This should fix that.
