### PR TITLE
Fixed `Bundle: Sendable` conformance

### DIFF
--- a/Sources/Misc/SandboxEnvironmentDetector.swift
+++ b/Sources/Misc/SandboxEnvironmentDetector.swift
@@ -23,11 +23,11 @@ protocol SandboxEnvironmentDetector: Sendable {
 /// ``SandboxEnvironmentDetector`` that uses a `Bundle` to detect the environment
 final class BundleSandboxEnvironmentDetector: SandboxEnvironmentDetector {
 
-    private let bundle: Bundle
+    private let bundle: Atomic<Bundle>
     private let isRunningInSimulator: Bool
 
     init(bundle: Bundle = .main, isRunningInSimulator: Bool = SystemInfo.isRunningInSimulator) {
-        self.bundle = bundle
+        self.bundle = .init(bundle)
         self.isRunningInSimulator = isRunningInSimulator
     }
 
@@ -36,7 +36,7 @@ final class BundleSandboxEnvironmentDetector: SandboxEnvironmentDetector {
             return true
         }
 
-        guard let path = self.bundle.appStoreReceiptURL?.path else {
+        guard let path = self.bundle.value.appStoreReceiptURL?.path else {
             return false
         }
 
@@ -53,7 +53,4 @@ final class BundleSandboxEnvironmentDetector: SandboxEnvironmentDetector {
 
 }
 
-#if swift(<5.8)
-// `Bundle` is not `Sendable` as of Swift 5.7, but this class performs no mutations.
-extension BundleSandboxEnvironmentDetector: @unchecked Sendable {}
-#endif
+extension BundleSandboxEnvironmentDetector: Sendable {}

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -32,7 +32,6 @@ class SystemInfo {
     let operationDispatcher: OperationDispatcher
     let platformFlavor: String
     let platformFlavorVersion: String?
-    let bundle: Bundle
     let responseVerificationMode: Signing.ResponseVerificationMode
     let dangerousSettings: DangerousSettings
 
@@ -41,10 +40,13 @@ class SystemInfo {
         set { self._finishTransactions.value = newValue }
     }
 
+    var bundle: Bundle { return self._bundle.value }
+
     var observerMode: Bool { return !self.finishTransactions }
 
     private let sandboxEnvironmentDetector: SandboxEnvironmentDetector
     private let _finishTransactions: Atomic<Bool>
+    private let _bundle: Atomic<Bundle>
 
     var isSandbox: Bool {
         return self.sandboxEnvironmentDetector.isSandbox
@@ -118,7 +120,7 @@ class SystemInfo {
          dangerousSettings: DangerousSettings? = nil) throws {
         self.platformFlavor = platformInfo?.flavor ?? "native"
         self.platformFlavorVersion = platformInfo?.version
-        self.bundle = bundle
+        self._bundle = .init(bundle)
 
         self._finishTransactions = .init(finishTransactions)
         self.operationDispatcher = operationDispatcher
@@ -176,7 +178,6 @@ extension SystemInfo: SandboxEnvironmentDetector {}
 
 // @unchecked because:
 // - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
-// - It includes `Bundle`, which isn't `Sendable` as of Swift 5.7.
 extension SystemInfo: @unchecked Sendable {}
 
 extension SystemInfo {


### PR DESCRIPTION
Fixes the last bit of #2291.

Turns out that `Bundle` was never actually `Sendable`, even though it was marked as such in Swift 5.7 (https://github.com/apple/swift/issues/63763).
Now we know this won't be fixed in time for Swift 5.8, so this PR handles that by wrapping it in `Atomic`.
