### PR TITLE
Finished signature verification `HTTPClient` tests

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -230,6 +230,7 @@
 		5744D8AB28E3B86600646735 /* AppleReceiptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5744D8AA28E3B86600646735 /* AppleReceiptTests.swift */; };
 		5746508C27586B2E0053AB09 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5746508B27586B2E0053AB09 /* Result+Extensions.swift */; };
 		5746508E275949F20053AB09 /* DispatchTimeInterval+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5746508D275949F20053AB09 /* DispatchTimeInterval+Extensions.swift */; };
+		5748008C29BFC6660032F001 /* SignatureVerificationHTTPClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5748008B29BFC6660032F001 /* SignatureVerificationHTTPClientTests.swift */; };
 		574A2EE7282C3F0800150D40 /* AnyDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574A2EE6282C3F0800150D40 /* AnyDecodable.swift */; };
 		574A2EE9282C403800150D40 /* AnyDecodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574A2EE8282C403800150D40 /* AnyDecodableTests.swift */; };
 		574A2F3F282D75E300150D40 /* OfferingsDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 574A2F3E282D75E300150D40 /* OfferingsDecodingTests.swift */; };
@@ -853,6 +854,7 @@
 		5744D8AA28E3B86600646735 /* AppleReceiptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleReceiptTests.swift; sourceTree = "<group>"; };
 		5746508B27586B2E0053AB09 /* Result+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Extensions.swift"; sourceTree = "<group>"; };
 		5746508D275949F20053AB09 /* DispatchTimeInterval+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchTimeInterval+Extensions.swift"; sourceTree = "<group>"; };
+		5748008B29BFC6660032F001 /* SignatureVerificationHTTPClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignatureVerificationHTTPClientTests.swift; sourceTree = "<group>"; };
 		574A2EE6282C3F0800150D40 /* AnyDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyDecodable.swift; sourceTree = "<group>"; };
 		574A2EE8282C403800150D40 /* AnyDecodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyDecodableTests.swift; sourceTree = "<group>"; };
 		574A2F3E282D75E300150D40 /* OfferingsDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfferingsDecodingTests.swift; sourceTree = "<group>"; };
@@ -1808,6 +1810,7 @@
 				5796A38427D6B83C00653165 /* Backend */,
 				5774F9BF2805EA1200997128 /* Responses */,
 				37E353CBE9CF2572A72A347F /* HTTPClientTests.swift */,
+				5748008B29BFC6660032F001 /* SignatureVerificationHTTPClientTests.swift */,
 				35D832FF262FAD8000E60AC5 /* ETagManagerTests.swift */,
 				B380D69A27726AB500984578 /* DNSCheckerTests.swift */,
 				576C8AD827D2BCB90058FA6E /* HTTPRequestTests.swift */,
@@ -3107,6 +3110,7 @@
 				57D04BB827D947C6006DAC06 /* HTTPResponseTests.swift in Sources */,
 				5796A38127D6B78500653165 /* BaseBackendTest.swift in Sources */,
 				351B516226D44BEE00BD2BD7 /* CustomerInfoManagerTests.swift in Sources */,
+				5748008C29BFC6660032F001 /* SignatureVerificationHTTPClientTests.swift in Sources */,
 				351B51A326D450BC00BD2BD7 /* DictionaryExtensionsTests.swift in Sources */,
 				573A10D92800ADCD00F976E5 /* StoreKitErrorTests.swift in Sources */,
 				5766AABF283E80B500FA6091 /* BasePurchasesTests.swift in Sources */,

--- a/Sources/Security/VerificationResult.swift
+++ b/Sources/Security/VerificationResult.swift
@@ -83,7 +83,7 @@ extension VerificationResult {
         case (.verified, .notRequested): return .notRequested
         case (.verified, .failed): return .failed
 
-        case (.notRequested, .verified): return .notRequested
+        case (.notRequested, .verified): return .verified
         case (.notRequested, .failed): return .failed
 
         case (.failed, .notRequested): return .notRequested

--- a/Sources/Security/VerificationResult.swift
+++ b/Sources/Security/VerificationResult.swift
@@ -83,14 +83,11 @@ extension VerificationResult {
         case (.verified, .notRequested): return .notRequested
         case (.verified, .failed): return .failed
 
-        // These shouldn't happen because `ETagManager` will ignore not verified cached responses
-        // if verification is enabled.
         case (.notRequested, .verified): return .notRequested
         case (.notRequested, .failed): return .failed
 
-        // These shouldn't happen because `ETagManager` won't store responses with failed verification.
-        case (.failed, .notRequested): return .failed
-        case (.failed, .verified): return .failed
+        case (.failed, .notRequested): return .notRequested
+        case (.failed, .verified): return .verified
         }
     }
 

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -1,0 +1,621 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SignatureVerificationHTTPClientTests.swift
+//
+//  Created by Nacho Soto on 3/13/23.
+
+import Nimble
+import OHHTTPStubs
+import OHHTTPStubsSwift
+import XCTest
+
+@testable import RevenueCat
+
+// swiftlint:disable type_name
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+class BaseSignatureVerificationHTTPClientTests: BaseHTTPClientTests {
+
+    override func setUpWithError() throws {
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
+        try super.setUpWithError()
+    }
+
+    fileprivate static let path: HTTPRequest.Path = .mockPath
+    fileprivate static let eTag = "etag"
+    fileprivate static let sampleSignature = "signature"
+    fileprivate static let date1 = Date().addingTimeInterval(-30000000)
+    fileprivate static let date2 = Date().addingTimeInterval(-1000000)
+
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPClientTests {
+
+    func testAutomaticallyAddsNonceIfRequired() throws {
+        try self.changeClient(.informational)
+
+        let request = HTTPRequest(method: .get, path: .getCustomerInfo(appUserID: "user"))
+
+        let headers: [String: String]? = waitUntilValue { completion in
+            stub(condition: isPath(request.path)) { request in
+                completion(request.allHTTPHeaderFields)
+                return .emptySuccessResponse()
+            }
+
+            self.client.perform(request) { (_: EmptyResponse) in }
+        }
+
+        expect(headers).toNot(beEmpty())
+        expect(headers?.keys).to(contain(HTTPClient.RequestHeader.nonce.rawValue))
+        expect(headers?[HTTPClient.RequestHeader.nonce.rawValue]).toNot(beNil())
+    }
+
+    func testRequestIncludesRandomNonce() throws {
+        let request = HTTPRequest.createWithResponseVerification(method: .get, path: Self.path)
+
+        let headers: [String: String]? = waitUntilValue { completion in
+            stub(condition: isPath(request.path)) { request in
+                completion(request.allHTTPHeaderFields)
+                return .emptySuccessResponse()
+            }
+
+            self.client.perform(request) { (_: EmptyResponse) in }
+        }
+
+        expect(headers).toNot(beEmpty())
+        expect(headers?.keys).to(contain(HTTPClient.RequestHeader.nonce.rawValue))
+        expect(headers?[HTTPClient.RequestHeader.nonce.rawValue]) == request.nonce?.base64EncodedString()
+    }
+
+    func testFailedVerificationIfResponseContainsNoSignature() throws {
+        let logger = TestLogHandler()
+
+        try self.changeClient(.informational)
+        self.mockResponse()
+
+        MockSigning.stubbedVerificationResult = true
+
+        let request: HTTPRequest = .createWithResponseVerification(method: .get, path: Self.path)
+        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+            self.client.perform(request, completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.verificationResult) == .failed
+        expect(MockSigning.requests).to(beEmpty())
+
+        logger.verifyMessageWasLogged(
+            Strings.signing.signature_was_requested_but_not_provided(request),
+            level: .warn
+        )
+    }
+
+    func testHeadersAreCaseInsensitive() throws {
+        try self.changeClient(.informational)
+
+        stub(condition: isPath(Self.path)) { _ in
+            return .init(data: Data(),
+                         statusCode: .success,
+                         headers: [
+                            "x-signature": "signature",
+                            "x-revenuecat-request-time": String(Date().millisecondsSince1970)
+                         ])
+        }
+
+        MockSigning.stubbedVerificationResult = true
+
+        let request: HTTPRequest = .createWithResponseVerification(method: .get, path: Self.path)
+
+        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+            self.client.perform(request, completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.verificationResult) == .verified
+    }
+
+    func testSignatureNotRequested() throws {
+        try self.changeClient(.disabled)
+        self.mockResponse()
+
+        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+            self.client.perform(.init(method: .get, path: Self.path), completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.verificationResult) == .notRequested
+
+        expect(MockSigning.requests).to(beEmpty())
+    }
+
+    func testVerifiedCachedResponseWithNotRequestedVerificationResponse() throws {
+        try self.changeClient(.disabled)
+
+        let cachedResponse = BodyWithDate(data: "test", requestDate: Self.date1)
+
+        try self.mockETagCache(
+            response: cachedResponse,
+            requestDate: Self.date1,
+            verificationResult: .verified
+        )
+        self.mockPath(statusCode: .notModified, requestDate: Self.date2)
+
+        let response: HTTPResponse<BodyWithDate>.Result? = waitUntilValue { completion in
+            self.client.perform(.createWithResponseVerification(method: .get, path: Self.path),
+                                completionHandler: completion)
+        }
+
+        expect(MockSigning.requests).to(beEmpty())
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.body.data) == cachedResponse.data
+        expect(response?.value?.body.requestDate).to(beCloseTo(Self.date1, within: 1))
+        expect(response?.value?.verificationResult) == .notRequested
+    }
+
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPClientTests {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        try self.changeClient(.informational)
+    }
+
+    func testValidSignature() throws {
+        let body = "body".asData
+
+        self.mockResponse(signature: Self.sampleSignature,
+                          requestDate: Self.date2,
+                          body: body)
+        MockSigning.stubbedVerificationResult = true
+
+        let request: HTTPRequest = .createWithResponseVerification(method: .get, path: Self.path)
+
+        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+            self.client.perform(request, completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.verificationResult) == .verified
+
+        expect(MockSigning.requests).to(haveCount(1))
+        let signingRequest = try XCTUnwrap(MockSigning.requests.onlyElement)
+
+        expect(signingRequest.parameters.message) == body
+        expect(signingRequest.parameters.nonce) == request.nonce
+        expect(signingRequest.parameters.requestDate) == Self.date2.millisecondsSince1970
+        expect(signingRequest.signature) == Self.sampleSignature
+        expect(signingRequest.publicKey).toNot(beNil())
+    }
+
+    func testPerformRequestOverridesVerificationMode() throws {
+        self.mockPath(statusCode: .success, requestDate: Self.date1)
+
+        MockSigning.stubbedVerificationResult = false
+
+        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+            self.client.perform(.createWithResponseVerification(method: .get, path: .logIn),
+                                with: Signing.verificationMode(with: .informational),
+                                completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.verificationResult) == .failed
+    }
+
+    func testValidSignatureWithETagResponse() throws {
+        let body = "body".asData
+
+        self.mockPath(statusCode: .notModified, requestDate: Self.date1)
+        MockSigning.stubbedVerificationResult = true
+
+        self.eTagManager.shouldReturnResultFromBackend = false
+        self.eTagManager.stubbedHTTPResultFromCacheOrBackendResult = .init(
+            statusCode: .success,
+            responseHeaders: [:],
+            body: body,
+            verificationResult: .verified
+        )
+
+        let request: HTTPRequest = .createWithResponseVerification(method: .get, path: Self.path)
+
+        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+            self.client.perform(request, completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.verificationResult) == .verified
+        expect(response?.value?.body) == body
+
+        expect(MockSigning.requests).to(haveCount(1))
+        let signingRequest = try XCTUnwrap(MockSigning.requests.onlyElement)
+
+        expect(signingRequest.parameters.message) == Self.eTag.asData
+        expect(signingRequest.parameters.nonce) == request.nonce
+        expect(signingRequest.parameters.requestDate) == Self.date1.millisecondsSince1970
+        expect(signingRequest.signature) == Self.sampleSignature
+        expect(signingRequest.publicKey).toNot(beNil())
+    }
+
+    func testIncorrectSignatureReturnsResponse() throws {
+        self.mockPath(statusCode: .success, requestDate: Self.date1)
+
+        MockSigning.stubbedVerificationResult = false
+
+        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+            self.client.perform(.createWithResponseVerification(method: .get, path: Self.path),
+                                completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.verificationResult) == .failed
+        expect(MockSigning.requests).to(haveCount(1))
+    }
+
+    func testIgnoresResponseFromETagManagerIfItHadNotBeenVerified() throws {
+        MockSigning.stubbedVerificationResult = true
+
+        stub(condition: isPath(Self.path)) { request in
+            expect(request.allHTTPHeaderFields?.keys).toNot(contain(ETagManager.eTagResponseHeaderName))
+
+            return .init(data: Data(),
+                         statusCode: .success,
+                         headers: [
+                            HTTPClient.ResponseHeader.signature.rawValue: Self.sampleSignature,
+                            HTTPClient.ResponseHeader.requestDate.rawValue: String(Self.date1.millisecondsSince1970)
+                         ])
+        }
+
+        self.eTagManager.shouldReturnResultFromBackend = true
+
+        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+            self.client.perform(
+                .createWithResponseVerification(method: .get, path: Self.path)
+            ) { (result: HTTPResponse<Data>.Result) in
+                completion(result)
+            }
+        }
+
+        expect(self.eTagManager.invokedETagHeaderParametersList).to(haveCount(1))
+        expect(self.eTagManager.invokedETagHeaderParameters?.withSignatureVerification) == true
+        expect(self.eTagManager.invokedETagHeaderParameters?.refreshETag) == false
+
+        expect(response).toNot(beNil())
+        expect(response?.value?.statusCode) == .success
+        expect(response?.value?.verificationResult) == .verified
+    }
+
+    func testCachedResponseDoesNotUpdateRequestDateIfNewResponseVerificationFails() throws {
+        let cachedResponse = BodyWithDate(data: "test", requestDate: Self.date1)
+
+        try self.mockETagCache(response: cachedResponse,
+                               requestDate: Self.date1,
+                               verificationResult: .notRequested)
+        self.mockPath(statusCode: .notModified, requestDate: Self.date2)
+        MockSigning.stubbedVerificationResult = false
+
+        let response: HTTPResponse<BodyWithDate>.Result? = waitUntilValue { completion in
+            self.client.perform(.createWithResponseVerification(method: .get, path: Self.path),
+                                completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.body.data) == cachedResponse.data
+        expect(response?.value?.body.requestDate).to(beCloseTo(cachedResponse.requestDate, within: 1))
+        expect(response?.value?.verificationResult) == .failed
+    }
+
+    func testNotModifiedResponseFailedVerification() throws {
+        let cachedResponse = BodyWithDate(data: "test", requestDate: Self.date1)
+
+        try self.mockETagCache(response: cachedResponse,
+                               requestDate: Self.date2,
+                               verificationResult: .verified)
+        self.mockPath(statusCode: .notModified, requestDate: Self.date2)
+
+        MockSigning.stubbedVerificationResult = false
+
+        let response: HTTPResponse<BodyWithDate>.Result? = waitUntilValue { completion in
+            self.client.perform(.createWithResponseVerification(method: .get, path: Self.path),
+                                completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.body.data) == cachedResponse.data
+        expect(response?.value?.body.requestDate).to(beCloseTo(cachedResponse.requestDate, within: 1))
+        expect(response?.value?.verificationResult) == .failed
+    }
+
+    func testCachedResponseUpdatesRequestDateIfNewResponseIsVerified() throws {
+        let cachedResponse = BodyWithDate(data: "test", requestDate: Self.date1)
+
+        MockSigning.stubbedVerificationResult = true
+        try self.mockETagCache(response: cachedResponse,
+                               requestDate: Self.date2,
+                               verificationResult: .verified)
+        self.mockPath(statusCode: .notModified, requestDate: Self.date2)
+
+        let response: HTTPResponse<BodyWithDate>.Result? = waitUntilValue { completion in
+            self.client.perform(.createWithResponseVerification(method: .get, path: Self.path),
+                                completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.body.requestDate).to(beCloseTo(Self.date2, within: 1))
+        expect(response?.value?.verificationResult) == .verified
+    }
+
+    func testCachedResponseWithFailedVerificationAndNotRequestedVerification() throws {
+        let cachedResponse = BodyWithDate(data: "test", requestDate: Self.date1)
+
+        try self.mockETagCache(response: cachedResponse,
+                               requestDate: Self.date2,
+                               verificationResult: .failed)
+        self.mockPath(statusCode: .notModified, requestDate: Self.date2)
+
+        let response: HTTPResponse<BodyWithDate>.Result? = waitUntilValue { completion in
+            self.client.perform(.init(method: .get, path: .getOfferings(appUserID: "user")),
+                                completionHandler: completion)
+        }
+
+        expect(MockSigning.requests).to(beEmpty())
+        expect(response).to(beSuccess())
+        expect(response?.value?.body.requestDate).to(beCloseTo(Self.date2, within: 1))
+        expect(response?.value?.verificationResult) == .notRequested
+    }
+
+    func testCachedResponseWithFailedVerificationAndVerifiedResponse() throws {
+        let cachedResponse = BodyWithDate(data: "test", requestDate: Self.date1)
+
+        try self.mockETagCache(response: cachedResponse,
+                               requestDate: Self.date2,
+                               verificationResult: .failed)
+        self.mockPath(statusCode: .notModified, requestDate: Self.date2)
+        MockSigning.stubbedVerificationResult = true
+
+        let response: HTTPResponse<BodyWithDate>.Result? = waitUntilValue { completion in
+            self.client.perform(.init(method: .get, path: Self.path),
+                                completionHandler: completion)
+        }
+
+        expect(MockSigning.requests).to(haveCount(1))
+        expect(response).to(beSuccess())
+        expect(response?.value?.body.requestDate).to(beCloseTo(Self.date2, within: 1))
+        expect(response?.value?.verificationResult) == .verified
+    }
+
+    func testCachedResponseWithFailedVerificationAndFailedResponse() throws {
+        let cachedResponse = BodyWithDate(data: "test", requestDate: Self.date1)
+
+        try self.mockETagCache(response: cachedResponse,
+                               requestDate: Self.date2,
+                               verificationResult: .failed)
+        self.mockPath(statusCode: .notModified, requestDate: Self.date2)
+        MockSigning.stubbedVerificationResult = false
+
+        let response: HTTPResponse<BodyWithDate>.Result? = waitUntilValue { completion in
+            self.client.perform(.init(method: .get, path: Self.path),
+                                completionHandler: completion)
+        }
+
+        expect(MockSigning.requests).to(haveCount(1))
+        expect(response).to(beSuccess())
+        expect(response?.value?.body.requestDate).to(beCloseTo(Self.date1, within: 1))
+        expect(response?.value?.verificationResult) == .failed
+    }
+
+    func testIgnoredCachedResponseAndNotVerifiedResponse() throws {
+        let cachedResponse = BodyWithDate(data: "test", requestDate: Self.date1)
+
+        try self.mockETagCache(response: cachedResponse,
+                               requestDate: Self.date2,
+                               verificationResult: .failed)
+        self.mockPath(statusCode: .success, requestDate: Self.date2)
+
+        let response: HTTPResponse<BodyWithDate>.Result? = waitUntilValue { completion in
+            self.client.perform(.init(method: .get, path: .getOfferings(appUserID: "user")),
+                                completionHandler: completion)
+        }
+
+        expect(MockSigning.requests).to(beEmpty())
+        expect(response).to(beSuccess())
+        expect(response?.value?.body.requestDate).to(beCloseTo(Self.date2, within: 1))
+        expect(response?.value?.verificationResult) == .notRequested
+    }
+
+    func testIgnoredCachedResponseAndVerifiedResponse() throws {
+        let cachedResponse = BodyWithDate(data: "test", requestDate: Self.date1)
+
+        try self.mockETagCache(response: cachedResponse,
+                               requestDate: Self.date2,
+                               verificationResult: .failed)
+        self.mockPath(statusCode: .success, requestDate: Self.date2)
+        MockSigning.stubbedVerificationResult = true
+
+        let response: HTTPResponse<BodyWithDate>.Result? = waitUntilValue { completion in
+            self.client.perform(.init(method: .get, path: Self.path),
+                                completionHandler: completion)
+        }
+
+        expect(MockSigning.requests).to(haveCount(1))
+        expect(response).to(beSuccess())
+        expect(response?.value?.body.requestDate).to(beCloseTo(Self.date2, within: 1))
+        expect(response?.value?.verificationResult) == .verified
+    }
+
+    func testIgnoredCachedResponseWithFailedVerificationAndFailedResponse() throws {
+        let cachedResponse = BodyWithDate(data: "test", requestDate: Self.date1)
+
+        try self.mockETagCache(response: cachedResponse,
+                               requestDate: Self.date2,
+                               verificationResult: .failed)
+        self.mockPath(statusCode: .success, requestDate: Self.date2)
+        MockSigning.stubbedVerificationResult = false
+
+        let response: HTTPResponse<BodyWithDate>.Result? = waitUntilValue { completion in
+            self.client.perform(.init(method: .get, path: Self.path),
+                                completionHandler: completion)
+        }
+
+        expect(MockSigning.requests).to(haveCount(1))
+        expect(response).to(beSuccess())
+        expect(response?.value?.body.requestDate).to(beCloseTo(Self.date1, within: 1))
+        expect(response?.value?.verificationResult) == .failed
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPClientTests {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        try self.changeClientToEnforced()
+    }
+
+    func testValidSignature() throws {
+        self.mockResponse(signature: Self.sampleSignature, requestDate: Self.date1)
+
+        MockSigning.stubbedVerificationResult = true
+
+        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+            self.client.perform(.createWithResponseVerification(method: .get, path: Self.path),
+                                completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.verificationResult) == .verified
+        expect(MockSigning.requests).to(haveCount(1))
+    }
+
+    func testIncorrectSignatureReturnsError() throws {
+        self.mockResponse(signature: Self.sampleSignature, requestDate: Self.date1)
+
+        MockSigning.stubbedVerificationResult = false
+
+        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+            self.client.perform(.createWithResponseVerification(method: .get, path: Self.path),
+                                completionHandler: completion)
+        }
+
+        expect(response).to(beFailure())
+        expect(response?.error).to(matchError(NetworkError.signatureVerificationFailed(path: Self.path)))
+    }
+
+    func testPerformRequestOverridesIt() throws {
+        self.mockResponse(signature: Self.sampleSignature, requestDate: Self.date1)
+
+        MockSigning.stubbedVerificationResult = false
+
+        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+            self.client.perform(.createWithResponseVerification(method: .get, path: .logIn),
+                                with: Signing.enforcedVerificationMode(),
+                                completionHandler: completion)
+        }
+
+        expect(response).to(beFailure())
+        expect(response?.error).to(matchError(NetworkError.signatureVerificationFailed(path: Self.path)))
+    }
+
+    func testPerformRequestWithDisabledModeOverridesIt() throws {
+        self.mockResponse(signature: Self.sampleSignature, requestDate: Self.date1)
+
+        MockSigning.stubbedVerificationResult = false
+
+        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+            self.client.perform(.createWithResponseVerification(method: .get, path: Self.path),
+                                with: .disabled,
+                                completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+    }
+
+}
+
+// MARK: - Private
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+private extension BaseSignatureVerificationHTTPClientTests {
+
+    final func changeClient(_ verificationMode: Configuration.EntitlementVerificationMode) throws {
+        try self.createClient(Signing.verificationMode(with: verificationMode))
+    }
+
+    final func changeClientToEnforced() throws {
+        try self.createClient(Signing.enforcedVerificationMode())
+    }
+
+    private final func createClient(_ mode: Signing.ResponseVerificationMode) throws {
+        self.systemInfo = try MockSystemInfo(platformInfo: nil,
+                                             finishTransactions: false,
+                                             responseVerificationMode: mode)
+        self.client = self.createClient()
+    }
+
+    final func mockResponse() {
+        self.mockResponse(signature: nil, requestDate: nil)
+    }
+
+    final func mockResponse(
+        signature: String?,
+        requestDate: Date?,
+        eTag: String? = nil,
+        body: Data = .init(),
+        statusCode: HTTPStatusCode = .success
+    ) {
+        stub(condition: isPath(Self.path)) { _ in
+            if let signature = signature, let requestDate = requestDate {
+                let headers: [String: String?] = [
+                    HTTPClient.ResponseHeader.signature.rawValue: signature,
+                    HTTPClient.ResponseHeader.eTag.rawValue: eTag,
+                    HTTPClient.ResponseHeader.requestDate.rawValue: String(requestDate.millisecondsSince1970)
+                ]
+
+                return .init(data: body,
+                             statusCode: statusCode,
+                             headers: headers.compactMapValues { $0 })
+            } else {
+                return .emptySuccessResponse()
+            }
+        }
+    }
+
+    final func mockETagCache(response: BodyWithDate,
+                             requestDate: Date,
+                             verificationResult: VerificationResult) throws {
+        self.eTagManager.stubResponseEtag(Self.eTag)
+        self.eTagManager.shouldReturnResultFromBackend = false
+        self.eTagManager.stubbedHTTPResultFromCacheOrBackendResult = .init(
+            statusCode: .success,
+            responseHeaders: [
+                HTTPClient.ResponseHeader.requestDate.rawValue: String(requestDate.millisecondsSince1970)
+            ],
+            body: try response.asJSONEncodedData(),
+            verificationResult: verificationResult
+        )
+    }
+
+    func mockPath(statusCode: HTTPStatusCode, requestDate: Date) {
+        self.mockResponse(
+            signature: Self.sampleSignature,
+            requestDate: requestDate,
+            eTag: Self.eTag,
+            body: .init(),
+            statusCode: statusCode
+        )
+    }
+
+}

--- a/Tests/UnitTests/Security/SigningTests.swift
+++ b/Tests/UnitTests/Security/SigningTests.swift
@@ -316,9 +316,9 @@ class SigningTests: TestCase {
 
     func testFailedVerificationCachedResult() {
         expect(VerificationResult.from(cache: .failed,
-                                       response: .notRequested)) == .failed
+                                       response: .notRequested)) == .notRequested
         expect(VerificationResult.from(cache: .failed,
-                                       response: .verified)) == .failed
+                                       response: .verified)) == .verified
     }
 
 }

--- a/Tests/UnitTests/Security/SigningTests.swift
+++ b/Tests/UnitTests/Security/SigningTests.swift
@@ -302,7 +302,7 @@ class SigningTests: TestCase {
 
     func testVerificationNotRequestedCachedResult() {
         expect(VerificationResult.from(cache: .notRequested,
-                                       response: .verified)) == .notRequested
+                                       response: .verified)) == .verified
         expect(VerificationResult.from(cache: .notRequested,
                                        response: .failed)) == .failed
     }


### PR DESCRIPTION
See https://docs.google.com/spreadsheets/d/1kNcFNB8U47N5_vm8Ww57izMgdp60mdzUxZFK-cm46KU/edit#gid=0
<img width="585" alt="Screenshot 2023-03-13 at 15 59 42" src="https://user-images.githubusercontent.com/685609/224851071-ea150f7c-e282-4234-bbe2-b404da12208a.png">

### Changes:
- Extracted signature verification `HTTPClient` tests into a separate file
- Added helper stubbing methods to simplify tests
- Created `InformationalSignatureVerificationHTTPClientTests` and `EnforcedSignatureVerificationHTTPClientTests`
- Changed `VerificationResult.from(cache:response:)` to match new expected tests
- Finished coverage for `ResponseVerificationMode.informational` tests