### PR TITLE
`IntroEligibilityCalculator`: fixed logic for subscriptions in same group

### DIFF
--- a/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
@@ -76,9 +76,19 @@ extension AppleReceipt: @unchecked Sendable {}
 
 extension AppleReceipt {
 
+    var purchasedIntroOfferOrFreeTrialProductIdentifiers: Set<String> {
+        return Set(
+            self.inAppPurchases
+                .lazy
+                .filter { $0.isInIntroOfferPeriod == true || $0.isInTrialPeriod == true }
+                .map { $0.productId }
+        )
+    }
+
     var activeSubscriptionProductIdentifiers: Set<String> {
         return Set(
             self.inAppPurchases
+                .lazy
                 .filter { $0.isActiveSubscription }
                 .map(\.productId)
         )

--- a/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
@@ -76,11 +76,20 @@ extension AppleReceipt: @unchecked Sendable {}
 
 extension AppleReceipt {
 
+    // TODO: remove
     func purchasedIntroOfferOrFreeTrialProductIdentifiers() -> Set<String> {
         let productIdentifiers = self.inAppPurchases
             .filter { $0.isInIntroOfferPeriod == true || $0.isInTrialPeriod == true }
             .map { $0.productId }
         return Set(productIdentifiers)
+    }
+
+    var activeSubscriptionProductIdentifiers: Set<String> {
+        return Set(
+            self.inAppPurchases
+                .filter { $0.isActiveSubscription }
+                .map(\.productId)
+        )
     }
 
     func containsActivePurchase(forProductIdentifier identifier: String) -> Bool {

--- a/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
@@ -76,14 +76,6 @@ extension AppleReceipt: @unchecked Sendable {}
 
 extension AppleReceipt {
 
-    // TODO: remove
-    func purchasedIntroOfferOrFreeTrialProductIdentifiers() -> Set<String> {
-        let productIdentifiers = self.inAppPurchases
-            .filter { $0.isInIntroOfferPeriod == true || $0.isInTrialPeriod == true }
-            .map { $0.productId }
-        return Set(productIdentifiers)
-    }
-
     var activeSubscriptionProductIdentifiers: Set<String> {
         return Set(
             self.inAppPurchases

--- a/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
@@ -76,20 +76,20 @@ extension AppleReceipt: @unchecked Sendable {}
 
 extension AppleReceipt {
 
-    var purchasedIntroOfferOrFreeTrialProductIdentifiers: Set<String> {
+    var activeSubscriptionsProductIdentifiers: Set<String> {
         return Set(
             self.inAppPurchases
                 .lazy
-                .filter { $0.isInIntroOfferPeriod == true || $0.isInTrialPeriod == true }
-                .map { $0.productId }
+                .filter(\.isActiveSubscription)
+                .map(\.productId)
         )
     }
 
-    var activeSubscriptionProductIdentifiers: Set<String> {
+    var expiredSubscriptionProductIdentifiers: Set<String> {
         return Set(
             self.inAppPurchases
                 .lazy
-                .filter { $0.isActiveSubscription }
+                .filter(\.isExpiredSubscription)
                 .map(\.productId)
         )
     }

--- a/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
@@ -85,15 +85,6 @@ extension AppleReceipt {
         )
     }
 
-    var expiredSubscriptionProductIdentifiers: Set<String> {
-        return Set(
-            self.inAppPurchases
-                .lazy
-                .filter(\.isExpiredSubscription)
-                .map(\.productId)
-        )
-    }
-
     var expiredTrialProductIdentifiers: Set<String> {
         return Set(
             self.inAppPurchases

--- a/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
@@ -94,6 +94,16 @@ extension AppleReceipt {
         )
     }
 
+    var expiredTrialProductIdentifiers: Set<String> {
+        return Set(
+            self.inAppPurchases
+                .lazy
+                .filter(\.isExpiredSubscription)
+                .filter { $0.isInIntroOfferPeriod == true || $0.isInTrialPeriod == true }
+                .map(\.productId)
+        )
+    }
+
     func containsActivePurchase(forProductIdentifier identifier: String) -> Bool {
         return (
             self.inAppPurchases.contains { $0.isActiveSubscription } ||

--- a/Sources/LocalReceiptParsing/BasicTypes/InAppPurchase.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/InAppPurchase.swift
@@ -134,6 +134,12 @@ extension AppleReceipt.InAppPurchase {
         return expiration > Date()
     }
 
+    var isExpiredSubscription: Bool {
+        guard self.isSubscription, let expiration = self.expiresDate else { return false }
+
+        return expiration <= Date()
+    }
+
     var purchaseDateEqualsExpiration: Bool {
         guard self.isSubscription, let expiration = self.expiresDate else { return false }
 

--- a/Sources/LocalReceiptParsing/BasicTypes/InAppPurchase.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/InAppPurchase.swift
@@ -131,13 +131,13 @@ extension AppleReceipt.InAppPurchase {
     var isActiveSubscription: Bool {
         guard self.isSubscription, let expiration = self.expiresDate else { return false }
 
-        return expiration > Date()
+        return expiration >= Date()
     }
 
     var isExpiredSubscription: Bool {
         guard self.isSubscription, let expiration = self.expiresDate else { return false }
 
-        return expiration <= Date()
+        return expiration < Date()
     }
 
     var purchaseDateEqualsExpiration: Bool {

--- a/Sources/Purchasing/IntroEligibilityCalculator.swift
+++ b/Sources/Purchasing/IntroEligibilityCalculator.swift
@@ -120,8 +120,8 @@ private extension IntroEligibilityCalculator {
             } else {
                 // TODO: this isn't quite right, see failing tests
                 result[candidate.productIdentifier] = usedIntroForProductIdentifier || usedIntroInSubscriptionGroup
-                    ? IntroEligibilityStatus.ineligible
-                    : IntroEligibilityStatus.eligible
+                    ? .ineligible
+                    : .eligible
             }
         }
         return result

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -69,6 +69,7 @@ extension BaseStoreKitIntegrationTests {
     static let entitlementIdentifier = "premium"
     static let consumable10Coins = "consumable.10_coins"
     static let monthlyNoIntroProductID = "com.revenuecat.monthly_4.99.no_intro"
+    static let annualNoIntroProductID = "com.revenuecat.annual_39.99.no_intro"
 
     private var currentOffering: Offering {
         get async throws {
@@ -90,9 +91,19 @@ extension BaseStoreKitIntegrationTests {
 
     var monthlyNoIntroProduct: StoreProduct {
         get async throws {
-            let products = await Purchases.shared.products([Self.monthlyNoIntroProductID])
-            return try XCTUnwrap(products.onlyElement)
+            return try await self.product(Self.monthlyNoIntroProductID)
         }
+    }
+
+    var annualNoIntroProduct: StoreProduct {
+        get async throws {
+            return try await self.product(Self.annualNoIntroProductID)
+        }
+    }
+
+    func product(_ identifier: String) async throws -> StoreProduct {
+        let products = await Purchases.shared.products([identifier])
+        return try XCTUnwrap(products.onlyElement)
     }
 
     @discardableResult

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -69,7 +69,8 @@ extension BaseStoreKitIntegrationTests {
     static let entitlementIdentifier = "premium"
     static let consumable10Coins = "consumable.10_coins"
     static let monthlyNoIntroProductID = "com.revenuecat.monthly_4.99.no_intro"
-    static let annualNoIntroProductID = "com.revenuecat.annual_39.99.no_intro"
+    static let group3MonthlyTrialProductID = "com.revenuecat.monthly.1.99.1_free_week"
+    static let group3MonthlyNoTrialProductID = "com.revenuecat.monthly.1.99.no_intro"
 
     private var currentOffering: Offering {
         get async throws {
@@ -92,12 +93,6 @@ extension BaseStoreKitIntegrationTests {
     var monthlyNoIntroProduct: StoreProduct {
         get async throws {
             return try await self.product(Self.monthlyNoIntroProductID)
-        }
-    }
-
-    var annualNoIntroProduct: StoreProduct {
-        get async throws {
-            return try await self.product(Self.annualNoIntroProductID)
         }
     }
 

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -71,6 +71,7 @@ extension BaseStoreKitIntegrationTests {
     static let monthlyNoIntroProductID = "com.revenuecat.monthly_4.99.no_intro"
     static let group3MonthlyTrialProductID = "com.revenuecat.monthly.1.99.1_free_week"
     static let group3MonthlyNoTrialProductID = "com.revenuecat.monthly.1.99.no_intro"
+    static let group3YearlyTrialProductID = "com.revenuecat.annual.10.99.1_free_week"
 
     private var currentOffering: Offering {
         get async throws {

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -265,6 +265,16 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         expect(eligibility) == .eligible
     }
 
+    func testIneligibleForIntroForDifferentProductInSameSubscriptionGroupAfterPurchase() async throws {
+        let product1 = try await self.annualPackage.storeProduct
+        let product2 = try await self.annualNoIntroProduct
+
+        _ = try await Purchases.shared.purchase(product: product2)
+
+        let eligibility = await Purchases.shared.checkTrialOrIntroDiscountEligibility(product: product1)
+        expect(eligibility) == .ineligible
+    }
+
     func testIneligibleForIntroAfterPurchaseExpires() async throws {
         let product = try await self.monthlyPackage.storeProduct
 

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -272,7 +272,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         )
 
         let productWithNoTrial = try await self.product(Self.group3MonthlyNoTrialProductID)
-        let productWithTrial = try await self.annualPackage.storeProduct
+        let productWithTrial = try await self.product(Self.group3MonthlyTrialProductID)
 
         _ = try await Purchases.shared.purchase(product: productWithNoTrial)
 

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -285,7 +285,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         let productWithTrial = try await self.annualPackage.storeProduct
 
         let customerInfo = try await Purchases.shared.purchase(product: productWithNoTrial).customerInfo
-        let entitlement = try await self.verifyEntitlementWentThrough(customerInfo)
+        let entitlement = try XCTUnwrap(customerInfo.entitlements[Self.entitlementIdentifier])
 
         try await self.expireSubscription(entitlement)
 

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -293,6 +293,18 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         expect(eligibility) == .eligible
     }
 
+    func testIneligibleForIntroForDifferentProductInSameSubscriptionGroupAfterTrialExpiration() async throws {
+        let monthlyWithTrial = try await self.product(Self.group3YearlyTrialProductID)
+        let annualWithTrial = try await self.product(Self.group3MonthlyTrialProductID)
+
+        let customerInfo = try await Purchases.shared.purchase(product: monthlyWithTrial).customerInfo
+        let entitlement = try XCTUnwrap(customerInfo.entitlements[Self.entitlementIdentifier])
+        try await self.expireSubscription(entitlement)
+
+        let eligibility = await Purchases.shared.checkTrialOrIntroDiscountEligibility(product: annualWithTrial)
+        expect(eligibility) == .ineligible
+    }
+
     func testIneligibleForIntroAfterPurchaseExpires() async throws {
         let product = try await self.monthlyPackage.storeProduct
 

--- a/Tests/TestingApps/PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit
+++ b/Tests/TestingApps/PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit
@@ -235,6 +235,31 @@
           "referenceName" : "annual free trial",
           "subscriptionGroupID" : "727DE911",
           "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "39.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "911CDB66",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Annual subscription with no trial",
+              "displayName" : "Annual subscription",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.revenuecat.annual_39.99.no_intro",
+          "recurringSubscriptionPeriod" : "P1Y",
+          "referenceName" : "annual no trial",
+          "subscriptionGroupID" : "727DE911",
+          "type" : "RecurringSubscription"
         }
       ]
     }

--- a/Tests/TestingApps/PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit
+++ b/Tests/TestingApps/PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit
@@ -235,6 +235,40 @@
           "referenceName" : "annual free trial",
           "subscriptionGroupID" : "727DE911",
           "type" : "RecurringSubscription"
+        }
+      ]
+    },
+    {
+      "id" : "45445385",
+      "localizations" : [
+
+      ],
+      "name" : "subscription_group_3",
+      "subscriptions" : [
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "1.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "70B67278",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Monthly subscription with no trial",
+              "displayName" : "Monthly subscription",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.revenuecat.monthly.1.99.no_intro",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "monthly no trial",
+          "subscriptionGroupID" : "45445385",
+          "type" : "RecurringSubscription"
         },
         {
           "adHocOffers" : [
@@ -243,22 +277,26 @@
           "codeOffers" : [
 
           ],
-          "displayPrice" : "39.99",
+          "displayPrice" : "1.99",
           "familyShareable" : false,
           "groupNumber" : 1,
-          "internalID" : "911CDB66",
-          "introductoryOffer" : null,
+          "internalID" : "38AF2E0E",
+          "introductoryOffer" : {
+            "internalID" : "A5963DDA",
+            "paymentMode" : "free",
+            "subscriptionPeriod" : "P1W"
+          },
           "localizations" : [
             {
-              "description" : "Annual subscription with no trial",
-              "displayName" : "Annual subscription",
+              "description" : "Monthly subscription with free week",
+              "displayName" : "Monthly subscription",
               "locale" : "en_US"
             }
           ],
-          "productID" : "com.revenuecat.annual_39.99.no_intro",
-          "recurringSubscriptionPeriod" : "P1Y",
-          "referenceName" : "annual no trial",
-          "subscriptionGroupID" : "727DE911",
+          "productID" : "com.revenuecat.monthly.1.99.1_free_week",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "monthly free trial",
+          "subscriptionGroupID" : "45445385",
           "type" : "RecurringSubscription"
         }
       ]

--- a/Tests/TestingApps/PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit
+++ b/Tests/TestingApps/PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit
@@ -298,6 +298,35 @@
           "referenceName" : "monthly free trial",
           "subscriptionGroupID" : "45445385",
           "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "10.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "F9A3C72D",
+          "introductoryOffer" : {
+            "internalID" : "BDFE5F42",
+            "paymentMode" : "free",
+            "subscriptionPeriod" : "P1W"
+          },
+          "localizations" : [
+            {
+              "description" : "Monthly subscription with free week",
+              "displayName" : "Monthly subscription",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.revenuecat.annual.10.99.1_free_week",
+          "recurringSubscriptionPeriod" : "P1Y",
+          "referenceName" : "annual free trial",
+          "subscriptionGroupID" : "45445385",
+          "type" : "RecurringSubscription"
         }
       ]
     }

--- a/Tests/UnitTests/Purchasing/IntroEligibilityCalculatorTests.swift
+++ b/Tests/UnitTests/Purchasing/IntroEligibilityCalculatorTests.swift
@@ -55,7 +55,6 @@ class IntroEligibilityCalculatorTests: TestCase {
     func testCheckTrialOrIntroDiscountEligibilityMakesOnlyOneProductsRequest() {
         let receipt = mockReceipt()
         mockReceiptParser.stubbedParseResult = receipt
-        let receiptIdentifiers = receipt.activeSubscriptionProductIdentifiers
 
         mockProductsManager.stubbedProductsCompletionResult = .success(
             Set(
@@ -74,7 +73,9 @@ class IntroEligibilityCalculatorTests: TestCase {
         }
 
         expect(self.mockProductsManager.invokedProductsCount) == 1
-        expect(self.mockProductsManager.invokedProductsParameters) == candidateIdentifiers.union(receiptIdentifiers)
+        expect(self.mockProductsManager.invokedProductsParameters) == candidateIdentifiers
+            .union(receipt.activeSubscriptionsProductIdentifiers)
+            .union(receipt.expiredSubscriptionProductIdentifiers)
     }
 
     func testCheckTrialOrIntroDiscountEligibilityGetsCorrectResult() {

--- a/Tests/UnitTests/Purchasing/IntroEligibilityCalculatorTests.swift
+++ b/Tests/UnitTests/Purchasing/IntroEligibilityCalculatorTests.swift
@@ -75,7 +75,6 @@ class IntroEligibilityCalculatorTests: TestCase {
         expect(self.mockProductsManager.invokedProductsCount) == 1
         expect(self.mockProductsManager.invokedProductsParameters) == candidateIdentifiers
             .union(receipt.activeSubscriptionsProductIdentifiers)
-            .union(receipt.expiredSubscriptionProductIdentifiers)
     }
 
     func testCheckTrialOrIntroDiscountEligibilityGetsCorrectResult() {
@@ -100,10 +99,10 @@ class IntroEligibilityCalculatorTests: TestCase {
     func testCheckTrialOrIntroDiscountEligibilityReturnsIneligibleForPreviouslyOwnedSubscription() {
         self.testEligibility(
             purchaseExpirationsByProductIdentifier: [
-                "com.revenuecat.product1": Date().addingTimeInterval(-1000)
+                ("com.revenuecat.product1", Date().addingTimeInterval(-1000), true)
             ],
             productsInGroups: [
-                "com.revenuecat.product1": "group1"
+                "com.revenuecat.product1": (groupID: "group1", hasTrial: true)
             ],
             expectedResult: [
                 "com.revenuecat.product1": .ineligible

--- a/Tests/UnitTests/Purchasing/IntroEligibilityCalculatorTests.swift
+++ b/Tests/UnitTests/Purchasing/IntroEligibilityCalculatorTests.swift
@@ -110,6 +110,20 @@ class IntroEligibilityCalculatorTests: TestCase {
         )
     }
 
+    func testCheckTrialOrIntroDiscountEligibilityReturnsEligibleForPreviouslyOwnedSubscriptionWithUnusedTrial() {
+        self.testEligibility(
+            purchaseExpirationsByProductIdentifier: [
+                ("com.revenuecat.product1", Date().addingTimeInterval(-1000), false)
+            ],
+            productsInGroups: [
+                "com.revenuecat.product1": (groupID: "group1", hasTrial: true)
+            ],
+            expectedResult: [
+                "com.revenuecat.product1": .eligible
+            ]
+        )
+    }
+
     func testCheckTrialOrIntroDiscountEligibilityReturnsEligibleForPreviouslyOwnedSubscriptionInDifferentGroup() {
         self.testEligibility(
             purchaseExpirationsByProductIdentifier: [


### PR DESCRIPTION
- Fixes  [TRIAGE-221] for `SK1`.
- Filed `FB11889732` for `SK2`.

### Changes:
- Added 2 `IntroEligibilityCalculatorTests` unit tests to cover this scenario
- Added 1  `IntroEligibilityCalculatorTests` unit tests to cover the equivalent of the `testIneligibleForIntroAfterPurchaseExpires` integration test
- Added 2 `StoreKitIntegrationTests` to cover this scenario (one of them disabled in SK2)
- Updated `IntroEligibilityCalculator` logic to fix the new tests.
- Refactored `IntroEligibilityCalculatorTests` to avoid duplication and allow adding new cases more easily.
- Added a few more tests to ensure other cases are correct.

[TRIAGE-221]: https://revenuecats.atlassian.net/browse/TRIAGE-221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ