### PR TITLE
`Purchase Tester`: fixed `SubscriptionPeriod`

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Offerings/OfferingDetailView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Offerings/OfferingDetailView.swift
@@ -55,8 +55,8 @@ struct OfferingDetailView: View {
                         Text("**Sub Group:** \(package.storeProduct.subscriptionGroupIdentifier ?? "-")")
                         Text("**Package type:** \(package.display)")
 
-                        if let period = package.storeProduct.sk1Product?.subscriptionPeriod?.unit.rawValue {
-                            Text("**Sub Period:** \(period)")
+                        if let period = package.storeProduct.subscriptionPeriod {
+                            Text("**\(period.debugDescription)**")
                         } else {
                             Text("**Sub Period:** -")
                         }


### PR DESCRIPTION
This was probably done before we exposed this as part of `StoreProduct`. With SK2 enabled, no period was being displayed.