### PR TITLE
`StoreKit1WrapperTests`: avoid using `Bool.random` to fix flaky code coverage

### DIFF
--- a/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
@@ -25,7 +25,7 @@ class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
 
         self.operationDispatcher = .init()
         self.paymentQueue = .init()
-        self.sandboxEnvironmentDetector = .init(isSandbox: .random())
+        self.sandboxEnvironmentDetector = .init(isSandbox: true)
 
         self.wrapper = StoreKit1Wrapper(paymentQueue: self.paymentQueue,
                                         operationDispatcher: self.operationDispatcher,


### PR DESCRIPTION
Fixes https://app.codecov.io/gh/RevenueCat/purchases-ios/pull/2257

![Screenshot 2023-02-02 at 11 48 14](https://user-images.githubusercontent.com/685609/216434512-c84ee0b3-2019-4e03-bd0f-142ebbed62ed.png)

Depending on this value, we were evaluating a different string.
