### PR TITLE
Fix issue with missing subscriber attributes if set after login but before login callback

### DIFF
--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -286,8 +286,7 @@ class DeviceCache {
                 return
             }
 
-            Logger.info(Strings.attribution.copying_attributes_from_to_user(oldAppUserID: oldAppUserID,
-                                                                            newAppUserID: newAppUserID))
+            Logger.info(Strings.attribution.copying_attributes(oldAppUserID: oldAppUserID, newAppUserID: newAppUserID))
             Self.store($0, subscriberAttributesByKey: unsyncedAttributesToCopy, appUserID: newAppUserID)
             Self.deleteAllAttributes($0, appUserID: oldAppUserID)
         }

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -107,7 +107,7 @@ extension IdentityManager {
 private extension IdentityManager {
 
     func performLogIn(appUserID: String, completion: @escaping IdentityAPI.LogInResponseHandler) {
-        let oldAppUserID = currentAppUserID
+        let oldAppUserID = self.currentAppUserID
         let newAppUserID = appUserID.trimmingWhitespacesAndNewLines
         guard !newAppUserID.isEmpty else {
             Logger.error(Strings.identity.logging_in_with_empty_appuserid)

--- a/Sources/Logging/Strings/AttributionStrings.swift
+++ b/Sources/Logging/Strings/AttributionStrings.swift
@@ -44,6 +44,7 @@ enum AttributionStrings {
     case adservices_token_post_succeeded
     case adservices_token_unavailable_in_simulator
     case latest_attribution_sent_user_defaults_invalid(networkKey: String)
+    case copying_attributes_from_to_user(oldAppUserID: String, newAppUserID: String)
 
 }
 
@@ -138,6 +139,9 @@ extension AttributionStrings: CustomStringConvertible {
 
         case .latest_attribution_sent_user_defaults_invalid(let networkKey):
             return "Attribution data stored in UserDefaults has invalid format for network key: \(networkKey)"
+
+        case .copying_attributes_from_to_user(let oldAppUserID, let newAppUserID):
+            return "Copying unsynced subscriber attributes from user \(oldAppUserID) to user \(newAppUserID)"
 
         }
     }

--- a/Sources/Logging/Strings/AttributionStrings.swift
+++ b/Sources/Logging/Strings/AttributionStrings.swift
@@ -44,7 +44,7 @@ enum AttributionStrings {
     case adservices_token_post_succeeded
     case adservices_token_unavailable_in_simulator
     case latest_attribution_sent_user_defaults_invalid(networkKey: String)
-    case copying_attributes_from_to_user(oldAppUserID: String, newAppUserID: String)
+    case copying_attributes(oldAppUserID: String, newAppUserID: String)
 
 }
 
@@ -140,7 +140,7 @@ extension AttributionStrings: CustomStringConvertible {
         case .latest_attribution_sent_user_defaults_invalid(let networkKey):
             return "Attribution data stored in UserDefaults has invalid format for network key: \(networkKey)"
 
-        case .copying_attributes_from_to_user(let oldAppUserID, let newAppUserID):
+        case .copying_attributes(let oldAppUserID, let newAppUserID):
             return "Copying unsynced subscriber attributes from user \(oldAppUserID) to user \(newAppUserID)"
 
         }

--- a/Sources/Logging/Strings/IdentityStrings.swift
+++ b/Sources/Logging/Strings/IdentityStrings.swift
@@ -32,7 +32,7 @@ enum IdentityStrings {
 
     case null_currentappuserid
 
-    case deleting_synced_attributes_none_found
+    case deleting_attributes_none_found
 
 }
 
@@ -60,8 +60,8 @@ extension IdentityStrings: CustomStringConvertible {
             return "Identifying App User ID"
         case .null_currentappuserid:
             return "currentAppUserID is nil. This might happen if the cache in UserDefaults is unintentionally cleared."
-        case .deleting_synced_attributes_none_found:
-            return "Attempt to delete synced attributes for user, but there were none to delete"
+        case .deleting_attributes_none_found:
+            return "Attempt to delete attributes for user, but there were none to delete"
         }
     }
 

--- a/Tests/UnitTests/Caching/DeviceCacheTests.swift
+++ b/Tests/UnitTests/Caching/DeviceCacheTests.swift
@@ -10,6 +10,8 @@ import XCTest
 
 class DeviceCacheTests: TestCase {
 
+    private let subscriberAttributesKey = "com.revenuecat.userdefaults.subscriberAttributes"
+
     private var sandboxEnvironmentDetector: MockSandboxEnvironmentDetector! = nil
     private var mockUserDefaults: MockUserDefaults! = nil
     private var deviceCache: DeviceCache! = nil
@@ -69,7 +71,6 @@ class DeviceCacheTests: TestCase {
 
     func testClearCachesForAppUserIDAndSaveNewUserIDDoesntRemoveCachedSubscriberAttributesIfUnsynced() {
         let userID = "andy"
-        let attributesKey = "com.revenuecat.userdefaults.subscriberAttributes"
         let key = "band"
         let unsyncedSubscriberAttribute = SubscriberAttribute(withKey: key,
                                                               value: "La Renga",
@@ -78,31 +79,30 @@ class DeviceCacheTests: TestCase {
         let mockAttributes: [String: [String: [String: NSObject]]] = [
             userID: [key: unsyncedSubscriberAttribute]
         ]
-        mockUserDefaults.mockValues[attributesKey] = mockAttributes
+        mockUserDefaults.mockValues[self.subscriberAttributesKey] = mockAttributes
 
         self.deviceCache.clearCaches(oldAppUserID: userID, andSaveWithNewUserID: "newUser")
-        let mockValues = self.mockUserDefaults.mockValues[attributesKey]
+        let mockValues = self.mockUserDefaults.mockValues[self.subscriberAttributesKey]
         expect(mockValues as? [String: [String: [String: NSObject]]]) == mockAttributes
     }
 
     func testClearCachesForAppUserIDAndSaveNewUserIDRemovesCachedSubscriberAttributesIfSynced() {
         let userID = "andy"
-        let attributesKey = "com.revenuecat.userdefaults.subscriberAttributes"
         let key = "band"
         let unsyncedSubscriberAttribute = SubscriberAttribute(withKey: key,
                                                               value: "La Renga",
                                                               isSynced: true,
                                                               setTime: Date()).asDictionary()
 
-        mockUserDefaults.mockValues[attributesKey] = [
+        mockUserDefaults.mockValues[self.subscriberAttributesKey] = [
             userID: [key: unsyncedSubscriberAttribute]
         ]
 
-        expect(self.mockUserDefaults.mockValues[attributesKey] as? [String: NSObject]).notTo(beEmpty())
+        expect(self.mockUserDefaults.mockValues[self.subscriberAttributesKey] as? [String: NSObject]).notTo(beEmpty())
 
         self.deviceCache.clearCaches(oldAppUserID: userID, andSaveWithNewUserID: "newUser")
 
-        expect(self.mockUserDefaults.mockValues[attributesKey] as? [String: NSObject]).to(beEmpty())
+        expect(self.mockUserDefaults.mockValues[self.subscriberAttributesKey] as? [String: NSObject]).to(beEmpty())
 
     }
 
@@ -446,7 +446,6 @@ class DeviceCacheTests: TestCase {
     func testCopySubscriberAttributesDoesNothingIfOldUserIdHasNoUnsyncedAttributes() {
         let oldAppUserId = "test-user-id"
         let newAppUserId = "new-test-user-id"
-        let attributesKey = "com.revenuecat.userdefaults.subscriberAttributes"
         let key = "band"
         let unsyncedSubscriberAttribute = SubscriberAttribute(withKey: key,
                                                               value: "La Renga",
@@ -455,7 +454,7 @@ class DeviceCacheTests: TestCase {
         let mockAttributes: [String: [String: [String: NSObject]]] = [
             oldAppUserId: [key: unsyncedSubscriberAttribute]
         ]
-        self.mockUserDefaults.mockValues[attributesKey] = mockAttributes
+        self.mockUserDefaults.mockValues[self.subscriberAttributesKey] = mockAttributes
 
         self.deviceCache.copySubscriberAttributes(oldAppUserID: oldAppUserId, newAppUserID: newAppUserId)
 
@@ -465,7 +464,6 @@ class DeviceCacheTests: TestCase {
     func testCopySubscriberAttributesCopiesAttributesAndDeletesOldAttributesIfOldUserIdHasUnsyncedAttributes() {
         let oldAppUserId = "test-user-id"
         let newAppUserId = "new-test-user-id"
-        let attributesKey = "com.revenuecat.userdefaults.subscriberAttributes"
         let key = "band"
         let unsyncedSubscriberAttribute = SubscriberAttribute(withKey: key,
                                                               value: "La Renga",
@@ -477,12 +475,13 @@ class DeviceCacheTests: TestCase {
         let expectedAttributesSet: [String: [String: [String: NSObject]]] = [
             newAppUserId: [key: unsyncedSubscriberAttribute]
         ]
-        self.mockUserDefaults.mockValues[attributesKey] = originalAttributesSet
+        self.mockUserDefaults.mockValues[self.subscriberAttributesKey] = originalAttributesSet
 
         self.deviceCache.copySubscriberAttributes(oldAppUserID: oldAppUserId, newAppUserID: newAppUserId)
 
-        expect(self.mockUserDefaults.setObjectForKeyCalledValue) == attributesKey
-        let storedAttributes = self.mockUserDefaults.mockValues[attributesKey]
+        expect(self.mockUserDefaults.setObjectForKeyCalledValue) == self.subscriberAttributesKey
+        let storedAttributes = self.mockUserDefaults.mockValues[self.subscriberAttributesKey]
         expect(storedAttributes as? [String: [String: [String: NSObject]]]) == expectedAttributesSet
     }
+
 }

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -321,7 +321,7 @@ class IdentityManagerTests: TestCase {
             }
         }
 
-        expect(self.mockDeviceCache.invokedCopySubscriberAttributes).to(beFalse())
+        expect(self.mockDeviceCache.invokedCopySubscriberAttributes) == false
     }
 }
 

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -293,6 +293,36 @@ class IdentityManagerTests: TestCase {
         expect(self.mockAttributeSyncing.invokedSyncAttributesUserIDs) == ["nacho"]
     }
 
+    func testLogInCopiesAttributesToNewUserIfPreviousUserWasAnonymous() {
+        let manager = self.create(appUserID: nil)
+        let anonymousUserID = manager.currentAppUserID
+
+        self.mockIdentityAPI.stubbedLogInCompletionResult = .success((mockCustomerInfo, true))
+
+        waitUntil { completed in
+            manager.logIn(appUserID: "test-user-id") { _ in
+                completed()
+            }
+        }
+
+        expect(self.mockDeviceCache.invokedCopySubscriberAttributesCount) == 1
+        expect(self.mockDeviceCache.invokedCopySubscriberAttributesParameters?.oldAppUserID) == anonymousUserID
+        expect(self.mockDeviceCache.invokedCopySubscriberAttributesParameters?.newAppUserID) == "test-user-id"
+    }
+
+    func testLogInDoesNotCopyAttributesToNewUserIfPreviousUserWasNotAnonymous() {
+        let manager = self.create(appUserID: "old-user-id")
+
+        self.mockIdentityAPI.stubbedLogInCompletionResult = .success((mockCustomerInfo, true))
+
+        waitUntil { completed in
+            manager.logIn(appUserID: "test-user-id") { _ in
+                completed()
+            }
+        }
+
+        expect(self.mockDeviceCache.invokedCopySubscriberAttributes).to(beFalse())
+    }
 }
 
 private extension IdentityManagerTests {

--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -252,4 +252,16 @@ class MockDeviceCache: DeviceCache {
         return invokedSetLatestNetworkAndAdvertisingIdsSentParameters?.adIdsByNetwork ?? [:]
     }
 
+    var invokedCopySubscriberAttributes = false
+    var invokedCopySubscriberAttributesCount = 0
+    var invokedCopySubscriberAttributesParameters: (oldAppUserID: String, newAppUserID: String)?
+    var invokedCopySubscriberAttributesParametersList = [(oldAppUserID: String, newAppUserID: String)]()
+
+    override func copySubscriberAttributes(oldAppUserID: String, newAppUserID: String) {
+        invokedCopySubscriberAttributes = true
+        invokedCopySubscriberAttributesCount += 1
+        invokedCopySubscriberAttributesParameters = (oldAppUserID, newAppUserID)
+        invokedCopySubscriberAttributesParametersList.append((oldAppUserID, newAppUserID))
+    }
+
 }


### PR DESCRIPTION
### Description
Deals with [SDK-2817](https://linear.app/revenuecat/issue/SDK-2817/fix-issue-with-missing-subscriber-attributes-on-purchases-[ios])
This is the iOS counterpart to https://github.com/RevenueCat/purchases-android/pull/809

There was an issue where subscriber attributes could be delayed to be synced to the backend. This happened when setting a subscriber attribute AFTER the `logIn` call but BEFORE the `logIn` operation was completed.

This issue happens because we start syncing subscriber attributes immediately when calling `logIn`, but if we set any after that but before the login is complete, they will be assigned to the old user id. We would sync those the next time the app is backgrounded/foregrounded but might be missed if there is a purchase before that happens. When there is a purchase, we only sync the current user's unsynced attributes, but not attributes of other users.

This PR copies all unsynced attributes from the old user id to the new one upon a successful login. This way, the unsynced attributes will be sent if the user tries to purchase.

Note that we only copy these attributes when the old user id was anonymous. This is because there is a possible edge case of copying attributes from a user to a different user if the sync request fails and remains unsynced when changing between user ids.