### PR TITLE
clarifies error messages for storekit 1 bugs

### DIFF
--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -165,28 +165,27 @@ extension PurchaseStrings: CustomStringConvertible {
             return "Product purchase for '\(productIdentifier)' failed with error: \(error)"
 
         case .skpayment_missing_from_skpaymenttransaction:
-            return "There is a problem with the " +
-            "SKPaymentTransaction missing an SKPayment - this is an issue with the App Store."
+            return """
+            The SKPaymentTransaction has a nil value for SKPayment - this is an bug in StoreKit.
+            Transactions in the backend and in webhooks are unaffected.
+            """
 
         case .skpayment_missing_product_identifier:
             return "There is a problem with the SKPayment missing " +
             "a product identifier - this is an issue with the App Store."
 
         case .sktransaction_missing_transaction_date:
-            return "There is a problem with the SKPaymentTransaction missing " +
-            "a transaction date - this is an issue with the App Store. Unix Epoch will be used instead. \n" +
-            "Transactions in the backend and in webhooks are unaffected and will have the correct timestamps. " +
-            "This is a bug in StoreKit 1. To prevent running into this issue on devices running " +
-            "iOS 15+, watchOS 8+, macOS 12+, and tvOS 15+, make sure " +
-            "`usesStoreKit2IfAvailable` is set to true when calling `configure`."
+            return """
+            The SKPaymentTransaction has a nil value for transaction date - this is a bug in StoreKit.
+            Unix Epoch will be used instead for the transaction within the app.
+            Transactions in the backend and in webhooks are unaffected and will have the correct timestamps.
+            """
 
         case .sktransaction_missing_transaction_identifier:
-            return "There is a problem with the SKPaymentTransaction missing " +
-            "a transaction identifier - this is an issue with the App Store. " +
-            "Transactions in the backend and in webhooks are unaffected and will have the correct identifier. " +
-            "This is a bug in StoreKit 1. To prevent running into this issue on devices running " +
-            "iOS 15+, watchOS 8+, macOS 12+, and tvOS 15+, make sure " +
-            "`usesStoreKit2IfAvailable` is set to true when calling `configure`."
+            return """
+            The SKPaymentTransaction has a nil value for transaction identifier - this is a bug in StoreKit.
+            Transactions in the backend and in webhooks are unaffected and will have the correct identifier.
+            """
 
         case .could_not_purchase_product_id_not_found:
             return "makePurchase - Could not purchase SKProduct. " +

--- a/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
@@ -44,7 +44,7 @@ extension SKPaymentTransaction {
 
         guard let productIdentifier = payment.productIdentifier as String?,
               !productIdentifier.isEmpty else {
-                  Logger.appleWarning(Strings.purchase.skpayment_missing_product_identifier)
+                  Logger.verbose(Strings.purchase.skpayment_missing_product_identifier)
                   return nil
               }
 
@@ -53,7 +53,7 @@ extension SKPaymentTransaction {
 
     fileprivate var purchaseDate: Date {
         guard let date = self.transactionDate else {
-            Logger.appleWarning(Strings.purchase.sktransaction_missing_transaction_date)
+            Logger.verbose(Strings.purchase.sktransaction_missing_transaction_date)
 
             return Date(timeIntervalSince1970: 0)
         }
@@ -63,7 +63,7 @@ extension SKPaymentTransaction {
 
     fileprivate var transactionID: String {
         guard let identifier = self.transactionIdentifier else {
-            Logger.appleWarning(Strings.purchase.sktransaction_missing_transaction_identifier)
+            Logger.verbose(Strings.purchase.sktransaction_missing_transaction_identifier)
 
             return UUID().uuidString
         }

--- a/Sources/Purchasing/StoreKitAbstractions/StoreKitWorkarounds.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreKitWorkarounds.swift
@@ -37,7 +37,7 @@ extension SKPaymentTransaction {
     /// Due to that an optional reference is created so that the compiler would allow us to check for nullability.
     var paymentIfPresent: SKPayment? {
         guard let payment = self.payment as SKPayment? else {
-            Logger.appleWarning(Strings.purchase.skpayment_missing_from_skpaymenttransaction)
+            Logger.verbose(Strings.purchase.skpayment_missing_from_skpaymenttransaction)
             return nil
         }
 

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/xcshareddata/xcschemes/PurchaseTester.xcscheme
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/xcshareddata/xcschemes/PurchaseTester.xcscheme
@@ -60,6 +60,9 @@
             ReferencedContainer = "container:PurchaseTester.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <StoreKitConfigurationFileReference
+         identifier = "../../PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit">
+      </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/xcshareddata/xcschemes/PurchaseTester.xcscheme
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/xcshareddata/xcschemes/PurchaseTester.xcscheme
@@ -60,9 +60,6 @@
             ReferencedContainer = "container:PurchaseTester.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <StoreKitConfigurationFileReference
-         identifier = "../../PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit">
-      </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
We have a few error messages for StoreKit 1 bugs that look pretty scary. 

However, they really aren't - while they surface genuine bugs in StoreKit, they require no action on the developer's side, and our backend won't be affected. So in practice, they're not useful. 

This PR updates the copy so that: 
- it doesn't suggest using SK2
- it moves from `warn` to `verbose`, since there's really no action on the developer's side needed
- it clarifies what's going on under the hood



| Before | After |
| :-: | :-: |
| <img width="1311" alt="Screenshot 2023-02-17 at 3 43 02 PM" src="https://user-images.githubusercontent.com/3922667/219758984-c9593d12-23fb-4076-ab87-2c5454f7084b.png"> | <img width="1304" alt="Screenshot 2023-02-17 at 3 52 05 PM" src="https://user-images.githubusercontent.com/3922667/219759107-9abdb01b-f626-41de-b20c-a08bbd6c1c05.png"> |