### PR TITLE
`TestLogHandler`: increased default capacity

### DIFF
--- a/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
@@ -308,7 +308,7 @@ class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
     }
 
     func testUpdatedTransactionsLogsWarningWhenSendingTooManyTransactions() {
-        let logger = TestLogHandler(capacity: 150)
+        let logger = TestLogHandler()
 
         let payment = SKPayment(product: .init())
         let transactions = (0..<110).map { _ in

--- a/Tests/UnitTests/TestHelpers/TestLogHandler.swift
+++ b/Tests/UnitTests/TestHelpers/TestLogHandler.swift
@@ -159,7 +159,7 @@ extension TestLogHandler: LogMessageObserver {
         }
     }
 
-    private static let defaultMessageLimit = 100
+    private static let defaultMessageLimit = 200
 
 }
 


### PR DESCRIPTION
This fixes flaky test failures.

`TestLogHandler` wires into the global log handler. When running test concurrently, depending on which tests and how many are running, there could be a lot of logs being stored in there.
Specifically, `StoreKit1WrapperTests.testUpdatedTransactionsLogsWarningWhenSendingTooManyTransactions` logs 100 messages to test that too many transactions lead to a warning. With the current limit, it only took 50 other logs to trigger this `precondition`, which could happen relatively easily.
