### PR TITLE
Fix path to storekit file in purchase tester

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/xcshareddata/xcschemes/PurchaseTester.xcscheme
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/xcshareddata/xcschemes/PurchaseTester.xcscheme
@@ -61,7 +61,7 @@
          </BuildableReference>
       </BuildableProductRunnable>
       <StoreKitConfigurationFileReference
-         identifier = "../../PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit">
+         identifier = "../../../PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit">
       </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction


### PR DESCRIPTION
### Motivation
Fix issue on purchase tester

### Description

Fix path. When opening PurchaseTester and check the schema, I see this error

<img width="815" alt="image" src="https://user-images.githubusercontent.com/1765468/209984410-a349d724-1b73-4642-b8db-405868ca3989.png">

