### PR TITLE
PurchaseTester: Add Receipt Inspector UI

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		2CD2C518278C9B02005D1CC2 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CD2C4EF278C9B01005D1CC2 /* ContentView.swift */; };
 		2CD2C51A278C9B02005D1CC2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2CD2C4F0278C9B02005D1CC2 /* Assets.xcassets */; };
 		2CF428692863EEAC007E6A78 /* Package+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF428682863EEAC007E6A78 /* Package+Extensions.swift */; };
+		2DD2CBB129831A09004A3A6A /* ReceiptInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD2CBB029831A09004A3A6A /* ReceiptInspector.swift */; };
+		2DD2CBB329831A22004A3A6A /* ReceiptVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD2CBB229831A22004A3A6A /* ReceiptVerifier.swift */; };
 		575642A4290C7A2700719219 /* LoggerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575642A3290C7A2700719219 /* LoggerView.swift */; };
 		575642A6290C7D3100719219 /* Windows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575642A5290C7D3100719219 /* Windows.swift */; };
 		5759B472296F9B3B002472D5 /* LocalReceiptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5759B471296F9B3B002472D5 /* LocalReceiptView.swift */; };
@@ -128,6 +130,8 @@
 		2CD2C4F0278C9B02005D1CC2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2CD2C4F5278C9B02005D1CC2 /* PurchaseTester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PurchaseTester.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2CF428682863EEAC007E6A78 /* Package+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Package+Extensions.swift"; sourceTree = "<group>"; };
+		2DD2CBB029831A09004A3A6A /* ReceiptInspector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReceiptInspector.swift; sourceTree = "<group>"; };
+		2DD2CBB229831A22004A3A6A /* ReceiptVerifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReceiptVerifier.swift; sourceTree = "<group>"; };
 		575642A1290C78DD00719219 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		575642A3290C7A2700719219 /* LoggerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerView.swift; sourceTree = "<group>"; };
 		575642A5290C7D3100719219 /* Windows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Windows.swift; sourceTree = "<group>"; };
@@ -236,6 +240,8 @@
 		2CD2C4ED278C9B01005D1CC2 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				2DD2CBB229831A22004A3A6A /* ReceiptVerifier.swift */,
+				2DD2CBB029831A09004A3A6A /* ReceiptInspector.swift */,
 				2C8C610427C5206D00F86F21 /* RevenueCat_SwiftUIConfiguration.storekit */,
 				576B00A02950FA9700139C53 /* RevenueCat_IntegrationPurchaseTesterConfiguration.storekit */,
 				2CD2C4EE278C9B01005D1CC2 /* PurchaseTesterApp.swift */,
@@ -483,7 +489,9 @@
 				57B5795629536B8C003EAA40 /* ObserverModeManager.swift in Sources */,
 				2CD2C516278C9B02005D1CC2 /* PurchaseTesterApp.swift in Sources */,
 				575642A4290C7A2700719219 /* LoggerView.swift in Sources */,
+				2DD2CBB329831A22004A3A6A /* ReceiptVerifier.swift in Sources */,
 				2C10F18227A9943D0078444D /* PromoOfferDetailsView.swift in Sources */,
+				2DD2CBB129831A09004A3A6A /* ReceiptInspector.swift in Sources */,
 				575642A6290C7D3100719219 /* Windows.swift in Sources */,
 				57B5795729536B8C003EAA40 /* ProductFetcherSK1.swift in Sources */,
 				2C10F19727AC31B80078444D /* CustomerInfoView.swift in Sources */,
@@ -692,9 +700,11 @@
 				CLANG_MODULES_AUTOLINK = YES;
 				CODE_SIGN_ENTITLEMENTS = PurchaseTester.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "3rd Party Mac Developer Application";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 8SXR2327BM;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = 8SXR2327BM;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "PurchaseTester-Info.plist";
@@ -713,7 +723,7 @@
 				PRODUCT_NAME = PurchaseTester;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.revenuecat.sampleapp";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "match Development com.revenuecat.sampleapp macos";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "match AppStore com.revenuecat.sampleapp macos";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=watchos*]" = "match Development com.revenuecat.sampleapp";
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator";
 				SUPPORTS_MACCATALYST = YES;

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
@@ -700,11 +700,9 @@
 				CLANG_MODULES_AUTOLINK = YES;
 				CODE_SIGN_ENTITLEMENTS = PurchaseTester.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "3rd Party Mac Developer Application";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 8SXR2327BM;
-				"DEVELOPMENT_TEAM[sdk=macosx*]" = 8SXR2327BM;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "PurchaseTester-Info.plist";
@@ -723,7 +721,7 @@
 				PRODUCT_NAME = PurchaseTester;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.revenuecat.sampleapp";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "match AppStore com.revenuecat.sampleapp macos";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "match Development com.revenuecat.sampleapp macos";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=watchos*]" = "match Development com.revenuecat.sampleapp";
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator";
 				SUPPORTS_MACCATALYST = YES;

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
@@ -51,6 +51,25 @@ struct PurchaseTesterApp: App {
         WindowGroup(id: Windows.logs.rawValue) {
             LoggerView(logger: ConfiguredPurchases.logger)
         }
+
+        #if os(macOS)
+        MenuBarExtra("ReceiptParser", systemImage: "doc.text.magnifyingglass") {
+            VStack {
+                ReceiptInspectorView()
+
+                Divider()
+
+                Button("Quit") {
+                    NSApplication.shared.terminate(nil)
+                }
+                .keyboardShortcut("q")
+                .padding()
+            }
+        }
+        .menuBarExtraStyle(.window)
+        .defaultSize(width: 800, height: 1000)
+        #endif
+
     }
 
     private var configurationView: some View {

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptInspector.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptInspector.swift
@@ -23,7 +23,9 @@ struct ReceiptInspectorView: View {
 
             TextField("Enter receipt text here (base64 encoded)", text: $encodedReceipt, onEditingChanged: { isEditing in
                     if !isEditing {
-                        inspectReceipt()
+                        Task {
+                            await inspectReceipt()
+                        }
                     }
                 })
                     .textFieldStyle(.roundedBorder)
@@ -31,7 +33,9 @@ struct ReceiptInspectorView: View {
 
             TextField("Enter shared secret here", text: $sharedSecret, onEditingChanged: { isEditing in
                     if !isEditing {
-                        inspectReceipt()
+                        Task {
+                            await inspectReceipt()
+                        }
                     }
                 })
                     .textFieldStyle(.roundedBorder)
@@ -64,13 +68,12 @@ struct ReceiptInspectorView: View {
         }.frame(minWidth: 800, maxWidth: .infinity, minHeight: 1000, maxHeight: .infinity, alignment: .center)
     }
 
-    func inspectReceipt() {
+    func inspectReceipt() async {
         do {
             guard !encodedReceipt.isEmpty else { return }
             parsedReceipt = try PurchasesReceiptParser.default.parse(base64String: encodedReceipt).debugDescription
-            Task {
-                verifyReceiptResult = await ReceiptVerifier().verifyReceipt(base64Encoded: encodedReceipt, sharedSecret: sharedSecret)
-            }
+            verifyReceiptResult = await ReceiptVerifier().verifyReceipt(base64Encoded: encodedReceipt,
+                                                                        sharedSecret: sharedSecret)
         } catch {
             parsedReceipt = "Couldn't decode receipt. Error:\n\(error)"
         }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptInspector.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptInspector.swift
@@ -12,7 +12,8 @@ struct ReceiptInspectorView: View {
     @State private var encodedReceipt: String = ""
     @State private var parsedReceipt: String = ""
     @State private var verifyReceiptResult: String = ""
-    
+    @State private var sharedSecret: String = ""
+
 
     var body: some View {
         VStack {
@@ -22,20 +23,19 @@ struct ReceiptInspectorView: View {
 
             TextField("Enter receipt text here (base64 encoded)", text: $encodedReceipt, onEditingChanged: { isEditing in
                     if !isEditing {
-                        do {
-                            print("did set")
-                            parsedReceipt = try PurchasesReceiptParser.default.parse(base64String: encodedReceipt).debugDescription
-                            Task {
-                                verifyReceiptResult = await ReceiptVerifier().verifyReceipt(base64Encoded: encodedReceipt)
-                            }
-                        } catch {
-                            parsedReceipt = "Couldn't decode receipt. Error:\n\(error)"
-                        }
+                        inspectReceipt()
                     }
                 })
                     .textFieldStyle(.roundedBorder)
                     .padding()
 
+            TextField("Enter shared secret here", text: $sharedSecret, onEditingChanged: { isEditing in
+                    if !isEditing {
+                        inspectReceipt()
+                    }
+                })
+                    .textFieldStyle(.roundedBorder)
+                    .padding()
 
             Divider()
             Text("Parsed Receipt")
@@ -62,6 +62,18 @@ struct ReceiptInspectorView: View {
                     .textSelection(.enabled)
             }.frame(maxWidth: .infinity, maxHeight: .infinity)
         }.frame(minWidth: 800, maxWidth: .infinity, minHeight: 1000, maxHeight: .infinity, alignment: .center)
+    }
+
+    func inspectReceipt() {
+        do {
+            guard !encodedReceipt.isEmpty else { return }
+            parsedReceipt = try PurchasesReceiptParser.default.parse(base64String: encodedReceipt).debugDescription
+            Task {
+                verifyReceiptResult = await ReceiptVerifier().verifyReceipt(base64Encoded: encodedReceipt, sharedSecret: sharedSecret)
+            }
+        } catch {
+            parsedReceipt = "Couldn't decode receipt. Error:\n\(error)"
+        }
     }
 }
 

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptInspector.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptInspector.swift
@@ -1,0 +1,72 @@
+//
+//  ContentView.swift
+//  ReceiptParser
+//
+//  Created by Andrés Boedo on 1/25/23.
+//
+
+import SwiftUI
+import ReceiptParser
+
+struct ReceiptInspectorView: View {
+    @State private var encodedReceipt: String = ""
+    @State private var parsedReceipt: String = ""
+    @State private var verifyReceiptResult: String = ""
+    
+
+    var body: some View {
+        VStack {
+            Text("Receipt Parser")
+                .font(.title)
+                .padding()
+
+            TextField("Enter receipt text here (base64 encoded)", text: $encodedReceipt, onEditingChanged: { isEditing in
+                    if !isEditing {
+                        do {
+                            print("did set")
+                            parsedReceipt = try PurchasesReceiptParser.default.parse(base64String: encodedReceipt).debugDescription
+                            Task {
+                                verifyReceiptResult = await ReceiptVerifier().verifyReceipt(base64Encoded: encodedReceipt)
+                            }
+                        } catch {
+                            parsedReceipt = "Couldn't decode receipt. Error:\n\(error)"
+                        }
+                    }
+                })
+                    .textFieldStyle(.roundedBorder)
+                    .padding()
+
+
+            Divider()
+            Text("Parsed Receipt")
+                .font(.title2)
+                .padding()
+
+            ScrollView {
+                Text(parsedReceipt)
+                    .padding()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .textSelection(.enabled)
+            }.frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            Divider()
+
+            Text("Verify Receipt")
+                .font(.title2)
+                .padding()
+            
+            ScrollView {
+                Text(verifyReceiptResult)
+                    .padding()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .textSelection(.enabled)
+            }.frame(maxWidth: .infinity, maxHeight: .infinity)
+        }.frame(minWidth: 800, maxWidth: .infinity, minHeight: 1000, maxHeight: .infinity, alignment: .center)
+    }
+}
+
+struct ReceiptInspectorView_Previews: PreviewProvider {
+    static var previews: some View {
+        ReceiptInspectorView()
+    }
+}

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptVerifier.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptVerifier.swift
@@ -26,8 +26,7 @@ struct ReceiptVerifier {
     ]
 
     private static let internalDataAccessError = "Internal data access error."
-    private static let internalDataAccessErrorMinRange = 21100
-    private static let internalDataAccessErrorMaxRange = 21199
+    private static let internalDataAccessErrorRange = 21100...21199
 
     private static let sandboxUrl = URL(string: "https://sandbox.itunes.apple.com/verifyReceipt")!
     private static let productionUrl = URL(string: "https://buy.itunes.apple.com/verifyReceipt")!
@@ -76,7 +75,7 @@ struct ReceiptVerifier {
             return message
         }
 
-        if code >= Self.internalDataAccessErrorMinRange && code <= Self.internalDataAccessErrorMaxRange {
+        if Self.internalDataAccessErrorRange.contains(code) {
             return Self.internalDataAccessError
         }
 

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptVerifier.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptVerifier.swift
@@ -38,7 +38,7 @@ struct ReceiptVerifier {
         request.httpMethod = "POST"
 
         var parameters = [ "receipt-data": base64Encoded ]
-        if let sharedSecret = sharedSecret {
+        if let sharedSecret = sharedSecret, !sharedSecret.isEmpty {
             parameters["password"] = sharedSecret
         }
 

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptVerifier.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptVerifier.swift
@@ -1,0 +1,86 @@
+//
+//  ReceiptVerifier.swift
+//  ReceiptParserApp
+//
+//  Created by Andrés Boedo on 1/26/23.
+//
+
+import Foundation
+
+struct ReceiptVerifier {
+
+    private static let errorMessagesByCode = [
+        21000: "The App Store could not read the JSON object you provided.",
+        21002: "The data in the receipt-data property was malformed or missing.",
+        21003: "The receipt could not be authenticated.",
+        21004: "The shared secret you provided does not match the shared secret on file for your account.",
+        21005: "The receipt server is not currently available.",
+        21006: "This receipt is valid but the subscription has expired. When this status code is returned to your " +
+        "server, the receipt data is also decoded and returned as part of the response. Only returned for " +
+        "iOS 6 style transaction receipts for auto-renewable subscriptions.",
+        21007: "This receipt is from the test environment, but it was sent to the production environment for " +
+        "verification. Send it to the test environment instead.",
+        21008: "This receipt is from the production environment, but it was sent to the test environment for " +
+        "verification. Send it to the production environment instead.",
+        21010: "This receipt could not be authorized. Treat this the same as if a purchase was never made."
+    ]
+
+    private static let internalDataAccessError = "Internal data access error."
+    private static let internalDataAccessErrorMinRange = 21100
+    private static let internalDataAccessErrorMaxRange = 21199
+
+    private static let sandboxUrl = URL(string: "https://sandbox.itunes.apple.com/verifyReceipt")!
+    private static let productionUrl = URL(string: "https://buy.itunes.apple.com/verifyReceipt")!
+    private static let receiptIsFromTestEnvironmentErrorCode = 21007
+
+    func verifyReceipt(base64Encoded: String, sharedSecret: String? = nil, url: URL = Self.productionUrl) async -> String {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+
+        var parameters = [ "receipt-data": base64Encoded ]
+        if let sharedSecret = sharedSecret {
+            parameters["password"] = sharedSecret
+        }
+
+        guard let postData = (try? JSONSerialization.data(withJSONObject: parameters, options: [])) else {
+            return "couldn't form parameters for http request to verify receipt. Params: \(parameters)"
+        }
+        request.httpBody = postData
+
+        do {
+            let (data, _) = try await URLSession.shared.data(for: request)
+            do {
+                let json = try JSONSerialization.jsonObject(with: data, options: [.allowFragments]) as? [String: Any]
+                let status = json?["status"] as? Int
+                if let status = status, status == Self.receiptIsFromTestEnvironmentErrorCode {
+                    // receipt is a sandbox receipt, try with production url
+                    return await self.verifyReceipt(base64Encoded: base64Encoded, sharedSecret: sharedSecret, url: Self.sandboxUrl)
+                } else {
+                    if let status = status, let errorMessage = errorMessage(from: status) {
+                        return errorMessage
+                    }
+                    let jsonData = try JSONSerialization.data(withJSONObject: json ?? [:], options: .prettyPrinted)
+                    let jsonString = String(data: jsonData, encoding: .utf8)
+                    return jsonString ?? "Verify receipt result was empty for url: \(url)"
+                }
+            } catch {
+                return "Verify receipt result parsing failed for url: \(url)"
+            }
+        } catch {
+            return "Verify receipt request failed for url: \(url)"
+        }
+    }
+
+    private func errorMessage(from code: Int) -> String? {
+        if let message = Self.errorMessagesByCode[code] {
+            return message
+        }
+
+        if code >= Self.internalDataAccessErrorMinRange && code <= Self.internalDataAccessErrorMaxRange {
+            return Self.internalDataAccessError
+        }
+
+        return nil
+    }
+
+}

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptVerifier.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/ReceiptVerifier.swift
@@ -64,10 +64,10 @@ struct ReceiptVerifier {
                     return jsonString ?? "Verify receipt result was empty for url: \(url)"
                 }
             } catch {
-                return "Verify receipt result parsing failed for url: \(url)"
+                return "Verify receipt result parsing failed for url: \(url)\nError: \(error.localizedDescription)"
             }
         } catch {
-            return "Verify receipt request failed for url: \(url)"
+            return "Verify receipt request failed for url: \(url)\nError: \(error.localizedDescription)"
         }
     }
 


### PR DESCRIPTION
Adds a new MenuBar UI to the PurchaseTester app on macOS. 

The UI provides a quick utility to parse the local receipt and to check it against `/verifyReceipt`. This makes it super easy to debug receipts using PurchaseTester. 

<img width="859" alt="image" src="https://user-images.githubusercontent.com/3922667/214950089-3c6ad4c2-2ae1-4024-83a5-b1490eed9744.png">
