### PR TITLE
`PostReceiptDataOperation`: replaced receipt `base64` with `hash` for cache key

### DIFF
--- a/Sources/FoundationExtensions/Data+Extensions.swift
+++ b/Sources/FoundationExtensions/Data+Extensions.swift
@@ -68,8 +68,8 @@ extension Data {
             return Self.hexString(sha256.finalize().makeIterator())
         } else {
             let hash = self.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) -> [UInt8] in
-                var hash = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
-                CC_SHA1(bytes.baseAddress, CC_LONG(self.count), &hash)
+                var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+                CC_SHA256(bytes.baseAddress, CC_LONG(self.count), &hash)
                 return hash
             }
 

--- a/Sources/FoundationExtensions/Data+Extensions.swift
+++ b/Sources/FoundationExtensions/Data+Extensions.swift
@@ -41,6 +41,19 @@ extension Data {
         return (self as NSData).asString()
     }
 
+    /// - Returns: `UUID` from the first 16 bytes of the underlying data.
+    var uuid: UUID? {
+        /// This implementation is equivalent to `return NSUUID(uuidBytes: [UInt8](self)) as UUID`
+        /// but ensures that the `Data` isn't unnecessarily copied in memory.
+        return self.withUnsafeBytes {
+            guard let baseAddress = $0.bindMemory(to: UInt8.self).baseAddress else {
+                return nil
+            }
+
+            return NSUUID(uuidBytes: baseAddress) as UUID
+        }
+    }
+
     /// - Returns: a string representing a fetch token.
     var asFetchToken: String {
         return self.base64EncodedString()

--- a/Sources/FoundationExtensions/Data+Extensions.swift
+++ b/Sources/FoundationExtensions/Data+Extensions.swift
@@ -13,6 +13,8 @@
 //  Created by Josh Holtz on 6/28/21.
 //
 
+import CommonCrypto
+import CryptoKit
 import Foundation
 
 extension NSData {
@@ -44,17 +46,26 @@ extension Data {
         return self.base64EncodedString()
     }
 
-    /// Creates an `UUID` from the underlying bytes.
-    var uuid: UUID? {
-        /// This implementation is equivalent to `return NSUUID(uuidBytes: [UInt8](self)) as UUID`
-        /// but ensures that the `Data` isn't unnecessarily copied in memory.
-        return self.withUnsafeBytes {
-            guard let baseAddress = $0.bindMemory(to: UInt8.self).baseAddress else {
-                return nil
+    /// - Returns: a hash representation of the underlying bytes.
+    var hashString: String {
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
+            var sha256 = SHA256()
+            sha256.update(data: self)
+
+            return Self.hexString(sha256.finalize().makeIterator())
+        } else {
+            let hash = self.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) -> [UInt8] in
+                var hash = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
+                CC_SHA1(bytes.baseAddress, CC_LONG(self.count), &hash)
+                return hash
             }
 
-            return NSUUID(uuidBytes: baseAddress) as UUID
+            return Self.hexString(hash.makeIterator())
         }
+    }
+
+    private static func hexString(_ iterator: Array<UInt8>.Iterator) -> String {
+        return iterator.map { String(format: "%02x", $0) }.joined()
     }
 
 }

--- a/Sources/FoundationExtensions/Data+Extensions.swift
+++ b/Sources/FoundationExtensions/Data+Extensions.swift
@@ -78,7 +78,10 @@ extension Data {
     }
 
     private static func hexString(_ iterator: Array<UInt8>.Iterator) -> String {
-        return iterator.map { String(format: "%02x", $0) }.joined()
+        return iterator
+            .lazy
+            .map { String(format: "%02x", $0) }
+            .joined()
     }
 
 }

--- a/Sources/FoundationExtensions/Data+Extensions.swift
+++ b/Sources/FoundationExtensions/Data+Extensions.swift
@@ -31,11 +31,6 @@ extension NSData {
         return deviceTokenString as String
     }
 
-    var uuid: UUID? {
-        let bytes = [UInt8](self)
-        return NSUUID(uuidBytes: bytes) as UUID
-    }
-
 }
 
 extension Data {
@@ -44,13 +39,22 @@ extension Data {
         return (self as NSData).asString()
     }
 
-    // Returns a string representing a fetch token.
+    /// - Returns: a string representing a fetch token.
     var asFetchToken: String {
         return self.base64EncodedString()
     }
 
+    /// Creates an `UUID` from the underlying bytes.
     var uuid: UUID? {
-        (self as NSData).uuid
+        /// This implementation is equivalent to `return NSUUID(uuidBytes: [UInt8](self)) as UUID`
+        /// but ensures that the `Data` isn't unnecessarily copied in memory.
+        return self.withUnsafeBytes {
+            guard let baseAddress = $0.bindMemory(to: UInt8.self).baseAddress else {
+                return nil
+            }
+
+            return NSUUID(uuidBytes: baseAddress) as UUID
+        }
     }
 
 }

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -41,7 +41,7 @@ final class PostReceiptDataOperation: CacheableNetworkOperation {
     ) -> CacheableNetworkOperationFactory<PostReceiptDataOperation> {
         let cacheKey =
         """
-        \(configuration.appUserID)-\(postData.isRestore)-\(postData.receiptData.uuid?.uuidString ?? "")
+        \(configuration.appUserID)-\(postData.isRestore)-\(postData.receiptData.hashString)
         -\(postData.productData?.cacheKey ?? "")
         -\(postData.presentedOfferingIdentifier ?? "")-\(postData.observerMode)
         -\(postData.subscriberAttributesByKey?.debugDescription ?? "")"

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -41,7 +41,7 @@ final class PostReceiptDataOperation: CacheableNetworkOperation {
     ) -> CacheableNetworkOperationFactory<PostReceiptDataOperation> {
         let cacheKey =
         """
-        \(configuration.appUserID)-\(postData.isRestore)-\(postData.receiptData.asFetchToken)
+        \(configuration.appUserID)-\(postData.isRestore)-\(postData.receiptData.uuid?.uuidString ?? "")
         -\(postData.productData?.cacheKey ?? "")
         -\(postData.presentedOfferingIdentifier ?? "")-\(postData.observerMode)
         -\(postData.subscriberAttributesByKey?.debugDescription ?? "")"

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -39,6 +39,14 @@ final class PostReceiptDataOperation: CacheableNetworkOperation {
         customerInfoResponseHandler: CustomerInfoResponseHandler = CustomerInfoResponseHandler(),
         customerInfoCallbackCache: CallbackCache<CustomerInfoCallback>
     ) -> CacheableNetworkOperationFactory<PostReceiptDataOperation> {
+        /// Cache key comprises of the following:
+        /// - `appUserID`
+        /// - `isRestore`
+        /// - Receipt (`hashString` instead of `fetchToken` to avoid big receipts leading to a huge cache key)
+        /// - `ProductRequestData.cacheKey`
+        /// - `presentedOfferingIdentifier`
+        /// - `observerMode`
+        /// - `subscriberAttributesByKey`
         let cacheKey =
         """
         \(configuration.appUserID)-\(postData.isRestore)-\(postData.receiptData.hashString)

--- a/Tests/UnitTests/FoundationExtensions/NSData+RCExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/NSData+RCExtensionsTests.swift
@@ -29,14 +29,24 @@ class NSDataExtensionsTests: TestCase {
     }
 
     func testAsFetchToken() {
-        let receiptFilename = "base64EncodedReceiptSampleForDataExtension"
-        let storedReceiptText = NSDataExtensionsTests.readFile(named: receiptFilename)
-        let storedReceiptData = NSDataExtensionsTests.sampleReceiptData(receiptName: receiptFilename)
+        let storedReceiptText = NSDataExtensionsTests.readFile(named: Self.receiptFilename)
+        let storedReceiptData = NSDataExtensionsTests.sampleReceiptData(receiptName: Self.receiptFilename)
         let fetchToken = storedReceiptData.asFetchToken
 
         expect(fetchToken).to(equal(storedReceiptText))
         expect(storedReceiptData.asFetchToken).to(equal(storedReceiptText))
     }
+
+    func testStringDataAsUUID() {
+        expect("sample string".asData.uuid) == UUID(uuidString: "73616D70-6C65-2073-7472-696E67000000")
+    }
+
+    func testReceiptDataAsUUID() {
+        let storedReceiptData = Self.sampleReceiptData(receiptName: Self.receiptFilename)
+
+        expect(storedReceiptData.uuid) == UUID(uuidString: "308220E5-0609-2A86-4886-F70D010702A0")
+    }
+
 }
 
 extension NSDataExtensionsTests {
@@ -63,5 +73,7 @@ extension NSDataExtensionsTests {
     }
 
     private static let fileExtension = "txt"
+
+    private static let receiptFilename = "base64EncodedReceiptSampleForDataExtension"
 
 }

--- a/Tests/UnitTests/FoundationExtensions/NSData+RCExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/NSData+RCExtensionsTests.swift
@@ -37,19 +37,19 @@ class NSDataExtensionsTests: TestCase {
         expect(storedReceiptData.asFetchToken).to(equal(storedReceiptText))
     }
 
-    func testStringDataAsUUID() {
-        expect("sample string".asData.uuid) == UUID(uuidString: "73616D70-6C65-2073-7472-696E67000000")
+    func testStringDataAsHashString() {
+        expect("sample string".asData.hashString) == "99ad9154f94977dd8913f3b7ea14091d00e52b8931c2bc1cfc7ea62b7c26727b"
     }
 
-    func testDataAsUUIDHashesTheEntireData() {
-        expect("a relatively long string that ends in 0".asData.uuid)
-        != "a relatively long string that ends in 1".asData.uuid
+    func testDataAsHashStringHashesTheEntireData() {
+        expect("a relatively long string that ends in 0".asData.hashString)
+        != "a relatively long string that ends in 1".asData.hashString
     }
 
-    func testReceiptDataAsUUID() {
+    func testReceiptDataAsHashString() {
         let storedReceiptData = Self.sampleReceiptData(receiptName: Self.receiptFilename)
 
-        expect(storedReceiptData.uuid) == UUID(uuidString: "308220E5-0609-2A86-4886-F70D010702A0")
+        expect(storedReceiptData.hashString) == "d18b7c0ffe3577a9dd732840a30ac4b3655b412e69d84f07d991f48e8d3273d8"
     }
 
 }

--- a/Tests/UnitTests/FoundationExtensions/NSData+RCExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/NSData+RCExtensionsTests.swift
@@ -41,6 +41,11 @@ class NSDataExtensionsTests: TestCase {
         expect("sample string".asData.uuid) == UUID(uuidString: "73616D70-6C65-2073-7472-696E67000000")
     }
 
+    func testDataAsUUIDHashesTheEntireData() {
+        expect("a relatively long string that ends in 0".asData.uuid)
+        != "a relatively long string that ends in 1".asData.uuid
+    }
+
     func testReceiptDataAsUUID() {
         let storedReceiptData = Self.sampleReceiptData(receiptName: Self.receiptFilename)
 

--- a/Tests/UnitTests/FoundationExtensions/NSData+RCExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/NSData+RCExtensionsTests.swift
@@ -37,6 +37,10 @@ class NSDataExtensionsTests: TestCase {
         expect(storedReceiptData.asFetchToken).to(equal(storedReceiptText))
     }
 
+    func testStringDataAsUUID() {
+        expect("sample string".asData.uuid) == UUID(uuidString: "73616D70-6C65-2073-7472-696E67000000")
+    }
+
     func testStringDataAsHashString() {
         expect("sample string".asData.hashString) == "99ad9154f94977dd8913f3b7ea14091d00e52b8931c2bc1cfc7ea62b7c26727b"
     }


### PR DESCRIPTION
Should fix #2198 and [SDKONCALL-200]. This is a big performance optimization in time and memory, as we no longer need to convert the entire receipt to `base64` and concatenate it to the string, which is what was likely causing #2198.
This now uses `Data.hashString`, which avoids any data copies and efficiently creates a hash with the receipt content.

Apart from the new tests for this property, `BackendPostReceiptDataTests.testDoesntCacheForDifferentReceipts` ensures that different receipts have different cache keys, and therefore this new implementation still avoids collisions (other than the extremely unlikely hash collisions).


[SDKONCALL-200]: https://revenuecats.atlassian.net/browse/SDKONCALL-200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ