### PR TITLE
`JSONDecoder`: added decoding type when logging `DecodingError.keyNotFound`

### DIFF
--- a/Sources/FoundationExtensions/JSONDecoder+Extensions.swift
+++ b/Sources/FoundationExtensions/JSONDecoder+Extensions.swift
@@ -52,7 +52,7 @@ extension JSONDecoder {
             return try self.decode(type, from: jsonData)
         } catch {
             if logErrors {
-                ErrorUtils.logDecodingError(error)
+                ErrorUtils.logDecodingError(error, type: type)
             }
             throw error
         }
@@ -86,7 +86,7 @@ extension JSONDecoder {
 
 extension ErrorUtils {
 
-    static func logDecodingError(_ error: Error) {
+    static func logDecodingError(_ error: Error, type: Any.Type) {
         guard let decodingError = error as? DecodingError else {
             Logger.error(Strings.codable.decoding_error(error))
             return
@@ -97,7 +97,7 @@ extension ErrorUtils {
             Logger.error(Strings.codable.corrupted_data_error(context: context))
         case let .keyNotFound(key, context):
             // This is expected to happen occasionally, the backend doesn't always populate all key/values.
-            Logger.debug(Strings.codable.keyNotFoundError(key: key, context: context))
+            Logger.debug(Strings.codable.keyNotFoundError(type: type, key: key, context: context))
         case let .valueNotFound(value, context):
             Logger.debug(Strings.codable.valueNotFoundError(value: value, context: context))
         case let .typeMismatch(type, context):

--- a/Sources/Logging/Strings/CodableStrings.swift
+++ b/Sources/Logging/Strings/CodableStrings.swift
@@ -38,7 +38,8 @@ extension CodableStrings: CustomStringConvertible {
             return "No value found for: \(value), codingPath: \(context.codingPath), description:\n\(description)"
         case let .keyNotFoundError(type, key, context):
             let description = context.debugDescription
-            return "Error deserializing `\(type)`. Key '\(key)' not found, codingPath: \(context.codingPath), description:\n\(description)"
+            return "Error deserializing `\(type)`. " +
+            "Key '\(key)' not found, codingPath: \(context.codingPath), description:\n\(description)"
         case let .invalid_json_error(jsonData):
             return "The given json data was not valid: \n\(jsonData)"
         case let .encoding_error(error):

--- a/Sources/Logging/Strings/CodableStrings.swift
+++ b/Sources/Logging/Strings/CodableStrings.swift
@@ -18,7 +18,7 @@ enum CodableStrings {
 
     case unexpectedValueError(type: Any.Type, value: Any)
     case valueNotFoundError(value: Any.Type, context: DecodingError.Context)
-    case keyNotFoundError(key: CodingKey, context: DecodingError.Context)
+    case keyNotFoundError(type: Any.Type, key: CodingKey, context: DecodingError.Context)
     case invalid_json_error(jsonData: [String: Any])
     case encoding_error(_ error: Error)
     case decoding_error(_ error: Error)
@@ -36,9 +36,9 @@ extension CodableStrings: CustomStringConvertible {
         case let .valueNotFoundError(value, context):
             let description = context.debugDescription
             return "No value found for: \(value), codingPath: \(context.codingPath), description:\n\(description)"
-        case let .keyNotFoundError(key, context):
+        case let .keyNotFoundError(type, key, context):
             let description = context.debugDescription
-            return "Key '\(key)' not found, codingPath: \(context.codingPath), description:\n\(description)"
+            return "Error deserializing `\(type)`. Key '\(key)' not found, codingPath: \(context.codingPath), description:\n\(description)"
         case let .invalid_json_error(jsonData):
             return "The given json data was not valid: \n\(jsonData)"
         case let .encoding_error(error):


### PR DESCRIPTION
See [TRIAGE-240].

That logged an error:
```
Key 'CodingKeys(stringValue: "data", intValue: nil)' not found, codingPath: [], description:
No value associated with key CodingKeys(stringValue: "data", intValue: nil) ("data").
```

But it was impossible to determine where it was coming from.
With this change now we get:
```
Error deserializing `Response`. Key 'CodingKeys(stringValue: "data", intValue: nil)' not found, codingPath: [], description:
No value associated with key CodingKeys(stringValue: "data", intValue: nil) ("data").
```

[TRIAGE-240]: https://revenuecats.atlassian.net/browse/TRIAGE-240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ