### PR TITLE
`PurchaseTester`: fixed `macOS` support

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
@@ -18,36 +18,48 @@ struct PurchaseTesterApp: App {
     
     var body: some Scene {
         WindowGroup(id: Windows.default.rawValue) {
-            NavigationView {
+            Group {
                 if let configuration {
-                    ContentView(configuration: configuration)
-                        .toolbar {
-                            ToolbarItem(placement: .navigationBarLeading) {
-                                Button {
-                                    self.configuration = nil
-                                } label: {
-                                    Text("Reconfigure")
+                    NavigationView {
+                        ContentView(configuration: configuration)
+                            .toolbar {
+                                ToolbarItem(placement: .principal) {
+                                    Button {
+                                        self.configuration = nil
+                                    } label: {
+                                        Text("Reconfigure")
+                                    }
                                 }
                             }
-                        }
-                } else {
-                    ConfigurationView { data in
-                        self.configuration = .init(
-                            apiKey: data.apiKey,
-                            proxyURL: data.proxy.nonEmpty,
-                            useStoreKit2: data.storeKit2Enabled,
-                            observerMode: data.observerMode
-                        )
                     }
+                } else {
+                    #if os(macOS)
+                    self.configurationView
+                    #else
+                    NavigationView {
+                        self.configurationView
+                    }
+                    #endif
                 }
             }
-            .navigationViewStyle(.stack)
+            .navigationViewStyle(.automatic)
             .animation(.default, value: self.isConfigured)
             .transition(.opacity)
         }
 
         WindowGroup(id: Windows.logs.rawValue) {
             LoggerView(logger: ConfiguredPurchases.logger)
+        }
+    }
+
+    private var configurationView: some View {
+        ConfigurationView { data in
+            self.configuration = .init(
+                apiKey: data.apiKey,
+                proxyURL: data.proxy.nonEmpty,
+                useStoreKit2: data.storeKit2Enabled,
+                observerMode: data.observerMode
+            )
         }
     }
 

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/ConfigurationView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/ConfigurationView.swift
@@ -56,11 +56,13 @@ struct ConfigurationView: View {
                 }
             }
         }
+        #if !os(macOS)
         .textInputAutocapitalization(.never)
+        #endif
         .autocorrectionDisabled(true)
         .navigationTitle("Purchase Tester")
         .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
+            ToolbarItem(placement: self.buttonPlacement) {
                 Button {
                     self.saveData()
                     self.onContinue(self.data)
@@ -101,6 +103,14 @@ struct ConfigurationView: View {
 
     private func saveData() {
         self.storedData = try? JSONEncoder().encode(self.data)
+    }
+
+    private var buttonPlacement: ToolbarItemPlacement {
+        #if os(macOS)
+        return .automatic
+        #else
+        return .navigationBarTrailing
+        #endif
     }
 
 }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
@@ -233,7 +233,7 @@ private struct CustomerInfoHeaderView: View {
 
                 Spacer()
 
-                #if targetEnvironment(macCatalyst)
+                #if targetEnvironment(macCatalyst) || os(macOS)
                 if #available(macCatalyst 16.0, *) {
                     OpenWindowButton()
                 }
@@ -283,7 +283,7 @@ private struct LocalizedAlertError: LocalizedError {
 
 }
 
-#if targetEnvironment(macCatalyst)
+#if targetEnvironment(macCatalyst) || os(macOS)
 @available(macCatalyst 16.0, *)
 private struct OpenWindowButton: View {
 


### PR DESCRIPTION
It was working well for Mac Catalyst, but not compiling with `macOS` directly. This fixes that, and makes the configuration UI work.

### Catalyst:
![Screenshot 2022-12-20 at 09 17 51](https://user-images.githubusercontent.com/685609/208732995-0951cd5a-56ef-466c-bb20-96bf28cccb8d.png)

### macOS:
![Screenshot 2022-12-20 at 09 16 09](https://user-images.githubusercontent.com/685609/208732983-0bbf59bc-a21a-4df2-b7e1-cf451888eb2d.png)