### PR TITLE
`Signing`: added request time & eTag to signature verification

### DIFF
--- a/Sources/FoundationExtensions/Date+Extensions.swift
+++ b/Sources/FoundationExtensions/Date+Extensions.swift
@@ -24,8 +24,12 @@ extension NSDate {
 
 extension Date {
 
+    var millisecondsSince1970: Int {
+        return Int(self.timeIntervalSince1970 * 1000.0)
+    }
+
     func millisecondsSince1970AsUInt64() -> UInt64 {
-        return UInt64(self.timeIntervalSince1970 * 1000.0)
+        return UInt64(self.millisecondsSince1970)
     }
 
 }

--- a/Sources/Logging/Strings/SigningStrings.swift
+++ b/Sources/Logging/Strings/SigningStrings.swift
@@ -24,6 +24,8 @@ enum SigningStrings {
 
     case signature_was_requested_but_not_provided(HTTPRequest)
 
+    case request_time_missing_from_headers(HTTPRequest)
+
 }
 
 extension SigningStrings: CustomStringConvertible {
@@ -38,6 +40,10 @@ extension SigningStrings: CustomStringConvertible {
 
         case .signature_failed_verification:
             return "Signature failed verification"
+
+        case let .request_time_missing_from_headers(request):
+            return "Request to '\(request.path)' required a request time but none was provided. " +
+            "This will be reported as a verification failure."
 
         case let .signature_was_requested_but_not_provided(request):
             return "Request to '\(request.path)' required a signature but none was provided. " +

--- a/Sources/Misc/Signing+ResponseVerification.swift
+++ b/Sources/Misc/Signing+ResponseVerification.swift
@@ -85,13 +85,15 @@ extension HTTPResponse where Body == Data {
         let eTag = HTTPResponse.value(forCaseInsensitiveHeaderField: HTTPClient.ResponseHeader.eTag.rawValue,
                                       in: headers)
 
+        let messageToSign = statusCode == .notModified
+            ? eTag?.asData ?? .init()
+            : body
+
         if signing.verify(signature: signature,
                           with: .init(
-                            notModifiedResponse: statusCode == .notModified,
-                            message: body,
+                            message: messageToSign,
                             nonce: nonce,
-                            requestTime: requestTime,
-                            eTag: eTag
+                            requestTime: requestTime
                           ),
                           publicKey: publicKey) {
             return .verified

--- a/Sources/Misc/Signing+ResponseVerification.swift
+++ b/Sources/Misc/Signing+ResponseVerification.swift
@@ -40,6 +40,7 @@ extension HTTPResponse where Body == Data {
             body: body,
             verificationResult: Self.verificationResult(
                 body: body,
+                statusCode: statusCode,
                 headers: headers,
                 request: request,
                 publicKey: publicKey,
@@ -48,8 +49,10 @@ extension HTTPResponse where Body == Data {
         )
     }
 
+    // swiftlint:disable:next function_parameter_count
     private static func verificationResult(
         body: Data,
+        statusCode: HTTPStatusCode,
         headers: HTTPClient.ResponseHeaders,
         request: HTTPRequest,
         publicKey: Signing.PublicKey?,
@@ -61,17 +64,36 @@ extension HTTPResponse where Body == Data {
             return .notVerified
         }
 
-        guard let signature = HTTPResponse.value(forCaseInsensitiveHeaderField: HTTPClient.responseSignatureHeaderName,
-                                                 in: headers) else {
+        guard let signature = HTTPResponse.value(
+            forCaseInsensitiveHeaderField: HTTPClient.ResponseHeader.signature.rawValue,
+            in: headers
+        ) else {
             Logger.warn(Strings.signing.signature_was_requested_but_not_provided(request))
 
             return .failed
         }
 
-        if signing.verify(message: body,
-                          nonce: nonce,
-                          hasValidSignature: signature,
-                          with: publicKey) {
+        guard let requestTimeString = HTTPResponse.value(
+            forCaseInsensitiveHeaderField: HTTPClient.ResponseHeader.requestTime.rawValue,
+            in: headers
+        ), let requestTime = Int(requestTimeString) else {
+            Logger.warn(Strings.signing.request_time_missing_from_headers(request))
+
+            return .failed
+        }
+
+        let eTag = HTTPResponse.value(forCaseInsensitiveHeaderField: HTTPClient.ResponseHeader.eTag.rawValue,
+                                      in: headers)
+
+        if signing.verify(signature: signature,
+                          with: .init(
+                            notModifiedResponse: statusCode == .notModified,
+                            message: body,
+                            nonce: nonce,
+                            requestTime: requestTime,
+                            eTag: eTag
+                          ),
+                          publicKey: publicKey) {
             return .verified
         } else {
             return .failed
@@ -90,31 +112,18 @@ extension Result where Success == Data?, Failure == NetworkError {
         verificationMode: Signing.ResponseVerificationMode
     ) -> Result<HTTPResponse<Data?>, Failure> {
         return self.flatMap { body in
-            if let body = body {
-                let response = HTTPResponse.create(
-                    with: response,
-                    body: body,
-                    request: request,
-                    publicKey: verificationMode.publicKey,
-                    signing: signing
-                )
+            let response = HTTPResponse.create(
+                with: response,
+                body: body ?? .init(),
+                request: request,
+                publicKey: verificationMode.publicKey,
+                signing: signing
+            )
 
-                if response.verificationResult == .failed, case .enforced = verificationMode {
-                    return .failure(.signatureVerificationFailed(path: request.path))
-                } else {
-                    return .success(response.mapBody(Optional.some))
-                }
+            if response.verificationResult == .failed, case .enforced = verificationMode {
+                return .failure(.signatureVerificationFailed(path: request.path))
             } else {
-                // No body means that the status code `HTTPStatusCode.notModified`
-                // so the response will be fetched from `ETagManager`.
-                return .success(
-                    .init(
-                        statusCode: HTTPStatusCode(rawValue: response.statusCode),
-                        responseHeaders: response.allHeaderFields,
-                        body: body,
-                        verificationResult: .notVerified
-                    )
-                )
+                return .success(response.mapBody(Optional.some))
             }
         }
     }

--- a/Sources/Misc/Signing.swift
+++ b/Sources/Misc/Signing.swift
@@ -18,10 +18,9 @@ import Foundation
 protocol SigningType {
 
     static func verify(
-        message: Data,
-        nonce: Data,
-        hasValidSignature signature: String,
-        with publicKey: Signing.PublicKey
+        signature: String,
+        with parameters: Signing.SignatureParameters,
+        publicKey: Signing.PublicKey
     ) -> Bool
 
 }
@@ -31,6 +30,18 @@ enum Signing: SigningType {
 
     /// An object that represents a cryptographic key.
     typealias PublicKey = SigningPublicKey
+
+    /// Parameters used for signature creation / verification.
+    struct SignatureParameters {
+
+        /// Whether the response had `HTTPStatusCode.notModified`
+        let notModifiedResponse: Bool
+        let message: Data
+        let nonce: Data
+        let requestTime: Int
+        let eTag: String?
+
+    }
 
     /// Parses the binary `key` and returns a `PublicKey`
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
@@ -53,10 +64,9 @@ enum Signing: SigningType {
     }
 
     static func verify(
-        message: Data,
-        nonce: Data,
-        hasValidSignature signature: String,
-        with publicKey: PublicKey
+        signature: String,
+        with parameters: SignatureParameters,
+        publicKey: Signing.PublicKey
     ) -> Bool {
         guard let signature = Data(base64Encoded: signature) else {
             Logger.warn(Strings.signing.signature_not_base64(signature))
@@ -65,7 +75,7 @@ enum Signing: SigningType {
 
         let salt = signature.subdata(in: 0..<Self.saltSize)
         let signatureToVerify = signature.subdata(in: Self.saltSize..<signature.count)
-        let messageToVerify = salt + nonce + message
+        let messageToVerify = salt + parameters.asData
 
         let isValid = publicKey.isValidSignature(signatureToVerify, for: messageToVerify)
 
@@ -166,14 +176,30 @@ extension Signing {
         }
 
         do {
-            // Fix-me: figure out the prefix with the final production key.
-            return try CryptoKit.Curve25519.Signing.PublicKey(rawRepresentation: data.prefix(32))
+            return try CryptoKit.Curve25519.Signing.PublicKey(rawRepresentation: data)
         } catch {
             throw ErrorUtils.configurationError(
                 message: Strings.configure.public_key_could_not_load_key.description,
                 underlyingError: error
             )
         }
+    }
+
+}
+
+extension Signing.SignatureParameters {
+
+    var asData: Data {
+        // Not modified responses sign the Etag
+        let payload: Data = self.notModifiedResponse
+        ? self.eTag?.asData ?? Data()
+        : self.message
+
+        return (
+            self.nonce +
+            String(self.requestTime).asData +
+            payload
+        )
     }
 
 }

--- a/Sources/Misc/Signing.swift
+++ b/Sources/Misc/Signing.swift
@@ -34,12 +34,9 @@ enum Signing: SigningType {
     /// Parameters used for signature creation / verification.
     struct SignatureParameters {
 
-        /// Whether the response had `HTTPStatusCode.notModified`
-        let notModifiedResponse: Bool
         let message: Data
         let nonce: Data
         let requestTime: Int
-        let eTag: String?
 
     }
 
@@ -190,15 +187,10 @@ extension Signing {
 extension Signing.SignatureParameters {
 
     var asData: Data {
-        // Not modified responses sign the Etag
-        let payload: Data = self.notModifiedResponse
-        ? self.eTag?.asData ?? Data()
-        : self.message
-
         return (
             self.nonce +
             String(self.requestTime).asData +
-            payload
+            self.message
         )
     }
 

--- a/Sources/Networking/HTTPClient/ETagManager.swift
+++ b/Sources/Networking/HTTPClient/ETagManager.swift
@@ -16,7 +16,8 @@ import Foundation
 
 class ETagManager {
 
-    static let eTagHeaderName = "X-RevenueCat-ETag"
+    static let eTagRequestHeaderName = HTTPClient.RequestHeader.eTag.rawValue
+    static let eTagResponseHeaderName = HTTPClient.ResponseHeader.eTag.rawValue
 
     private let userDefaults: SynchronizedUserDefaults
 
@@ -45,7 +46,7 @@ class ETagManager {
             }
         }
 
-        return [ETagManager.eTagHeaderName: storedETag]
+        return [HTTPClient.RequestHeader.eTag.rawValue: storedETag]
     }
 
     func httpResultFromCacheOrBackend(with response: HTTPResponse<Data?>,
@@ -54,7 +55,7 @@ class ETagManager {
         let statusCode: HTTPStatusCode = response.statusCode
         let resultFromBackend = response.asOptionalResponse
 
-        let eTagInResponse = response.value(forHeaderField: ETagManager.eTagHeaderName)
+        let eTagInResponse = response.value(forHeaderField: HTTPClient.ResponseHeader.eTag.rawValue)
 
         guard let eTagInResponse = eTagInResponse else { return resultFromBackend }
         if self.shouldUseCachedVersion(responseCode: statusCode) {

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -73,16 +73,28 @@ class HTTPClient {
 extension HTTPClient {
 
     static func authorizationHeader(withAPIKey apiKey: String) -> RequestHeaders {
-        return [Self.authorizationHeaderName: "Bearer \(apiKey)"]
+        return [RequestHeader.authorization.rawValue: "Bearer \(apiKey)"]
     }
 
     static func nonceHeader(with data: Data) -> RequestHeaders {
-        return [Self.nonceHeaderName: data.base64EncodedString()]
+        return [RequestHeader.nonce.rawValue: data.base64EncodedString()]
     }
 
-    static let authorizationHeaderName = "Authorization"
-    static let nonceHeaderName = "X-Nonce"
-    static let responseSignatureHeaderName = "X-Signature"
+    enum RequestHeader: String {
+
+        case authorization = "Authorization"
+        case nonce = "X-Nonce"
+        case eTag = "X-RevenueCat-ETag"
+
+    }
+
+    enum ResponseHeader: String {
+
+        case eTag = "X-RevenueCat-ETag"
+        case signature = "X-Signature"
+        case requestTime = "X-RevenueCat-Request-Time"
+
+    }
 
 }
 

--- a/Tests/UnitTests/Misc/SigningTests.swift
+++ b/Tests/UnitTests/Misc/SigningTests.swift
@@ -74,11 +74,9 @@ class SigningTests: TestCase {
         expect(Signing.verify(
             signature: signature,
             with: .init(
-                notModifiedResponse: false,
                 message: message.asData,
                 nonce: nonce.asData,
-                requestTime: requestTime,
-                eTag: nil
+                requestTime: requestTime
             ),
             publicKey: Signing.loadPublicKey()
         )) == false
@@ -90,11 +88,9 @@ class SigningTests: TestCase {
         expect(Signing.verify(
             signature: "invalid signature".asData.base64EncodedString(),
             with: .init(
-                notModifiedResponse: false,
                 message: "Hello World".asData,
                 nonce: "nonce".asData,
-                requestTime: 1677005916012,
-                eTag: nil
+                requestTime: 1677005916012
             ),
             publicKey: Signing.loadPublicKey()
         )) == false
@@ -105,11 +101,9 @@ class SigningTests: TestCase {
 
         _ = Signing.verify(signature: "invalid signature".asData.base64EncodedString(),
                            with: .init(
-                            notModifiedResponse: false,
                             message: "Hello World".asData,
                             nonce: "nonce".asData,
-                            requestTime: 1677005916012,
-                            eTag: nil
+                            requestTime: 1677005916012
                            ),
                            publicKey: Signing.loadPublicKey())
 
@@ -124,11 +118,9 @@ class SigningTests: TestCase {
 
         let signature = try self.sign(
             parameters: .init(
-                notModifiedResponse: false,
                 message: message.asData,
                 nonce: nonce.asData,
-                requestTime: requestTime,
-                eTag: nil
+                requestTime: requestTime
             ),
             salt: salt.asData
         )
@@ -137,11 +129,9 @@ class SigningTests: TestCase {
         expect(Signing.verify(
             signature: fullSignature.base64EncodedString(),
             with: .init(
-                notModifiedResponse: false,
                 message: message.asData,
                 nonce: nonce.asData,
-                requestTime: requestTime,
-                eTag: nil
+                requestTime: requestTime
             ),
             publicKey: self.publicKey
         )) == true
@@ -171,11 +161,9 @@ class SigningTests: TestCase {
             Signing.verify(
                 signature: expectedSignature,
                 with: .init(
-                    notModifiedResponse: false,
                     message: response.asData,
                     nonce: nonce,
-                    requestTime: requestTime,
-                    eTag: nil
+                    requestTime: requestTime
                 ),
                 publicKey: Signing.loadPublicKey()
             )
@@ -193,7 +181,6 @@ class SigningTests: TestCase {
          -H 'Host: api.revenuecat.com'
          */
 
-        let response = ""
         let nonce = try XCTUnwrap(Data(base64Encoded: "MTIzNDU2Nzg5MGFi"))
         let requestTime = 1677013582768
         let eTag = "b7bd9a697c7fd1a2"
@@ -205,11 +192,9 @@ class SigningTests: TestCase {
             Signing.verify(
                 signature: expectedSignature,
                 with: .init(
-                    notModifiedResponse: true,
-                    message: response.asData,
+                    message: eTag.asData,
                     nonce: nonce,
-                    requestTime: requestTime,
-                    eTag: eTag
+                    requestTime: requestTime
                 ),
                 publicKey: Signing.loadPublicKey()
             )
@@ -259,11 +244,9 @@ class SigningTests: TestCase {
         let requestTime = Date().millisecondsSince1970
         let salt = Self.createSalt()
 
-        let signature = try self.sign(parameters: .init(notModifiedResponse: false,
-                                                        message: message.asData,
+        let signature = try self.sign(parameters: .init(message: message.asData,
                                                         nonce: nonce.asData,
-                                                        requestTime: requestTime,
-                                                        eTag: nil),
+                                                        requestTime: requestTime),
                                       salt: salt.asData)
         let fullSignature = salt.asData + signature
 
@@ -289,11 +272,9 @@ class SigningTests: TestCase {
         let requestTime = Date().millisecondsSince1970
         let salt = Self.createSalt()
 
-        let signature = try self.sign(parameters: .init(notModifiedResponse: true,
-                                                        message: message.asData,
+        let signature = try self.sign(parameters: .init(message: etag.asData,
                                                         nonce: nonce.asData,
-                                                        requestTime: requestTime,
-                                                        eTag: etag),
+                                                        requestTime: requestTime),
                                       salt: salt.asData)
         let fullSignature = salt.asData + signature
 

--- a/Tests/UnitTests/Misc/SigningTests.swift
+++ b/Tests/UnitTests/Misc/SigningTests.swift
@@ -68,30 +68,50 @@ class SigningTests: TestCase {
 
         let message = "Hello World"
         let nonce = "nonce"
+        let requestTime = 1677005916012
         let signature = "this is not a signature"
 
-        expect(Signing.verify(message: message.asData,
-                              nonce: nonce.asData,
-                              hasValidSignature: signature,
-                              with: Signing.loadPublicKey())) == false
+        expect(Signing.verify(
+            signature: signature,
+            with: .init(
+                notModifiedResponse: false,
+                message: message.asData,
+                nonce: nonce.asData,
+                requestTime: requestTime,
+                eTag: nil
+            ),
+            publicKey: Signing.loadPublicKey()
+        )) == false
 
         logger.verifyMessageWasLogged("Signature is not base64: \(signature)")
     }
 
     func testVerifySignatureWithInvalidSignature() throws {
-        expect(Signing.verify(message: "Hello World".asData,
-                              nonce: "nonce".asData,
-                              hasValidSignature: "invalid signature".asData.base64EncodedString(),
-                              with: Signing.loadPublicKey())) == false
+        expect(Signing.verify(
+            signature: "invalid signature".asData.base64EncodedString(),
+            with: .init(
+                notModifiedResponse: false,
+                message: "Hello World".asData,
+                nonce: "nonce".asData,
+                requestTime: 1677005916012,
+                eTag: nil
+            ),
+            publicKey: Signing.loadPublicKey()
+        )) == false
     }
 
     func testVerifySignatureLogsWarningWhenFail() throws {
         let logger = TestLogHandler()
 
-        _ = Signing.verify(message: "Hello World".asData,
-                           nonce: "nonce".asData,
-                           hasValidSignature: "invalid signature".asData.base64EncodedString(),
-                           with: Signing.loadPublicKey())
+        _ = Signing.verify(signature: "invalid signature".asData.base64EncodedString(),
+                           with: .init(
+                            notModifiedResponse: false,
+                            message: "Hello World".asData,
+                            nonce: "nonce".asData,
+                            requestTime: 1677005916012,
+                            eTag: nil
+                           ),
+                           publicKey: Signing.loadPublicKey())
 
         logger.verifyMessageWasLogged("Signature failed verification", level: .warn)
     }
@@ -99,45 +119,100 @@ class SigningTests: TestCase {
     func testVerifySignatureWithValidSignature() throws {
         let message = "Hello World"
         let nonce = "nonce"
+        let requestTime = 1677005916012
         let salt = Self.createSalt()
 
-        let signature = try self.sign(message: message, nonce: nonce, salt: salt)
+        let signature = try self.sign(
+            parameters: .init(
+                notModifiedResponse: false,
+                message: message.asData,
+                nonce: nonce.asData,
+                requestTime: requestTime,
+                eTag: nil
+            ),
+            salt: salt.asData
+        )
         let fullSignature = salt.asData + signature
 
-        expect(Signing.verify(message: message.asData,
-                              nonce: nonce.asData,
-                              hasValidSignature: fullSignature.base64EncodedString(),
-                              with: self.publicKey)) == true
+        expect(Signing.verify(
+            signature: fullSignature.base64EncodedString(),
+            with: .init(
+                notModifiedResponse: false,
+                message: message.asData,
+                nonce: nonce.asData,
+                requestTime: requestTime,
+                eTag: nil
+            ),
+            publicKey: self.publicKey
+        )) == true
     }
 
-    func testVerifyKnownSignature() throws {
+    func testVerifyKnownSignatureWithNoETag() throws {
         /*
          Signature retrieved with:
-        curl -v 'https://api.revenuecat.com/v1/subscribers/identify' \
-        -X POST \
+        curl -v 'https://api.revenuecat.com/v1/subscribers/login' \
+        -X GET \
         -H 'X-Nonce: MTIzNDU2Nzg5MGFi' \
         -H 'Authorization: Bearer {api_key}' \
-        -H 'content-type: application/json' \
-        -H 'Host: api.revenuecat.com' \
-        -H 'Connection: close' \
-        -H 'Content-Length: 54' \
-        -d '{"app_user_id": "test", "new_app_user_id": "new_user"}'
+        -H 'Host: api.revenuecat.com'
          */
 
         // swiftlint:disable line_length
         let response = """
-        {"request_date":"2023-02-14T17:10:11Z","request_date_ms":1676394611556,"subscriber":{"entitlements":{},"first_seen":"2023-02-07T18:26:02Z","last_seen":"2023-02-07T18:26:02Z","management_url":null,"non_subscriptions":{},"original_app_user_id":"new_user","original_application_version":null,"original_purchase_date":null,"other_purchases":{},"subscriptions":{}}}\n
+        {"request_date":"2023-02-21T18:58:36Z","request_date_ms":1677005916011,"subscriber":{"entitlements":{},"first_seen":"2023-02-21T18:58:35Z","last_seen":"2023-02-21T18:58:35Z","management_url":null,"non_subscriptions":{},"original_app_user_id":"login","original_application_version":null,"original_purchase_date":null,"other_purchases":{},"subscriptions":{}}}\n
         """
-        let expectedSignature = "Jmax3TdnBIe0/zFeHT5KJrFNoGxWtQAOuYTjnEXDHa0z3/npDG9nRB4vrUkt/ZxVh7SU+P++O3LnObxeuz3tFAILs75bxIqXwp6LqdV7Tgo="
+        let expectedSignature = "2bm3QppRywK5ULyCRLS5JJy9sq+84IkMk0Ue4LsywEp87t0tDObpzPlu30l4Desq9X65UFuosqwCLMizruDHbKvPqQLce0hrIuZpgic+cQ8="
         // swiftlint:enable line_length
 
         let nonce = try XCTUnwrap(Data(base64Encoded: "MTIzNDU2Nzg5MGFi"))
+        let requestTime = 1677005916012
 
         expect(
-            Signing.verify(message: response.asData,
-                           nonce: nonce,
-                           hasValidSignature: expectedSignature,
-                           with: Signing.loadPublicKey())
+            Signing.verify(
+                signature: expectedSignature,
+                with: .init(
+                    notModifiedResponse: false,
+                    message: response.asData,
+                    nonce: nonce,
+                    requestTime: requestTime,
+                    eTag: nil
+                ),
+                publicKey: Signing.loadPublicKey()
+            )
+        ) == true
+    }
+
+    func testVerifyKnownSignatureWithETag() throws {
+        /*
+         Signature retrieved with:
+         curl -v 'https://api.revenuecat.com/v1/subscribers/login' \
+         -X GET \
+         -H 'X-Nonce: MTIzNDU2Nzg5MGFi' \
+         -H 'Authorization: Bearer {api_key}' \
+         -H 'X-RevenueCat-ETag: b7bd9a697c7fd1a2 \
+         -H 'Host: api.revenuecat.com'
+         */
+
+        let response = ""
+        let nonce = try XCTUnwrap(Data(base64Encoded: "MTIzNDU2Nzg5MGFi"))
+        let requestTime = 1677013582768
+        let eTag = "b7bd9a697c7fd1a2"
+
+        // swiftlint:disable:next line_length
+        let expectedSignature = "IbHvwMBfhgF6Et6AH2KigMF9to3O8Ioh/z9GlG/8mhBInfd8wkzdhp/p/QOucYJZYe7nwKRCtuGjC5d3iBqdX53WUHCpT0IVFo1dzZFAegU="
+
+        expect(
+            Signing.verify(
+                signature: expectedSignature,
+                with: .init(
+                    notModifiedResponse: true,
+                    message: response.asData,
+                    nonce: nonce,
+                    requestTime: requestTime,
+                    eTag: eTag
+                ),
+                publicKey: Signing.loadPublicKey()
+            )
         ) == true
     }
 
@@ -169,7 +244,7 @@ class SigningTests: TestCase {
             with: Data(),
             statusCode: .success,
             headers: [
-                HTTPClient.responseSignatureHeaderName: "invalid_signature"
+                HTTPClient.ResponseHeader.signature.rawValue: "invalid_signature"
             ],
             request: request,
             publicKey: self.publicKey
@@ -181,9 +256,15 @@ class SigningTests: TestCase {
     func testResponseVerificationWithValidSignature() throws {
         let message = "Hello World"
         let nonce = "0123456789ab"
+        let requestTime = Date().millisecondsSince1970
         let salt = Self.createSalt()
 
-        let signature = try self.sign(message: message, nonce: nonce, salt: salt)
+        let signature = try self.sign(parameters: .init(notModifiedResponse: false,
+                                                        message: message.asData,
+                                                        nonce: nonce.asData,
+                                                        requestTime: requestTime,
+                                                        eTag: nil),
+                                      salt: salt.asData)
         let fullSignature = salt.asData + signature
 
         let request = HTTPRequest(method: .get, path: .health, nonce: nonce.asData)
@@ -191,7 +272,39 @@ class SigningTests: TestCase {
             with: message.asData,
             statusCode: .success,
             headers: [
-                HTTPClient.responseSignatureHeaderName: fullSignature.base64EncodedString()
+                HTTPClient.ResponseHeader.signature.rawValue: fullSignature.base64EncodedString(),
+                HTTPClient.ResponseHeader.requestTime.rawValue: String(requestTime)
+            ],
+            request: request,
+            publicKey: self.publicKey
+        )
+
+        expect(response.verificationResult) == .verified
+    }
+
+    func testResponseVerificationWithETagValidSignature() throws {
+        let message = "Hello World"
+        let nonce = "0123456789ab"
+        let etag = "etag"
+        let requestTime = Date().millisecondsSince1970
+        let salt = Self.createSalt()
+
+        let signature = try self.sign(parameters: .init(notModifiedResponse: true,
+                                                        message: message.asData,
+                                                        nonce: nonce.asData,
+                                                        requestTime: requestTime,
+                                                        eTag: etag),
+                                      salt: salt.asData)
+        let fullSignature = salt.asData + signature
+
+        let request = HTTPRequest(method: .get, path: .logIn, nonce: nonce.asData)
+        let response = HTTPResponse.create(
+            with: message.asData,
+            statusCode: .notModified,
+            headers: [
+                HTTPClient.ResponseHeader.signature.rawValue: fullSignature.base64EncodedString(),
+                HTTPClient.ResponseHeader.eTag.rawValue: etag,
+                HTTPClient.ResponseHeader.requestTime.rawValue: String(requestTime)
             ],
             request: request,
             publicKey: self.publicKey
@@ -211,14 +324,12 @@ extension SigningTests {
         return (key, key.publicKey)
     }
 
-    private func sign(message: String, nonce: String, salt: String) throws -> Data {
-        return try self.sign(key: self.privateKey,
-                             message: message.asData,
-                             nonce: nonce.asData,
-                             salt: salt.asData)
+    private func sign(parameters: Signing.SignatureParameters, salt: Data) throws -> Data {
+        return try self.sign(key: self.privateKey, parameters: parameters, salt: salt)
     }
-    private func sign(key: PrivateKey, message: Data, nonce: Data, salt: Data) throws -> Data {
-        return try key.signature(for: salt + nonce + message)
+
+    private func sign(key: PrivateKey, parameters: Signing.SignatureParameters, salt: Data) throws -> Data {
+        return try key.signature(for: salt + parameters.asData)
     }
 
     private static func createSalt() -> String {

--- a/Tests/UnitTests/Mocks/MockETagManager.swift
+++ b/Tests/UnitTests/Mocks/MockETagManager.swift
@@ -25,6 +25,10 @@ class MockETagManager: ETagManager {
     var invokedETagHeaderParametersList: [ETagHeaderRequest] = []
     var stubbedETagHeaderResult: [String: String]! = [:]
 
+    func stubResponseEtag(_ tag: String) {
+        self.stubbedETagHeaderResult[ETagManager.eTagResponseHeaderName] = tag
+    }
+
     override func eTagHeader(
         for urlRequest: URLRequest,
         refreshETag: Bool = false,

--- a/Tests/UnitTests/Mocks/MockSigning.swift
+++ b/Tests/UnitTests/Mocks/MockSigning.swift
@@ -16,9 +16,8 @@
 final class MockSigning: SigningType {
 
     struct VerificationRequest {
-        let message: Data
-        let nonce: Data
         let signature: String
+        let parameters: Signing.SignatureParameters
         let publicKey: Signing.PublicKey
     }
 
@@ -26,15 +25,13 @@ final class MockSigning: SigningType {
     static var stubbedVerificationResult: Bool?
 
     static func verify(
-        message: Data,
-        nonce: Data,
-        hasValidSignature signature: String,
-        with publicKey: Signing.PublicKey
+        signature: String,
+        with parameters: Signing.SignatureParameters,
+        publicKey: Signing.PublicKey
     ) -> Bool {
         Self.requests.append(.init(
-            message: message,
-            nonce: nonce,
             signature: signature,
+            parameters: parameters,
             publicKey: publicKey
         ))
 

--- a/Tests/UnitTests/Networking/ETagManagerTests.swift
+++ b/Tests/UnitTests/Networking/ETagManagerTests.swift
@@ -28,7 +28,7 @@ class ETagManagerTests: TestCase {
         let url = urlForTest()
         let request = URLRequest(url: url)
         let header = eTagManager.eTagHeader(for: request, signatureVerificationEnabled: false)
-        let value2: String? = header[ETagManager.eTagHeaderName]
+        let value2: String? = header[ETagManager.eTagRequestHeaderName]
 
         expect(value2).toNot(beNil())
         expect(value2) == ""
@@ -39,7 +39,7 @@ class ETagManagerTests: TestCase {
         _ = mockStoredETagResponse(for: url)
         let request = URLRequest(url: url)
         let header = eTagManager.eTagHeader(for: request, signatureVerificationEnabled: false)
-        let value2: String? = header[ETagManager.eTagHeaderName]
+        let value2: String? = header[ETagManager.eTagRequestHeaderName]
 
         expect(value2).toNot(beNil())
         expect(value2) == "an_etag"
@@ -318,7 +318,7 @@ class ETagManagerTests: TestCase {
 
         let response = self.eTagManager.eTagHeader(for: request,
                                                    signatureVerificationEnabled: true)
-        expect(response[ETagManager.eTagHeaderName]).to(beEmpty())
+        expect(response[ETagManager.eTagResponseHeaderName]).to(beEmpty())
     }
 
     func testETagHeaderIsFoundIfItsMissingResponseVerificationAndVerificationIsDisabled() {
@@ -339,7 +339,7 @@ class ETagManagerTests: TestCase {
 
         let response = self.eTagManager.eTagHeader(for: request,
                                                    signatureVerificationEnabled: false)
-        expect(response[ETagManager.eTagHeaderName]) == eTag
+        expect(response[ETagManager.eTagResponseHeaderName]) == eTag
     }
 
     func testETagHeaderIsIgnoredIfVerificationFailed() {
@@ -358,7 +358,7 @@ class ETagManagerTests: TestCase {
         ).asData()
 
         let response = self.eTagManager.eTagHeader(for: request, signatureVerificationEnabled: true)
-        expect(response[ETagManager.eTagHeaderName]).to(beEmpty())
+        expect(response[ETagManager.eTagResponseHeaderName]).to(beEmpty())
     }
 
     func testETagHeaderIsReturnedIfVerificationSucceded() {
@@ -378,7 +378,7 @@ class ETagManagerTests: TestCase {
 
         let response = self.eTagManager.eTagHeader(for: request,
                                                    signatureVerificationEnabled: false)
-        expect(response[ETagManager.eTagHeaderName]) == eTag
+        expect(response[ETagManager.eTagResponseHeaderName]) == eTag
     }
 
     func testETagHeaderIsIgnoredIfVerificationWasNotRequested() {
@@ -398,7 +398,7 @@ class ETagManagerTests: TestCase {
 
         let response = self.eTagManager.eTagHeader(for: request,
                                                    signatureVerificationEnabled: false)
-        expect(response[ETagManager.eTagHeaderName]) == eTag
+        expect(response[ETagManager.eTagResponseHeaderName]) == eTag
     }
 
     func testCachedResponseWithNoVerificationResultIsNotIgnored() {
@@ -535,7 +535,7 @@ private extension ETagManagerTests {
             "X-Client-Locale": "en-US",
             "X-Client-Version": "1.0",
             "X-Observer-Mode-Enabled": "false",
-            ETagManager.eTagHeaderName: eTag
+            ETagManager.eTagRequestHeaderName: eTag
         ]
             .merging(HTTPClient.authorizationHeader(withAPIKey: "apikey"))
     }

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1269,11 +1269,9 @@ final class SignatureVerificationHTTPClientTests: BaseHTTPClientTests {
         expect(MockSigning.requests).to(haveCount(1))
         let signingRequest = try XCTUnwrap(MockSigning.requests.onlyElement)
 
-        expect(signingRequest.parameters.notModifiedResponse) == false
         expect(signingRequest.parameters.message) == body
         expect(signingRequest.parameters.nonce) == request.nonce
         expect(signingRequest.parameters.requestTime) == self.requestTime
-        expect(signingRequest.parameters.eTag).to(beNil())
         expect(signingRequest.signature) == self.sampleSignature
         expect(signingRequest.publicKey).toNot(beNil())
     }
@@ -1309,11 +1307,9 @@ final class SignatureVerificationHTTPClientTests: BaseHTTPClientTests {
         expect(MockSigning.requests).to(haveCount(1))
         let signingRequest = try XCTUnwrap(MockSigning.requests.onlyElement)
 
-        expect(signingRequest.parameters.notModifiedResponse) == true
-        expect(signingRequest.parameters.message) == .init()
+        expect(signingRequest.parameters.message) == self.sampleETag.asData
         expect(signingRequest.parameters.nonce) == request.nonce
         expect(signingRequest.parameters.requestTime) == self.requestTime
-        expect(signingRequest.parameters.eTag) == self.sampleETag
         expect(signingRequest.signature) == self.sampleSignature
         expect(signingRequest.publicKey).toNot(beNil())
     }


### PR DESCRIPTION
See https://github.com/RevenueCat/khepri/pull/5300