### PR TITLE
`HTTPClientTests`: refactored tests to use `waitUntil`

### DIFF
--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -838,7 +838,7 @@ class HTTPClientTests: TestCase {
                          headers: nil)
         }
 
-        let response: HTTPResponse<Data>.Result? = waitUntilValue(timeout: .seconds(1)) { completion in
+        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
             self.client.perform(.init(method: .get, path: path)) { (result: HTTPResponse<Data>.Result) in
                 completion(result)
             }


### PR DESCRIPTION
See also #2168 and #2071.

I was looking into randomness in tests that might lead to test coverage fluctuations and saw that these tests could be simplified to avoid use of `toEventually`.
