### PR TITLE
Updated targets and schemes for Xcode 14.2

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -2429,7 +2429,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1300;
-				LastUpgradeCheck = 1410;
+				LastUpgradeCheck = 1420;
 				ORGANIZATIONNAME = RevenueCat;
 				TargetAttributes = {
 					2DAC5F7126F13C9800C5258F = {

--- a/RevenueCat.xcodeproj/xcshareddata/xcschemes/BackendIntegrationTests.xcscheme
+++ b/RevenueCat.xcodeproj/xcshareddata/xcschemes/BackendIntegrationTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1420"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/RevenueCat.xcodeproj/xcshareddata/xcschemes/ReceiptParser.xcscheme
+++ b/RevenueCat.xcodeproj/xcshareddata/xcschemes/ReceiptParser.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1420"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/RevenueCat.xcodeproj/xcshareddata/xcschemes/RevenueCat.xcscheme
+++ b/RevenueCat.xcodeproj/xcshareddata/xcschemes/RevenueCat.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1420"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj/project.pbxproj
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj/project.pbxproj
@@ -228,7 +228,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1300;
-				LastUpgradeCheck = 1410;
+				LastUpgradeCheck = 1420;
 				TargetAttributes = {
 					2DD778F4270E235B0079CBD4 = {
 						CreatedOnToolsVersion = 13.0;

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj/xcshareddata/xcschemes/ObjCAPITester.xcscheme
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj/xcshareddata/xcschemes/ObjCAPITester.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1420"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tests/APITesters/ReceiptParserAPITester/ReceiptParserAPITester.xcodeproj/project.pbxproj
+++ b/Tests/APITesters/ReceiptParserAPITester/ReceiptParserAPITester.xcodeproj/project.pbxproj
@@ -120,7 +120,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1300;
-				LastUpgradeCheck = 1340;
+				LastUpgradeCheck = 1420;
 				TargetAttributes = {
 					2DD778CF270E233F0079CBD4 = {
 						CreatedOnToolsVersion = 13.0;

--- a/Tests/APITesters/ReceiptParserAPITester/ReceiptParserAPITester.xcodeproj/xcshareddata/xcschemes/ReceiptParserAPITester.xcscheme
+++ b/Tests/APITesters/ReceiptParserAPITester/ReceiptParserAPITester.xcodeproj/xcshareddata/xcschemes/ReceiptParserAPITester.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1420"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj/project.pbxproj
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj/project.pbxproj
@@ -183,7 +183,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1300;
-				LastUpgradeCheck = 1340;
+				LastUpgradeCheck = 1420;
 				TargetAttributes = {
 					2DD778CF270E233F0079CBD4 = {
 						CreatedOnToolsVersion = 13.0;

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj/xcshareddata/xcschemes/SwiftAPITester.xcscheme
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj/xcshareddata/xcschemes/SwiftAPITester.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1420"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
This fixes the last few warnings in the project:
![Screenshot 2023-02-14 at 09 17 27](https://user-images.githubusercontent.com/685609/218810146-1119ee49-fec8-4d6d-a607-674933e6bb7d.png)
