### PR TITLE
`IntroEligibilityStatus`: added `CustomStringConvertible` implementation

### DIFF
--- a/Sources/Purchasing/IntroEligibility.swift
+++ b/Sources/Purchasing/IntroEligibility.swift
@@ -47,6 +47,23 @@ import Foundation
 
 extension IntroEligibilityStatus: CaseIterable, Sendable {}
 
+extension IntroEligibilityStatus: CustomStringConvertible {
+
+    // swiftlint:disable:next missing_docs
+    public var description: String {
+        switch self {
+        case .eligible: return "\(type(of: self)).eligible"
+        case .ineligible: return "\(type(of: self)).ineligible"
+        case .noIntroOfferExists: return "\(type(of: self)).noIntroOfferExists"
+
+        case .unknown: fallthrough
+        @unknown default:
+            return "\(type(of: self)).unknown"
+        }
+    }
+
+}
+
 private extension IntroEligibilityStatus {
 
     enum IntroEligibilityStatusError: LocalizedError {


### PR DESCRIPTION
This fixes the following log:
> DEBUG: ℹ️ Local intro eligibility computed locally. Result: ["com.revenuecat.annual_39.99.2_week_intro": RevenueCat.IntroEligibilityStatus]

And now we get a much more useful value:
> DEBUG: ℹ️ Local intro eligibility computed locally. Result: ["com.revenuecat.annual_39.99.2_week_intro": IntroEligibilityStatus.eligible]
