### PR TITLE
`DeviceCache`: simplified constructor

### DIFF
--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -25,7 +25,7 @@ class DeviceCache {
             $0.string(forKey: CacheKeys.legacyGeneratedAppUserDefaults)
         }
     }
-    var cachedOfferings: Offerings? { self.offeringsCachedObject.cachedInstance() }
+    var cachedOfferings: Offerings? { self.offeringsCachedObject.cachedInstance }
 
     private let sandboxEnvironmentDetector: SandboxEnvironmentDetector
     private let userDefaults: SynchronizedUserDefaults
@@ -38,21 +38,13 @@ class DeviceCache {
 
     private var userDefaultsObserver: NSObjectProtocol?
 
-    convenience init(sandboxEnvironmentDetector: SandboxEnvironmentDetector,
-                     userDefaults: UserDefaults) {
-        self.init(sandboxEnvironmentDetector: sandboxEnvironmentDetector,
-                  userDefaults: userDefaults,
-                  offeringsCachedObject: nil,
-                  notificationCenter: nil)
-    }
-
     init(sandboxEnvironmentDetector: SandboxEnvironmentDetector,
          userDefaults: UserDefaults,
-         offeringsCachedObject: InMemoryCachedObject<Offerings>? = InMemoryCachedObject(),
-         notificationCenter: NotificationCenter? = NotificationCenter.default) {
+         offeringsCachedObject: InMemoryCachedObject<Offerings> = .init(),
+         notificationCenter: NotificationCenter = .default) {
         self.sandboxEnvironmentDetector = sandboxEnvironmentDetector
-        self.offeringsCachedObject = offeringsCachedObject ?? InMemoryCachedObject()
-        self.notificationCenter = notificationCenter ?? NotificationCenter.default
+        self.offeringsCachedObject = offeringsCachedObject
+        self.notificationCenter = notificationCenter
         self.userDefaults = .init(userDefaults: userDefaults)
         self.appUserIDHasBeenSet.value = userDefaults.string(forKey: .appUserDefaults) != nil
 

--- a/Sources/Caching/InMemoryCachedObject.swift
+++ b/Sources/Caching/InMemoryCachedObject.swift
@@ -59,7 +59,7 @@ class InMemoryCachedObject<T> {
         }
     }
 
-    func cachedInstance() -> T? {
+    var cachedInstance: T? {
         return self.content.value.cachedObject
     }
 }

--- a/Tests/UnitTests/Caching/DeviceCacheTests.swift
+++ b/Tests/UnitTests/Caching/DeviceCacheTests.swift
@@ -157,8 +157,7 @@ class DeviceCacheTests: TestCase {
         let mockCachedObject = MockInMemoryCachedOfferings<Offerings>()
         self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
-                                       offeringsCachedObject: mockCachedObject,
-                                       notificationCenter: nil)
+                                       offeringsCachedObject: mockCachedObject)
         let offerings = Offerings(offerings: [:], currentOfferingID: "")
         self.deviceCache.cache(offerings: offerings)
         let isAppBackgrounded = false
@@ -226,7 +225,6 @@ class DeviceCacheTests: TestCase {
 
         self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
-                                       offeringsCachedObject: nil,
                                        notificationCenter: mockNotificationCenter)
 
         expectNoFatalError { mockNotificationCenter.fireNotifications() }
@@ -246,7 +244,6 @@ class DeviceCacheTests: TestCase {
         mockUserDefaults.mockValues["com.revenuecat.userdefaults.appUserID.new"] = nil
         self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
-                                       offeringsCachedObject: nil,
                                        notificationCenter: mockNotificationCenter)
 
         expectNoFatalError { mockNotificationCenter.fireNotifications() }
@@ -260,7 +257,6 @@ class DeviceCacheTests: TestCase {
 
         self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: userDefaults,
-                                       offeringsCachedObject: nil,
                                        notificationCenter: mockNotificationCenter)
 
         userDefaults.set(nil, forKey: "com.revenuecat.userdefaults.appUserID.new")
@@ -276,7 +272,6 @@ class DeviceCacheTests: TestCase {
         mockUserDefaults.mockValues[cackeKey] = fourMinutesAgo
         self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
-                                       offeringsCachedObject: nil,
                                        notificationCenter: mockNotificationCenter)
 
         expect(self.deviceCache.isCustomerInfoCacheStale(appUserID: appUserID,
@@ -290,7 +285,6 @@ class DeviceCacheTests: TestCase {
         mockUserDefaults.mockValues["com.revenuecat.userdefaults.purchaserInfoLastUpdated.\(appUserID)"] = fourDaysAgo
         self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
-                                       offeringsCachedObject: nil,
                                        notificationCenter: mockNotificationCenter)
 
         expect(self.deviceCache.isCustomerInfoCacheStale(appUserID: appUserID,
@@ -302,7 +296,6 @@ class DeviceCacheTests: TestCase {
         let appUserID = "myUser"
         self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
-                                       offeringsCachedObject: nil,
                                        notificationCenter: mockNotificationCenter)
 
         expect(self.deviceCache.isCustomerInfoCacheStale(appUserID: appUserID,
@@ -314,7 +307,6 @@ class DeviceCacheTests: TestCase {
         let appUserID = "myUser"
         self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
-                                       offeringsCachedObject: nil,
                                        notificationCenter: mockNotificationCenter)
         let outdatedCacheDateForBackground = Calendar.current.date(byAdding: .hour, value: -25, to: Date())!
         self.deviceCache.setCustomerInfoCache(timestamp: outdatedCacheDateForBackground, appUserID: appUserID)
@@ -334,7 +326,6 @@ class DeviceCacheTests: TestCase {
         let appUserID = "myUser"
         self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
-                                       offeringsCachedObject: nil,
                                        notificationCenter: mockNotificationCenter)
         let outdatedCacheDateForForeground = Calendar.current.date(byAdding: .minute, value: -25, to: Date())!
         self.deviceCache.setCustomerInfoCache(timestamp: outdatedCacheDateForForeground, appUserID: appUserID)
@@ -354,7 +345,6 @@ class DeviceCacheTests: TestCase {
         let appUserID = "myUser"
         self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
-                                       offeringsCachedObject: nil,
                                        notificationCenter: mockNotificationCenter)
 
         let data = Data()
@@ -374,7 +364,6 @@ class DeviceCacheTests: TestCase {
         let currentAppUserID = "myUser"
         self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
-                                       offeringsCachedObject: nil,
                                        notificationCenter: mockNotificationCenter)
         let validCacheDate = Calendar.current.date(byAdding: .minute, value: -3, to: Date())!
         self.deviceCache.setCustomerInfoCache(timestamp: validCacheDate, appUserID: otherAppUserID)
@@ -412,8 +401,7 @@ class DeviceCacheTests: TestCase {
         let mockCachedObject = MockInMemoryCachedOfferings<Offerings>()
         self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
-                                       offeringsCachedObject: mockCachedObject,
-                                       notificationCenter: nil)
+                                       offeringsCachedObject: mockCachedObject)
 
         self.deviceCache.clearCachedOfferings()
 

--- a/Tests/UnitTests/Caching/InMemoryCachedObjectTests.swift
+++ b/Tests/UnitTests/Caching/InMemoryCachedObjectTests.swift
@@ -58,11 +58,11 @@ class InMemoryCachedObjectTests: TestCase {
         let cachedObject = InMemoryCachedObject<NSString>()
         cachedObject.cache(instance: "myString")
         expect(cachedObject.lastUpdatedAt).toNot(beNil())
-        expect(cachedObject.cachedInstance()).toNot(beNil())
+        expect(cachedObject.cachedInstance).toNot(beNil())
 
         cachedObject.clearCacheTimestamp()
         expect(cachedObject.lastUpdatedAt).to(beNil())
-        expect(cachedObject.cachedInstance()).toNot(beNil())
+        expect(cachedObject.cachedInstance).toNot(beNil())
     }
 
     // MARK: clearCache
@@ -72,12 +72,12 @@ class InMemoryCachedObjectTests: TestCase {
         cachedObject.cache(instance: "myString")
 
         expect(cachedObject.lastUpdatedAt).toNot(beNil())
-        expect(cachedObject.cachedInstance()).toNot(beNil())
+        expect(cachedObject.cachedInstance).toNot(beNil())
 
         cachedObject.clearCache()
 
         expect(cachedObject.lastUpdatedAt).to(beNil())
-        expect(cachedObject.cachedInstance()).to(beNil())
+        expect(cachedObject.cachedInstance).to(beNil())
     }
 
     // MARK: updateCacheTimestampWithDate
@@ -104,7 +104,7 @@ class InMemoryCachedObjectTests: TestCase {
         let cachedObject = InMemoryCachedObject<NSString>()
         cachedObject.cache(instance: myString)
 
-        expect(cachedObject.cachedInstance()) == myString
+        expect(cachedObject.cachedInstance) == myString
     }
 
     func testCacheInstanceWithDateSetsDateCorrectly() {

--- a/Tests/UnitTests/Mocks/MockInMemoryCachedOfferings.swift
+++ b/Tests/UnitTests/Mocks/MockInMemoryCachedOfferings.swift
@@ -61,9 +61,10 @@ class MockInMemoryCachedOfferings<T: Offerings>: InMemoryCachedObject<Offerings>
     var invokedCachedInstanceCount = 0
     var stubbedCachedInstanceResult: Offerings!
 
-    override func cachedInstance() -> Offerings? {
-        invokedCachedInstance = true
-        invokedCachedInstanceCount += 1
-        return stubbedCachedInstanceResult
+    override var cachedInstance: Offerings? {
+        self.invokedCachedInstance = true
+        self.invokedCachedInstanceCount += 1
+        return self.stubbedCachedInstanceResult
     }
+
 }


### PR DESCRIPTION
Having an optional with a default value is redundant. This simply provides a default value in the parameter to simplify the implementation
Also made `InMemoryCachedObject.cachedInstance` a property instead of a method.
