### PR TITLE
`StoreKitIntegrationTests`: replaced `XCTSkipIf` with `XCTExpectFailure`

### DIFF
--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -266,10 +266,9 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     }
 
     func testIneligibleForIntroForDifferentProductInSameSubscriptionGroupAfterPurchase() async throws {
-        try XCTSkipIf(
-            Self.storeKit2Setting == .enabledForCompatibleDevices,
-            "This test currently does not pass with SK2 (see FB11889732)"
-        )
+        if Self.storeKit2Setting == .enabledForCompatibleDevices {
+            XCTExpectFailure("This test currently does not pass with SK2 (see FB11889732)")
+        }
 
         let productWithNoTrial = try await self.product(Self.group3MonthlyNoTrialProductID)
         let productWithTrial = try await self.product(Self.group3MonthlyTrialProductID)


### PR DESCRIPTION
See https://developer.apple.com/documentation/xctest/expected_failures

I realized this going through the old PR. Better to actually run the test so that if/when it gets fixed in the future, we're notified because it will "fail".
