### PR TITLE
Added `@DefaultDecodable.Now`

### DIFF
--- a/Sources/FoundationExtensions/Decoder+Extensions.swift
+++ b/Sources/FoundationExtensions/Decoder+Extensions.swift
@@ -217,6 +217,10 @@ enum DefaultDecodable {
             static var defaultValue: T { [:] }
         }
 
+        enum Now: DefaultValueProvider {
+            static var defaultValue: Date { Date() }
+        }
+
     }
 
 }
@@ -231,6 +235,7 @@ enum DefaultDecodable {
  *   @DefaultDecodable.EmptyString var identifier: String
  *   @DefaultDecodable.EmptyArray var values: [String]
  *   @DefaultDecodable.EmptyDictionary var dictionary: [String: Int]
+ *   @DefaultDecodable.Now var date: Date
  * }
  * ```
  */
@@ -241,5 +246,6 @@ extension DefaultDecodable {
     typealias EmptyString = DefaultValue<Sources.EmptyString>
     typealias EmptyArray<T: List> = DefaultValue<Sources.EmptyArray<T>>
     typealias EmptyDictionary<T: Map> = DefaultValue<Sources.EmptyDictionary<T>>
+    typealias Now = DefaultValue<Sources.Now>
 
 }

--- a/Tests/UnitTests/FoundationExtensions/DecoderExtensionTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/DecoderExtensionTests.swift
@@ -123,24 +123,32 @@ class DecoderExtensionsDefaultDecodableTests: TestCase {
         @DefaultDecodable.EmptyString var string: String
         @DefaultDecodable.EmptyArray var array: [String]
         @DefaultDecodable.EmptyDictionary var dictionary: [String: Int]
+        @DefaultDecodable.Now var date: Date
 
         init(
             bool1: Bool,
             bool2: Bool,
             string: String,
             array: [String],
-            dictionary: [String: Int]
+            dictionary: [String: Int],
+            date: Date
         ) {
             self.bool1 = bool1
             self.bool2 = bool2
             self.string = string
             self.array = array
             self.dictionary = dictionary
+            self.date = date
         }
     }
 
     func testDecodesActualValues() throws {
-        let data = Data(bool1: false, bool2: true, string: "test", array: ["a", "b"], dictionary: ["a": 1])
+        let data = Data(bool1: false,
+                        bool2: true,
+                        string: "test",
+                        array: ["a", "b"],
+                        dictionary: ["a": 1],
+                        date: Date(timeIntervalSince1970: 200000))
         let decodedData = try data.encodeAndDecode()
 
         expect(decodedData) == data
@@ -164,6 +172,10 @@ class DecoderExtensionsDefaultDecodableTests: TestCase {
 
     func testDecodesDefaultDictionary() throws {
         expect(try Data.decodeEmptyData().dictionary) == [:]
+    }
+
+    func testDecodesDateAsNow() throws {
+        expect(try Data.decodeEmptyData().date).to(beCloseTo(Date()))
     }
 
     func testDoesNotIgnoreErrorsIfNotArray() throws {


### PR DESCRIPTION
This allows `Codable` types to provide a default value for a new `Date` field that defaults to `Date()`.

This is going to be used to add a new `Date` field to `ETagManager.Response`.
