### PR TITLE
Made `Configuration.EntitlementVerificationMode.enforced` unavailable

### DIFF
--- a/Sources/Networking/InternalAPI.swift
+++ b/Sources/Networking/InternalAPI.swift
@@ -108,7 +108,7 @@ private final class HealthOperation: CacheableNetworkOperation {
 
     private var verificationMode: Signing.ResponseVerificationMode {
         if self.signatureVerification, #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
-            return Signing.verificationMode(with: .enforced)
+            return Signing.enforcedVerificationMode()
         } else {
             return .disabled
         }

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -228,6 +228,7 @@ public extension Configuration {
         ///
         /// If verification fails when fetching ``CustomerInfo`` and/or ``EntitlementInfos``
         /// ``ErrorCode/signatureVerificationFailed`` will be thrown.
+        @available(*, unavailable, message: "This will be supported in a future release")
         case enforced = 2
 
     }

--- a/Sources/Security/Signing.swift
+++ b/Sources/Security/Signing.swift
@@ -94,6 +94,13 @@ enum Signing: SigningType {
         }
     }
 
+    /// - Returns: `ResponseVerificationMode.enforced`
+    /// This is useful while ``Configuration.EntitlementVerificationMode`` is unavailable.
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    static func enforcedVerificationMode() -> ResponseVerificationMode {
+        return .enforced(Self.loadPublicKey())
+    }
+
     // MARK: -
 
     private static let publicKey = "UC1upXWg5QVmyOSwozp755xLqquBKjjU+di6U8QhMlM="

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
@@ -20,7 +20,7 @@ func checkConfigurationAPI() {
         .with(networkTimeout: 1)
         .with(storeKit1Timeout: 1)
         .with(platformInfo: Purchases.PlatformInfo(flavor: "", version: ""))
-        .with(entitlementVerificationMode: .enforced)
+        .with(entitlementVerificationMode: .informational)
         .build()
     print(configuration)
 }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Extensions/Extensions.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Extensions/Extensions.swift
@@ -59,8 +59,9 @@ extension Configuration.EntitlementVerificationMode {
 
     static let all: [Self] = [
         .disabled,
-        .informational,
-        .enforced
+        .informational
+        // Disabled for now:
+        // .enforced
     ]
 
 }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Extensions/Extensions.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Extensions/Extensions.swift
@@ -60,7 +60,8 @@ extension Configuration.EntitlementVerificationMode {
     static let all: [Self] = [
         .disabled,
         .informational
-        // Disabled for now:
+        // .enforced is unavailable while the feature is in beta
+        // It will be enabled again in a future release.
         // .enforced
     ]
 

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -119,7 +119,7 @@ class HTTPRequestTests: TestCase {
 
         let existingNonce = Data.randomNonce()
         let request: HTTPRequest = .init(method: .get, path: .health, nonce: existingNonce)
-        let mode = Signing.verificationMode(with: .enforced)
+        let mode = Signing.enforcedVerificationMode()
 
         expect(request.requestAddingNonceIfRequired(with: mode).nonce) == existingNonce
     }
@@ -134,7 +134,7 @@ class HTTPRequestTests: TestCase {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
         let request: HTTPRequest = .init(method: .get, path: .postOfferForSigning)
-        let mode = Signing.verificationMode(with: .enforced)
+        let mode = Signing.enforcedVerificationMode()
 
         expect(request.requestAddingNonceIfRequired(with: mode).nonce).to(beNil())
     }
@@ -144,7 +144,7 @@ class HTTPRequestTests: TestCase {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
         let request: HTTPRequest = .init(method: .get, path: .getCustomerInfo(appUserID: "user"))
-        let mode = Signing.verificationMode(with: .enforced)
+        let mode = Signing.enforcedVerificationMode()
 
         expect(request.requestAddingNonceIfRequired(with: mode).nonce).toNot(beNil())
     }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -180,6 +180,8 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expect(purchases.publicKey).toNot(beNil())
     }
 
+    // Can't compile this test while `Configuration.EntitlementVerificationMode.enforced` is unavailable.
+    /*
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func testEntitlementVerificationModeEnforcedSetsPublicKey() throws {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
@@ -190,6 +192,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         )
         expect(purchases.publicKey).toNot(beNil())
     }
+    */
 
     func testFirstInitializationCallDelegate() {
         self.setupPurchases()


### PR DESCRIPTION
Depends on #2326 and #2328.

This allows us to keep all the code, except users won't be able to configure the SDK with this option.
Note that `Signing.ResponseVerificationMode.enforced` _is_ available, so we can still test all that behavior, including from integration tests.