### PR TITLE
`StoreKit2StorefrontListener`: added tests to fix flaky code coverage

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -305,6 +305,8 @@
 		579189FD28F4966500BF4963 /* OtherIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579189FC28F4966500BF4963 /* OtherIntegrationTests.swift */; };
 		5791A1C82767FC9400C972AA /* ManageSubscriptionsHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791A1C72767FC9400C972AA /* ManageSubscriptionsHelperTests.swift */; };
 		5791CE80273F26A000E50C4B /* base64encoded_sandboxReceipt.txt in Resources */ = {isa = PBXBuildFile; fileRef = 5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */; };
+		5791FBD2299184EF00F1FEDA /* MockAsyncSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791FBD1299184EF00F1FEDA /* MockAsyncSequence.swift */; };
+		5791FBD3299184EF00F1FEDA /* MockAsyncSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791FBD1299184EF00F1FEDA /* MockAsyncSequence.swift */; };
 		5791FC7A2991D31600F1FEDA /* public_key.der in Resources */ = {isa = PBXBuildFile; fileRef = 5791FC792991D31600F1FEDA /* public_key.der */; };
 		5791FCF32992D3EC00F1FEDA /* SigningStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791FCF22992D3EC00F1FEDA /* SigningStrings.swift */; };
 		579234E327F7788900B39C68 /* BaseBackendIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579234E127F777EE00B39C68 /* BaseBackendIntegrationTests.swift */; };
@@ -914,6 +916,7 @@
 		579189FC28F4966500BF4963 /* OtherIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherIntegrationTests.swift; sourceTree = "<group>"; };
 		5791A1C72767FC9400C972AA /* ManageSubscriptionsHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManageSubscriptionsHelperTests.swift; sourceTree = "<group>"; };
 		5791CE7F273F26A000E50C4B /* base64encoded_sandboxReceipt.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = base64encoded_sandboxReceipt.txt; sourceTree = "<group>"; };
+		5791FBD1299184EF00F1FEDA /* MockAsyncSequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAsyncSequence.swift; sourceTree = "<group>"; };
 		5791FC792991D31600F1FEDA /* public_key.der */ = {isa = PBXFileReference; lastKnownFileType = file; path = public_key.der; sourceTree = "<group>"; };
 		5791FCF22992D3EC00F1FEDA /* SigningStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigningStrings.swift; sourceTree = "<group>"; };
 		579234E127F777EE00B39C68 /* BaseBackendIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBackendIntegrationTests.swift; sourceTree = "<group>"; };
@@ -1585,6 +1588,7 @@
 				575A8EE42922C9F300936709 /* MockStoreKit2TransactionListenerDelegate.swift */,
 				57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */,
 				578DAA492948EF4F001700FD /* TestClock.swift */,
+				5791FBD1299184EF00F1FEDA /* MockAsyncSequence.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -2644,6 +2648,7 @@
 				2D90F8C326FD214F009B9142 /* MockAttributionTypeFactory.swift in Sources */,
 				A55D083427235DED00D919E0 /* BeginRefundRequestHelperTests.swift in Sources */,
 				57DE80892807540D008D6C6F /* StorefrontTests.swift in Sources */,
+				5791FBD3299184EF00F1FEDA /* MockAsyncSequence.swift in Sources */,
 				2D90F8CC26FD2BA1009B9142 /* StoreKitConfigTestCase.swift in Sources */,
 				2D90F8BC26FD20C2009B9142 /* MockReceiptParser.swift in Sources */,
 				57DE80812807529F008D6C6F /* MockStorefront.swift in Sources */,
@@ -2911,6 +2916,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				576C8A9227D27DDD0058FA6E /* SnapshotTesting+Extensions.swift in Sources */,
+				5791FBD2299184EF00F1FEDA /* MockAsyncSequence.swift in Sources */,
 				5766C620282DA3D50067D886 /* GetIntroEligibilityDecodingTests.swift in Sources */,
 				57C381E2279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */,
 				2DDF41E824F6F61B005BC22D /* MockSKProductDiscount.swift in Sources */,

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -811,8 +811,8 @@ extension PurchasesOrchestrator: StoreKit2TransactionListenerDelegate {
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
 extension PurchasesOrchestrator: StoreKit2StorefrontListenerDelegate {
 
-    func storefrontDidUpdate() {
-        handleStorefrontChange()
+    func storefrontDidUpdate(with storefront: StorefrontType) {
+        self.handleStorefrontChange()
     }
 
 }

--- a/Sources/Purchasing/StoreKit2/StoreKit2StorefrontListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2StorefrontListener.swift
@@ -16,7 +16,7 @@ import StoreKit
 
 protocol StoreKit2StorefrontListenerDelegate: AnyObject, Sendable {
 
-    func storefrontDidUpdate()
+    func storefrontDidUpdate(with storefront: StorefrontType)
 
 }
 
@@ -32,17 +32,29 @@ class StoreKit2StorefrontListener {
     }
 
     weak var delegate: StoreKit2StorefrontListenerDelegate?
+    private let updates: AsyncStream<StorefrontType>
 
-    init(delegate: StoreKit2StorefrontListenerDelegate?) {
+    convenience init(delegate: StoreKit2StorefrontListenerDelegate?) {
+        self.init(
+            delegate: delegate,
+            updates: StoreKit.Storefront.updates.map(Storefront.init(sk2Storefront:))
+        )
+    }
+
+    init<S: AsyncSequence>(
+        delegate: StoreKit2StorefrontListenerDelegate?,
+        updates: S
+    ) where S.Element == StorefrontType {
         self.delegate = delegate
+        self.updates = updates.toAsyncStream()
     }
 
     func listenForStorefrontChanges() {
-        self.taskHandle = Task(priority: .utility) { [weak self] in
-            for await _ in StoreKit.Storefront.updates {
+        self.taskHandle = Task(priority: .utility) { [weak self, updates = self.updates] in
+            for await storefront in updates {
                 guard let delegate = self?.delegate else { break }
                 await MainActor.run { @Sendable in
-                    delegate.storefrontDidUpdate()
+                    delegate.storefrontDidUpdate(with: storefront)
                 }
             }
         }
@@ -51,6 +63,18 @@ class StoreKit2StorefrontListener {
     deinit {
         self.taskHandle?.cancel()
         self.taskHandle = nil
+    }
+
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+private extension AsyncSequence {
+
+    func toAsyncStream() -> AsyncStream<Element> {
+        var asyncIterator = self.makeAsyncIterator()
+        return AsyncStream<Element> {
+            try? await asyncIterator.next()
+        }
     }
 
 }

--- a/Sources/Purchasing/StoreKit2/StoreKit2StorefrontListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2StorefrontListener.swift
@@ -41,6 +41,8 @@ class StoreKit2StorefrontListener {
         )
     }
 
+    /// Creates a listener with an `AsyncSequence` of `StorefrontType`s
+    /// By default `StoreKit.Storefront.updates` is used, but a custom one can be passed for testing.
     init<S: AsyncSequence>(
         delegate: StoreKit2StorefrontListenerDelegate?,
         updates: S

--- a/Sources/Purchasing/StoreKitAbstractions/Storefront.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Storefront.swift
@@ -127,12 +127,12 @@ internal protocol StorefrontType: Sendable {
 extension Storefront {
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, macCatalyst 13.1, *)
-    internal convenience init?(sk1Storefront: SKStorefront) {
+    internal convenience init(sk1Storefront: SKStorefront) {
         self.init(SK1Storefront(sk1Storefront))
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    internal convenience init?(sk2Storefront: StoreKit.Storefront) {
+    internal convenience init(sk2Storefront: StoreKit.Storefront) {
         self.init(SK2Storefront(sk2Storefront))
     }
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -710,7 +710,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     func testClearCachedProductsAndOfferingsAfterStorefrontChangesWithSK2() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        self.orchestrator.storefrontDidUpdate()
+        self.orchestrator.storefrontDidUpdate(with: MockStorefront(countryCode: "ESP"))
 
         expect(self.mockOfferingsManager.invokedInvalidateAndReFetchCachedOfferingsIfAppropiateCount) == 1
         expect(self.productsManager.invokedClearCacheCount) == 1

--- a/Tests/StoreKitUnitTests/StoreKit2StorefrontListenerTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2StorefrontListenerTests.swift
@@ -77,29 +77,6 @@ class StoreKit2StorefrontListenerTests: TestCase {
 
 }
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-private final class MockAsyncSequence<Element>: AsyncSequence, AsyncIteratorProtocol {
-
-    init(with elements: [Element]) {
-        self.elements = elements
-    }
-
-    func next() async throws -> Element? {
-        return self.getNextElement()
-    }
-
-    func makeAsyncIterator() -> MockAsyncSequence {
-        return self
-    }
-
-    private var elements: [Element]
-
-    private func getNextElement() -> Element? {
-        return self.elements.popFirst()
-    }
-
-}
-
 private final class MockStoreKit2StorefrontListenerDelegate: StoreKit2StorefrontListenerDelegate {
 
     let invokedStorefrontDidUpdateStorefronts: Atomic<[RevenueCat.Storefront]> = .init([])

--- a/Tests/UnitTests/Mocks/MockAsyncSequence.swift
+++ b/Tests/UnitTests/Mocks/MockAsyncSequence.swift
@@ -1,0 +1,37 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockAsyncSequence.swift
+//
+//  Created by Nacho Soto on 2/6/23.
+
+import Foundation
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+final class MockAsyncSequence<Element>: AsyncSequence, AsyncIteratorProtocol {
+
+    private var elements: [Element]
+
+    init(with elements: [Element]) {
+        self.elements = elements.reversed()
+    }
+
+    func next() async throws -> Element? {
+        return self.getNextElement()
+    }
+
+    func makeAsyncIterator() -> MockAsyncSequence {
+        return self
+    }
+
+    private func getNextElement() -> Element? {
+        return self.elements.popLast()
+    }
+
+}


### PR DESCRIPTION
Similarly to #2262, test execution ordering was leading to [flaky code coverage results](https://app.codecov.io/gh/RevenueCat/purchases-ios/pull/2262) with this.

![Screenshot 2023-02-06 at 10 48 45](https://user-images.githubusercontent.com/685609/217058841-33a07262-7959-4732-9706-7426d8f4efb7.png)

Because we didn't have any test coverage, only if some other test changed the `Storefront`, this test was calling the delegate code.

This adds explicit test coverage using a `MockAsyncSequence`.

### Other changes:
- Added `StorefrontType` to `StoreKit2StorefrontListenerDelegate` method
- `Storefront` initializers are no longer `Optional` `init?`
- Simplified `StoreKit2StorefrontListenerTests` by moving `AvailabilityChecks` to `setUp`
