### PR TITLE
`BundleSandboxEnvironmentDetector`: always return `true` when running on simulator

### DIFF
--- a/Sources/Misc/SandboxEnvironmentDetector.swift
+++ b/Sources/Misc/SandboxEnvironmentDetector.swift
@@ -24,12 +24,18 @@ protocol SandboxEnvironmentDetector: Sendable {
 final class BundleSandboxEnvironmentDetector: SandboxEnvironmentDetector {
 
     private let bundle: Bundle
+    private let isRunningInSimulator: Bool
 
-    init(bundle: Bundle = .main) {
+    init(bundle: Bundle = .main, isRunningInSimulator: Bool = SystemInfo.isRunningInSimulator) {
         self.bundle = bundle
+        self.isRunningInSimulator = isRunningInSimulator
     }
 
     var isSandbox: Bool {
+        guard !self.isRunningInSimulator else {
+            return true
+        }
+
         guard let path = self.bundle.appStoreReceiptURL?.path else {
             return false
         }
@@ -43,12 +49,7 @@ final class BundleSandboxEnvironmentDetector: SandboxEnvironmentDetector {
         }
     }
 
-    #if DEBUG
-    // Mutable in tests so it can be overriden
-    static var `default`: SandboxEnvironmentDetector = BundleSandboxEnvironmentDetector()
-    #else
     static let `default`: SandboxEnvironmentDetector = BundleSandboxEnvironmentDetector()
-    #endif
 
 }
 

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -112,6 +112,7 @@ class SystemInfo {
          finishTransactions: Bool,
          operationDispatcher: OperationDispatcher = .default,
          bundle: Bundle = .main,
+         sandboxEnvironmentDetector: SandboxEnvironmentDetector = BundleSandboxEnvironmentDetector.default,
          storeKit2Setting: StoreKit2Setting = .default,
          responseVerificationLevel: Signing.ResponseVerificationLevel = .default,
          dangerousSettings: DangerousSettings? = nil) throws {
@@ -122,11 +123,9 @@ class SystemInfo {
         self._finishTransactions = .init(finishTransactions)
         self.operationDispatcher = operationDispatcher
         self.storeKit2Setting = storeKit2Setting
+        self.sandboxEnvironmentDetector = sandboxEnvironmentDetector
         self.responseVerificationLevel = responseVerificationLevel
         self.dangerousSettings = dangerousSettings ?? DangerousSettings()
-        self.sandboxEnvironmentDetector = bundle === Bundle.main
-            ? BundleSandboxEnvironmentDetector.default
-            : BundleSandboxEnvironmentDetector(bundle: bundle)
     }
 
     /// Asynchronous API if caller can't ensure that it's invoked in the `@MainActor`

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -150,6 +150,12 @@ class SystemInfo {
     #endif
     }
 
+    #if targetEnvironment(simulator)
+    static let isRunningInSimulator = true
+    #else
+    static let isRunningInSimulator = false
+    #endif
+
     func isOperatingSystemAtLeast(_ version: OperatingSystemVersion) -> Bool {
         return ProcessInfo.processInfo.isOperatingSystemAtLeast(version)
     }

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -37,10 +37,6 @@ class BaseBackendIntegrationTests: XCTestCase {
     class var storeKit2Setting: StoreKit2Setting { return .default }
     class var observerMode: Bool { return false }
 
-    override class func setUp() {
-        BundleSandboxEnvironmentDetector.default = MockSandboxEnvironmentDetector()
-    }
-
     @MainActor
     override func setUp() async throws {
         try await super.setUp()
@@ -123,11 +119,5 @@ private extension BaseBackendIntegrationTests {
         return .init(autoSyncPurchases: true,
                      internalSettings: .init(enableReceiptFetchRetry: true))
     }
-
-}
-
-private final class MockSandboxEnvironmentDetector: SandboxEnvironmentDetector {
-
-    let isSandbox: Bool = true
 
 }

--- a/Tests/UnitTests/Misc/SandboxEnvironmentDetectorTests.swift
+++ b/Tests/UnitTests/Misc/SandboxEnvironmentDetectorTests.swift
@@ -19,34 +19,43 @@ import XCTest
 class SandboxEnvironmentDetectorTests: TestCase {
 
     func testIsSandbox() throws {
-        expect(try SystemInfo.withReceiptResult(.sandboxReceipt).isSandbox) == true
+        expect(try SystemInfo.with(receiptReceipt: .sandboxReceipt, inSimulator: false).isSandbox) == true
     }
 
     func testIsNotSandbox() throws {
-        expect(try SystemInfo.withReceiptResult(.receiptWithData).isSandbox) == false
+        expect(try SystemInfo.with(receiptReceipt: .receiptWithData, inSimulator: false).isSandbox) == false
     }
 
     func testIsNotSandboxIfNoReceiptURL() throws {
-        expect(try SystemInfo.withReceiptResult(.nilURL).isSandbox) == false
+        expect(try SystemInfo.with(receiptReceipt: .nilURL, inSimulator: false).isSandbox) == false
     }
 
     func testMacSandboxReceiptIsSandbox() throws {
-        expect(try SystemInfo.withReceiptResult(.macOSSandboxReceipt).isSandbox) == true
+        expect(try SystemInfo.with(receiptReceipt: .macOSSandboxReceipt, inSimulator: false).isSandbox) == true
     }
 
     func testMacAppStoreReceiptIsNotSandbox() throws {
-        expect(try SystemInfo.withReceiptResult(.macOSAppStoreReceipt).isSandbox) == false
+        expect(try SystemInfo.with(receiptReceipt: .macOSAppStoreReceipt, inSimulator: false).isSandbox) == false
+    }
+
+    func testIsAlwaysSandboxIfRunningInSimulator() {
+        expect(try SystemInfo.with(receiptReceipt: .sandboxReceipt, inSimulator: true).isSandbox) == true
+        expect(try SystemInfo.with(receiptReceipt: .receiptWithData, inSimulator: true).isSandbox) == true
+        expect(try SystemInfo.with(receiptReceipt: .nilURL, inSimulator: true).isSandbox) == true
     }
 
 }
 
 private extension SandboxEnvironmentDetector {
 
-    static func withReceiptResult(_ result: MockBundle.ReceiptURLResult) throws -> SandboxEnvironmentDetector {
+    static func with(
+        receiptReceipt result: MockBundle.ReceiptURLResult,
+        inSimulator: Bool
+    ) throws -> SandboxEnvironmentDetector {
         let bundle = MockBundle()
         bundle.receiptURLResult = result
 
-        return BundleSandboxEnvironmentDetector(bundle: bundle)
+        return BundleSandboxEnvironmentDetector(bundle: bundle, isRunningInSimulator: inSimulator)
     }
 
 }

--- a/Tests/UnitTests/Misc/SandboxEnvironmentDetectorTests.swift
+++ b/Tests/UnitTests/Misc/SandboxEnvironmentDetectorTests.swift
@@ -19,29 +19,29 @@ import XCTest
 class SandboxEnvironmentDetectorTests: TestCase {
 
     func testIsSandbox() throws {
-        expect(try SystemInfo.with(receiptReceipt: .sandboxReceipt, inSimulator: false).isSandbox) == true
+        expect(try SystemInfo.with(receiptResult: .sandboxReceipt, inSimulator: false).isSandbox) == true
     }
 
     func testIsNotSandbox() throws {
-        expect(try SystemInfo.with(receiptReceipt: .receiptWithData, inSimulator: false).isSandbox) == false
+        expect(try SystemInfo.with(receiptResult: .receiptWithData, inSimulator: false).isSandbox) == false
     }
 
     func testIsNotSandboxIfNoReceiptURL() throws {
-        expect(try SystemInfo.with(receiptReceipt: .nilURL, inSimulator: false).isSandbox) == false
+        expect(try SystemInfo.with(receiptResult: .nilURL, inSimulator: false).isSandbox) == false
     }
 
     func testMacSandboxReceiptIsSandbox() throws {
-        expect(try SystemInfo.with(receiptReceipt: .macOSSandboxReceipt, inSimulator: false).isSandbox) == true
+        expect(try SystemInfo.with(receiptResult: .macOSSandboxReceipt, inSimulator: false).isSandbox) == true
     }
 
     func testMacAppStoreReceiptIsNotSandbox() throws {
-        expect(try SystemInfo.with(receiptReceipt: .macOSAppStoreReceipt, inSimulator: false).isSandbox) == false
+        expect(try SystemInfo.with(receiptResult: .macOSAppStoreReceipt, inSimulator: false).isSandbox) == false
     }
 
     func testIsAlwaysSandboxIfRunningInSimulator() {
-        expect(try SystemInfo.with(receiptReceipt: .sandboxReceipt, inSimulator: true).isSandbox) == true
-        expect(try SystemInfo.with(receiptReceipt: .receiptWithData, inSimulator: true).isSandbox) == true
-        expect(try SystemInfo.with(receiptReceipt: .nilURL, inSimulator: true).isSandbox) == true
+        expect(try SystemInfo.with(receiptResult: .sandboxReceipt, inSimulator: true).isSandbox) == true
+        expect(try SystemInfo.with(receiptResult: .receiptWithData, inSimulator: true).isSandbox) == true
+        expect(try SystemInfo.with(receiptResult: .nilURL, inSimulator: true).isSandbox) == true
     }
 
 }
@@ -49,7 +49,7 @@ class SandboxEnvironmentDetectorTests: TestCase {
 private extension SandboxEnvironmentDetector {
 
     static func with(
-        receiptReceipt result: MockBundle.ReceiptURLResult,
+        receiptResult result: MockBundle.ReceiptURLResult,
         inSimulator: Bool
     ) throws -> SandboxEnvironmentDetector {
         let bundle = MockBundle()

--- a/Tests/UnitTests/Misc/SystemInfoTests.swift
+++ b/Tests/UnitTests/Misc/SystemInfoTests.swift
@@ -57,6 +57,20 @@ class SystemInfoTests: TestCase {
         expect(systemInfo.observerMode) == !finishTransactions
     }
 
+    func testIsSandbox() throws {
+        let sandboxDetector = MockSandboxEnvironmentDetector(isSandbox: true)
+
+        expect(try SystemInfo.withReceiptResult(.sandboxReceipt, sandboxDetector).isSandbox) == true
+        expect(try SystemInfo.withReceiptResult(.receiptWithData, sandboxDetector).isSandbox) == true
+    }
+
+    func testIsNotSandbox() throws {
+        let sandboxDetector = MockSandboxEnvironmentDetector(isSandbox: false)
+
+        expect(try SystemInfo.withReceiptResult(.sandboxReceipt, sandboxDetector).isSandbox) == false
+        expect(try SystemInfo.withReceiptResult(.receiptWithData, sandboxDetector).isSandbox) == false
+    }
+
     func testIsAppleSubscriptionURLWithAnotherURL() {
         expect(SystemInfo.isAppleSubscription(managementURL: URL(string: "www.google.com")!)) == false
     }
@@ -82,13 +96,19 @@ class SystemInfoTests: TestCase {
 
 private extension SystemInfo {
 
-    static func withReceiptResult(_ result: MockBundle.ReceiptURLResult) throws -> SystemInfo {
+    static func withReceiptResult(
+        _ result: MockBundle.ReceiptURLResult,
+        _ sandboxEnvironmentDetector: SandboxEnvironmentDetector? = nil
+    ) throws -> SystemInfo {
         let bundle = MockBundle()
         bundle.receiptURLResult = result
 
+        let sandboxDetector = sandboxEnvironmentDetector ?? BundleSandboxEnvironmentDetector(bundle: bundle)
+
         return try SystemInfo(platformInfo: nil,
                               finishTransactions: false,
-                              bundle: bundle)
+                              bundle: bundle,
+                              sandboxEnvironmentDetector: sandboxDetector)
     }
 
 }

--- a/Tests/UnitTests/Misc/SystemInfoTests.swift
+++ b/Tests/UnitTests/Misc/SystemInfoTests.swift
@@ -57,18 +57,6 @@ class SystemInfoTests: TestCase {
         expect(systemInfo.observerMode) == !finishTransactions
     }
 
-    func testIsSandbox() throws {
-        expect(try SystemInfo.withReceiptResult(.sandboxReceipt).isSandbox) == true
-    }
-
-    func testIsNotSandbox() throws {
-        expect(try SystemInfo.withReceiptResult(.receiptWithData).isSandbox) == false
-    }
-
-    func testIsNotSandboxIfNoReceiptURL() throws {
-        expect(try SystemInfo.withReceiptResult(.nilURL).isSandbox) == false
-    }
-
     func testIsAppleSubscriptionURLWithAnotherURL() {
         expect(SystemInfo.isAppleSubscription(managementURL: URL(string: "www.google.com")!)) == false
     }


### PR DESCRIPTION
Thanks to @chrisvasselli for the find and initial implementation (#2275).

This supersedes the workaround introduced in #1730, now making `IntegrationTests` not override the `SandboxEnvironmentDetector`.
