### PR TITLE
`PurchaseOrchestrator`: always refresh receipt purchasing in sandbox

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -787,7 +787,8 @@ private extension PurchasesOrchestrator {
             //      We don't _want_ to always refresh receipts to avoid throttling errors
             //      We don't _need_ to because the receipt will be refreshed by the backend using /verifyReceipt
             // - Debug and sandbox builds (potentially using StoreKit config files):
-            //      We need to always refresh the receipt because the backend might not use /verifyReceipt
+            //      We need to always refresh the receipt because the backend does not use /verifyReceipt
+            //          when it was generated locally with SK config files.
 
             #if DEBUG
             return self.systemInfo.isSandbox

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -781,7 +781,21 @@ private extension PurchasesOrchestrator {
                                              maximumRetries: Self.receiptRetryCount,
                                              sleepDuration: Self.receiptRetrySleepDuration)
         } else {
+            // See https://github.com/RevenueCat/purchases-ios/pull/2245 and
+            // https://github.com/RevenueCat/purchases-ios/issues/2260
+            // - Release or production builds:
+            //      We don't _want_ to always refresh receipts to avoid throttling errors
+            //      We don't _need_ to because the receipt will be refreshed by the backend using /verifyReceipt
+            // - Debug and sandbox builds (potentially using StoreKit config files):
+            //      We need to always refresh the receipt because the backend might not use /verifyReceipt
+
+            #if DEBUG
+            return self.systemInfo.isSandbox
+            ? .always
+            : .onlyIfEmpty
+            #else
             return .onlyIfEmpty
+            #endif
         }
     }
 }

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -86,6 +86,19 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         verifyPurchase(info2)
     }
 
+    func testCanPurchaseMultipleSubscriptions() async throws {
+        let product1 = try await self.monthlyPackage.storeProduct
+        let product2 = try await self.annualPackage.storeProduct
+
+        _ = try await Purchases.shared.purchase(product: product1)
+        let info = try await Purchases.shared.purchase(product: product2).customerInfo
+
+        expect(info.allPurchasedProductIdentifiers) == [
+            product1.productIdentifier,
+            product2.productIdentifier
+        ]
+    }
+
     func testSubscriptionIsSandbox() async throws {
         let info = try await self.purchaseMonthlyOffering().customerInfo
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
@@ -702,7 +702,21 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         expect(self.deviceCache.cacheCustomerInfoCount).toEventually(equal(2))
     }
 
-    func testWhenNoReceiptDataReceiptIsRefreshed() {
+    func testReceiptIsAlwaysRefreshedInSandbox() {
+        self.systemInfo.stubbedIsSandbox = true
+
+        self.receiptFetcher.shouldReturnReceipt = true
+        self.receiptFetcher.shouldReturnZeroBytesReceipt = true
+
+        self.makeAPurchase()
+
+        expect(self.receiptFetcher.receiptDataCalled) == true
+        expect(self.receiptFetcher.receiptDataReceivedRefreshPolicy) == .always
+    }
+
+    func testReceiptIsOnlyRefreshedIfEmptyInProduction() {
+        self.systemInfo.stubbedIsSandbox = false
+
         self.receiptFetcher.shouldReturnReceipt = true
         self.receiptFetcher.shouldReturnZeroBytesReceipt = true
 


### PR DESCRIPTION
Fixes #2260 and [SDKONCALL-216].
Follow up to #2245.

The change in #2245 was meant to avoid receipt refresh throttling errors (#2116).
However, that was a regression when using StoreKit config files because those don't get refreshed in the backend.

Unfortunately the workaround introduced in #1945 prevented us from noticing this, because we use `DangerousSettings.InternalSettings.enableReceiptFetchRetry` in our own integration tests.
I added an integration test that explicitly covers this scenario. That fails without this change if disabling that dangerous setting. I thought about making that test run without the setting, but that might lead to flaky failures in CI, which is why we introduced that workaround in the first place. But at least now we have an explicit integration test for this, as well as 2 unit tests.


[SDKONCALL-216]: https://revenuecats.atlassian.net/browse/SDKONCALL-216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ