### PR TITLE
`ETagManager`: added test for 304 responses with no etag

### DIFF
--- a/Sources/Networking/HTTPClient/ETagManager.swift
+++ b/Sources/Networking/HTTPClient/ETagManager.swift
@@ -65,9 +65,9 @@ class ETagManager {
         let statusCode: HTTPStatusCode = response.statusCode
         let resultFromBackend = response.asOptionalResponse
 
-        let eTagInResponse = response.value(forHeaderField: HTTPClient.ResponseHeader.eTag.rawValue)
-
-        guard let eTagInResponse = eTagInResponse else { return resultFromBackend }
+        guard let eTagInResponse = response.value(forHeaderField: Self.eTagResponseHeaderName) else {
+            return resultFromBackend
+        }
 
         if self.shouldUseCachedVersion(responseCode: statusCode) {
             if let storedResponse = self.storedHTTPResponse(for: request, withRequestDate: response.requestDate) {

--- a/Tests/UnitTests/Networking/ETagManagerTests.swift
+++ b/Tests/UnitTests/Networking/ETagManagerTests.swift
@@ -86,28 +86,20 @@ class ETagManagerTests: TestCase {
         expect(response?.requestDate) == requestDate
     }
 
-    func testStoredResponseIsNotUsedIfResponseCodeIs304ButContainsNoETag() throws {
-        let eTag = "an_etag"
+    func testResultIsNilIfResponseCodeIs304ButContainsNoETag() throws {
         let url = self.urlForTest()
-        let request = URLRequest(url: url)
-        _ = self.mockStoredETagResponse(for: url, statusCode: .success, eTag: eTag)
-        let responseObject = try JSONSerialization.data(withJSONObject: ["a": "response"])
-        let requestDate = Date().addingTimeInterval(-100000)
 
         let response = self.eTagManager.httpResultFromCacheOrBackend(
             with: self.responseForTest(url: url,
-                                       body: responseObject,
+                                       body: nil,
                                        eTag: nil,
                                        statusCode: .notModified,
-                                       requestDate: requestDate),
-            request: request,
+                                       requestDate: Date()),
+            request: URLRequest(url: url),
             retried: false
         )
 
-        expect(response).toNot(beNil())
-        expect(response?.statusCode) == .notModified
-        expect(response?.body) == responseObject
-        expect(response?.requestDate) == requestDate
+        expect(response).to(beNil())
     }
 
     func testBackendResponseIsReturnedIf304AndCantFindCachedAndItHasAlreadyRetried() throws {

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -497,7 +497,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         self.eTagManager.stubResponseEtag(eTag)
 
         stub(condition: isPath(request.path)) { request in
-            headerPresent.value = request.allHTTPHeaderFields?[ETagManager.eTagResponseHeaderName] == eTag
+            headerPresent.value = request.allHTTPHeaderFields?[ETagManager.eTagRequestHeaderName] == eTag
             return .emptySuccessResponse()
         }
 
@@ -514,7 +514,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         let headerPresent: Atomic<Bool?> = nil
 
         stub(condition: isPath(request.path)) { request in
-            headerPresent.value = request.allHTTPHeaderFields?.keys.contains(ETagManager.eTagResponseHeaderName) == true
+            headerPresent.value = request.allHTTPHeaderFields?.keys.contains(ETagManager.eTagRequestHeaderName) == true
             return .emptySuccessResponse()
         }
 
@@ -959,7 +959,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         )
 
         stub(condition: isPath(path)) { response in
-            expect(response.allHTTPHeaderFields?[ETagManager.eTagResponseHeaderName]) == eTag
+            expect(response.allHTTPHeaderFields?[ETagManager.eTagRequestHeaderName]) == eTag
 
             return .init(data: Data(),
                          statusCode: .notModified,


### PR DESCRIPTION
Technically the backend would be breaking the contract with this, but it's worth checking that the SDK does something reasonable in this scenario.
