### PR TITLE
`OfferingsManager`: ensure underlying `OfferingsManager.Error.configurationError` is logged

### DIFF
--- a/Sources/Logging/Strings/OfferingStrings.swift
+++ b/Sources/Logging/Strings/OfferingStrings.swift
@@ -55,6 +55,10 @@ extension OfferingStrings: CustomStringConvertible {
         case let .fetching_offerings_error(error, underlyingError):
             var result = "Error fetching offerings - \(error.localizedDescription)"
 
+            if let message = error.errorDescription {
+                result += "\n\(message)"
+            }
+
             if let underlyingError = underlyingError {
                 result += "\nUnderlying error: \(underlyingError.localizedDescription)"
             }
@@ -116,7 +120,7 @@ extension OfferingStrings: CustomStringConvertible {
             return "There are no products registered in the RevenueCat dashboard for your offerings. " +
             "If you don't want to use the offerings system, you can safely ignore this message. " +
             "To configure offerings and their products, follow the instructions in " +
-            "https://rev.cat/how-to-configure-offerings. \nMore information: https://rev.cat/why-are-offerings-empty"
+            "https://rev.cat/how-to-configure-offerings.\nMore information: https://rev.cat/why-are-offerings-empty"
 
         case .offering_empty(let offeringIdentifier):
             return "There's a problem with your configuration. No packages could be found for offering with  " +

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -290,6 +290,15 @@ extension OfferingsManager.Error: CustomNSError {
         ]
     }
 
+    var errorDescription: String? {
+        switch self {
+        case .backendError: return nil
+        case let .configurationError(message, _, _): return message
+        case .noOfferingsFound: return nil
+        case .missingProducts: return nil
+        }
+    }
+
     fileprivate var underlyingError: Error? {
         switch self {
         case let .backendError(.networkError(error)): return error


### PR DESCRIPTION
Changes this:
> ERROR: 🍎‼️ Error fetching offerings - The operation couldn't be completed. (RevenueCat.OfferingsManager.Error error 1.)

Into this:
> 🍎‼️ Error fetching offerings - The operation couldn’t be completed. (RevenueCat.OfferingsManager.Error error 1.)
There are no products registered in the RevenueCat dashboard for your offerings. If you don't want to use the offerings system, you can safely ignore this message. To configure offerings and their products, follow the instructions in https://rev.cat/how-to-configure-offerings.
More information: https://rev.cat/why-are-offerings-empty

This was likely a regression at some point, leading to a confusing error message that was missing the underlying `message` inside of `OfferingsManager.Error.configurationError`.
