### PR TITLE
`PurchasesOrchestrator`: finish SK2 transactions from `StoreKit.Transaction.updates` after posting receipt

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -793,17 +793,17 @@ extension PurchasesOrchestrator: StoreKit2TransactionListenerDelegate {
         _ listener: StoreKit2TransactionListener,
         updatedTransaction transaction: StoreTransactionType
     ) async throws {
-        await Async.call { completion in
-            self.finishTransactionIfNeeded(transaction) { @MainActor in
-                completion(())
-            }
-        }
-
         let isRestore = self.systemInfo.observerMode
 
         _ = try await self.syncPurchases(receiptRefreshPolicy: .always,
                                          isRestore: isRestore,
                                          initiationSource: .queue)
+
+        await Async.call { completion in
+            self.finishTransactionIfNeeded(transaction) { @MainActor in
+                completion(())
+            }
+        }
     }
 
 }

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -597,6 +597,34 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testStoreKit2TransactionListenerDoesNotFinishTransactionIfPostingReceiptFails() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        self.setUpStoreKit2Listener()
+
+        let expectedError: BackendError = .missingReceiptFile()
+
+        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
+        self.backend.stubbedPostReceiptResult = .failure(expectedError)
+
+        let transaction = MockStoreTransaction()
+
+        do {
+            try await self.orchestrator.storeKit2TransactionListener(
+                self.mockStoreKit2TransactionListener!,
+                updatedTransaction: transaction
+            )
+            fail("Expected error")
+        } catch {
+            expect(error).to(matchError(expectedError.asPurchasesError))
+        }
+
+        expect(transaction.finishInvoked) == false
+        expect(self.backend.invokedPostReceiptData) == true
+        expect(self.backend.invokedPostReceiptDataParameters?.isRestore) == false
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testStoreKit2TransactionListenerDelegateWithObserverMode() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 


### PR DESCRIPTION
This won't affect the most common scenario (observer mode), since transactions are not finished there.
But it's possible that `StoreKit.Transaction.updates` will have unfinished transactions (maybe those that failed to post previously). In that case, we don't want to finish them until successfully posting the receipts.
