### PR TITLE
SwiftUI: Paywall View should respond to changes on the UserView model

### DIFF
--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/Views/PaywallView.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/Views/PaywallView.swift
@@ -21,8 +21,15 @@ struct PaywallView: View {
     @State
     private(set) var isPurchasing: Bool = false
     
+    /// - This can change during the lifetime of the PaywallView (e.g. if poor network conditions mean that loading offerings is slow)
+    /// So set this as an observed object to trigger view updates as necessary
+    @ObservedObject var userViewModel = UserViewModel.shared
+    
     /// - The current offering saved from PurchasesDelegateHandler
-    private(set) var offering: Offering? = UserViewModel.shared.offerings?.current
+    ///  if this is nil, then you might want to show a loading indicator or similar
+    private var offering: Offering? {
+        userViewModel.offerings?.current
+    }
     
     private let footerText = "Don't forget to add your subscription terms and conditions. Read more about this here: https://www.revenuecat.com/blog/schedule-2-section-3-8-b"
     


### PR DESCRIPTION
I hit this bug when I first tried the example. My offerings loaded slowly - so the paywall was empty, and didn't update when the offerings were retrieved.



### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids
nope

### Motivation
swiftui example app doesn't update paywall when offerings are retrieved

### Description
app stores current state in the shared UserViewModel, but the PaywallView doesn't currently observe changes on this model - so it only shows the state at the point where the view was shown.
This is potentially a state where offerings have not yet been retrieved.
