### PR TITLE
`IdentityManager`: clear `ETagManager` and `DeviceCache` if verification is enabled but cached `CustomerInfo` is not

### DIFF
--- a/Sources/Logging/Strings/IdentityStrings.swift
+++ b/Sources/Logging/Strings/IdentityStrings.swift
@@ -34,6 +34,8 @@ enum IdentityStrings {
 
     case deleting_attributes_none_found
 
+    case invalidating_cached_customer_info
+
 }
 
 extension IdentityStrings: CustomStringConvertible {
@@ -62,6 +64,8 @@ extension IdentityStrings: CustomStringConvertible {
             return "currentAppUserID is nil. This might happen if the cache in UserDefaults is unintentionally cleared."
         case .deleting_attributes_none_found:
             return "Attempt to delete attributes for user, but there were none to delete"
+        case .invalidating_cached_customer_info:
+            return "Detected unverified cached CustomerInfo but verification is enabled. Invalidating cache."
         }
     }
 

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -143,6 +143,21 @@ extension Backend {
 // - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
 extension Backend: @unchecked Sendable {}
 
+// MARK: - Internal
+
+extension Backend {
+
+    // For testing
+    var networkTimeout: TimeInterval {
+        return self.config.httpClient.timeout
+    }
+
+    @objc var signatureVerificationEnabled: Bool {
+        return self.config.httpClient.signatureVerificationEnabled
+    }
+
+}
+
 extension Backend {
 
     enum QueueProvider {
@@ -154,15 +169,6 @@ extension Backend {
             return operationQueue
         }
 
-    }
-
-}
-
-// Testing extension
-extension Backend {
-
-    var networkTimeout: TimeInterval {
-        return self.config.httpClient.timeout
     }
 
 }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -68,6 +68,10 @@ class HTTPClient {
         self.eTagManager.clearCaches()
     }
 
+    var signatureVerificationEnabled: Bool {
+        return self.systemInfo.responseVerificationMode.isEnabled
+    }
+
 }
 
 extension HTTPClient {

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -173,6 +173,20 @@ class MockBackend: Backend {
         let appUserID: String?
     }
 
+    var invokedClearHTTPClientCaches = false
+    var invokedClearHTTPClientCachesCount = 0
+
+    override func clearHTTPClientCaches() {
+        self.invokedClearHTTPClientCaches = true
+        self.invokedClearHTTPClientCachesCount += 1
+    }
+
+    var stubbedSignatureVerificationEnabled: Bool?
+
+    override var signatureVerificationEnabled: Bool {
+        return self.stubbedSignatureVerificationEnabled ?? super.signatureVerificationEnabled
+    }
+
     static let referenceDate = Date(timeIntervalSinceReferenceDate: 700000000) // 2023-03-08 20:26:40
 
 }

--- a/Tests/UnitTests/Mocks/MockCustomerInfoManager.swift
+++ b/Tests/UnitTests/Mocks/MockCustomerInfoManager.swift
@@ -86,9 +86,9 @@ class MockCustomerInfoManager: CustomerInfoManager {
     var invokedCachedCustomerInfoCount = 0
     var invokedCachedCustomerInfoParameters: (appUserID: String, Void)?
     var invokedCachedCustomerInfoParametersList = [(appUserID: String, Void)]()
-    var stubbedCachedCustomerInfoResult: CustomerInfo!
+    var stubbedCachedCustomerInfoResult: CustomerInfo?
 
-    override func cachedCustomerInfo(appUserID: String) -> CustomerInfo {
+    override func cachedCustomerInfo(appUserID: String) -> CustomerInfo? {
         self.invokedCachedCustomerInfo = true
         self.invokedCachedCustomerInfoCount += 1
         self.invokedCachedCustomerInfoParameters = (appUserID, ())


### PR DESCRIPTION
Android counterpart: https://github.com/RevenueCat/purchases-android/pull/844