### PR TITLE
`Purchases`: fixed documentation warnings

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -108,8 +108,8 @@ public protocol PurchasesType: AnyObject {
      *
      * #### Related Articles
      * - [Identifying Users](https://docs.revenuecat.com/docs/user-ids)
-     * - ``logIn(_:completion:)``
-     * - ``isAnonymous``
+     * - ``Purchases/logIn(_:)-arja``
+     * - ``Purchases/isAnonymous``
      * - ``Purchases/appUserID``
      */
     func logOut(completion: ((CustomerInfo?, PublicError?) -> Void)?)
@@ -122,8 +122,8 @@ public protocol PurchasesType: AnyObject {
      *
      * #### Related Articles
      * - [Identifying Users](https://docs.revenuecat.com/docs/user-ids)
-     * - ``logIn(_:)``
-     * - ``isAnonymous``
+     * - ``Purchases/logIn(_:)-arja``
+     * - ``Purchases/isAnonymous``
      * - ``Purchases/appUserID``
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)


### PR DESCRIPTION
### Changes:
Fixed this warning:
<img width="877" alt="Screenshot 2023-01-20 at 15 19 32" src="https://user-images.githubusercontent.com/685609/213822055-bdbec3c5-4a11-482c-8236-f38dd5886422.png">

### Explanation:
These started happening after #1958. I assumed it was an Xcode bug, because they were showing up on the wrong file pointing to some unrelated code.
Turns out that by itself was an Xcode bug (filed as `FB11959877`):
<img width="810" alt="Screenshot 2023-01-20 at 15 19 11" src="https://user-images.githubusercontent.com/685609/213822022-99a493ac-3a1b-4435-90a3-806fd41a8d6f.png">

---

But the underlying warning was correct, which this fixes. We just needed to fix the reference to `logIn` to point to the specific overload.
