### PR TITLE
`OfferingsManager`: moved log to common method to remove hardcoded string

### DIFF
--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -58,10 +58,6 @@ class OfferingsManager {
 
         systemInfo.isApplicationBackgrounded { isAppBackgrounded in
             if self.deviceCache.isOfferingsCacheStale(isAppBackgrounded: isAppBackgrounded) {
-                Logger.debug(isAppBackgrounded
-                             ? Strings.offering.offerings_stale_updating_in_background
-                             : Strings.offering.offerings_stale_updating_in_foreground)
-
                 self.updateOfferingsCache(appUserID: appUserID,
                                           isAppBackgrounded: isAppBackgrounded,
                                           fetchPolicy: fetchPolicy,
@@ -78,6 +74,10 @@ class OfferingsManager {
         fetchPolicy: FetchPolicy = .default,
         completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
     ) {
+        Logger.debug(isAppBackgrounded
+                     ? Strings.offering.offerings_stale_updating_in_background
+                     : Strings.offering.offerings_stale_updating_in_foreground)
+
         self.backend.offerings.getOfferings(appUserID: appUserID, withRandomDelay: isAppBackgrounded) { result in
             switch result {
             case let .success(response):

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1297,7 +1297,6 @@ private extension Purchases {
                 return
             }
 
-            Logger.debug("Offerings cache is stale, updating caches")
             self.offeringsManager.updateOfferingsCache(appUserID: self.appUserID,
                                                        isAppBackgrounded: isAppBackgrounded,
                                                        completion: nil)


### PR DESCRIPTION
Instead of having the log in `OfferingsManager.offerings()`, this is now in `OfferingsManager.updateOfferingsCache`, which is called by the former as well as `Purchases.updateAllCachesIfNeeded`.
This means that we no longer need that hardcoded string.
