### PR TITLE
`ErrorUtils.purchasesError(withUntypedError:)`: handle `PublicError`s

### DIFF
--- a/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
+++ b/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
@@ -72,6 +72,21 @@ class ErrorUtilsTests: TestCase {
         }
     }
 
+    func testPurchasesErrorWithUntypedErrorCode() throws {
+        let error: ErrorCode = .apiEndpointBlockedError
+
+        expect(ErrorUtils.purchasesError(withUntypedError: error)).to(matchError(error))
+    }
+
+    func testPurchasesErrorWithUntypedPublicError() throws {
+        let error: PublicError = ErrorUtils.configurationError().asPublicError
+        let purchasesError = ErrorUtils.purchasesError(withUntypedError: error)
+        let userInfo = try XCTUnwrap(purchasesError.userInfo as? [String: String])
+
+        expect(error).to(matchError(purchasesError))
+        expect(userInfo) == error.userInfo as? [String: String]
+    }
+
     func testPurchasesErrorWithUntypedPurchasesError() throws {
         let error = ErrorUtils.offlineConnectionError()
 


### PR DESCRIPTION
See https://github.com/RevenueCat/purchases-hybrid-common/pull/278.
A valid error ended up as:
> failed: caught error: "Unknown error."

This change ensures that calling this method with an `NSError` does not return `ErrorCode.unknownError`, and instead we extract the correct error.