### PR TITLE
`PurchaseTester`: added ability to set `Configuration.EntitlementVerificationMode`

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Core/ConfiguredPurchases.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Core/ConfiguredPurchases.swift
@@ -25,7 +25,8 @@ public final class ConfiguredPurchases {
         apiKey: String,
         proxyURL: String?,
         useStoreKit2: Bool,
-        observerMode: Bool
+        observerMode: Bool,
+        entitlementVerificationMode: Configuration.EntitlementVerificationMode
     ) {
         Purchases.logLevel = .debug
         Purchases.logHandler = Self.logger.logHandler
@@ -38,6 +39,7 @@ public final class ConfiguredPurchases {
             with: .builder(withAPIKey: apiKey)
                 .with(usesStoreKit2IfAvailable: useStoreKit2)
                 .with(observerMode: observerMode)
+                .with(entitlementVerificationMode: entitlementVerificationMode)
                 .build()
         )
 

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Extensions/Extensions.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Extensions/Extensions.swift
@@ -21,6 +21,30 @@ extension String {
 
 }
 
+extension Configuration.EntitlementVerificationMode {
+
+    var label: String {
+        switch self {
+        case .disabled: return "Disabled"
+        case .informational: return "Information Only"
+        case .enforced: return "Enforced"
+        }
+    }
+
+    static let all: [Self] = [
+        .disabled,
+        .informational,
+        .enforced
+    ]
+
+}
+
+extension Configuration.EntitlementVerificationMode: Identifiable {
+
+    public var id: Int { return self.rawValue }
+
+}
+
 extension VerificationResult: CustomStringConvertible {
 
     public var description: String {

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Extensions/Extensions.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Extensions/Extensions.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+import RevenueCat
+
 extension String {
 
     var nonEmpty: String? {
@@ -15,6 +17,18 @@ extension String {
         return trimmed.isEmpty
             ? nil
             : trimmed
+    }
+
+}
+
+extension VerificationResult: CustomStringConvertible {
+
+    public var description: String {
+        switch self {
+        case .notVerified: return "Not verified"
+        case .verified: return "Verified"
+        case .failed: return "Failed verification"
+        }
     }
 
 }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
@@ -78,7 +78,8 @@ struct PurchaseTesterApp: App {
                 apiKey: data.apiKey,
                 proxyURL: data.proxy.nonEmpty,
                 useStoreKit2: data.storeKit2Enabled,
-                observerMode: data.observerMode
+                observerMode: data.observerMode,
+                entitlementVerificationMode: data.verificationMode
             )
         }
     }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/ConfigurationView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/ConfigurationView.swift
@@ -50,9 +50,9 @@ struct ConfigurationView: View {
 
             Section(header: Text("Settings")) {
                 Picker("Entitlement Verification", selection: self.$data.verificationMode) {
-                    Text("Disabled").tag(Configuration.EntitlementVerificationMode.disabled)
-                    Text("Information Only").tag(Configuration.EntitlementVerificationMode.informational)
-                    Text("Enforced").tag(Configuration.EntitlementVerificationMode.enforced)
+                    ForEach(Configuration.EntitlementVerificationMode.all) { mode in
+                        Text(mode.label).tag(mode)
+                    }
                 }
 
                 Toggle(isOn: self.$data.storeKit2Enabled) {

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/ConfigurationView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/ConfigurationView.swift
@@ -17,6 +17,7 @@ struct ConfigurationView: View {
                                                                    with: "")
         var proxy: String = ""
         var storeKit2Enabled: Bool = true
+        var verificationMode: Configuration.EntitlementVerificationMode = .disabled
         var observerMode: Bool = false
     }
 
@@ -32,6 +33,14 @@ struct ConfigurationView: View {
     }
 
     var body: some View {
+        if #available(iOS 16.0, macOS 13.0, *) {
+            self.form.formStyle(.grouped)
+        } else {
+            self.form
+        }
+    }
+
+    private var form: some View {
         Form {
             Section(header: Text("Configuration")) {
                 TextField("API Key (required)", text: self.$data.apiKey)
@@ -39,7 +48,13 @@ struct ConfigurationView: View {
                 TextField("Proxy URL (optional)", text: self.$data.proxy)
             }
 
-            Section {
+            Section(header: Text("Settings")) {
+                Picker("Entitlement Verification", selection: self.$data.verificationMode) {
+                    Text("Disabled").tag(Configuration.EntitlementVerificationMode.disabled)
+                    Text("Information Only").tag(Configuration.EntitlementVerificationMode.informational)
+                    Text("Enforced").tag(Configuration.EntitlementVerificationMode.enforced)
+                }
+
                 Toggle(isOn: self.$data.storeKit2Enabled) {
                     Text("StoreKit2 enabled")
                 }
@@ -115,6 +130,8 @@ struct ConfigurationView: View {
     }
 
 }
+
+extension Configuration.EntitlementVerificationMode: Codable {}
 
 // MARK: -
 

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/CustomerInfoView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/CustomerInfoView.swift
@@ -41,6 +41,7 @@ private extension CustomerInfoView {
             ("Original Purchase Date", self.date(customerInfo.originalPurchaseDate) ?? "-"),
             ("Latest Expiration Date", self.date(customerInfo.latestExpirationDate) ?? "-"),
             ("Request Date", self.date(customerInfo.requestDate) ?? "-"),
+            ("Entitlement Verification", self.customerInfo.entitlementVerification.description),
         ]
     }
 


### PR DESCRIPTION
Depends on #2277

<img width="832" alt="Screenshot 2023-02-15 at 16 11 44" src="https://user-images.githubusercontent.com/685609/219228654-220d7596-aca3-4fa6-8c5c-466173c00865.png">
<img width="916" alt="Screenshot 2023-02-15 at 16 48 00" src="https://user-images.githubusercontent.com/685609/219229250-47fe810a-7289-4dd8-a1cd-2b6ca49f6438.png">
<img width="372" alt="Screenshot 2023-02-15 at 16 51 41" src="https://user-images.githubusercontent.com/685609/219229746-91906749-d2df-42b4-8075-e58865061988.png">
