### PR TITLE
Fix an issue where sandbox detector would return false in simulator builds.

### DIFF
--- a/Sources/Misc/SandboxEnvironmentDetector.swift
+++ b/Sources/Misc/SandboxEnvironmentDetector.swift
@@ -30,6 +30,10 @@ final class BundleSandboxEnvironmentDetector: SandboxEnvironmentDetector {
     }
 
     var isSandbox: Bool {
+        #if targetEnvironment(simulator)
+        return true
+        #endif
+        
         guard let path = self.bundle.appStoreReceiptURL?.path else {
             return false
         }

--- a/Sources/Misc/SandboxEnvironmentDetector.swift
+++ b/Sources/Misc/SandboxEnvironmentDetector.swift
@@ -24,15 +24,17 @@ protocol SandboxEnvironmentDetector: Sendable {
 final class BundleSandboxEnvironmentDetector: SandboxEnvironmentDetector {
 
     private let bundle: Bundle
+    private let isRunningInSimulator: Bool
 
-    init(bundle: Bundle = .main) {
+    init(bundle: Bundle = .main, isRunningInSimulator: Bool = SystemInfo.isRunningInSimulator) {
         self.bundle = bundle
+        self.isRunningInSimulator = isRunningInSimulator
     }
 
     var isSandbox: Bool {
-        #if targetEnvironment(simulator)
-        return true
-        #endif
+        guard !isRunningInSimulator else {
+            return true
+        }
         
         guard let path = self.bundle.appStoreReceiptURL?.path else {
             return false

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -184,7 +184,12 @@ extension SystemInfo {
     #elseif os(macOS)
     static let platformHeaderConstant = "macOS"
     #endif
-
+    
+    #if targetEnvironment(simulator)
+    static let isRunningInSimulator = true
+    #else
+    static let isRunningInSimulator = false
+    #endif
 }
 
 extension SystemInfo {

--- a/Tests/UnitTests/Misc/SandboxEnvironmentDetectorTests.swift
+++ b/Tests/UnitTests/Misc/SandboxEnvironmentDetectorTests.swift
@@ -17,36 +17,39 @@ import XCTest
 @testable import RevenueCat
 
 class SandboxEnvironmentDetectorTests: TestCase {
-
+    
     func testIsSandbox() throws {
-        expect(try SystemInfo.withReceiptResult(.sandboxReceipt).isSandbox) == true
+        expect(try SystemInfo.withReceiptResult(.sandboxReceipt, inSimulator: false).isSandbox) == true
     }
 
     func testIsNotSandbox() throws {
-        expect(try SystemInfo.withReceiptResult(.receiptWithData).isSandbox) == false
+        expect(try SystemInfo.withReceiptResult(.receiptWithData, inSimulator: false).isSandbox) == false
     }
 
     func testIsNotSandboxIfNoReceiptURL() throws {
-        expect(try SystemInfo.withReceiptResult(.nilURL).isSandbox) == false
+        expect(try SystemInfo.withReceiptResult(.nilURL, inSimulator: false).isSandbox) == false
     }
 
     func testMacSandboxReceiptIsSandbox() throws {
-        expect(try SystemInfo.withReceiptResult(.macOSSandboxReceipt).isSandbox) == true
+        expect(try SystemInfo.withReceiptResult(.macOSSandboxReceipt, inSimulator: false).isSandbox) == true
     }
 
     func testMacAppStoreReceiptIsNotSandbox() throws {
-        expect(try SystemInfo.withReceiptResult(.macOSAppStoreReceipt).isSandbox) == false
+        expect(try SystemInfo.withReceiptResult(.macOSAppStoreReceipt, inSimulator: false).isSandbox) == false
     }
 
+    func testIsSandboxIfRunningInSimulator() {
+        expect(try SystemInfo.withReceiptResult(.receiptWithData, inSimulator: true).isSandbox) == true
+    }
 }
 
 private extension SandboxEnvironmentDetector {
 
-    static func withReceiptResult(_ result: MockBundle.ReceiptURLResult) throws -> SandboxEnvironmentDetector {
+    static func withReceiptResult(_ result: MockBundle.ReceiptURLResult, inSimulator isRunningInSimulator: Bool) throws -> SandboxEnvironmentDetector {
         let bundle = MockBundle()
         bundle.receiptURLResult = result
 
-        return BundleSandboxEnvironmentDetector(bundle: bundle)
+        return BundleSandboxEnvironmentDetector(bundle: bundle, isRunningInSimulator: isRunningInSimulator)
     }
 
 }


### PR DESCRIPTION
### Checklist
- [X] If applicable, unit tests
- [X] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
I have extensive UI tests checking various upgrade and conversion scenarios in my app. I recently transitioned from on-device receipt checking using StoreKit 1 to RevenueCat, and my tests were failing because the simulator was being treated as a non-sandbox environment.

### Description
When running in the simulator, the receipt does not seem to be named sandboxReceipt, even though purchases are always made in the sandbox. This change handles this case.

I have tried to update the unit tests where appropriate, although currently there are some SystemInfo tests that are failing. I wasn't sure exactly the best approach to updating those tests, and would welcome suggestions on how to update them.
