### PR TITLE
Replaced `Any` uses for workaround with `Box`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -203,8 +203,6 @@
 		57032ABF28C13CE4004FF47A /* StoreKit2SettingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57032ABE28C13CE4004FF47A /* StoreKit2SettingTests.swift */; };
 		57057FF828B0048900995F21 /* TestLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57057FF728B0048900995F21 /* TestLogHandler.swift */; };
 		57057FF928B0048900995F21 /* TestLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57057FF728B0048900995F21 /* TestLogHandler.swift */; };
-		5705800328B0085200995F21 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5705800228B0085200995F21 /* Box.swift */; };
-		5705800428B0085200995F21 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5705800228B0085200995F21 /* Box.swift */; };
 		57069A5428E3918400B86355 /* AsyncExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57069A5328E3918400B86355 /* AsyncExtensions.swift */; };
 		57069A5E28E398E100B86355 /* AsyncExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57069A5D28E398E100B86355 /* AsyncExtensionsTests.swift */; };
 		570FAF4B2864EC2300D3C769 /* NonSubscriptionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570FAF4A2864EC2300D3C769 /* NonSubscriptionTransaction.swift */; };
@@ -348,6 +346,7 @@
 		57C381DC27961547009E3940 /* SK2StoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381DB27961547009E3940 /* SK2StoreProductDiscount.swift */; };
 		57C381E2279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */; };
 		57C381E3279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */; };
+		57CCC6EC2984496D001CE9B6 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CCC6EB2984496D001CE9B6 /* Box.swift */; };
 		57CD86DA291C1E2300768DE1 /* UserDefaults+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CD86D9291C1E2300768DE1 /* UserDefaults+Extensions.swift */; };
 		57CD86E6291C344000768DE1 /* UserDefaultsDefaultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CD86E5291C344000768DE1 /* UserDefaultsDefaultTests.swift */; };
 		57CFB96C27FE0E79002A6730 /* MockCurrentUserProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CFB96B27FE0E79002A6730 /* MockCurrentUserProvider.swift */; };
@@ -809,7 +808,6 @@
 		37E35FDA0A44EA03EA12DAA2 /* DateFormatter+ExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DateFormatter+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		57032ABE28C13CE4004FF47A /* StoreKit2SettingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2SettingTests.swift; sourceTree = "<group>"; };
 		57057FF728B0048900995F21 /* TestLogHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestLogHandler.swift; sourceTree = "<group>"; };
-		5705800228B0085200995F21 /* Box.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
 		57069A5328E3918400B86355 /* AsyncExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncExtensions.swift; sourceTree = "<group>"; };
 		57069A5D28E398E100B86355 /* AsyncExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncExtensionsTests.swift; sourceTree = "<group>"; };
 		570814C128A308050018BAE3 /* BackendIntegrationTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = BackendIntegrationTests.xctestplan; path = Tests/TestPlans/BackendIntegrationTests.xctestplan; sourceTree = "<group>"; };
@@ -950,6 +948,7 @@
 		57C381D92796153D009E3940 /* SK1StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1StoreProductDiscount.swift; sourceTree = "<group>"; };
 		57C381DB27961547009E3940 /* SK2StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreProductDiscount.swift; sourceTree = "<group>"; };
 		57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreProductDiscount.swift; sourceTree = "<group>"; };
+		57CCC6EB2984496D001CE9B6 /* Box.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
 		57CD86D9291C1E2300768DE1 /* UserDefaults+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Extensions.swift"; sourceTree = "<group>"; };
 		57CD86E5291C344000768DE1 /* UserDefaultsDefaultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsDefaultTests.swift; sourceTree = "<group>"; };
 		57CFB96B27FE0E79002A6730 /* MockCurrentUserProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCurrentUserProvider.swift; sourceTree = "<group>"; };
@@ -1424,6 +1423,7 @@
 				574A2EE6282C3F0800150D40 /* AnyDecodable.swift */,
 				576C8A8A27CFCB150058FA6E /* AnyEncodable.swift */,
 				57A0FBEF2749C0C2009E2FC3 /* Atomic.swift */,
+				57CCC6EB2984496D001CE9B6 /* Box.swift */,
 				352B7D7827BD919B002A47DD /* DangerousSettings.swift */,
 				37E3567189CF6A746EE3CCC2 /* DateExtensions.swift */,
 				0313FD40268A506400168386 /* DateProvider.swift */,
@@ -1867,7 +1867,6 @@
 				576C8A9127D27DDD0058FA6E /* SnapshotTesting+Extensions.swift */,
 				57DE80AD28075D77008D6C6F /* OSVersionEquivalent.swift */,
 				57057FF728B0048900995F21 /* TestLogHandler.swift */,
-				5705800228B0085200995F21 /* Box.swift */,
 				57E4A52028BD8F610095C793 /* ErrorMatcher.swift */,
 				575A8EE02922C56300936709 /* AsyncTestHelpers.swift */,
 			);
@@ -2649,7 +2648,6 @@
 				2D90F8C026FD20DF009B9142 /* MockAttributionDataMigrator.swift in Sources */,
 				F55FFA5D27634E1900995146 /* MockTransactionsManager.swift in Sources */,
 				57554CC2282AE1E3009A7E58 /* TestCase.swift in Sources */,
-				5705800428B0085200995F21 /* Box.swift in Sources */,
 				2D90F8B826FD20AA009B9142 /* MockReceiptFetcher.swift in Sources */,
 				2D90F8B626FD2099009B9142 /* MockSubscriberAttributesManager.swift in Sources */,
 				2D90F8BF26FD20D6009B9142 /* MockAttributionFetcher.swift in Sources */,
@@ -2821,6 +2819,7 @@
 				5774F9B62805E6CC00997128 /* CustomerInfoResponse.swift in Sources */,
 				B34605D1279A6E600031CA74 /* CustomerAPI.swift in Sources */,
 				2DDF41A224F6F331005BC22D /* ProductsManager.swift in Sources */,
+				57CCC6EC2984496D001CE9B6 /* Box.swift in Sources */,
 				575137CF27F50D2F0064AB2C /* HTTPResponseBody.swift in Sources */,
 				573E7F092819B989007C9128 /* StoreKitWorkarounds.swift in Sources */,
 				B3AA6236268A81C700894871 /* EntitlementInfos.swift in Sources */,
@@ -2978,7 +2977,6 @@
 				57FFD2512922DBED00A9A878 /* MockStoreTransaction.swift in Sources */,
 				F591492826B9956C00D32E58 /* MockTransaction.swift in Sources */,
 				5796A39427D6BD6900653165 /* BackendGetOfferingsTests.swift in Sources */,
-				5705800328B0085200995F21 /* Box.swift in Sources */,
 				5766AA42283C768600FA6091 /* OperatorExtensionsTests.swift in Sources */,
 				351B516A26D44CB300BD2BD7 /* ISOPeriodFormatterTests.swift in Sources */,
 				57DC9F4A27CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift in Sources */,

--- a/Sources/Misc/Box.swift
+++ b/Sources/Misc/Box.swift
@@ -14,6 +14,7 @@
 import Foundation
 
 // Workaround for https://openradar.appspot.com/radar?id=4970535809187840 / https://github.com/apple/swift/issues/58099
+/// Holds a reference to a value.
 final class Box<T> {
 
     let value: T

--- a/Sources/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
@@ -18,7 +18,7 @@ internal struct SK2StoreProduct: StoreProductType {
 
     init(sk2Product: SK2Product) {
         #if swift(<5.7)
-        self._underlyingSK2Product = sk2Product
+        self._underlyingSK2Product = .init(sk2Product)
         #else
         self.underlyingSK2Product = sk2Product
         #endif
@@ -27,13 +27,9 @@ internal struct SK2StoreProduct: StoreProductType {
     #if swift(<5.7)
     // We can't directly store instances of StoreKit.Product, since that causes
     // linking issues in iOS < 15, even with @available checks correctly in place.
-    // So instead, we store the underlying product as Any and wrap it with casting.
-    // https://openradar.appspot.com/radar?id=4970535809187840
-    private let _underlyingSK2Product: Any
-    var underlyingSK2Product: SK2Product {
-        // swiftlint:disable:next force_cast
-        _underlyingSK2Product as! SK2Product
-    }
+    // See https://openradar.appspot.com/radar?id=4970535809187840 / https://github.com/apple/swift/issues/58099
+    private let _underlyingSK2Product: Box<SK2Product>
+    var underlyingSK2Product: SK2Product { self._underlyingSK2Product.value }
     #else
     let underlyingSK2Product: SK2Product
     #endif

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -401,7 +401,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
         self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
-        mockListener.mockTransaction.value = try await self.createTransactionWithPurchase()
+        mockListener.mockTransaction = .init(try await self.createTransactionWithPurchase())
 
         let product = try await fetchSk2Product()
 
@@ -423,7 +423,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
         self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
-        mockListener.mockTransaction.value = try await self.createTransactionWithPurchase()
+        mockListener.mockTransaction = .init(try await self.createTransactionWithPurchase())
 
         let product = try await fetchSk2Product()
 
@@ -464,7 +464,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
         self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
 
-        mockListener.mockTransaction.value = try await self.createTransactionWithPurchase()
+        mockListener.mockTransaction = .init(try await self.createTransactionWithPurchase())
 
         let product = try await self.fetchSk2Product()
 
@@ -563,7 +563,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         )
 
         self.receiptFetcher.shouldReturnReceipt = false
-        mockListener.mockTransaction.value = try await self.createTransactionWithPurchase()
+        mockListener.mockTransaction = .init(try await self.createTransactionWithPurchase())
 
         do {
             _ = try await self.orchestrator.purchase(sk2Product: product, package: nil, promotionalOffer: nil)

--- a/Tests/UnitTests/Mocks/MockNotificationCenter.swift
+++ b/Tests/UnitTests/Mocks/MockNotificationCenter.swift
@@ -4,6 +4,8 @@
 //
 import Foundation
 
+@testable import RevenueCat
+
 class MockNotificationCenter: NotificationCenter {
 
     typealias ObserversWithSelector = (observer: WeakBox<AnyObject>,

--- a/Tests/UnitTests/Mocks/MockSK2BeginRefundRequestHelper.swift
+++ b/Tests/UnitTests/Mocks/MockSK2BeginRefundRequestHelper.swift
@@ -25,19 +25,14 @@ class MockSK2BeginRefundRequestHelper: SK2BeginRefundRequestHelper {
 
     var mockSK2Error: Error?
 
-    // We can't directly store instances of StoreKit.Transaction.RefundRequestStatus, since that causes
+    // We can't directly store instances of `StoreKit.Transaction.RefundRequestStatus`, since that causes
     // linking issues in iOS < 15, even with @available checks correctly in place.
-    // So instead, we store the underlying product as Any and wrap it with casting.
     // https://openradar.appspot.com/radar?id=4970535809187840
-    private var untypedSK2Status: Any?
+    // https://github.com/apple/swift/issues/58099
+    private var untypedSK2Status: Box<StoreKit.Transaction.RefundRequestStatus?> = .init(nil)
     var mockSK2Status: StoreKit.Transaction.RefundRequestStatus? {
-        get {
-            // swiftlint:disable:next force_cast
-            return untypedSK2Status as! StoreKit.Transaction.RefundRequestStatus?
-        }
-        set {
-            untypedSK2Status = newValue
-        }
+        get { return self.untypedSK2Status.value }
+        set { self.untypedSK2Status = .init(newValue) }
     }
 
     var transactionVerified = true

--- a/Tests/UnitTests/TestHelpers/Box.swift
+++ b/Tests/UnitTests/TestHelpers/Box.swift
@@ -13,10 +13,10 @@
 
 import Foundation
 
-// Workaround for https://openradar.appspot.com/radar?id=4970535809187840 / https://bugs.swift.org/browse/SR-15825
+// Workaround for https://openradar.appspot.com/radar?id=4970535809187840 / https://github.com/apple/swift/issues/58099
 final class Box<T> {
 
-    var value: T
+    let value: T
 
     init(_ value: T) { self.value = value }
 


### PR DESCRIPTION
See https://github.com/apple/swift/issues/58099
This is fixed in newer versions of Xcode, but we still need the workaround for older ones. Instead of using `Any` and force-casting, `Box` is better since it's type safe.

### Other changes:
- Moved `Box` to `RevenueCat` to be able to use the workaround there too.
- Made `Box` immutable. It's very dangerous to have a reference value (`Box` is a `class`) with reference semantics be mutable. Instead, we force users to have a mutable property instead and re-create the `Box`, to avoid mutating that data under the hood.
- Updated the comments to point to the new `Swift` GitHub issue page.
