### PR TITLE
`Trusted Entitlements`: changed all APIs to `internal`

### DIFF
--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -180,8 +180,9 @@ import Foundation
         /// ### Related Symbols
         /// - ``Configuration/EntitlementVerificationMode``
         /// - ``VerificationResult``
+        // Trusted Entitlements: internal until ready to be made public.
         @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-        @objc public func with(entitlementVerificationMode mode: EntitlementVerificationMode) -> Builder {
+        @objc internal func with(entitlementVerificationMode mode: EntitlementVerificationMode) -> Builder {
             self.responseVerificationMode = Signing.verificationMode(with: mode)
             return self
         }
@@ -211,7 +212,8 @@ import Foundation
 
 // MARK: - Public Keys
 
-public extension Configuration {
+// Trusted Entitlements: internal until ready to be made public.
+internal extension Configuration {
 
     /// Defines how strict ``EntitlementInfo`` verification ought to be.
     ///

--- a/Sources/Purchasing/EntitlementInfo.swift
+++ b/Sources/Purchasing/EntitlementInfo.swift
@@ -165,8 +165,9 @@ extension PeriodType: DefaultValueProvider {
     ///
     /// ### Related Symbols
     /// - ``VerificationResult``
+    // Trusted Entitlements: internal until ready to be made public.
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    @objc public var verification: VerificationResult { self.contents.verification }
+    @objc internal var verification: VerificationResult { self.contents.verification }
 
     // Docs inherited from protocol
     // swiftlint:disable:next missing_docs

--- a/Sources/Purchasing/EntitlementInfos.swift
+++ b/Sources/Purchasing/EntitlementInfos.swift
@@ -34,8 +34,9 @@ import Foundation
     /// Whether these entitlements were verified.
     /// ### Related Symbols
     /// - ``VerificationResult``
+    // Trusted Entitlements: internal until ready to be made public.
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    @objc public var verification: VerificationResult { return self._verification }
+    @objc internal var verification: VerificationResult { return self._verification }
 
     public override var description: String {
         return "<\(NSStringFromClass(Self.self)): " +

--- a/Sources/Security/VerificationResult.swift
+++ b/Sources/Security/VerificationResult.swift
@@ -40,8 +40,9 @@ import Foundation
 /// - ``Configuration/EntitlementVerificationMode``
 /// - ``Configuration/Builder/with(entitlementVerificationMode:)``
 /// - ``EntitlementInfos/verification``
+// Trusted Entitlements: internal until ready to be made public.
 @objc(RCVerificationResult)
-public enum VerificationResult: Int {
+internal enum VerificationResult: Int {
 
     /// No verification was done.
     ///

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCEntitlementInfosAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCEntitlementInfosAPI.m
@@ -19,9 +19,10 @@
     NSDictionary<NSString *, RCEntitlementInfo *> *activeInAnyEnvironment = ei.activeInAnyEnvironment;
     NSDictionary<NSString *, RCEntitlementInfo *> *activeInCurrentEnvironment = ei.activeInCurrentEnvironment;
     RCEntitlementInfo *e = [ei objectForKeyedSubscript:@""];
-    RCVerificationResult verification = ei.verification;
+    // Trusted Entitlements: internal until ready to be made public.
+     // __unused RCVerificationResult verification = ei.verification;
 
-    NSLog(ei, all, active, activeInAnyEnvironment, activeInCurrentEnvironment, e, verification);
+    NSLog(ei, all, active, activeInAnyEnvironment, activeInCurrentEnvironment, e);
 }
 
 @end

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
@@ -20,7 +20,8 @@ func checkConfigurationAPI() {
         .with(networkTimeout: 1)
         .with(storeKit1Timeout: 1)
         .with(platformInfo: Purchases.PlatformInfo(flavor: "", version: ""))
-        .with(entitlementVerificationMode: .informational)
+        // Trusted Entitlements: internal until ready to be made public.
+        // .with(entitlementVerificationMode: .informational)
         .build()
     print(configuration)
 }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/EntitlementInfoAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/EntitlementInfoAPI.swift
@@ -31,12 +31,13 @@ func checkEntitlementInfoAPI() {
     let uda: Date? = entitlementInfo.unsubscribeDetectedAt
     let bida: Date? = entitlementInfo.billingIssueDetectedAt
     let oType: PurchaseOwnershipType = entitlementInfo.ownershipType
-    let ver: VerificationResult = entitlementInfo.verification
+    // Trusted Entitlements: internal until ready to be made public.
+    // let _: VerificationResult = entitlementInfo.verification
 
     let rawData: [String: Any] = entitlementInfo.rawData
 
     print(entitlementInfo!, ident, isActive, isActiveInAnyEnvironment, isActiveInCurrentEnvironment,
-          willRenew, pType, lpd!, opd!, eDate!, store, pId, iss, uda!, bida!, oType, ver, rawData)
+          willRenew, pType, lpd!, opd!, eDate!, store, pId, iss, uda!, bida!, oType, rawData)
 }
 
 var store: Store!

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/EntitlementInfosAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/EntitlementInfosAPI.swift
@@ -21,7 +21,8 @@ func checkEntitlementInfosAPI() {
     let activeInAnyEnvironment: [String: EntitlementInfo] = eis.activeInAnyEnvironment
     let activeInCurrentEnvironment: [String: EntitlementInfo] = eis.activeInCurrentEnvironment
     let enti: EntitlementInfo? = eis[""]
-    let evr: VerificationResult = eis.verification
+    // Trusted Entitlements: internal until ready to be made public.
+    // let _: VerificationResult = eis.verification
 
-    print(eis!, all, active, activeInAnyEnvironment, activeInCurrentEnvironment, enti!, evr)
+    print(eis!, all, active, activeInAnyEnvironment, activeInCurrentEnvironment, enti!)
 }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/VerificationResultAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/VerificationResultAPI.swift
@@ -8,6 +8,8 @@
 import Foundation
 import RevenueCat
 
+// Trusted Entitlements: internal until ready to be made public.
+/*
 func checkVerificationResultAPI(_ mode: EntitlementVerificationMode = .disabled,
                                 _ result: VerificationResult = .notRequested) {
     switch mode {
@@ -28,3 +30,4 @@ func checkVerificationResultAPI(_ mode: EntitlementVerificationMode = .disabled,
     @unknown default: break
     }
 }
+*/

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/main.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/main.swift
@@ -62,7 +62,8 @@ func main() -> Int {
 
     checkStorefrontAPI()
 
-    checkVerificationResultAPI()
+    // Trusted Entitlements: internal until ready to be made public.
+    // checkVerificationResultAPI()
 
     return 0
 }


### PR DESCRIPTION
This isn't ready quite ready to be released yet. With this change, `main` can be released once again.

I've added a comment to all the changes so we can easily find them when ready to be made `public` again.