### PR TITLE
`SPM`: added `APPLICATION_EXTENSION_API_ONLY` flag to `RevenueCat` and `ReceiptParser`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,13 @@ if shouldIncludeDocCPlugin {
     dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
 }
 
+// Equivalent to `APPLICATION_EXTENSION_API_ONLY`
+// (see https://xcodebuildsettings.com/#application_extension_api_only)
+// This is the only way to set this flag for SPM at the moment.
+// The Xcode targets have this flag as well.
+// It allows users to embed these frameworks in a non-app target without receiving warnings.
+let noApplicationExtension: LinkerSetting = .unsafeFlags(["-Xlinker", "-no_application_extension"])
+
 let package = Package(
     name: "RevenueCat",
     platforms: [
@@ -36,14 +43,12 @@ let package = Package(
                 path: "Sources",
                 exclude: ["Info.plist", "LocalReceiptParsing/ReceiptParser-only-files"],
                 linkerSettings: [
-                    // Equivalent to `APPLICATION_EXTENSION_API_ONLY`
-                    .unsafeFlags(["-Xlinker", "-no_application_extension"])
+                    noApplicationExtension
                 ]),
         .target(name: "ReceiptParser",
                 path: "LocalReceiptParsing",
                 linkerSettings: [
-                    // Equivalent to `APPLICATION_EXTENSION_API_ONLY`
-                    .unsafeFlags(["-Xlinker", "-no_application_extension"])
+                    noApplicationExtension
                 ]),
         .testTarget(name: "ReceiptParserTests", dependencies: ["ReceiptParser", "Nimble"])
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -36,11 +36,13 @@ let package = Package(
                 path: "Sources",
                 exclude: ["Info.plist", "LocalReceiptParsing/ReceiptParser-only-files"],
                 linkerSettings: [
+                    // Equivalent to `APPLICATION_EXTENSION_API_ONLY`
                     .unsafeFlags(["-Xlinker", "-no_application_extension"])
                 ]),
         .target(name: "ReceiptParser",
                 path: "LocalReceiptParsing",
                 linkerSettings: [
+                    // Equivalent to `APPLICATION_EXTENSION_API_ONLY`
                     .unsafeFlags(["-Xlinker", "-no_application_extension"])
                 ]),
         .testTarget(name: "ReceiptParserTests", dependencies: ["ReceiptParser", "Nimble"])

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,10 @@ let package = Package(
     targets: [
         .target(name: "RevenueCat",
                 path: "Sources",
-                exclude: ["Info.plist", "LocalReceiptParsing/ReceiptParser-only-files"]),
+                exclude: ["Info.plist", "LocalReceiptParsing/ReceiptParser-only-files"],
+                linkerSettings: [
+                    .unsafeFlags(["-Xlinker", "-no_application_extension"])
+                ]),
         .target(name: "ReceiptParser",
                 path: "LocalReceiptParsing",
                 linkerSettings: [

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,10 @@ let package = Package(
                 path: "Sources",
                 exclude: ["Info.plist", "LocalReceiptParsing/ReceiptParser-only-files"]),
         .target(name: "ReceiptParser",
-                path: "LocalReceiptParsing"),
+                path: "LocalReceiptParsing",
+                linkerSettings: [
+                    .unsafeFlags(["-Xlinker", "-no_application_extension"])
+                ]),
         .testTarget(name: "ReceiptParserTests", dependencies: ["ReceiptParser", "Nimble"])
     ]
 )


### PR DESCRIPTION
This flag is already set in `Xcode`'s target, so setting it here matches it when embedding the frameworks through `SPM`.

<img width="715" alt="Screenshot 2023-01-16 at 10 09 30" src="https://user-images.githubusercontent.com/685609/212742637-ccdd050b-e36a-41ff-b22c-47d7d8e8afbc.png">

This allows users to embed these package in non-app targets.
Unfortunately setting the flag directly is the only way to do this at the moment.
