### PR TITLE
`StoreKitTestHelpers`: cleaned up unnecessary log

### DIFF
--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
@@ -47,6 +47,7 @@ extension XCTestCase {
 
     func finishAllUnfinishedTransactions() async {
         let transactions = await self.unfinishedTransactions
+        guard !transactions.isEmpty else { return }
 
         Logger.debug("Finishing \(transactions.count) transactions before running tests")
 


### PR DESCRIPTION
See #2066.

I saw a bunch of these messages:
> DEBUG: ℹ️ Finishing 0 transactions before running tests

Which doesn't add anything if there aren't any leftover transactions.
