### PR TITLE
Fixed `AttributionFetcher.adServicesToken` hanging when called in simulator

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -243,6 +243,7 @@
 		5752E8482892DC500069281E /* ErrorUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5752E8472892DC500069281E /* ErrorUtilsTests.swift */; };
 		57536A2627851FFE00E2AE7F /* SK1StoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57536A2527851FFE00E2AE7F /* SK1StoreTransaction.swift */; };
 		57536A28278522B400E2AE7F /* SK2StoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57536A27278522B400E2AE7F /* SK2StoreTransaction.swift */; };
+		5753EE00294B8C0C00CBAB54 /* AttributionFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5753EDFF294B8C0C00CBAB54 /* AttributionFetcherTests.swift */; };
 		57544C28285FA94B004E54D5 /* MockAttributeSyncing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57544C24285FA8E6004E54D5 /* MockAttributeSyncing.swift */; };
 		57544C29285FA95E004E54D5 /* MockAttributeSyncing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57544C24285FA8E6004E54D5 /* MockAttributeSyncing.swift */; };
 		57554C62282ABFD9009A7E58 /* StoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554C61282ABFD9009A7E58 /* StoreTests.swift */; };
@@ -784,6 +785,7 @@
 		5752E8472892DC500069281E /* ErrorUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorUtilsTests.swift; sourceTree = "<group>"; };
 		57536A2527851FFE00E2AE7F /* SK1StoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1StoreTransaction.swift; sourceTree = "<group>"; };
 		57536A27278522B400E2AE7F /* SK2StoreTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreTransaction.swift; sourceTree = "<group>"; };
+		5753EDFF294B8C0C00CBAB54 /* AttributionFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributionFetcherTests.swift; sourceTree = "<group>"; };
 		57544C24285FA8E6004E54D5 /* MockAttributeSyncing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAttributeSyncing.swift; sourceTree = "<group>"; };
 		57554C61282ABFD9009A7E58 /* StoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreTests.swift; sourceTree = "<group>"; };
 		57554C83282AC273009A7E58 /* PeriodTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeriodTypeTests.swift; sourceTree = "<group>"; };
@@ -2037,6 +2039,7 @@
 		F5BE444626985E6E00254A30 /* Attribution */ = {
 			isa = PBXGroup;
 			children = (
+				5753EDFF294B8C0C00CBAB54 /* AttributionFetcherTests.swift */,
 				37E350420D54B99BB39448E0 /* AttributionTypeFactoryTests.swift */,
 				A524378A284FFF0200E788BD /* AttributionPosterTests.swift */,
 			);
@@ -2648,6 +2651,7 @@
 				57C381E2279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */,
 				2DDF41E824F6F61B005BC22D /* MockSKProductDiscount.swift in Sources */,
 				579189B728F4747700BF4963 /* EitherTests.swift in Sources */,
+				5753EE00294B8C0C00CBAB54 /* AttributionFetcherTests.swift in Sources */,
 				57069A5E28E398E100B86355 /* AsyncExtensionsTests.swift in Sources */,
 				35272E2226D0048D00F22C3B /* HTTPClientTests.swift in Sources */,
 				2DDF41CB24F6F4C3005BC22D /* ASN1ObjectIdentifierBuilderTests.swift in Sources */,

--- a/Sources/Attribution/AttributionFetcher.swift
+++ b/Sources/Attribution/AttributionFetcher.swift
@@ -85,7 +85,8 @@ class AttributionFetcher {
 #if canImport(AdServices)
         do {
             #if targetEnvironment(simulator)
-                Logger.appleWarning(Strings.attribution.adservices_target_environment_is_simulator)
+                // See https://github.com/RevenueCat/purchases-ios/issues/2121
+                Logger.appleWarning(Strings.attribution.adservices_token_unavailable_in_simulator)
                 return nil
             #else
                 return try AAAttribution.attributionToken()

--- a/Sources/Attribution/AttributionFetcher.swift
+++ b/Sources/Attribution/AttributionFetcher.swift
@@ -84,7 +84,12 @@ class AttributionFetcher {
     var adServicesToken: String? {
 #if canImport(AdServices)
         do {
-            return try AAAttribution.attributionToken()
+            #if targetEnvironment(simulator)
+                Logger.appleWarning(Strings.attribution.adservices_target_environment_is_simulator)
+                return nil
+            #else
+                return try AAAttribution.attributionToken()
+            #endif
         } catch {
             let message = Strings.attribution.adservices_token_fetch_failed(error: error)
             Logger.appleWarning(message)

--- a/Sources/Logging/Strings/AttributionStrings.swift
+++ b/Sources/Logging/Strings/AttributionStrings.swift
@@ -42,7 +42,7 @@ enum AttributionStrings {
     case adservices_token_fetch_failed(error: Error)
     case adservices_token_post_failed(error: BackendError)
     case adservices_token_post_succeeded
-    case adservices_target_environment_is_simulator
+    case adservices_token_unavailable_in_simulator
     case latest_attribution_sent_user_defaults_invalid(networkKey: String)
 
 }
@@ -133,8 +133,8 @@ extension AttributionStrings: CustomStringConvertible {
         case .adservices_token_post_succeeded:
             return "AdServices attribution token successfully posted"
 
-        case .adservices_target_environment_is_simulator:
-            return "AdServices attribution is not available in the simulator"
+        case .adservices_token_unavailable_in_simulator:
+            return "AdServices attribution token is not available in the simulator"
 
         case .latest_attribution_sent_user_defaults_invalid(let networkKey):
             return "Attribution data stored in UserDefaults has invalid format for network key: \(networkKey)"

--- a/Sources/Logging/Strings/AttributionStrings.swift
+++ b/Sources/Logging/Strings/AttributionStrings.swift
@@ -42,6 +42,7 @@ enum AttributionStrings {
     case adservices_token_fetch_failed(error: Error)
     case adservices_token_post_failed(error: BackendError)
     case adservices_token_post_succeeded
+    case adservices_target_environment_is_simulator
     case latest_attribution_sent_user_defaults_invalid(networkKey: String)
 
 }
@@ -131,6 +132,9 @@ extension AttributionStrings: CustomStringConvertible {
 
         case .adservices_token_post_succeeded:
             return "AdServices attribution token successfully posted"
+
+        case .adservices_target_environment_is_simulator:
+            return "AdServices attribution is not available in the simulator"
 
         case .latest_attribution_sent_user_defaults_invalid(let networkKey):
             return "Attribution data stored in UserDefaults has invalid format for network key: \(networkKey)"

--- a/Tests/UnitTests/Attribution/AttributionFetcherTests.swift
+++ b/Tests/UnitTests/Attribution/AttributionFetcherTests.swift
@@ -1,0 +1,51 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  AttributionFetcherTests.swift
+//
+//  Created by Nacho Soto on 12/15/22.
+
+import Foundation
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+class AttributionFetcherTests: TestCase {
+
+    private var systemInfo: MockSystemInfo!
+    private var attributionFetcher: AttributionFetcher!
+
+    override func setUp() {
+        super.setUp()
+
+        self.systemInfo = MockSystemInfo(finishTransactions: false)
+        self.attributionFetcher = .init(attributionFactory: .init(),
+                                        systemInfo: self.systemInfo)
+    }
+
+    #if canImport(AdServices)
+    @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
+    func testAdServicesTokenIfAvailable() throws {
+        try AvailabilityChecks.iOS14APIAvailableOrSkipTest()
+
+        // Can't guarantee that this will produce a value in tests
+        // but at least we ensure that it doesn't hang.
+        // See https://github.com/RevenueCat/purchases-ios/issues/2121
+        _ = self.attributionFetcher.adServicesToken
+    }
+    #else
+    @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
+    func testAdServicesTokenNilIfNotAvailable() throws {
+        try AvailabilityChecks.iOS14APIAvailableOrSkipTest()
+
+        expect(self.attributionFetcher.adServicesToken).to(beNil())
+    }
+    #endif
+
+}


### PR DESCRIPTION
Fixes #2121 and [CSDK-600].

Initially I wanted to check `.toNot(beEmpty())`, but at least locally it's throwing an error:
> Error Domain=com.apple.ap.adservices.attributionError Code=2 "Error generating token" UserInfo={NSLocalizedDescription=Error generating token}

Which is `AAAttributionError.Code.internalError`.
At least we have some test coverage to see if in any combination of Xcode / iOS it hangs, as reported.

[CSDK-600]: https://revenuecats.atlassian.net/browse/CSDK-600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ