### PR TITLE
`Offline Entitlements`: use offline-computed `CustomerInfo` when server is down

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -201,6 +201,8 @@
 		42F1DF385E3C1F9903A07FBF /* ProductsFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */; };
 		4F69EB092A14406E00ED6D4B /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F69EB082A14406E00ED6D4B /* Matchers.swift */; };
 		4F69EB0A2A14406E00ED6D4B /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F69EB082A14406E00ED6D4B /* Matchers.swift */; };
+		4F8A58172A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */; };
+		4F8A58182A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */; };
 		4FA4C8DA2A168956007D2803 /* OfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA4C8D92A168956007D2803 /* OfflineCustomerInfoCreator.swift */; };
 		4FA4C9732A16D3AC007D2803 /* MockBackendConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA4C9722A16D3AC007D2803 /* MockBackendConfiguration.swift */; };
 		4FA4C9742A16D3AC007D2803 /* MockBackendConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA4C9722A16D3AC007D2803 /* MockBackendConfiguration.swift */; };
@@ -870,6 +872,7 @@
 		37E35F783903362B65FB7AF3 /* MockProductsRequestFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockProductsRequestFactory.swift; sourceTree = "<group>"; };
 		37E35FDA0A44EA03EA12DAA2 /* DateFormatter+ExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DateFormatter+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		4F69EB082A14406E00ED6D4B /* Matchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Matchers.swift; sourceTree = "<group>"; };
+		4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOfflineCustomerInfoCreator.swift; sourceTree = "<group>"; };
 		4FA4C8D92A168956007D2803 /* OfflineCustomerInfoCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineCustomerInfoCreator.swift; sourceTree = "<group>"; };
 		4FA4C9722A16D3AC007D2803 /* MockBackendConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackendConfiguration.swift; sourceTree = "<group>"; };
 		4FA696A329FC43C600D228B1 /* ReceiptParserTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ReceiptParserTests-Info.plist"; sourceTree = "<group>"; };
@@ -1691,6 +1694,7 @@
 				578DAA492948EF4F001700FD /* TestClock.swift */,
 				5791FBD1299184EF00F1FEDA /* MockAsyncSequence.swift */,
 				57CB2A7B29CCC91800C91439 /* MockProductEntitlementMappingFetcher.swift */,
+				4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -2906,6 +2910,7 @@
 				57488B2B29CA803F0000EE7E /* MockSandboxEnvironmentDetector.swift in Sources */,
 				F55FFA5D27634E1900995146 /* MockTransactionsManager.swift in Sources */,
 				4FA4C9742A16D3AC007D2803 /* MockBackendConfiguration.swift in Sources */,
+				4F8A58182A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift in Sources */,
 				57554CC2282AE1E3009A7E58 /* TestCase.swift in Sources */,
 				2D90F8B826FD20AA009B9142 /* MockReceiptFetcher.swift in Sources */,
 				2D90F8B626FD2099009B9142 /* MockSubscriberAttributesManager.swift in Sources */,
@@ -3167,6 +3172,7 @@
 				4FA4C9732A16D3AC007D2803 /* MockBackendConfiguration.swift in Sources */,
 				5766C620282DA3D50067D886 /* GetIntroEligibilityDecodingTests.swift in Sources */,
 				57C381E2279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */,
+				4F8A58172A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift in Sources */,
 				2DDF41E824F6F61B005BC22D /* MockSKProductDiscount.swift in Sources */,
 				579189B728F4747700BF4963 /* EitherTests.swift in Sources */,
 				5753EE00294B8C0C00CBAB54 /* AttributionFetcherTests.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -202,6 +202,9 @@
 		4F69EB092A14406E00ED6D4B /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F69EB082A14406E00ED6D4B /* Matchers.swift */; };
 		4F69EB0A2A14406E00ED6D4B /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F69EB082A14406E00ED6D4B /* Matchers.swift */; };
 		4FA4C8DA2A168956007D2803 /* OfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA4C8D92A168956007D2803 /* OfflineCustomerInfoCreator.swift */; };
+		4FA4C9732A16D3AC007D2803 /* MockBackendConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA4C9722A16D3AC007D2803 /* MockBackendConfiguration.swift */; };
+		4FA4C9742A16D3AC007D2803 /* MockBackendConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA4C9722A16D3AC007D2803 /* MockBackendConfiguration.swift */; };
+		4FA4C9752A16D49E007D2803 /* MockOfflineEntitlementsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57488BE929CB83540000EE7E /* MockOfflineEntitlementsManager.swift */; };
 		4FA696BD2A0020A000D228B1 /* MainThreadMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA696BC2A0020A000D228B1 /* MainThreadMonitor.swift */; };
 		4FCBA84F2A15391B004134BD /* SnapshotTesting+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A9127D27DDD0058FA6E /* SnapshotTesting+Extensions.swift */; };
 		4FCBA8512A153940004134BD /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 4FCBA8502A153940004134BD /* SnapshotTesting */; };
@@ -868,6 +871,7 @@
 		37E35FDA0A44EA03EA12DAA2 /* DateFormatter+ExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DateFormatter+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		4F69EB082A14406E00ED6D4B /* Matchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Matchers.swift; sourceTree = "<group>"; };
 		4FA4C8D92A168956007D2803 /* OfflineCustomerInfoCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineCustomerInfoCreator.swift; sourceTree = "<group>"; };
+		4FA4C9722A16D3AC007D2803 /* MockBackendConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackendConfiguration.swift; sourceTree = "<group>"; };
 		4FA696A329FC43C600D228B1 /* ReceiptParserTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ReceiptParserTests-Info.plist"; sourceTree = "<group>"; };
 		4FA696BC2A0020A000D228B1 /* MainThreadMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainThreadMonitor.swift; sourceTree = "<group>"; };
 		4FCBA8522A1539D0004134BD /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
@@ -1630,6 +1634,7 @@
 				351B515926D44B6200BD2BD7 /* MockAttributionFetcher.swift */,
 				351B514426D449E600BD2BD7 /* MockAttributionTypeFactory.swift */,
 				351B514026D4498F00BD2BD7 /* MockBackend.swift */,
+				4FA4C9722A16D3AC007D2803 /* MockBackendConfiguration.swift */,
 				A563F585271E072B00246E0C /* MockBeginRefundRequestHelper.swift */,
 				57BF87582967880C00424254 /* MockCachingTrialOrIntroPriceEligibilityChecker.swift */,
 				57CFB96B27FE0E79002A6730 /* MockCurrentUserProvider.swift */,
@@ -2853,6 +2858,7 @@
 				3543913826F90FE100E669DF /* MockIntroEligibilityCalculator.swift in Sources */,
 				3543914126F911CC00E669DF /* MockDeviceCache.swift in Sources */,
 				3543913C26F9101600E669DF /* MockOperationDispatcher.swift in Sources */,
+				4FA4C9752A16D49E007D2803 /* MockOfflineEntitlementsManager.swift in Sources */,
 				F5E5E2EE28479BD000216ECD /* ProductsFetcherSK2Tests.swift in Sources */,
 				3543913626F90D6A00E669DF /* TrialOrIntroPriceEligibilityCheckerSK1Tests.swift in Sources */,
 				2D34D9D227481D9B00C05DB6 /* TrialOrIntroPriceEligibilityCheckerSK2Tests.swift in Sources */,
@@ -2899,6 +2905,7 @@
 				2D90F8C026FD20DF009B9142 /* MockAttributionDataMigrator.swift in Sources */,
 				57488B2B29CA803F0000EE7E /* MockSandboxEnvironmentDetector.swift in Sources */,
 				F55FFA5D27634E1900995146 /* MockTransactionsManager.swift in Sources */,
+				4FA4C9742A16D3AC007D2803 /* MockBackendConfiguration.swift in Sources */,
 				57554CC2282AE1E3009A7E58 /* TestCase.swift in Sources */,
 				2D90F8B826FD20AA009B9142 /* MockReceiptFetcher.swift in Sources */,
 				2D90F8B626FD2099009B9142 /* MockSubscriberAttributesManager.swift in Sources */,
@@ -3157,6 +3164,7 @@
 			files = (
 				576C8A9227D27DDD0058FA6E /* SnapshotTesting+Extensions.swift in Sources */,
 				5791FBD2299184EF00F1FEDA /* MockAsyncSequence.swift in Sources */,
+				4FA4C9732A16D3AC007D2803 /* MockBackendConfiguration.swift in Sources */,
 				5766C620282DA3D50067D886 /* GetIntroEligibilityDecodingTests.swift in Sources */,
 				57C381E2279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */,
 				2DDF41E824F6F61B005BC22D /* MockSKProductDiscount.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -378,6 +378,10 @@
 		57C381DC27961547009E3940 /* SK2StoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381DB27961547009E3940 /* SK2StoreProductDiscount.swift */; };
 		57C381E2279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */; };
 		57C381E3279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */; };
+		57CB2A7829CCC3AA00C91439 /* ProductEntitlementMappingFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CB2A7729CCC3AA00C91439 /* ProductEntitlementMappingFetcher.swift */; };
+		57CB2A7A29CCC61600C91439 /* CustomerInfoResponseHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CB2A7929CCC61600C91439 /* CustomerInfoResponseHandlerTests.swift */; };
+		57CB2A7C29CCC91800C91439 /* MockProductEntitlementMappingFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CB2A7B29CCC91800C91439 /* MockProductEntitlementMappingFetcher.swift */; };
+		57CB2A7D29CCC96400C91439 /* MockProductEntitlementMappingFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CB2A7B29CCC91800C91439 /* MockProductEntitlementMappingFetcher.swift */; };
 		57CB2AD429CCF21A00C91439 /* RedirectLoggerTaskDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CB2AD329CCF21900C91439 /* RedirectLoggerTaskDelegate.swift */; };
 		57CB2B6029CDF63200C91439 /* PurchasedProductsFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CB2B5F29CDF63200C91439 /* PurchasedProductsFetcherTests.swift */; };
 		57CCC6EC2984496D001CE9B6 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CCC6EB2984496D001CE9B6 /* Box.swift */; };
@@ -412,6 +416,8 @@
 		57DC9F4A27CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DC9F4927CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift */; };
 		57DD426D2926B9620026DF09 /* StoreKitConfigTestCase+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DD426C2926B9620026DF09 /* StoreKitConfigTestCase+Extensions.swift */; };
 		57DD426E2926B9A50026DF09 /* StoreKitTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571E7AD3279F2D0C003B3606 /* StoreKitTestHelpers.swift */; };
+		57DDA7B329CBEFB30098B89D /* MockPurchasedProductsFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DDA7B229CBEFB30098B89D /* MockPurchasedProductsFetcher.swift */; };
+		57DDA7B429CBEFB30098B89D /* MockPurchasedProductsFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DDA7B229CBEFB30098B89D /* MockPurchasedProductsFetcher.swift */; };
 		57DE806D28074976008D6C6F /* Storefront.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DE806C28074976008D6C6F /* Storefront.swift */; };
 		57DE807128074C23008D6C6F /* SK1Storefront.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DE807028074C23008D6C6F /* SK1Storefront.swift */; };
 		57DE807328074C76008D6C6F /* SK2Storefront.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DE807228074C76008D6C6F /* SK2Storefront.swift */; };
@@ -1031,6 +1037,9 @@
 		57C381D92796153D009E3940 /* SK1StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1StoreProductDiscount.swift; sourceTree = "<group>"; };
 		57C381DB27961547009E3940 /* SK2StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreProductDiscount.swift; sourceTree = "<group>"; };
 		57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreProductDiscount.swift; sourceTree = "<group>"; };
+		57CB2A7729CCC3AA00C91439 /* ProductEntitlementMappingFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEntitlementMappingFetcher.swift; sourceTree = "<group>"; };
+		57CB2A7929CCC61600C91439 /* CustomerInfoResponseHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoResponseHandlerTests.swift; sourceTree = "<group>"; };
+		57CB2A7B29CCC91800C91439 /* MockProductEntitlementMappingFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductEntitlementMappingFetcher.swift; sourceTree = "<group>"; };
 		57CB2AD329CCF21900C91439 /* RedirectLoggerTaskDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedirectLoggerTaskDelegate.swift; sourceTree = "<group>"; };
 		57CB2B5F29CDF63200C91439 /* PurchasedProductsFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasedProductsFetcherTests.swift; sourceTree = "<group>"; };
 		57CCC6EB2984496D001CE9B6 /* Box.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
@@ -1050,6 +1059,7 @@
 		57DC9F4527CC2E4900DA6AF9 /* HTTPRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequest.swift; sourceTree = "<group>"; };
 		57DC9F4927CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCodeTests.swift; sourceTree = "<group>"; };
 		57DD426C2926B9620026DF09 /* StoreKitConfigTestCase+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StoreKitConfigTestCase+Extensions.swift"; sourceTree = "<group>"; };
+		57DDA7B229CBEFB30098B89D /* MockPurchasedProductsFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPurchasedProductsFetcher.swift; sourceTree = "<group>"; };
 		57DE806C28074976008D6C6F /* Storefront.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Storefront.swift; sourceTree = "<group>"; };
 		57DE807028074C23008D6C6F /* SK1Storefront.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1Storefront.swift; sourceTree = "<group>"; };
 		57DE807228074C76008D6C6F /* SK2Storefront.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SK2Storefront.swift; sourceTree = "<group>"; };
@@ -1646,6 +1656,7 @@
 				37E35C9439E087F63ECC4F59 /* MockProductsManager.swift */,
 				37E35B08709090FBBFB16EBD /* MockProductsRequest.swift */,
 				37E35F783903362B65FB7AF3 /* MockProductsRequestFactory.swift */,
+				57DDA7B229CBEFB30098B89D /* MockPurchasedProductsFetcher.swift */,
 				579189EA28F47F0F00BF4963 /* MockPurchases.swift */,
 				351B515D26D44B9900BD2BD7 /* MockPurchasesDelegate.swift */,
 				351B515126D44AF000BD2BD7 /* MockReceiptFetcher.swift */,
@@ -1672,6 +1683,7 @@
 				57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */,
 				578DAA492948EF4F001700FD /* TestClock.swift */,
 				5791FBD1299184EF00F1FEDA /* MockAsyncSequence.swift */,
+				57CB2A7B29CCC91800C91439 /* MockProductEntitlementMappingFetcher.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -2032,6 +2044,7 @@
 			isa = PBXGroup;
 			children = (
 				57488B7E29CB70E50000EE7E /* ProductEntitlementMapping.swift */,
+				57CB2A7729CCC3AA00C91439 /* ProductEntitlementMappingFetcher.swift */,
 				57488BD329CB7E2D0000EE7E /* OfflineEntitlementsManager.swift */,
 				57488C7329CB90F90000EE7E /* CustomerInfo+OfflineEntitlements.swift */,
 				57488C7429CB90F90000EE7E /* PurchasedProductsFetcher.swift */,
@@ -2045,6 +2058,7 @@
 			children = (
 				57488B8A29CB756A0000EE7E /* ProductEntitlementMappingTests.swift */,
 				57488C2229CB89CC0000EE7E /* OfflineEntitlementsManagerTests.swift */,
+				57CB2A7929CCC61600C91439 /* CustomerInfoResponseHandlerTests.swift */,
 			);
 			path = OfflineEntitlements;
 			sourceTree = "<group>";
@@ -2858,6 +2872,7 @@
 				2D90F8C226FD20F7009B9142 /* MockETagManager.swift in Sources */,
 				2D90F8B526FD2093009B9142 /* MockSystemInfo.swift in Sources */,
 				2D90F8C126FD20F2009B9142 /* MockHTTPClient.swift in Sources */,
+				57DDA7B429CBEFB30098B89D /* MockPurchasedProductsFetcher.swift in Sources */,
 				57E6195028D291DC0093170C /* StoreKit2CachingProductsManagerTests.swift in Sources */,
 				F5847431278D00C1001B1CE6 /* MockDNSChecker.swift in Sources */,
 				5799708B2936CE5700FF3573 /* LoggerTests.swift in Sources */,
@@ -2876,6 +2891,7 @@
 				57CFB96D27FE0E79002A6730 /* MockCurrentUserProvider.swift in Sources */,
 				2D90F8C826FD2225009B9142 /* MockAppleReceiptBuilder.swift in Sources */,
 				57C381B72791E593009E3940 /* StoreKit2TransactionListenerTests.swift in Sources */,
+				57CB2A7D29CCC96400C91439 /* MockProductEntitlementMappingFetcher.swift in Sources */,
 				57488C0129CB85BE0000EE7E /* MockOfflineEntitlementsAPI.swift in Sources */,
 				2D90F8C026FD20DF009B9142 /* MockAttributionDataMigrator.swift in Sources */,
 				57488B2B29CA803F0000EE7E /* MockSandboxEnvironmentDetector.swift in Sources */,
@@ -3040,6 +3056,7 @@
 				80E80EF226970E04008F245A /* ReceiptFetcher.swift in Sources */,
 				2DDF41AB24F6F37C005BC22D /* AppleReceipt.swift in Sources */,
 				2DDF41BB24F6F392005BC22D /* UInt8+Extensions.swift in Sources */,
+				57CB2A7829CCC3AA00C91439 /* ProductEntitlementMappingFetcher.swift in Sources */,
 				5712BE9029241EB500A83F15 /* TimingUtil.swift in Sources */,
 				B3B5FBC1269E17CE00104A0C /* DeviceCache.swift in Sources */,
 				F5BE424226965F9F00254A30 /* ProductRequestData+Initialization.swift in Sources */,
@@ -3168,6 +3185,7 @@
 				351B514726D44A0D00BD2BD7 /* MockSystemInfo.swift in Sources */,
 				B300E4C226D439B700B22262 /* IntroEligibilityCalculatorTests.swift in Sources */,
 				57554C62282ABFD9009A7E58 /* StoreTests.swift in Sources */,
+				57CB2A7C29CCC91800C91439 /* MockProductEntitlementMappingFetcher.swift in Sources */,
 				5733D00928CFA7A4008638D8 /* MockPaymentQueueWrapper.swift in Sources */,
 				2DDF41CA24F6F4C3005BC22D /* ArraySlice_UInt8+ExtensionsTests.swift in Sources */,
 				2DDF41E124F6F527005BC22D /* MockReceiptParser.swift in Sources */,
@@ -3195,6 +3213,7 @@
 				351B515426D44B0A00BD2BD7 /* MockStoreKit1Wrapper.swift in Sources */,
 				35F8B8FA26E02AE1003C3363 /* MockTrialOrIntroPriceEligibilityChecker.swift in Sources */,
 				35D83300262FAD8000E60AC5 /* ETagManagerTests.swift in Sources */,
+				57DDA7B329CBEFB30098B89D /* MockPurchasedProductsFetcher.swift in Sources */,
 				5796A39027D6BCD100653165 /* BackendGetIntroEligibilityTests.swift in Sources */,
 				351B514126D4498F00BD2BD7 /* MockBackend.swift in Sources */,
 				B380D69B27726AB500984578 /* DNSCheckerTests.swift in Sources */,
@@ -3233,6 +3252,7 @@
 				574A2F3F282D75E300150D40 /* OfferingsDecodingTests.swift in Sources */,
 				35E840CE2710E2EB00899AE2 /* MockManageSubscriptionsHelper.swift in Sources */,
 				57FFD2512922DBED00A9A878 /* MockStoreTransaction.swift in Sources */,
+				57CB2A7A29CCC61600C91439 /* CustomerInfoResponseHandlerTests.swift in Sources */,
 				F591492826B9956C00D32E58 /* MockTransaction.swift in Sources */,
 				5796A39427D6BD6900653165 /* BackendGetOfferingsTests.swift in Sources */,
 				5766AA42283C768600FA6091 /* OperatorExtensionsTests.swift in Sources */,

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -201,6 +201,7 @@
 		42F1DF385E3C1F9903A07FBF /* ProductsFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */; };
 		4F69EB092A14406E00ED6D4B /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F69EB082A14406E00ED6D4B /* Matchers.swift */; };
 		4F69EB0A2A14406E00ED6D4B /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F69EB082A14406E00ED6D4B /* Matchers.swift */; };
+		4FA4C8DA2A168956007D2803 /* OfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA4C8D92A168956007D2803 /* OfflineCustomerInfoCreator.swift */; };
 		4FA696BD2A0020A000D228B1 /* MainThreadMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA696BC2A0020A000D228B1 /* MainThreadMonitor.swift */; };
 		4FCBA84F2A15391B004134BD /* SnapshotTesting+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A9127D27DDD0058FA6E /* SnapshotTesting+Extensions.swift */; };
 		4FCBA8512A153940004134BD /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 4FCBA8502A153940004134BD /* SnapshotTesting */; };
@@ -866,6 +867,7 @@
 		37E35F783903362B65FB7AF3 /* MockProductsRequestFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockProductsRequestFactory.swift; sourceTree = "<group>"; };
 		37E35FDA0A44EA03EA12DAA2 /* DateFormatter+ExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DateFormatter+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		4F69EB082A14406E00ED6D4B /* Matchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Matchers.swift; sourceTree = "<group>"; };
+		4FA4C8D92A168956007D2803 /* OfflineCustomerInfoCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineCustomerInfoCreator.swift; sourceTree = "<group>"; };
 		4FA696A329FC43C600D228B1 /* ReceiptParserTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ReceiptParserTests-Info.plist"; sourceTree = "<group>"; };
 		4FA696BC2A0020A000D228B1 /* MainThreadMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainThreadMonitor.swift; sourceTree = "<group>"; };
 		4FCBA8522A1539D0004134BD /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
@@ -2043,10 +2045,11 @@
 		57488B7D29CB70DA0000EE7E /* OfflineEntitlements */ = {
 			isa = PBXGroup;
 			children = (
+				57488C7329CB90F90000EE7E /* CustomerInfo+OfflineEntitlements.swift */,
 				57488B7E29CB70E50000EE7E /* ProductEntitlementMapping.swift */,
 				57CB2A7729CCC3AA00C91439 /* ProductEntitlementMappingFetcher.swift */,
+				4FA4C8D92A168956007D2803 /* OfflineCustomerInfoCreator.swift */,
 				57488BD329CB7E2D0000EE7E /* OfflineEntitlementsManager.swift */,
-				57488C7329CB90F90000EE7E /* CustomerInfo+OfflineEntitlements.swift */,
 				57488C7429CB90F90000EE7E /* PurchasedProductsFetcher.swift */,
 				57488C7529CB90F90000EE7E /* PurchasedSK2Product.swift */,
 			);
@@ -3092,6 +3095,7 @@
 				B34605CE279A6E380031CA74 /* PostSubscriberAttributesOperation.swift in Sources */,
 				57488BC629CB7BDC0000EE7E /* OfflineEntitlementsAPI.swift in Sources */,
 				F5BE44432698581100254A30 /* AttributionTypeFactory.swift in Sources */,
+				4FA4C8DA2A168956007D2803 /* OfflineCustomerInfoCreator.swift in Sources */,
 				2D971CC12744364C0093F35F /* SKError+Extensions.swift in Sources */,
 				57F2C60C29784C11009EE527 /* SwiftVersionCheck.swift in Sources */,
 				57EAE527274324C60060EB74 /* Lock.swift in Sources */,

--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -372,6 +372,16 @@ class DeviceCache {
 // - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
 extension DeviceCache: @unchecked Sendable {}
 
+// MARK: -
+
+extension DeviceCache: ProductEntitlementMappingFetcher {
+
+    var productEntitlementMapping: ProductEntitlementMapping? {
+        return self.cachedProductEntitlementMapping
+    }
+
+}
+
 // MARK: - Private
 
 // All methods that modify or read from the UserDefaults data source but require external mechanisms for ensuring

--- a/Sources/Error Handling/BackendError.swift
+++ b/Sources/Error Handling/BackendError.swift
@@ -134,6 +134,11 @@ extension BackendError {
         return self.networkError?.finishable ?? false
     }
 
+    /// Whether the error represents a `NetworkError` from the server being down.
+    var isServerDown: Bool {
+        return self.networkError?.isServerDown == true
+    }
+
     private var networkError: NetworkError? {
         switch self {
         case let .networkError(networkError):

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -194,6 +194,7 @@ class CustomerInfoManager {
             }
         } else {
             Logger.debug(Strings.customerInfo.not_caching_offline_customer_info)
+            self.clearCustomerInfoCache(forAppUserID: appUserID)
         }
 
         self.sendUpdateIfChanged(customerInfo: customerInfo)

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -47,7 +47,11 @@ class CustomerInfoManager {
 
             case let .success(info):
                 self.cache(customerInfo: info, appUserID: appUserID)
-                Logger.rcSuccess(Strings.customerInfo.customerinfo_updated_from_network)
+                Logger.rcSuccess(
+                    info.isComputedOffline
+                    ? Strings.customerInfo.customerinfo_updated_offline
+                    : Strings.customerInfo.customerinfo_updated_from_network
+                )
             }
 
             if let completion = completion {

--- a/Sources/Logging/Strings/CustomerInfoStrings.swift
+++ b/Sources/Logging/Strings/CustomerInfoStrings.swift
@@ -28,6 +28,7 @@ enum CustomerInfoStrings {
     case customerinfo_stale_updating_in_foreground
     case customerinfo_updated_from_network
     case customerinfo_updated_from_network_error(BackendError)
+    case customerinfo_updated_offline
     case updating_request_date(CustomerInfo, Date)
     case sending_latest_customerinfo_to_delegate
     case sending_updated_customerinfo_to_delegate
@@ -68,6 +69,8 @@ extension CustomerInfoStrings: CustomStringConvertible {
             }
 
             return result
+        case .customerinfo_updated_offline:
+            return "CustomerInfo computed offline."
         case let .updating_request_date(info, newRequestDate):
             return "Updating CustomerInfo '\(info.originalAppUserId)' request date: \(newRequestDate)"
         case .sending_latest_customerinfo_to_delegate:

--- a/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
+++ b/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
@@ -64,7 +64,7 @@ extension OfflineEntitlementsStrings: CustomStringConvertible {
             "Creation error: \(error.localizedDescription)"
 
         case let .computed_offline_customer_info(entitlements):
-            return "Computed offline CustomerInfo with \(entitlements.active) active entitlements."
+            return "Computed offline CustomerInfo with \(entitlements.active.count) active entitlements."
         }
     }
 

--- a/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
+++ b/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
@@ -24,6 +24,10 @@ enum OfflineEntitlementsStrings {
     case product_entitlement_mapping_fetching_error(BackendError)
     case found_unverified_transactions_in_sk2(transactionID: UInt64, Error)
 
+    case computing_offline_customer_info_with_no_entitlement_mapping
+    case computing_offline_customer_info
+    case computing_offline_customer_info_failed(Error)
+
 }
 
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
@@ -48,6 +52,16 @@ extension OfflineEntitlementsStrings: CustomStringConvertible {
                 Transaction ID: \(transactionID)
             """
 
+        case .computing_offline_customer_info_with_no_entitlement_mapping:
+            return "Attempting to compute offline CustomerInfo with no product entitlement mapping. " +
+            "Will use empty mapping."
+
+        case .computing_offline_customer_info:
+            return "Encountered a server error. Will attempt to compute an offline CustomerInfo from local purchases."
+
+        case let .computing_offline_customer_info_failed(error):
+            return "Error computing offline CustomerInfo. Will return original error.\n" +
+            "Creation error: \(error.localizedDescription)"
         }
     }
 

--- a/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
+++ b/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
@@ -27,6 +27,7 @@ enum OfflineEntitlementsStrings {
     case computing_offline_customer_info_with_no_entitlement_mapping
     case computing_offline_customer_info
     case computing_offline_customer_info_failed(Error)
+    case computed_offline_customer_info(EntitlementInfos)
 
 }
 
@@ -62,6 +63,9 @@ extension OfflineEntitlementsStrings: CustomStringConvertible {
         case let .computing_offline_customer_info_failed(error):
             return "Error computing offline CustomerInfo. Will return original error.\n" +
             "Creation error: \(error.localizedDescription)"
+
+        case let .computed_offline_customer_info(entitlements):
+            return "Computed offline CustomerInfo with \(entitlements.active) active entitlements."
         }
     }
 

--- a/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
+++ b/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
@@ -16,8 +16,9 @@ import StoreKit
 
 // swiftlint:disable identifier_name
 
-@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 enum OfflineEntitlementsStrings {
+
+    case offline_entitlements_not_available
 
     case product_entitlement_mapping_stale_updating
     case product_entitlement_mapping_updated_from_network
@@ -31,11 +32,13 @@ enum OfflineEntitlementsStrings {
 
 }
 
-@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 extension OfflineEntitlementsStrings: CustomStringConvertible {
 
     var description: String {
         switch self {
+        case .offline_entitlements_not_available:
+            return "OS version does not support offline entitlements."
+
         case .product_entitlement_mapping_stale_updating:
             return "ProductEntitlementMapping cache is stale, updating from network."
 

--- a/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
+++ b/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
@@ -54,8 +54,7 @@ extension OfflineEntitlementsStrings: CustomStringConvertible {
             """
 
         case .computing_offline_customer_info_with_no_entitlement_mapping:
-            return "Attempting to compute offline CustomerInfo with no product entitlement mapping. " +
-            "Will use empty mapping."
+            return "Unable to compute offline CustomerInfo with no product entitlement mapping."
 
         case .computing_offline_customer_info:
             return "Encountered a server error. Will attempt to compute an offline CustomerInfo from local purchases."

--- a/Sources/Logging/Strings/Strings.swift
+++ b/Sources/Logging/Strings/Strings.swift
@@ -23,7 +23,6 @@ enum Strings {
     static let identity = IdentityStrings.self
     static let network = NetworkStrings.self
     static let offering = OfferingStrings.self
-    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     static let offlineEntitlements = OfflineEntitlementsStrings.self
     static let purchase = PurchaseStrings.self
     static let receipt = ReceiptStrings.self

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -190,11 +190,7 @@ extension Backend {
     }
 
     static func createDefaultProductFetcher() -> PurchasedProductsFetcherType {
-        if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
-            return PurchasedProductsFetcher()
-        } else {
-            return VoidPurchasedProductsFetcher()
-        }
+        return PurchasedProductsFetcher()
     }
 
 }

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -23,13 +23,17 @@ class Backend {
 
     private let config: BackendConfiguration
 
-    convenience init(apiKey: String,
-                     systemInfo: SystemInfo,
-                     httpClientTimeout: TimeInterval = Configuration.networkTimeoutDefault,
-                     eTagManager: ETagManager,
-                     operationDispatcher: OperationDispatcher,
-                     attributionFetcher: AttributionFetcher,
-                     dateProvider: DateProvider = DateProvider()) {
+    convenience init(
+        apiKey: String,
+        systemInfo: SystemInfo,
+        httpClientTimeout: TimeInterval = Configuration.networkTimeoutDefault,
+        eTagManager: ETagManager,
+        operationDispatcher: OperationDispatcher,
+        attributionFetcher: AttributionFetcher,
+        productEntitlementMappingFetcher: ProductEntitlementMappingFetcher,
+        purchasedProductsFetcher: PurchasedProductsFetcherType = Backend.createDefaultProductFetcher(),
+        dateProvider: DateProvider = DateProvider()
+    ) {
         let httpClient = HTTPClient(apiKey: apiKey,
                                     systemInfo: systemInfo,
                                     eTagManager: eTagManager,
@@ -37,8 +41,10 @@ class Backend {
         let config = BackendConfiguration(httpClient: httpClient,
                                           operationDispatcher: operationDispatcher,
                                           operationQueue: QueueProvider.createBackendQueue(),
-                                          dateProvider: dateProvider,
-                                          systemInfo: systemInfo)
+                                          systemInfo: systemInfo,
+                                          productEntitlementMappingFetcher: productEntitlementMappingFetcher,
+                                          purchasedProductsFetcher: purchasedProductsFetcher,
+                                          dateProvider: dateProvider)
         self.init(backendConfig: config, attributionFetcher: attributionFetcher)
     }
 
@@ -181,6 +187,14 @@ extension Backend {
             return operationQueue
         }
 
+    }
+
+    static func createDefaultProductFetcher() -> PurchasedProductsFetcherType {
+        if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
+            return PurchasedProductsFetcher()
+        } else {
+            return VoidPurchasedProductsFetcher()
+        }
     }
 
 }

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -30,8 +30,7 @@ class Backend {
         eTagManager: ETagManager,
         operationDispatcher: OperationDispatcher,
         attributionFetcher: AttributionFetcher,
-        productEntitlementMappingFetcher: ProductEntitlementMappingFetcher,
-        purchasedProductsFetcher: PurchasedProductsFetcherType = Backend.createDefaultProductFetcher(),
+        offlineCustomerInfoCreator: OfflineCustomerInfoCreator?,
         dateProvider: DateProvider = DateProvider()
     ) {
         let httpClient = HTTPClient(apiKey: apiKey,
@@ -42,8 +41,7 @@ class Backend {
                                           operationDispatcher: operationDispatcher,
                                           operationQueue: QueueProvider.createBackendQueue(),
                                           systemInfo: systemInfo,
-                                          productEntitlementMappingFetcher: productEntitlementMappingFetcher,
-                                          purchasedProductsFetcher: purchasedProductsFetcher,
+                                          offlineCustomerInfoCreator: offlineCustomerInfoCreator,
                                           dateProvider: dateProvider)
         self.init(backendConfig: config, attributionFetcher: attributionFetcher)
     }
@@ -189,10 +187,6 @@ extension Backend {
             return operationQueue
         }
 
-    }
-
-    static func createDefaultProductFetcher() -> PurchasedProductsFetcherType {
-        return PurchasedProductsFetcher()
     }
 
 }

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -102,9 +102,11 @@ class Backend {
 
     func getCustomerInfo(appUserID: String,
                          withRandomDelay randomDelay: Bool,
+                         allowComputingOffline: Bool = true,
                          completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
         self.customer.getCustomerInfo(appUserID: appUserID,
                                       withRandomDelay: randomDelay,
+                                      allowComputingOffline: allowComputingOffline,
                                       completion: completion)
     }
 

--- a/Sources/Networking/BackendConfiguration.swift
+++ b/Sources/Networking/BackendConfiguration.swift
@@ -21,15 +21,21 @@ final class BackendConfiguration {
     let operationQueue: OperationQueue
     let dateProvider: DateProvider
     let systemInfo: SystemInfo
+    let productEntitlementMappingFetcher: ProductEntitlementMappingFetcher
+    let purchasedProductsFetcher: PurchasedProductsFetcherType
 
     init(httpClient: HTTPClient,
          operationDispatcher: OperationDispatcher,
          operationQueue: OperationQueue,
-         dateProvider: DateProvider = DateProvider(),
-         systemInfo: SystemInfo) {
+         systemInfo: SystemInfo,
+         productEntitlementMappingFetcher: ProductEntitlementMappingFetcher,
+         purchasedProductsFetcher: PurchasedProductsFetcherType,
+         dateProvider: DateProvider = DateProvider()) {
         self.httpClient = httpClient
         self.operationDispatcher = operationDispatcher
         self.operationQueue = operationQueue
+        self.productEntitlementMappingFetcher = productEntitlementMappingFetcher
+        self.purchasedProductsFetcher = purchasedProductsFetcher
         self.dateProvider = dateProvider
         self.systemInfo = systemInfo
     }

--- a/Sources/Networking/BackendConfiguration.swift
+++ b/Sources/Networking/BackendConfiguration.swift
@@ -21,8 +21,9 @@ final class BackendConfiguration {
     let operationQueue: OperationQueue
     let dateProvider: DateProvider
     let systemInfo: SystemInfo
-    let productEntitlementMappingFetcher: ProductEntitlementMappingFetcher
-    let purchasedProductsFetcher: PurchasedProductsFetcherType
+
+    private let productEntitlementMappingFetcher: ProductEntitlementMappingFetcher
+    private let purchasedProductsFetcher: PurchasedProductsFetcherType
 
     init(httpClient: HTTPClient,
          operationDispatcher: OperationDispatcher,
@@ -42,6 +43,11 @@ final class BackendConfiguration {
 
     func clearCache() {
         self.httpClient.clearCaches()
+    }
+
+    func createOfflineCustomerInfoCreator() -> OfflineCustomerInfoCreator {
+        return .init(purchasedProductsFetcher: self.purchasedProductsFetcher,
+                     productEntitlementMapping: self.productEntitlementMappingFetcher.productEntitlementMapping)
     }
 
 }

--- a/Sources/Networking/BackendConfiguration.swift
+++ b/Sources/Networking/BackendConfiguration.swift
@@ -13,7 +13,7 @@
 
 import Foundation
 
-final class BackendConfiguration {
+class BackendConfiguration {
 
     let httpClient: HTTPClient
 
@@ -71,4 +71,5 @@ extension BackendConfiguration {
 
 // @unchecked because:
 // - `OperationQueue` is not `Sendable` as of Swift 5.7
+// - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
 extension BackendConfiguration: @unchecked Sendable {}

--- a/Sources/Networking/BackendConfiguration.swift
+++ b/Sources/Networking/BackendConfiguration.swift
@@ -21,33 +21,24 @@ class BackendConfiguration {
     let operationQueue: OperationQueue
     let dateProvider: DateProvider
     let systemInfo: SystemInfo
-
-    private let productEntitlementMappingFetcher: ProductEntitlementMappingFetcher
-    private let purchasedProductsFetcher: PurchasedProductsFetcherType
+    let offlineCustomerInfoCreator: OfflineCustomerInfoCreator?
 
     init(httpClient: HTTPClient,
          operationDispatcher: OperationDispatcher,
          operationQueue: OperationQueue,
          systemInfo: SystemInfo,
-         productEntitlementMappingFetcher: ProductEntitlementMappingFetcher,
-         purchasedProductsFetcher: PurchasedProductsFetcherType,
+         offlineCustomerInfoCreator: OfflineCustomerInfoCreator?,
          dateProvider: DateProvider = DateProvider()) {
         self.httpClient = httpClient
         self.operationDispatcher = operationDispatcher
         self.operationQueue = operationQueue
-        self.productEntitlementMappingFetcher = productEntitlementMappingFetcher
-        self.purchasedProductsFetcher = purchasedProductsFetcher
+        self.offlineCustomerInfoCreator = offlineCustomerInfoCreator
         self.dateProvider = dateProvider
         self.systemInfo = systemInfo
     }
 
     func clearCache() {
         self.httpClient.clearCaches()
-    }
-
-    func createOfflineCustomerInfoCreator() -> OfflineCustomerInfoCreator {
-        return .init(purchasedProductsFetcher: self.purchasedProductsFetcher,
-                     productEntitlementMapping: self.productEntitlementMappingFetcher.productEntitlementMapping)
     }
 
 }

--- a/Sources/Networking/CustomerAPI.swift
+++ b/Sources/Networking/CustomerAPI.swift
@@ -34,8 +34,12 @@ final class CustomerAPI {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
                                                                 appUserID: appUserID)
 
-        let factory = GetCustomerInfoOperation.createFactory(configuration: config,
-                                                             customerInfoCallbackCache: self.customerInfoCallbackCache)
+        let factory = GetCustomerInfoOperation.createFactory(
+            configuration: config,
+            customerInfoCallbackCache: self.customerInfoCallbackCache,
+            purchasedProductsFetcher: self.backendConfig.purchasedProductsFetcher,
+            productEntitlementMapping: self.backendConfig.productEntitlementMappingFetcher.productEntitlementMapping
+        )
 
         let callback = CustomerInfoCallback(cacheKey: factory.cacheKey,
                                             source: factory.operationType,
@@ -113,9 +117,13 @@ final class CustomerAPI {
                                                          observerMode: observerMode,
                                                          initiationSource: initiationSource,
                                                          subscriberAttributesByKey: subscriberAttributesToPost)
-        let factory = PostReceiptDataOperation.createFactory(configuration: config,
-                                                             postData: postData,
-                                                             customerInfoCallbackCache: self.customerInfoCallbackCache)
+        let factory = PostReceiptDataOperation.createFactory(
+            configuration: config,
+            postData: postData,
+            customerInfoCallbackCache: self.customerInfoCallbackCache,
+            purchasedProductsFetcher: self.backendConfig.purchasedProductsFetcher,
+            productEntitlementMapping: self.backendConfig.productEntitlementMappingFetcher.productEntitlementMapping
+        )
 
         let callbackObject = CustomerInfoCallback(cacheKey: factory.cacheKey,
                                                   source: PostReceiptDataOperation.self,

--- a/Sources/Networking/CustomerAPI.swift
+++ b/Sources/Networking/CustomerAPI.swift
@@ -37,8 +37,7 @@ final class CustomerAPI {
         let factory = GetCustomerInfoOperation.createFactory(
             configuration: config,
             customerInfoCallbackCache: self.customerInfoCallbackCache,
-            purchasedProductsFetcher: self.backendConfig.purchasedProductsFetcher,
-            productEntitlementMapping: self.backendConfig.productEntitlementMappingFetcher.productEntitlementMapping
+            offlineCreator: self.backendConfig.createOfflineCustomerInfoCreator()
         )
 
         let callback = CustomerInfoCallback(cacheKey: factory.cacheKey,
@@ -121,8 +120,7 @@ final class CustomerAPI {
             configuration: config,
             postData: postData,
             customerInfoCallbackCache: self.customerInfoCallbackCache,
-            purchasedProductsFetcher: self.backendConfig.purchasedProductsFetcher,
-            productEntitlementMapping: self.backendConfig.productEntitlementMappingFetcher.productEntitlementMapping
+            offlineCustomerInfoCreator: self.backendConfig.createOfflineCustomerInfoCreator()
         )
 
         let callbackObject = CustomerInfoCallback(cacheKey: factory.cacheKey,

--- a/Sources/Networking/CustomerAPI.swift
+++ b/Sources/Networking/CustomerAPI.swift
@@ -30,6 +30,7 @@ final class CustomerAPI {
 
     func getCustomerInfo(appUserID: String,
                          withRandomDelay randomDelay: Bool,
+                         allowComputingOffline: Bool,
                          completion: @escaping CustomerInfoResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
                                                                 appUserID: appUserID)
@@ -37,7 +38,9 @@ final class CustomerAPI {
         let factory = GetCustomerInfoOperation.createFactory(
             configuration: config,
             customerInfoCallbackCache: self.customerInfoCallbackCache,
-            offlineCreator: self.backendConfig.createOfflineCustomerInfoCreator()
+            offlineCreator: allowComputingOffline
+                ? self.backendConfig.createOfflineCustomerInfoCreator()
+                : nil
         )
 
         let callback = CustomerInfoCallback(cacheKey: factory.cacheKey,

--- a/Sources/Networking/CustomerAPI.swift
+++ b/Sources/Networking/CustomerAPI.swift
@@ -39,7 +39,7 @@ final class CustomerAPI {
             configuration: config,
             customerInfoCallbackCache: self.customerInfoCallbackCache,
             offlineCreator: allowComputingOffline
-                ? self.backendConfig.createOfflineCustomerInfoCreator()
+                ? self.backendConfig.offlineCustomerInfoCreator
                 : nil
         )
 
@@ -123,7 +123,7 @@ final class CustomerAPI {
             configuration: config,
             postData: postData,
             customerInfoCallbackCache: self.customerInfoCallbackCache,
-            offlineCustomerInfoCreator: self.backendConfig.createOfflineCustomerInfoCreator()
+            offlineCustomerInfoCreator: self.backendConfig.offlineCustomerInfoCreator
         )
 
         let callbackObject = CustomerInfoCallback(cacheKey: factory.cacheKey,

--- a/Sources/Networking/Operations/GetCustomerInfoOperation.swift
+++ b/Sources/Networking/Operations/GetCustomerInfoOperation.swift
@@ -21,7 +21,23 @@ final class GetCustomerInfoOperation: CacheableNetworkOperation {
 
     static func createFactory(
         configuration: UserSpecificConfiguration,
-        customerInfoResponseHandler: CustomerInfoResponseHandler = CustomerInfoResponseHandler(),
+        customerInfoCallbackCache: CallbackCache<CustomerInfoCallback>,
+        purchasedProductsFetcher: PurchasedProductsFetcherType,
+        productEntitlementMapping: ProductEntitlementMapping?
+    ) -> CacheableNetworkOperationFactory<GetCustomerInfoOperation> {
+        return Self.createFactory(
+            configuration: configuration,
+            customerInfoResponseHandler: .init(
+                purchasedProductsFetcher: purchasedProductsFetcher,
+                productEntitlementMapping: productEntitlementMapping,
+                userID: configuration.appUserID
+            ),
+            customerInfoCallbackCache: customerInfoCallbackCache)
+    }
+
+    static func createFactory(
+        configuration: UserSpecificConfiguration,
+        customerInfoResponseHandler: CustomerInfoResponseHandler,
         customerInfoCallbackCache: CallbackCache<CustomerInfoCallback>
     ) -> CacheableNetworkOperationFactory<GetCustomerInfoOperation> {
         return .init({

--- a/Sources/Networking/Operations/GetCustomerInfoOperation.swift
+++ b/Sources/Networking/Operations/GetCustomerInfoOperation.swift
@@ -22,7 +22,7 @@ final class GetCustomerInfoOperation: CacheableNetworkOperation {
     static func createFactory(
         configuration: UserSpecificConfiguration,
         customerInfoCallbackCache: CallbackCache<CustomerInfoCallback>,
-        offlineCreator: OfflineCustomerInfoCreator
+        offlineCreator: OfflineCustomerInfoCreator?
     ) -> CacheableNetworkOperationFactory<GetCustomerInfoOperation> {
         return Self.createFactory(
             configuration: configuration,

--- a/Sources/Networking/Operations/GetCustomerInfoOperation.swift
+++ b/Sources/Networking/Operations/GetCustomerInfoOperation.swift
@@ -22,14 +22,12 @@ final class GetCustomerInfoOperation: CacheableNetworkOperation {
     static func createFactory(
         configuration: UserSpecificConfiguration,
         customerInfoCallbackCache: CallbackCache<CustomerInfoCallback>,
-        purchasedProductsFetcher: PurchasedProductsFetcherType,
-        productEntitlementMapping: ProductEntitlementMapping?
+        offlineCreator: OfflineCustomerInfoCreator
     ) -> CacheableNetworkOperationFactory<GetCustomerInfoOperation> {
         return Self.createFactory(
             configuration: configuration,
             customerInfoResponseHandler: .init(
-                purchasedProductsFetcher: purchasedProductsFetcher,
-                productEntitlementMapping: productEntitlementMapping,
+                offlineCreator: offlineCreator,
                 userID: configuration.appUserID
             ),
             customerInfoCallbackCache: customerInfoCallbackCache)

--- a/Sources/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
+++ b/Sources/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
@@ -131,7 +131,7 @@ private extension CustomerInfoResponseHandler {
             self.userID
         )
 
-        // TODO: merge with existing one?
+        // Fixme: merge with existing one?
 
         return offlineCustomerInfo
     }

--- a/Sources/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
+++ b/Sources/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
@@ -18,7 +18,7 @@ class CustomerInfoResponseHandler {
     private let offlineCreator: OfflineCustomerInfoCreator?
     private let userID: String
 
-    /// - Parameter offlineCreator: can be `nil` if offline ``CustomerInfo`` shouldn't be computed.
+    /// - Parameter offlineCreator: can be `nil` if offline ``CustomerInfo`` shouldn't or can't be computed.
     init(offlineCreator: OfflineCustomerInfoCreator?, userID: String) {
         self.offlineCreator = offlineCreator
         self.userID = userID

--- a/Sources/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
+++ b/Sources/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
@@ -133,6 +133,8 @@ private extension CustomerInfoResponseHandler {
 
         // Fixme: merge with existing one?
 
+        Logger.info(Strings.offlineEntitlements.computed_offline_customer_info(offlineCustomerInfo.entitlements))
+
         return offlineCustomerInfo
     }
 

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -36,7 +36,26 @@ final class PostReceiptDataOperation: CacheableNetworkOperation {
     static func createFactory(
         configuration: UserSpecificConfiguration,
         postData: PostData,
-        customerInfoResponseHandler: CustomerInfoResponseHandler = CustomerInfoResponseHandler(),
+        customerInfoCallbackCache: CallbackCache<CustomerInfoCallback>,
+        purchasedProductsFetcher: PurchasedProductsFetcherType,
+        productEntitlementMapping: ProductEntitlementMapping?
+    ) -> CacheableNetworkOperationFactory<PostReceiptDataOperation> {
+        return Self.createFactory(
+            configuration: configuration,
+            postData: postData,
+            customerInfoResponseHandler: .init(
+                purchasedProductsFetcher: purchasedProductsFetcher,
+                productEntitlementMapping: productEntitlementMapping,
+                userID: configuration.appUserID
+            ),
+            customerInfoCallbackCache: customerInfoCallbackCache
+        )
+    }
+
+    static func createFactory(
+        configuration: UserSpecificConfiguration,
+        postData: PostData,
+        customerInfoResponseHandler: CustomerInfoResponseHandler,
         customerInfoCallbackCache: CallbackCache<CustomerInfoCallback>
     ) -> CacheableNetworkOperationFactory<PostReceiptDataOperation> {
         /// Cache key comprises of the following:

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -37,7 +37,7 @@ final class PostReceiptDataOperation: CacheableNetworkOperation {
         configuration: UserSpecificConfiguration,
         postData: PostData,
         customerInfoCallbackCache: CallbackCache<CustomerInfoCallback>,
-        offlineCustomerInfoCreator: OfflineCustomerInfoCreator
+        offlineCustomerInfoCreator: OfflineCustomerInfoCreator?
     ) -> CacheableNetworkOperationFactory<PostReceiptDataOperation> {
         return Self.createFactory(
             configuration: configuration,

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -37,15 +37,13 @@ final class PostReceiptDataOperation: CacheableNetworkOperation {
         configuration: UserSpecificConfiguration,
         postData: PostData,
         customerInfoCallbackCache: CallbackCache<CustomerInfoCallback>,
-        purchasedProductsFetcher: PurchasedProductsFetcherType,
-        productEntitlementMapping: ProductEntitlementMapping?
+        offlineCustomerInfoCreator: OfflineCustomerInfoCreator
     ) -> CacheableNetworkOperationFactory<PostReceiptDataOperation> {
         return Self.createFactory(
             configuration: configuration,
             postData: postData,
             customerInfoResponseHandler: .init(
-                purchasedProductsFetcher: purchasedProductsFetcher,
-                productEntitlementMapping: productEntitlementMapping,
+                offlineCreator: offlineCustomerInfoCreator,
                 userID: configuration.appUserID
             ),
             customerInfoCallbackCache: customerInfoCallbackCache

--- a/Sources/OfflineEntitlements/CustomerInfo+OfflineEntitlements.swift
+++ b/Sources/OfflineEntitlements/CustomerInfo+OfflineEntitlements.swift
@@ -13,7 +13,6 @@
 
 import Foundation
 
-@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 extension CustomerInfo {
 
     convenience init(
@@ -48,7 +47,17 @@ extension CustomerInfo {
         )
     }
 
-    private static func createEntitlements(
+}
+
+extension CustomerInfo {
+
+    static let defaultManagementURL = URL(string: "https://apps.apple.com/account/subscriptions")!
+
+}
+
+private extension CustomerInfo {
+
+    static func createEntitlements(
         with products: [PurchasedSK2Product],
         mapping: ProductEntitlementMapping
     ) -> [String: CustomerInfoResponse.Entitlement] {
@@ -85,7 +94,5 @@ extension CustomerInfo {
 
     /// Purchases are verified with StoreKit 2.
     private static let verification: VerificationResult = .verifiedOnDevice
-
-    static let defaultManagementURL = URL(string: "https://apps.apple.com/account/subscriptions")!
 
 }

--- a/Sources/OfflineEntitlements/CustomerInfo+OfflineEntitlements.swift
+++ b/Sources/OfflineEntitlements/CustomerInfo+OfflineEntitlements.swift
@@ -23,7 +23,7 @@ extension CustomerInfo {
     ) {
         let subscriber = CustomerInfoResponse.Subscriber(
             originalAppUserId: userID,
-            managementUrl: Self.defaultManagementURL,
+            managementUrl: SystemInfo.appleSubscriptionsURL,
             originalApplicationVersion: SystemInfo.buildVersion,
             originalPurchaseDate: Date(),
             firstSeen: Date(),
@@ -46,12 +46,6 @@ extension CustomerInfo {
             sandboxEnvironmentDetector: sandboxEnvironmentDetector
         )
     }
-
-}
-
-extension CustomerInfo {
-
-    static let defaultManagementURL = URL(string: "https://apps.apple.com/account/subscriptions")!
 
 }
 

--- a/Sources/OfflineEntitlements/CustomerInfo+OfflineEntitlements.swift
+++ b/Sources/OfflineEntitlements/CustomerInfo+OfflineEntitlements.swift
@@ -51,30 +51,6 @@ extension CustomerInfo {
         )
     }
 
-    /// Creates an offline `CustomerInfo`
-    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    static func createOffline(
-        with mapping: ProductEntitlementMapping?,
-        fetcher: PurchasedProductsFetcherType,
-        creator: OfflineCreator,
-        userID: String
-    ) async throws -> CustomerInfo {
-        Logger.info(Strings.offlineEntitlements.computing_offline_customer_info)
-
-        guard let mapping = mapping, !mapping.entitlementsByProduct.isEmpty else {
-            Logger.warn(Strings.offlineEntitlements.computing_offline_customer_info_with_no_entitlement_mapping)
-            throw Error.noEntitlementMappingAvailable
-        }
-
-        let products = try await fetcher.fetchPurchasedProducts()
-
-        let offlineCustomerInfo = creator(products, mapping, userID)
-
-        Logger.info(Strings.offlineEntitlements.computed_offline_customer_info(offlineCustomerInfo.entitlements))
-
-        return offlineCustomerInfo
-    }
-
 }
 
 // MARK: - Private
@@ -129,37 +105,6 @@ internal extension CustomerInfo {
         } else {
             return false
         }
-    }
-
-}
-
-// MARK: - Errors
-
-private extension CustomerInfo {
-
-    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    enum Error: Swift.Error {
-
-        case noEntitlementMappingAvailable
-
-    }
-
-}
-
-@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-extension CustomerInfo.Error: DescribableError, CustomNSError {
-
-    var description: String {
-        switch self {
-        case .noEntitlementMappingAvailable:
-            return Strings.offlineEntitlements.computing_offline_customer_info_with_no_entitlement_mapping.description
-        }
-    }
-
-    var errorUserInfo: [String: Any] {
-        return [
-            NSLocalizedDescriptionKey: self.description
-        ]
     }
 
 }

--- a/Sources/OfflineEntitlements/CustomerInfo+OfflineEntitlements.swift
+++ b/Sources/OfflineEntitlements/CustomerInfo+OfflineEntitlements.swift
@@ -121,6 +121,18 @@ private extension CustomerInfo {
 
 }
 
+internal extension CustomerInfo {
+
+    var isComputedOffline: Bool {
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
+            return self.entitlements.verification == .verifiedOnDevice
+        } else {
+            return false
+        }
+    }
+
+}
+
 // MARK: - Errors
 
 private extension CustomerInfo {

--- a/Sources/OfflineEntitlements/OfflineCustomerInfoCreator.swift
+++ b/Sources/OfflineEntitlements/OfflineCustomerInfoCreator.swift
@@ -1,0 +1,97 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  OfflineCustomerInfoCreator.swift
+//
+//  Created by Nacho Soto on 5/18/23.
+
+import Foundation
+
+/// Holds the necessary dependencies to create a `CustomerInfo` while offline.
+final class OfflineCustomerInfoCreator {
+
+    typealias Creator = @Sendable ([PurchasedSK2Product],
+                                   ProductEntitlementMapping,
+                                   String) -> CustomerInfo
+
+    private let purchasedProductsFetcher: PurchasedProductsFetcherType
+    private let productEntitlementMapping: ProductEntitlementMapping?
+    private let creator: Creator
+
+    convenience init(purchasedProductsFetcher: PurchasedProductsFetcherType,
+                     productEntitlementMapping: ProductEntitlementMapping?) {
+        self.init(
+            purchasedProductsFetcher: purchasedProductsFetcher,
+            productEntitlementMapping: productEntitlementMapping,
+            creator: { products, mapping, userID in
+                CustomerInfo(from: products, mapping: mapping, userID: userID)
+            }
+        )
+    }
+
+    init(
+        purchasedProductsFetcher: PurchasedProductsFetcherType,
+        productEntitlementMapping: ProductEntitlementMapping?,
+        creator: @escaping Creator
+    ) {
+        self.purchasedProductsFetcher = purchasedProductsFetcher
+        self.productEntitlementMapping = productEntitlementMapping
+        self.creator = creator
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func create(for userID: String) async throws -> CustomerInfo {
+        Logger.info(Strings.offlineEntitlements.computing_offline_customer_info)
+
+        guard let mapping = self.productEntitlementMapping, !mapping.entitlementsByProduct.isEmpty else {
+            Logger.warn(Strings.offlineEntitlements.computing_offline_customer_info_with_no_entitlement_mapping)
+            throw Error.noEntitlementMappingAvailable
+        }
+
+        let products = try await self.purchasedProductsFetcher.fetchPurchasedProducts()
+
+        let offlineCustomerInfo = creator(products, mapping, userID)
+
+        Logger.info(Strings.offlineEntitlements.computed_offline_customer_info(offlineCustomerInfo.entitlements))
+
+        return offlineCustomerInfo
+    }
+
+}
+
+// MARK: - Errors
+
+private extension OfflineCustomerInfoCreator {
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    enum Error: Swift.Error {
+
+        case noEntitlementMappingAvailable
+
+    }
+
+}
+
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+extension OfflineCustomerInfoCreator.Error: DescribableError, CustomNSError {
+
+    var description: String {
+        switch self {
+        case .noEntitlementMappingAvailable:
+            return Strings.offlineEntitlements.computing_offline_customer_info_with_no_entitlement_mapping.description
+        }
+    }
+
+    var errorUserInfo: [String: Any] {
+        return [
+            NSLocalizedDescriptionKey: self.description
+        ]
+    }
+
+}

--- a/Sources/OfflineEntitlements/OfflineEntitlementsManager.swift
+++ b/Sources/OfflineEntitlements/OfflineEntitlementsManager.swift
@@ -62,7 +62,7 @@ class OfflineEntitlementsManager {
     }
 
     func shouldComputeOfflineCustomerInfo(appUserID: String) -> Bool {
-        return self.deviceCache.cachedCustomerInfoData(appUserID: appUserID) != nil
+        return self.deviceCache.cachedCustomerInfoData(appUserID: appUserID) == nil
     }
 
 }

--- a/Sources/OfflineEntitlements/OfflineEntitlementsManager.swift
+++ b/Sources/OfflineEntitlements/OfflineEntitlementsManager.swift
@@ -61,6 +61,10 @@ class OfflineEntitlementsManager {
         }
     }
 
+    func shouldComputeOfflineCustomerInfo(appUserID: String) -> Bool {
+        return self.deviceCache.cachedCustomerInfoData(appUserID: appUserID) != nil
+    }
+
 }
 
 extension OfflineEntitlementsManager {

--- a/Sources/OfflineEntitlements/ProductEntitlementMappingFetcher.swift
+++ b/Sources/OfflineEntitlements/ProductEntitlementMappingFetcher.swift
@@ -1,0 +1,21 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ProductEntitlementMappingFetcher.swift
+//
+//  Created by Nacho Soto on 3/23/23.
+
+import Foundation
+
+/// A type that can synchronously fetch `ProductEntitlementMapping`.
+protocol ProductEntitlementMappingFetcher {
+
+    var productEntitlementMapping: ProductEntitlementMapping? { get }
+
+}

--- a/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
+++ b/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
@@ -16,7 +16,9 @@ import StoreKit
 
 protocol PurchasedProductsFetcherType {
 
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func fetchPurchasedProducts() async throws -> [PurchasedSK2Product]
+
 }
 
 /// A type that can fetch purchased products from StoreKit 2.
@@ -74,6 +76,7 @@ class PurchasedProductsFetcher: PurchasedProductsFetcherType {
 /// that don't support `PurchasedProductsFetcher`.
 final class VoidPurchasedProductsFetcher: PurchasedProductsFetcherType {
 
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func fetchPurchasedProducts() async throws -> [PurchasedSK2Product] {
         assertionFailure("This should never be used")
         return []

--- a/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
+++ b/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
@@ -14,9 +14,14 @@
 import Foundation
 import StoreKit
 
+protocol PurchasedProductsFetcherType {
+
+    func fetchPurchasedProducts() async throws -> [PurchasedSK2Product]
+}
+
 /// A type that can fetch purchased products from StoreKit 2.
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-class PurchasedProductsFetcher {
+class PurchasedProductsFetcher: PurchasedProductsFetcherType {
 
     private let sandboxDetector: SandboxEnvironmentDetector
 
@@ -47,6 +52,19 @@ class PurchasedProductsFetcher {
 
     private static func forceSyncToEnsureAllTransactionsAreAccountedFor() async throws {
         try await AppStore.sync()
+    }
+
+}
+
+// MARK: -
+
+/// An empty implementation of `PurchasedProductsFetcherType` for platforms
+/// that don't support `PurchasedProductsFetcher`.
+final class VoidPurchasedProductsFetcher: PurchasedProductsFetcherType {
+
+    func fetchPurchasedProducts() async throws -> [PurchasedSK2Product] {
+        assertionFailure("This should never be used")
+        return []
     }
 
 }

--- a/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
+++ b/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
@@ -22,6 +22,7 @@ protocol PurchasedProductsFetcherType {
 }
 
 /// A type that can fetch purchased products from StoreKit 2.
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 class PurchasedProductsFetcher: PurchasedProductsFetcherType {
 
     private let sandboxDetector: SandboxEnvironmentDetector
@@ -30,7 +31,6 @@ class PurchasedProductsFetcher: PurchasedProductsFetcherType {
         self.sandboxDetector = sandboxDetector
     }
 
-    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func fetchPurchasedProducts() async throws -> [PurchasedSK2Product] {
         var result: [PurchasedSK2Product] = []
 
@@ -52,7 +52,6 @@ class PurchasedProductsFetcher: PurchasedProductsFetcherType {
         return result
     }
 
-    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     private static func forceSyncToEnsureAllTransactionsAreAccountedFor() async throws {
         try await AppStore.sync()
     }

--- a/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
+++ b/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
@@ -16,13 +16,12 @@ import StoreKit
 
 protocol PurchasedProductsFetcherType {
 
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func fetchPurchasedProducts() async throws -> [PurchasedSK2Product]
 
 }
 
 /// A type that can fetch purchased products from StoreKit 2.
-@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 class PurchasedProductsFetcher: PurchasedProductsFetcherType {
 
     private let sandboxDetector: SandboxEnvironmentDetector
@@ -31,6 +30,7 @@ class PurchasedProductsFetcher: PurchasedProductsFetcherType {
         self.sandboxDetector = sandboxDetector
     }
 
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func fetchPurchasedProducts() async throws -> [PurchasedSK2Product] {
         var result: [PurchasedSK2Product] = []
 
@@ -64,22 +64,9 @@ class PurchasedProductsFetcher: PurchasedProductsFetcherType {
         }
     }
 
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     private static func forceSyncToEnsureAllTransactionsAreAccountedFor() async throws {
         try await AppStore.sync()
-    }
-
-}
-
-// MARK: -
-
-/// An empty implementation of `PurchasedProductsFetcherType` for platforms
-/// that don't support `PurchasedProductsFetcher`.
-final class VoidPurchasedProductsFetcher: PurchasedProductsFetcherType {
-
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func fetchPurchasedProducts() async throws -> [PurchasedSK2Product] {
-        assertionFailure("This should never be used")
-        return []
     }
 
 }

--- a/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
+++ b/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
@@ -34,13 +34,7 @@ class PurchasedProductsFetcher: PurchasedProductsFetcherType {
     func fetchPurchasedProducts() async throws -> [PurchasedSK2Product] {
         var result: [PurchasedSK2Product] = []
 
-        let syncError: Error?
-        do {
-            try await Self.forceSyncToEnsureAllTransactionsAreAccountedFor()
-            syncError = nil
-        } catch {
-            syncError = error
-        }
+        try await Self.forceSyncToEnsureAllTransactionsAreAccountedFor()
 
         for await transaction in StoreKit.Transaction.currentEntitlements {
             switch transaction {
@@ -55,13 +49,7 @@ class PurchasedProductsFetcher: PurchasedProductsFetcherType {
             }
         }
 
-        if result.isEmpty, let error = syncError {
-            // Only throw errors when syncing with the store if there were no entitlements found
-            throw error
-        } else {
-            // If there are any entitlements, ignore the error.
-            return result
-        }
+        return result
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)

--- a/Sources/OfflineEntitlements/PurchasedSK2Product.swift
+++ b/Sources/OfflineEntitlements/PurchasedSK2Product.swift
@@ -15,7 +15,6 @@ import Foundation
 import StoreKit
 
 /// Contains all information from a StoreKit 2 transaction necessary to create an ``EntitlementInfo``.
-@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 struct PurchasedSK2Product {
 
     let productIdentifier: String
@@ -23,6 +22,8 @@ struct PurchasedSK2Product {
     let entitlement: CustomerInfoResponse.Entitlement
 
 }
+
+extension PurchasedSK2Product: Equatable {}
 
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 extension PurchasedSK2Product {

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -294,7 +294,12 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         let offeringsFactory = OfferingsFactory()
         let receiptParser = PurchasesReceiptParser.default
         let transactionsManager = TransactionsManager(receiptParser: receiptParser)
-        let customerInfoManager = CustomerInfoManager(operationDispatcher: operationDispatcher,
+
+        let offlineEntitlementsManager = OfflineEntitlementsManager(deviceCache: deviceCache,
+                                                                    operationDispatcher: operationDispatcher,
+                                                                    api: backend.offlineEntitlements)
+        let customerInfoManager = CustomerInfoManager(offlineEntitlementsManager: offlineEntitlementsManager,
+                                                      operationDispatcher: operationDispatcher,
                                                       deviceCache: deviceCache,
                                                       backend: backend,
                                                       systemInfo: systemInfo)
@@ -331,9 +336,6 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                                                 backend: backend,
                                                 offeringsFactory: offeringsFactory,
                                                 productsManager: productsManager)
-        let offlineEntitlementsManager = OfflineEntitlementsManager(deviceCache: deviceCache,
-                                                                    operationDispatcher: operationDispatcher,
-                                                                    api: backend.offlineEntitlements)
         let manageSubsHelper = ManageSubscriptionsHelper(systemInfo: systemInfo,
                                                          customerInfoManager: customerInfoManager,
                                                          currentUserProvider: identityManager)

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -277,20 +277,21 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         let eTagManager = ETagManager(verificationMode: systemInfo.responseVerificationMode)
         let attributionTypeFactory = AttributionTypeFactory()
         let attributionFetcher = AttributionFetcher(attributionFactory: attributionTypeFactory, systemInfo: systemInfo)
+        let userDefaults = userDefaults ?? UserDefaults.computeDefault()
+        let deviceCache = DeviceCache(sandboxEnvironmentDetector: systemInfo, userDefaults: userDefaults)
         let backend = Backend(apiKey: apiKey,
                               systemInfo: systemInfo,
                               httpClientTimeout: networkTimeout,
                               eTagManager: eTagManager,
                               operationDispatcher: operationDispatcher,
-                              attributionFetcher: attributionFetcher)
+                              attributionFetcher: attributionFetcher,
+                              productEntitlementMappingFetcher: deviceCache)
 
         let paymentQueueWrapper: EitherPaymentQueueWrapper = systemInfo.storeKit2Setting.shouldOnlyUseStoreKit2
             ? .right(.init())
             : .left(.init(operationDispatcher: operationDispatcher, sandboxEnvironmentDetector: systemInfo))
 
         let offeringsFactory = OfferingsFactory()
-        let userDefaults = userDefaults ?? UserDefaults.computeDefault()
-        let deviceCache = DeviceCache(sandboxEnvironmentDetector: systemInfo, userDefaults: userDefaults)
         let receiptParser = PurchasesReceiptParser.default
         let transactionsManager = TransactionsManager(receiptParser: receiptParser)
         let customerInfoManager = CustomerInfoManager(operationDispatcher: operationDispatcher,

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -285,7 +285,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                               eTagManager: eTagManager,
                               operationDispatcher: operationDispatcher,
                               attributionFetcher: attributionFetcher,
-                              productEntitlementMappingFetcher: deviceCache)
+                              offlineCustomerInfoCreator: .createDefault(productEntitlementMappingFetcher: deviceCache))
 
         let paymentQueueWrapper: EitherPaymentQueueWrapper = systemInfo.storeKit2Setting.shouldOnlyUseStoreKit2
             ? .right(.init())

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1000,8 +1000,12 @@ private extension PurchasesOrchestrator {
             case let .success(customerInfo):
                 self.customerInfoManager.cache(customerInfo: customerInfo, appUserID: appUserID)
 
-                self.finishTransactionIfNeeded(transaction) {
+                if customerInfo.isComputedOffline {
                     completion?(transaction, customerInfo, nil, false)
+                } else {
+                    self.finishTransactionIfNeeded(transaction) {
+                        completion?(transaction, customerInfo, nil, false)
+                    }
                 }
 
             case let .failure(error):

--- a/Tests/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
+++ b/Tests/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
@@ -46,6 +46,7 @@ class BeginRefundRequestHelperTests: TestCase {
 
         self.systemInfo = MockSystemInfo(finishTransactions: true)
         self.customerInfoManager = MockCustomerInfoManager(
+            offlineEntitlementsManager: MockOfflineEntitlementsManager(),
             operationDispatcher: MockOperationDispatcher(),
             deviceCache: MockDeviceCache(sandboxEnvironmentDetector: self.systemInfo),
             backend: MockBackend(),

--- a/Tests/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
+++ b/Tests/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
@@ -42,6 +42,7 @@ class ManageSubscriptionsHelperTests: TestCase {
 
         self.systemInfo = MockSystemInfo(finishTransactions: true)
         self.customerInfoManager = MockCustomerInfoManager(
+            offlineEntitlementsManager: MockOfflineEntitlementsManager(),
             operationDispatcher: MockOperationDispatcher(),
             deviceCache: MockDeviceCache(sandboxEnvironmentDetector: self.systemInfo),
             backend: MockBackend(),

--- a/Tests/StoreKitUnitTests/OfflineEntitlements/CustomerInfoOfflineEntitlementsStoreKitTest.swift
+++ b/Tests/StoreKitUnitTests/OfflineEntitlements/CustomerInfoOfflineEntitlementsStoreKitTest.swift
@@ -217,7 +217,7 @@ private extension CustomerInfoOfflineEntitlementsStoreKitTest {
 
     func verifyInfo(_ info: CustomerInfo) {
         expect(info.firstSeen).to(beCloseToNow())
-        expect(info.managementURL) == CustomerInfo.defaultManagementURL
+        expect(info.managementURL) == SystemInfo.appleSubscriptionsURL
         expect(info.originalAppUserId).toNot(beEmpty())
         expect(info.originalAppUserId) == Self.userID
         expect(info.originalApplicationVersion) == SystemInfo.buildVersion

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -62,7 +62,8 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                                                          offeringsFactory: OfferingsFactory(),
                                                          productsManager: self.productsManager)
 
-        self.customerInfoManager = MockCustomerInfoManager(operationDispatcher: OperationDispatcher(),
+        self.customerInfoManager = MockCustomerInfoManager(offlineEntitlementsManager: MockOfflineEntitlementsManager(),
+                                                           operationDispatcher: OperationDispatcher(),
                                                            deviceCache: self.deviceCache,
                                                            backend: self.backend,
                                                            systemInfo: self.systemInfo)

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -431,6 +431,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
 
         expect(self.customerInfoManager.cachedCustomerInfo(appUserID: appUserID)).to(beNil())
         expect(self.mockDeviceCache.cacheCustomerInfoCount) == 0
+        expect(self.mockDeviceCache.invokedClearCustomerInfoCache) == true
 
         logger.verifyMessageWasLogged(Strings.customerInfo.not_caching_offline_customer_info, level: .debug)
     }

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -36,10 +36,13 @@ class IdentityManagerTests: TestCase {
         let systemInfo = MockSystemInfo(finishTransactions: false)
 
         self.mockDeviceCache = MockDeviceCache(sandboxEnvironmentDetector: systemInfo)
-        self.mockCustomerInfoManager = MockCustomerInfoManager(operationDispatcher: MockOperationDispatcher(),
-                                                               deviceCache: self.mockDeviceCache,
-                                                               backend: MockBackend(),
-                                                               systemInfo: systemInfo)
+        self.mockCustomerInfoManager = MockCustomerInfoManager(
+            offlineEntitlementsManager: MockOfflineEntitlementsManager(),
+            operationDispatcher: MockOperationDispatcher(),
+            deviceCache: self.mockDeviceCache,
+            backend: MockBackend(),
+            systemInfo: systemInfo
+        )
         self.mockAttributeSyncing = MockAttributeSyncing()
     }
 

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -29,23 +29,11 @@ class MockBackend: Backend {
         let systemInfo = try! MockSystemInfo(platformInfo: nil, finishTransactions: false, dangerousSettings: nil)
         let attributionFetcher = AttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
                                                     systemInfo: systemInfo)
-        let mockAPIKey = "mockAPIKey"
-        let httpClient = MockHTTPClient(apiKey: mockAPIKey,
-                                        systemInfo: systemInfo,
-                                        eTagManager: MockETagManager(),
-                                        requestTimeout: 7)
-        let backendConfig = BackendConfiguration(
-            httpClient: httpClient,
-            operationDispatcher: MockOperationDispatcher(),
-            operationQueue: QueueProvider.createBackendQueue(),
-            systemInfo: systemInfo,
-            productEntitlementMappingFetcher: MockProductEntitlementMappingFetcher(),
-            purchasedProductsFetcher: MockPurchasedProductsFetcher(),
-            dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate)
-        )
+
+        let backendConfig = MockBackendConfiguration()
         let identity = MockIdentityAPI(backendConfig: backendConfig)
         let offerings = MockOfferingsAPI(backendConfig: backendConfig)
-        let offlineEntitlements = MockOfflineEntitlementsAPI(backendConfig: backendConfig)
+        let offlineEntitlements = MockOfflineEntitlementsAPI()
         let customer = CustomerAPI(backendConfig: backendConfig, attributionFetcher: attributionFetcher)
         let internalAPI = InternalAPI(backendConfig: backendConfig)
 
@@ -96,20 +84,23 @@ class MockBackend: Backend {
     var invokedGetSubscriberDataCount = 0
     var invokedGetSubscriberDataParameters: (appUserID: String?,
                                              randomDelay: Bool,
+                                             allowComputingOffline: Bool,
                                              completion: CustomerAPI.CustomerInfoResponseHandler?)?
     var invokedGetSubscriberDataParametersList = [(appUserID: String?,
                                                    randomDelay: Bool,
+                                                   allowComputingOffline: Bool,
                                                    completion: CustomerAPI.CustomerInfoResponseHandler?)]()
 
     var stubbedGetCustomerInfoResult: Result<CustomerInfo, BackendError> = .failure(.missingAppUserID())
 
     override func getCustomerInfo(appUserID: String,
                                   withRandomDelay randomDelay: Bool,
+                                  allowComputingOffline: Bool,
                                   completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
         invokedGetSubscriberData = true
         invokedGetSubscriberDataCount += 1
-        invokedGetSubscriberDataParameters = (appUserID, randomDelay, completion)
-        invokedGetSubscriberDataParametersList.append((appUserID, randomDelay, completion))
+        invokedGetSubscriberDataParameters = (appUserID, randomDelay, allowComputingOffline, completion)
+        invokedGetSubscriberDataParametersList.append((appUserID, randomDelay, allowComputingOffline, completion))
 
         completion(self.stubbedGetCustomerInfoResult)
     }

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -34,11 +34,15 @@ class MockBackend: Backend {
                                         systemInfo: systemInfo,
                                         eTagManager: MockETagManager(),
                                         requestTimeout: 7)
-        let backendConfig = BackendConfiguration(httpClient: httpClient,
-                                                 operationDispatcher: MockOperationDispatcher(),
-                                                 operationQueue: QueueProvider.createBackendQueue(),
-                                                 dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate),
-                                                 systemInfo: systemInfo)
+        let backendConfig = BackendConfiguration(
+            httpClient: httpClient,
+            operationDispatcher: MockOperationDispatcher(),
+            operationQueue: QueueProvider.createBackendQueue(),
+            systemInfo: systemInfo,
+            productEntitlementMappingFetcher: MockProductEntitlementMappingFetcher(),
+            purchasedProductsFetcher: MockPurchasedProductsFetcher(),
+            dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate)
+        )
         let identity = MockIdentityAPI(backendConfig: backendConfig)
         let offerings = MockOfferingsAPI(backendConfig: backendConfig)
         let offlineEntitlements = MockOfflineEntitlementsAPI(backendConfig: backendConfig)

--- a/Tests/UnitTests/Mocks/MockBackendConfiguration.swift
+++ b/Tests/UnitTests/Mocks/MockBackendConfiguration.swift
@@ -28,8 +28,7 @@ class MockBackendConfiguration: BackendConfiguration {
             operationDispatcher: MockOperationDispatcher(),
             operationQueue: Backend.QueueProvider.createBackendQueue(),
             systemInfo: systemInfo,
-            productEntitlementMappingFetcher: MockProductEntitlementMappingFetcher(),
-            purchasedProductsFetcher: MockPurchasedProductsFetcher(),
+            offlineCustomerInfoCreator: MockOfflineCustomerInfoCreator(),
             dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate)
         )
     }

--- a/Tests/UnitTests/Mocks/MockBackendConfiguration.swift
+++ b/Tests/UnitTests/Mocks/MockBackendConfiguration.swift
@@ -1,0 +1,37 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockBackendConfig.swift
+//
+//  Created by Nacho Soto on 5/18/23.
+
+@testable import RevenueCat
+
+class MockBackendConfiguration: BackendConfiguration {
+
+    init() {
+        let systemInfo = MockSystemInfo(finishTransactions: false)
+        let mockAPIKey = "mockAPIKey"
+        let httpClient = MockHTTPClient(apiKey: mockAPIKey,
+                                        systemInfo: systemInfo,
+                                        eTagManager: MockETagManager(),
+                                        requestTimeout: 7)
+
+        super.init(
+            httpClient: httpClient,
+            operationDispatcher: MockOperationDispatcher(),
+            operationQueue: Backend.QueueProvider.createBackendQueue(),
+            systemInfo: systemInfo,
+            productEntitlementMappingFetcher: MockProductEntitlementMappingFetcher(),
+            purchasedProductsFetcher: MockPurchasedProductsFetcher(),
+            dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate)
+        )
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -7,7 +7,7 @@
 
 class MockDeviceCache: DeviceCache {
 
-    convenience init(sandboxEnvironmentDetector: SandboxEnvironmentDetector) {
+    convenience init(sandboxEnvironmentDetector: SandboxEnvironmentDetector = MockSandboxEnvironmentDetector()) {
         self.init(sandboxEnvironmentDetector: sandboxEnvironmentDetector,
                   userDefaults: .computeDefault())
     }

--- a/Tests/UnitTests/Mocks/MockIdentityAPI.swift
+++ b/Tests/UnitTests/Mocks/MockIdentityAPI.swift
@@ -24,11 +24,15 @@ class MockIdentityAPI: IdentityAPI {
                                         systemInfo: systemInfo,
                                         eTagManager: MockETagManager(),
                                         requestTimeout: 7)
-        let backendConfig = BackendConfiguration(httpClient: httpClient,
-                                                 operationDispatcher: MockOperationDispatcher(),
-                                                 operationQueue: Backend.QueueProvider.createBackendQueue(),
-                                                 dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate),
-                                                 systemInfo: systemInfo)
+        let backendConfig = BackendConfiguration(
+            httpClient: httpClient,
+            operationDispatcher: MockOperationDispatcher(),
+            operationQueue: Backend.QueueProvider.createBackendQueue(),
+            systemInfo: systemInfo,
+            productEntitlementMappingFetcher: MockProductEntitlementMappingFetcher(),
+            purchasedProductsFetcher: MockPurchasedProductsFetcher(),
+            dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate)
+        )
         self.init(backendConfig: backendConfig)
     }
 

--- a/Tests/UnitTests/Mocks/MockIdentityAPI.swift
+++ b/Tests/UnitTests/Mocks/MockIdentityAPI.swift
@@ -17,23 +17,7 @@ import Foundation
 class MockIdentityAPI: IdentityAPI {
 
     public convenience init() {
-        // swiftlint:disable:next force_try
-        let systemInfo = try! MockSystemInfo(platformInfo: nil, finishTransactions: false, dangerousSettings: nil)
-        let mockAPIKey = "mockAPIKey"
-        let httpClient = MockHTTPClient(apiKey: mockAPIKey,
-                                        systemInfo: systemInfo,
-                                        eTagManager: MockETagManager(),
-                                        requestTimeout: 7)
-        let backendConfig = BackendConfiguration(
-            httpClient: httpClient,
-            operationDispatcher: MockOperationDispatcher(),
-            operationQueue: Backend.QueueProvider.createBackendQueue(),
-            systemInfo: systemInfo,
-            productEntitlementMappingFetcher: MockProductEntitlementMappingFetcher(),
-            purchasedProductsFetcher: MockPurchasedProductsFetcher(),
-            dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate)
-        )
-        self.init(backendConfig: backendConfig)
+        self.init(backendConfig: MockBackendConfiguration())
     }
 
     var invokedLogIn = false

--- a/Tests/UnitTests/Mocks/MockIdentityManager.swift
+++ b/Tests/UnitTests/Mocks/MockIdentityManager.swift
@@ -27,10 +27,13 @@ class MockIdentityManager: IdentityManager {
 
         super.init(deviceCache: mockDeviceCache,
                    backend: mockBackend,
-                   customerInfoManager: MockCustomerInfoManager(operationDispatcher: MockOperationDispatcher(),
-                                                                deviceCache: mockDeviceCache,
-                                                                backend: mockBackend,
-                                                                systemInfo: mockSystemInfo),
+                   customerInfoManager: MockCustomerInfoManager(
+                    offlineEntitlementsManager: MockOfflineEntitlementsManager(),
+                    operationDispatcher: MockOperationDispatcher(),
+                    deviceCache: mockDeviceCache,
+                    backend: mockBackend,
+                    systemInfo: mockSystemInfo
+                   ),
                    attributeSyncing: self.mockAttributeSyncing,
                    appUserID: mockAppUserID)
     }

--- a/Tests/UnitTests/Mocks/MockOfflineCustomerInfoCreator.swift
+++ b/Tests/UnitTests/Mocks/MockOfflineCustomerInfoCreator.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockOfflineCustomerInfoCreator.swift
+//
+//  Created by Nacho Soto on 5/18/23.
+
+@testable import RevenueCat
+
+class MockOfflineCustomerInfoCreator: OfflineCustomerInfoCreator {
+
+    init() {
+        super.init(
+            purchasedProductsFetcher: MockPurchasedProductsFetcher(),
+            productEntitlementMappingFetcher: MockProductEntitlementMappingFetcher(),
+            creator: { CustomerInfo(from: $0, mapping: $1, userID: $2) }
+        )
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockOfflineEntitlementsAPI.swift
+++ b/Tests/UnitTests/Mocks/MockOfflineEntitlementsAPI.swift
@@ -16,6 +16,10 @@ import Foundation
 
 class MockOfflineEntitlementsAPI: OfflineEntitlementsAPI {
 
+    init() {
+        super.init(backendConfig: MockBackendConfiguration())
+    }
+
     var invokedGetProductEntitlementMapping = false
     var invokedGetProductEntitlementMappingCount = 0
     var invokedGetProductEntitlementMappingParameter: Bool?

--- a/Tests/UnitTests/Mocks/MockOfflineEntitlementsManager.swift
+++ b/Tests/UnitTests/Mocks/MockOfflineEntitlementsManager.swift
@@ -7,7 +7,7 @@
 //
 //      https://opensource.org/licenses/MIT
 //
-//  MockOfflineEntitlementsManager.swift
+//  MockOfflineEntitlementsManager.swiftz
 //
 //  Created by Nacho Soto on 3/22/23.
 
@@ -15,6 +15,12 @@ import Foundation
 @testable import RevenueCat
 
 class MockOfflineEntitlementsManager: OfflineEntitlementsManager {
+
+    init() {
+        super.init(deviceCache: MockDeviceCache(),
+                   operationDispatcher: MockOperationDispatcher(),
+                   api: MockOfflineEntitlementsAPI())
+    }
 
     var invokedUpdateProductsEntitlementsCacheIfStale = false
     var invokedUpdateProductsEntitlementsCacheIfStaleCount = 0
@@ -29,6 +35,12 @@ class MockOfflineEntitlementsManager: OfflineEntitlementsManager {
         self.invokedUpdateProductsEntitlementsCacheIfStaleCount += 1
         self.invokedUpdateProductsEntitlementsCacheIfStaleParameters = isAppBackgrounded
         self.invokedUpdateProductsEntitlementsCacheIfStaleParametersList.append(isAppBackgrounded)
+    }
+
+    var stubbedShouldComputeOfflineCustomerInfo: Bool = false
+
+    override func shouldComputeOfflineCustomerInfo(appUserID: String) -> Bool {
+        return self.stubbedShouldComputeOfflineCustomerInfo
     }
 
 }

--- a/Tests/UnitTests/Mocks/MockProductEntitlementMappingFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockProductEntitlementMappingFetcher.swift
@@ -1,0 +1,25 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockProductEntitlementMappingFetcher.swift
+//
+//  Created by Nacho Soto on 3/23/23.
+
+import Foundation
+@testable import RevenueCat
+
+final class MockProductEntitlementMappingFetcher: ProductEntitlementMappingFetcher {
+
+    var stubbedResult: ProductEntitlementMapping?
+
+    var productEntitlementMapping: ProductEntitlementMapping? {
+        return self.stubbedResult
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockPurchasedProductsFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockPurchasedProductsFetcher.swift
@@ -1,0 +1,31 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockPurchasedProductsFetcher.swift
+//
+//  Created by Nacho Soto on 3/22/23.
+
+import Foundation
+@testable import RevenueCat
+import StoreKit
+
+final class MockPurchasedProductsFetcher: PurchasedProductsFetcherType {
+
+    var invokedFetch = false
+    var invokedFetchCount = 0
+    var stubbedResult: Result<[PurchasedSK2Product], Error> = .failure(ErrorCode.invalidAppUserIdError)
+
+    func fetchPurchasedProducts() async throws -> [PurchasedSK2Product] {
+        self.invokedFetch = true
+        self.invokedFetchCount += 1
+
+        return try self.stubbedResult.get()
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockPurchasedProductsFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockPurchasedProductsFetcher.swift
@@ -21,6 +21,7 @@ final class MockPurchasedProductsFetcher: PurchasedProductsFetcherType {
     var invokedFetchCount = 0
     var stubbedResult: Result<[PurchasedSK2Product], Error> = .failure(ErrorCode.invalidAppUserIdError)
 
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func fetchPurchasedProducts() async throws -> [PurchasedSK2Product] {
         self.invokedFetch = true
         self.invokedFetchCount += 1

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -55,8 +55,7 @@ class BaseBackendTests: TestCase {
             operationDispatcher: self.operationDispatcher,
             operationQueue: MockBackend.QueueProvider.createBackendQueue(),
             systemInfo: self.systemInfo,
-            productEntitlementMappingFetcher: self.mockProductEntitlementMappingFetcher,
-            purchasedProductsFetcher: self.mockPurchasedProductsFetcher,
+            offlineCustomerInfoCreator: MockOfflineCustomerInfoCreator(),
             dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate)
         )
 

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -23,6 +23,8 @@ class BaseBackendTests: TestCase {
     private(set) var systemInfo: SystemInfo!
     private(set) var httpClient: MockHTTPClient!
     private(set) var operationDispatcher: MockOperationDispatcher!
+    private(set) var mockProductEntitlementMappingFetcher: MockProductEntitlementMappingFetcher!
+    private(set) var mockPurchasedProductsFetcher: MockPurchasedProductsFetcher!
     private(set) var backend: Backend!
     private(set) var offerings: OfferingsAPI!
     private(set) var offlineEntitlements: OfflineEntitlementsAPI!
@@ -43,14 +45,20 @@ class BaseBackendTests: TestCase {
         )
         self.httpClient = self.createClient()
         self.operationDispatcher = MockOperationDispatcher()
+        self.mockProductEntitlementMappingFetcher = MockProductEntitlementMappingFetcher()
+        self.mockPurchasedProductsFetcher = MockPurchasedProductsFetcher()
 
         let attributionFetcher = AttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
                                                     systemInfo: self.systemInfo)
-        let backendConfig = BackendConfiguration(httpClient: self.httpClient,
-                                                 operationDispatcher: operationDispatcher,
-                                                 operationQueue: MockBackend.QueueProvider.createBackendQueue(),
-                                                 dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate),
-                                                 systemInfo: self.systemInfo)
+        let backendConfig = BackendConfiguration(
+            httpClient: self.httpClient,
+            operationDispatcher: self.operationDispatcher,
+            operationQueue: MockBackend.QueueProvider.createBackendQueue(),
+            systemInfo: self.systemInfo,
+            productEntitlementMappingFetcher: self.mockProductEntitlementMappingFetcher,
+            purchasedProductsFetcher: self.mockPurchasedProductsFetcher,
+            dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate)
+        )
 
         let customer = CustomerAPI(backendConfig: backendConfig, attributionFetcher: attributionFetcher)
         self.identity = IdentityAPI(backendConfig: backendConfig)

--- a/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
+++ b/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
@@ -1,0 +1,318 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CustomerInfoResponseHandlerTests.swift
+//
+//  Created by Nacho Soto on 3/23/23.
+
+import Nimble
+@testable import RevenueCat
+import StoreKit
+import XCTest
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+class BaseCustomerInfoResponseHandlerTests: TestCase {
+
+    fileprivate let userID = "nacho"
+    fileprivate var fetcher: MockPurchasedProductsFetcher!
+    fileprivate var factory: CustomerInfoFactory!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        // These tests are written using async for simplicity
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
+        self.fetcher = MockPurchasedProductsFetcher()
+        self.factory = CustomerInfoFactory()
+    }
+
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+class NormalCustomerInfoResponseHandlerTests: BaseCustomerInfoResponseHandlerTests {
+
+    func testHandleNormalResponse() async {
+        let result = await self.handle(
+            .success(
+                .init(statusCode: .success,
+                      responseHeaders: [:],
+                      body: .init(customerInfo: Self.sampleCustomerInfo,
+                                  errorResponse: .default),
+                      verificationResult: .verified)
+            ),
+            nil
+        )
+        expect(result).to(beSuccess())
+        expect(result.value) == Self.sampleCustomerInfo.copy(with: .verified)
+
+        expect(self.factory.createRequested) == false
+    }
+
+    func testHandleWithFailedVerification() async {
+        let result = await self.handle(
+            .success(
+                .init(statusCode: .success,
+                      responseHeaders: [:],
+                      body: .init(customerInfo: Self.sampleCustomerInfo,
+                                  errorResponse: .default),
+                      verificationResult: .failed)
+            ),
+            nil
+        )
+        expect(result).to(beSuccess())
+        expect(result.value) == Self.sampleCustomerInfo.copy(with: .failed)
+
+        expect(self.factory.createRequested) == false
+    }
+
+    func testNotFoundError() async {
+        let error: NetworkError = .errorResponse(.default, .notFoundError)
+        let result = await self.handle(
+            .failure(error),
+            nil
+        )
+        expect(result).to(beFailure())
+        expect(result.error).to(matchError(BackendError.networkError(error)))
+
+        expect(self.factory.createRequested) == false
+    }
+
+    func testCustomerInfoWithAttributeErrors() async {
+        let errorResponse = ErrorResponse(
+            code: .invalidSubscriberAttributes,
+            originalCode: BackendErrorCode.invalidSubscriberAttributes.rawValue,
+            message: "Invalid attributes",
+            attributeErrors: [
+                "$email": "Email is not valid"
+            ]
+        )
+
+        let logger = TestLogHandler()
+
+        let result = await self.handle(
+            .success(
+                .init(statusCode: .success,
+                      responseHeaders: [:],
+                      body: .init(customerInfo: Self.sampleCustomerInfo,
+                                  errorResponse: errorResponse),
+                      verificationResult: .notRequested)
+            ),
+            nil
+        )
+        expect(result).to(beSuccess())
+        expect(result.value) == Self.sampleCustomerInfo.copy(with: .notRequested)
+        expect(self.factory.createRequested) == false
+
+        logger.verifyMessageWasLogged(
+            "\(ErrorCode.invalidSubscriberAttributesError.description) \(errorResponse.attributeErrors)",
+            level: .error
+        )
+    }
+
+    func testServerErrorBeforeIOS15() async throws {
+        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            throw XCTSkip("This test is for older versions")
+        }
+
+        let error: NetworkError = .errorResponse(.default, .internalServerError)
+
+        let result = await self.handle(.failure(error), nil)
+        expect(result).to(beFailure())
+        expect(result.error).to(matchError(BackendError.networkError(error)))
+
+        expect(self.factory.createRequested) == false
+    }
+}
+
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+class OfflineCustomerInfoResponseHandlerTests: BaseCustomerInfoResponseHandlerTests {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+    }
+
+    func testServerErrorWithNoEntitlementMappingAndNoProducts() async {
+        self.fetcher.stubbedResult = .success([])
+        self.factory.stubbedResult = Self.offlineCustomerInfo
+
+        let error: NetworkError = .errorResponse(.default, .internalServerError)
+
+        let result = await self.handle(.failure(error), nil)
+        expect(result).to(beSuccess())
+        expect(result.value) == Self.offlineCustomerInfo
+
+        expect(self.factory.createRequested) == true
+        expect(self.factory.createRequestParameters?.products) == []
+        expect(self.factory.createRequestParameters?.mapping) == .empty
+        expect(self.factory.createRequestParameters?.userID) == self.userID
+    }
+
+    func testServerErrorLogsWarningIfCreatingOfflineCustomerInfoWithNoMapping() async {
+        self.fetcher.stubbedResult = .success([])
+        self.factory.stubbedResult = Self.offlineCustomerInfo
+
+        let error: NetworkError = .errorResponse(.default, .internalServerError)
+        let logger = TestLogHandler()
+
+        let result = await self.handle(.failure(error), nil)
+        expect(result).to(beSuccess())
+
+        logger.verifyMessageWasLogged(
+            Strings.offlineEntitlements.computing_offline_customer_info_with_no_entitlement_mapping,
+            level: .warn
+        )
+    }
+
+    func testServerErrorCreatesOfflineCustomerInfo() async {
+        self.fetcher.stubbedResult = .success([
+            Self.purchasedProduct
+        ])
+        self.factory.stubbedResult = Self.offlineCustomerInfo
+
+        let logger = TestLogHandler()
+        let error: NetworkError = .errorResponse(.default, .internalServerError)
+
+        let result = await self.handle(.failure(error), Self.mapping)
+        expect(result).to(beSuccess())
+        expect(result.value) == Self.offlineCustomerInfo
+
+        expect(self.factory.createRequested) == true
+        expect(self.factory.createRequestCount) == 1
+        expect(self.factory.createRequestParameters?.products) == [Self.purchasedProduct]
+        expect(self.factory.createRequestParameters?.mapping) == Self.mapping
+        expect(self.factory.createRequestParameters?.userID) == self.userID
+
+        logger.verifyMessageWasLogged(Strings.offlineEntitlements.computing_offline_customer_info, level: .info)
+    }
+
+    func testServerErrorWithFailingPurchasedProductsFetcher() async {
+        let logger = TestLogHandler()
+
+        let fetcherError = StoreKitError.systemError(StoreKitError.unknown)
+        let error: NetworkError = .errorResponse(.default, .internalServerError)
+
+        self.fetcher.stubbedResult = .failure(fetcherError)
+
+        let result = await self.handle(.failure(error), Self.mapping)
+        expect(result).to(beFailure())
+        expect(result.error).to(matchError(BackendError.networkError(error)))
+
+        expect(self.factory.createRequested) == false
+
+        logger.verifyMessageWasLogged(Strings.offlineEntitlements.computing_offline_customer_info_failed(fetcherError),
+                                      level: .error)
+    }
+
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+private extension BaseCustomerInfoResponseHandlerTests {
+
+    private func create(_ mapping: ProductEntitlementMapping?) -> CustomerInfoResponseHandler {
+        return .init(purchasedProductsFetcher: self.fetcher,
+                     productEntitlementMapping: mapping,
+                     customerInfoCreator: self.factory.create,
+                     userID: self.userID)
+    }
+
+    func handle(
+        _ response: HTTPResponse<CustomerInfoResponseHandler.Response>.Result,
+        _ mapping: ProductEntitlementMapping?
+    ) async -> Result<CustomerInfo, BackendError> {
+        let handler = self.create(mapping)
+
+        return await Async.call { completion in
+            handler.handle(customerInfoResponse: response, completion: completion)
+        }
+    }
+
+    static let purchasedProduct: PurchasedSK2Product = .init(
+        productIdentifier: "product",
+        subscription: .init(),
+        entitlement: .init(productIdentifier: "entitlement", rawData: [:])
+    )
+    static let mapping: ProductEntitlementMapping = .init(entitlementsByProduct: [
+        "product": ["entitlement"]
+    ])
+
+    static let sampleCustomerInfo: CustomerInfo = .init(testData: [
+        "request_date": "2019-08-16T10:30:42Z",
+        "subscriber": [
+            "subscriptions": [:] as [String: Any],
+            "first_seen": "2019-07-17T00:05:54Z",
+            "original_app_user_id": "nacho",
+            "other_purchases": [:]  as [String: Any]
+        ]  as [String: Any]
+    ])!
+    static let offlineCustomerInfo: CustomerInfo = .init(testData: [
+        "request_date": "2023-08-16T10:30:42Z",
+        "subscriber": [
+            "subscriptions": [
+                "monthly_freetrial": [
+                    "billing_issues_detected_at": nil,
+                    "expires_date": "2019-07-26T23:50:40Z",
+                    "is_sandbox": true,
+                    "original_purchase_date": "2019-07-26T23:30:41Z",
+                    "period_type": "normal",
+                    "purchase_date": "2019-07-26T23:45:40Z",
+                    "store": "app_store",
+                    "unsubscribe_detected_at": nil
+                ]  as [String: Any?]
+            ],
+            "non_subscriptions": [:]  as [String: Any],
+            "entitlements": [
+                "pro": [
+                    "product_identifier": "monthly_freetrial",
+                    "expires_date": "2018-12-19T02:40:36Z",
+                    "purchase_date": "2018-07-26T23:30:41Z"
+                ]
+            ],
+            "first_seen": "2023-07-17T00:05:54Z",
+            "original_app_user_id": "nacho2",
+            "other_purchases": [:]  as [String: Any]
+        ]  as [String: Any]
+    ])!
+
+}
+
+private final class CustomerInfoFactory {
+
+    var stubbedResult: CustomerInfo?
+
+    var createRequested: Bool = false
+    var createRequestCount: Int = 0
+    var createRequestParameters: (
+        products: [PurchasedSK2Product],
+        mapping: ProductEntitlementMapping,
+        userID: String
+    )?
+
+    func create(products: [PurchasedSK2Product], mapping: ProductEntitlementMapping, userID: String) -> CustomerInfo {
+        guard let result = self.stubbedResult else {
+            fatalError("Creation requested without stub")
+        }
+
+        self.createRequested = true
+        self.createRequestCount += 1
+        self.createRequestParameters = (products, mapping, userID)
+
+        return result
+    }
+
+}
+
+private extension ErrorResponse {
+
+    static let `default`: Self = .init(code: .unknownBackendError,
+                                       originalCode: BackendErrorCode.unknownError.rawValue)
+
+}

--- a/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
+++ b/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
@@ -192,6 +192,10 @@ class OfflineCustomerInfoResponseHandlerTests: BaseCustomerInfoResponseHandlerTe
         expect(self.factory.createRequestParameters?.userID) == self.userID
 
         logger.verifyMessageWasLogged(Strings.offlineEntitlements.computing_offline_customer_info, level: .info)
+        logger.verifyMessageWasLogged(
+            Strings.offlineEntitlements.computed_offline_customer_info(Self.offlineCustomerInfo.entitlements),
+            level: .info
+        )
     }
 
     func testServerErrorWithFailingPurchasedProductsFetcher() async {

--- a/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
+++ b/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
@@ -256,11 +256,15 @@ class OfflineCustomerInfoResponseHandlerTests: BaseCustomerInfoResponseHandlerTe
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 private extension BaseCustomerInfoResponseHandlerTests {
 
+    private struct MappingFetcher: ProductEntitlementMappingFetcher {
+        let productEntitlementMapping: ProductEntitlementMapping?
+    }
+
     private func create(_ mapping: ProductEntitlementMapping?) -> CustomerInfoResponseHandler {
         return .init(
             offlineCreator: .init(
                 purchasedProductsFetcher: self.fetcher,
-                productEntitlementMapping: mapping,
+                productEntitlementMappingFetcher: MappingFetcher(productEntitlementMapping: mapping),
                 creator: self.factory.create
             ),
             userID: self.userID

--- a/Tests/UnitTests/OfflineEntitlements/OfflineEntitlementsManagerTests.swift
+++ b/Tests/UnitTests/OfflineEntitlements/OfflineEntitlementsManagerTests.swift
@@ -103,6 +103,15 @@ class OfflineEntitlementsManagerAvailableTests: BaseOfflineEntitlementsManagerTe
         expect(self.mockOfflineEntitlements.invokedGetProductEntitlementMappingCount) == 1
     }
 
+    func testShouldComputeOfflineCustomerInfo() {
+        expect(self.manager.shouldComputeOfflineCustomerInfo(appUserID: "test")) == true
+    }
+
+    func testShouldNotComputeOfflineCustomerInfo() {
+        self.mockDeviceCache.cachedCustomerInfo["test"] = Data()
+        expect(self.manager.shouldComputeOfflineCustomerInfo(appUserID: "test")) == false
+    }
+
 }
 
 // swiftlint:disable:next type_name

--- a/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
@@ -875,6 +875,30 @@ class BasicCustomerInfoTests: TestCase {
         expect(updatedCustomerInfo.entitlements["expired_pro"]?.isActive) == true
     }
 
+    func testIsNeverComputedOfflinePriorToIOS13() throws {
+        if #available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *) {
+            throw XCTSkip("Test only for iOS 12.")
+        }
+
+        expect(self.customerInfo.copy(with: .verifiedOnDevice).isComputedOffline) == false
+    }
+
+    func testIsNotComputedOfflineIfVerificationNotRequested() {
+        expect(self.customerInfo.copy(with: .notRequested).isComputedOffline) == false
+    }
+
+    func testIsNotComputedOfflineIfVerified() {
+        expect(self.customerInfo.copy(with: .verified).isComputedOffline) == false
+    }
+
+    func testIsNotComputedOfflineIfFailedVerification() {
+        expect(self.customerInfo.copy(with: .failed).isComputedOffline) == false
+    }
+
+    func testIsComputedOffline() {
+        expect(self.customerInfo.copy(with: .verifiedOnDevice).isComputedOffline) == true
+    }
+
     // MARK: - Private
 
     private func verifyCopy(

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -77,7 +77,9 @@ class BasePurchasesTests: TestCase {
         self.attribution = Attribution(subscriberAttributesManager: self.subscriberAttributesManager,
                                        currentUserProvider: self.identityManager,
                                        attributionPoster: self.attributionPoster)
-        self.customerInfoManager = CustomerInfoManager(operationDispatcher: self.mockOperationDispatcher,
+        self.mockOfflineEntitlementsManager = MockOfflineEntitlementsManager()
+        self.customerInfoManager = CustomerInfoManager(offlineEntitlementsManager: self.mockOfflineEntitlementsManager,
+                                                       operationDispatcher: self.mockOperationDispatcher,
                                                        deviceCache: self.deviceCache,
                                                        backend: self.backend,
                                                        systemInfo: self.systemInfo)
@@ -87,11 +89,6 @@ class BasePurchasesTests: TestCase {
                                                          backend: self.backend,
                                                          offeringsFactory: self.offeringsFactory,
                                                          productsManager: self.mockProductsManager)
-        self.mockOfflineEntitlementsManager = MockOfflineEntitlementsManager(
-            deviceCache: self.deviceCache,
-            operationDispatcher: self.mockOperationDispatcher,
-            api: self.backend.offlineEntitlements
-        )
         self.mockManageSubsHelper = MockManageSubscriptionsHelper(systemInfo: self.systemInfo,
                                                                   customerInfoManager: self.customerInfoManager,
                                                                   currentUserProvider: self.identityManager)
@@ -402,6 +399,7 @@ extension BasePurchasesTests {
 
         override func getCustomerInfo(appUserID: String,
                                       withRandomDelay randomDelay: Bool,
+                                      allowComputingOffline: Bool,
                                       completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
             self.getSubscriberCallCount += 1
             self.userID = appUserID

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -58,8 +58,7 @@ class BasePurchasesTests: TestCase {
                                           operationDispatcher: self.mockOperationDispatcher,
                                           operationQueue: MockBackend.QueueProvider.createBackendQueue(),
                                           systemInfo: self.systemInfo,
-                                          productEntitlementMappingFetcher: self.mockProductEntitlementMappingFetcher,
-                                          purchasedProductsFetcher: self.mockPurchasedProductsFetcher,
+                                          offlineCustomerInfoCreator: MockOfflineCustomerInfoCreator(),
                                           dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
         self.backend = MockBackend(backendConfig: config, attributionFetcher: self.attributionFetcher)
         self.subscriberAttributesManager = MockSubscriberAttributesManager(

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -49,14 +49,18 @@ class BasePurchasesTests: TestCase {
         self.receiptFetcher = MockReceiptFetcher(requestFetcher: self.requestFetcher, systemInfo: systemInfoAttribution)
         self.attributionFetcher = MockAttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
                                                          systemInfo: systemInfoAttribution)
+        self.mockProductEntitlementMappingFetcher = MockProductEntitlementMappingFetcher()
+        self.mockPurchasedProductsFetcher = MockPurchasedProductsFetcher()
 
         let apiKey = "mockAPIKey"
         let httpClient = MockHTTPClient(apiKey: apiKey, systemInfo: self.systemInfo, eTagManager: MockETagManager())
         let config = BackendConfiguration(httpClient: httpClient,
                                           operationDispatcher: self.mockOperationDispatcher,
                                           operationQueue: MockBackend.QueueProvider.createBackendQueue(),
-                                          dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate),
-                                          systemInfo: self.systemInfo)
+                                          systemInfo: self.systemInfo,
+                                          productEntitlementMappingFetcher: self.mockProductEntitlementMappingFetcher,
+                                          purchasedProductsFetcher: self.mockPurchasedProductsFetcher,
+                                          dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
         self.backend = MockBackend(backendConfig: config, attributionFetcher: self.attributionFetcher)
         self.subscriberAttributesManager = MockSubscriberAttributesManager(
             backend: self.backend,
@@ -143,6 +147,7 @@ class BasePurchasesTests: TestCase {
             self.identityManager = nil
             self.mockOfferingsManager = nil
             self.mockOfflineEntitlementsManager = nil
+            self.mockPurchasedProductsFetcher = nil
             self.mockManageSubsHelper = nil
             self.mockBeginRefundRequestHelper = nil
             self.purchasesOrchestrator = nil
@@ -180,6 +185,8 @@ class BasePurchasesTests: TestCase {
     var customerInfoManager: CustomerInfoManager!
     var mockOfferingsManager: MockOfferingsManager!
     var mockOfflineEntitlementsManager: MockOfflineEntitlementsManager!
+    var mockProductEntitlementMappingFetcher: MockProductEntitlementMappingFetcher!
+    var mockPurchasedProductsFetcher: MockPurchasedProductsFetcher!
     var purchasesOrchestrator: PurchasesOrchestrator!
     var trialOrIntroPriceEligibilityChecker: MockTrialOrIntroPriceEligibilityChecker!
     var cachingTrialOrIntroPriceEligibilityChecker: MockCachingTrialOrIntroPriceEligibilityChecker!

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -55,11 +55,13 @@ class BackendSubscriberAttributesTests: TestCase {
         let attributionFetcher = AttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
                                                     systemInfo: self.systemInfo)
 
-        let config = BackendConfiguration(httpClient: mockHTTPClient,
+        let config = BackendConfiguration(httpClient: self.mockHTTPClient,
                                           operationDispatcher: MockOperationDispatcher(),
                                           operationQueue: MockBackend.QueueProvider.createBackendQueue(),
-                                          dateProvider: dateProvider,
-                                          systemInfo: self.systemInfo)
+                                          systemInfo: self.systemInfo,
+                                          productEntitlementMappingFetcher: MockProductEntitlementMappingFetcher(),
+                                          purchasedProductsFetcher: MockPurchasedProductsFetcher(),
+                                          dateProvider: self.dateProvider)
 
         self.backend = Backend(backendConfig: config, attributionFetcher: attributionFetcher)
 

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -59,8 +59,7 @@ class BackendSubscriberAttributesTests: TestCase {
                                           operationDispatcher: MockOperationDispatcher(),
                                           operationQueue: MockBackend.QueueProvider.createBackendQueue(),
                                           systemInfo: self.systemInfo,
-                                          productEntitlementMappingFetcher: MockProductEntitlementMappingFetcher(),
-                                          purchasedProductsFetcher: MockPurchasedProductsFetcher(),
+                                          offlineCustomerInfoCreator: MockOfflineCustomerInfoCreator(),
                                           dateProvider: self.dateProvider)
 
         self.backend = Backend(backendConfig: config, attributionFetcher: attributionFetcher)

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -104,21 +104,18 @@ class PurchasesSubscriberAttributesTests: TestCase {
         self.attribution = Attribution(subscriberAttributesManager: self.mockSubscriberAttributesManager,
                                        currentUserProvider: self.mockIdentityManager,
                                        attributionPoster: self.mockAttributionPoster)
-        self.customerInfoManager = CustomerInfoManager(operationDispatcher: mockOperationDispatcher,
-                                                       deviceCache: mockDeviceCache,
-                                                       backend: mockBackend,
-                                                       systemInfo: systemInfo)
+        self.mockOfflineEntitlementsManager = MockOfflineEntitlementsManager()
+        self.customerInfoManager = CustomerInfoManager(offlineEntitlementsManager: self.mockOfflineEntitlementsManager,
+                                                       operationDispatcher: self.mockOperationDispatcher,
+                                                       deviceCache: self.mockDeviceCache,
+                                                       backend: self.mockBackend,
+                                                       systemInfo: self.systemInfo)
         self.mockOfferingsManager = MockOfferingsManager(deviceCache: mockDeviceCache,
                                                          operationDispatcher: mockOperationDispatcher,
                                                          systemInfo: systemInfo,
                                                          backend: mockBackend,
                                                          offeringsFactory: MockOfferingsFactory(),
                                                          productsManager: mockProductsManager)
-        self.mockOfflineEntitlementsManager = MockOfflineEntitlementsManager(
-            deviceCache: mockDeviceCache,
-            operationDispatcher: mockOperationDispatcher,
-            api: mockBackend.offlineEntitlements
-        )
         self.mockReceiptFetcher = MockReceiptFetcher(
             requestFetcher: mockRequestFetcher,
             systemInfo: systemInfoAttribution


### PR DESCRIPTION
### Changes:
- Created `PurchasedProductsFetcherType` to be able to mock and hold fetchers, even on older devices
- Created `ProductEntitlementMappingFetcher` to abstract injecting `ProductEntitlementMapping`
- Added logic to `CustomerInfoResponseHandler` to compute offline `CustomerInfo` after a server error (see #2367). **This is used by all `CustomerInfo` requests as well as `PostReceiptDataOperation`**.
- Wrote comprehensive `CustomerInfoResponseHandler` tests

### TODO:
- [x] Don't cache offline computed `CustomerInfo`: #2378
- [x] Integration tests: #2501.