### PR TITLE
`AppleReceipt.mostRecentActiveSubscription`: performance optimization

### DIFF
--- a/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
@@ -107,8 +107,7 @@ extension AppleReceipt {
         return self.inAppPurchases
             .lazy
             .filter { $0.isActiveSubscription }
-            .sorted { $0.purchaseDate > $1.purchaseDate }
-            .first
+            .min { $0.purchaseDate > $1.purchaseDate }
     }
 
 }


### PR DESCRIPTION
No need to sort the entire list of subscriptions
