### PR TITLE
`DNSChecker`: added log with resolved host

### DIFF
--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -31,6 +31,7 @@ enum NetworkStrings {
     case retrying_request(httpMethod: String, path: String)
     case could_not_find_cached_response
     case could_not_find_cached_response_in_already_retried(response: String)
+    case failing_url_resolved_to_host(url: URL, resolvedHost: String)
     case blocked_network(url: URL, newHost: String?)
 
 }
@@ -86,7 +87,10 @@ extension NetworkStrings: CustomStringConvertible {
             return "We can't find the cached response, but call has already been retried. " +
                 "Returning result from backend \(response)"
 
-        case .blocked_network(let url, let newHost):
+        case let .failing_url_resolved_to_host(url, resolvedHost):
+            return "Failing url '\(url)' resolved to host '\(resolvedHost)'"
+
+        case let .blocked_network(url, newHost):
             return "It looks like requests to RevenueCat are being blocked. Context: We're attempting to connect " +
             "to \(url.absoluteString) host: (\(newHost ?? "<unable to resolve>")), " +
             "see: https://rev.cat/dnsBlocking for more info."

--- a/Sources/Networking/HTTPClient/DNSChecker.swift
+++ b/Sources/Networking/HTTPClient/DNSChecker.swift
@@ -60,6 +60,9 @@ enum DNSChecker: DNSCheckerType {
             return false
         }
 
+        Logger.debug(Strings.network.failing_url_resolved_to_host(url: url,
+                                                                  resolvedHost: resolvedHostName))
+
         return self.invalidHosts.contains(resolvedHostName)
     }
 


### PR DESCRIPTION
Example:
> DEBUG: ℹ️ Failing url 'https://0.0.0.0/offers' resolved to host '0.0.0.0'

Looking into #2028, it appears that the user is getting a `NSURLErrorCannotFindHost` with a `NSErrorFailingURLKey`. We didn't determine that this was a `DNS` error because whatever the host resolved to, wasn't one of `Set(["0.0.0.0", "127.0.0.1"])`.

This will add a log that will help us figure out why they got a `NSURLErrorCannotFindHost`.