### PR TITLE
`HTTPClient`: added signature validation and introduced `ErrorCode.signatureVerificationFailed`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -309,6 +309,8 @@
 		5791FBD3299184EF00F1FEDA /* MockAsyncSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791FBD1299184EF00F1FEDA /* MockAsyncSequence.swift */; };
 		5791FC7A2991D31600F1FEDA /* public_key.der in Resources */ = {isa = PBXBuildFile; fileRef = 5791FC792991D31600F1FEDA /* public_key.der */; };
 		5791FCF32992D3EC00F1FEDA /* SigningStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791FCF22992D3EC00F1FEDA /* SigningStrings.swift */; };
+		5791FDBE299419D900F1FEDA /* MockSigning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791FDBD299419D900F1FEDA /* MockSigning.swift */; };
+		5791FE4A2994453500F1FEDA /* Signing+ResponseValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5791FE492994453500F1FEDA /* Signing+ResponseValidation.swift */; };
 		579234E327F7788900B39C68 /* BaseBackendIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579234E127F777EE00B39C68 /* BaseBackendIntegrationTests.swift */; };
 		579234E527F779FE00B39C68 /* SubscriberAttributesManagerIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579234E427F779FE00B39C68 /* SubscriberAttributesManagerIntegrationTests.swift */; };
 		5793397028E77A5100C1232C /* PaymentQuueWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5793396F28E77A5100C1232C /* PaymentQuueWrapperTests.swift */; };
@@ -919,6 +921,8 @@
 		5791FBD1299184EF00F1FEDA /* MockAsyncSequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAsyncSequence.swift; sourceTree = "<group>"; };
 		5791FC792991D31600F1FEDA /* public_key.der */ = {isa = PBXFileReference; lastKnownFileType = file; path = public_key.der; sourceTree = "<group>"; };
 		5791FCF22992D3EC00F1FEDA /* SigningStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigningStrings.swift; sourceTree = "<group>"; };
+		5791FDBD299419D900F1FEDA /* MockSigning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockSigning.swift; sourceTree = "<group>"; };
+		5791FE492994453500F1FEDA /* Signing+ResponseValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Signing+ResponseValidation.swift"; sourceTree = "<group>"; };
 		579234E127F777EE00B39C68 /* BaseBackendIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBackendIntegrationTests.swift; sourceTree = "<group>"; };
 		579234E427F779FE00B39C68 /* SubscriberAttributesManagerIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriberAttributesManagerIntegrationTests.swift; sourceTree = "<group>"; };
 		5793396F28E77A5100C1232C /* PaymentQuueWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentQuueWrapperTests.swift; sourceTree = "<group>"; };
@@ -1455,6 +1459,7 @@
 				5721360E28B4602C006C46BE /* Purchases+nonasync.swift */,
 				57EAE52C274468900060EB74 /* RawDataContainer.swift */,
 				57E6C27B29723A94001AFE98 /* Signing.swift */,
+				5791FE492994453500F1FEDA /* Signing+ResponseValidation.swift */,
 				57CFB98327FE2258002A6730 /* StoreKit2Setting.swift */,
 				57A0FBF12749CF66009E2FC3 /* SynchronizedUserDefaults.swift */,
 				B3AA6237268B926F00894871 /* SystemInfo.swift */,
@@ -1570,6 +1575,7 @@
 				37E354B13440508B46C9A530 /* MockReceiptParser.swift */,
 				351B517926D44FF000BD2BD7 /* MockRequestFetcher.swift */,
 				57FDAABF28493C13009A48F1 /* MockSandboxEnvironmentDetector.swift */,
+				5791FDBD299419D900F1FEDA /* MockSigning.swift */,
 				2DDF41E524F6F5DC005BC22D /* MockSK1Product.swift */,
 				A55D08312722471200D919E0 /* MockSK2BeginRefundRequestHelper.swift */,
 				2DDF41E724F6F61B005BC22D /* MockSKProductDiscount.swift */,
@@ -2783,6 +2789,7 @@
 				57ABA76D28F08DDA003D9181 /* Either.swift in Sources */,
 				35F82BB426A9A74D0051DF03 /* HTTPClient.swift in Sources */,
 				B3A55B7D26C452A7007EFC56 /* AttributionPoster.swift in Sources */,
+				5791FE4A2994453500F1FEDA /* Signing+ResponseValidation.swift in Sources */,
 				2DC19195255F36D10039389A /* Logger.swift in Sources */,
 				2DDF419F24F6F331005BC22D /* ReceiptParsingError.swift in Sources */,
 				57BB070E28D27A2B007F5DF0 /* CachingProductsManager.swift in Sources */,
@@ -3094,6 +3101,7 @@
 				A563F586271E072B00246E0C /* MockBeginRefundRequestHelper.swift in Sources */,
 				2DA85A8A26DEA7DC00F1136D /* MockProductsRequestFactory.swift in Sources */,
 				5793397028E77A5100C1232C /* PaymentQuueWrapperTests.swift in Sources */,
+				5791FDBE299419D900F1FEDA /* MockSigning.swift in Sources */,
 				57FDAA9A2846C2BD009A48F1 /* PurchasesDelegateTests.swift in Sources */,
 				351B516026D44BB600BD2BD7 /* MockAttributionDataMigrator.swift in Sources */,
 				2DDF41E024F6F527005BC22D /* MockInAppPurchaseBuilder.swift in Sources */,

--- a/Sources/Error Handling/ErrorCode.swift
+++ b/Sources/Error Handling/ErrorCode.swift
@@ -57,6 +57,7 @@ import Foundation
     @objc(RCAPIEndpointBlocked) case apiEndpointBlockedError = 33
     @objc(RCInvalidPromotionalOfferError) case invalidPromotionalOfferError = 34
     @objc(RCOfflineConnectionError) case offlineConnectionError = 35
+    @objc(RCSignatureVerificationFailed) case signatureVerificationFailed = 36
 
     // swiftlint:enable missing_docs
 
@@ -174,6 +175,9 @@ extension ErrorCode: DescribableError {
         case .offlineConnectionError:
             return "Error performing request because the internet connection appears to be offline."
 
+        case .signatureVerificationFailed:
+            return "Request failed signature verification."
+
         @unknown default:
             return "Something went wrong."
         }
@@ -270,6 +274,8 @@ extension ErrorCode {
             return "INVALID_PROMOTIONAL_OFFER_ERROR"
         case .offlineConnectionError:
             return "OFFLINE_CONNECTION_ERROR"
+        case .signatureVerificationFailed:
+            return "SIGNATURE_VERIFICATION_FAILED"
         @unknown default:
             return "UNRECOGNIZED_ERROR"
         }

--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -60,6 +60,22 @@ enum ErrorUtils {
     }
 
     /**
+     * Constructs an NSError with the ``ErrorCode/signatureVerificationFailed`` code.
+     */
+    static func signatureVerificationFailedError(
+        path: HTTPRequest.Path,
+        fileName: String = #fileID, functionName: String = #function, line: UInt = #line
+    ) -> PurchasesError {
+        return error(
+            with: .signatureVerificationFailed,
+            extraUserInfo: [
+                "request_path": path.relativePath
+            ],
+            fileName: fileName, functionName: functionName, line: line
+        )
+    }
+
+    /**
      * Maps a ``BackendErrorCode`` code to a ``ErrorCode``. code. Constructs an Error with the mapped code and adds a
      * `NSUnderlyingErrorKey` in the `NSError.userInfo` dictionary. The backend error code will be mapped using
      * ``BackendErrorCode/toPurchasesErrorCode()``.
@@ -624,7 +640,8 @@ private extension ErrorUtils {
                 .beginRefundRequestError,
                 .apiEndpointBlockedError,
                 .invalidPromotionalOfferError,
-                .offlineConnectionError:
+                .offlineConnectionError,
+                .signatureVerificationFailed:
                 Logger.error(
                     localizedDescription,
                     fileName: fileName,

--- a/Sources/Logging/Strings/SigningStrings.swift
+++ b/Sources/Logging/Strings/SigningStrings.swift
@@ -20,6 +20,8 @@ enum SigningStrings {
 
     case signature_failed_verification
 
+    case signature_was_requested_but_not_provided(HTTPRequest)
+
 }
 
 extension SigningStrings: CustomStringConvertible {
@@ -31,6 +33,10 @@ extension SigningStrings: CustomStringConvertible {
 
         case .signature_failed_verification:
             return "Signature failed validation"
+
+        case let .signature_was_requested_but_not_provided(request):
+            return "Request to '\(request.path)' required a signature but none was provided. " +
+            "This will be reported as a validation failure."
         }
     }
 

--- a/Sources/Misc/Signing+ResponseValidation.swift
+++ b/Sources/Misc/Signing+ResponseValidation.swift
@@ -15,25 +15,25 @@ import Foundation
 
 extension HTTPResponse where Body == Data {
 
-    static func createAndValidate(with response: HTTPURLResponse,
-                                  body: Data,
-                                  request: HTTPRequest,
-                                  publicKey: Signing.PublicKey?,
-                                  signing: SigningType.Type = Signing.self) -> Self {
-        return Self.createAndValidate(body: body,
-                                      statusCode: .init(rawValue: response.statusCode),
-                                      headers: response.allHeaderFields,
-                                      request: request,
-                                      publicKey: publicKey,
-                                      signing: signing)
+    static func create(with response: HTTPURLResponse,
+                       body: Data,
+                       request: HTTPRequest,
+                       publicKey: Signing.PublicKey?,
+                       signing: SigningType.Type = Signing.self) -> Self {
+        return Self.create(with: body,
+                           statusCode: .init(rawValue: response.statusCode),
+                           headers: response.allHeaderFields,
+                           request: request,
+                           publicKey: publicKey,
+                           signing: signing)
     }
 
-    static func createAndValidate(body: Data,
-                                  statusCode: HTTPStatusCode,
-                                  headers: HTTPClient.ResponseHeaders,
-                                  request: HTTPRequest,
-                                  publicKey: Signing.PublicKey?,
-                                  signing: SigningType.Type = Signing.self) -> Self {
+    static func create(with body: Data,
+                       statusCode: HTTPStatusCode,
+                       headers: HTTPClient.ResponseHeaders,
+                       request: HTTPRequest,
+                       publicKey: Signing.PublicKey?,
+                       signing: SigningType.Type = Signing.self) -> Self {
         return .init(
             statusCode: statusCode,
             responseHeaders: headers,
@@ -83,18 +83,16 @@ extension Result where Success == Data?, Failure == NetworkError {
 
     /// Converts a `Result<Data?, NetworkError>` into `Result<HTTPResponse<Data?>, NetworkError>`
     func mapToResponse(
-        responseHeaders: HTTPClient.ResponseHeaders,
-        statusCode: HTTPStatusCode,
+        response: HTTPURLResponse,
         request: HTTPRequest,
         signing: SigningType.Type,
         verificationLevel: Signing.ResponseVerificationLevel
     ) -> Result<HTTPResponse<Data?>, Failure> {
         return self.flatMap { body in
             if let body = body {
-                let response = HTTPResponse.createAndValidate(
+                let response = HTTPResponse.create(
+                    with: response,
                     body: body,
-                    statusCode: statusCode,
-                    headers: responseHeaders,
                     request: request,
                     publicKey: verificationLevel.publicKey,
                     signing: signing
@@ -110,8 +108,8 @@ extension Result where Success == Data?, Failure == NetworkError {
                 // so the response will be fetched from `ETagManager`.
                 return .success(
                     .init(
-                        statusCode: statusCode,
-                        responseHeaders: responseHeaders,
+                        statusCode: HTTPStatusCode(rawValue: response.statusCode),
+                        responseHeaders: response.allHeaderFields,
                         body: body,
                         validationResult: .notRequested
                     )

--- a/Sources/Misc/Signing+ResponseValidation.swift
+++ b/Sources/Misc/Signing+ResponseValidation.swift
@@ -1,0 +1,123 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Signing+ResponseValidation.swift
+//
+//  Created by Nacho Soto on 2/8/23.
+
+import Foundation
+
+extension HTTPResponse where Body == Data {
+
+    static func createAndValidate(with response: HTTPURLResponse,
+                                  body: Data,
+                                  request: HTTPRequest,
+                                  publicKey: Signing.PublicKey?,
+                                  signing: SigningType.Type = Signing.self) -> Self {
+        return Self.createAndValidate(body: body,
+                                      statusCode: .init(rawValue: response.statusCode),
+                                      headers: response.allHeaderFields,
+                                      request: request,
+                                      publicKey: publicKey,
+                                      signing: signing)
+    }
+
+    static func createAndValidate(body: Data,
+                                  statusCode: HTTPStatusCode,
+                                  headers: HTTPClient.ResponseHeaders,
+                                  request: HTTPRequest,
+                                  publicKey: Signing.PublicKey?,
+                                  signing: SigningType.Type = Signing.self) -> Self {
+        return .init(
+            statusCode: statusCode,
+            responseHeaders: headers,
+            body: body,
+            validationResult: Self.validationResult(
+                body: body,
+                headers: headers,
+                request: request,
+                publicKey: publicKey,
+                signing: signing
+            )
+        )
+    }
+
+    private static func validationResult(
+        body: Data,
+        headers: HTTPClient.ResponseHeaders,
+        request: HTTPRequest,
+        publicKey: Signing.PublicKey?,
+        signing: SigningType.Type
+    ) -> HTTPResponseValidationResult {
+        guard let nonce = request.nonce,
+              let publicKey = publicKey,
+              #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) else {
+            return .notRequested
+        }
+
+        guard let signature = headers[HTTPClient.responseSignatureHeaderName] as? String else {
+            Logger.warn(Strings.signing.signature_was_requested_but_not_provided(request))
+
+            return .failedValidation
+        }
+
+        if signing.verify(message: body,
+                          nonce: nonce,
+                          hasValidSignature: signature,
+                          with: publicKey) {
+            return .validated
+        } else {
+            return .failedValidation
+        }
+    }
+
+}
+
+extension Result where Success == Data?, Failure == NetworkError {
+
+    /// Converts a `Result<Data?, NetworkError>` into `Result<HTTPResponse<Data?>, NetworkError>`
+    func mapToResponse(
+        responseHeaders: HTTPClient.ResponseHeaders,
+        statusCode: HTTPStatusCode,
+        request: HTTPRequest,
+        signing: SigningType.Type,
+        verificationLevel: Signing.ResponseVerificationLevel
+    ) -> Result<HTTPResponse<Data?>, Failure> {
+        return self.flatMap { body in
+            if let body = body {
+                let response = HTTPResponse.createAndValidate(
+                    body: body,
+                    statusCode: statusCode,
+                    headers: responseHeaders,
+                    request: request,
+                    publicKey: verificationLevel.publicKey,
+                    signing: signing
+                )
+
+                if response.validationResult == .failedValidation, case .enforced = verificationLevel {
+                    return .failure(.signatureVerificationFailed(path: request.path))
+                } else {
+                    return .success(response.mapBody(Optional.some))
+                }
+            } else {
+                // No body means that the status code `HTTPStatusCode.notModified`
+                // so the response will be fetched from `ETagManager`.
+                return .success(
+                    .init(
+                        statusCode: statusCode,
+                        responseHeaders: responseHeaders,
+                        body: body,
+                        validationResult: .notRequested
+                    )
+                )
+            }
+        }
+    }
+
+}

--- a/Sources/Misc/Signing.swift
+++ b/Sources/Misc/Signing.swift
@@ -14,8 +14,20 @@
 import CryptoKit
 import Foundation
 
-/// Utilities for handling certificates and keys.
-enum Signing {
+/// A type that can verify signatures
+protocol SigningType {
+
+    static func verify(
+        message: Data,
+        nonce: Data,
+        hasValidSignature signature: String,
+        with publicKey: Signing.PublicKey
+    ) -> Bool
+
+}
+
+/// Utilities for handling signature verification.
+enum Signing: SigningType {
 
     /// An object that represents a cryptographic key.
     typealias PublicKey = SigningPublicKey

--- a/Sources/Networking/HTTPClient/ETagManager.swift
+++ b/Sources/Networking/HTTPClient/ETagManager.swift
@@ -35,28 +35,27 @@ class ETagManager {
 
     func eTagHeader(for urlRequest: URLRequest, refreshETag: Bool = false) -> [String: String] {
         var storedETag = ""
-        if !refreshETag, let storedETagAndResponse = storedETagAndResponse(for: urlRequest) {
+        if !refreshETag,
+           let storedETagAndResponse = self.storedETagAndResponse(for: urlRequest),
+           storedETagAndResponse.validationResult != .failedValidation {
             storedETag = storedETagAndResponse.eTag
         }
         return [ETagManager.eTagHeaderName: storedETag]
     }
 
-    func httpResultFromCacheOrBackend(with response: HTTPURLResponse,
-                                      data: Data?,
+    func httpResultFromCacheOrBackend(with response: HTTPResponse<Data?>,
                                       request: URLRequest,
                                       retried: Bool) -> HTTPResponse<Data>? {
-        let statusCode: HTTPStatusCode = .init(rawValue: response.statusCode)
-        let resultFromBackend = HTTPResponse(statusCode: statusCode, body: data)
-            .asOptionalResponse
-
-        let headersInResponse = response.allHeaderFields
+        let statusCode: HTTPStatusCode = response.statusCode
+        let resultFromBackend = response.asOptionalResponse
+        let headersInResponse = response.responseHeaders
 
         let eTagInResponse: String? = headersInResponse[ETagManager.eTagHeaderName] as? String ??
         headersInResponse[ETagManager.eTagHeaderName.lowercased()] as? String
 
         guard let eTagInResponse = eTagInResponse else { return resultFromBackend }
-        if shouldUseCachedVersion(responseCode: statusCode) {
-            if let storedResponse = storedHTTPResponse(for: request) {
+        if self.shouldUseCachedVersion(responseCode: statusCode) {
+            if let storedResponse = self.storedHTTPResponse(for: request) {
                 return storedResponse
             }
             if retried {
@@ -69,10 +68,10 @@ class ETagManager {
             }
             return nil
         }
-        storeStatusCodeAndResponseIfNoError(
+
+        self.storeStatusCodeAndResponseIfNoError(
                 for: request,
-                statusCode: statusCode,
-                data: data,
+                response: response,
                 eTag: eTagInResponse
         )
         return resultFromBackend
@@ -105,16 +104,21 @@ private extension ETagManager {
     }
 
     func storedHTTPResponse(for request: URLRequest) -> HTTPResponse<Data>? {
-        return storedETagAndResponse(for: request)?.asResponse
+        return self.storedETagAndResponse(for: request)?.asResponse
     }
 
     func storeStatusCodeAndResponseIfNoError(for request: URLRequest,
-                                             statusCode: HTTPStatusCode,
-                                             data: Data?,
+                                             response: HTTPResponse<Data?>,
                                              eTag: String) {
-        if let data = data, statusCode != .notModified && !statusCode.isServerError,
-           let cacheKey = eTagDefaultCacheKey(for: request) {
-            let eTagAndResponse = Response(eTag: eTag, statusCode: statusCode, data: data)
+        if let data = response.body,
+           response.shouldStore,
+           let cacheKey = self.eTagDefaultCacheKey(for: request) {
+            let eTagAndResponse = Response(
+                eTag: eTag,
+                statusCode: response.statusCode,
+                data: data,
+                validationResult: response.validationResult
+            )
             if let dataToStore = eTagAndResponse.asData() {
                 self.userDefaults.write {
                     $0.set(dataToStore, forKey: cacheKey)
@@ -150,6 +154,7 @@ extension ETagManager {
         let eTag: String
         let statusCode: HTTPStatusCode
         let data: Data
+        let validationResult: HTTPResponseValidationResult
 
     }
 
@@ -166,7 +171,24 @@ extension ETagManager.Response {
     fileprivate var asResponse: HTTPResponse<Data> {
         return HTTPResponse(
             statusCode: self.statusCode,
-            body: self.data
+            responseHeaders: [:],
+            body: self.data,
+            validationResult: self.validationResult
         )
     }
+
+}
+
+// MARK: -
+
+private extension HTTPResponse {
+
+    var shouldStore: Bool {
+        return (
+            self.statusCode != .notModified &&
+            !self.statusCode.isServerError &&
+            self.validationResult != .failedValidation
+        )
+    }
+
 }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -76,7 +76,7 @@ extension HTTPClient {
 
     static let authorizationHeaderName = "Authorization"
     static let nonceHeaderName = "X-Nonce"
-    static let responseSignatureHeaderName = "x-signature"
+    static let responseSignatureHeaderName = "X-Signature"
 
 }
 
@@ -334,7 +334,11 @@ private extension HTTPClient {
 
     private func headers(for request: Request, urlRequest: URLRequest) -> HTTPClient.RequestHeaders {
         if request.httpRequest.path.shouldSendEtag {
-            let eTagHeader = self.eTagManager.eTagHeader(for: urlRequest, refreshETag: request.retried)
+            let eTagHeader = self.eTagManager.eTagHeader(
+                for: urlRequest,
+                refreshETag: request.retried,
+                signatureVerificationEnabled: request.httpRequest.nonce != nil
+            )
             return request.headers.merging(eTagHeader)
         } else {
             return request.headers

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -226,8 +226,7 @@ private extension HTTPClient {
 
         return Result
             .success(dataIfAvailable(statusCode))
-            .mapToResponse(responseHeaders: httpURLResponse.allHeaderFields,
-                           statusCode: statusCode,
+            .mapToResponse(response: httpURLResponse,
                            request: request.httpRequest,
                            signing: self.signing,
                            verificationLevel: self.systemInfo.responseVerificationLevel)

--- a/Sources/Networking/HTTPClient/HTTPRequest.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequest.swift
@@ -36,7 +36,7 @@ struct HTTPRequest {
 
     /// Creates an `HTTPRequest` with a `nonce`.
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    static func createIntegrityEnforcedRequestRequest(method: Method, path: Path) -> Self {
+    static func createWithResponseVerification(method: Method, path: Path) -> Self {
         return .init(method: method, path: path, nonce: Data.randomNonce())
     }
 

--- a/Sources/Networking/HTTPClient/HTTPResponse.swift
+++ b/Sources/Networking/HTTPClient/HTTPResponse.swift
@@ -18,19 +18,48 @@ struct HTTPResponse<Body: HTTPResponseBody> {
 
     typealias Result = Swift.Result<Self, NetworkError>
 
-    let statusCode: HTTPStatusCode
-    let body: Body
+    var statusCode: HTTPStatusCode
+    var responseHeaders: HTTPClient.ResponseHeaders
+    var body: Body
+    var validationResult: HTTPResponseValidationResult = .notRequested
 
 }
+
+/// Information about the validity of an `HTTPResponse`.
+/// - Seealso: `Signing`
+enum HTTPResponseValidationResult: Int {
+
+    /// `HTTPRequest` did not have a `nonce`, validation was not performed.
+    case notRequested = 0
+
+    /// Response passed validation.
+    case validated = 1
+
+    /// Response failed to validate.
+    case failedValidation = 2
+
+}
+
+extension HTTPResponseValidationResult: Codable {}
 
 extension HTTPResponse: CustomStringConvertible {
 
     var description: String {
-        if let bodyDescription = (self.body as? CustomStringConvertible)?.description {
-            return "HTTPResponse(statusCode: \(self.statusCode.rawValue), body: \(bodyDescription))"
-        } else {
-            return "HTTPResponse(statusCode: \(self.statusCode.rawValue), body: \(type(of: self.body))"
-        }
+        let body: String = {
+            if let bodyDescription = (self.body as? CustomStringConvertible)?.description {
+                return bodyDescription
+            } else {
+                return "\(type(of: self.body))"
+            }
+        }()
+
+        return """
+        HTTPResponse(" +
+        statusCode: \(self.statusCode.rawValue),
+        body: \(body),
+        validation: \(self.validationResult)
+        )
+        """
     }
 
 }
@@ -43,7 +72,10 @@ extension HTTPResponse where Body: OptionalType, Body.Wrapped: HTTPResponseBody 
             return nil
         }
 
-        return .init(statusCode: self.statusCode, body: body)
+        return .init(statusCode: self.statusCode,
+                     responseHeaders: self.responseHeaders,
+                     body: body,
+                     validationResult: self.validationResult)
     }
 
 }
@@ -51,7 +83,10 @@ extension HTTPResponse where Body: OptionalType, Body.Wrapped: HTTPResponseBody 
 extension HTTPResponse {
 
     func mapBody<NewBody>(_ mapping: (Body) throws -> NewBody) rethrows -> HTTPResponse<NewBody> {
-        return .init(statusCode: self.statusCode, body: try mapping(self.body))
+        return .init(statusCode: self.statusCode,
+                     responseHeaders: self.responseHeaders,
+                     body: try mapping(self.body),
+                     validationResult: self.validationResult)
     }
 
 }

--- a/Sources/Networking/HTTPClient/HTTPResponse.swift
+++ b/Sources/Networking/HTTPClient/HTTPResponse.swift
@@ -42,6 +42,12 @@ enum HTTPResponseValidationResult: Int {
 
 extension HTTPResponseValidationResult: Codable {}
 
+extension HTTPResponseValidationResult: DefaultValueProvider {
+
+    static let defaultValue: Self = .notRequested
+
+}
+
 extension HTTPResponse: CustomStringConvertible {
 
     var description: String {

--- a/Sources/Networking/HTTPClient/HTTPResponse.swift
+++ b/Sources/Networking/HTTPClient/HTTPResponse.swift
@@ -21,7 +21,7 @@ struct HTTPResponse<Body: HTTPResponseBody> {
     var statusCode: HTTPStatusCode
     var responseHeaders: HTTPClient.ResponseHeaders
     var body: Body
-    var validationResult: HTTPResponseValidationResult = .notRequested
+    var validationResult: HTTPResponseValidationResult
 
 }
 

--- a/Sources/Networking/HTTPClient/NetworkError.swift
+++ b/Sources/Networking/HTTPClient/NetworkError.swift
@@ -25,6 +25,7 @@ enum NetworkError: Swift.Error, Equatable {
     case unableToCreateRequest(HTTPRequest.Path, Source)
     case unexpectedResponse(URLResponse?, Source)
     case errorResponse(ErrorResponse, HTTPStatusCode, Source)
+    case signatureVerificationFailed(HTTPRequest.Path, Source)
 
 }
 
@@ -84,6 +85,16 @@ extension NetworkError {
         file: String = #fileID, function: String = #function, line: UInt = #line
     ) -> Self {
         return .errorResponse(response, statusCode, .init(file: file, function: function, line: line))
+    }
+
+    static func signatureVerificationFailed(
+        path: HTTPRequest.Path,
+        file: String = #fileID, function: String = #function, line: UInt = #line
+    ) -> Self {
+        return .signatureVerificationFailed(
+            path,
+            .init(file: file, function: function, line: line)
+        )
     }
 
 }
@@ -150,6 +161,13 @@ extension NetworkError: PurchasesErrorConvertible {
                                            function: source.function,
                                            line: source.line)
 
+        case let .signatureVerificationFailed(path, source):
+            return ErrorUtils.signatureVerificationFailedError(
+                path: path,
+                fileName: source.file,
+                functionName: source.function,
+                line: source.line
+            )
         }
     }
 
@@ -184,7 +202,8 @@ extension NetworkError {
              .networkError,
              .dnsError,
              .unableToCreateRequest,
-             .unexpectedResponse:
+             .unexpectedResponse,
+             .signatureVerificationFailed:
             return nil
         }
     }

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesErrorCodeAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesErrorCodeAPI.m
@@ -57,6 +57,7 @@
         case RCAPIEndpointBlocked:
         case RCInvalidPromotionalOfferError:
         case RCOfflineConnectionError:
+        case RCSignatureVerificationFailed:
             NSLog(@"%ld", (long)errCode);
     }
 }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/ErrorCodesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/ErrorCodesAPI.swift
@@ -51,7 +51,8 @@ func checkPurchasesErrorCodeEnums() {
          .productRequestTimedOut,
          .apiEndpointBlockedError,
          .invalidPromotionalOfferError,
-         .offlineConnectionError:
+         .offlineConnectionError,
+         .signatureVerificationFailed:
         print(errCode!)
     @unknown default:
         fatalError()

--- a/Tests/UnitTests/Misc/SigningTests.swift
+++ b/Tests/UnitTests/Misc/SigningTests.swift
@@ -23,6 +23,8 @@ class SigningTests: TestCase {
     private typealias PrivateKey = Curve25519.Signing.PrivateKey
     private typealias PublicKey = Curve25519.Signing.PublicKey
 
+    private let (privateKey, publicKey) = SigningTests.createRandomKey()
+
     override func setUpWithError() throws {
         try super.setUpWithError()
 
@@ -95,18 +97,76 @@ class SigningTests: TestCase {
     }
 
     func testVerifySignatureWithValidSignature() throws {
-        let (privateKey, publicKey) = Self.createRandomKey()
         let message = "Hello World"
         let nonce = "nonce"
-        let salt = Array(repeating: "a", count: Signing.saltSize).joined()
+        let salt = Self.createSalt()
 
-        let signature = try self.sign(key: privateKey, message: message, nonce: nonce, salt: salt)
+        let signature = try self.sign(message: message, nonce: nonce, salt: salt)
         let fullSignature = salt.asData + signature
 
         expect(Signing.verify(message: message.asData,
                               nonce: nonce.asData,
                               hasValidSignature: fullSignature.base64EncodedString(),
-                              with: publicKey)) == true
+                              with: self.publicKey)) == true
+    }
+
+    func testResponseValidationWithNoProvidedKey() throws {
+        let request = HTTPRequest.createWithResponseVerification(method: .get, path: .health)
+        let response = HTTPResponse.createAndValidate(body: Data(),
+                                                      statusCode: .success,
+                                                      headers: [:],
+                                                      request: request,
+                                                      publicKey: nil)
+
+        expect(response.validationResult) == .notRequested
+    }
+
+    func testResponseValidationWithNoSignatureInResponse() throws {
+        let request = HTTPRequest.createWithResponseVerification(method: .get, path: .health)
+        let response = HTTPResponse.createAndValidate(body: Data(),
+                                                      statusCode: .success,
+                                                      headers: [:],
+                                                      request: request,
+                                                      publicKey: self.publicKey)
+
+        expect(response.validationResult) == .failedValidation
+    }
+
+    func testResponseValidationWithInvalidSignature() throws {
+        let request = HTTPRequest.createWithResponseVerification(method: .get, path: .health)
+        let response = HTTPResponse.createAndValidate(
+            body: Data(),
+            statusCode: .success,
+            headers: [
+                HTTPClient.responseSignatureHeaderName: "invalid_signature"
+            ],
+            request: request,
+            publicKey: self.publicKey
+        )
+
+        expect(response.validationResult) == .failedValidation
+    }
+
+    func testResponseValidationWithValidSignature() throws {
+        let message = "Hello World"
+        let nonce = "0123456789ab"
+        let salt = Self.createSalt()
+
+        let signature = try self.sign(message: message, nonce: nonce, salt: salt)
+        let fullSignature = salt.asData + signature
+
+        let request = HTTPRequest(method: .get, path: .health, nonce: nonce.asData)
+        let response = HTTPResponse.createAndValidate(
+            body: message.asData,
+            statusCode: .success,
+            headers: [
+                HTTPClient.responseSignatureHeaderName: fullSignature.base64EncodedString()
+            ],
+            request: request,
+            publicKey: self.publicKey
+        )
+
+        expect(response.validationResult) == .validated
     }
 
 }
@@ -120,10 +180,14 @@ extension SigningTests {
         return (key, key.publicKey)
     }
 
-    private func sign(key: PrivateKey, message: String, nonce: String, salt: String) throws -> Data {
+    private func sign(message: String, nonce: String, salt: String) throws -> Data {
         let fullMessage = salt.asData + nonce.asData + message.asData
 
-        return try key.signature(for: fullMessage)
+        return try self.privateKey.signature(for: fullMessage)
+    }
+
+    private static func createSalt() -> String {
+        return Array(repeating: "a", count: Signing.saltSize).joined()
     }
 
 }

--- a/Tests/UnitTests/Misc/SigningTests.swift
+++ b/Tests/UnitTests/Misc/SigningTests.swift
@@ -112,30 +112,30 @@ class SigningTests: TestCase {
 
     func testResponseValidationWithNoProvidedKey() throws {
         let request = HTTPRequest.createWithResponseVerification(method: .get, path: .health)
-        let response = HTTPResponse.createAndValidate(body: Data(),
-                                                      statusCode: .success,
-                                                      headers: [:],
-                                                      request: request,
-                                                      publicKey: nil)
+        let response = HTTPResponse.create(with: Data(),
+                                           statusCode: .success,
+                                           headers: [:],
+                                           request: request,
+                                           publicKey: nil)
 
         expect(response.validationResult) == .notRequested
     }
 
     func testResponseValidationWithNoSignatureInResponse() throws {
         let request = HTTPRequest.createWithResponseVerification(method: .get, path: .health)
-        let response = HTTPResponse.createAndValidate(body: Data(),
-                                                      statusCode: .success,
-                                                      headers: [:],
-                                                      request: request,
-                                                      publicKey: self.publicKey)
+        let response = HTTPResponse.create(with: Data(),
+                                           statusCode: .success,
+                                           headers: [:],
+                                           request: request,
+                                           publicKey: self.publicKey)
 
         expect(response.validationResult) == .failedValidation
     }
 
     func testResponseValidationWithInvalidSignature() throws {
         let request = HTTPRequest.createWithResponseVerification(method: .get, path: .health)
-        let response = HTTPResponse.createAndValidate(
-            body: Data(),
+        let response = HTTPResponse.create(
+            with: Data(),
             statusCode: .success,
             headers: [
                 HTTPClient.responseSignatureHeaderName: "invalid_signature"
@@ -156,8 +156,8 @@ class SigningTests: TestCase {
         let fullSignature = salt.asData + signature
 
         let request = HTTPRequest(method: .get, path: .health, nonce: nonce.asData)
-        let response = HTTPResponse.createAndValidate(
-            body: message.asData,
+        let response = HTTPResponse.create(
+            with: message.asData,
             statusCode: .success,
             headers: [
                 HTTPClient.responseSignatureHeaderName: fullSignature.base64EncodedString()

--- a/Tests/UnitTests/Mocks/MockETagManager.swift
+++ b/Tests/UnitTests/Mocks/MockETagManager.swift
@@ -30,8 +30,7 @@ class MockETagManager: ETagManager {
     }
 
     private struct InvokedHTTPResultFromCacheOrBackendParams {
-        let response: HTTPURLResponse
-        let body: Data?
+        let response: HTTPResponse<Data?>
         let request: URLRequest
         let retried: Bool
     }
@@ -43,26 +42,23 @@ class MockETagManager: ETagManager {
     var stubbedHTTPResultFromCacheOrBackendResult: HTTPResponse<Data>!
     var shouldReturnResultFromBackend = true
 
-    override func httpResultFromCacheOrBackend(with response: HTTPURLResponse,
-                                               data: Data?,
+    override func httpResultFromCacheOrBackend(with response: HTTPResponse<Data?>,
                                                request: URLRequest,
                                                retried: Bool) -> HTTPResponse<Data>? {
-        return lock.perform {
-            invokedHTTPResultFromCacheOrBackend = true
-            invokedHTTPResultFromCacheOrBackendCount += 1
+        return self.lock.perform {
+            self.invokedHTTPResultFromCacheOrBackend = true
+            self.invokedHTTPResultFromCacheOrBackendCount += 1
             let params = InvokedHTTPResultFromCacheOrBackendParams(
                 response: response,
-                body: data,
                 request: request,
                 retried: retried
             )
-            invokedHTTPResultFromCacheOrBackendParameters = params
-            invokedHTTPResultFromCacheOrBackendParametersList.append(params)
-            if shouldReturnResultFromBackend {
-                return HTTPResponse(statusCode: .init(rawValue: response.statusCode), body: data)
-                    .asOptionalResponse
+            self.invokedHTTPResultFromCacheOrBackendParameters = params
+            self.invokedHTTPResultFromCacheOrBackendParametersList.append(params)
+            if self.shouldReturnResultFromBackend {
+                return response.asOptionalResponse
             }
-            return stubbedHTTPResultFromCacheOrBackendResult
+            return self.stubbedHTTPResultFromCacheOrBackendResult
         }
     }
 

--- a/Tests/UnitTests/Mocks/MockETagManager.swift
+++ b/Tests/UnitTests/Mocks/MockETagManager.swift
@@ -13,19 +13,34 @@ import Foundation
 // swiftlint:disable type_name
 class MockETagManager: ETagManager {
 
+    struct ETagHeaderRequest {
+        var urlRequest: URLRequest
+        var refreshETag: Bool
+        var signatureVerificationEnabled: Bool
+    }
+
     var invokedETagHeader = false
     var invokedETagHeaderCount = 0
-    var invokedETagHeaderParameters: (urlRequest: URLRequest, refreshETag: Bool)?
-    var invokedETagHeaderParametersList = [(urlRequest: URLRequest, refreshETag: Bool)]()
+    var invokedETagHeaderParameters: ETagHeaderRequest?
+    var invokedETagHeaderParametersList: [ETagHeaderRequest] = []
     var stubbedETagHeaderResult: [String: String]! = [:]
 
-    override func eTagHeader(for urlRequest: URLRequest, refreshETag: Bool = false) -> [String: String] {
-        return lock.perform {
-            invokedETagHeader = true
-            invokedETagHeaderCount += 1
-            invokedETagHeaderParameters = (urlRequest, refreshETag)
-            invokedETagHeaderParametersList.append((urlRequest, refreshETag))
-            return stubbedETagHeaderResult
+    override func eTagHeader(
+        for urlRequest: URLRequest,
+        refreshETag: Bool = false,
+        signatureVerificationEnabled: Bool
+    ) -> [String: String] {
+        return self.lock.perform {
+            let request: ETagHeaderRequest = .init(urlRequest: urlRequest,
+                                                   refreshETag: refreshETag,
+                                                   signatureVerificationEnabled: signatureVerificationEnabled)
+
+            self.invokedETagHeader = true
+            self.invokedETagHeaderCount += 1
+            self.invokedETagHeaderParameters = request
+            self.invokedETagHeaderParametersList.append(request)
+
+            return self.stubbedETagHeaderResult
         }
     }
 

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -31,13 +31,14 @@ class MockHTTPClient: HTTPClient {
             // swiftlint:disable:next force_try
             let data = try! JSONSerialization.data(withJSONObject: response)
 
-            self.init(response: .success(.init(
+            let response = HTTPResponse(
                 statusCode: statusCode,
                 responseHeaders: [:],
                 body: data,
                 validationResult: .notRequested
-            )),
-                      delay: delay)
+            )
+
+            self.init(response: .success(response), delay: delay)
         }
 
         init(error: NetworkError, delay: DispatchTimeInterval = .never) {

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -31,7 +31,7 @@ class MockHTTPClient: HTTPClient {
             // swiftlint:disable:next force_try
             let data = try! JSONSerialization.data(withJSONObject: response)
 
-            self.init(response: .success(.init(statusCode: statusCode, body: data)),
+            self.init(response: .success(.init(statusCode: statusCode, responseHeaders: [:], body: data)),
                       delay: delay)
         }
 

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -31,7 +31,12 @@ class MockHTTPClient: HTTPClient {
             // swiftlint:disable:next force_try
             let data = try! JSONSerialization.data(withJSONObject: response)
 
-            self.init(response: .success(.init(statusCode: statusCode, responseHeaders: [:], body: data)),
+            self.init(response: .success(.init(
+                statusCode: statusCode,
+                responseHeaders: [:],
+                body: data,
+                validationResult: .notRequested
+            )),
                       delay: delay)
         }
 

--- a/Tests/UnitTests/Mocks/MockSigning.swift
+++ b/Tests/UnitTests/Mocks/MockSigning.swift
@@ -1,0 +1,49 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockSigning.swift
+//
+//  Created by Nacho Soto on 2/8/23.
+
+@testable import RevenueCat
+
+final class MockSigning: SigningType {
+
+    struct VerificationRequest {
+        let message: Data
+        let nonce: Data
+        let signature: String
+        let publicKey: Signing.PublicKey
+    }
+
+    static var requests: [VerificationRequest] = []
+    static var stubbedVerificationResult: Bool?
+
+    static func verify(
+        message: Data,
+        nonce: Data,
+        hasValidSignature signature: String,
+        with publicKey: Signing.PublicKey
+    ) -> Bool {
+        Self.requests.append(.init(
+            message: message,
+            nonce: nonce,
+            signature: signature,
+            publicKey: publicKey
+        ))
+
+        return Self.stubbedVerificationResult!
+    }
+
+    static func resetData() {
+        self.requests.removeAll()
+        self.stubbedVerificationResult = nil
+    }
+
+}

--- a/Tests/UnitTests/Networking/ETagManagerTests.swift
+++ b/Tests/UnitTests/Networking/ETagManagerTests.swift
@@ -446,7 +446,7 @@ class ETagManagerTests: TestCase {
         "e_tag": "\(eTag)",
         "status_code": 200,
         "data": "\(actualResponse.asFetchToken)",
-        "validation_result": 1
+        "validation_result": \(HTTPResponseValidationResult.validated.rawValue)
         }
         """.asData
 

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -944,7 +944,8 @@ final class HTTPClientTests: BaseHTTPClientTests {
         self.eTagManager.stubbedHTTPResultFromCacheOrBackendResult = .init(
             statusCode: .success,
             responseHeaders: [:],
-            body: mockedCachedResponse
+            body: mockedCachedResponse,
+            validationResult: .notRequested
         )
 
         stub(condition: isPath(path)) { _ in

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -13,16 +13,16 @@ import XCTest
 
 @testable import RevenueCat
 
-class HTTPClientTests: TestCase {
+class BaseHTTPClientTests: TestCase {
 
-    private typealias EmptyResponse = HTTPResponse<HTTPEmptyResponseBody>.Result
+    fileprivate typealias EmptyResponse = HTTPResponse<HTTPEmptyResponseBody>.Result
 
-    private let apiKey = "MockAPIKey"
-    private let systemInfo = MockSystemInfo(finishTransactions: true)
-    private var client: HTTPClient!
-    private var userDefaults: UserDefaults!
-    private var eTagManager: MockETagManager!
-    private var operationDispatcher: OperationDispatcher!
+    fileprivate let apiKey = "MockAPIKey"
+    fileprivate var systemInfo = MockSystemInfo(finishTransactions: true)
+    fileprivate var client: HTTPClient!
+    fileprivate var userDefaults: UserDefaults!
+    fileprivate var eTagManager: MockETagManager!
+    fileprivate var operationDispatcher: OperationDispatcher!
 
     override func setUp() {
         super.setUp()
@@ -31,12 +31,9 @@ class HTTPClientTests: TestCase {
         self.eTagManager = MockETagManager(userDefaults: self.userDefaults)
         self.operationDispatcher = OperationDispatcher()
         MockDNSChecker.resetData()
+        MockSigning.resetData()
 
-        self.client = HTTPClient(apiKey: self.apiKey,
-                                 systemInfo: self.systemInfo,
-                                 eTagManager: self.eTagManager,
-                                 dnsChecker: MockDNSChecker.self,
-                                 requestTimeout: 3)
+        self.client = self.createClient()
     }
 
     override func tearDown() {
@@ -44,6 +41,19 @@ class HTTPClientTests: TestCase {
 
         super.tearDown()
     }
+
+    fileprivate final func createClient() -> HTTPClient {
+        return HTTPClient(apiKey: self.apiKey,
+                          systemInfo: self.systemInfo,
+                          eTagManager: self.eTagManager,
+                          dnsChecker: MockDNSChecker.self,
+                          signing: MockSigning.self,
+                          requestTimeout: 3)
+    }
+
+}
+
+final class HTTPClientTests: BaseHTTPClientTests {
 
     func testUsesTheCorrectHost() throws {
         let hostCorrect: Atomic<Bool> = false
@@ -94,26 +104,6 @@ class HTTPClientTests: TestCase {
 
         expect(headers).toNot(beEmpty())
         expect(headers?.keys).toNot(contain(HTTPClient.nonceHeaderName))
-    }
-
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func testRequestIncludesRandomNonce() throws {
-        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
-
-        let request = HTTPRequest.createIntegrityEnforcedRequestRequest(method: .get, path: .mockPath)
-
-        let headers: [String: String]? = waitUntilValue { completion in
-            stub(condition: isPath(request.path)) { request in
-                completion(request.allHTTPHeaderFields)
-                return .emptySuccessResponse()
-            }
-
-            self.client.perform(request) { (_: EmptyResponse) in }
-        }
-
-        expect(headers).toNot(beEmpty())
-        expect(headers?.keys).to(contain(HTTPClient.nonceHeaderName))
-        expect(headers?[HTTPClient.nonceHeaderName]) == request.nonce?.base64EncodedString()
     }
 
     func testRequestIncludesNonceInBase64() {
@@ -953,6 +943,7 @@ class HTTPClientTests: TestCase {
         self.eTagManager.shouldReturnResultFromBackend = false
         self.eTagManager.stubbedHTTPResultFromCacheOrBackendResult = .init(
             statusCode: .success,
+            responseHeaders: [:],
             body: mockedCachedResponse
         )
 
@@ -1154,6 +1145,169 @@ class HTTPClientTests: TestCase {
 
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+final class SignatureVerificationHTTPClientTests: BaseHTTPClientTests {
+
+    override func setUpWithError() throws {
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
+        try super.setUpWithError()
+    }
+
+    func testRequestIncludesRandomNonce() throws {
+        let request = HTTPRequest.createWithResponseVerification(method: .get, path: .mockPath)
+
+        let headers: [String: String]? = waitUntilValue { completion in
+            stub(condition: isPath(request.path)) { request in
+                completion(request.allHTTPHeaderFields)
+                return .emptySuccessResponse()
+            }
+
+            self.client.perform(request) { (_: EmptyResponse) in }
+        }
+
+        expect(headers).toNot(beEmpty())
+        expect(headers?.keys).to(contain(HTTPClient.nonceHeaderName))
+        expect(headers?[HTTPClient.nonceHeaderName]) == request.nonce?.base64EncodedString()
+    }
+
+    func testFailedValidationIfResponseContainsNoSignature() throws {
+        let logger = TestLogHandler()
+
+        try self.changeClient(.informationOnly)
+        self.mockResponse()
+
+        MockSigning.stubbedVerificationResult = true
+
+        let request: HTTPRequest = .createWithResponseVerification(method: .get, path: .mockPath)
+        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+            self.client.perform(request, completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.validationResult) == .failedValidation
+        expect(MockSigning.requests).to(beEmpty())
+
+        logger.verifyMessageWasLogged(
+            Strings.signing.signature_was_requested_but_not_provided(request),
+            level: .warn
+        )
+    }
+
+    func testValidSignatureWithVerificationLevelInformationOnly() throws {
+        let signature = "signature"
+
+        try self.changeClient(.informationOnly)
+        self.mockResponse(signature: signature)
+
+        MockSigning.stubbedVerificationResult = true
+
+        let request: HTTPRequest = .createWithResponseVerification(method: .get, path: .mockPath)
+
+        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+            self.client.perform(request, completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.validationResult) == .validated
+
+        expect(MockSigning.requests).to(haveCount(1))
+        expect(MockSigning.requests.onlyElement?.message) == Data()
+        expect(MockSigning.requests.onlyElement?.nonce) == request.nonce
+        expect(MockSigning.requests.onlyElement?.signature) == signature
+        expect(MockSigning.requests.onlyElement?.publicKey).toNot(beNil())
+    }
+
+    func testSignatureNotRequested() throws {
+        try self.changeClient(.enforced)
+        self.mockResponse()
+
+        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+            self.client.perform(.init(method: .get, path: .mockPath), completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.validationResult) == .notRequested
+
+        expect(MockSigning.requests).to(beEmpty())
+    }
+
+    func testValidSignatureWithVerificationLevelEnforced() throws {
+        try self.changeClient(.enforced)
+        self.mockResponse(signature: "signature")
+
+        MockSigning.stubbedVerificationResult = true
+
+        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+            self.client.perform(.createWithResponseVerification(method: .get, path: .mockPath),
+                                completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.validationResult) == .validated
+        expect(MockSigning.requests).to(haveCount(1))
+    }
+
+    func testIncorrectSignatureWithVerificationLevelInformationOnlyReturnsResponse() throws {
+        let signature = "signature"
+
+        try self.changeClient(.informationOnly)
+        self.mockResponse(signature: signature)
+
+        MockSigning.stubbedVerificationResult = false
+
+        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+            self.client.perform(.createWithResponseVerification(method: .get, path: .mockPath),
+                                completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.validationResult) == .failedValidation
+        expect(MockSigning.requests).to(haveCount(1))
+    }
+
+    func testIncorrectSignatureWithVerificationLevelEnforcedReturnsError() throws {
+        let signature = "signature"
+
+        try self.changeClient(.enforced)
+        self.mockResponse(signature: signature)
+
+        MockSigning.stubbedVerificationResult = false
+
+        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+            self.client.perform(.createWithResponseVerification(method: .get, path: .mockPath),
+                                completionHandler: completion)
+        }
+
+        expect(response).to(beFailure())
+        expect(response?.error).to(matchError(NetworkError.signatureVerificationFailed(path: .mockPath)))
+    }
+
+    private func changeClient(_ verificationLevel: Configuration.EntitlementVerificationLevel) throws {
+        let level = try Signing.verificationLevel(with: verificationLevel)
+
+        self.systemInfo = try MockSystemInfo(platformInfo: nil,
+                                             finishTransactions: false,
+                                             responseVerificationLevel: level)
+        self.client = self.createClient()
+    }
+
+    private func mockResponse(signature: String? = nil) {
+        stub(condition: isPath(HTTPRequest.Path.mockPath)) { _ in
+            if let signature = signature {
+                return .init(data: Data(),
+                             statusCode: .success,
+                             headers: [
+                                HTTPClient.responseSignatureHeaderName: signature
+                             ])
+            } else {
+                return .emptySuccessResponse()
+            }
+        }
+    }
+
+}
+
 // MARK: - Extensions
 
 private extension HTTPRequest.Path {
@@ -1185,7 +1339,7 @@ extension HTTPRequest.Method {
 
 }
 
-private extension HTTPClientTests {
+private extension BaseHTTPClientTests {
 
     static func extractRequestNumber(from urlRequest: URLRequest) -> Int? {
         do {

--- a/Tests/UnitTests/Networking/HTTPResponseTests.swift
+++ b/Tests/UnitTests/Networking/HTTPResponseTests.swift
@@ -11,10 +11,42 @@
 //
 //  Created by Nacho Soto on 3/9/22.
 
+import CryptoKit
 import Nimble
 import XCTest
 
 @testable import RevenueCat
+
+class HTTPResponseTests: TestCase {
+
+    func testResponseValidationNotRequestedWithNoPublicKey() {
+        let request = HTTPRequest(method: .get, path: .health)
+        let response = HTTPResponse.createAndValidate(body: Data(),
+                                                      statusCode: .success,
+                                                      headers: [:],
+                                                      request: request,
+                                                      publicKey: nil)
+
+        expect(response.validationResult) == .notRequested
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func testResponseValidationNotRequestedWithPublicKey() throws {
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
+        let key = Curve25519.Signing.PrivateKey().publicKey
+
+        let request = HTTPRequest(method: .get, path: .health)
+        let response = HTTPResponse.createAndValidate(body: Data(),
+                                                      statusCode: .success,
+                                                      headers: [:],
+                                                      request: request,
+                                                      publicKey: key)
+
+        expect(response.validationResult) == .notRequested
+    }
+
+}
 
 class ErrorResponseTests: TestCase {
 

--- a/Tests/UnitTests/Networking/HTTPResponseTests.swift
+++ b/Tests/UnitTests/Networking/HTTPResponseTests.swift
@@ -21,11 +21,11 @@ class HTTPResponseTests: TestCase {
 
     func testResponseValidationNotRequestedWithNoPublicKey() {
         let request = HTTPRequest(method: .get, path: .health)
-        let response = HTTPResponse.createAndValidate(body: Data(),
-                                                      statusCode: .success,
-                                                      headers: [:],
-                                                      request: request,
-                                                      publicKey: nil)
+        let response = HTTPResponse.create(with: Data(),
+                                           statusCode: .success,
+                                           headers: [:],
+                                           request: request,
+                                           publicKey: nil)
 
         expect(response.validationResult) == .notRequested
     }
@@ -37,11 +37,11 @@ class HTTPResponseTests: TestCase {
         let key = Curve25519.Signing.PrivateKey().publicKey
 
         let request = HTTPRequest(method: .get, path: .health)
-        let response = HTTPResponse.createAndValidate(body: Data(),
-                                                      statusCode: .success,
-                                                      headers: [:],
-                                                      request: request,
-                                                      publicKey: key)
+        let response = HTTPResponse.create(with: Data(),
+                                           statusCode: .success,
+                                           headers: [:],
+                                           request: request,
+                                           publicKey: key)
 
         expect(response.validationResult) == .notRequested
     }

--- a/Tests/UnitTests/Purchasing/ErrorCodeTests.swift
+++ b/Tests/UnitTests/Purchasing/ErrorCodeTests.swift
@@ -168,8 +168,13 @@ class ErrorCodeTests: TestCase {
                                               expectedRawValue: 35)
     }
 
+    func testSignatureVerificationFailedError() {
+        ensureEnumCaseMatchesExpectedRawValue(errorCode: .signatureVerificationFailed,
+                                              expectedRawValue: 36)
+    }
+
     func testErrorCodeEnumCasesAreCoveredInTests() {
-        expect(ErrorCode.allCases).to(haveCount(35))
+        expect(ErrorCode.allCases).to(haveCount(36))
     }
 
     func ensureEnumCaseMatchesExpectedRawValue(errorCode: ErrorCode, expectedRawValue: Int) {


### PR DESCRIPTION
Fixes [CSDK-634].

## Changes:
- Created `HTTPResponseValidationResult`
- Added `HTTPResponseValidationResult` and `HTTPClient.ResponseHeaders` to `HTTPResponse`
- Added new `ErrorCode.signatureVerificationFailed`
- Extracted `SigningType` to create `MockSigning` to test `HTTPClient` without bothering with signatures
- Refactored `ETagManager` to use `HTTPResponse`, making it easier to pass through response headers and verification results
- Stored `HTTPResponseValidationResult` in `ETagManager` cache
- `HTTPClient` handles signatures from response based on `SystemInfo.responseVerificationLevel`
- Renamed `HTTPRequest.createIntegrityEnforcedRequestRequest` to `HTTPRequest.createWithResponseVerification`
- Added lots of tests for this new behavior in `HTTPClient`
- Added lots of new tests for `ETagManager`

[CSDK-634]: https://revenuecats.atlassian.net/browse/CSDK-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ