### PR TITLE
`PurchasesReceiptParser`: improved documentation to reference `default`

### DIFF
--- a/Sources/LocalReceiptParsing/PurchasesReceiptParser.swift
+++ b/Sources/LocalReceiptParsing/PurchasesReceiptParser.swift
@@ -16,6 +16,12 @@ import Foundation
 
 /// A type that can parse Apple receipts from a device.
 /// This implements parsing based on [Apple's documentation](https://rev.cat/apple-receipt-fields).
+///
+/// To use this class you must access ``PurchasesReceiptParser/default``:
+/// ```swift
+/// let parser = PurchasesReceiptParser.default
+/// let receipt = try parser.parse(from: data)
+/// ```
 public class PurchasesReceiptParser: NSObject {
 
     private let logger: LoggerType


### PR DESCRIPTION
The most obvious way to create `PurchasesReceiptParser` is using `.init`.
In order to expose that we'd need to `override` `init` from an `extension` because each (RC / `ReceiptParser`) `target` needs a different `LoggerType`. However,  `NSObject.init` can't be overridden from an extension.

That's why the API exposes `default` instead. This will make the usage clearer:

![Screenshot 2023-01-05 at 10 22 16](https://user-images.githubusercontent.com/685609/210852731-4ac7336a-90a9-4fa8-8135-a8bb723a3701.png)
