### PR TITLE
`CustomerInfo`: support parsing schema version 2 to restore SDK `v3.x` compatibility

### DIFF
--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -221,6 +221,7 @@ extension CustomerInfo {
     static let currentSchemaVersion = "3"
 
     private static let compatibleSchemaVersions: Set<String> = [
+        // Version 3 is virtually identical to 2 (only difference is `Codable` vs manual decoding).
         "2",
         CustomerInfo.currentSchemaVersion
     ]

--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -212,11 +212,18 @@ extension CustomerInfo {
         return self.data.schemaVersion
     }
 
-    var isInCurrentSchemaVersion: Bool {
-        return self.schemaVersion == Self.currentSchemaVersion
+    var schemaVersionIsCompatible: Bool {
+        guard let version = self.schemaVersion else { return false }
+
+        return Self.compatibleSchemaVersions.contains(version)
     }
 
     static let currentSchemaVersion = "3"
+
+    private static let compatibleSchemaVersions: Set<String> = [
+        "2",
+        CustomerInfo.currentSchemaVersion
+    ]
 
 }
 

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -164,7 +164,7 @@ class CustomerInfoManager {
         do {
             let info: CustomerInfo = try JSONDecoder.default.decode(jsonData: customerInfoData)
 
-            if info.isInCurrentSchemaVersion {
+            if info.schemaVersionIsCompatible {
                 return info
             } else {
                 return nil

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -357,7 +357,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
     }
 
     func testCachedCustomerInfoReturnsNilIfDifferentSchema() throws {
-        let oldSchemaVersion = Int(CustomerInfo.currentSchemaVersion)! - 1
+        let oldSchemaVersion = Int(CustomerInfo.currentSchemaVersion)! - 2
         let data: [String: Any] = [
             "request_date": "2019-08-16T10:30:42Z",
             "schema_version": "\(oldSchemaVersion)",
@@ -375,6 +375,27 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
 
         let receivedCustomerInfo = customerInfoManager.cachedCustomerInfo(appUserID: appUserID)
         expect(receivedCustomerInfo).to(beNil())
+    }
+
+    func testCachedCustomerInfoParsesVersion2() throws {
+        let oldSchemaVersion = 2
+        let data: [String: Any] = [
+            "request_date": "2019-08-16T10:30:42Z",
+            "schema_version": "\(oldSchemaVersion)",
+            "subscriber": [
+                "original_app_user_id": Self.appUserID,
+                "first_seen": "2019-06-17T16:05:33Z",
+                "subscriptions": ["product_a": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]],
+                "other_purchases": [:]
+            ]
+        ]
+
+        let object = try JSONSerialization.data(withJSONObject: data, options: [])
+        let appUserID = "myUser"
+        self.mockDeviceCache.cachedCustomerInfo[appUserID] = object
+
+        let receivedCustomerInfo = self.customerInfoManager.cachedCustomerInfo(appUserID: appUserID)
+        expect(receivedCustomerInfo).toNot(beNil())
     }
 
     func testCacheCustomerInfoStoresCorrectly() {

--- a/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
@@ -16,9 +16,10 @@ import Nimble
 import SnapshotTesting
 import XCTest
 
+private let dateFormatter = ISO8601DateFormatter.default
+
 class CustomerInfoDecodingTests: BaseHTTPResponseTest {
 
-    private static let dateFormatter = ISO8601DateFormatter()
     private static let nonSubscriptionID = "com.revenuecat.product.tip"
     private static let subscriptionID = "com.revenuecat.monthly_4.99.1_week_intro"
 
@@ -41,11 +42,11 @@ class CustomerInfoDecodingTests: BaseHTTPResponseTest {
     func testSubscriberData() throws {
         let subscriber = self.customerInfo.subscriber
 
-        expect(subscriber.firstSeen) == Self.dateFormatter.date(from: "2022-03-08T17:42:58Z")
+        expect(subscriber.firstSeen) == dateFormatter.date(from: "2022-03-08T17:42:58Z")
         expect(subscriber.managementUrl) == URL(string: "https://apps.apple.com/account/subscriptions")!
         expect(subscriber.originalAppUserId) == "$RCAnonymousID:5b6fdbac3a0c4f879e43d269ecdf9ba1"
         expect(subscriber.originalApplicationVersion) == "1.0"
-        expect(subscriber.originalPurchaseDate) == Self.dateFormatter.date(from: "2022-04-12T00:03:24Z")
+        expect(subscriber.originalPurchaseDate) == dateFormatter.date(from: "2022-04-12T00:03:24Z")
     }
 
     func testNonSubscriptions() throws {
@@ -55,8 +56,8 @@ class CustomerInfoDecodingTests: BaseHTTPResponseTest {
         expect(subscriber.nonSubscriptions[Self.nonSubscriptionID]).to(haveCount(1))
 
         let transaction = try XCTUnwrap(subscriber.nonSubscriptions[Self.nonSubscriptionID]?.first)
-        expect(transaction.purchaseDate) == Self.dateFormatter.date(from: "2022-02-11T00:03:28Z")
-        expect(transaction.originalPurchaseDate) == Self.dateFormatter.date(from: "2022-03-10T00:04:28Z")
+        expect(transaction.purchaseDate) == dateFormatter.date(from: "2022-02-11T00:03:28Z")
+        expect(transaction.originalPurchaseDate) == dateFormatter.date(from: "2022-03-10T00:04:28Z")
         expect(transaction.transactionIdentifier) == "17459f5ff7"
         expect(transaction.store) == .appStore
         expect(transaction.isSandbox) == false
@@ -72,11 +73,11 @@ class CustomerInfoDecodingTests: BaseHTTPResponseTest {
         let subscription = try XCTUnwrap(subscriber.subscriptions[Self.subscriptionID])
 
         expect(subscription.billingIssuesDetectedAt).to(beNil())
-        expect(subscription.expiresDate) == Self.dateFormatter.date(from: "2022-04-12T00:03:35Z")
+        expect(subscription.expiresDate) == dateFormatter.date(from: "2022-04-12T00:03:35Z")
         expect(subscription.isSandbox) == true
-        expect(subscription.originalPurchaseDate) == Self.dateFormatter.date(from: "2022-04-12T00:03:28Z")
+        expect(subscription.originalPurchaseDate) == dateFormatter.date(from: "2022-04-12T00:03:28Z")
         expect(subscription.periodType) == .intro
-        expect(subscription.purchaseDate) == Self.dateFormatter.date(from: "2022-04-12T00:03:28Z")
+        expect(subscription.purchaseDate) == dateFormatter.date(from: "2022-04-12T00:03:28Z")
         expect(subscription.store) == .appStore
         expect(subscription.unsubscribeDetectedAt).to(beNil())
 
@@ -87,14 +88,14 @@ class CustomerInfoDecodingTests: BaseHTTPResponseTest {
         let subscriber = self.customerInfo.subscriber
 
         let entitlement1 = try XCTUnwrap(subscriber.entitlements["premium"])
-        expect(entitlement1.expiresDate) == Self.dateFormatter.date(from: "1990-08-30T02:40:36Z")
+        expect(entitlement1.expiresDate) == dateFormatter.date(from: "1990-08-30T02:40:36Z")
         expect(entitlement1.productIdentifier) == Self.subscriptionID
-        expect(entitlement1.purchaseDate) == Self.dateFormatter.date(from: "1990-08-30T02:40:36Z")
+        expect(entitlement1.purchaseDate) == dateFormatter.date(from: "1990-08-30T02:40:36Z")
 
         let entitlement2 = try XCTUnwrap(subscriber.entitlements["tip"])
         expect(entitlement2.expiresDate).to(beNil())
         expect(entitlement2.productIdentifier) == Self.nonSubscriptionID
-        expect(entitlement2.purchaseDate) == Self.dateFormatter.date(from: "1990-09-30T02:40:36Z")
+        expect(entitlement2.purchaseDate) == dateFormatter.date(from: "1990-09-30T02:40:36Z")
     }
 
     func testEntitlementsContainAllRawData() throws {
@@ -139,6 +140,75 @@ class CustomerInfoDecodingTests: BaseHTTPResponseTest {
 
     func testEncoding() {
         assertSnapshot(matching: self.customerInfo, as: .backwardsCompatibleFormattedJson)
+    }
+
+}
+
+class CustomerInfoVersion2DecodingTests: BaseHTTPResponseTest {
+
+    private var customerInfo: CustomerInfo!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        self.customerInfo = try self.decodeFixture("CustomerInfo-v2")
+    }
+
+    func testSchemaVersion() {
+        expect(self.customerInfo.schemaVersion) == "2"
+    }
+
+    func testRequestDate() throws {
+        expect(self.customerInfo.requestDate) == Date(timeIntervalSince1970: 1673555557)
+    }
+
+    func testSubscriberData() throws {
+        let subscriber = self.customerInfo.subscriber
+
+        expect(subscriber.firstSeen) == dateFormatter.date(from: "2023-01-12T20:15:09Z")
+        expect(subscriber.managementUrl) == URL(string: "https://apps.apple.com/account/subscriptions")!
+        expect(subscriber.originalAppUserId) == "$RCAnonymousID:8e603271a2e24df49f02f14704d8287c"
+        expect(subscriber.originalApplicationVersion) == "1.0"
+        expect(subscriber.originalPurchaseDate) == dateFormatter.date(from: "2013-08-01T07:00:00Z")
+    }
+
+    func testNonSubscriptions() throws {
+        expect(self.customerInfo.subscriber.nonSubscriptions).to(beEmpty())
+    }
+
+    func testSubscriptions() throws {
+        let subscriber = self.customerInfo.subscriber
+
+        expect(Set(subscriber.subscriptions.keys)) == [
+            "com.revenuecat.monthly_4.99.1_week_intro",
+            "com.revenuecat.intro_test.monthly.no_intro",
+            "com.revenuecat.annual_39.99.2_week_intro",
+            "com.revenuecat.intro_test.monthly.1_week_intro"
+        ]
+        let subscription = try XCTUnwrap(subscriber.subscriptions["com.revenuecat.monthly_4.99.1_week_intro"])
+
+        expect(subscription.billingIssuesDetectedAt).to(beNil())
+        expect(subscription.expiresDate) == dateFormatter.date(from: "2023-01-12T20:34:44Z")
+        expect(subscription.isSandbox) == true
+        expect(subscription.originalPurchaseDate) == dateFormatter.date(from: "2022-12-19T22:34:04Z")
+        expect(subscription.periodType) == .normal
+        expect(subscription.purchaseDate) == dateFormatter.date(from: "2023-01-12T20:29:44Z")
+        expect(subscription.store) == .appStore
+        expect(subscription.unsubscribeDetectedAt).to(beNil())
+    }
+
+    func testEntitlements() throws {
+        let entitlements = self.customerInfo.subscriber.entitlements
+        expect(Set(entitlements.keys)) == ["premium"]
+
+        let entitlement = try XCTUnwrap(entitlements["premium"])
+        expect(entitlement.expiresDate) == dateFormatter.date(from: "2023-01-12T20:34:44Z")
+        expect(entitlement.productIdentifier) == "com.revenuecat.monthly_4.99.1_week_intro"
+        expect(entitlement.purchaseDate) == dateFormatter.date(from: "2023-01-12T20:29:44Z")
+    }
+
+    func testReencoding() {
+        expect(try self.customerInfo.encodeAndDecode()) == self.customerInfo
     }
 
 }

--- a/Tests/UnitTests/Networking/Responses/Fixtures/CustomerInfo-v2.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/CustomerInfo-v2.json
@@ -1,0 +1,81 @@
+{
+    "request_date_ms": 1673555557519,
+    "subscriber": {
+        "non_subscriptions": {},
+        "first_seen": "2023-01-12T20:15:09Z",
+        "original_application_version": "1.0",
+        "other_purchases": {},
+        "management_url": "https://apps.apple.com/account/subscriptions",
+        "subscriptions": {
+            "com.revenuecat.monthly_4.99.1_week_intro": {
+                "original_purchase_date": "2022-12-19T22:34:04Z",
+                "expires_date": "2023-01-12T20:34:44Z",
+                "is_sandbox": true,
+                "refunded_at": null,
+                "unsubscribe_detected_at": null,
+                "grace_period_expires_date": null,
+                "period_type": "normal",
+                "purchase_date": "2023-01-12T20:29:44Z",
+                "billing_issues_detected_at": null,
+                "ownership_type": "PURCHASED",
+                "store": "app_store",
+                "auto_resume_date": null
+            },
+            "com.revenuecat.intro_test.monthly.no_intro": {
+                "original_purchase_date": "2022-12-21T18:14:53Z",
+                "expires_date": "2022-12-21T18:39:49Z",
+                "is_sandbox": true,
+                "refunded_at": null,
+                "unsubscribe_detected_at": "2023-01-12T20:16:21Z",
+                "grace_period_expires_date": null,
+                "period_type": "normal",
+                "purchase_date": "2022-12-21T18:34:49Z",
+                "billing_issues_detected_at": null,
+                "ownership_type": "PURCHASED",
+                "store": "app_store",
+                "auto_resume_date": null
+            },
+            "com.revenuecat.annual_39.99.2_week_intro": {
+                "original_purchase_date": "2022-12-19T22:34:04Z",
+                "expires_date": "2022-12-20T09:34:35Z",
+                "is_sandbox": true,
+                "refunded_at": null,
+                "unsubscribe_detected_at": null,
+                "grace_period_expires_date": null,
+                "period_type": "normal",
+                "purchase_date": "2022-12-20T08:34:35Z",
+                "billing_issues_detected_at": null,
+                "ownership_type": "PURCHASED",
+                "store": "app_store",
+                "auto_resume_date": null
+            },
+            "com.revenuecat.intro_test.monthly.1_week_intro": {
+                "original_purchase_date": "2022-12-21T18:14:53Z",
+                "expires_date": "2022-12-21T19:17:44Z",
+                "is_sandbox": true,
+                "refunded_at": null,
+                "unsubscribe_detected_at": "2023-01-12T20:16:21Z",
+                "grace_period_expires_date": null,
+                "period_type": "normal",
+                "purchase_date": "2022-12-21T19:12:44Z",
+                "billing_issues_detected_at": null,
+                "ownership_type": "PURCHASED",
+                "store": "app_store",
+                "auto_resume_date": null
+            }
+        },
+        "entitlements": {
+            "premium": {
+                "grace_period_expires_date": null,
+                "purchase_date": "2023-01-12T20:29:44Z",
+                "product_identifier": "com.revenuecat.monthly_4.99.1_week_intro",
+                "expires_date": "2023-01-12T20:34:44Z"
+            }
+        },
+        "original_purchase_date": "2013-08-01T07:00:00Z",
+        "original_app_user_id": "$RCAnonymousID:8e603271a2e24df49f02f14704d8287c",
+        "last_seen": "2023-01-12T20:15:09Z"
+    },
+    "request_date": "2023-01-12T20:32:37Z",
+    "schema_version": "2"
+}


### PR DESCRIPTION
Fixes [TRIAGE-240].

When we converted `CustomerInfo` to use `Codable` (#1496), the schema version was also changed from 2 to 3.
I don't remember if this was done on purpose, but turns out that it was not necessary.

This means that a user opening an app while offline, after upgrading from version `3.x` to `4.x` (>= `4.3`), would not have a cached `CustomerInfo` and therefore no entitlements.
This fixes that by restoring support and adding a specific test with a sample version 2 JSON (which is virtually identical).


[TRIAGE-240]: https://revenuecats.atlassian.net/browse/TRIAGE-240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ