### PR TITLE
[DO NOT MERGE] `IntegrationTests`: disabled signature verification

### DIFF
--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -93,7 +93,7 @@ private extension BaseBackendIntegrationTests {
                             observerMode: Self.observerMode,
                             userDefaults: self.userDefaults,
                             platformInfo: nil,
-                            responseVerificationMode: .enforced(Signing.loadPublicKey()),
+                            responseVerificationMode: .informational(Signing.loadPublicKey()),
                             storeKit2Setting: Self.storeKit2Setting,
                             storeKitTimeout: Configuration.storeKitRequestTimeoutDefault,
                             networkTimeout: Configuration.networkTimeoutDefault,


### PR DESCRIPTION
Signatures are currently invalid until we add the new `timestamp`.
But this is a temporary PR to test [CF-1222].


[CF-1222]: https://revenuecats.atlassian.net/browse/CF-1222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ