### PR TITLE
`PurchaseTester`: added ability to reload `CustomerInfo` with a custom `CacheFetchPolicy`

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Extensions/Extensions.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Extensions/Extensions.swift
@@ -21,6 +21,32 @@ extension String {
 
 }
 
+extension CacheFetchPolicy {
+
+    var label: String {
+        switch self {
+        case .cachedOrFetched: return "Cached or fetched"
+        case .fetchCurrent: return "Fetch current"
+        case .fromCacheOnly: return "Cache only"
+        case .notStaleCachedOrFetched: return "Not stale cached or fetched"
+        }
+    }
+
+    static let all: [Self] = [
+         .cachedOrFetched,
+         .fetchCurrent,
+         .fromCacheOnly,
+         .notStaleCachedOrFetched
+    ]
+
+}
+
+extension CacheFetchPolicy: Identifiable {
+
+    public var id: Int { return self.rawValue }
+
+}
+
 extension Configuration.EntitlementVerificationMode {
 
     var label: String {

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
@@ -20,6 +20,7 @@ struct HomeView: View {
     
     @State private var showingAlert = false
     @State private var newAppUserID: String = ""
+    @State private var cacheFetchPolicy: CacheFetchPolicy = .default
 
     @State private var error: Error?
     
@@ -71,6 +72,26 @@ struct HomeView: View {
                         Text("Sync Purchases")
                     }
                     
+                    HStack {
+                        Picker("CustomerInfo", selection: self.$cacheFetchPolicy) {
+                            ForEach(CacheFetchPolicy.all) { policy in
+                                Text(policy.label).tag(policy)
+                            }
+                        }
+                        
+                        Button {
+                            Task<Void, Never> {
+                                do {
+                                    _ = try await Purchases.shared.customerInfo(fetchPolicy: self.cacheFetchPolicy)
+                                } catch {
+                                    print("🚀 Info 💁‍♂️ - Error: \(error)")
+                                }
+                            }
+                        } label: {
+                            Text("Go")
+                        }
+                    }
+
                     #if os(iOS) && !targetEnvironment(macCatalyst)
                     Button {
                         Purchases.shared.presentCodeRedemptionSheet()
@@ -171,6 +192,7 @@ struct HomeView: View {
 }
 
 private struct CustomerInfoHeaderView: View {
+    
     @EnvironmentObject var revenueCatCustomerData: RevenueCatCustomerData
     
     typealias Completion = (Action) async -> ()


### PR DESCRIPTION
This will help testing cache invalidation in the context of signature verification.
See https://linear.app/revenuecat/issue/SDK-2873/invalidate-devicecache-cache-if-entitlement-verification-is-missing

![Screenshot 2023-02-21 at 14 45 17](https://user-images.githubusercontent.com/685609/220475952-e64689e7-ac98-485b-9f13-3e38b9db4e02.png)
