### PR TITLE
`ReceiptFetcher`: refactored implementation to log error when failing to fetch receipt

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -256,6 +256,7 @@
 		57554CC1282AE1E3009A7E58 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554CC0282AE1E3009A7E58 /* TestCase.swift */; };
 		57554CC2282AE1E3009A7E58 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554CC0282AE1E3009A7E58 /* TestCase.swift */; };
 		575642B62910116900719219 /* EligibilityStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575642B52910116900719219 /* EligibilityStrings.swift */; };
+		5759B322296DEF56002472D5 /* OptionalExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5759B321296DEF56002472D5 /* OptionalExtensionsTests.swift */; };
 		575A17AB2773A59300AA6F22 /* CurrentTestCaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */; };
 		575A8EE12922C56300936709 /* AsyncTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A8EE02922C56300936709 /* AsyncTestHelpers.swift */; };
 		575A8EE22922C56300936709 /* AsyncTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A8EE02922C56300936709 /* AsyncTestHelpers.swift */; };
@@ -827,6 +828,7 @@
 		57554C87282AC293009A7E58 /* PurchaseOwnershipTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseOwnershipTypeTests.swift; sourceTree = "<group>"; };
 		57554CC0282AE1E3009A7E58 /* TestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCase.swift; sourceTree = "<group>"; };
 		575642B52910116900719219 /* EligibilityStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EligibilityStrings.swift; sourceTree = "<group>"; };
+		5759B321296DEF56002472D5 /* OptionalExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalExtensionsTests.swift; sourceTree = "<group>"; };
 		575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentTestCaseTracker.swift; sourceTree = "<group>"; };
 		575A8EE02922C56300936709 /* AsyncTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTestHelpers.swift; sourceTree = "<group>"; };
 		575A8EE42922C9F300936709 /* MockStoreKit2TransactionListenerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreKit2TransactionListenerDelegate.swift; sourceTree = "<group>"; };
@@ -1771,6 +1773,7 @@
 				37E3508EC20EEBAB4EAC4C82 /* NSDate+RCExtensionsTests.swift */,
 				37E353AF2CAD3CEDE6D9B368 /* NSError+RCExtensionsTests.swift */,
 				5766AA41283C768600FA6091 /* OperatorExtensionsTests.swift */,
+				5759B321296DEF56002472D5 /* OptionalExtensionsTests.swift */,
 				5796A3BF27D7D64500653165 /* ResultExtensionsTests.swift */,
 				57A1772A276A726C0052D3A8 /* SetExtensionsTests.swift */,
 				57D56FC92853C005009E8E1E /* StringExtensionsTests.swift */,
@@ -2946,6 +2949,7 @@
 				351B515A26D44B6200BD2BD7 /* MockAttributionFetcher.swift in Sources */,
 				5796A38C27D6BA1600653165 /* BackendLoginTests.swift in Sources */,
 				351B51BD26D450E800BD2BD7 /* EntitlementInfosTests.swift in Sources */,
+				5759B322296DEF56002472D5 /* OptionalExtensionsTests.swift in Sources */,
 				57DE80AE28075D77008D6C6F /* OSVersionEquivalent.swift in Sources */,
 				F5847430278D00C0001B1CE6 /* MockDNSChecker.swift in Sources */,
 				5722482727C2BD3200C524A7 /* LockTests.swift in Sources */,

--- a/Sources/FoundationExtensions/Data+Extensions.swift
+++ b/Sources/FoundationExtensions/Data+Extensions.swift
@@ -90,15 +90,15 @@ extension Data {
 /// Useful for mocking.
 protocol FileReader {
 
-    func contents(of url: URL) -> Data?
+    func contents(of url: URL) throws -> Data
 
 }
 
 /// Default implementation of `FileReader` that simply uses `Data`'s implementation.
 final class DefaultFileReader: FileReader {
 
-    func contents(of url: URL) -> Data? {
-        return try? Data(contentsOf: url)
+    func contents(of url: URL) throws -> Data {
+        return try Data(contentsOf: url)
     }
 
 }

--- a/Sources/FoundationExtensions/Optional+Extensions.swift
+++ b/Sources/FoundationExtensions/Optional+Extensions.swift
@@ -31,6 +31,20 @@ extension Optional: OptionalType {
 
 }
 
+extension OptionalType {
+
+    /// - Returns: unwrapped value if present.
+    /// - Throws: `error` if the value is not present.
+    func orThrow(_ error: @autoclosure () -> Error) throws -> Wrapped {
+        if let value = self.asOptional {
+            return value
+        } else {
+            throw error()
+        }
+    }
+
+}
+
 // MARK: -
 
 internal extension Optional where Wrapped == String {

--- a/Sources/LocalReceiptParsing/Helpers/ReceiptStrings.swift
+++ b/Sources/LocalReceiptParsing/Helpers/ReceiptStrings.swift
@@ -27,7 +27,7 @@ enum ReceiptStrings {
     case parsing_receipt_success
     case parsing_receipt
     case refreshing_empty_receipt
-    case unable_to_load_receipt
+    case unable_to_load_receipt(Error)
     case posting_receipt(AppleReceipt)
     case receipt_subscription_purchase_equals_expiration(
         productIdentifier: String,
@@ -83,8 +83,9 @@ extension ReceiptStrings: CustomStringConvertible {
         case .refreshing_empty_receipt:
             return "Receipt empty, refreshing"
 
-        case .unable_to_load_receipt:
-            return "Unable to load receipt, ensure you are logged in to a valid Apple account."
+        case let .unable_to_load_receipt(error):
+            return "Unable to load receipt, ensure you are logged in to a valid Apple account.\n" +
+            "Error: \(error))"
 
         case let .posting_receipt(receipt):
             return "Posting receipt (note: the contents might not be up-to-date, " +

--- a/Sources/LocalReceiptParsing/Helpers/ReceiptStrings.swift
+++ b/Sources/LocalReceiptParsing/Helpers/ReceiptStrings.swift
@@ -85,7 +85,7 @@ extension ReceiptStrings: CustomStringConvertible {
 
         case let .unable_to_load_receipt(error):
             return "Unable to load receipt, ensure you are logged in to a valid Apple account.\n" +
-            "Error: \(error))"
+            "Error: \(error)"
 
         case let .posting_receipt(receipt):
             return "Posting receipt (note: the contents might not be up-to-date, " +

--- a/Tests/UnitTests/FoundationExtensions/OptionalExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/OptionalExtensionsTests.swift
@@ -1,0 +1,53 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  OptionalExtensionsTests.swift
+//
+//  Created by Nacho Soto on 1/10/23.
+
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+class OptionalExtensionsTests: TestCase {
+
+    func testNotEmptyStringWithValue() {
+        expect("test".notEmpty) == "test"
+        expect(" ".notEmpty) == " "
+    }
+
+    func testNotEmptyStringWithEmptyStringReturnsNil() {
+        expect("".notEmpty).to(beNil())
+    }
+
+    func testOrThrowWithValue() throws {
+        expect(try Optional("").orThrow(Error.error1)) == ""
+    }
+
+    func testOrThrowWithNoValue() throws {
+        let value: String? = nil
+
+        do {
+            _ = try value.orThrow(Error.error1)
+            fail("Expected error")
+        } catch {
+            expect(error).to(matchError(Error.error1))
+        }
+    }
+
+}
+
+private extension OptionalExtensionsTests {
+
+    enum Error: Swift.Error {
+        case error1
+    }
+
+}


### PR DESCRIPTION
### Changes:

- Added `Optional.orThrow` to simplify implementation (this will be useful in many other parts of the code too)
- Added missing `OptinalExtensionsTests`
`DefaultFileReader` was implemented using `try?`, now it throws an error instead of returning `nil`
- `ReceiptFetcher`: logging specific error when loading receipt fails
- Refactored `ReceiptFetcher`:
  - No longer logging "loaded receipt" if the content was empty
  - No longer logging an error twice if the receipt failed to load
  - Simplified logic to handle errors only once
