### PR TITLE
Fixed `PurchasesOrchestrator` compilation error on Xcode 14.3 beta 1

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -957,23 +957,12 @@ private extension PurchasesOrchestrator {
             case let .failure(error):
                 let purchasesError = error.asPublicError
 
-                #if swift(>=5.6)
-                @MainActor
-                func complete() {
-                    completion?(transaction, nil, purchasesError, false)
-                }
-                #else
-                @Sendable
-                @MainActor
-                func complete() {
-                    completion?(transaction, nil, purchasesError, false)
-                }
-                #endif
-
                 if finishable {
-                    self.finishTransactionIfNeeded(transaction) { complete() }
+                    self.finishTransactionIfNeeded(transaction) {
+                        completion?(transaction, nil, purchasesError, false)
+                    }
                 } else {
-                    complete()
+                    completion?(transaction, nil, purchasesError, false)
                 }
             }
         }


### PR DESCRIPTION
Fixes #2291.

This has led to issues in the past too (#1994, #2221, 	https://github.com/RevenueCat/purchases-flutter/issues/516, https://github.com/RevenueCat/purchases-flutter/issues/507) because I tried to reuse that code to call a single completion method.
The new version of Swift makes that impossible now, because it detects that `@MainActor` isn't available in iOS 12.

To finally work around all those issues, this simply duplicates this single line of code, which should work across all versions of Swift.
