### PR TITLE
`CustomerInfo`: removed `entitlementVerification`

### DIFF
--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -45,13 +45,6 @@ import Foundation
      */
     @objc public let nonSubscriptions: [NonSubscriptionTransaction]
 
-    /// Whether the entitlements were verified.
-    ///
-    /// ### Related Symbols
-    /// - ``VerificationResult``
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    @objc public var entitlementVerification: VerificationResult { self.entitlements.verification }
-
     /**
      * Returns the fetch date of this CustomerInfo.
      */

--- a/Sources/Purchasing/VerificationResult.swift
+++ b/Sources/Purchasing/VerificationResult.swift
@@ -31,7 +31,7 @@ import Foundation
 /// )
 ///
 /// let customerInfo = try await purchases.customerInfo()
-/// if customerInfo.entitlementVerification != .verified {
+/// if customerInfo.entitlements.verification != .verified {
 ///   print("Entitlements could not be verified")
 /// }
 /// ```
@@ -39,7 +39,6 @@ import Foundation
 /// ### Related Symbols
 /// - ``Configuration/EntitlementVerificationMode``
 /// - ``Configuration/Builder/with(entitlementVerificationMode:)``
-/// - ``CustomerInfo/entitlementVerification``
 /// - ``EntitlementInfos/verification``
 @objc(RCVerificationResult)
 public enum VerificationResult: Int {

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCCustomerInfoAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCCustomerInfoAPI.m
@@ -16,7 +16,6 @@
     // RCCustomerInfo initializer is publically unavailable.
     RCCustomerInfo *ci = nil;
     RCEntitlementInfos *ei = ci.entitlements;
-    RCVerificationResult vr = ci.entitlementVerification;
     NSSet<NSString *> *as = ci.activeSubscriptions;
     NSSet<NSString *> *appis = ci.allPurchasedProductIdentifiers;
     NSDate *led = ci.latestExpirationDate;
@@ -39,7 +38,7 @@
 
     NSDictionary<NSString *, id> *rawData = [ci rawData];
     
-    NSLog(ci, ei, vr, as, appis, led, ncp, ns, nst, oav, opd, rd, fs, oaud, murl, edfpi, pdfpi, exdf, pdfe, d, rawData);
+    NSLog(ci, ei, as, appis, led, ncp, ns, nst, oav, opd, rd, fs, oaud, murl, edfpi, pdfpi, exdf, pdfe, d, rawData);
 }
 
 + (void)checkCacheFetchPolicyEnum:(RCCacheFetchPolicy) policy {

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/CustomerInfoAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/CustomerInfoAPI.swift
@@ -17,7 +17,6 @@ import RevenueCat
 var customerInfo: CustomerInfo!
 func checkCustomerInfoAPI() {
     let entitlementInfo: EntitlementInfos = customerInfo.entitlements
-    let evr: VerificationResult = customerInfo.entitlementVerification
     let asubs: Set<String> = customerInfo.activeSubscriptions
     let appis: Set<String> = customerInfo.allPurchasedProductIdentifiers
     let led: Date? = customerInfo.latestExpirationDate
@@ -39,7 +38,7 @@ func checkCustomerInfoAPI() {
 
     let rawData: [String: Any] = customerInfo.rawData
 
-    print(customerInfo!, entitlementInfo, evr, asubs, appis, led!, nst, oav!, opd!, rDate!, fSeen,
+    print(customerInfo!, entitlementInfo, asubs, appis, led!, nst, oav!, opd!, rDate!, fSeen,
           oaud!, murl!, edfpi!, pdfpi!, exdf!, pdfe!, desc, rawData)
 }
 

--- a/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
@@ -70,7 +70,6 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         expect(customerInfo).to(beSuccess())
 
         if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
-            expect(customerInfo?.value?.entitlementVerification) == .notRequested
             expect(customerInfo?.value?.entitlements.verification) == .notRequested
         }
     }
@@ -168,7 +167,6 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         }
 
         expect(customerInfo).to(beSuccess())
-        expect(customerInfo?.value?.entitlementVerification) == .verified
         expect(customerInfo?.value?.entitlements.verification) == .verified
     }
 
@@ -188,7 +186,6 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         }
 
         expect(customerInfo).to(beSuccess())
-        expect(customerInfo?.value?.entitlementVerification) == .failed
         expect(customerInfo?.value?.entitlements.verification) == .failed
     }
 

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -652,7 +652,6 @@ class BackendPostReceiptDataTests: BaseBackendTests {
         expect(result).to(beSuccess())
 
         if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
-            expect(result?.value?.entitlementVerification) == .verified
             expect(result?.value?.entitlements.verification) == .verified
         }
     }
@@ -682,7 +681,6 @@ class BackendPostReceiptDataTests: BaseBackendTests {
         expect(result).to(beSuccess())
 
         if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
-            expect(result?.value?.entitlementVerification) == .failed
             expect(result?.value?.entitlements.verification) == .failed
         }
     }

--- a/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
@@ -225,7 +225,6 @@ class CustomerInfoVersion2DecodingTests: BaseHTTPResponseTest {
     func testDecodingDefaultsToEntitlementsNotValidated() throws {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
-        expect(self.customerInfo.entitlementVerification) == .notRequested
         expect(self.customerInfo.entitlements.verification) == .notRequested
     }
 
@@ -235,7 +234,6 @@ class CustomerInfoVersion2DecodingTests: BaseHTTPResponseTest {
 
         let reencoded = try self.customerInfo.copy(with: .verified).encodeAndDecode()
 
-        expect(reencoded.entitlementVerification) == .verified
         expect(reencoded.entitlements.verification) == .verified
     }
 
@@ -245,7 +243,6 @@ class CustomerInfoVersion2DecodingTests: BaseHTTPResponseTest {
 
         let reencoded = try self.customerInfo.copy(with: .failed).encodeAndDecode()
 
-        expect(reencoded.entitlementVerification) == .failed
         expect(reencoded.entitlements.verification) == .failed
     }
 

--- a/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
@@ -851,10 +851,9 @@ class BasicCustomerInfoTests: TestCase {
         expect(customerInfo) != copy
 
         if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
-            expect(copy.entitlementVerification) == newVerification
             expect(copy.entitlements.verification) == newVerification
 
-            let copyWithOriginalVerification = copy.copy(with: customerInfo.entitlementVerification)
+            let copyWithOriginalVerification = copy.copy(with: customerInfo.entitlements.verification)
             expect(copyWithOriginalVerification) == customerInfo
         }
     }


### PR DESCRIPTION
See conversation in https://linear.app/revenuecat/issue/SDK-2842/[android]-create-trusted-property-in-entitlementinfo
This was redundant, it makes more sense to access this from `EntitlementInfos`.
