### PR TITLE
`BundleSandboxEnvironmentDetector`: fixed logic for `macOS`

### DIFF
--- a/Sources/Misc/SandboxEnvironmentDetector.swift
+++ b/Sources/Misc/SandboxEnvironmentDetector.swift
@@ -30,11 +30,17 @@ final class BundleSandboxEnvironmentDetector: SandboxEnvironmentDetector {
     }
 
     var isSandbox: Bool {
-        guard let url = self.bundle.appStoreReceiptURL else {
+        guard let path = self.bundle.appStoreReceiptURL?.path else {
             return false
         }
 
-        return url.path.contains("sandboxReceipt")
+        // `true` for either `macOS` or `Catalyst`
+        let isMASReceipt = path.contains("MASReceipt/receipt")
+        if isMASReceipt {
+            return path.contains("Xcode/DerivedData")
+        } else {
+            return path.contains("sandboxReceipt")
+        }
     }
 
     #if DEBUG

--- a/Tests/UnitTests/Misc/SandboxEnvironmentDetectorTests.swift
+++ b/Tests/UnitTests/Misc/SandboxEnvironmentDetectorTests.swift
@@ -30,6 +30,14 @@ class SandboxEnvironmentDetectorTests: TestCase {
         expect(try SystemInfo.withReceiptResult(.nilURL).isSandbox) == false
     }
 
+    func testMacSandboxReceiptIsSandbox() throws {
+        expect(try SystemInfo.withReceiptResult(.macOSSandboxReceipt).isSandbox) == true
+    }
+
+    func testMacAppStoreReceiptIsNotSandbox() throws {
+        expect(try SystemInfo.withReceiptResult(.macOSAppStoreReceipt).isSandbox) == false
+    }
+
 }
 
 private extension SandboxEnvironmentDetector {

--- a/Tests/UnitTests/Mocks/MockBundle.swift
+++ b/Tests/UnitTests/Mocks/MockBundle.swift
@@ -22,6 +22,8 @@ final class MockBundle: Bundle {
         case receiptWithData
         case emptyReceipt
         case sandboxReceipt
+        case macOSAppStoreReceipt
+        case macOSSandboxReceipt
         case nilURL
 
     }
@@ -40,6 +42,11 @@ final class MockBundle: Bundle {
         case .sandboxReceipt:
             return testBundle
                 .url(forResource: Self.mockSandboxReceiptFileName, withExtension: "txt")
+        case .macOSSandboxReceipt:
+            // swiftlint:disable:next line_length
+            return URL(string: "/Users/nachosoto/Library/Developer/Xcode/DerivedData/PurchaseTester-coxthvoqhbhicvcmwbbwnogtdrle/Build/Products/Debug-maccatalyst/PurchaseTester.app/Contents/_MASReceipt/receipt")!
+        case .macOSAppStoreReceipt:
+            return URL(string: "/Applications/PurchaseTester.app/Contents/_MASReceipt/receipt")!
         case .nilURL:
             return nil
         }


### PR DESCRIPTION
I found out today that when running `PurchaseTester` on `macOS` (either native or with Catalyst), the SDK was sending `X-Is-Sandbox` = `true`.
The new examples in `MockBundle` illustrate this.