### PR TITLE
Added `ReceiptParserTests`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -22,7 +22,9 @@ disabled_rules:
 custom_rules:
   xctestcase_superclass:
     included: ".*\\.swift"
-    excluded: Tests/BackendIntegrationTests
+    excluded:
+      - Tests/BackendIntegrationTests
+      - Tests/ReceiptParserTests
     regex: "\\: XCTestCase \\{"
     name: "XCTestCase Superclass"
     message: "Test classes must inherit `TestCase` instead."

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,9 @@ import class Foundation.ProcessInfo
 let environmentVariables = ProcessInfo.processInfo.environment
 let shouldIncludeDocCPlugin = environmentVariables["INCLUDE_DOCC_PLUGIN"] == "true"
 
-var dependencies: [Package.Dependency] = []
+var dependencies: [Package.Dependency] = [
+    .package(url: "git@github.com:Quick/Nimble.git", from: "10.0.0")
+]
 if shouldIncludeDocCPlugin {
     dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
 }
@@ -34,6 +36,10 @@ let package = Package(
                 path: "Sources",
                 exclude: ["Info.plist", "LocalReceiptParsing/ReceiptParser-only-files"]),
         .target(name: "ReceiptParser",
-                path: "LocalReceiptParsing")
+                path: "LocalReceiptParsing",
+                linkerSettings: [
+			    	.unsafeFlags(["-Xlinker", "-no_application_extension"])
+			    ]),
+        .testTarget(name: "ReceiptParserTests", dependencies: ["ReceiptParser", "Nimble"])
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -36,10 +36,7 @@ let package = Package(
                 path: "Sources",
                 exclude: ["Info.plist", "LocalReceiptParsing/ReceiptParser-only-files"]),
         .target(name: "ReceiptParser",
-                path: "LocalReceiptParsing",
-                linkerSettings: [
-			    	.unsafeFlags(["-Xlinker", "-no_application_extension"])
-			    ]),
+                path: "LocalReceiptParsing"),
         .testTarget(name: "ReceiptParserTests", dependencies: ["ReceiptParser", "Nimble"])
     ]
 )

--- a/ReceiptParserTests-Info.plist
+++ b/ReceiptParserTests-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>4.17.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -257,6 +257,9 @@
 		57554CC2282AE1E3009A7E58 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554CC0282AE1E3009A7E58 /* TestCase.swift */; };
 		575642B62910116900719219 /* EligibilityStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575642B52910116900719219 /* EligibilityStrings.swift */; };
 		5759B322296DEF56002472D5 /* OptionalExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5759B321296DEF56002472D5 /* OptionalExtensionsTests.swift */; };
+		5759B3F4296DF65D002472D5 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B36824BD268FBC5B00957E4C /* XCTest.framework */; };
+		5759B3F7296DF65D002472D5 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 5759B335296DF65D002472D5 /* Nimble */; };
+		5759B406296DF8EE002472D5 /* ReceiptParserFetchingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5759B404296DF6C4002472D5 /* ReceiptParserFetchingTests.swift */; };
 		575A17AB2773A59300AA6F22 /* CurrentTestCaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */; };
 		575A8EE12922C56300936709 /* AsyncTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A8EE02922C56300936709 /* AsyncTestHelpers.swift */; };
 		575A8EE22922C56300936709 /* AsyncTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A8EE02922C56300936709 /* AsyncTestHelpers.swift */; };
@@ -589,6 +592,13 @@
 			remoteGlobalIDString = 2DEAC2D926EFE46E006914ED;
 			remoteInfo = UnitTestsHostApp;
 		};
+		5759B420296DFEE2002472D5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 352629F51F7C4B9100C04F2C /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 57D92C32293E4D0C00D1912A;
+			remoteInfo = ReceiptParser;
+		};
 		578BB35E2936BA9400E8AA8A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 578BB3552936BA8E00E8AA8A /* ReceiptParserAPITester.xcodeproj */;
@@ -829,6 +839,9 @@
 		57554CC0282AE1E3009A7E58 /* TestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCase.swift; sourceTree = "<group>"; };
 		575642B52910116900719219 /* EligibilityStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EligibilityStrings.swift; sourceTree = "<group>"; };
 		5759B321296DEF56002472D5 /* OptionalExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalExtensionsTests.swift; sourceTree = "<group>"; };
+		5759B401296DF65D002472D5 /* ReceiptParserTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReceiptParserTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		5759B402296DF65D002472D5 /* ReceiptParserTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "ReceiptParserTests-Info.plist"; path = "/Users/nachosoto/dev/purchases-ios/ReceiptParserTests-Info.plist"; sourceTree = "<absolute>"; };
+		5759B404296DF6C4002472D5 /* ReceiptParserFetchingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptParserFetchingTests.swift; sourceTree = "<group>"; };
 		575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentTestCaseTracker.swift; sourceTree = "<group>"; };
 		575A8EE02922C56300936709 /* AsyncTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTestHelpers.swift; sourceTree = "<group>"; };
 		575A8EE42922C9F300936709 /* MockStoreKit2TransactionListenerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreKit2TransactionListenerDelegate.swift; sourceTree = "<group>"; };
@@ -1120,6 +1133,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		5759B3F2296DF65D002472D5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5759B3F4296DF65D002472D5 /* XCTest.framework in Frameworks */,
+				5759B3F7296DF65D002472D5 /* Nimble in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		57D92C30293E4D0C00D1912A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1335,6 +1357,7 @@
 				2DDF41DD24F6F4F9005BC22D /* Mocks */,
 				35D832FE262FAD6900E60AC5 /* Networking */,
 				354235D624C11160008C84EE /* Purchasing */,
+				5759B403296DF68D002472D5 /* ReceiptParserTests */,
 				2DDE559824C8B5D100DCB087 /* Resources */,
 				F591492426B994A100D32E58 /* StoreKitExtensions */,
 				B36824BB268FBB9B00957E4C /* SubscriberAttributes */,
@@ -1592,6 +1615,7 @@
 				2DEAC2DA26EFE46E006914ED /* UnitTestsHostApp.app */,
 				2DAC5F7226F13C9800C5258F /* StoreKitUnitTests.xctest */,
 				57D92C33293E4D0C00D1912A /* ReceiptParser.framework */,
+				5759B401296DF65D002472D5 /* ReceiptParserTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1876,6 +1900,16 @@
 			);
 			path = "ReceiptParser-only-files";
 			sourceTree = "<group>";
+		};
+		5759B403296DF68D002472D5 /* ReceiptParserTests */ = {
+			isa = PBXGroup;
+			children = (
+				5759B402296DF65D002472D5 /* ReceiptParserTests-Info.plist */,
+				5759B404296DF6C4002472D5 /* ReceiptParserFetchingTests.swift */,
+			);
+			name = ReceiptParserTests;
+			path = Tests/ReceiptParserTests;
+			sourceTree = SOURCE_ROOT;
 		};
 		5766AABB283E809D00FA6091 /* Purchases */ = {
 			isa = PBXGroup;
@@ -2281,6 +2315,26 @@
 			productReference = 2DEAC2DA26EFE46E006914ED /* UnitTestsHostApp.app */;
 			productType = "com.apple.product-type.application";
 		};
+		5759B330296DF65D002472D5 /* ReceiptParserTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5759B3FE296DF65D002472D5 /* Build configuration list for PBXNativeTarget "ReceiptParserTests" */;
+			buildPhases = (
+				5759B33C296DF65D002472D5 /* Sources */,
+				5759B3F2296DF65D002472D5 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5759B421296DFEE2002472D5 /* PBXTargetDependency */,
+			);
+			name = ReceiptParserTests;
+			packageProductDependencies = (
+				5759B335296DF65D002472D5 /* Nimble */,
+			);
+			productName = PurchasesTests;
+			productReference = 5759B401296DF65D002472D5 /* ReceiptParserTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		57D92C32293E4D0C00D1912A /* ReceiptParser */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 57D92C37293E4D0C00D1912A /* Build configuration list for PBXNativeTarget "ReceiptParser" */;
@@ -2375,6 +2429,7 @@
 				2DC5621524EC63420031F69B /* RevenueCat */,
 				57D92C32293E4D0C00D1912A /* ReceiptParser */,
 				2DC5621D24EC63430031F69B /* UnitTests */,
+				5759B330296DF65D002472D5 /* ReceiptParserTests */,
 				2DE20B7E26409EB7004C597D /* BackendIntegrationTestsHostApp */,
 				2DE20B6B264087FB004C597D /* BackendIntegrationTests */,
 				2DEAC2D926EFE46E006914ED /* UnitTestsHostApp */,
@@ -3013,6 +3068,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		5759B33C296DF65D002472D5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5759B406296DF8EE002472D5 /* ReceiptParserFetchingTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		57D92C2F293E4D0C00D1912A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3070,6 +3133,11 @@
 			isa = PBXTargetDependency;
 			target = 2DEAC2D926EFE46E006914ED /* UnitTestsHostApp */;
 			targetProxy = 2DFF6C54270CA11400ECAFAB /* PBXContainerItemProxy */;
+		};
+		5759B421296DFEE2002472D5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 57D92C32293E4D0C00D1912A /* ReceiptParser */;
+			targetProxy = 5759B420296DFEE2002472D5 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -3546,6 +3614,62 @@
 			};
 			name = Release;
 		};
+		5759B3FF296DF65D002472D5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 8SXR2327BM;
+				INFOPLIST_FILE = "ReceiptParserTests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.ReceiptParserTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = "";
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				TARGETED_DEVICE_FAMILY = "1,2,3,6";
+			};
+			name = Debug;
+		};
+		5759B400296DF65D002472D5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 8SXR2327BM;
+				INFOPLIST_FILE = "ReceiptParserTests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.ReceiptParserTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = "";
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "";
+				TARGETED_DEVICE_FAMILY = "1,2,3,6";
+			};
+			name = Release;
+		};
 		57D92C38293E4D0C00D1912A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3686,6 +3810,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		5759B3FE296DF65D002472D5 /* Build configuration list for PBXNativeTarget "ReceiptParserTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5759B3FF296DF65D002472D5 /* Debug */,
+				5759B400296DF65D002472D5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		57D92C37293E4D0C00D1912A /* Build configuration list for PBXNativeTarget "ReceiptParser" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -3712,6 +3845,14 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 9.0.0;
+			};
+		};
+		5759B336296DF65D002472D5 /* XCRemoteSwiftPackageReference "nimble" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/quick/nimble";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 10.0.0;
 			};
 		};
 		57E04739277260DE0082FE91 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {
@@ -3759,6 +3900,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2D9C5ECB26F2815E0057FC45 /* XCRemoteSwiftPackageReference "OHHTTPStubs" */;
 			productName = OHHTTPStubsSwift;
+		};
+		5759B335296DF65D002472D5 /* Nimble */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5759B336296DF65D002472D5 /* XCRemoteSwiftPackageReference "nimble" */;
+			productName = Nimble;
 		};
 		576C8ABD27D299860058FA6E /* SnapshotTesting */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/RevenueCat.xcodeproj/xcshareddata/xcschemes/ReceiptParser.xcscheme
+++ b/RevenueCat.xcodeproj/xcshareddata/xcschemes/ReceiptParser.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:RevenueCat.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2DD778CF270E233F0079CBD4"
+               BuildableName = "ReceiptParserAPITester.app"
+               BlueprintName = "ReceiptParserAPITester"
+               ReferencedContainer = "container:Tests/APITesters/ReceiptParserAPITester/ReceiptParserAPITester.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -28,6 +42,18 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5759B330296DF65D002472D5"
+               BuildableName = "ReceiptParserTests.xctest"
+               BlueprintName = "ReceiptParserTests"
+               ReferencedContainer = "container:RevenueCat.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Tests/ReceiptParserTests/ReceiptParserFetchingTests.swift
+++ b/Tests/ReceiptParserTests/ReceiptParserFetchingTests.swift
@@ -1,0 +1,20 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ReceiptParserFetchingTests.swift
+//
+//  Created by Nacho Soto on 1/10/23.
+
+import Nimble
+@testable import ReceiptParser
+import XCTest
+
+class ReceiptParserFetchingTests: XCTestCase {
+
+}

--- a/Tests/TestPlans/AllTests.xctestplan
+++ b/Tests/TestPlans/AllTests.xctestplan
@@ -39,6 +39,14 @@
         "identifier" : "2DAC5F7126F13C9800C5258F",
         "name" : "StoreKitUnitTests"
       }
+    },
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:RevenueCat.xcodeproj",
+        "identifier" : "5759B330296DF65D002472D5",
+        "name" : "ReceiptParserTests"
+      }
     }
   ],
   "version" : 1

--- a/Tests/TestPlans/CI-AllTests.xctestplan
+++ b/Tests/TestPlans/CI-AllTests.xctestplan
@@ -40,6 +40,13 @@
         "identifier" : "2DAC5F7126F13C9800C5258F",
         "name" : "StoreKitUnitTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:RevenueCat.xcodeproj",
+        "identifier" : "5759B330296DF65D002472D5",
+        "name" : "ReceiptParserTests"
+      }
     }
   ],
   "version" : 1


### PR DESCRIPTION
For [CSDK-622], we need to be able to write tests specific to `ReceiptParser` implementations.
This sets up that target, and allows running those tests via Xcode or SPM.

### Changes:

- Added `ReceiptParserTests` target to Xcode
- Added `ReceiptParserTests` target to `Package.swift`
- Added `ReceiptParserTests` to "test" phase of `ReceiptParser` scheme
- Added `ReceiptParserTests` to All-Tests test plan
- Added `ReceiptParserTests` to CI-All-Tests test plan


[CSDK-622]: https://revenuecats.atlassian.net/browse/CSDK-622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ