### PR TITLE
Re-enable `pod lib lint` for `watchOS`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -647,8 +647,7 @@ lane :check_pods do
   pod_lib_lint(
     verbose: true,
     podspec:'RevenueCat.podspec', 
-    # TODO: re-add watchOS when https://github.com/CocoaPods/CocoaPods/issues/11558 is fixed.
-    platforms:"ios,osx,tvos",
+    platforms:"ios,watchos,osx,tvos",
     fail_fast: true
   )
 end


### PR DESCRIPTION
This was fixed by https://github.com/CocoaPods/CocoaPods/issues/11558 in https://github.com/CocoaPods/CocoaPods/releases/tag/1.12.0
