### PR TITLE
`ETagManager`: don't ignore failed etags with `Signing.VerificationMode.informational`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -419,6 +419,7 @@
 		57EFDC6B27BC1F370057EC39 /* ProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EFDC6A27BC1F370057EC39 /* ProductType.swift */; };
 		57F2C60C29784C11009EE527 /* SwiftVersionCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F2C60B29784C11009EE527 /* SwiftVersionCheck.swift */; };
 		57F3C10529B7B22E0004FD7E /* CustomerInfo+ActiveDates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57F3C10429B7B22E0004FD7E /* CustomerInfo+ActiveDates.swift */; };
+		57F3C10C29B7EAE90004FD7E /* MockUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E357D16038F07915D7825D /* MockUserDefaults.swift */; };
 		57FD7B1528DA4037009CA4E4 /* PurchasesType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FD7B1428DA4037009CA4E4 /* PurchasesType.swift */; };
 		57FDAA962846BDE2009A48F1 /* PurchasesTransactionHandlingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDAA952846BDE2009A48F1 /* PurchasesTransactionHandlingTests.swift */; };
 		57FDAA9A2846C2BD009A48F1 /* PurchasesDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FDAA992846C2BD009A48F1 /* PurchasesDelegateTests.swift */; };
@@ -2745,6 +2746,7 @@
 				35B745A82711001A00458D46 /* MockManageSubscriptionsHelper.swift in Sources */,
 				2D90F8B126FD1E52009B9142 /* PurchasesOrchestratorTests.swift in Sources */,
 				A563F589271E1DAD00246E0C /* MockBeginRefundRequestHelper.swift in Sources */,
+				57F3C10C29B7EAE90004FD7E /* MockUserDefaults.swift in Sources */,
 				2D90F8B426FD208B009B9142 /* MockStoreKit1Wrapper.swift in Sources */,
 				2D90F8BB26FD20BD009B9142 /* MockIdentityManager.swift in Sources */,
 				A55D083627236F0200D919E0 /* MockSK2BeginRefundRequestHelper.swift in Sources */,

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -369,8 +369,8 @@ private extension HTTPClient {
         if request.httpRequest.path.shouldSendEtag {
             let eTagHeader = self.eTagManager.eTagHeader(
                 for: urlRequest,
-                refreshETag: request.retried,
-                signatureVerificationEnabled: request.httpRequest.nonce != nil
+                withSignatureVerification: request.httpRequest.nonce != nil,
+                refreshETag: request.retried
             )
             return request.headers.merging(eTagHeader)
         } else {

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -264,7 +264,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         }
 
         let receiptFetcher = ReceiptFetcher(requestFetcher: fetcher, systemInfo: systemInfo)
-        let eTagManager = ETagManager()
+        let eTagManager = ETagManager(verificationMode: systemInfo.responseVerificationMode)
         let attributionTypeFactory = AttributionTypeFactory()
         let attributionFetcher = AttributionFetcher(attributionFactory: attributionTypeFactory, systemInfo: systemInfo)
         let backend = Backend(apiKey: apiKey,

--- a/Sources/Security/Signing.swift
+++ b/Sources/Security/Signing.swift
@@ -135,6 +135,13 @@ extension Signing {
             }
         }
 
+        var isEnforced: Bool {
+            switch self {
+            case .disabled, .informational: return false
+            case .enforced: return true
+            }
+        }
+
     }
 
 }

--- a/Tests/UnitTests/Mocks/MockETagManager.swift
+++ b/Tests/UnitTests/Mocks/MockETagManager.swift
@@ -13,10 +13,14 @@ import Foundation
 // swiftlint:disable type_name
 class MockETagManager: ETagManager {
 
+    init() {
+        super.init(userDefaults: MockUserDefaults(), verificationMode: .default)
+    }
+
     struct ETagHeaderRequest {
         var urlRequest: URLRequest
+        var withSignatureVerification: Bool
         var refreshETag: Bool
-        var signatureVerificationEnabled: Bool
     }
 
     var invokedETagHeader = false
@@ -31,13 +35,13 @@ class MockETagManager: ETagManager {
 
     override func eTagHeader(
         for urlRequest: URLRequest,
-        refreshETag: Bool = false,
-        signatureVerificationEnabled: Bool
+        withSignatureVerification: Bool,
+        refreshETag: Bool = false
     ) -> [String: String] {
         return self.lock.perform {
             let request: ETagHeaderRequest = .init(urlRequest: urlRequest,
-                                                   refreshETag: refreshETag,
-                                                   signatureVerificationEnabled: signatureVerificationEnabled)
+                                                   withSignatureVerification: withSignatureVerification,
+                                                   refreshETag: refreshETag)
 
             self.invokedETagHeader = true
             self.invokedETagHeaderCount += 1

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -75,7 +75,7 @@ class BaseBackendTests: TestCase {
 extension BaseBackendTests {
 
     final func createClient(_ file: StaticString) -> MockHTTPClient {
-        let eTagManager = MockETagManager(userDefaults: MockUserDefaults())
+        let eTagManager = MockETagManager()
 
         return MockHTTPClient(apiKey: Self.apiKey,
                               systemInfo: self.systemInfo,

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -20,15 +20,13 @@ class BaseHTTPClientTests: TestCase {
     fileprivate let apiKey = "MockAPIKey"
     fileprivate var systemInfo = MockSystemInfo(finishTransactions: true)
     fileprivate var client: HTTPClient!
-    fileprivate var userDefaults: UserDefaults!
     fileprivate var eTagManager: MockETagManager!
     fileprivate var operationDispatcher: OperationDispatcher!
 
     override func setUp() {
         super.setUp()
 
-        self.userDefaults = MockUserDefaults()
-        self.eTagManager = MockETagManager(userDefaults: self.userDefaults)
+        self.eTagManager = MockETagManager()
         self.operationDispatcher = OperationDispatcher()
         MockDNSChecker.resetData()
         MockSigning.resetData()
@@ -975,7 +973,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         expect(response?.value?.verificationResult) == .notRequested
 
         expect(self.eTagManager.invokedETagHeaderParametersList).to(haveCount(1))
-        expect(self.eTagManager.invokedETagHeaderParameters?.signatureVerificationEnabled) == false
+        expect(self.eTagManager.invokedETagHeaderParameters?.withSignatureVerification) == false
     }
 
     func testDNSCheckerIsCalledWhenGETRequestFailedWithUnknownError() {
@@ -1536,8 +1534,8 @@ final class SignatureVerificationHTTPClientTests: BaseHTTPClientTests {
         }
 
         expect(self.eTagManager.invokedETagHeaderParametersList).to(haveCount(1))
+        expect(self.eTagManager.invokedETagHeaderParameters?.withSignatureVerification) == true
         expect(self.eTagManager.invokedETagHeaderParameters?.refreshETag) == false
-        expect(self.eTagManager.invokedETagHeaderParameters?.signatureVerificationEnabled) == true
 
         expect(response).toNot(beNil())
         expect(response?.value?.statusCode) == .success

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -377,12 +377,11 @@ class BackendSubscriberAttributesTests: TestCase {
     }
 
     final func createClient(_ file: StaticString) -> MockHTTPClient {
-        let eTagManager = MockETagManager(userDefaults: MockUserDefaults())
-        self.mockETagManager = eTagManager
+        self.mockETagManager = MockETagManager()
 
         return MockHTTPClient(apiKey: Self.apiKey,
                               systemInfo: self.systemInfo,
-                              eTagManager: eTagManager,
+                              eTagManager: self.mockETagManager,
                               sourceTestFile: file)
     }
 


### PR DESCRIPTION
Essentially we don't want to modify any behavior on `.informational` mode. Everything will continue behaving normally, and simply report verification failures.