### PR TITLE
`HTTPClient`: automatically add `nonce` based on `HTTPRequest.Path`

### DIFF
--- a/Sources/Misc/Signing.swift
+++ b/Sources/Misc/Signing.swift
@@ -114,6 +114,13 @@ extension Signing {
             }
         }
 
+        var isEnabled: Bool {
+            switch self {
+            case .disabled: return false
+            case .informational, .enforced: return true
+            }
+        }
+
     }
 
 }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -53,6 +53,9 @@ class HTTPClient {
     }
 
     func perform<Value: HTTPResponseBody>(_ request: HTTPRequest, completionHandler: Completion<Value>?) {
+        var request = request
+        self.addNonceIfRequired(&request)
+
         self.perform(request: .init(httpRequest: request,
                                     authHeaders: self.authHeaders,
                                     completionHandler: completionHandler))
@@ -65,6 +68,15 @@ class HTTPClient {
 }
 
 extension HTTPClient {
+
+    func addNonceIfRequired(_ request: inout HTTPRequest) {
+        if request.nonce == nil,
+           request.path.hasSignatureValidation,
+           self.systemInfo.responseVerificationMode.isEnabled,
+           #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
+            request.addRandomNonce()
+        }
+    }
 
     static func authorizationHeader(withAPIKey apiKey: String) -> RequestHeaders {
         return [Self.authorizationHeaderName: "Bearer \(apiKey)"]

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -366,7 +366,7 @@ extension HTTPRequest {
         var result = self
 
         if result.nonce == nil,
-           result.path.hasSignatureValidation,
+           result.path.supportsSignatureValidation,
            verificationMode.isEnabled,
            #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
             result.addRandomNonce()

--- a/Sources/Networking/HTTPClient/HTTPRequest.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequest.swift
@@ -21,11 +21,7 @@ struct HTTPRequest {
     /// If present, this will be used by the server to compute a checksum of the response signed with a private key.
     var nonce: Data?
 
-    init(method: Method, path: Path) {
-        self.init(method: method, path: path, nonce: nil)
-    }
-
-    init(method: Method, path: Path, nonce: Data?) {
+    init(method: Method, path: Path, nonce: Data? = nil) {
         assert(nonce == nil || nonce?.count == Data.nonceLength,
                "Invalid nonce: \(nonce?.description ?? "")")
 
@@ -129,7 +125,7 @@ extension HTTPRequest.Path {
         }
     }
 
-    /// Whether requests to this path can be cached using `ETagManager`
+    /// Whether requests to this path can be cached using `ETagManager`.
     var shouldSendEtag: Bool {
         switch self {
         case .getCustomerInfo,
@@ -143,6 +139,24 @@ extension HTTPRequest.Path {
                 .postAdServicesToken:
             return true
         case .health:
+            return false
+        }
+    }
+
+    // Whether the endpoint will perform signature validation.
+    var hasSignatureValidation: Bool {
+        switch self {
+        case .getCustomerInfo,
+                .logIn,
+                .postReceiptData,
+                .health:
+            return true
+        case .getOfferings,
+                .getIntroEligibility,
+                .postSubscriberAttributes,
+                .postAttributionData,
+                .postAdServicesToken,
+                .postOfferForSigning:
             return false
         }
     }

--- a/Sources/Networking/HTTPClient/HTTPRequest.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequest.swift
@@ -144,7 +144,7 @@ extension HTTPRequest.Path {
     }
 
     // Whether the endpoint will perform signature validation.
-    var hasSignatureValidation: Bool {
+    var supportsSignatureValidation: Bool {
         switch self {
         case .getCustomerInfo,
                 .logIn,

--- a/Sources/Networking/InternalAPI.swift
+++ b/Sources/Networking/InternalAPI.swift
@@ -83,7 +83,7 @@ private final class HealthOperation: CacheableNetworkOperation {
     }
 
     override func begin(completion: @escaping () -> Void) {
-        let request = self.createRequest()
+        let request: HTTPRequest = .init(method: .get, path: .health)
 
         self.httpClient.perform(request) { (response: HTTPResponse<HTTPEmptyResponseBody>.Result) in
             if self.signatureVerification, response.value?.verificationResult != .verified {
@@ -92,16 +92,6 @@ private final class HealthOperation: CacheableNetworkOperation {
                 self.finish(with: response, completion: completion)
             }
         }
-    }
-
-    private func createRequest() -> HTTPRequest {
-        var request: HTTPRequest = .init(method: .get, path: .health)
-
-        if self.signatureVerification, #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
-            request.addRandomNonce()
-        }
-
-        return request
     }
 
     private func finish(with response: HTTPResponse<HTTPEmptyResponseBody>.Result,

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -69,7 +69,9 @@ class MockHTTPClient: HTTPClient {
     private let sourceTestFile: StaticString
 
     override func perform<Value: HTTPResponseBody>(_ request: HTTPRequest, completionHandler: Completion<Value>?) {
-        let request = request.withHardcodedNonce
+        let request = request
+            .addNonceIfRequired(self)
+            .withHardcodedNonce
 
         let call = Call(request: request,
                         headers: request.headers(with: self.authHeaders))
@@ -151,6 +153,12 @@ private extension HTTPRequest {
 
             return copy
         }
+    }
+
+    func addNonceIfRequired(_ client: HTTPClient) -> Self {
+        var copy = self
+        client.addNonceIfRequired(&copy)
+        return copy
     }
 
 }

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -68,9 +68,13 @@ class MockHTTPClient: HTTPClient {
 
     private let sourceTestFile: StaticString
 
-    override func perform<Value: HTTPResponseBody>(_ request: HTTPRequest, completionHandler: Completion<Value>?) {
+    override func perform<Value: HTTPResponseBody>(
+        _ request: HTTPRequest,
+        with verificationMode: Signing.ResponseVerificationMode? = nil,
+        completionHandler: Completion<Value>?
+    ) {
         let request = request
-            .addNonceIfRequired(self)
+            .requestAddingNonceIfRequired(with: verificationMode ?? self.systemInfo.responseVerificationMode)
             .withHardcodedNonce
 
         let call = Call(request: request,
@@ -153,12 +157,6 @@ private extension HTTPRequest {
 
             return copy
         }
-    }
-
-    func addNonceIfRequired(_ client: HTTPClient) -> Self {
-        var copy = self
-        client.addNonceIfRequired(&copy)
-        return copy
     }
 
 }

--- a/Tests/UnitTests/Networking/Backend/BackendSignatureVerificationTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendSignatureVerificationTests.swift
@@ -43,7 +43,7 @@ class BackendSignatureVerificationTests: BaseBackendTests {
     func testRequestFailsIfSignatureVerificationFails() throws {
         self.httpClient.mock(
             requestPath: .health,
-            response: .init(statusCode: .success, verificationResult: .failed)
+            response: .init(error: .signatureVerificationFailed(path: .health))
         )
 
         let error = waitUntilValue { completed in

--- a/Tests/UnitTests/Networking/Backend/BackendSignatureVerificationTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendSignatureVerificationTests.swift
@@ -19,6 +19,10 @@ import XCTest
 
 class BackendSignatureVerificationTests: BaseBackendTests {
 
+    override var verificationMode: Configuration.EntitlementVerificationMode {
+        return .informational
+    }
+
     override func createClient() -> MockHTTPClient {
         super.createClient(#file)
     }

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -34,7 +34,11 @@ class BaseBackendTests: TestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        self.systemInfo = try SystemInfo(platformInfo: nil, finishTransactions: true)
+        self.systemInfo = try SystemInfo(
+            platformInfo: nil,
+            finishTransactions: true,
+            responseVerificationMode: self.responseVerificationMode
+        )
         self.httpClient = self.createClient()
         self.operationDispatcher = MockOperationDispatcher()
 
@@ -57,6 +61,10 @@ class BaseBackendTests: TestCase {
                                internalAPI: self.internalAPI)
     }
 
+    var verificationMode: Configuration.EntitlementVerificationMode {
+        return .disabled
+    }
+
     func createClient() -> MockHTTPClient {
         XCTFail("\(#function) must be overriden by subclasses")
         return self.createClient(#file)
@@ -73,6 +81,14 @@ extension BaseBackendTests {
                               systemInfo: self.systemInfo,
                               eTagManager: eTagManager,
                               sourceTestFile: file)
+    }
+
+    private var responseVerificationMode: Signing.ResponseVerificationMode {
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
+            return Signing.verificationMode(with: self.verificationMode)
+        } else {
+            return .disabled
+        }
     }
 
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testSendsNonceWhenEnabled.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testSendsNonceWhenEnabled.1.json
@@ -1,0 +1,11 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testSendsNonceWhenEnabled.1.json
@@ -1,0 +1,11 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testSendsNonceWhenEnabled.1.json
@@ -1,0 +1,11 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testSendsNonceWhenEnabled.1.json
@@ -1,0 +1,11 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
+  }
+}

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -40,6 +40,12 @@ class HTTPRequestTests: TestCase {
     private static let pathsWithoutETags: Set<HTTPRequest.Path> = [
         .health
     ]
+    private static let pathsWithSignatureValidation: Set<HTTPRequest.Path> = [
+        .getCustomerInfo(appUserID: userID),
+        .logIn,
+        .postReceiptData,
+        .health
+    ]
 
     func testPathsDontHaveLeadingSlash() {
         for path in Self.paths {
@@ -85,6 +91,24 @@ class HTTPRequestTests: TestCase {
             expect(path.shouldSendEtag).to(
                 beFalse(),
                 description: "Path '\(path)' should not send etag"
+            )
+        }
+    }
+
+    func testPathsHaveSignatureValidation() {
+        for path in Self.pathsWithSignatureValidation {
+            expect(path.hasSignatureValidation).to(
+                beTrue(),
+                description: "Path '\(path)' should have signature validation"
+            )
+        }
+    }
+
+    func testPathsWithoutSignatureValidation() {
+        for path in Self.paths where !Self.pathsWithSignatureValidation.contains(path) {
+            expect(path.hasSignatureValidation).to(
+                beFalse(),
+                description: "Path '\(path)' should not have signature validation"
             )
         }
     }

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -113,4 +113,58 @@ class HTTPRequestTests: TestCase {
         }
     }
 
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func testAddNonceIfRequiredWithExistingNonceDoesNotReplaceNonce() throws {
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
+        let existingNonce = Data.randomNonce()
+        let request: HTTPRequest = .init(method: .get, path: .health, nonce: existingNonce)
+        let mode = Signing.verificationMode(with: .enforced)
+
+        expect(request.requestAddingNonceIfRequired(with: mode).nonce) == existingNonce
+    }
+
+    func testAddNonceIfRequiredWithDisabledVerification() throws {
+        let request: HTTPRequest = .init(method: .get, path: .mockPath)
+        expect(request.requestAddingNonceIfRequired(with: .disabled).nonce).to(beNil())
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func testAddNonceIfRequiredWithPathWithNoSignatureValidation() throws {
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
+        let request: HTTPRequest = .init(method: .get, path: .postOfferForSigning)
+        let mode = Signing.verificationMode(with: .enforced)
+
+        expect(request.requestAddingNonceIfRequired(with: mode).nonce).to(beNil())
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func testAddNonceIfRequiredForPathWithSignatureValidationWhenEnforced() throws {
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
+        let request: HTTPRequest = .init(method: .get, path: .getCustomerInfo(appUserID: "user"))
+        let mode = Signing.verificationMode(with: .enforced)
+
+        expect(request.requestAddingNonceIfRequired(with: mode).nonce).toNot(beNil())
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func testAddNonceIfRequiredForPathWithSignatureValidationWhenModeInformational() throws {
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
+        let request: HTTPRequest = .init(method: .get, path: .getCustomerInfo(appUserID: "user"))
+        let mode = Signing.verificationMode(with: .informational)
+
+        expect(request.requestAddingNonceIfRequired(with: mode).nonce).toNot(beNil())
+    }
+
+    func testAddNonceIfRequiredForOldVersions() throws {
+        if #available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *) {
+            throw XCTSkip("Test only for older versions")
+        }
+
+        let request: HTTPRequest = .init(method: .get, path: .logIn)
+        expect(request.requestAddingNonceIfRequired(with: .disabled).nonce).to(beNil())
+    }
 }

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -167,4 +167,5 @@ class HTTPRequestTests: TestCase {
         let request: HTTPRequest = .init(method: .get, path: .logIn)
         expect(request.requestAddingNonceIfRequired(with: .disabled).nonce).to(beNil())
     }
+
 }

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -95,18 +95,18 @@ class HTTPRequestTests: TestCase {
         }
     }
 
-    func testPathsHaveSignatureValidation() {
+    func testPathsSupportingSignatureSignatureValidation() {
         for path in Self.pathsWithSignatureValidation {
-            expect(path.hasSignatureValidation).to(
+            expect(path.supportsSignatureValidation).to(
                 beTrue(),
                 description: "Path '\(path)' should have signature validation"
             )
         }
     }
 
-    func testPathsWithoutSignatureValidation() {
+    func testPathsNotSupportingSignatureValidation() {
         for path in Self.paths where !Self.pathsWithSignatureValidation.contains(path) {
-            expect(path.hasSignatureValidation).to(
+            expect(path.supportsSignatureValidation).to(
                 beFalse(),
                 description: "Path '\(path)' should not have signature validation"
             )


### PR DESCRIPTION
Instead of manually choosing when to include `nonce` in requests, this data-driven approach ensures that all requests to endpoints that support signature verification will make `HTTPClient` do the right thing.

See also #2277 for how `CustomerInfo` and `EntitlementInfo` will use this.