### PR TITLE
`HTTPClient`: new flag to force server errors

### DIFF
--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -19,7 +19,15 @@ import Foundation
         /// Whether `ReceiptFetcher` can retry fetching receipts.
         let enableReceiptFetchRetry: Bool
 
-        static let `default`: Self = .init(enableReceiptFetchRetry: false)
+        /// Whether `HTTPClient` will fake server errors
+        let forceServerErrors: Bool
+
+        init(enableReceiptFetchRetry: Bool = false, forceServerErrors: Bool = false) {
+            self.enableReceiptFetchRetry = enableReceiptFetchRetry
+            self.forceServerErrors = forceServerErrors
+        }
+
+        static let `default`: Self = .init()
     }
 
     /**

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -58,6 +58,15 @@ class HTTPClient {
         with verificationMode: Signing.ResponseVerificationMode? = nil,
         completionHandler: Completion<Value>?
     ) {
+        #if DEBUG
+        if self.systemInfo.dangerousSettings.internalSettings.forceServerErrors {
+            completionHandler?(
+                .failure(.errorResponse(Self.serverErrorResponse, .internalServerError))
+            )
+            return
+        }
+        #endif
+
         self.perform(request: .init(httpRequest: request,
                                     authHeaders: self.authHeaders,
                                     verificationMode: verificationMode ?? self.systemInfo.responseVerificationMode,
@@ -198,6 +207,9 @@ private extension HTTPClient {
         }
         return headers
     }
+
+    static let serverErrorResponse: ErrorResponse = .init(code: .internalServerError,
+                                                          originalCode: BackendErrorCode.unknownBackendError.rawValue)
 
     func perform(request: Request) {
         if !request.retried {

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -59,7 +59,7 @@ class HTTPClient {
         completionHandler: Completion<Value>?
     ) {
         #if DEBUG
-        if self.systemInfo.dangerousSettings.internalSettings.forceServerErrors {
+        guard !self.systemInfo.dangerousSettings.internalSettings.forceServerErrors else {
             completionHandler?(
                 .failure(.errorResponse(Self.serverErrorResponse, .internalServerError))
             )


### PR DESCRIPTION
This will help testing offline entitlements.
Note that this is only available as an `internal` API, and only on `debug` builds.