### PR TITLE
`RELEASING.md`: added GitHub rate limiting parameter

### DIFF
--- a/Contributing/RELEASING.md
+++ b/Contributing/RELEASING.md
@@ -1,6 +1,6 @@
 #### Releasing:
 1. Create a `fastlane/.env` file with your GitHub API token (see `fastlane/.env.SAMPLE`). This will be used to create the PR, so you should use your own token so the PR gets assigned to you.
-2. Run `bundle exec fastlane ios bump`
+2. Run `bundle exec fastlane ios bump github_rate_limit:10`
     1. Confirm base branch is correct
     2. Input new version number
     3. Update CHANGELOG.latest.md to include the latest changes. Call out API changes (if any). You can use the existing CHANGELOG.md as a base for formatting. To compile the changelog, you can compare the changes between the base branch for the release (usually main) against the latest release, by checking https://github.com/revenuecat/purchases-ios/compare/<latest_release>...<base_branch>. For example, https://github.com/revenuecat/purchases-ios/compare/4.1.0...main.


### PR DESCRIPTION
This is necessary to avoid rate limiting errors.
