### PR TITLE
`EntitlementInfo`: add a grace period limit to outdated entitlements

### DIFF
--- a/Sources/FoundationExtensions/DispatchTimeInterval+Extensions.swift
+++ b/Sources/FoundationExtensions/DispatchTimeInterval+Extensions.swift
@@ -21,6 +21,12 @@ extension DispatchTimeInterval {
         self = .milliseconds(Int(timeInterval * 1000))
     }
 
+    static func days(_ days: Int) -> Self {
+        precondition(days >= 0, "Days must be positive: \(days)")
+
+        return .seconds(days * 60 * 60 * 24)
+    }
+
     /// `DispatchTimeInterval` can only be used by specifying a unit of time.
     /// This allows us to easily convert any `DispatchTimeInterval` into nanoseconds.
     var nanoseconds: Int {
@@ -45,6 +51,10 @@ extension DispatchTimeInterval {
         case .never: return 0
         @unknown default: fatalError("Unknown value: \(self)")
         }
+    }
+
+    var days: Double {
+        return self.seconds / (60 * 60 * 24)
     }
 
 }

--- a/Sources/LocalReceiptParsing/DataConverters/DateFormatter+Extensions.swift
+++ b/Sources/LocalReceiptParsing/DataConverters/DateFormatter+Extensions.swift
@@ -45,7 +45,7 @@ extension ISO8601DateFormatter {
             }
 
             func string(from date: Date) -> String {
-                return ISO8601DateFormatter.withMilliseconds.string(from: date)
+                return ISO8601DateFormatter.noMilliseconds.string(from: date)
             }
         }
 

--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -25,6 +25,7 @@ enum PurchaseStrings {
     case device_cache_deinit(DeviceCache)
     case cannot_purchase_product_appstore_configuration_error
     case entitlements_revoked_syncing_purchases(productIdentifiers: [String])
+    case entitlement_expired_outside_grace_period(expiration: Date, reference: Date)
     case finishing_transaction(StoreTransactionType)
     case purchasing_with_observer_mode_and_finish_transactions_false_warning
     case paymentqueue_revoked_entitlements_for_product_identifiers(productIdentifiers: [String])
@@ -96,6 +97,10 @@ extension PurchaseStrings: CustomStringConvertible {
         case .entitlements_revoked_syncing_purchases(let productIdentifiers):
             return "Entitlements revoked for product " +
             "identifiers: \(productIdentifiers). \nsyncing purchases"
+
+        case let .entitlement_expired_outside_grace_period(expiration, reference):
+            return "Entitlement is no longer active (expired \(expiration)) " +
+            "and it's outside grace period window (last updated \(reference))"
 
         case let .finishing_transaction(transaction):
             return "Finishing transaction '\(transaction.transactionIdentifier)' " +


### PR DESCRIPTION
This prevents users from keeping an outdated active entitlement forever.
One could start a free trial then block all further requests from the backend in order to keep that active.

When this check fails, a new warning log is generated:
> WARN: ⚠️ Entitlement is no longer active (expired 2023-02-12 18:15:11 +0000) and it's outside grace period window (last updated 2023-02-12 18:13:31 +0000)

Depends on #2310