### PR TITLE
`IntroEligibilityCalculator`: changed logic to handle products with no subscription group

### DIFF
--- a/Sources/Purchasing/IntroEligibilityCalculator.swift
+++ b/Sources/Purchasing/IntroEligibilityCalculator.swift
@@ -102,18 +102,12 @@ private extension IntroEligibilityCalculator {
                 result[candidate.productIdentifier] = .unknown
                 continue
             }
-            let activeSubscriptionInGroup = (
-                candidate.subscriptionGroupIdentifier != nil &&
-                activeSubscriptionsProducts.contains {
-                    $0.subscriptionGroupIdentifier == candidate.subscriptionGroupIdentifier
-                }
-            )
-            let expiredTrialInGroup = (
-                candidate.subscriptionGroupIdentifier != nil &&
-                expiredTrialProducts.contains {
-                    $0.subscriptionGroupIdentifier == candidate.subscriptionGroupIdentifier
-                }
-            )
+            let activeSubscriptionInGroup = activeSubscriptionsProducts.contains {
+                $0.subscriptionGroupIdentifier == candidate.subscriptionGroupIdentifier
+            }
+            let expiredTrialInGroup = expiredTrialProducts.contains {
+                $0.subscriptionGroupIdentifier == candidate.subscriptionGroupIdentifier
+            }
 
             if candidate.introductoryDiscount == nil {
                 result[candidate.productIdentifier] = .noIntroOfferExists

--- a/Tests/UnitTests/Purchasing/IntroEligibilityCalculatorTests.swift
+++ b/Tests/UnitTests/Purchasing/IntroEligibilityCalculatorTests.swift
@@ -215,6 +215,48 @@ class IntroEligibilityCalculatorTests: TestCase {
         )
     }
 
+    func testCheckTrialEligibilityReturnsIneligibleForProductWithNoSubscriptionGroupAndActiveSubscription() {
+        self.testEligibility(
+            purchaseExpirationsByProductIdentifier: [
+                "com.revenuecat.product1": Date().addingTimeInterval(1000)
+            ],
+            productsInGroups: [
+                "com.revenuecat.product1": nil
+            ],
+            expectedResult: [
+                "com.revenuecat.product1": .ineligible
+            ]
+        )
+    }
+
+    func testCheckTrialEligibilityReturnsEligibleForProductWithNoSubscriptionGroupAndExpiredSubscriptionWithNoTrial() {
+        self.testEligibility(
+            purchaseExpirationsByProductIdentifier: [
+                ("com.revenuecat.product1", Date().addingTimeInterval(-1000), false)
+            ],
+            productsInGroups: [
+                "com.revenuecat.product1": (groupID: nil, hasTrial: true)
+            ],
+            expectedResult: [
+                "com.revenuecat.product1": .eligible
+            ]
+        )
+    }
+
+    func testCheckTrialEligibilityReturnsIneligibleForProductWithNoSubscriptionGroupAndExpiredSubscriptionWithTrial() {
+        self.testEligibility(
+            purchaseExpirationsByProductIdentifier: [
+                ("com.revenuecat.product1", Date().addingTimeInterval(-1000), true)
+            ],
+            productsInGroups: [
+                "com.revenuecat.product1": (groupID: nil, hasTrial: true)
+            ],
+            expectedResult: [
+                "com.revenuecat.product1": .ineligible
+            ]
+        )
+    }
+
     func testCheckTrialOrIntroDiscountEligibilityForConsumableReturnsUnknown() {
         let receipt = mockReceipt()
         mockReceiptParser.stubbedParseResult = receipt
@@ -247,7 +289,7 @@ private extension IntroEligibilityCalculatorTests {
 
     func testEligibility(
         purchaseExpirationsByProductIdentifier: [String: Date?],
-        productsInGroups: [String: String],
+        productsInGroups: [String: String?],
         expectedResult: [String: IntroEligibilityStatus],
         file: FileString = #file,
         line: UInt = #line
@@ -263,7 +305,7 @@ private extension IntroEligibilityCalculatorTests {
 
     func testEligibility(
         purchaseExpirationsByProductIdentifier: [(productID: String, expiration: Date?, inTrial: Bool)],
-        productsInGroups: [String: (groupID: String, hasTrial: Bool)],
+        productsInGroups: [String: (groupID: String?, hasTrial: Bool)],
         expectedResult: [String: IntroEligibilityStatus],
         file: FileString = #file,
         line: UInt = #line


### PR DESCRIPTION
Follow up to #2174.
