### PR TITLE
`PurchaseTester`: fixed leak when reconfiguring `Purchases`

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Core/ConfiguredPurchases.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Core/ConfiguredPurchases.swift
@@ -28,7 +28,7 @@ public final class ConfiguredPurchases {
         observerMode: Bool,
         entitlementVerificationMode: Configuration.EntitlementVerificationMode
     ) {
-        Purchases.logLevel = .debug
+        Purchases.logLevel = .verbose
         Purchases.logHandler = Self.logger.logHandler
 
         if let proxyURL {

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/ContentView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/ContentView.swift
@@ -32,7 +32,7 @@ struct ContentView: View {
         HomeView()
             .environmentObject(self.revenueCatCustomerData)
             .environmentObject(self.observerModeManager)
-            .task {
+            .task(id: self.configuration.purchases) {
                 for await customerInfo in self.configuration.purchases.customerInfoStream {
                     self.revenueCatCustomerData.customerInfo = customerInfo
                     self.revenueCatCustomerData.appUserID = self.configuration.purchases.appUserID


### PR DESCRIPTION
The `task` was not being cancelled when `Purchases` was reinitialized, which meant that it was kept in memory,
and so multiple `Purchases` instances were in memory, leading to weird errors.

I've also enabled `verbose` logs to be able to see this more clearly.
