### PR TITLE
`NetworkError`: added underlying error to description

### DIFF
--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -43,7 +43,7 @@ enum ErrorUtils {
         }
 
         return error(with: errorCode,
-                     message: message,
+                     message: message ?? underlyingError?.localizedDescription,
                      underlyingError: underlyingError,
                      extraUserInfo: extraUserInfo,
                      fileName: fileName, functionName: functionName, line: line)

--- a/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
+++ b/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
@@ -121,6 +121,21 @@ class ErrorUtilsTests: TestCase {
         self.expectLoggedError(error, .rcError)
     }
 
+    func testNetworkErrorsLogUnderlyingError() throws {
+        let underlyingError = NSError(domain: NSURLErrorDomain, code: NSURLErrorDNSLookupFailed)
+        let networkError = ErrorUtils.networkError(withUnderlyingError: underlyingError)
+
+        let loggedMessage = try XCTUnwrap(self.loggedMessages.onlyElement)
+
+        expect(loggedMessage.level) == .error
+        expect(loggedMessage.message) == [
+            LogIntent.rcError.prefix,
+            networkError.error.description,
+            underlyingError.localizedDescription
+        ]
+            .joined(separator: " ")
+    }
+
     func testLoggedErrorsWithNoMessage() throws {
         let error = ErrorUtils.customerInfoError()
 


### PR DESCRIPTION
### Before:
> [Purchases] - ERROR: 😿‼️ Error performing request.

### After:
> [Purchases] - ERROR: 😿‼️ Error performing request. The operation couldn’t be completed. (NSURLErrorDomain error -1.)
