### PR TITLE
Added new `ReceiptParser.fetchAndParseLocalReceipt`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -19,7 +19,6 @@
 		2D1015DE275A57FC0086173F /* SubscriptionPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1015DD275A57FC0086173F /* SubscriptionPeriod.swift */; };
 		2D1015E2275A67E40086173F /* SubscriptionPeriodTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1015E0275A676F0086173F /* SubscriptionPeriodTests.swift */; };
 		2D11F5E1250FF886005A70E8 /* AttributionStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D11F5E0250FF886005A70E8 /* AttributionStrings.swift */; };
-		2D1C3F3926B9D8B800112626 /* MockBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D1C3F3826B9D8B800112626 /* MockBundle.swift */; };
 		2D222BAB27FB7008003D5F37 /* LocalReceiptParserStoreKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D222BAA27FB7008003D5F37 /* LocalReceiptParserStoreKitTests.swift */; };
 		2D22BF6526F3CB31001AE2F9 /* FatalErrorUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D22BF6426F3CB31001AE2F9 /* FatalErrorUtil.swift */; };
 		2D22BF6826F3CC6D001AE2F9 /* XCTestCase+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D22BF6626F3CBFB001AE2F9 /* XCTestCase+Extensions.swift */; };
@@ -257,9 +256,14 @@
 		57554CC2282AE1E3009A7E58 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554CC0282AE1E3009A7E58 /* TestCase.swift */; };
 		575642B62910116900719219 /* EligibilityStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575642B52910116900719219 /* EligibilityStrings.swift */; };
 		5759B322296DEF56002472D5 /* OptionalExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5759B321296DEF56002472D5 /* OptionalExtensionsTests.swift */; };
+		5759B32E296DF4E3002472D5 /* PurchasesReceiptParser+Fetching.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5759B323296DF3C2002472D5 /* PurchasesReceiptParser+Fetching.swift */; };
 		5759B3F4296DF65D002472D5 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B36824BD268FBC5B00957E4C /* XCTest.framework */; };
 		5759B3F7296DF65D002472D5 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 5759B335296DF65D002472D5 /* Nimble */; };
 		5759B406296DF8EE002472D5 /* ReceiptParserFetchingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5759B404296DF6C4002472D5 /* ReceiptParserFetchingTests.swift */; };
+		5759B409296DFA75002472D5 /* FileReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5759B407296DFA75002472D5 /* FileReader.swift */; };
+		5759B41E296DFD4C002472D5 /* MockFileReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5759B41D296DFD4C002472D5 /* MockFileReader.swift */; };
+		5759B464296E1A4B002472D5 /* MockBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5759B463296E1A4B002472D5 /* MockBundle.swift */; };
+		5759B465296E1A4B002472D5 /* MockBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5759B463296E1A4B002472D5 /* MockBundle.swift */; };
 		575A17AB2773A59300AA6F22 /* CurrentTestCaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */; };
 		575A8EE12922C56300936709 /* AsyncTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A8EE02922C56300936709 /* AsyncTestHelpers.swift */; };
 		575A8EE22922C56300936709 /* AsyncTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A8EE02922C56300936709 /* AsyncTestHelpers.swift */; };
@@ -393,6 +397,11 @@
 		57E4A52128BD8F610095C793 /* ErrorMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E4A52028BD8F610095C793 /* ErrorMatcher.swift */; };
 		57E4A52228BD8F610095C793 /* ErrorMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E4A52028BD8F610095C793 /* ErrorMatcher.swift */; };
 		57E6195028D291DC0093170C /* StoreKit2CachingProductsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E6194F28D291DC0093170C /* StoreKit2CachingProductsManagerTests.swift */; };
+		57E6C2C72975AAE1001AFE98 /* FileReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5759B407296DFA75002472D5 /* FileReader.swift */; };
+		57E6C2C92975C777001AFE98 /* verifyReceiptSample1.txt in CopyFiles */ = {isa = PBXBuildFile; fileRef = 2DDE559A24C8B5E300DCB087 /* verifyReceiptSample1.txt */; };
+		57E6C2CA2975C777001AFE98 /* base64encodedreceiptsample1.txt in CopyFiles */ = {isa = PBXBuildFile; fileRef = 2DDE559B24C8B5E300DCB087 /* base64encodedreceiptsample1.txt */; };
+		57E6C2CB2975C777001AFE98 /* base64encoded_sandboxReceipt.txt in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */; };
+		57E6C2CC2975C777001AFE98 /* base64EncodedReceiptSampleForDataExtension.txt in CopyFiles */ = {isa = PBXBuildFile; fileRef = B319514A26C1991E002CA9AC /* base64EncodedReceiptSampleForDataExtension.txt */; };
 		57E9CF0F290B2A4B00EE12D1 /* CachingTrialOrIntroPriceEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E9CF0E290B2A4B00EE12D1 /* CachingTrialOrIntroPriceEligibilityChecker.swift */; };
 		57E9CF11290B2ADC00EE12D1 /* CachingTrialOrIntroPriceEligibilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E9CF10290B2ADC00EE12D1 /* CachingTrialOrIntroPriceEligibilityCheckerTests.swift */; };
 		57EAE527274324C60060EB74 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE526274324C60060EB74 /* Lock.swift */; };
@@ -608,6 +617,22 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		57E6C2C82975C764001AFE98 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 7;
+			files = (
+				57E6C2C92975C777001AFE98 /* verifyReceiptSample1.txt in CopyFiles */,
+				57E6C2CA2975C777001AFE98 /* base64encodedreceiptsample1.txt in CopyFiles */,
+				57E6C2CB2975C777001AFE98 /* base64encoded_sandboxReceipt.txt in CopyFiles */,
+				57E6C2CC2975C777001AFE98 /* base64EncodedReceiptSampleForDataExtension.txt in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		0313FD40268A506400168386 /* DateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateProvider.swift; sourceTree = "<group>"; };
 		2C0B98CC2797070B00C5874F /* PromotionalOffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionalOffer.swift; sourceTree = "<group>"; };
@@ -620,7 +645,6 @@
 		2D1015DD275A57FC0086173F /* SubscriptionPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPeriod.swift; sourceTree = "<group>"; };
 		2D1015E0275A676F0086173F /* SubscriptionPeriodTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPeriodTests.swift; sourceTree = "<group>"; };
 		2D11F5E0250FF886005A70E8 /* AttributionStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributionStrings.swift; sourceTree = "<group>"; };
-		2D1C3F3826B9D8B800112626 /* MockBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBundle.swift; sourceTree = "<group>"; };
 		2D222BAA27FB7008003D5F37 /* LocalReceiptParserStoreKitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalReceiptParserStoreKitTests.swift; sourceTree = "<group>"; };
 		2D22BF6426F3CB31001AE2F9 /* FatalErrorUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FatalErrorUtil.swift; sourceTree = "<group>"; };
 		2D22BF6626F3CBFB001AE2F9 /* XCTestCase+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Extensions.swift"; sourceTree = "<group>"; };
@@ -839,9 +863,13 @@
 		57554CC0282AE1E3009A7E58 /* TestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCase.swift; sourceTree = "<group>"; };
 		575642B52910116900719219 /* EligibilityStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EligibilityStrings.swift; sourceTree = "<group>"; };
 		5759B321296DEF56002472D5 /* OptionalExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionalExtensionsTests.swift; sourceTree = "<group>"; };
+		5759B323296DF3C2002472D5 /* PurchasesReceiptParser+Fetching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PurchasesReceiptParser+Fetching.swift"; sourceTree = "<group>"; };
 		5759B401296DF65D002472D5 /* ReceiptParserTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ReceiptParserTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5759B402296DF65D002472D5 /* ReceiptParserTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "ReceiptParserTests-Info.plist"; path = "/Users/nachosoto/dev/purchases-ios/ReceiptParserTests-Info.plist"; sourceTree = "<absolute>"; };
 		5759B404296DF6C4002472D5 /* ReceiptParserFetchingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptParserFetchingTests.swift; sourceTree = "<group>"; };
+		5759B407296DFA75002472D5 /* FileReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileReader.swift; sourceTree = "<group>"; };
+		5759B41D296DFD4C002472D5 /* MockFileReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFileReader.swift; sourceTree = "<group>"; };
+		5759B463296E1A4B002472D5 /* MockBundle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockBundle.swift; sourceTree = "<group>"; };
 		575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentTestCaseTracker.swift; sourceTree = "<group>"; };
 		575A8EE02922C56300936709 /* AsyncTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTestHelpers.swift; sourceTree = "<group>"; };
 		575A8EE42922C9F300936709 /* MockStoreKit2TransactionListenerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreKit2TransactionListenerDelegate.swift; sourceTree = "<group>"; };
@@ -1493,7 +1521,6 @@
 				351B514426D449E600BD2BD7 /* MockAttributionTypeFactory.swift */,
 				351B514026D4498F00BD2BD7 /* MockBackend.swift */,
 				A563F585271E072B00246E0C /* MockBeginRefundRequestHelper.swift */,
-				2D1C3F3826B9D8B800112626 /* MockBundle.swift */,
 				57BF87582967880C00424254 /* MockCachingTrialOrIntroPriceEligibilityChecker.swift */,
 				57CFB96B27FE0E79002A6730 /* MockCurrentUserProvider.swift */,
 				351B514826D44A2F00BD2BD7 /* MockCustomerInfoManager.swift */,
@@ -1501,6 +1528,7 @@
 				351B513C26D4491E00BD2BD7 /* MockDeviceCache.swift */,
 				F584742F278D00C0001B1CE6 /* MockDNSChecker.swift */,
 				35D83311262FBD4200E60AC5 /* MockETagManager.swift */,
+				5759B41D296DFD4C002472D5 /* MockFileReader.swift */,
 				351B514C26D44A8600BD2BD7 /* MockHTTPClient.swift */,
 				B31C8BEB285BD58F001017B7 /* MockIdentityAPI.swift */,
 				351B513E26D4496000BD2BD7 /* MockIdentityManager.swift */,
@@ -1897,6 +1925,7 @@
 			isa = PBXGroup;
 			children = (
 				5753EDDD294A7A9D00CBAB54 /* PurchasesReceiptParser+Extensions.swift */,
+				5759B323296DF3C2002472D5 /* PurchasesReceiptParser+Fetching.swift */,
 			);
 			path = "ReceiptParser-only-files";
 			sourceTree = "<group>";
@@ -1904,12 +1933,21 @@
 		5759B403296DF68D002472D5 /* ReceiptParserTests */ = {
 			isa = PBXGroup;
 			children = (
+				5759B462296E1A3E002472D5 /* Helpers */,
 				5759B402296DF65D002472D5 /* ReceiptParserTests-Info.plist */,
 				5759B404296DF6C4002472D5 /* ReceiptParserFetchingTests.swift */,
 			);
 			name = ReceiptParserTests;
 			path = Tests/ReceiptParserTests;
 			sourceTree = SOURCE_ROOT;
+		};
+		5759B462296E1A3E002472D5 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				5759B463296E1A4B002472D5 /* MockBundle.swift */,
+			);
+			path = Helpers;
+			sourceTree = "<group>";
 		};
 		5766AABB283E809D00FA6091 /* Purchases */ = {
 			isa = PBXGroup;
@@ -1959,6 +1997,7 @@
 				579415D429368AB200218FBC /* ReceiptStrings.swift */,
 				578D79732936A36B0042E434 /* LoggerType.swift */,
 				57D92C4F293E506100D1912A /* ReceiptParserLogger.swift */,
+				5759B407296DFA75002472D5 /* FileReader.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -2319,6 +2358,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5759B3FE296DF65D002472D5 /* Build configuration list for PBXNativeTarget "ReceiptParserTests" */;
 			buildPhases = (
+				57E6C2C82975C764001AFE98 /* CopyFiles */,
 				5759B33C296DF65D002472D5 /* Sources */,
 				5759B3F2296DF65D002472D5 /* Frameworks */,
 			);
@@ -2719,6 +2759,7 @@
 				57DE807128074C23008D6C6F /* SK1Storefront.swift in Sources */,
 				578D79742936A36B0042E434 /* LoggerType.swift in Sources */,
 				B34605EB279A766C0031CA74 /* OperationQueue+Extensions.swift in Sources */,
+				57E6C2C72975AAE1001AFE98 /* FileReader.swift in Sources */,
 				5766AB4728401B8400FA6091 /* PackageType.swift in Sources */,
 				B3F3E8DA277158FE0047A5B9 /* DNSChecker.swift in Sources */,
 				A525BF4B26C320D100C354C4 /* SubscriberAttributesManager.swift in Sources */,
@@ -2879,6 +2920,7 @@
 				578FB10E27ADDA8000F70709 /* AvailabilityChecks.swift in Sources */,
 				57E415EF284697A300EA5460 /* PurchasesDeferredPurchasesTests.swift in Sources */,
 				35F82BB226A98EC50051DF03 /* AttributionDataMigratorTests.swift in Sources */,
+				5759B41E296DFD4C002472D5 /* MockFileReader.swift in Sources */,
 				5744D8AB28E3B86600646735 /* AppleReceiptTests.swift in Sources */,
 				B3CAFF10285CE8E30048A994 /* MockOfferingsAPI.swift in Sources */,
 				351B51BF26D450E800BD2BD7 /* StoreKitRequestFetcherTests.swift in Sources */,
@@ -2910,6 +2952,7 @@
 				5733D01128D00354008638D8 /* PromotionalOfferTests.swift in Sources */,
 				57544C28285FA94B004E54D5 /* MockAttributeSyncing.swift in Sources */,
 				57DE80802807529F008D6C6F /* MockStorefront.swift in Sources */,
+				5759B464296E1A4B002472D5 /* MockBundle.swift in Sources */,
 				35D83312262FBD4200E60AC5 /* MockETagManager.swift in Sources */,
 				351B51C326D450F200BD2BD7 /* InMemoryCachedObjectTests.swift in Sources */,
 				576C8A8F27CFCD110058FA6E /* AnyEncodableTests.swift in Sources */,
@@ -2994,7 +3037,6 @@
 				B319514926C19856002CA9AC /* NSData+RCExtensionsTests.swift in Sources */,
 				5733B1A427FF9F8300EC2045 /* NetworkErrorTests.swift in Sources */,
 				351B517026D44E8D00BD2BD7 /* MockDateProvider.swift in Sources */,
-				2D1C3F3926B9D8B800112626 /* MockBundle.swift in Sources */,
 				57FDAAC028493C13009A48F1 /* MockSandboxEnvironmentDetector.swift in Sources */,
 				5766AAD1283E981700FA6091 /* PurchasesPurchasingTests.swift in Sources */,
 				351B515E26D44B9900BD2BD7 /* MockPurchasesDelegate.swift in Sources */,
@@ -3073,6 +3115,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5759B406296DF8EE002472D5 /* ReceiptParserFetchingTests.swift in Sources */,
+				5759B465296E1A4B002472D5 /* MockBundle.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3086,6 +3129,7 @@
 				57D92C4E293E4DE500D1912A /* Codable+Extensions.swift in Sources */,
 				57D92C41293E4DE500D1912A /* ASN1ObjectIdentifier.swift in Sources */,
 				57D92C4B293E4DE500D1912A /* UInt8+Extensions.swift in Sources */,
+				5759B409296DFA75002472D5 /* FileReader.swift in Sources */,
 				57D92C48293E4DE500D1912A /* PurchasesReceiptParser.swift in Sources */,
 				57D92C46293E4DE500D1912A /* AppleReceiptBuilder.swift in Sources */,
 				5753ED8F294A662400CBAB54 /* DateFormatter+Extensions.swift in Sources */,
@@ -3093,6 +3137,7 @@
 				57D92C4A293E4DE500D1912A /* ArraySlice_UInt8+Extensions.swift in Sources */,
 				57D92C4D293E4DE500D1912A /* InAppPurchase.swift in Sources */,
 				57D92C42293E4DE500D1912A /* ASN1ObjectIdentifierBuilder.swift in Sources */,
+				5759B32E296DF4E3002472D5 /* PurchasesReceiptParser+Fetching.swift in Sources */,
 				57D92C47293E4DE500D1912A /* ReceiptParsingError.swift in Sources */,
 				5753EDDE294A7A9D00CBAB54 /* PurchasesReceiptParser+Extensions.swift in Sources */,
 				57D92C50293E506100D1912A /* ReceiptParserLogger.swift in Sources */,

--- a/Sources/FoundationExtensions/Data+Extensions.swift
+++ b/Sources/FoundationExtensions/Data+Extensions.swift
@@ -85,20 +85,3 @@ extension Data {
     }
 
 }
-
-/// A type that can read data from disk
-/// Useful for mocking.
-protocol FileReader {
-
-    func contents(of url: URL) throws -> Data
-
-}
-
-/// Default implementation of `FileReader` that simply uses `Data`'s implementation.
-final class DefaultFileReader: FileReader {
-
-    func contents(of url: URL) throws -> Data {
-        return try Data(contentsOf: url)
-    }
-
-}

--- a/Sources/LocalReceiptParsing/Helpers/FileReader.swift
+++ b/Sources/LocalReceiptParsing/Helpers/FileReader.swift
@@ -1,0 +1,31 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  FileReader.swift
+//
+//  Created by Nacho Soto on 1/10/23.
+
+import Foundation
+
+/// A type that can read data from disk
+/// Useful for mocking.
+protocol FileReader {
+
+    func contents(of url: URL) throws -> Data
+
+}
+
+/// Default implementation of `FileReader` that simply uses `Data`'s implementation.
+final class DefaultFileReader: FileReader {
+
+    func contents(of url: URL) throws -> Data {
+        return try Data(contentsOf: url)
+    }
+
+}

--- a/Sources/LocalReceiptParsing/ReceiptParser-only-files/PurchasesReceiptParser+Fetching.swift
+++ b/Sources/LocalReceiptParsing/ReceiptParser-only-files/PurchasesReceiptParser+Fetching.swift
@@ -1,0 +1,60 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ReceiptFetcher.swift
+//
+//  Created by Nacho Soto on 1/10/23.
+
+import Foundation
+
+public extension PurchasesReceiptParser {
+
+    // Note: this is a simplified version of `ReceiptFetcher`
+    // available for public use.
+
+    /// Fetches and parses the local receipt
+    /// - Returns: ``AppleReceipt`` of the parsed local receipt.
+    /// - Throws: ``PurchasesReceiptParser/Error`` if fetching or parsing failed.
+    ///
+    /// - Note: this method won't use ``SKReceiptRefreshRequest`` to
+    ///  fetch the receipt if it's not already available.
+    ///
+    /// ### Related Symbols
+    /// - ``SKReceiptRefreshRequest``
+    /// - ``Bundle/appStoreReceiptURL``
+    /// - ``PurchasesReceiptParser/parse(from:)``
+    func fetchAndParseLocalReceipt() throws -> AppleReceipt {
+        return try self.fetchAndParseLocalReceipt(reader: DefaultFileReader(),
+                                                  bundle: .main)
+    }
+
+    internal func fetchAndParseLocalReceipt(
+        reader: FileReader,
+        bundle: Bundle
+    ) throws -> AppleReceipt {
+        return try self.parse(from: self.fetchReceipt(reader, bundle))
+    }
+
+}
+
+private extension PurchasesReceiptParser {
+
+    func fetchReceipt(_ reader: FileReader, _ bundle: Bundle) throws -> Data {
+        guard let url = bundle.appStoreReceiptURL else {
+            throw Error.receiptNotPresent
+        }
+
+        do {
+            return try reader.contents(of: url)
+        } catch {
+            throw Error.failedToLoadLocalReceipt(error)
+        }
+    }
+
+}

--- a/Sources/LocalReceiptParsing/ReceiptParsingError.swift
+++ b/Sources/LocalReceiptParsing/ReceiptParsingError.swift
@@ -18,7 +18,7 @@ import Foundation
 extension PurchasesReceiptParser {
 
     /// An error thrown by ``PurchasesReceiptParser``
-    public enum Error: Swift.Error, Equatable {
+    public enum Error: Swift.Error {
 
         /// The data object identifier couldn't be found on the receipt.
         case dataObjectIdentifierMissing
@@ -35,6 +35,15 @@ extension PurchasesReceiptParser {
         /// ``PurchasesReceiptParser/parse(base64String:)`` was unable
         /// to decode the base64 string.
         case failedToDecodeBase64String
+
+        /// `Bundle.appStoreReceiptURL` returned `nil`.
+        case receiptNotPresent
+
+        /// Fetching the local receipt failed with an underlying error
+        case failedToLoadLocalReceipt(Swift.Error)
+
+        /// The receipt found on the device was found empty.
+        case foundEmptyLocalReceipt
 
     }
 }
@@ -54,6 +63,12 @@ extension PurchasesReceiptParser.Error: LocalizedError {
             return "Error while parsing in-app purchase. One or more attributes are missing or in the wrong format."
         case .failedToDecodeBase64String:
             return "Error decoding base64 string."
+        case .receiptNotPresent:
+            return "Error loading local receipt: Bundle.appStoreReceiptURL was nil."
+        case let .failedToLoadLocalReceipt(error):
+            return "Error loading local receipt: \(error)"
+        case .foundEmptyLocalReceipt:
+            return "Loaded receipt was found empty."
         }
     }
 

--- a/Tests/APITesters/ReceiptParserAPITester/ReceiptParserAPITester/PurchasesReceiptParserAPI.swift
+++ b/Tests/APITesters/ReceiptParserAPITester/ReceiptParserAPITester/PurchasesReceiptParserAPI.swift
@@ -21,6 +21,7 @@ func checkReceiptParserAPI() {
     do {
         let _: AppleReceipt = try parser.parse(from: Data())
         let _: AppleReceipt = try parser.parse(base64String: "")
+        let _: AppleReceipt = try parser.fetchAndParseLocalReceipt()
     } catch {}
 }
 
@@ -31,6 +32,9 @@ private func checkErrors(_ error: PurchasesReceiptParser.Error) {
     case .receiptParsingError: break
     case .inAppPurchaseParsingError: break
     case .failedToDecodeBase64String: break
+    case .receiptNotPresent: break
+    case let .failedToLoadLocalReceipt(error): print(error)
+    case .foundEmptyLocalReceipt: break
     @unknown default: break
     }
 }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesReceiptParserAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesReceiptParserAPI.swift
@@ -24,6 +24,9 @@ private func checkErrors(_ error: PurchasesReceiptParser.Error) {
     case .receiptParsingError: break
     case .inAppPurchaseParsingError: break
     case .failedToDecodeBase64String: break
+    case .receiptNotPresent: break
+    case let .failedToLoadLocalReceipt(error): print(error)
+    case .foundEmptyLocalReceipt: break
     @unknown default: break
     }
 }

--- a/Tests/ReceiptParserTests/Helpers/MockBundle.swift
+++ b/Tests/ReceiptParserTests/Helpers/MockBundle.swift
@@ -13,8 +13,6 @@
 
 import Foundation
 
-@testable import RevenueCat
-
 final class MockBundle: Bundle {
 
     enum ReceiptURLResult {
@@ -56,38 +54,5 @@ final class MockBundle: Bundle {
 
     private static let mockAppStoreReceiptFileName = "base64encodedreceiptsample1"
     private static let mockSandboxReceiptFileName = "base64encoded_sandboxReceipt"
-
-}
-
-final class MockFileReader: FileReader {
-
-    enum Error: Swift.Error {
-        case noMockedData
-        case emptyMockedData
-    }
-
-    var mockedURLContents: [URL: [Data?]] = [:]
-
-    func mock(url: URL, with data: Data) {
-        self.mockedURLContents[url] = [data]
-    }
-
-    var invokedContentsOfURL: [URL: Int] = [:]
-
-    func contents(of url: URL) throws -> Data {
-        let previouslyInvokedContentsOfURL = self.invokedContentsOfURL[url] ?? 0
-
-        self.invokedContentsOfURL[url, default: 0] += 1
-
-        guard let mockedData = self.mockedURLContents[url] else { throw Error.noMockedData }
-
-        if mockedData.isEmpty {
-            throw Error.emptyMockedData
-        } else if let data = mockedData.onlyElement {
-            return try data.orThrow(Error.noMockedData)
-        } else {
-            return try mockedData[previouslyInvokedContentsOfURL].orThrow(Error.noMockedData)
-        }
-    }
 
 }

--- a/Tests/ReceiptParserTests/ReceiptParserFetchingTests.swift
+++ b/Tests/ReceiptParserTests/ReceiptParserFetchingTests.swift
@@ -17,4 +17,117 @@ import XCTest
 
 class ReceiptParserFetchingTests: XCTestCase {
 
+    private let parser: PurchasesReceiptParser = .default
+    private var mockFileReader: MockFileReader!
+    private var mockBundle: MockBundle!
+
+    override func setUp() {
+        super.setUp()
+
+        self.mockFileReader = .init()
+        self.mockBundle = .init()
+    }
+
+    func testParseWithNoReceiptThrowsError() throws {
+        self.mockBundle.receiptURLResult = .sandboxReceipt
+
+        do {
+            _ = try self.fetchAndParse()
+            fail("Expected error")
+        } catch PurchasesReceiptParser.Error.failedToLoadLocalReceipt {
+            // expected error
+        } catch {
+            fail("Unexpected error: \(error)")
+        }
+
+        expect(self.mockFileReader.invokedContentsOfURL).to(haveCount(1))
+        expect(self.mockFileReader.invokedContentsOfURL.first?.value) == 1
+    }
+
+    func testParseWithNilURLThrowsError() throws {
+        self.mockBundle.receiptURLResult = .nilURL
+
+        do {
+            _ = try self.fetchAndParse()
+            fail("Expected error")
+        } catch {
+            expect(error).to(matchError(PurchasesReceiptParser.Error.receiptNotPresent))
+        }
+    }
+
+    func testParsingEmptyReceiptThrowsError() throws {
+        self.mockBundle.receiptURLResult = .sandboxReceipt
+        self.mockFileReader.mock(url: try XCTUnwrap(self.mockBundle.appStoreReceiptURL), with: Data())
+
+        do {
+            _ = try self.fetchAndParse()
+            fail("Expected error")
+        } catch PurchasesReceiptParser.Error.failedToLoadLocalReceipt(MockFileReader.Error.emptyMockedData) {
+            // expected error
+        } catch {
+            fail("Unexpected error: \(error)")
+        }
+    }
+
+    func testParseReceipt() throws {
+        self.mockBundle.receiptURLResult = .receiptWithData
+
+        let receiptURL = try XCTUnwrap(self.mockBundle.appStoreReceiptURL)
+        let data = try DefaultFileReader().contents(of: receiptURL)
+        let decodedData = try XCTUnwrap(
+            Data(base64Encoded: XCTUnwrap(String(data: data, encoding: .utf8)))
+        )
+
+        self.mockFileReader.mock(url: receiptURL, with: decodedData)
+
+        let receipt = try self.fetchAndParse()
+        expect(receipt.bundleId) == "com.revenuecat.sampleapp"
+        expect(receipt.applicationVersion) == "4"
+        expect(receipt.originalApplicationVersion) == "1.0"
+        expect(receipt.opaqueValue).toNot(beNil())
+        expect(receipt.sha1Hash).toNot(beNil())
+    }
+
+}
+
+// MARK: - Private
+
+private extension ReceiptParserFetchingTests {
+
+    func fetchAndParse() throws -> AppleReceipt {
+        return try self.parser.fetchAndParseLocalReceipt(reader: self.mockFileReader,
+                                                         bundle: self.mockBundle)
+    }
+
+}
+
+// MARK: - MockFileReader
+
+private final class MockFileReader: FileReader {
+
+    enum Error: Swift.Error {
+        case noMockedData
+        case emptyMockedData
+    }
+
+    var mockedURLContents: [URL: Data] = [:]
+
+    func mock(url: URL, with data: Data) {
+        self.mockedURLContents[url] = data
+    }
+
+    var invokedContentsOfURL: [URL: Int] = [:]
+
+    func contents(of url: URL) throws -> Data {
+        self.invokedContentsOfURL[url, default: 0] += 1
+
+        guard let mockedData = self.mockedURLContents[url] else { throw Error.noMockedData }
+
+        if mockedData.isEmpty {
+            throw Error.emptyMockedData
+        } else {
+            return mockedData
+        }
+    }
+
 }

--- a/Tests/UnitTests/Mocks/MockFileReader.swift
+++ b/Tests/UnitTests/Mocks/MockFileReader.swift
@@ -1,0 +1,47 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockFileReader.swift
+//
+//  Created by Nacho Soto on 1/10/23.
+
+@testable import RevenueCat
+
+final class MockFileReader: FileReader {
+
+    enum Error: Swift.Error {
+        case noMockedData
+        case emptyMockedData
+    }
+
+    var mockedURLContents: [URL: [Data?]] = [:]
+
+    func mock(url: URL, with data: Data) {
+        self.mockedURLContents[url] = [data]
+    }
+
+    var invokedContentsOfURL: [URL: Int] = [:]
+
+    func contents(of url: URL) throws -> Data {
+        let previouslyInvokedContentsOfURL = self.invokedContentsOfURL[url] ?? 0
+
+        self.invokedContentsOfURL[url, default: 0] += 1
+
+        guard let mockedData = self.mockedURLContents[url] else { throw Error.noMockedData }
+
+        if mockedData.isEmpty {
+            throw Error.emptyMockedData
+        } else if let data = mockedData.onlyElement {
+            return try data.orThrow(Error.noMockedData)
+        } else {
+            return try mockedData[previouslyInvokedContentsOfURL].orThrow(Error.noMockedData)
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes [CSDK-622].

### Changes:
- Extracted `FileReader` to be able to use it in `ReceiptParser`
- Extracted `MockBundle` to be able to use it in `ReceiptParser`
- Added new `public` `ReceiptParser.fetchAndParseLocalReceipt()`, **only to `ReceiptParser`** (this is not available through `RevenueCat`).
- Added tests for the new API
- Added new API to `ReceiptParserAPITester`

Initially I thought about moving `ReceiptFetcher` to the `Receipt|Parser` target. Unfortunately that would require moving a whole bunch of other dependencies (`OperationDispatcher`, etc, etc).
We have no easy way to create a third "Core" framework in which to place these common dependencies, so that wouldn't be trivial.

This solution adds a much simpler version of `ReceiptFetcher` that simply reads from `Bundle.appStoreReceiptURL`. As it's documented there, under normal circumstances `SKReceiptRefreshRequest` is not required, so this implementation should work for 99% of use cases, and so this way we avoid increasing the.codebase complexity unnecessarily.

[CSDK-622]: https://revenuecats.atlassian.net/browse/CSDK-622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ