### PR TITLE
`DNSChecker`: simplified `NetworkError` initialization

### DIFF
--- a/Sources/Networking/HTTPClient/DNSChecker.swift
+++ b/Sources/Networking/HTTPClient/DNSChecker.swift
@@ -45,18 +45,18 @@ enum DNSChecker: DNSCheckerType {
     }
 
     static func errorWithBlockedHostFromError(_ error: Error?) -> NetworkError? {
-        guard isBlockedAPIError(error),
+        guard self.isBlockedAPIError(error),
               let nsError = error as NSError?,
               let failedURL = nsError.userInfo[NSURLErrorFailingURLErrorKey] as? URL else {
             return nil
         }
 
-        let host = resolvedHost(fromURL: failedURL)
+        let host = self.resolvedHost(fromURL: failedURL)
         return .dnsError(failedURL: failedURL, resolvedHost: host)
     }
 
     static func isBlockedURL(_ url: URL) -> Bool {
-        guard let resolvedHostName = resolvedHost(fromURL: url) else {
+        guard let resolvedHostName = self.resolvedHost(fromURL: url) else {
             return false
         }
 

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -351,8 +351,7 @@ private extension NetworkError {
 
     /// Creates a `NetworkError` from any request `Error`.
     init(_ error: Error, dnsChecker: DNSCheckerType.Type) {
-        if dnsChecker.isBlockedAPIError(error),
-           let blockedError = dnsChecker.errorWithBlockedHostFromError(error) {
+        if let blockedError = dnsChecker.errorWithBlockedHostFromError(error) {
             Logger.error(blockedError.description)
             self = blockedError
         } else {

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -829,8 +829,8 @@ class HTTPClientTests: TestCase {
             }
         }
 
-        expect(MockDNSChecker.invokedIsBlockedAPIError.value) == true
-        expect(MockDNSChecker.invokedErrorWithBlockedHostFromError.value) == false
+        expect(MockDNSChecker.invokedErrorWithBlockedHostFromError.value) == true
+        expect(MockDNSChecker.invokedIsBlockedAPIError.value) == false
     }
 
     func testDNSCheckerIsCalledWhenPOSTRequestFailedWithUnknownError() {
@@ -851,8 +851,8 @@ class HTTPClientTests: TestCase {
             }
         }
 
-        expect(MockDNSChecker.invokedIsBlockedAPIError.value) == true
-        expect(MockDNSChecker.invokedErrorWithBlockedHostFromError.value) == false
+        expect(MockDNSChecker.invokedErrorWithBlockedHostFromError.value) == true
+        expect(MockDNSChecker.invokedIsBlockedAPIError.value) == false
     }
 
     func testDNSCheckedIsCalledWhenPOSTRequestFailedWithDNSError() {
@@ -877,8 +877,8 @@ class HTTPClientTests: TestCase {
             }
         }
 
-        expect(MockDNSChecker.invokedIsBlockedAPIError.value) == true
         expect(MockDNSChecker.invokedErrorWithBlockedHostFromError.value) == true
+        expect(MockDNSChecker.invokedIsBlockedAPIError.value) == false
     }
 
     func testDNSCheckedIsCalledWhenGETRequestFailedWithDNSError() {
@@ -902,8 +902,8 @@ class HTTPClientTests: TestCase {
             }
         }
 
-        expect(MockDNSChecker.invokedIsBlockedAPIError.value) == true
         expect(MockDNSChecker.invokedErrorWithBlockedHostFromError.value) == true
+        expect(MockDNSChecker.invokedIsBlockedAPIError.value) == false
     }
 
     func testOfflineConnectionError() {
@@ -953,8 +953,8 @@ class HTTPClientTests: TestCase {
             }
         }
 
-        expect(MockDNSChecker.invokedIsBlockedAPIError.value) == true
         expect(MockDNSChecker.invokedErrorWithBlockedHostFromError.value) == true
+        expect(MockDNSChecker.invokedIsBlockedAPIError.value) == false
         expect(obtainedError) == expectedDNSError
         expect(logHandler.messages.map(\.message))
             .to(contain(expectedMessage))
@@ -984,8 +984,8 @@ class HTTPClientTests: TestCase {
             }
         }
 
-        expect(MockDNSChecker.invokedIsBlockedAPIError.value) == true
-        expect(MockDNSChecker.invokedErrorWithBlockedHostFromError.value) == false
+        expect(MockDNSChecker.invokedErrorWithBlockedHostFromError.value) == true
+        expect(MockDNSChecker.invokedIsBlockedAPIError.value) == false
         expect(logHandler.messages.map(\.message))
             .toNot(contain(unexpectedDNSError.description))
     }


### PR DESCRIPTION
`DNSChecker.errorWithBlockedHostFromError` already checks `isBlockedAPIError` when constructing this error, so we can simplify this to avoid calling `DNSChecker.resolvedHost` twice.
