### PR TITLE
`SystemInfo.isApplicationBackgrounded`: added overload for `@MainActor`

### DIFF
--- a/Tests/BackendIntegrationTests/SubscriberAttributesManagerIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/SubscriberAttributesManagerIntegrationTests.swift
@@ -39,7 +39,13 @@ class SubscriberAttributesManagerIntegrationTests: BaseBackendIntegrationTests {
     // MARK: -
 
     func testNothingToSync() {
-        expect(Purchases.shared.syncSubscriberAttributes()) == 0
+        waitUntil { completion in
+            let parameters = Purchases.shared.syncSubscriberAttributes(completion: {
+                completion()
+            })
+
+            expect(parameters) == 0
+        }
     }
 
     func testSyncOneAttribute() async throws {


### PR DESCRIPTION
Unfortunately we can't use this in any of the places that use the asynchronous method, but as we move more code to `async` this might be beneficial.

For now this also improves the documentation to explain why the API is asynchronous.