### PR TITLE
Created `Signing.verify(message:hasValidSignature:with:)`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -306,6 +306,7 @@
 		5791A1C82767FC9400C972AA /* ManageSubscriptionsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791A1C72767FC9400C972AA /* ManageSubscriptionsHelperTests.swift */; };
 		5791CE80273F26A000E50C4B /* base64encoded_sandboxReceipt.txt in Resources */ = {isa = PBXBuildFile; fileRef = 5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */; };
 		5791FC7A2991D31600F1FEDA /* public_key.der in Resources */ = {isa = PBXBuildFile; fileRef = 5791FC792991D31600F1FEDA /* public_key.der */; };
+		5791FCF32992D3EC00F1FEDA /* SigningStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791FCF22992D3EC00F1FEDA /* SigningStrings.swift */; };
 		579234E327F7788900B39C68 /* BaseBackendIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579234E127F777EE00B39C68 /* BaseBackendIntegrationTests.swift */; };
 		579234E527F779FE00B39C68 /* SubscriberAttributesManagerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579234E427F779FE00B39C68 /* SubscriberAttributesManagerIntegrationTests.swift */; };
 		5793397028E77A5100C1232C /* PaymentQuueWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5793396F28E77A5100C1232C /* PaymentQuueWrapperTests.swift */; };
@@ -914,6 +915,7 @@
 		5791A1C72767FC9400C972AA /* ManageSubscriptionsHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionsHelperTests.swift; sourceTree = "<group>"; };
 		5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = base64encoded_sandboxReceipt.txt; sourceTree = "<group>"; };
 		5791FC792991D31600F1FEDA /* public_key.der */ = {isa = PBXFileReference; lastKnownFileType = file; path = public_key.der; sourceTree = "<group>"; };
+		5791FCF22992D3EC00F1FEDA /* SigningStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigningStrings.swift; sourceTree = "<group>"; };
 		579234E127F777EE00B39C68 /* BaseBackendIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBackendIntegrationTests.swift; sourceTree = "<group>"; };
 		579234E427F779FE00B39C68 /* SubscriberAttributesManagerIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriberAttributesManagerIntegrationTests.swift; sourceTree = "<group>"; };
 		5793396F28E77A5100C1232C /* PaymentQuueWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentQuueWrapperTests.swift; sourceTree = "<group>"; };
@@ -1283,6 +1285,7 @@
 				9A65E09F2591A23200DE00B0 /* OfferingStrings.swift */,
 				9A65E0A42591A23500DE00B0 /* PurchaseStrings.swift */,
 				9A65E0A92591A23800DE00B0 /* RestoreStrings.swift */,
+				5791FCF22992D3EC00F1FEDA /* SigningStrings.swift */,
 				F5C0196826E880800005D61E /* StoreKitStrings.swift */,
 				37E3507939634ED5A9280544 /* Strings.swift */,
 			);
@@ -2845,6 +2848,7 @@
 				57CCC6EC2984496D001CE9B6 /* Box.swift in Sources */,
 				575137CF27F50D2F0064AB2C /* HTTPResponseBody.swift in Sources */,
 				573E7F092819B989007C9128 /* StoreKitWorkarounds.swift in Sources */,
+				5791FCF32992D3EC00F1FEDA /* SigningStrings.swift in Sources */,
 				B3AA6236268A81C700894871 /* EntitlementInfos.swift in Sources */,
 				B372EC56268FEF020099171E /* ProductRequestData.swift in Sources */,
 				359E8E3F26DEBEEB00B869F9 /* TrialOrIntroPriceEligibilityChecker.swift in Sources */,

--- a/Sources/Logging/Strings/SigningStrings.swift
+++ b/Sources/Logging/Strings/SigningStrings.swift
@@ -1,0 +1,37 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SigningStrings.swift
+//
+//  Created by Nacho Soto on 2/7/23.
+
+import Foundation
+
+// swiftlint:disable identifier_name
+enum SigningStrings {
+
+    case signature_not_base64(String)
+
+    case signature_failed_verification
+
+}
+
+extension SigningStrings: CustomStringConvertible {
+
+    var description: String {
+        switch self {
+        case let .signature_not_base64(signature):
+            return "Signature is not base64: \(signature)"
+
+        case .signature_failed_verification:
+            return "Signature failed validation"
+        }
+    }
+
+}

--- a/Sources/Logging/Strings/Strings.swift
+++ b/Sources/Logging/Strings/Strings.swift
@@ -26,6 +26,7 @@ enum Strings {
     static let purchase = PurchaseStrings.self
     static let receipt = ReceiptStrings.self
     static let restore = RestoreStrings.self
+    static let signing = SigningStrings.self
     static let storeKit = StoreKitStrings.self
 
 }

--- a/Sources/Misc/Signing.swift
+++ b/Sources/Misc/Signing.swift
@@ -36,6 +36,32 @@ enum Signing {
         return try Self.loadPublicKey(in: url)
     }
 
+    static func verify(
+        message: Data,
+        nonce: Data,
+        hasValidSignature signature: String,
+        with publicKey: PublicKey
+    ) -> Bool {
+        // TODO: extract warning Strings
+
+        guard let signature = Data(base64Encoded: signature) else {
+            Logger.warn("Signature is not base64: \(signature)")
+            return false
+        }
+
+        let salt = signature.subdata(in: 0..<Self.saltSize)
+        let signatureToVerify = signature.subdata(in: Self.saltSize..<signature.count)
+        let messageToVerify = salt + nonce + message
+
+        let isValid = publicKey.isValidSignature(signatureToVerify, for: messageToVerify)
+
+        if !isValid {
+            Logger.warn("Signature failed validation")
+        }
+
+        return isValid
+    }
+
     /// - Throws: ``ErrorCode/configurationError``
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     static func verificationLevel(
@@ -53,6 +79,7 @@ enum Signing {
     private static let publicKeyFileName = "public_key"
     private static let publicKeyFileExtension = "der"
 
+    internal static let saltSize = 16
 }
 
 extension Signing {

--- a/Sources/Misc/Signing.swift
+++ b/Sources/Misc/Signing.swift
@@ -42,10 +42,8 @@ enum Signing {
         hasValidSignature signature: String,
         with publicKey: PublicKey
     ) -> Bool {
-        // TODO: extract warning Strings
-
         guard let signature = Data(base64Encoded: signature) else {
-            Logger.warn("Signature is not base64: \(signature)")
+            Logger.warn(Strings.signing.signature_not_base64(signature))
             return false
         }
 
@@ -56,7 +54,7 @@ enum Signing {
         let isValid = publicKey.isValidSignature(signatureToVerify, for: messageToVerify)
 
         if !isValid {
-            Logger.warn("Signature failed validation")
+            Logger.warn(Strings.signing.signature_failed_verification)
         }
 
         return isValid

--- a/Tests/UnitTests/Misc/SigningTests.swift
+++ b/Tests/UnitTests/Misc/SigningTests.swift
@@ -118,5 +118,5 @@ extension SigningTests {
 
         return try key.signature(for: fullMessage)
     }
-    
+
 }

--- a/Tests/UnitTests/Misc/SigningTests.swift
+++ b/Tests/UnitTests/Misc/SigningTests.swift
@@ -76,15 +76,22 @@ class SigningTests: TestCase {
         logger.verifyMessageWasLogged("Signature is not base64: \(signature)")
     }
 
-    func testVerifySignatureReturnsFalseAndLogsError() throws {
-        let logger = TestLogHandler()
-
+    func testVerifySignatureWithInvalidSignature() throws {
         expect(Signing.verify(message: "Hello World".asData,
                               nonce: "nonce".asData,
                               hasValidSignature: "invalid signature".asData.base64EncodedString(),
                               with: try Signing.loadPublicKey())) == false
+    }
 
-        logger.verifyMessageWasLogged("Signature failed validation")
+    func testVerifySignatureLogsWarningWhenFail() throws {
+        let logger = TestLogHandler()
+
+        _ = Signing.verify(message: "Hello World".asData,
+                           nonce: "nonce".asData,
+                           hasValidSignature: "invalid signature".asData.base64EncodedString(),
+                           with: try Signing.loadPublicKey())
+
+        logger.verifyMessageWasLogged("Signature failed validation", level: .warn)
     }
 
     func testVerifySignatureWithValidSignature() throws {


### PR DESCRIPTION
Fixes [CSDK-633].
This adds `Signing.verify(message:nonce:hasValidSignature:with:)`.

Thanks to @tonidero for helping with the signature part (#2253).

[CSDK-633]: https://revenuecats.atlassian.net/browse/CSDK-633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ