### PR TITLE
`Purchase Tester`: fixed scene manifest

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester-Info.plist
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester-Info.plist
@@ -2,6 +2,21 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default</string>
+				</dict>
+			</array>
+		</dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
Fixes the following warnings when launching the app:
```
2022-12-19 11:57:15.692222-0800 PurchaseTester[40211:4411274] [SceneConfiguration] Info.plist contained no UIScene configuration dictionary (looking for configuration named "(no name)")
2022-12-19 11:57:15.692564-0800 PurchaseTester[40211:4411274] [SceneConfiguration] Info.plist contained no UIScene configuration dictionary (looking for configuration named "(no name)")
2022-12-19 11:57:15.692707-0800 PurchaseTester[40211:4411274] [SceneConfiguration] Info.plist contained no UIScene configuration dictionary (looking for configuration named "(no name)")
2022-12-19 11:57:15.692810-0800 PurchaseTester[40211:4411274] [SceneConfiguration] Info.plist contained no UIScene configuration dictionary (looking for configuration named "(no name)")
2022-12-19 11:57:15.917335-0800 PurchaseTester[40211:4411274] [SceneConfiguration] Info.plist contained no UIScene configuration dictionary (looking for configuration named "(no name)")
```
