### PR TITLE
`PurchaseTester`: ignore errors when restoring purchases

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/LocalReceiptView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/LocalReceiptView.swift
@@ -30,14 +30,13 @@ struct LocalReceiptView: View {
             Spacer(minLength: 10)
 
             Button {
-                // There's no public API to refresh the receipt other than this.
-                // This is the simplest way to force a receipt refresh before fetching it again.
-                Purchases.shared.restorePurchases { _, _ in
+                Task<Void, Never> {
+                    // There's no public API to refresh the receipt other than this.
+                    // This is the simplest way to force a receipt refresh before fetching it again.
                     // Ignoring error, since the receipt might have actually been refreshed
                     // and that's all we care about here.
-                    Task<Void, Never> {
-                        await self.refreshReceipt()
-                    }
+                    _ = try? await Purchases.shared.restorePurchases()
+                    await self.refreshReceipt()
                 }
             } label: {
                 Text("Refresh receipt")

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/LocalReceiptView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/LocalReceiptView.swift
@@ -32,13 +32,11 @@ struct LocalReceiptView: View {
             Button {
                 // There's no public API to refresh the receipt other than this.
                 // This is the simplest way to force a receipt refresh before fetching it again.
-                Purchases.shared.restorePurchases { _, error in
-                    if let error = error {
-                        self.receipt = .failure(error)
-                    } else {
-                        Task<Void, Never> {
-                            await self.refreshReceipt()
-                        }
+                Purchases.shared.restorePurchases { _, _ in
+                    // Ignoring error, since the receipt might have actually been refreshed
+                    // and that's all we care about here.
+                    Task<Void, Never> {
+                        await self.refreshReceipt()
                     }
                 }
             } label: {


### PR DESCRIPTION
See #2211.

If `restorePurchases` fails for any reason, we still want to try to load the local receipt. We're only interested in refreshing the receipt to load it.
