### PR TITLE
`HTTPClient`: debug log when performing redirects

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -367,6 +367,7 @@
 		57C381DC27961547009E3940 /* SK2StoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381DB27961547009E3940 /* SK2StoreProductDiscount.swift */; };
 		57C381E2279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */; };
 		57C381E3279627B7009E3940 /* MockStoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */; };
+		57CB2AD429CCF21A00C91439 /* RedirectLoggerTaskDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CB2AD329CCF21900C91439 /* RedirectLoggerTaskDelegate.swift */; };
 		57CCC6EC2984496D001CE9B6 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CCC6EB2984496D001CE9B6 /* Box.swift */; };
 		57CD86DA291C1E2300768DE1 /* UserDefaults+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CD86D9291C1E2300768DE1 /* UserDefaults+Extensions.swift */; };
 		57CD86E6291C344000768DE1 /* UserDefaultsDefaultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CD86E5291C344000768DE1 /* UserDefaultsDefaultTests.swift */; };
@@ -995,6 +996,7 @@
 		57C381D92796153D009E3940 /* SK1StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1StoreProductDiscount.swift; sourceTree = "<group>"; };
 		57C381DB27961547009E3940 /* SK2StoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2StoreProductDiscount.swift; sourceTree = "<group>"; };
 		57C381E1279627B7009E3940 /* MockStoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreProductDiscount.swift; sourceTree = "<group>"; };
+		57CB2AD329CCF21900C91439 /* RedirectLoggerTaskDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedirectLoggerTaskDelegate.swift; sourceTree = "<group>"; };
 		57CCC6EB2984496D001CE9B6 /* Box.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
 		57CD86D9291C1E2300768DE1 /* UserDefaults+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Extensions.swift"; sourceTree = "<group>"; };
 		57CD86E5291C344000768DE1 /* UserDefaultsDefaultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsDefaultTests.swift; sourceTree = "<group>"; };
@@ -2263,6 +2265,7 @@
 				B3F3E8D9277158FE0047A5B9 /* DNSChecker.swift */,
 				35D832CC262A5B7500E60AC5 /* ETagManager.swift */,
 				35F82BB326A9A74D0051DF03 /* HTTPClient.swift */,
+				57CB2AD329CCF21900C91439 /* RedirectLoggerTaskDelegate.swift */,
 				57DC9F4527CC2E4900DA6AF9 /* HTTPRequest.swift */,
 				35D832F3262E606500E60AC5 /* HTTPResponse.swift */,
 				575137CE27F50D2F0064AB2C /* HTTPResponseBody.swift */,
@@ -2861,6 +2864,7 @@
 				F5714EE526DC2F1D00635477 /* CodableStrings.swift in Sources */,
 				57488BE829CB7FB60000EE7E /* OfflineEntitlementsStrings.swift in Sources */,
 				57E6C27C29723A94001AFE98 /* Signing.swift in Sources */,
+				57CB2AD429CCF21A00C91439 /* RedirectLoggerTaskDelegate.swift in Sources */,
 				57C381DC27961547009E3940 /* SK2StoreProductDiscount.swift in Sources */,
 				B34605CA279A6E380031CA74 /* GetCustomerInfoOperation.swift in Sources */,
 				5751379527F4C4D80064AB2C /* Optional+Extensions.swift in Sources */,

--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -33,6 +33,7 @@ enum NetworkStrings {
     case could_not_find_cached_response_in_already_retried(response: String)
     case failing_url_resolved_to_host(url: URL, resolvedHost: String)
     case blocked_network(url: URL, newHost: String?)
+    case api_request_redirect(from: URL, to: URL)
 
 }
 
@@ -94,6 +95,9 @@ extension NetworkStrings: CustomStringConvertible {
             return "It looks like requests to RevenueCat are being blocked. Context: We're attempting to connect " +
             "to \(url.absoluteString) host: (\(newHost ?? "<unable to resolve>")), " +
             "see: https://rev.cat/dnsBlocking for more info."
+
+        case let .api_request_redirect(from, to):
+            return "Performing redirect from '\(from.absoluteString)' to '\(to.absoluteString)'"
         }
     }
 

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -42,7 +42,9 @@ class HTTPClient {
         config.httpMaximumConnectionsPerHost = 1
         config.timeoutIntervalForRequest = requestTimeout
         config.timeoutIntervalForResource = requestTimeout
-        self.session = URLSession(configuration: config)
+        self.session = URLSession(configuration: config,
+                                  delegate: RedirectLoggerSessionDelegate(),
+                                  delegateQueue: nil)
         self.systemInfo = systemInfo
         self.eTagManager = eTagManager
         self.dnsChecker = dnsChecker
@@ -355,10 +357,6 @@ private extension HTTPClient {
                         urlRequest: urlRequest,
                         data: data,
                         error: error)
-        }
-
-        if #available(iOS 15.0, *) {
-            task.delegate = RedirectLoggerTaskDelegate()
         }
         task.resume()
     }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -96,6 +96,7 @@ extension HTTPClient {
     enum RequestHeader: String {
 
         case authorization = "Authorization"
+        case location = "Location"
         case nonce = "X-Nonce"
         case eTag = "X-RevenueCat-ETag"
 
@@ -348,12 +349,16 @@ private extension HTTPClient {
 
         Logger.debug(Strings.network.api_request_started(request.httpRequest))
 
-        let task = session.dataTask(with: urlRequest) { (data, urlResponse, error) -> Void in
+        let task = self.session.dataTask(with: urlRequest) { (data, urlResponse, error) -> Void in
             self.handle(urlResponse: urlResponse,
                         request: request,
                         urlRequest: urlRequest,
                         data: data,
                         error: error)
+        }
+
+        if #available(iOS 15.0, *) {
+            task.delegate = RedirectLoggerTaskDelegate()
         }
         task.resume()
     }

--- a/Sources/Networking/HTTPClient/HTTPStatusCode.swift
+++ b/Sources/Networking/HTTPClient/HTTPStatusCode.swift
@@ -20,6 +20,7 @@ enum HTTPStatusCode {
     case createdSuccess
     case redirect
     case notModified
+    case temporaryRedirect
     case invalidRequest
     case notFoundError
     case internalServerError
@@ -32,6 +33,7 @@ enum HTTPStatusCode {
         .createdSuccess,
         .redirect,
         .notModified,
+        .temporaryRedirect,
         .invalidRequest,
         .notFoundError,
         .internalServerError,
@@ -52,6 +54,7 @@ extension HTTPStatusCode: RawRepresentable {
         case .createdSuccess: return 201
         case .redirect: return 300
         case .notModified: return 304
+        case .temporaryRedirect: return 307
         case .invalidRequest: return 400
         case .notFoundError: return 404
         case .internalServerError: return 500

--- a/Sources/Networking/HTTPClient/RedirectLoggerTaskDelegate.swift
+++ b/Sources/Networking/HTTPClient/RedirectLoggerTaskDelegate.swift
@@ -1,0 +1,32 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  RedirectLoggerTaskDelegate.swift
+//
+//  Created by Nacho Soto on 3/23/23.
+
+import Foundation
+
+/// Implementation of `URLSessionTaskDelegate` that logs when the task will perform a redirection.
+final class RedirectLoggerTaskDelegate: NSObject, URLSessionTaskDelegate {
+
+    func urlSession(_ session: URLSession,
+                    task: URLSessionTask,
+                    willPerformHTTPRedirection response: HTTPURLResponse,
+                    newRequest request: URLRequest
+    ) async -> URLRequest? {
+        if let responseURL = response.url, let requestURL = request.url {
+            Logger.debug(Strings.network.api_request_redirect(from: responseURL,
+                                                              to: requestURL))
+        }
+
+        return request
+    }
+
+}

--- a/Sources/Networking/HTTPClient/RedirectLoggerTaskDelegate.swift
+++ b/Sources/Networking/HTTPClient/RedirectLoggerTaskDelegate.swift
@@ -16,17 +16,19 @@ import Foundation
 /// Implementation of `URLSessionTaskDelegate` that logs when the task will perform a redirection.
 final class RedirectLoggerSessionDelegate: NSObject, URLSessionTaskDelegate {
 
-    func urlSession(_ session: URLSession,
-                    task: URLSessionTask,
-                    willPerformHTTPRedirection response: HTTPURLResponse,
-                    newRequest request: URLRequest
-    ) async -> URLRequest? {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
         if let responseURL = response.url, let requestURL = request.url {
             Logger.debug(Strings.network.api_request_redirect(from: responseURL,
                                                               to: requestURL))
         }
 
-        return request
+        completionHandler(request)
     }
 
 }

--- a/Sources/Networking/HTTPClient/RedirectLoggerTaskDelegate.swift
+++ b/Sources/Networking/HTTPClient/RedirectLoggerTaskDelegate.swift
@@ -7,14 +7,14 @@
 //
 //      https://opensource.org/licenses/MIT
 //
-//  RedirectLoggerTaskDelegate.swift
+//  RedirectLoggerSessionDelegate.swift
 //
 //  Created by Nacho Soto on 3/23/23.
 
 import Foundation
 
 /// Implementation of `URLSessionTaskDelegate` that logs when the task will perform a redirection.
-final class RedirectLoggerTaskDelegate: NSObject, URLSessionTaskDelegate {
+final class RedirectLoggerSessionDelegate: NSObject, URLSessionTaskDelegate {
 
     func urlSession(_ session: URLSession,
                     task: URLSessionTask,

--- a/Tests/UnitTests/Networking/HTTPStatusCodeTests.swift
+++ b/Tests/UnitTests/Networking/HTTPStatusCodeTests.swift
@@ -48,6 +48,7 @@ class HTTPStatusCodeTests: TestCase {
         expect(HTTPStatusCode.createdSuccess.isSuccessfulResponse) == true
         expect(HTTPStatusCode.redirect.isSuccessfulResponse) == true
         expect(HTTPStatusCode.notModified.isSuccessfulResponse) == true
+        expect(HTTPStatusCode.temporaryRedirect.isSuccessfulResponse) == true
         expect(status(202).isSuccessfulResponse) == true
         expect(status(226).isSuccessfulResponse) == true
         expect(status(299).isSuccessfulResponse) == true
@@ -73,6 +74,7 @@ class HTTPStatusCodeTests: TestCase {
         expect(HTTPStatusCode.createdSuccess.isServerError) == false
         expect(HTTPStatusCode.redirect.isServerError) == false
         expect(HTTPStatusCode.notModified.isServerError) == false
+        expect(HTTPStatusCode.temporaryRedirect.isServerError) == false
         expect(HTTPStatusCode.invalidRequest.isServerError) == false
         expect(HTTPStatusCode.notFoundError.isServerError) == false
         expect(status(100).isServerError) == false
@@ -87,6 +89,7 @@ class HTTPStatusCodeTests: TestCase {
         expect(HTTPStatusCode.createdSuccess.isSuccessfullySynced) == true
         expect(HTTPStatusCode.redirect.isSuccessfullySynced) == true
         expect(HTTPStatusCode.notModified.isSuccessfullySynced) == true
+        expect(HTTPStatusCode.temporaryRedirect.isSuccessfullySynced) == true
         expect(HTTPStatusCode.invalidRequest.isSuccessfullySynced) == true
         expect(status(100).isSuccessfullySynced) == true
         expect(status(202).isSuccessfullySynced) == true


### PR DESCRIPTION
This will be used to detect the load balancer redirecting to the load shedder. See also #2362.
