### PR TITLE
`Purchase Tester`: added ability to purchase products directly with `StoreKit`

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
@@ -37,6 +37,10 @@
 		578DAA312947E256001700FD /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = 578DAA302947E256001700FD /* RevenueCat */; };
 		578DAA322947E256001700FD /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 578DAA202947DD8C001700FD /* Core.framework */; };
 		578DAA332947E256001700FD /* Core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 578DAA202947DD8C001700FD /* Core.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		57B5795429536B8C003EAA40 /* PurchasesOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B5795029536B8C003EAA40 /* PurchasesOrchestrator.swift */; };
+		57B5795529536B8C003EAA40 /* ProductFetcherSK2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B5795129536B8C003EAA40 /* ProductFetcherSK2.swift */; };
+		57B5795629536B8C003EAA40 /* ObserverModeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B5795229536B8C003EAA40 /* ObserverModeManager.swift */; };
+		57B5795729536B8C003EAA40 /* ProductFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B5795329536B8C003EAA40 /* ProductFetcherSK1.swift */; };
 		57C217AD29159B83005236DB /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = 57C217AC29159B83005236DB /* RevenueCat */; };
 		57E9CF09290B0E0600EE12D1 /* AppIcon.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 57E9CF08290B0BE500EE12D1 /* AppIcon.xcassets */; };
 		57ED6A80290886B6009580C6 /* ConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ED6A7F290886B6009580C6 /* ConfigurationView.swift */; };
@@ -132,6 +136,10 @@
 		578DAA0F2947DD21001700FD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		578DAA202947DD8C001700FD /* Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		578DAA222947DD8C001700FD /* Core.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Core.h; sourceTree = "<group>"; };
+		57B5795029536B8C003EAA40 /* PurchasesOrchestrator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchasesOrchestrator.swift; sourceTree = "<group>"; };
+		57B5795129536B8C003EAA40 /* ProductFetcherSK2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductFetcherSK2.swift; sourceTree = "<group>"; };
+		57B5795229536B8C003EAA40 /* ObserverModeManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObserverModeManager.swift; sourceTree = "<group>"; };
+		57B5795329536B8C003EAA40 /* ProductFetcherSK1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductFetcherSK1.swift; sourceTree = "<group>"; };
 		57E9CF08290B0BE500EE12D1 /* AppIcon.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = AppIcon.xcassets; sourceTree = "<group>"; };
 		57ED6A7F290886B6009580C6 /* ConfigurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationView.swift; sourceTree = "<group>"; };
 		57ED6A8129089111009580C6 /* Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
@@ -227,6 +235,7 @@
 				2CD2C4EE278C9B01005D1CC2 /* PurchaseTesterApp.swift */,
 				575642A5290C7D3100719219 /* Windows.swift */,
 				2CF428672863EE9D007E6A78 /* Extensions */,
+				57B5794F29536B8C003EAA40 /* Helpers */,
 				2C10F18727A9952B0078444D /* Views */,
 				2CD2C4F0278C9B02005D1CC2 /* Assets.xcassets */,
 			);
@@ -272,6 +281,17 @@
 				578DAA222947DD8C001700FD /* Core.h */,
 			);
 			path = Core;
+			sourceTree = "<group>";
+		};
+		57B5794F29536B8C003EAA40 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				57B5795029536B8C003EAA40 /* PurchasesOrchestrator.swift */,
+				57B5795129536B8C003EAA40 /* ProductFetcherSK2.swift */,
+				57B5795229536B8C003EAA40 /* ObserverModeManager.swift */,
+				57B5795329536B8C003EAA40 /* ProductFetcherSK1.swift */,
+			);
+			path = Helpers;
 			sourceTree = "<group>";
 		};
 		57C217AB29159B83005236DB /* Frameworks */ = {
@@ -446,14 +466,18 @@
 				2CD2C518278C9B02005D1CC2 /* ContentView.swift in Sources */,
 				2CF428692863EEAC007E6A78 /* Package+Extensions.swift in Sources */,
 				2C10F17F27A993EA0078444D /* OfferingDetailView.swift in Sources */,
+				57B5795529536B8C003EAA40 /* ProductFetcherSK2.swift in Sources */,
 				2C10F18527A995150078444D /* HomeView.swift in Sources */,
 				2C10F19127AC31610078444D /* TransactionsView.swift in Sources */,
+				57B5795429536B8C003EAA40 /* PurchasesOrchestrator.swift in Sources */,
 				2C10F18B27A997570078444D /* CustomerView.swift in Sources */,
 				2C10F19A27AC32840078444D /* SubscriberAttributesView.swift in Sources */,
+				57B5795629536B8C003EAA40 /* ObserverModeManager.swift in Sources */,
 				2CD2C516278C9B02005D1CC2 /* PurchaseTesterApp.swift in Sources */,
 				575642A4290C7A2700719219 /* LoggerView.swift in Sources */,
 				2C10F18227A9943D0078444D /* PromoOfferDetailsView.swift in Sources */,
 				575642A6290C7D3100719219 /* Windows.swift in Sources */,
+				57B5795729536B8C003EAA40 /* ProductFetcherSK1.swift in Sources */,
 				2C10F19727AC31B80078444D /* CustomerInfoView.swift in Sources */,
 				57ED6A86290893B6009580C6 /* Extensions.swift in Sources */,
 				57ED6A8229089111009580C6 /* Identifiable.swift in Sources */,

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/ObserverModeManager.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/ObserverModeManager.swift
@@ -1,0 +1,46 @@
+//
+//  ObserverModeManager.swift
+//  PurchaseTester
+//
+//  Created by Nacho Soto on 12/19/22.
+//
+
+import RevenueCat
+
+import SwiftUI
+
+/// A type that simplfiies performing purchases directly with StoreKit to test observer mode.
+final class ObserverModeManager: ObservableObject {
+
+    let observerModeEnabled: Bool
+
+    private let productFetcherSK1: ProductFetcherSK1
+    private let productFetcherSK2: ProductFetcherSK2
+    private let purchasesOrchestrator: PurchasesOrchestrator
+
+    init(observerModeEnabled: Bool) {
+        self.observerModeEnabled = observerModeEnabled
+        self.productFetcherSK1 = .init()
+        self.productFetcherSK2 = .init()
+        self.purchasesOrchestrator = .init()
+    }
+
+    func purchaseAsSK1Product(_ product: StoreProduct) async throws {
+        guard let sk1Product = try await self.productFetcherSK1.products(with: [product.productIdentifier]).first else {
+            print("Failed to find product")
+            return
+        }
+
+        _ = await self.purchasesOrchestrator.purchase(sk1Product: sk1Product)
+    }
+
+    func purchaseAsSK2Product(_ product: StoreProduct) async throws {
+        guard let sk2Product = try await self.productFetcherSK2.products(with: [product.productIdentifier]).first else {
+            print("Failed to find product")
+            return
+        }
+
+        try await self.purchasesOrchestrator.purchase(sk2Product: sk2Product)
+    }
+
+}

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/ProductFetcherSK1.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/ProductFetcherSK1.swift
@@ -1,0 +1,63 @@
+//
+//  ProductFetcherSK1.swift
+//  PurchaseTester
+//
+//  Created by Nacho Soto on 12/19/22.
+//
+
+import RevenueCat
+import StoreKit
+
+/// Simplified version of the fetcher in RevenueCat.
+/// Used to fetch products directly and test observer mode.
+final class ProductFetcherSK1: NSObject {
+
+    typealias Callback = (Result<Set<SK1Product>, Error>) -> Void
+
+    private var completionHandlers: [Set<String>: Callback] = [:]
+    private var productsByRequests: [SKRequest: Set<String>] = [:]
+
+    func products(with identifiers: Set<String>, completion: @escaping Callback) {
+        assert(self.completionHandlers[identifiers] == nil)
+
+        self.completionHandlers[identifiers] = completion
+        self.startRequest(for: identifiers)
+    }
+
+    private func startRequest(for identifiers: Set<String>) {
+        let request = SKProductsRequest(productIdentifiers: identifiers)
+        request.delegate = self
+        self.productsByRequests[request] = identifiers
+        request.start()
+    }
+
+    func products(with identifiers: Set<String>) async throws -> Set<SK1Product> {
+        return try await withCheckedThrowingContinuation { continuation in
+            self.products(with: identifiers) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+
+}
+
+extension ProductFetcherSK1: SKProductsRequestDelegate {
+
+    func productsRequest(_ request: SKProductsRequest, didReceive response: SKProductsResponse) {
+        self.report(result: .success(Set(response.products)), from: request)
+    }
+
+    func request(_ request: SKRequest, didFailWithError error: Error) {
+        self.report(result: .failure(error), from: request)
+    }
+
+    private func report(result: Result<Set<SK1Product>, Error>, from request: SKRequest) {
+        guard let identifiers = self.productsByRequests.removeValue(forKey: request),
+              let completion = self.completionHandlers.removeValue(forKey: identifiers) else {
+            fatalError("Couldn't find matching callback")
+        }
+
+        completion(result)
+    }
+
+}

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/ProductFetcherSK2.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/ProductFetcherSK2.swift
@@ -1,0 +1,19 @@
+//
+//  ProductFetcherSK1.swift
+//  PurchaseTester
+//
+//  Created by Nacho Soto on 12/19/22.
+//
+
+import RevenueCat
+import StoreKit
+
+/// Simplified version of the fetcher in RevenueCat.
+/// Used to fetch products directly and test observer mode.
+final actor ProductFetcherSK2 {
+
+    func products(with identifiers: Set<String>) async throws -> Set<SK2Product> {
+        return try await Set(StoreKit.Product.products(for: identifiers))
+    }
+
+}

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/PurchasesOrchestrator.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/PurchasesOrchestrator.swift
@@ -49,7 +49,9 @@ final class PurchasesOrchestrator: NSObject {
             await transaction.finish()
 
             print("Successfully purchased SK2 product")
-        case let .success(.unverified(_, error)):
+        case let .success(.unverified(transaction, error)):
+            await transaction.finish()
+
             throw error
         case .userCancelled:
             return

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/PurchasesOrchestrator.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/PurchasesOrchestrator.swift
@@ -1,0 +1,112 @@
+//
+//  PurchasesOrchestrator.swift
+//  PurchaseTester
+//
+//  Created by Nacho Soto on 12/19/22.
+//
+
+import RevenueCat
+import StoreKit
+
+/// Used to purchase products directly and test with observer mode.
+final class PurchasesOrchestrator: NSObject {
+
+    typealias PurchaseCompletedResult = SK1Transaction
+
+    private let paymentQueue: SKPaymentQueue
+
+    private var purchaseCompleteCallbacksByProductID: [String: (PurchaseCompletedResult) -> Void] = [:]
+
+    override init() {
+        self.paymentQueue = .init()
+
+        super.init()
+
+        self.paymentQueue.add(self)
+    }
+
+    deinit {
+        self.paymentQueue.remove(self)
+    }
+
+    func purchase(
+        sk1Product product: SK1Product,
+        completion: @escaping (PurchaseCompletedResult) -> Void
+    ) {
+        let productIdentifier = product.productIdentifier
+        assert(!productIdentifier.isEmpty)
+        assert(self.purchaseCompleteCallbacksByProductID[productIdentifier] == nil)
+
+        self.purchaseCompleteCallbacksByProductID[productIdentifier] = completion
+        self.paymentQueue.add(.init(product: product))
+    }
+
+    func purchase(sk2Product product: SK2Product) async throws {
+        let result = try await product.purchase()
+
+        switch result {
+        case let .success(.verified(transaction)):
+            await transaction.finish()
+
+            print("Successfully purchased SK2 product")
+        case let .success(.unverified(_, error)):
+            throw error
+        case .userCancelled:
+            return
+        case .pending:
+            return
+        @unknown default:
+            fatalError()
+        }
+    }
+
+}
+
+extension PurchasesOrchestrator {
+
+    func purchase(sk1Product product: SK1Product) async -> PurchaseCompletedResult {
+        return await withCheckedContinuation { continuation in
+            self.purchase(sk1Product: product) { result in
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
+}
+
+extension PurchasesOrchestrator: SKPaymentTransactionObserver {
+
+    func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
+        for transaction in transactions {
+            let productIdentifier = transaction.payment.productIdentifier
+            guard let completion = self.purchaseCompleteCallbacksByProductID[productIdentifier] else {
+                continue
+            }
+
+            func finishAndReportCompletion() {
+                completion(transaction)
+                self.paymentQueue.finishTransaction(transaction)
+                self.purchaseCompleteCallbacksByProductID.removeValue(forKey: productIdentifier)
+            }
+
+            switch transaction.transactionState {
+            case .purchasing: break
+
+            case .restored, .purchased:
+                print("Successfully purchased SK1 product")
+                finishAndReportCompletion()
+
+            case .failed:
+                print("Error purchasing SK1 product")
+                finishAndReportCompletion()
+
+            case .deferred:
+                fatalError("Not supported right now")
+
+            @unknown default:
+                break
+            }
+        }
+    }
+
+}

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/ContentView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/ContentView.swift
@@ -15,11 +15,23 @@ struct ContentView: View {
     let configuration: ConfiguredPurchases
 
     @StateObject
-    private var revenueCatCustomerData = RevenueCatCustomerData()
+    private var revenueCatCustomerData: RevenueCatCustomerData
+
+    @StateObject
+    private var observerModeManager: ObserverModeManager
+
+    init(configuration: ConfiguredPurchases) {
+        self.configuration = configuration
+        self._revenueCatCustomerData = .init(wrappedValue: .init())
+        self._observerModeManager = .init(
+            wrappedValue: .init(observerModeEnabled: !configuration.purchases.finishTransactions)
+        )
+    }
 
     var body: some View {
         HomeView()
             .environmentObject(self.revenueCatCustomerData)
+            .environmentObject(self.observerModeManager)
             .task {
                 for await customerInfo in self.configuration.purchases.customerInfoStream {
                     self.revenueCatCustomerData.customerInfo = customerInfo

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
@@ -12,8 +12,9 @@ import Core
 import RevenueCat
 
 struct HomeView: View {
-    
-    @EnvironmentObject var revenueCatCustomerData: RevenueCatCustomerData
+
+    @EnvironmentObject private var revenueCatCustomerData: RevenueCatCustomerData
+    @EnvironmentObject private var observerModeManager: ObserverModeManager
     
     @State var offerings: [RevenueCat.Offering] = []
     
@@ -34,7 +35,10 @@ struct HomeView: View {
             List {
                 Section("Offerings") {
                     ForEach(self.offerings) { offering in
-                        NavigationLink(destination: OfferingDetailView(offering: offering)) {
+                        NavigationLink(
+                            destination: OfferingDetailView(offering: offering)
+                                .environmentObject(self.observerModeManager)
+                        ) {
                             OfferingItemView(offering: offering)
                         }
                     }


### PR DESCRIPTION
This will help test observer mode, mimicking how an app might use `RevenueCat` with observer mode.

When that setting is enabled, 2 new buttons will appear:
![Simulator Screen Shot - iPhone 14 Pro Max - 2022-12-20 at 08 58 07](https://user-images.githubusercontent.com/685609/208723050-56644a9a-d78f-4788-bda1-b64bdc400b40.png)

The implementation isn't the most maintainable, but we don't really need it to be. I favored simplicity instead of over-complicating the implementation. It's not meant to be a canonical example of the correct way to purchase with StoreKit, just a quick way of testing this behavior.