### PR TITLE
`Purchases.deinit`: don't reset `Purchases.proxyURL`

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -490,7 +490,6 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.paymentQueueWrapper.sk2Wrapper?.delegate = nil
         self.customerInfoObservationDisposable?()
         self.privateDelegate = nil
-        Self.proxyURL = nil
     }
 
     static func clearSingleton() {


### PR DESCRIPTION
This was breaking `PurchaseTester`. This property is global for all `Purchases` instances (it's `static`), so resetting it here meant that when re-initializing the SDK, depending on when the old instance was deallocated, the new proxy URL was being reset.

Example:
```swift
Purchases.proxyURL = customURL
Purchases.configure(...)

// Later on, reconfiguring. Not something users should really do
// But this would have unknowingly reset `Purchases.proxyURL` back to `nil`
Purchases.configure(...)
```