### PR TITLE
Improve logging for custom package durations

### DIFF
--- a/Sources/Logging/Strings/OfferingStrings.swift
+++ b/Sources/Logging/Strings/OfferingStrings.swift
@@ -132,7 +132,7 @@ extension OfferingStrings: CustomStringConvertible {
             return "Unknown subscription length for package '\(package.offeringIdentifier)'. Ignoring."
 
         case let .custom_package_type(package):
-            return "Package '\(package.offeringIdentifier)' has a custom duration. Ignoring."
+            return "Package '\(package.identifier)' in offering '\(package.offeringIdentifier)' has a custom duration. You can reference this package by its identifier ('\(package.identifier)') directly. More information: https://rev.cat/displaying-products"
         }
     }
 

--- a/Sources/Logging/Strings/OfferingStrings.swift
+++ b/Sources/Logging/Strings/OfferingStrings.swift
@@ -129,12 +129,14 @@ extension OfferingStrings: CustomStringConvertible {
             return "Empty Product titles are not supported. Found in product with identifier: \(identifier)"
 
         case let .unknown_package_type(package):
-            return "Package '\(package.identifier)' in offering '\(package.offeringIdentifier)' has an unknown duration." +
+            return "Package '\(package.identifier)' in offering '\(package.offeringIdentifier)' " +
+            "has an unknown duration." +
             "\nYou can reference this package by its identifier ('\(package.identifier)') directly." +
             "\nMore information: https://rev.cat/displaying-products"
 
         case let .custom_package_type(package):
-            return "Package '\(package.identifier)' in offering '\(package.offeringIdentifier)' has a custom duration." +
+            return "Package '\(package.identifier)' in offering '\(package.offeringIdentifier)' " +
+            "has a custom duration." +
             "\nYou can reference this package by its identifier ('\(package.identifier)') directly." +
             "\nMore information: https://rev.cat/displaying-products"
         }

--- a/Sources/Logging/Strings/OfferingStrings.swift
+++ b/Sources/Logging/Strings/OfferingStrings.swift
@@ -129,10 +129,14 @@ extension OfferingStrings: CustomStringConvertible {
             return "Empty Product titles are not supported. Found in product with identifier: \(identifier)"
 
         case let .unknown_package_type(package):
-            return "Unknown subscription length for package '\(package.offeringIdentifier)'. Ignoring."
+            return "Package '\(package.identifier)' in offering '\(package.offeringIdentifier)' has an unknown duration." +
+            "\nYou can reference this package by its identifier ('\(package.identifier)') directly." +
+            "\nMore information: https://rev.cat/displaying-products"
 
         case let .custom_package_type(package):
-            return "Package '\(package.identifier)' in offering '\(package.offeringIdentifier)' has a custom duration. You can reference this package by its identifier ('\(package.identifier)') directly. More information: https://rev.cat/displaying-products"
+            return "Package '\(package.identifier)' in offering '\(package.offeringIdentifier)' has a custom duration." +
+            "\nYou can reference this package by its identifier ('\(package.identifier)') directly." +
+            "\nMore information: https://rev.cat/displaying-products"
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
The previous logs were vague, seemed kind of scary mentioning that the packages would be ignored - but it was just referencing that they couldn't be accessed from an Offering's convenience methods for each duration.

### Description
Updates the logs to explain that packages can be referenced by their identifiers directly with a link to the docs.
