### PR TITLE
Fix issue where underlying error information for product fetch errors was not printed in log.

### DIFF
--- a/Sources/Purchasing/StoreKit2/ProductsFetcherSK2.swift
+++ b/Sources/Purchasing/StoreKit2/ProductsFetcherSK2.swift
@@ -49,9 +49,15 @@ extension ProductsFetcherSK2.Error: CustomNSError {
         switch self {
         case let .productsRequestError(inner):
             return [
-                NSUnderlyingErrorKey: inner
+                NSUnderlyingErrorKey: inner,
+                NSLocalizedDescriptionKey: self.localizedDescription
             ]
         }
     }
 
+    var localizedDescription: String {
+        switch self {
+        case let .productsRequestError(innerError): return "Products request error: \(innerError.localizedDescription)"
+        }
+    }
 }


### PR DESCRIPTION


<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [X] If applicable, unit tests
- [X] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
I am seeing errors in my logs that are not very helpful:
`2023-02-14 04:20:35.356 Nihongo[96412:1082124] [Purchases] - DEBUG: ℹ️ Store products request failed! Error: The operation couldn’t be completed. (RevenueCat.ProductsFetcherSK2.Error error 0.)`

It looks like there is an error being thrown by `StoreKit.Product.products(for: identifiers)`, but it is wrapped in `productsRequestError` and so no information from the actual underlying error is being printed to the logs.

### Description
I tried to follow the pattern I saw in other parts of the framework (specifically, `PurchasesDiagnostics.swift`) to update the localized description of the error to print the localized description of the underlying error.

I don't think there's any unit testing needed for this change, since it should just update the debug logging, but let me know if you disagree.
