### PR TITLE
Added `Dictionary.merge`

### DIFF
--- a/Sources/FoundationExtensions/Dictionary+Extensions.swift
+++ b/Sources/FoundationExtensions/Dictionary+Extensions.swift
@@ -81,7 +81,7 @@ extension Dictionary {
     /// - Parameters:
     ///   - lhs: A dictionary to merge.
     ///   - rhs: Another dictionary to merge.
-    /// - Returns: An dictionary with keys and values from both.
+    /// - Returns: A dictionary with keys and values from both.
     static func + (lhs: [Key: Value], rhs: [Key: Value]) -> [Key: Value] {
         return lhs.merging(rhs)
     }

--- a/Sources/FoundationExtensions/Dictionary+Extensions.swift
+++ b/Sources/FoundationExtensions/Dictionary+Extensions.swift
@@ -93,7 +93,7 @@ extension Dictionary {
     /// - Parameters:
     ///   - lhs: A dictionary to merge.
     ///   - rhs: Another dictionary to merge.
-    /// - Returns: An dictionary with keys and values from both.
+    /// - Returns: A dictionary with keys and values from both.
     static func += (lhs: inout [Key: Value], rhs: [Key: Value]) {
         lhs.merge(rhs)
     }

--- a/Sources/FoundationExtensions/Dictionary+Extensions.swift
+++ b/Sources/FoundationExtensions/Dictionary+Extensions.swift
@@ -60,7 +60,18 @@ extension Dictionary {
     /// - Returns: A new dictionary with the combined keys and values of this
     ///   dictionary and `other`.
     func merging(_ other: [Key: Value], strategy: MergeStrategy<Value> = .overwriteValue) -> [Key: Value] {
-        merging(other, uniquingKeysWith: strategy.combine)
+        return self.merging(other, uniquingKeysWith: strategy.combine)
+    }
+
+    /// Merges the given dictionary into this dictionary,
+    /// using a merge strategy to determine the value for duplicate keys.
+    ///
+    /// - Parameters:
+    ///   - other:  A dictionary to merge.
+    ///   - strategy: The merge strategy to use for any duplicate keys. The strategy provides a
+    ///   closure that returns the desired value for the final dictionary. The default is `overwriteValue`.
+    mutating func merge(_ other: [Key: Value], strategy: MergeStrategy<Value> = .overwriteValue) {
+        self.merge(other, uniquingKeysWith: strategy.combine)
     }
 
     /// Merge the keys/values of two dictionaries.
@@ -72,7 +83,7 @@ extension Dictionary {
     ///   - rhs: Another dictionary to merge.
     /// - Returns: An dictionary with keys and values from both.
     static func + (lhs: [Key: Value], rhs: [Key: Value]) -> [Key: Value] {
-        lhs.merging(rhs)
+        return lhs.merging(rhs)
     }
 
     /// Adds values from rhs to lhs dictionary
@@ -84,7 +95,7 @@ extension Dictionary {
     ///   - rhs: Another dictionary to merge.
     /// - Returns: An dictionary with keys and values from both.
     static func += (lhs: inout [Key: Value], rhs: [Key: Value]) {
-        lhs = lhs.merging(rhs)
+        lhs.merge(rhs)
     }
 
 }

--- a/Tests/UnitTests/FoundationExtensions/DictionaryExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/DictionaryExtensionsTests.swift
@@ -47,48 +47,81 @@ class DictionaryExtensionsTests: TestCase {
 
 class DictionaryExtensionsMergingTests: TestCase {
 
-    func testMergeStrategyKeepOriginalValue() {
+    func testMergingStrategyKeepOriginalValue() {
         let dict = ["a": "1", "b": "1"]
         let dict2 = ["a": "2", "b": "2", "c": "2"]
         let expectedDict = ["a": "1", "b": "1", "c": "2"]
 
         let obtainedDict = dict.merging(dict2, strategy: .keepOriginalValue)
 
-        expect(obtainedDict.keys.count).to(equal(expectedDict.keys.count))
-        expect(obtainedDict).to(equal(expectedDict))
+        expect(obtainedDict).to(haveCount(expectedDict.keys.count))
+        expect(obtainedDict) == expectedDict
     }
 
-    func testMergeStrategyOverwriteValue() {
+    func testMergingStrategyOverwriteValue() {
         let dict = ["a": "1", "b": "1"]
         let dict2 = ["a": "2", "b": "2", "c": "2"]
         let expectedDict = ["a": "2", "b": "2", "c": "2"]
 
         let obtainedDict = dict.merging(dict2, strategy: .overwriteValue)
 
-        expect(obtainedDict.keys.count).to(equal(expectedDict.keys.count))
-        expect(obtainedDict).to(equal(expectedDict))
+        expect(obtainedDict).to(haveCount(expectedDict.keys.count))
+        expect(obtainedDict) == expectedDict
     }
 
-    func testDefaultMergeStrategy() {
+    func testMergingDefaultStrategy() {
         let dict = ["a": "1", "b": "1"]
         let dict2 = ["a": "2", "b": "2", "c": "2"]
         let expectedDict = ["a": "2", "b": "2", "c": "2"]
 
         let obtainedDict = dict.merging(dict2)
 
-        expect(obtainedDict.keys.count).to(equal(expectedDict.keys.count))
-        expect(obtainedDict).to(equal(expectedDict))
+        expect(obtainedDict).to(haveCount(expectedDict.keys.count))
+        expect(obtainedDict) == expectedDict
     }
 
-    func testMergeDictionariesByOperatorPlus() {
+    func testMergeStrategyKeepOriginalValue() {
+        var dict = ["a": "1", "b": "1"]
+        let dict2 = ["a": "2", "b": "2", "c": "2"]
+        let expectedDict = ["a": "1", "b": "1", "c": "2"]
+
+        dict.merge(dict2, strategy: .keepOriginalValue)
+
+        expect(dict).to(haveCount(expectedDict.keys.count))
+        expect(dict) == expectedDict
+    }
+
+    func testMergeStrategyOverwriteValue() {
+        var dict = ["a": "1", "b": "1"]
+        let dict2 = ["a": "2", "b": "2", "c": "2"]
+        let expectedDict = ["a": "2", "b": "2", "c": "2"]
+
+        dict.merge(dict2, strategy: .overwriteValue)
+
+        expect(dict).to(haveCount(expectedDict.keys.count))
+        expect(dict) == expectedDict
+    }
+
+    func testMergeDefaultStrategy() {
+        var dict = ["a": "1", "b": "1"]
+        let dict2 = ["a": "2", "b": "2", "c": "2"]
+        let expectedDict = ["a": "2", "b": "2", "c": "2"]
+
+        dict.merge(dict2)
+
+        expect(dict).to(haveCount(expectedDict.keys.count))
+        expect(dict) == expectedDict
+    }
+
+    func testMergingDictionariesByOperatorPlus() {
         let dict = ["a": "1", "b": "1"]
         let dict2 = ["a": "2", "b": "2", "c": "2"]
         let expectedDict = ["a": "2", "b": "2", "c": "2"]
 
         let obtainedDict = dict + dict2
 
-        expect(obtainedDict.keys.count).to(equal(expectedDict.keys.count))
-        expect(obtainedDict).to(equal(expectedDict))
+        expect(obtainedDict).to(haveCount(expectedDict.keys.count))
+        expect(obtainedDict) == expectedDict
     }
 
     func testAddEntriesToDictionaryWithOperatorPlusAddsValuesCorrectly() {
@@ -98,8 +131,8 @@ class DictionaryExtensionsMergingTests: TestCase {
 
         original += addedValues
 
-        expect(original.keys.count).to(equal(expectedDict.keys.count))
-        expect(original).to(equal(expectedDict))
+        expect(original).to(haveCount(expectedDict.keys.count))
+        expect(original) == expectedDict
     }
 
 }


### PR DESCRIPTION
This simplifies the `+=` implementation by avoiding an intermediate dictionary, and allows a simpler way of merging dictionaries.

Will be used in #2174.
