### PR TITLE
`UserDefaultsDefaultTests`: fixed flaky failures

### DIFF
--- a/Tests/StoreKitUnitTests/UserDefaultsDefaultTests.swift
+++ b/Tests/StoreKitUnitTests/UserDefaultsDefaultTests.swift
@@ -25,7 +25,10 @@ final class UserDefaultsDefaultTests: TestCase {
     override func setUp() {
         super.setUp()
 
-        UserDefaults.standard.removeObject(forKey: Self.appUserKey)
+        // We don't care if `DeviceCache` detects the modification of `UserDefaults` from this test.
+        self.ignoreFatalErrors {
+            UserDefaults.standard.removeObject(forKey: Self.appUserKey)
+        }
     }
 
     func testRevenueCatSuiteIsNotStandard() {

--- a/Tests/UnitTests/Misc/XCTestCase+Extensions.swift
+++ b/Tests/UnitTests/Misc/XCTestCase+Extensions.swift
@@ -68,6 +68,15 @@ extension XCTestCase {
         }
     }
 
+    func ignoreFatalErrors(_ closure: () -> Void) {
+        FatalErrorUtil.replaceFatalError { _, _, _ in
+            self.unreachable()
+        }
+
+        closure()
+        FatalErrorUtil.restoreFatalError()
+    }
+
 }
 
 /// Similar to `XCTUnrap` but it allows an `async` closure.


### PR DESCRIPTION
See also #2046.
Depending on test execution order sometimes we were getting crashes when running this test.

Because we're removing `UserDefaults` on purpose to test `UserDefaults.computeDefault`, we want to ignore errors here.