### PR TITLE
`ETagManager`: don't use ETags if response verification failed

### DIFF
--- a/Sources/Networking/HTTPClient/ETagManager.swift
+++ b/Sources/Networking/HTTPClient/ETagManager.swift
@@ -147,7 +147,7 @@ private extension ETagManager {
     }
 
     var shouldIgnoreVerificationErrors: Bool {
-        return !self.verificationMode.isEnforced
+        return !self.verificationMode.isEnabled
     }
 
     static let suiteNameBase: String  = "revenuecat.etags"

--- a/Sources/Security/VerificationResult.swift
+++ b/Sources/Security/VerificationResult.swift
@@ -86,6 +86,9 @@ extension VerificationResult {
         case (.notRequested, .failed): return .failed
 
         case (.failed, .notRequested): return .notRequested
+        // If the cache verification failed, the etag won't be used
+        // so the response would only be a 200 and not 304.
+        // Therefore the cache verification error can be ignored
         case (.failed, .verified): return .verified
         }
     }

--- a/Tests/UnitTests/Networking/ETagManagerTests.swift
+++ b/Tests/UnitTests/Networking/ETagManagerTests.swift
@@ -221,7 +221,7 @@ class ETagManagerTests: TestCase {
         expect(self.mockUserDefaults.mockValues[cacheKey]).to(beNil())
     }
 
-    func testResponseIsStoredIfVerificationFailedWithInformationalMode() throws {
+    func testResponseIsNotStoredIfVerificationFailedWithInformationalMode() throws {
         self.eTagManager = self.create(with: .informational)
 
         let eTag = "an_etag"
@@ -242,19 +242,8 @@ class ETagManagerTests: TestCase {
         )
 
         expect(response).toNot(beNil())
-        expect(self.mockUserDefaults.setObjectForKeyCallCount) == 1
-
-        let cacheKey = url.absoluteString
-        expect(self.mockUserDefaults.mockValues[cacheKey]).toNot(beNil())
-        let setData = try XCTUnwrap(self.mockUserDefaults.mockValues[cacheKey] as? Data)
-
-        expect(setData).toNot(beNil())
-        let expectedCachedValue = "https://api.revenuecat.com/v1/subscribers/appUserID"
-        expect(self.mockUserDefaults.setObjectForKeyCalledValue) == expectedCachedValue
-
-        let eTagResponse = try ETagManager.Response.with(setData)
-        expect(eTagResponse.eTag) == eTag
-        expect(eTagResponse.data) == responseObject
+        expect(self.mockUserDefaults.setObjectForKeyCallCount) == 0
+        expect(self.mockUserDefaults.mockValues[url.absoluteString]).to(beNil())
     }
 
     func testResponseIsNotStoredIfVerificationFailedWithEnforcedMode() throws {
@@ -365,7 +354,7 @@ class ETagManagerTests: TestCase {
         expect(response[ETagManager.eTagResponseHeaderName]).to(beEmpty())
     }
 
-    func testETagHeaderIsFoundIfItsMissingResponseVerificationAndVerificationInformational() {
+    func testETagHeaderIsNotFoundIfItsMissingResponseVerificationAndVerificationInformational() {
         self.eTagManager = self.create(with: .informational)
 
         let eTag = "the_etag"
@@ -385,7 +374,7 @@ class ETagManagerTests: TestCase {
 
         let response = self.eTagManager.eTagHeader(for: request,
                                                    withSignatureVerification: true)
-        expect(response[ETagManager.eTagResponseHeaderName]).toNot(beEmpty())
+        expect(response[ETagManager.eTagResponseHeaderName]).to(beEmpty())
     }
 
     func testETagHeaderIsFoundIfItsMissingResponseVerificationAndVerificationIsDisabled() {
@@ -430,7 +419,7 @@ class ETagManagerTests: TestCase {
         expect(response[ETagManager.eTagResponseHeaderName]).to(beEmpty())
     }
 
-    func testETagHeaderIsNotIgnoredIfVerificationFailedAndModeInformational() {
+    func testETagHeaderIsIgnoredIfVerificationFailedAndModeInformational() {
         self.eTagManager = self.create(with: .informational)
 
         let eTag = "the_etag"
@@ -448,10 +437,10 @@ class ETagManagerTests: TestCase {
         ).asData()
 
         let response = self.eTagManager.eTagHeader(for: request, withSignatureVerification: true)
-        expect(response[ETagManager.eTagResponseHeaderName]).toNot(beEmpty())
+        expect(response[ETagManager.eTagResponseHeaderName]).to(beEmpty())
     }
 
-    func testETagHeaderIsNotIgnoredIfVerificationWasNotEnabledAndModeInformational() {
+    func testETagHeaderIsIgnoredIfVerificationWasNotEnabledAndModeInformational() {
         self.eTagManager = self.create(with: .informational)
 
         let eTag = "the_etag"
@@ -469,7 +458,7 @@ class ETagManagerTests: TestCase {
         ).asData()
 
         let response = self.eTagManager.eTagHeader(for: request, withSignatureVerification: true)
-        expect(response[ETagManager.eTagResponseHeaderName]).toNot(beEmpty())
+        expect(response[ETagManager.eTagResponseHeaderName]).to(beEmpty())
     }
 
     func testETagHeaderIsIgnoredIfVerificationWasNotEnabledAndModeEnforced() throws {

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -397,10 +397,12 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
     }
 
     func testCachedResponseWithFailedVerificationAndVerifiedResponse() throws {
+        // This won't happen in practice because the ETag won't be used if its verification failed.
+
         let cachedResponse = BodyWithDate(data: "test", requestDate: Self.date1)
 
         try self.mockETagCache(response: cachedResponse,
-                               requestDate: Self.date2,
+                               requestDate: Self.date1,
                                verificationResult: .failed)
         self.mockPath(statusCode: .notModified, requestDate: Self.date2)
         MockSigning.stubbedVerificationResult = true
@@ -412,7 +414,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
 
         expect(MockSigning.requests).to(haveCount(1))
         expect(response).to(beSuccess())
-        expect(response?.value?.body.requestDate).to(beCloseTo(Self.date2, within: 1))
+        expect(response?.value?.body.requestDate).to(beCloseTo(Self.date1, within: 1))
         expect(response?.value?.verificationResult) == .verified
     }
 


### PR DESCRIPTION
Scenario:
- Response 1: 200 / `VerificationResult.failed`
- Response 2: 304 / `VerificationResult.verified`

Before this change, that was resulting in `VerificationResult.verified`, even though it was using the unverified response body.
This fixes that so that we don't use the ETag for a response that failed validation, even in `ResponseVerificationMode.informational`.
