### PR TITLE
`IntroEligibilityCalculator`: added log including `AppleReceipt`

### DIFF
--- a/Sources/Logging/Strings/CustomerInfoStrings.swift
+++ b/Sources/Logging/Strings/CustomerInfoStrings.swift
@@ -20,6 +20,7 @@ enum CustomerInfoStrings {
     case checking_intro_eligibility_locally_error(error: Error)
     case checking_intro_eligibility_locally_result(productIdentifiers: [String: IntroEligibilityStatus])
     case checking_intro_eligibility_locally
+    case checking_intro_eligibility_locally_from_receipt(AppleReceipt)
     case invalidating_customerinfo_cache
     case no_cached_customerinfo
     case customerinfo_stale_updating_in_background
@@ -43,6 +44,8 @@ extension CustomerInfoStrings: CustomStringConvertible {
             return "Local intro eligibility computed locally. Result: \(productIdentifiers)"
         case .checking_intro_eligibility_locally:
             return "Attempting to check intro eligibility locally"
+        case let .checking_intro_eligibility_locally_from_receipt(receipt):
+            return "Checking intro eligibility locally from receipt: \((try? receipt.prettyPrintedJSON) ?? "")"
         case .invalidating_customerinfo_cache:
             return "Invalidating CustomerInfo cache."
         case .no_cached_customerinfo:

--- a/Sources/Purchasing/IntroEligibilityCalculator.swift
+++ b/Sources/Purchasing/IntroEligibilityCalculator.swift
@@ -40,7 +40,9 @@ class IntroEligibilityCalculator {
             resultDict[productId] = IntroEligibilityStatus.unknown
         }
         do {
-            let receipt = try receiptParser.parse(from: receiptData)
+            let receipt = try self.receiptParser.parse(from: receiptData)
+            Logger.debug(Strings.customerInfo.checking_intro_eligibility_locally_from_receipt(receipt))
+
             let purchasedProductIdsWithIntroOffersOrFreeTrials =
                 receipt.purchasedIntroOfferOrFreeTrialProductIdentifiers()
 


### PR DESCRIPTION
This is useful when debugging potentially incorrect logic, like [TRIAGE-221].


[TRIAGE-221]: https://revenuecats.atlassian.net/browse/TRIAGE-221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ