### PR TITLE
`Purchase Tester`: added button to clear messages on logger view

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Core/Logger.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Core/Logger.swift
@@ -19,7 +19,12 @@ public final class Logger: ObservableObject {
 
     @Published
     @MainActor
-    public var messages: [Entry] = []
+    public private(set) var messages: [Entry] = []
+
+    @MainActor
+    public func clearMessages() {
+        self.messages.removeAll(keepingCapacity: false)
+    }
 
     public init() {}
 

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
@@ -665,6 +665,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.sampleapp;
 				PRODUCT_NAME = PurchaseTester;
@@ -699,6 +700,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.sampleapp;
 				PRODUCT_NAME = PurchaseTester;

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/xcshareddata/xcschemes/PurchaseTesterWatchOS.xcscheme
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/xcshareddata/xcschemes/PurchaseTesterWatchOS.xcscheme
@@ -39,8 +39,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES"
-      notificationPayloadFile = "PushNotificationPayload.apns">
+      allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/LoggerView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/LoggerView.swift
@@ -17,6 +17,20 @@ struct LoggerView: View {
     var logger: Logger
 
     var body: some View {
+        #if os(macOS)
+        NavigationStack {
+            self.list
+        }
+        #else
+        NavigationView {
+            self.list
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationViewStyle(.stack)
+        #endif
+    }
+
+    private var list: some View {
         List(self.logger.messages.reversed()) { entry in
             self.item(entry)
         }
@@ -24,6 +38,15 @@ struct LoggerView: View {
         .listRowSeparator(.hidden)
         .transition(.slide)
         .animation(.easeInOut(duration: 1), value: self.logger.messages)
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    self.logger.clearMessages()
+                } label: {
+                    Text("Clear")
+                }
+            }
+        }
     }
 
     private func item(_ entry: Logger.Entry) -> some View {


### PR DESCRIPTION
See #2012.
This is useful when debugging some feature. You can now clear the logs before performing whatever action you need to test, and have a cleaner output with only the logs from that point.

![Screenshot 2022-12-20 at 13 40 18](https://user-images.githubusercontent.com/685609/208772324-7433194b-2274-4d18-a64b-ad42fd30900e.png)
