### PR TITLE
`CustomerInfo`: use same grace period logic for active subscriptions

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -418,6 +418,7 @@
 		57EAE52D274468900060EB74 /* RawDataContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EAE52C274468900060EB74 /* RawDataContainer.swift */; };
 		57EFDC6B27BC1F370057EC39 /* ProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EFDC6A27BC1F370057EC39 /* ProductType.swift */; };
 		57F2C60C29784C11009EE527 /* SwiftVersionCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F2C60B29784C11009EE527 /* SwiftVersionCheck.swift */; };
+		57F3C10529B7B22E0004FD7E /* CustomerInfo+ActiveDates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F3C10429B7B22E0004FD7E /* CustomerInfo+ActiveDates.swift */; };
 		57FD7B1528DA4037009CA4E4 /* PurchasesType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FD7B1428DA4037009CA4E4 /* PurchasesType.swift */; };
 		57FDAA962846BDE2009A48F1 /* PurchasesTransactionHandlingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDAA952846BDE2009A48F1 /* PurchasesTransactionHandlingTests.swift */; };
 		57FDAA9A2846C2BD009A48F1 /* PurchasesDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDAA992846C2BD009A48F1 /* PurchasesDelegateTests.swift */; };
@@ -1004,6 +1005,7 @@
 		57EAE52C274468900060EB74 /* RawDataContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawDataContainer.swift; sourceTree = "<group>"; };
 		57EFDC6A27BC1F370057EC39 /* ProductType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductType.swift; sourceTree = "<group>"; };
 		57F2C60B29784C11009EE527 /* SwiftVersionCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftVersionCheck.swift; sourceTree = "<group>"; };
+		57F3C10429B7B22E0004FD7E /* CustomerInfo+ActiveDates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerInfo+ActiveDates.swift"; sourceTree = "<group>"; };
 		57FD7B1428DA4037009CA4E4 /* PurchasesType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesType.swift; sourceTree = "<group>"; };
 		57FDAA952846BDE2009A48F1 /* PurchasesTransactionHandlingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesTransactionHandlingTests.swift; sourceTree = "<group>"; };
 		57FDAA992846C2BD009A48F1 /* PurchasesDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasesDelegateTests.swift; sourceTree = "<group>"; };
@@ -2184,6 +2186,7 @@
 			isa = PBXGroup;
 			children = (
 				A56F9AB026990E9200AFC48F /* CustomerInfo.swift */,
+				57F3C10429B7B22E0004FD7E /* CustomerInfo+ActiveDates.swift */,
 				B3A36AAD26BC76340059EDEA /* CustomerInfoManager.swift */,
 				B3852F9F26C1ED1F005384F8 /* IdentityManager.swift */,
 			);
@@ -2820,6 +2823,7 @@
 				2DC5623224EC63730031F69B /* TransactionsFactory.swift in Sources */,
 				579415D2293689DD00218FBC /* Codable+Extensions.swift in Sources */,
 				2DDF41B424F6F387005BC22D /* ASN1ContainerBuilder.swift in Sources */,
+				57F3C10529B7B22E0004FD7E /* CustomerInfo+ActiveDates.swift in Sources */,
 				B35F9E0926B4BEED00095C3F /* String+Extensions.swift in Sources */,
 				574A2EE7282C3F0800150D40 /* AnyDecodable.swift in Sources */,
 				B34605CF279A6E380031CA74 /* GetOfferingsOperation.swift in Sources */,

--- a/Sources/Identity/CustomerInfo+ActiveDates.swift
+++ b/Sources/Identity/CustomerInfo+ActiveDates.swift
@@ -1,0 +1,76 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CustomerInfo+ActiveDates.swift
+//
+//  Created by Nacho Soto on 3/7/23.
+
+import Foundation
+
+// MARK: - Internal
+
+extension CustomerInfo {
+
+    /// This grace period allows apps to continue functioning if the backend is down, but for a limited time.
+    /// We don't want to continue granting entitlements with an outdated `requestDate` forever,
+    /// since that would allow a user to get a free trial, then go offline and keep the entitlement with no time limit.
+    static let requestDateGracePeriod: DispatchTimeInterval = .days(3)
+
+    static func isDateActive(expirationDate: Date?, for requestDate: Date) -> Bool {
+        guard let expirationDate = expirationDate else {
+            return true
+        }
+
+        let (referenceDate, inGracePeriod) = Self.referenceDate(for: requestDate)
+        let isActive = expirationDate.timeIntervalSince(referenceDate) >= 0
+
+        if !inGracePeriod && !isActive {
+            Logger.warn(Strings.purchase.entitlement_expired_outside_grace_period(expiration: expirationDate,
+                                                                                  reference: requestDate))
+        }
+
+        return isActive
+    }
+
+    func activeKeys(dates: [String: Date?]) -> Set<String> {
+        return Set(
+            dates
+                .lazy
+                .filter { self.isDateActive($1) }
+                .map { key, _ in key }
+        )
+    }
+
+    static func extractExpirationDates(_ subscriber: CustomerInfoResponse.Subscriber) -> [String: Date?] {
+        return subscriber.subscriptions.mapValues { $0.expiresDate }
+    }
+
+    static func extractPurchaseDates(_ subscriber: CustomerInfoResponse.Subscriber) -> [String: Date?] {
+        return subscriber.allTransactionsByProductId.mapValues { $0.purchaseDate }
+    }
+
+}
+
+// MARK: - Private
+
+private extension CustomerInfo {
+
+    static func referenceDate(for requestDate: Date) -> (Date, inGracePeriod: Bool) {
+        if Date().timeIntervalSince(requestDate) <= Self.requestDateGracePeriod.seconds {
+            return (requestDate, true)
+        } else {
+            return (Date(), false)
+        }
+    }
+
+    func isDateActive(_ date: Date?) -> Bool {
+        return Self.isDateActive(expirationDate: date, for: self.requestDate)
+    }
+
+}

--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -24,7 +24,7 @@ import Foundation
     @objc public let entitlements: EntitlementInfos
 
     /// All *subscription* product identifiers with expiration dates in the future.
-    @objc public var activeSubscriptions: Set<String> { self.activeKeys(dates: expirationDatesByProductId) }
+    @objc public var activeSubscriptions: Set<String> { self.activeKeys(dates: self.expirationDatesByProductId) }
 
     /// All product identifiers purchases by the user regardless of expiration.
     @objc public let allPurchasedProductIdentifiers: Set<String>
@@ -360,15 +360,14 @@ private extension CustomerInfo {
         return Set(
             dates
                 .lazy
-                .filter {
-                    guard let date = $1 else { return true }
-                    return self.isAfterReferenceDate(date: date)
-                }
+                .filter { self.isDateActive($1) }
                 .map { key, _ in key }
         )
     }
 
-    func isAfterReferenceDate(date: Date) -> Bool { date.timeIntervalSince(self.requestDate) > 0 }
+    private func isDateActive(_ date: Date?) -> Bool {
+        return EntitlementInfo.isDateActive(expirationDate: date, for: self.requestDate)
+    }
 
     static func extractExpirationDates(_ subscriber: CustomerInfoResponse.Subscriber) -> [String: Date?] {
         return subscriber.subscriptions.mapValues { $0.expiresDate }

--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -353,28 +353,3 @@ extension CustomerInfo.Contents: Codable {
     }
 
 }
-
-private extension CustomerInfo {
-
-    func activeKeys(dates: [String: Date?]) -> Set<String> {
-        return Set(
-            dates
-                .lazy
-                .filter { self.isDateActive($1) }
-                .map { key, _ in key }
-        )
-    }
-
-    private func isDateActive(_ date: Date?) -> Bool {
-        return EntitlementInfo.isDateActive(expirationDate: date, for: self.requestDate)
-    }
-
-    static func extractExpirationDates(_ subscriber: CustomerInfoResponse.Subscriber) -> [String: Date?] {
-        return subscriber.subscriptions.mapValues { $0.expiresDate }
-    }
-
-    static func extractPurchaseDates(_ subscriber: CustomerInfoResponse.Subscriber) -> [String: Date?] {
-        return subscriber.allTransactionsByProductId.mapValues { $0.purchaseDate }
-    }
-
-}

--- a/Sources/Purchasing/EntitlementInfo.swift
+++ b/Sources/Purchasing/EntitlementInfo.swift
@@ -295,7 +295,7 @@ extension EntitlementInfo {
 
 // MARK: - Private
 
-private extension EntitlementInfo {
+extension EntitlementInfo {
 
     static func isDateActive(expirationDate: Date?, for requestDate: Date) -> Bool {
         guard let expirationDate = expirationDate else {
@@ -312,6 +312,10 @@ private extension EntitlementInfo {
 
         return isActive
     }
+
+}
+
+private extension EntitlementInfo {
 
     static func willRenewWithExpirationDate(expirationDate: Date?,
                                             store: Store,

--- a/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
+++ b/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
@@ -152,7 +152,7 @@ class EntitlementInfosTests: TestCase {
         let logger = TestLogHandler()
 
         let expirationAndRequestDate = Self.formatter.string(
-            from: Date().addingTimeInterval(EntitlementInfo.requestDateGracePeriod.seconds / -2)
+            from: Date().addingTimeInterval(CustomerInfo.requestDateGracePeriod.seconds / -2)
         )
         self.stubResponse(
                 entitlements: [
@@ -183,13 +183,13 @@ class EntitlementInfosTests: TestCase {
     }
 
     func testRequestDateGracePeriodIsLongerThanOneDay() {
-        expect(EntitlementInfo.requestDateGracePeriod.days) > 1
+        expect(CustomerInfo.requestDateGracePeriod.days) > 1
     }
 
     func testSubscriptionActiveIfExpiresDateAfterRequestDateAndRequestDateWithinGracePeriod() throws {
         let logger = TestLogHandler()
 
-        let requestDate = Date().addingTimeInterval(EntitlementInfo.requestDateGracePeriod.seconds / -2)
+        let requestDate = Date().addingTimeInterval(CustomerInfo.requestDateGracePeriod.seconds / -2)
         let expirationDate = requestDate.addingTimeInterval(100)
 
         self.stubResponse(
@@ -223,7 +223,7 @@ class EntitlementInfosTests: TestCase {
     func testSubscriptionNotActiveIfExpiresDateAfterRequestDateButRequestDateIsOlderThanGracePeriod() throws {
         let logger = TestLogHandler()
 
-        let requestDate = Date().addingTimeInterval(EntitlementInfo.requestDateGracePeriod.seconds * -1)
+        let requestDate = Date().addingTimeInterval(CustomerInfo.requestDateGracePeriod.seconds * -1)
         let expirationDate = requestDate.addingTimeInterval(100)
 
         self.stubResponse(


### PR DESCRIPTION
Follow up to #2288.
