### PR TITLE
Renamed `VerificationResult.notVerified` to `.notRequested`

### DIFF
--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -355,7 +355,7 @@ extension CustomerInfo.Contents: Codable {
         self.entitlementVerification = try container.decodeIfPresent(
             VerificationResult.self,
             forKey: .entitlementVerification
-        ) ?? .notVerified
+        ) ?? .notRequested
         self.schemaVersion = try container.decodeIfPresent(String.self, forKey: .schemaVersion)
     }
 

--- a/Sources/Misc/Signing+ResponseVerification.swift
+++ b/Sources/Misc/Signing+ResponseVerification.swift
@@ -66,7 +66,7 @@ extension HTTPResponse where Body == Data {
         guard let nonce = request.nonce,
               let publicKey = publicKey,
               #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) else {
-            return .notVerified
+            return .notRequested
         }
 
         guard let signature = HTTPResponse.value(

--- a/Sources/Purchasing/VerificationResult.swift
+++ b/Sources/Purchasing/VerificationResult.swift
@@ -50,7 +50,7 @@ public enum VerificationResult: Int {
     ///  1. Verification is not enabled in ``Configuration``
     ///  2. Verification can't be performed prior to iOS 13.0
     ///  3. Data was cached in an older version of the SDK not supporting verification
-    case notVerified = 0
+    case notRequested = 0
 
     /// Entitlements were verified with our server.
     case verified = 1
@@ -66,7 +66,7 @@ extension VerificationResult: Sendable, Codable {}
 
 extension VerificationResult: DefaultValueProvider {
 
-    static let defaultValue: Self = .notVerified
+    static let defaultValue: Self = .notRequested
 
 }
 
@@ -76,21 +76,21 @@ extension VerificationResult {
     /// the response verification.
     static func from(cache cachedResult: Self, response responseResult: Self) -> Self {
         switch (cachedResult, responseResult) {
-        case (.notVerified, .notVerified),
+        case (.notRequested, .notRequested),
             (.verified, .verified),
             (.failed, .failed):
             return cachedResult
 
-        case (.verified, .notVerified): return .notVerified
+        case (.verified, .notRequested): return .notRequested
         case (.verified, .failed): return .failed
 
         // These shouldn't happen because `ETagManager` will ignore not verified cached responses
         // if verification is enabled.
-        case (.notVerified, .verified): return .notVerified
-        case (.notVerified, .failed): return .failed
+        case (.notRequested, .verified): return .notRequested
+        case (.notRequested, .failed): return .failed
 
         // These shouldn't happen because `ETagManager` won't store responses with failed verification.
-        case (.failed, .notVerified): return .failed
+        case (.failed, .notRequested): return .failed
         case (.failed, .verified): return .failed
         }
     }

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCVerificationResultAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCVerificationResultAPI.m
@@ -15,7 +15,7 @@
     const __unused RCVerificationResult result = RCVerificationResultVerified;
 
     switch (result) {
-        case RCVerificationResultNotVerified:
+        case RCVerificationResultNotRequested:
         case RCVerificationResultVerified:
         case RCVerificationResultFailed:
             break;

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/VerificationResultAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/VerificationResultAPI.swift
@@ -9,7 +9,7 @@ import Foundation
 import RevenueCat
 
 func checkVerificationResultAPI(_ mode: EntitlementVerificationMode = .disabled,
-                                _ result: VerificationResult = .notVerified) {
+                                _ result: VerificationResult = .notRequested) {
     switch mode {
     case .disabled,
             .informational,
@@ -20,7 +20,7 @@ func checkVerificationResultAPI(_ mode: EntitlementVerificationMode = .disabled,
     }
 
     switch result {
-    case .notVerified,
+    case .notRequested,
             .verified,
             .failed:
         break

--- a/Tests/UnitTests/Misc/SigningTests.swift
+++ b/Tests/UnitTests/Misc/SigningTests.swift
@@ -209,7 +209,7 @@ class SigningTests: TestCase {
                                            request: request,
                                            publicKey: nil)
 
-        expect(response.verificationResult) == .notVerified
+        expect(response.verificationResult) == .notRequested
     }
 
     func testResponseVerificationWithNoSignatureInResponse() throws {
@@ -295,28 +295,28 @@ class SigningTests: TestCase {
     }
 
     func testVerificationResultWithSameCachedAndResponseResult() {
-        expect(VerificationResult.from(cache: .notVerified, response: .notVerified)) == .notVerified
+        expect(VerificationResult.from(cache: .notRequested, response: .notRequested)) == .notRequested
         expect(VerificationResult.from(cache: .verified, response: .verified)) == .verified
         expect(VerificationResult.from(cache: .failed, response: .failed)) == .failed
     }
 
-    func testNotVerifiedCachedResult() {
-        expect(VerificationResult.from(cache: .notVerified,
-                                       response: .verified)) == .notVerified
-        expect(VerificationResult.from(cache: .notVerified,
+    func testVerificationNotRequestedCachedResult() {
+        expect(VerificationResult.from(cache: .notRequested,
+                                       response: .verified)) == .notRequested
+        expect(VerificationResult.from(cache: .notRequested,
                                        response: .failed)) == .failed
     }
 
     func testVerifiedCachedResult() {
         expect(VerificationResult.from(cache: .verified,
-                                       response: .notVerified)) == .notVerified
+                                       response: .notRequested)) == .notRequested
         expect(VerificationResult.from(cache: .verified,
                                        response: .failed)) == .failed
     }
 
     func testFailedVerificationCachedResult() {
         expect(VerificationResult.from(cache: .failed,
-                                       response: .notVerified)) == .failed
+                                       response: .notRequested)) == .failed
         expect(VerificationResult.from(cache: .failed,
                                        response: .verified)) == .failed
     }

--- a/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
@@ -70,8 +70,8 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         expect(customerInfo).to(beSuccess())
 
         if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
-            expect(customerInfo?.value?.entitlementVerification) == .notVerified
-            expect(customerInfo?.value?.entitlements.verification) == .notVerified
+            expect(customerInfo?.value?.entitlementVerification) == .notRequested
+            expect(customerInfo?.value?.entitlements.verification) == .notRequested
         }
     }
 

--- a/Tests/UnitTests/Networking/ETagManagerTests.swift
+++ b/Tests/UnitTests/Networking/ETagManagerTests.swift
@@ -141,7 +141,7 @@ class ETagManagerTests: TestCase {
                 body: responseObject,
                 eTag: eTag,
                 statusCode: .success,
-                verificationResult: .notVerified
+                verificationResult: .notRequested
             ),
             request: request,
             retried: false
@@ -303,7 +303,7 @@ class ETagManagerTests: TestCase {
         expect(response).toNot(beNil())
         expect(response?.statusCode) == .notModified
         expect(response?.body) == actualResponse
-        expect(response?.verificationResult) == .notVerified
+        expect(response?.verificationResult) == .notRequested
     }
 
     func testETagHeaderIsNotFoundIfItsMissingResponseVerificationAndVerificationEnabled() {
@@ -379,7 +379,7 @@ class ETagManagerTests: TestCase {
             eTag: eTag,
             statusCode: .success,
             data: actualResponse,
-            verificationResult: .notVerified
+            verificationResult: .notRequested
         ).asData()
 
         let response = self.eTagManager.eTagHeader(for: request, signatureVerificationEnabled: true)
@@ -418,7 +418,7 @@ class ETagManagerTests: TestCase {
             eTag: eTag,
             statusCode: .success,
             data: actualResponse,
-            verificationResult: .notVerified
+            verificationResult: .notRequested
         ).asData()
 
         let response = self.eTagManager.eTagHeader(for: request,
@@ -479,7 +479,7 @@ class ETagManagerTests: TestCase {
             request: request,
             retried: false
         )
-        expect(response?.verificationResult) == .notVerified
+        expect(response?.verificationResult) == .notRequested
         expect(response?.body) == actualResponse
     }
 
@@ -495,7 +495,7 @@ class ETagManagerTests: TestCase {
             eTag: eTag,
             statusCode: .success,
             data: actualResponse,
-            verificationResult: .notVerified
+            verificationResult: .notRequested
         ).asData()
 
         let response = self.eTagManager.httpResultFromCacheOrBackend(
@@ -509,7 +509,7 @@ class ETagManagerTests: TestCase {
         expect(response).toNot(beNil())
         expect(response?.statusCode) == .success
         expect(response?.body) == actualResponse
-        expect(response?.verificationResult) == .notVerified
+        expect(response?.verificationResult) == .notRequested
     }
 
     func testCachedResponseIsFoundIfVerificationSucceeded() {

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -947,7 +947,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
             responseHeaders: [:],
             body: mockedCachedResponse,
             requestDate: requestDate,
-            verificationResult: .notVerified
+            verificationResult: .notRequested
         )
 
         stub(condition: isPath(path)) { response in
@@ -968,7 +968,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         expect(response?.value?.statusCode) == .success
         expect(response?.value?.body) == mockedCachedResponse
         expect(response?.value?.requestDate) == requestDate
-        expect(response?.value?.verificationResult) == .notVerified
+        expect(response?.value?.verificationResult) == .notRequested
 
         expect(self.eTagManager.invokedETagHeaderParametersList).to(haveCount(1))
         expect(self.eTagManager.invokedETagHeaderParameters?.signatureVerificationEnabled) == false
@@ -1191,7 +1191,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
             responseHeaders: [:],
             body: encodedResponse,
             requestDate: requestDate,
-            verificationResult: .notVerified
+            verificationResult: .notRequested
         )
 
         stub(condition: isPath(path)) { _ in
@@ -1210,7 +1210,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
 
         expect(response).to(beSuccess())
         expect(response?.value?.body.requestDate).to(beCloseTo(requestDate, within: 1))
-        expect(response?.value?.verificationResult) == .notVerified
+        expect(response?.value?.verificationResult) == .notRequested
 
         expect(self.eTagManager.invokedETagHeaderParametersList).to(haveCount(1))
     }
@@ -1405,7 +1405,7 @@ final class SignatureVerificationHTTPClientTests: BaseHTTPClientTests {
         }
 
         expect(response).to(beSuccess())
-        expect(response?.value?.verificationResult) == .notVerified
+        expect(response?.value?.verificationResult) == .notRequested
 
         expect(MockSigning.requests).to(beEmpty())
     }
@@ -1540,7 +1540,7 @@ final class SignatureVerificationHTTPClientTests: BaseHTTPClientTests {
         expect(response?.value?.verificationResult) == .verified
     }
 
-    func testCachedResponseDoesNotUpdateRequestDateIfNewResponseIsNotVerified() throws {
+    func testCachedResponseDoesNotUpdateRequestDateIfNewResponseVerificationIsNotRequested() throws {
         try self.changeClient(.informational)
 
         let path: HTTPRequest.Path = .mockPath
@@ -1557,7 +1557,7 @@ final class SignatureVerificationHTTPClientTests: BaseHTTPClientTests {
                 HTTPClient.ResponseHeader.requestDate.rawValue: String(newRequestDate.millisecondsSince1970)
             ],
             body: encodedCachedResponse,
-            verificationResult: .notVerified
+            verificationResult: .notRequested
         )
 
         MockSigning.stubbedVerificationResult = false

--- a/Tests/UnitTests/Networking/HTTPResponseTests.swift
+++ b/Tests/UnitTests/Networking/HTTPResponseTests.swift
@@ -27,7 +27,7 @@ class HTTPResponseTests: TestCase {
                                            request: request,
                                            publicKey: nil)
 
-        expect(response.verificationResult) == .notVerified
+        expect(response.verificationResult) == .notRequested
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
@@ -43,7 +43,7 @@ class HTTPResponseTests: TestCase {
                                            request: request,
                                            publicKey: key)
 
-        expect(response.verificationResult) == .notVerified
+        expect(response.verificationResult) == .notRequested
     }
 
     func testValueForHeaderFieldWithNonExistingField() {
@@ -85,7 +85,7 @@ private extension HTTPResponse where Body == HTTPEmptyResponseBody {
         return .init(statusCode: .success,
                      responseHeaders: headers,
                      body: .init(),
-                     verificationResult: .notVerified)
+                     verificationResult: .notRequested)
     }
 
 }

--- a/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
@@ -225,8 +225,8 @@ class CustomerInfoVersion2DecodingTests: BaseHTTPResponseTest {
     func testDecodingDefaultsToEntitlementsNotValidated() throws {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
-        expect(self.customerInfo.entitlementVerification) == .notVerified
-        expect(self.customerInfo.entitlements.verification) == .notVerified
+        expect(self.customerInfo.entitlementVerification) == .notRequested
+        expect(self.customerInfo.entitlements.verification) == .notRequested
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)

--- a/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
@@ -821,9 +821,9 @@ class BasicCustomerInfoTests: TestCase {
                         onlyModifiesEntitlementVerification: .failed)
     }
 
-    func testCopyWithVerificationResultNotVerified() throws {
+    func testCopyWithVerificationResultNotRequested() throws {
         self.verifyCopy(of: self.customerInfo.copy(with: .verified),
-                        onlyModifiesEntitlementVerification: .notVerified)
+                        onlyModifiesEntitlementVerification: .notRequested)
     }
 
     func testCopyWithNewRequestDateModifiesOnlyRequestDate() throws {


### PR DESCRIPTION
See conversation in https://linear.app/revenuecat/issue/SDK-2896/invalidate-devicecache-cache-if-entitlement-verification-is-missing
This is more clear, as "not verified" could be confused as "failed to verify".

This hasn't shipped yet so it's safe to rename.