### PR TITLE
Update `CustomerInfo.requestDate` from 304 responses

### DIFF
--- a/Sources/FoundationExtensions/Date+Extensions.swift
+++ b/Sources/FoundationExtensions/Date+Extensions.swift
@@ -24,6 +24,10 @@ extension NSDate {
 
 extension Date {
 
+    init(millisecondsSince1970: Int) {
+        self.init(timeIntervalSince1970: TimeInterval(millisecondsSince1970) / 1000)
+    }
+
     var millisecondsSince1970: Int {
         return Int(self.timeIntervalSince1970 * 1000.0)
     }

--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -291,7 +291,18 @@ extension CustomerInfo: Codable {
 
 }
 
-extension CustomerInfo: HTTPResponseBody {}
+extension CustomerInfo: HTTPResponseBody {
+
+    /// Creates a copy of this ``CustomerInfo`` modifying only the `requestDate`.
+    func copy(with newRequestDate: Date) -> CustomerInfo {
+        Logger.verbose(Strings.customerInfo.updating_request_date(self, newRequestDate))
+
+        var copy = self.data
+        copy.response.requestDate = newRequestDate
+        return .init(data: copy)
+    }
+
+}
 
 // MARK: - Private
 

--- a/Sources/Logging/Strings/CustomerInfoStrings.swift
+++ b/Sources/Logging/Strings/CustomerInfoStrings.swift
@@ -27,6 +27,7 @@ enum CustomerInfoStrings {
     case customerinfo_stale_updating_in_foreground
     case customerinfo_updated_from_network
     case customerinfo_updated_from_network_error(BackendError)
+    case updating_request_date(CustomerInfo, Date)
     case sending_latest_customerinfo_to_delegate
     case sending_updated_customerinfo_to_delegate
     case vending_cache
@@ -64,6 +65,8 @@ extension CustomerInfoStrings: CustomStringConvertible {
             }
 
             return result
+        case let .updating_request_date(info, newRequestDate):
+            return "Updating CustomerInfo '\(info.originalAppUserId)' request date: \(newRequestDate)"
         case .sending_latest_customerinfo_to_delegate:
             return "Sending latest CustomerInfo to delegate."
         case .sending_updated_customerinfo_to_delegate:

--- a/Sources/Logging/Strings/SigningStrings.swift
+++ b/Sources/Logging/Strings/SigningStrings.swift
@@ -24,7 +24,7 @@ enum SigningStrings {
 
     case signature_was_requested_but_not_provided(HTTPRequest)
 
-    case request_time_missing_from_headers(HTTPRequest)
+    case request_date_missing_from_headers(HTTPRequest)
 
 }
 
@@ -41,8 +41,8 @@ extension SigningStrings: CustomStringConvertible {
         case .signature_failed_verification:
             return "Signature failed verification"
 
-        case let .request_time_missing_from_headers(request):
-            return "Request to '\(request.path)' required a request time but none was provided. " +
+        case let .request_date_missing_from_headers(request):
+            return "Request to '\(request.path)' required a request date but none was provided. " +
             "This will be reported as a verification failure."
 
         case let .signature_was_requested_but_not_provided(request):

--- a/Sources/Misc/Signing.swift
+++ b/Sources/Misc/Signing.swift
@@ -36,7 +36,7 @@ enum Signing: SigningType {
 
         let message: Data
         let nonce: Data
-        let requestTime: Int
+        let requestDate: Int
 
     }
 
@@ -189,7 +189,7 @@ extension Signing.SignatureParameters {
     var asData: Data {
         return (
             self.nonce +
-            String(self.requestTime).asData +
+            String(self.requestDate).asData +
             self.message
         )
     }

--- a/Sources/Networking/HTTPClient/ETagManager.swift
+++ b/Sources/Networking/HTTPClient/ETagManager.swift
@@ -59,7 +59,7 @@ class ETagManager {
 
         guard let eTagInResponse = eTagInResponse else { return resultFromBackend }
         if self.shouldUseCachedVersion(responseCode: statusCode) {
-            if let storedResponse = self.storedHTTPResponse(for: request) {
+            if let storedResponse = self.storedHTTPResponse(for: request, withRequestDate: response.requestDate) {
                 return storedResponse
             }
             if retried {
@@ -107,8 +107,8 @@ private extension ETagManager {
         }
     }
 
-    func storedHTTPResponse(for request: URLRequest) -> HTTPResponse<Data>? {
-        return self.storedETagAndResponse(for: request)?.asResponse
+    func storedHTTPResponse(for request: URLRequest, withRequestDate requestDate: Date?) -> HTTPResponse<Data>? {
+        return self.storedETagAndResponse(for: request)?.asResponse(withRequestDate: requestDate)
     }
 
     func storeStatusCodeAndResponseIfNoError(for request: URLRequest,
@@ -185,11 +185,12 @@ extension ETagManager.Response {
         return try? JSONEncoder.default.encode(self)
     }
 
-    fileprivate var asResponse: HTTPResponse<Data> {
+    fileprivate func asResponse(withRequestDate requestDate: Date?) -> HTTPResponse<Data> {
         return HTTPResponse(
             statusCode: self.statusCode,
             responseHeaders: [:],
             body: self.data,
+            requestDate: requestDate,
             verificationResult: self.verificationResult
         )
     }

--- a/Sources/Networking/HTTPClient/HTTPResponse.swift
+++ b/Sources/Networking/HTTPClient/HTTPResponse.swift
@@ -24,6 +24,7 @@ struct HTTPResponse<Body: HTTPResponseBody> {
     /// To perform a case-insensitive header lookup, use the `value(forHeaderField:)` method instead.
     var responseHeaders: HTTPClient.ResponseHeaders
     var body: Body
+    var requestDate: Date?
     var verificationResult: VerificationResult
 
 }
@@ -80,6 +81,7 @@ extension HTTPResponse where Body: OptionalType, Body.Wrapped: HTTPResponseBody 
         return .init(statusCode: self.statusCode,
                      responseHeaders: self.responseHeaders,
                      body: body,
+                     requestDate: self.requestDate,
                      verificationResult: self.verificationResult)
     }
 
@@ -91,7 +93,18 @@ extension HTTPResponse {
         return .init(statusCode: self.statusCode,
                      responseHeaders: self.responseHeaders,
                      body: try mapping(self.body),
+                     requestDate: self.requestDate,
                      verificationResult: self.verificationResult)
+    }
+
+    func copy(with newVerificationResult: VerificationResult) -> Self {
+        return .init(
+            statusCode: self.statusCode,
+            responseHeaders: self.responseHeaders,
+            body: self.body,
+            requestDate: self.requestDate,
+            verificationResult: newVerificationResult
+        )
     }
 
 }

--- a/Sources/Networking/HTTPClient/HTTPResponseBody.swift
+++ b/Sources/Networking/HTTPClient/HTTPResponseBody.swift
@@ -19,6 +19,19 @@ protocol HTTPResponseBody {
 
     static func create(with data: Data) throws -> Self
 
+    /// Returns a copy of this response body updating only the request date
+    /// This is useful for types that include a response date (like `CustomerInfo`), that need to
+    /// get the most up-to-date time coming from the response header.
+    ///
+    /// - Note: The default implementation is a no-op.
+    func copy(with newRequestDate: Date) -> Self
+
+}
+
+extension HTTPResponseBody {
+
+    func copy(with newRequestDate: Date) -> Self { return self }
+
 }
 
 /// An empty `HTTPResponseBody` for responses with no content.

--- a/Sources/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
+++ b/Sources/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
@@ -41,12 +41,19 @@ extension CustomerInfoResponseHandler {
 
     struct Response: HTTPResponseBody {
 
-        let customerInfo: CustomerInfo
-        let errorResponse: ErrorResponse
+        var customerInfo: CustomerInfo
+        var errorResponse: ErrorResponse
 
         static func create(with data: Data) throws -> Self {
             return .init(customerInfo: try CustomerInfo.create(with: data),
                          errorResponse: ErrorResponse.from(data))
+        }
+
+        func copy(with newRequestDate: Date) -> Self {
+            var copy = self
+            copy.customerInfo = copy.customerInfo.copy(with: newRequestDate)
+
+            return copy
         }
 
     }

--- a/Sources/Purchasing/VerificationResult.swift
+++ b/Sources/Purchasing/VerificationResult.swift
@@ -69,3 +69,29 @@ extension VerificationResult: DefaultValueProvider {
     static let defaultValue: Self = .notVerified
 
 }
+
+extension VerificationResult {
+
+    /// - Returns: the most restrictive ``VerificationResult`` based on the cached verification and
+    /// the response verification.
+    static func from(cache cachedResult: Self, response responseResult: Self) -> Self {
+        switch (cachedResult, responseResult) {
+        case (.notVerified, .notVerified),
+            (.verified, .verified),
+            (.failed, .failed):
+            return cachedResult
+
+        // These shouldn't happen because `ETagManager` will ignore not verified cached responses
+        // if verification is enabled
+        case (.notVerified, .verified): return .notVerified
+        case (.notVerified, .failed): return .failed
+
+        case (.verified, .notVerified): return .notVerified
+        case (.verified, .failed): return .failed
+
+        case (.failed, .notVerified): return .failed
+        case (.failed, .verified): return .failed
+        }
+    }
+
+}

--- a/Sources/Purchasing/VerificationResult.swift
+++ b/Sources/Purchasing/VerificationResult.swift
@@ -81,14 +81,15 @@ extension VerificationResult {
             (.failed, .failed):
             return cachedResult
 
-        // These shouldn't happen because `ETagManager` will ignore not verified cached responses
-        // if verification is enabled
-        case (.notVerified, .verified): return .notVerified
-        case (.notVerified, .failed): return .failed
-
         case (.verified, .notVerified): return .notVerified
         case (.verified, .failed): return .failed
 
+        // These shouldn't happen because `ETagManager` will ignore not verified cached responses
+        // if verification is enabled.
+        case (.notVerified, .verified): return .notVerified
+        case (.notVerified, .failed): return .failed
+
+        // These shouldn't happen because `ETagManager` won't store responses with failed verification.
         case (.failed, .notVerified): return .failed
         case (.failed, .verified): return .failed
         }

--- a/Tests/UnitTests/FoundationExtensions/NSDate+RCExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/NSDate+RCExtensionsTests.swift
@@ -9,6 +9,7 @@ import XCTest
 @testable import RevenueCat
 
 class NSDateExtensionsTests: TestCase {
+
     func testMillisecondsSince1970ConvertsCorrectlyWithCurrentTime() {
         let date = NSDate()
         expect(date.millisecondsSince1970AsUInt64()) == (UInt64)(date.timeIntervalSince1970 * 1000)
@@ -20,4 +21,10 @@ class NSDateExtensionsTests: TestCase {
         let date = NSDate(timeIntervalSince1970: secondsSince1970)
         expect(date.millisecondsSince1970AsUInt64()) == millisecondsSince1970UInt64
     }
+
+    func testMillisecondsSince1970() {
+        let date = Date()
+        expect(Date(millisecondsSince1970: date.millisecondsSince1970)).to(beCloseTo(date, within: 0.01))
+    }
+
 }

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -196,7 +196,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                 "other_purchases": [:]
             ]])
 
-        let object = try info.asData()
+        let object = try info.asJSONEncodedData()
         self.mockDeviceCache.cachedCustomerInfo[Self.appUserID] = object
 
         customerInfoManager.sendCachedCustomerInfoIfAvailable(appUserID: Self.appUserID)
@@ -214,7 +214,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                 "other_purchases": [:]
             ]])
 
-        var object = try oldInfo.asData()
+        var object = try oldInfo.asJSONEncodedData()
 
         mockDeviceCache.cachedCustomerInfo[Self.appUserID] = object
 
@@ -229,7 +229,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                 "other_purchases": [:]
             ]])
 
-        object = try newInfo.asData()
+        object = try newInfo.asJSONEncodedData()
         mockDeviceCache.cachedCustomerInfo[Self.appUserID] = object
 
         customerInfoManager.sendCachedCustomerInfoIfAvailable(appUserID: Self.appUserID)
@@ -246,7 +246,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                 "other_purchases": [:]
             ]])
 
-        let object = try oldInfo.asData()
+        let object = try oldInfo.asJSONEncodedData()
         mockDeviceCache.cachedCustomerInfo[Self.appUserID] = object
 
         customerInfoManager.sendCachedCustomerInfoIfAvailable(appUserID: Self.appUserID)
@@ -310,7 +310,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                 "other_purchases": [:]
             ]])
 
-        let object = try info.asData()
+        let object = try info.asJSONEncodedData()
         self.mockDeviceCache.cachedCustomerInfo[Self.appUserID] = object
 
         let receivedCustomerInfo = try XCTUnwrap(self.customerInfoManager.cachedCustomerInfo(appUserID: Self.appUserID))
@@ -340,7 +340,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                 "other_purchases": [:]
             ]])
 
-        let object = try info.asData()
+        let object = try info.asJSONEncodedData()
         mockDeviceCache.cachedCustomerInfo["firstUser"] = object
 
         let receivedCustomerInfo = customerInfoManager.cachedCustomerInfo(appUserID: "secondUser")

--- a/Tests/UnitTests/Misc/CustomerInfo+TestExtensions.swift
+++ b/Tests/UnitTests/Misc/CustomerInfo+TestExtensions.swift
@@ -14,6 +14,14 @@
 @testable import RevenueCat
 import XCTest
 
+extension Encodable {
+
+    func asJSONEncodedData() throws -> Data {
+        return try JSONEncoder.default.encode(self)
+    }
+
+}
+
 extension CustomerInfo {
 
     /// Initializes the customer with a dictionary
@@ -26,16 +34,14 @@ extension CustomerInfo {
                   sandboxEnvironmentDetector: sandboxEnvironmentDetector)
     }
 
-    func asData() throws -> Data {
-        return try JSONEncoder.default.encode(self)
-    }
-
 }
 
 extension CustomerInfo {
 
     func asData(withNewSchemaVersion version: Any?) throws -> Data {
-        var dictionary = try XCTUnwrap(JSONSerialization.jsonObject(with: try self.asData()) as? [String: Any])
+        var dictionary = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: try self.asJSONEncodedData()) as? [String: Any]
+        )
 
         if let version = version {
             dictionary["schema_version"] = version

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -26,6 +26,7 @@ class MockHTTPClient: HTTPClient {
         init(
             statusCode: HTTPStatusCode,
             response: [String: Any] = [:],
+            responseHeaders: HTTPResponse.Headers = [:],
             verificationResult: VerificationResult = .defaultValue,
             delay: DispatchTimeInterval = .never
         ) {
@@ -34,7 +35,7 @@ class MockHTTPClient: HTTPClient {
 
             let response = HTTPResponse(
                 statusCode: statusCode,
-                responseHeaders: [:],
+                responseHeaders: responseHeaders,
                 body: data,
                 verificationResult: verificationResult
             )

--- a/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
@@ -192,6 +192,28 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         expect(customerInfo?.value?.entitlements.verification) == .failed
     }
 
+    func testUpdatesRequestDateFromResponseHeader() {
+        let requestDate = Date().addingTimeInterval(-10000)
+
+        self.httpClient.mock(
+            requestPath: .getCustomerInfo(appUserID: Self.userID),
+            response: .init(
+                statusCode: .success,
+                response: Self.validCustomerResponse,
+                responseHeaders: [
+                    HTTPClient.ResponseHeader.requestDate.rawValue: String(requestDate.millisecondsSince1970)
+                ]
+            )
+        )
+
+        let response = waitUntilValue { completed in
+            self.backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false, completion: completed)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.requestDate).to(beCloseTo(requestDate, within: 0.01))
+    }
+
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS12-testUpdatesRequestDateFromResponseHeader.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testUpdatesRequestDateFromResponseHeader.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testUpdatesRequestDateFromResponseHeader.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testUpdatesRequestDateFromResponseHeader.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testUpdatesRequestDateFromResponseHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testUpdatesRequestDateFromResponseHeader.1.json
@@ -1,0 +1,10 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : null,
+    "method" : "GET",
+    "url" : "https://api.revenuecat.com/v1/subscribers/user"
+  }
+}

--- a/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
+++ b/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
@@ -1201,7 +1201,7 @@ private extension EntitlementInfosTests {
         file: FileString = #file,
         line: UInt = #line
     ) throws {
-        let subscriberInfo = try CustomerInfo(data: response)
+        let subscriberInfo = try CustomerInfo(data: self.response)
         let proCat = try XCTUnwrap(subscriberInfo.entitlements[entitlement])
 
         expect(file: file, line: line, proCat.identifier) == entitlement

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -212,7 +212,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         self.systemInfo.stubbedIsApplicationBackgrounded = true
 
         let info = try CustomerInfo(data: Self.emptyCustomerInfoData)
-        let object = try info.asData()
+        let object = try info.asJSONEncodedData()
 
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
 
@@ -224,7 +224,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
 
     func testSettingTheDelegateAfterInitializationSendsCachedCustomerInfo() throws {
         let info = try CustomerInfo(data: Self.emptyCustomerInfoData)
-        let object = try info.asData()
+        let object = try info.asJSONEncodedData()
 
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
 
@@ -238,7 +238,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
 
     func testSettingTheDelegateLaterPastInitializationSendsCachedCustomerInfo() throws {
         let info = try CustomerInfo(data: Self.emptyCustomerInfoData)
-        let object = try info.asData()
+        let object = try info.asJSONEncodedData()
 
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetCustomerInfoTests.swift
@@ -32,7 +32,7 @@ class PurchasesGetCustomerInfoTests: BasePurchasesTests {
     func testCachedCustomerInfoHasSchemaVersion() throws {
         let info = try CustomerInfo(data: Self.emptyCustomerInfoData)
 
-        let object = try info.asData()
+        let object = try info.asJSONEncodedData()
         self.deviceCache.cachedCustomerInfo[self.identityManager.currentAppUserID] = object
 
         self.setupPurchases()
@@ -68,7 +68,7 @@ class PurchasesGetCustomerInfoTests: BasePurchasesTests {
     func testSendsCachedCustomerInfoToGetter() throws {
         let info = try CustomerInfo(data: Self.emptyCustomerInfoData)
 
-        self.deviceCache.cachedCustomerInfo[self.identityManager.currentAppUserID] = try info.asData()
+        self.deviceCache.cachedCustomerInfo[self.identityManager.currentAppUserID] = try info.asJSONEncodedData()
 
         self.setupPurchases()
 
@@ -83,7 +83,7 @@ class PurchasesGetCustomerInfoTests: BasePurchasesTests {
     func testCustomerInfoCompletionBlockCalledExactlyOnceWhenInfoCached() throws {
         let info = try CustomerInfo(data: Self.emptyCustomerInfoData)
 
-        self.deviceCache.cachedCustomerInfo[self.identityManager.currentAppUserID] = try info.asData()
+        self.deviceCache.cachedCustomerInfo[self.identityManager.currentAppUserID] = try info.asJSONEncodedData()
         self.deviceCache.stubbedIsCustomerInfoCacheStale = true
 
         self.setupPurchases()

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesRestoreTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesRestoreTests.swift
@@ -66,7 +66,7 @@ class PurchasesRestoreTests: BasePurchasesTests {
     func testRestoringPurchasesPostsIfReceiptHasTransactionsAndCustomerInfoLoaded() throws {
         let info = try CustomerInfo(data: Self.emptyCustomerInfoData)
 
-        let object = try info.asData()
+        let object = try info.asJSONEncodedData()
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
 
         self.mockTransactionsManager.stubbedCustomerHasTransactionsCompletionParameter = true
@@ -259,7 +259,7 @@ class PurchasesRestoreNoSetupTests: BasePurchasesTests {
                 "original_purchase_date": "2018-10-26T23:17:53Z"
             ]])
 
-        let object = try info.asData()
+        let object = try info.asJSONEncodedData()
 
         self.deviceCache.cachedCustomerInfo[self.identityManager.currentAppUserID] = object
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncPurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncPurchasesTests.swift
@@ -43,7 +43,7 @@ class PurchasesSyncPurchasesTests: BasePurchasesTests {
                 "original_purchase_date": "2018-10-26T23:17:53Z"
             ]])
 
-        let object = try info.asData()
+        let object = try info.asJSONEncodedData()
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
 
         self.mockTransactionsManager.stubbedCustomerHasTransactionsCompletionParameter = false
@@ -73,7 +73,7 @@ class PurchasesSyncPurchasesTests: BasePurchasesTests {
                 "original_purchase_date": "2018-10-26T23:17:53Z"
             ]])
 
-        let object = try info.asData()
+        let object = try info.asJSONEncodedData()
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
 
         self.mockTransactionsManager.stubbedCustomerHasTransactionsCompletionParameter = true


### PR DESCRIPTION
### Purpose:

This is a prerequisite for #2288. The new grace period means that if we didn't update the date from the cached responses, entitlements would become stale and expired after 3 days.

### Changes:
- Added `HTTPResponseBody.copy(with newRequestDate:)` to be able to modify responses from the header request date
- `CustomerInfo` implements this method to modify its request date
- Added `HTTPResponse.requestDate` to be able to keep track of the request date from the server
- Added `VerificationResult.from(cache:response:)` to determine the most restrictive verification result based on what's cached or checked from a response
- Added `HTTPResponse.copy(with:)` to modify the verification result of a response using the previous method
- `HTTPClient` now uses the most restrictive verification result
- `HTTPClient` updates request date from server responses or cached responses (unless verification failed). This was the missing piece for #2288.

### Tests:
- Verify that `ETagManager` does not use an ETag if verification was previously not enabled
- Verify that `ETagManager` returns the request date from the server when returning a cached response
- Verify that `HTTPClient` updates the request date from the server or from a cached response
- Verify that `HTTPClient` does not update request date if verification failed
- Tests for `HTTPResponse` request date parsing
- Test for `CustomerInfoResponseHandler` updating request date
- Tests for `CustomerInfo.copy(with newRequestDate:)`


### Other smaller changes:
- Moved `CustomerInfo.asData()` into `Encodable.asJSONEncodedData()`
- Renamed `requestTime` to `requestDate` everywhere for consistency
