### PR TITLE
`PurchaseTester`: added section to visualize `AppleReceipt`

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
@@ -940,7 +940,7 @@
 			repositoryURL = "https://github.com/RevenueCat/purchases-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.14.0;
+				minimumVersion = 4.17.0;
 			};
 		};
 		577E0E3B29159A8B0071E063 /* XCRemoteSwiftPackageReference "purchases-ios" */ = {

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
@@ -35,7 +35,6 @@
 		578DAA232947DD8C001700FD /* Core.h in Headers */ = {isa = PBXBuildFile; fileRef = 578DAA222947DD8C001700FD /* Core.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		578DAA262947DD8C001700FD /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 578DAA202947DD8C001700FD /* Core.framework */; platformFilters = (ios, maccatalyst, macos, ); };
 		578DAA272947DD8C001700FD /* Core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 578DAA202947DD8C001700FD /* Core.framework */; platformFilters = (ios, maccatalyst, macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		578DAA2C2947DD90001700FD /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = 578DAA2B2947DD90001700FD /* RevenueCat */; };
 		578DAA2D2947DE37001700FD /* ConfiguredPurchases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ED6A83290891AF009580C6 /* ConfiguredPurchases.swift */; };
 		578DAA2E2947DE59001700FD /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575642A1290C78DD00719219 /* Logger.swift */; };
 		578DAA2F2947DFA6001700FD /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCAF2AB286232EB0004E2CA /* Constants.swift */; };
@@ -940,8 +939,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/RevenueCat/purchases-ios";
 			requirement = {
-				branch = "receipt-parser-fetcher";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.14.0;
 			};
 		};
 		577E0E3B29159A8B0071E063 /* XCRemoteSwiftPackageReference "purchases-ios" */ = {

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
@@ -22,6 +22,12 @@
 		2CF428692863EEAC007E6A78 /* Package+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF428682863EEAC007E6A78 /* Package+Extensions.swift */; };
 		575642A4290C7A2700719219 /* LoggerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575642A3290C7A2700719219 /* LoggerView.swift */; };
 		575642A6290C7D3100719219 /* Windows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575642A5290C7D3100719219 /* Windows.swift */; };
+		5759B472296F9B3B002472D5 /* LocalReceiptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5759B471296F9B3B002472D5 /* LocalReceiptView.swift */; };
+		5759B47529707153002472D5 /* ReceiptParser in Frameworks */ = {isa = PBXBuildFile; productRef = 5759B47429707153002472D5 /* ReceiptParser */; };
+		5759B47729707153002472D5 /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = 5759B47629707153002472D5 /* RevenueCat */; };
+		5759B479297071AE002472D5 /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = 5759B478297071AE002472D5 /* RevenueCat */; };
+		5759B47D297077B1002472D5 /* ReceiptParser in Frameworks */ = {isa = PBXBuildFile; productRef = 5759B47C297077B1002472D5 /* ReceiptParser */; };
+		5759B47F297077B1002472D5 /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = 5759B47E297077B1002472D5 /* RevenueCat */; };
 		578DAA0C2947DD21001700FD /* PurchaseTesterWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578DAA0B2947DD21001700FD /* PurchaseTesterWatchApp.swift */; };
 		578DAA0E2947DD21001700FD /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578DAA0D2947DD21001700FD /* ContentView.swift */; };
 		578DAA102947DD21001700FD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 578DAA0F2947DD21001700FD /* Assets.xcassets */; };
@@ -33,14 +39,12 @@
 		578DAA2D2947DE37001700FD /* ConfiguredPurchases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ED6A83290891AF009580C6 /* ConfiguredPurchases.swift */; };
 		578DAA2E2947DE59001700FD /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575642A1290C78DD00719219 /* Logger.swift */; };
 		578DAA2F2947DFA6001700FD /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCAF2AB286232EB0004E2CA /* Constants.swift */; };
-		578DAA312947E256001700FD /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = 578DAA302947E256001700FD /* RevenueCat */; };
 		578DAA322947E256001700FD /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 578DAA202947DD8C001700FD /* Core.framework */; };
 		578DAA332947E256001700FD /* Core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 578DAA202947DD8C001700FD /* Core.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		57B5795429536B8C003EAA40 /* PurchasesOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B5795029536B8C003EAA40 /* PurchasesOrchestrator.swift */; };
 		57B5795529536B8C003EAA40 /* ProductFetcherSK2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B5795129536B8C003EAA40 /* ProductFetcherSK2.swift */; };
 		57B5795629536B8C003EAA40 /* ObserverModeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B5795229536B8C003EAA40 /* ObserverModeManager.swift */; };
 		57B5795729536B8C003EAA40 /* ProductFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B5795329536B8C003EAA40 /* ProductFetcherSK1.swift */; };
-		57C217AD29159B83005236DB /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = 57C217AC29159B83005236DB /* RevenueCat */; };
 		57E9CF09290B0E0600EE12D1 /* AppIcon.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 57E9CF08290B0BE500EE12D1 /* AppIcon.xcassets */; };
 		57ED6A80290886B6009580C6 /* ConfigurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ED6A7F290886B6009580C6 /* ConfigurationView.swift */; };
 		57ED6A8229089111009580C6 /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ED6A8129089111009580C6 /* Identifiable.swift */; };
@@ -128,6 +132,7 @@
 		575642A1290C78DD00719219 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		575642A3290C7A2700719219 /* LoggerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerView.swift; sourceTree = "<group>"; };
 		575642A5290C7D3100719219 /* Windows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Windows.swift; sourceTree = "<group>"; };
+		5759B471296F9B3B002472D5 /* LocalReceiptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalReceiptView.swift; sourceTree = "<group>"; };
 		576B00A02950FA9700139C53 /* RevenueCat_IntegrationPurchaseTesterConfiguration.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; name = RevenueCat_IntegrationPurchaseTesterConfiguration.storekit; path = ../../PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit; sourceTree = "<group>"; };
 		578DAA092947DD21001700FD /* PurchaseTesterWatchOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PurchaseTesterWatchOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		578DAA0B2947DD21001700FD /* PurchaseTesterWatchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseTesterWatchApp.swift; sourceTree = "<group>"; };
@@ -152,8 +157,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				57C217AD29159B83005236DB /* RevenueCat in Frameworks */,
+				5759B47529707153002472D5 /* ReceiptParser in Frameworks */,
 				578DAA262947DD8C001700FD /* Core.framework in Frameworks */,
+				5759B47729707153002472D5 /* RevenueCat in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -161,8 +167,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				578DAA312947E256001700FD /* RevenueCat in Frameworks */,
+				5759B47D297077B1002472D5 /* ReceiptParser in Frameworks */,
 				578DAA322947E256001700FD /* Core.framework in Frameworks */,
+				5759B47F297077B1002472D5 /* RevenueCat in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -170,7 +177,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				578DAA2C2947DD90001700FD /* RevenueCat in Frameworks */,
+				5759B479297071AE002472D5 /* RevenueCat in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -184,6 +191,7 @@
 				57ED6A7F290886B6009580C6 /* ConfigurationView.swift */,
 				2C10F18427A995150078444D /* HomeView.swift */,
 				575642A3290C7A2700719219 /* LoggerView.swift */,
+				5759B471296F9B3B002472D5 /* LocalReceiptView.swift */,
 				2C10F18D27AAD1F00078444D /* TextFieldAlert.swift */,
 				2C10F18927A996F10078444D /* Customer */,
 				2C10F18827A996B80078444D /* Offerings */,
@@ -333,7 +341,8 @@
 			);
 			name = PurchaseTester;
 			packageProductDependencies = (
-				57C217AC29159B83005236DB /* RevenueCat */,
+				5759B47429707153002472D5 /* ReceiptParser */,
+				5759B47629707153002472D5 /* RevenueCat */,
 			);
 			productName = "PurchaseTester (iOS)";
 			productReference = 2CD2C4F5278C9B02005D1CC2 /* PurchaseTester.app */;
@@ -355,7 +364,8 @@
 			);
 			name = PurchaseTesterWatchOS;
 			packageProductDependencies = (
-				578DAA302947E256001700FD /* RevenueCat */,
+				5759B47C297077B1002472D5 /* ReceiptParser */,
+				5759B47E297077B1002472D5 /* RevenueCat */,
 			);
 			productName = "PurchaseTesterWatchOS Watch App";
 			productReference = 578DAA092947DD21001700FD /* PurchaseTesterWatchOS.app */;
@@ -376,7 +386,7 @@
 			);
 			name = Core;
 			packageProductDependencies = (
-				578DAA2B2947DD90001700FD /* RevenueCat */,
+				5759B478297071AE002472D5 /* RevenueCat */,
 			);
 			productName = Core;
 			productReference = 578DAA202947DD8C001700FD /* Core.framework */;
@@ -413,7 +423,7 @@
 			);
 			mainGroup = 2CD2C4E8278C9B01005D1CC2;
 			packageReferences = (
-				577E0E3B29159A8B0071E063 /* XCRemoteSwiftPackageReference "purchases-ios" */,
+				5759B47329707153002472D5 /* XCRemoteSwiftPackageReference "purchases-ios" */,
 			);
 			productRefGroup = 2CD2C4F6278C9B02005D1CC2 /* Products */;
 			projectDirPath = "";
@@ -469,6 +479,7 @@
 				2C10F19127AC31610078444D /* TransactionsView.swift in Sources */,
 				57B5795429536B8C003EAA40 /* PurchasesOrchestrator.swift in Sources */,
 				2C10F18B27A997570078444D /* CustomerView.swift in Sources */,
+				5759B472296F9B3B002472D5 /* LocalReceiptView.swift in Sources */,
 				2C10F19A27AC32840078444D /* SubscriberAttributesView.swift in Sources */,
 				57B5795629536B8C003EAA40 /* ObserverModeManager.swift in Sources */,
 				2CD2C516278C9B02005D1CC2 /* PurchaseTesterApp.swift in Sources */,
@@ -925,6 +936,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		5759B47329707153002472D5 /* XCRemoteSwiftPackageReference "purchases-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/RevenueCat/purchases-ios";
+			requirement = {
+				branch = "receipt-parser-fetcher";
+				kind = branch;
+			};
+		};
 		577E0E3B29159A8B0071E063 /* XCRemoteSwiftPackageReference "purchases-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/RevenueCat/purchases-ios";
@@ -936,22 +955,32 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		5759B47429707153002472D5 /* ReceiptParser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5759B47329707153002472D5 /* XCRemoteSwiftPackageReference "purchases-ios" */;
+			productName = ReceiptParser;
+		};
+		5759B47629707153002472D5 /* RevenueCat */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5759B47329707153002472D5 /* XCRemoteSwiftPackageReference "purchases-ios" */;
+			productName = RevenueCat;
+		};
+		5759B478297071AE002472D5 /* RevenueCat */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5759B47329707153002472D5 /* XCRemoteSwiftPackageReference "purchases-ios" */;
+			productName = RevenueCat;
+		};
+		5759B47C297077B1002472D5 /* ReceiptParser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5759B47329707153002472D5 /* XCRemoteSwiftPackageReference "purchases-ios" */;
+			productName = ReceiptParser;
+		};
+		5759B47E297077B1002472D5 /* RevenueCat */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5759B47329707153002472D5 /* XCRemoteSwiftPackageReference "purchases-ios" */;
+			productName = RevenueCat;
+		};
 		577E0E3E29159B340071E063 /* RevenueCat */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 577E0E3B29159A8B0071E063 /* XCRemoteSwiftPackageReference "purchases-ios" */;
-			productName = RevenueCat;
-		};
-		578DAA2B2947DD90001700FD /* RevenueCat */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 577E0E3B29159A8B0071E063 /* XCRemoteSwiftPackageReference "purchases-ios" */;
-			productName = RevenueCat;
-		};
-		578DAA302947E256001700FD /* RevenueCat */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 577E0E3B29159A8B0071E063 /* XCRemoteSwiftPackageReference "purchases-ios" */;
-			productName = RevenueCat;
-		};
-		57C217AC29159B83005236DB /* RevenueCat */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 577E0E3B29159A8B0071E063 /* XCRemoteSwiftPackageReference "purchases-ios" */;
 			productName = RevenueCat;

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
@@ -220,6 +220,14 @@ private struct CustomerInfoHeaderView: View {
                 
                 Spacer()
 
+                NavigationLink {
+                    LocalReceiptView()
+                } label: {
+                    Text("Receipt")
+                }
+
+                Spacer()
+
                 if Purchases.shared.isAnonymous {
                     Button {
                         Task<Void, Never> {

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/LocalReceiptView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/LocalReceiptView.swift
@@ -1,0 +1,251 @@
+//
+//  LocalReceiptView.swift
+//  PurchaseTester
+//
+//  Created by Nacho Soto on 1/11/23.
+//
+
+import Foundation
+import SwiftUI
+import RevenueCat
+import ReceiptParser
+
+private typealias AppleReceipt = ReceiptParser.AppleReceipt
+
+@MainActor
+struct LocalReceiptView: View {
+
+    @State
+    private var receipt: Result<AppleReceipt, Error>?
+
+    var body: some View {
+        VStack {
+            if #available(iOS 16.0, macCatalyst 16.0, macOS 13.0, *) {
+                self.form
+                    .scrollContentBackground(.hidden)
+            } else {
+                self.form
+            }
+
+            Spacer(minLength: 10)
+
+            Button {
+                Purchases.shared.restorePurchases { _, error in
+                    if let error = error {
+                        self.receipt = .failure(error)
+                    } else {
+                        Task<Void, Never> {
+                            await self.refreshReceipt()
+                        }
+                    }
+                }
+            } label: {
+                Text("Refresh receipt")
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .navigationTitle("Local Receipt")
+        .task {
+            await self.refreshReceipt()
+        }
+    }
+
+    @ViewBuilder
+    private var form: some View {
+        Form {
+            switch self.receipt {
+            case .none: Text("Loading...")
+            case let .success(receipt)?: ReceiptDataView(receipt: receipt)
+            case let .failure(error)?: Text("Error loading receipt: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private func refreshReceipt() async {
+        self.receipt = await Self.loadReceipt()
+    }
+
+    private static func loadReceipt() async -> Result<ReceiptParser.AppleReceipt, Error> {
+        return await Task
+            .detached {
+                Result(
+                    catching: { try ReceiptParser.PurchasesReceiptParser.default.fetchAndParseLocalReceipt() }
+                )
+            }
+            .value
+    }
+
+}
+
+private struct ReceiptDataView: View {
+
+    private let values: [DataView.Value]
+    private let purchases: [AppleReceipt.InAppPurchase]
+
+    init(receipt: AppleReceipt) {
+        self.init(
+            values: [
+                .init("Bundle", receipt.bundleId),
+                .init("App Version", receipt.applicationVersion),
+                .init("Creation", receipt.creationDate.formatted()),
+                .init("Hash", receipt.sha1Hash.base64EncodedString())
+            ],
+            purchases: receipt.inAppPurchases
+        )
+    }
+    fileprivate init(values: [DataView.Value], purchases: [AppleReceipt.InAppPurchase]) {
+        self.values = values
+        self.purchases = purchases
+    }
+
+    var body: some View {
+        Section(header: Text("Receipt Data")) {
+            ForEach(self.values) { value in
+                DataView(value: value)
+            }
+        }
+
+        Section(header: Text("Purchases")) {
+            if self.purchases.isEmpty {
+                Text("No purchases found in this receipt.")
+            } else {
+                PurchasesView(purchases: self.purchases)
+            }
+        }
+    }
+
+}
+
+
+private struct PurchasesView: View {
+
+    private struct Item: Identifiable {
+        let index: Int
+        let purchase: AppleReceipt.InAppPurchase
+
+        var id: String { return "\(self.index)-\(self.purchase.transactionId)" }
+    }
+
+    let purchases: [AppleReceipt.InAppPurchase]
+
+    var body: some View {
+        List(self.purchases.enumerated().map(Item.init)) {
+            PurchaseView(purchase: $0.purchase)
+        }
+    }
+
+    private struct PurchaseView: View {
+
+        let purchase: AppleReceipt.InAppPurchase
+
+        var body: some View {
+            VStack {
+                Text(self.purchase.productId)
+                    .font(.title3.bold())
+                    .minimumScaleFactor(0.3)
+                    .lineLimit(1)
+                    .padding(.bottom, 5)
+
+                DataView(name: "Transaction", display: self.purchase.transactionId)
+                    .font(.caption2)
+
+                DataView(name: "Product Type", display: self.purchase.productType.display)
+
+                DataView(name: "Purchase Date", display: self.purchase.purchaseDate.formatted())
+
+                if let expiration = self.purchase.expiresDate {
+                    DataView(name: "Expiration", display: expiration.formatted())
+                }
+
+                if let cancellation = self.purchase.cancellationDate {
+                    DataView(name: "Cancellation", display: cancellation.formatted())
+                }
+
+                if let promoOffer = self.purchase.promotionalOfferIdentifier {
+                    DataView(name: "Promo Offer", display: promoOffer)
+                }
+
+                DataView(
+                    name: "In Trial Period",
+                    display: self.purchase.isInTrialPeriod?.description ?? "unknown"
+                )
+                DataView(
+                    name: "In Intro Offer Period",
+                    display: self.purchase.isInIntroOfferPeriod?.description ?? "unknown"
+                )
+            }
+        }
+
+    }
+
+}
+
+private struct DataView: View {
+
+    struct Value: Equatable, Identifiable {
+
+        let name: String
+        let display: String
+
+        init(_ name: String, _ display: String) {
+            self.name = name
+            self.display = display
+        }
+
+        var id: String { return self.name }
+
+    }
+
+    let value: Value
+
+    init(value: Value) { self.value = value }
+    init(name: String, display: String) { self.init(value: .init(name, display)) }
+
+    var body: some View {
+        HStack {
+            Text(self.value.name)
+                .font(.headline)
+
+            Spacer()
+
+            Text(self.value.display)
+                .font(.body)
+        }
+    }
+
+}
+
+private extension AppleReceipt.InAppPurchase.ProductType {
+
+    var display: String {
+        switch self {
+        case .nonConsumable: return "Non Consumable"
+        case .consumable: return "Consumable"
+        case .nonRenewingSubscription: return "Non-renewing Subscription"
+        case .autoRenewableSubscription: return "Auto-renewable Subscription"
+
+        case .unknown: fallthrough
+        @unknown default: return "unknown"
+        }
+    }
+
+}
+
+#if DEBUG
+
+struct LocalReceiptView_Previews: PreviewProvider {
+
+    static var previews: some View {
+        ReceiptDataView(
+            values: [
+                .init("Bundle", "com.revenuecat.purchasetester"),
+                .init("App Version", "1.0"),
+                .init("Creation", Date().formatted())
+            ],
+            purchases: []
+        )
+    }
+
+}
+
+#endif

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/LocalReceiptView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/LocalReceiptView.swift
@@ -30,6 +30,8 @@ struct LocalReceiptView: View {
             Spacer(minLength: 10)
 
             Button {
+                // There's no public API to refresh the receipt other than this.
+                // This is the simplest way to force a receipt refresh before fetching it again.
                 Purchases.shared.restorePurchases { _, error in
                     if let error = error {
                         self.receipt = .failure(error)


### PR DESCRIPTION
Fixes [CSDK-626].

Depends on #2199, #2200, #2202, #2203, #2204, #2210.

![Simulator Screen Shot - iPhone 14 Pro Max - 2023-01-12 at 09 59 26](https://user-images.githubusercontent.com/685609/212144932-4dd83560-69cd-44c5-9611-100ad35ba525.png)


[CSDK-626]: https://revenuecats.atlassian.net/browse/CSDK-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ