### PR TITLE
`ETagManager`/`HTTPClient`: sending new `X-RC-Last-Refresh-Time` header

### DIFF
--- a/Sources/Networking/HTTPClient/ETagManager.swift
+++ b/Sources/Networking/HTTPClient/ETagManager.swift
@@ -17,7 +17,7 @@ import Foundation
 class ETagManager {
 
     static let eTagRequestHeaderName = HTTPClient.RequestHeader.eTag.rawValue
-    static let eTagCreationTimeRequestHeaderName = HTTPClient.RequestHeader.eTagCreationTime.rawValue
+    static let eTagValidationTimeRequestHeaderName = HTTPClient.RequestHeader.eTagValidationTime.rawValue
     static let eTagResponseHeaderName = HTTPClient.ResponseHeader.eTag.rawValue
 
     private let userDefaults: SynchronizedUserDefaults
@@ -66,7 +66,7 @@ class ETagManager {
 
         return [
             HTTPClient.RequestHeader.eTag.rawValue: etag,
-            HTTPClient.RequestHeader.eTagCreationTime.rawValue: date
+            HTTPClient.RequestHeader.eTagValidationTime.rawValue: date
         ]
     }
 

--- a/Sources/Networking/HTTPClient/ETagManager.swift
+++ b/Sources/Networking/HTTPClient/ETagManager.swift
@@ -56,7 +56,7 @@ class ETagManager {
 
             if shouldUseETag {
                 return (tag: storedETagAndResponse.eTag,
-                        date: storedETagAndResponse.lastUsed.millisecondsSince1970.description)
+                        date: storedETagAndResponse.validationTime.millisecondsSince1970.description)
             } else {
                 return nil
             }
@@ -82,7 +82,7 @@ class ETagManager {
 
         if self.shouldUseCachedVersion(responseCode: statusCode) {
             if let storedResponse = self.storedETagAndResponse(for: request) {
-                let newResponse = storedResponse.withUpdatedLastUsedDate()
+                let newResponse = storedResponse.withUpdatedValidationTime()
 
                 self.storeIfPossible(newResponse, for: request)
                 return newResponse.asResponse(withRequestDate: response.requestDate)
@@ -195,7 +195,7 @@ extension ETagManager {
         var data: Data
         /// Used by the backend for advanced load shedding techniques.
         @DefaultDecodable.Now
-        var lastUsed: Date
+        var validationTime: Date
         @DefaultValue<VerificationResult>
         var verificationResult: VerificationResult
 
@@ -203,13 +203,13 @@ extension ETagManager {
             eTag: String,
             statusCode: HTTPStatusCode,
             data: Data,
-            lastUsed: Date = Date(),
+            validationTime: Date = Date(),
             verificationResult: VerificationResult
         ) {
             self.eTag = eTag
             self.statusCode = statusCode
             self.data = data
-            self.lastUsed = lastUsed
+            self.validationTime = validationTime
             self.verificationResult = verificationResult
         }
 
@@ -235,9 +235,9 @@ extension ETagManager.Response {
         )
     }
 
-    fileprivate func withUpdatedLastUsedDate() -> Self {
+    fileprivate func withUpdatedValidationTime() -> Self {
         var copy = self
-        copy.lastUsed = Date()
+        copy.validationTime = Date()
 
         return copy
     }

--- a/Sources/Networking/HTTPClient/ETagManager.swift
+++ b/Sources/Networking/HTTPClient/ETagManager.swift
@@ -82,7 +82,7 @@ class ETagManager {
 
         if self.shouldUseCachedVersion(responseCode: statusCode) {
             if let storedResponse = self.storedETagAndResponse(for: request) {
-                let newResponse = storedResponse.withUpdatedDate()
+                let newResponse = storedResponse.withUpdatedLastUsedDate()
 
                 self.store(newResponse, for: request)
                 return newResponse.asResponse(withRequestDate: response.requestDate)
@@ -193,6 +193,7 @@ extension ETagManager {
         var eTag: String
         var statusCode: HTTPStatusCode
         var data: Data
+        /// Used by the backend for advanced load shedding techniques.
         @DefaultDecodable.Now
         var lastUsed: Date
         @DefaultValue<VerificationResult>
@@ -234,7 +235,7 @@ extension ETagManager.Response {
         )
     }
 
-    fileprivate func withUpdatedDate() -> Self {
+    fileprivate func withUpdatedLastUsedDate() -> Self {
         var copy = self
         copy.lastUsed = Date()
 

--- a/Sources/Networking/HTTPClient/ETagManager.swift
+++ b/Sources/Networking/HTTPClient/ETagManager.swift
@@ -84,7 +84,7 @@ class ETagManager {
             if let storedResponse = self.storedETagAndResponse(for: request) {
                 let newResponse = storedResponse.withUpdatedLastUsedDate()
 
-                self.store(newResponse, for: request)
+                self.storeIfPossible(newResponse, for: request)
                 return newResponse.asResponse(withRequestDate: response.requestDate)
             }
             if retried {
@@ -141,7 +141,7 @@ private extension ETagManager {
                                              eTag: String) {
         if let data = response.body,
            response.shouldStore(ignoreVerificationErrors: self.shouldIgnoreVerificationErrors) {
-            self.store(
+            self.storeIfPossible(
                 Response(
                     eTag: eTag,
                     statusCode: response.statusCode,
@@ -153,7 +153,7 @@ private extension ETagManager {
         }
     }
 
-    func store(_ response: Response, for request: URLRequest) {
+    func storeIfPossible(_ response: Response, for request: URLRequest) {
         if let cacheKey = self.eTagDefaultCacheKey(for: request),
            let dataToStore = response.asData() {
             self.userDefaults.write {

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -101,6 +101,7 @@ extension HTTPClient {
         case location = "Location"
         case nonce = "X-Nonce"
         case eTag = "X-RevenueCat-ETag"
+        case eTagCreationTime = "X-RevenueCat-ETag-Creation-Time"
 
     }
 

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -101,7 +101,7 @@ extension HTTPClient {
         case location = "Location"
         case nonce = "X-Nonce"
         case eTag = "X-RevenueCat-ETag"
-        case eTagValidationTime = "X-ETag-Validation-Time"
+        case eTagValidationTime = "X-RC-Last-Refresh-Time"
 
     }
 

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -101,7 +101,7 @@ extension HTTPClient {
         case location = "Location"
         case nonce = "X-Nonce"
         case eTag = "X-RevenueCat-ETag"
-        case eTagCreationTime = "X-RevenueCat-ETag-Creation-Time"
+        case eTagValidationTime = "X-ETag-Validation-Time"
 
     }
 

--- a/Tests/UnitTests/Mocks/MockETagManager.swift
+++ b/Tests/UnitTests/Mocks/MockETagManager.swift
@@ -29,10 +29,10 @@ class MockETagManager: ETagManager {
     var invokedETagHeaderParametersList: [ETagHeaderRequest] = []
     var stubbedETagHeaderResult: [String: String]! = [:]
 
-    func stubResponseEtag(_ tag: String, creationTime: Date = Date()) {
+    func stubResponseEtag(_ tag: String, validationTime: Date = Date()) {
         self.stubbedETagHeaderResult = [
             ETagManager.eTagRequestHeaderName: tag,
-            ETagManager.eTagValidationTimeRequestHeaderName: creationTime.millisecondsSince1970.description
+            ETagManager.eTagValidationTimeRequestHeaderName: validationTime.millisecondsSince1970.description
         ]
     }
 

--- a/Tests/UnitTests/Mocks/MockETagManager.swift
+++ b/Tests/UnitTests/Mocks/MockETagManager.swift
@@ -29,8 +29,11 @@ class MockETagManager: ETagManager {
     var invokedETagHeaderParametersList: [ETagHeaderRequest] = []
     var stubbedETagHeaderResult: [String: String]! = [:]
 
-    func stubResponseEtag(_ tag: String) {
-        self.stubbedETagHeaderResult[ETagManager.eTagResponseHeaderName] = tag
+    func stubResponseEtag(_ tag: String, creationTime: Date = Date()) {
+        self.stubbedETagHeaderResult = [
+            ETagManager.eTagRequestHeaderName: tag,
+            ETagManager.eTagCreationTimeRequestHeaderName: creationTime.millisecondsSince1970.description
+        ]
     }
 
     override func eTagHeader(

--- a/Tests/UnitTests/Mocks/MockETagManager.swift
+++ b/Tests/UnitTests/Mocks/MockETagManager.swift
@@ -32,7 +32,7 @@ class MockETagManager: ETagManager {
     func stubResponseEtag(_ tag: String, creationTime: Date = Date()) {
         self.stubbedETagHeaderResult = [
             ETagManager.eTagRequestHeaderName: tag,
-            ETagManager.eTagCreationTimeRequestHeaderName: creationTime.millisecondsSince1970.description
+            ETagManager.eTagValidationTimeRequestHeaderName: creationTime.millisecondsSince1970.description
         ]
     }
 

--- a/Tests/UnitTests/Networking/ETagManagerTests.swift
+++ b/Tests/UnitTests/Networking/ETagManagerTests.swift
@@ -797,8 +797,7 @@ private extension ETagManagerTests {
                      verificationResult: verificationResult)
     }
 
-    private static let baseURL = URL(string: "https://api.revenuecat.com")!
-    private static let testURL = URL(string: "/v1/subscribers/appUserID", relativeTo: ETagManagerTests.baseURL)!
+    private static let testURL = HTTPRequest.Path.getCustomerInfo(appUserID: "appUserID").url!
 
 }
 

--- a/Tests/UnitTests/Networking/ETagManagerTests.swift
+++ b/Tests/UnitTests/Networking/ETagManagerTests.swift
@@ -8,7 +8,6 @@ class ETagManagerTests: TestCase {
 
     private var mockUserDefaults: MockUserDefaults! = nil
     private var eTagManager: ETagManager!
-    private let baseURL = URL(string: "https://api.revenuecat.com")!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -25,8 +24,7 @@ class ETagManagerTests: TestCase {
     }
 
     func testETagIsEmptyIfThereIsNoETagSavedForThatRequest() {
-        let url = self.urlForTest()
-        let request = URLRequest(url: url)
+        let request = URLRequest(url: Self.testURL)
         let header = self.eTagManager.eTagHeader(for: request, withSignatureVerification: false)
         let value2: String? = header[ETagManager.eTagRequestHeaderName]
 
@@ -34,9 +32,8 @@ class ETagManagerTests: TestCase {
     }
 
     func testETagIsAddedToHeadersIfThereIsACachedETagForThatURL() {
-        let url = self.urlForTest()
-        _ = self.mockStoredETagResponse(for: url)
-        let request = URLRequest(url: url)
+        _ = self.mockStoredETagResponse(for: Self.testURL)
+        let request = URLRequest(url: Self.testURL)
         let header = self.eTagManager.eTagHeader(for: request, withSignatureVerification: false)
         let value2: String? = header[ETagManager.eTagRequestHeaderName]
 
@@ -45,12 +42,11 @@ class ETagManagerTests: TestCase {
 
     func testStoredResponseIsUsedIfResponseCodeIs304() throws {
         let eTag = "an_etag"
-        let url = urlForTest()
-        let request = URLRequest(url: url)
-        let cachedResponse = mockStoredETagResponse(for: url, statusCode: .success, eTag: eTag)
+        let request = URLRequest(url: Self.testURL)
+        let cachedResponse = self.mockStoredETagResponse(for: Self.testURL, statusCode: .success, eTag: eTag)
 
         let response = self.eTagManager.httpResultFromCacheOrBackend(
-            with: self.responseForTest(url: url,
+            with: self.responseForTest(url: Self.testURL,
                                        body: nil,
                                        eTag: eTag,
                                        statusCode: .notModified),
@@ -62,16 +58,43 @@ class ETagManagerTests: TestCase {
         expect(response?.body) == cachedResponse
     }
 
+    func testLastValidationDateIsUpdatedWhenUsingStoredResponse() throws {
+        let eTag = "an_etag"
+        let request = URLRequest(url: Self.testURL)
+        let lastUsed = Date(timeIntervalSince1970: 10000)
+
+        let cachedResponse = self.mockStoredETagResponse(for: Self.testURL,
+                                                         statusCode: .success,
+                                                         eTag: eTag,
+                                                         lastUsed: lastUsed)
+        expect(try self.getCachedResponse(url: Self.testURL).lastUsed).to(beCloseTo(lastUsed, within: 1))
+
+        let response = self.eTagManager.httpResultFromCacheOrBackend(
+            with: self.responseForTest(url: Self.testURL,
+                                       body: nil,
+                                       eTag: eTag,
+                                       statusCode: .notModified),
+            request: request,
+            retried: false
+        )
+        expect(response).toNot(beNil())
+        expect(response?.statusCode) == .success
+        expect(response?.body) == cachedResponse
+
+        let newCachedResponse = try self.getCachedResponse(url: Self.testURL)
+        expect(newCachedResponse.lastUsed).toNot(beCloseTo(lastUsed, within: 1))
+        expect(newCachedResponse.lastUsed).to(beCloseTo(Date(), within: 1))
+    }
+
     func testStoredResponseIsNotUsedIfResponseCodeIs200() throws {
         let eTag = "an_etag"
-        let url = urlForTest()
-        let request = URLRequest(url: url)
-        _ = mockStoredETagResponse(for: url, statusCode: .success, eTag: eTag)
+        let request = URLRequest(url: Self.testURL)
+        _ = self.mockStoredETagResponse(for: Self.testURL, statusCode: .success, eTag: eTag)
         let responseObject = try JSONSerialization.data(withJSONObject: ["a": "response"])
         let requestDate = Date().addingTimeInterval(-100000)
 
         let response = self.eTagManager.httpResultFromCacheOrBackend(
-            with: self.responseForTest(url: url,
+            with: self.responseForTest(url: Self.testURL,
                                        body: responseObject,
                                        eTag: eTag,
                                        statusCode: .success,
@@ -87,15 +110,13 @@ class ETagManagerTests: TestCase {
     }
 
     func testResultIsNilIfResponseCodeIs304ButContainsNoETag() throws {
-        let url = self.urlForTest()
-
         let response = self.eTagManager.httpResultFromCacheOrBackend(
-            with: self.responseForTest(url: url,
+            with: self.responseForTest(url: Self.testURL,
                                        body: nil,
                                        eTag: nil,
                                        statusCode: .notModified,
                                        requestDate: Date()),
-            request: URLRequest(url: url),
+            request: URLRequest(url: Self.testURL),
             retried: false
         )
 
@@ -104,13 +125,12 @@ class ETagManagerTests: TestCase {
 
     func testBackendResponseIsReturnedIf304AndCantFindCachedAndItHasAlreadyRetried() throws {
         let eTag = "an_etag"
-        let url = urlForTest()
-        let request = URLRequest(url: url)
+        let request = URLRequest(url: Self.testURL)
         let responseObject = try JSONSerialization.data(withJSONObject: ["a": "response"])
 
         let response = self.eTagManager.httpResultFromCacheOrBackend(
             with: self.responseForTest(
-                url: url,
+                url: Self.testURL,
                 body: responseObject,
                 eTag: eTag,
                 statusCode: .notModified
@@ -126,13 +146,12 @@ class ETagManagerTests: TestCase {
 
     func testReturnNullIf304AndCantFindCachedResponse() throws {
         let eTag = "an_etag"
-        let url = urlForTest()
-        let request = URLRequest(url: url)
+        let request = URLRequest(url: Self.testURL)
         let responseObject = try JSONSerialization.data(withJSONObject: ["a": "response"])
 
         let response = self.eTagManager.httpResultFromCacheOrBackend(
             with: self.responseForTest(
-                url: url,
+                url: Self.testURL,
                 body: responseObject,
                 eTag: eTag,
                 statusCode: .notModified
@@ -146,12 +165,11 @@ class ETagManagerTests: TestCase {
 
     func testResponseIsStoredIfResponseCodeIs200AndVerificationWasNotRequested() throws {
         let eTag = "an_etag"
-        let url = urlForTest()
-        let request = URLRequest(url: url)
+        let request = URLRequest(url: Self.testURL)
         let responseObject = try JSONSerialization.data(withJSONObject: ["a": "response"])
         let response = self.eTagManager.httpResultFromCacheOrBackend(
             with: self.responseForTest(
-                url: url,
+                url: Self.testURL,
                 body: responseObject,
                 eTag: eTag,
                 statusCode: .success,
@@ -164,7 +182,7 @@ class ETagManagerTests: TestCase {
         expect(response).toNot(beNil())
         expect(self.mockUserDefaults.setObjectForKeyCallCount) == 1
 
-        let cacheKey = url.absoluteString
+        let cacheKey = Self.testURL.absoluteString
         expect(self.mockUserDefaults.mockValues[cacheKey]).toNot(beNil())
         let setData = try XCTUnwrap(self.mockUserDefaults.mockValues[cacheKey] as? Data)
 
@@ -179,12 +197,11 @@ class ETagManagerTests: TestCase {
 
     func testResponseIsStoredIfResponseCodeIs200AndVerificationSucceded() throws {
         let eTag = "an_etag"
-        let url = urlForTest()
-        let request = URLRequest(url: url)
+        let request = URLRequest(url: Self.testURL)
         let responseObject = try JSONSerialization.data(withJSONObject: ["a": "response"])
         let response = self.eTagManager.httpResultFromCacheOrBackend(
             with: self.responseForTest(
-                url: url,
+                url: Self.testURL,
                 body: responseObject,
                 eTag: eTag,
                 statusCode: .success,
@@ -197,7 +214,7 @@ class ETagManagerTests: TestCase {
         expect(response).toNot(beNil())
         expect(self.mockUserDefaults.setObjectForKeyCallCount) == 1
 
-        let cacheKey = url.absoluteString
+        let cacheKey = Self.testURL.absoluteString
         expect(self.mockUserDefaults.mockValues[cacheKey]).toNot(beNil())
         let setData = try XCTUnwrap(self.mockUserDefaults.mockValues[cacheKey] as? Data)
 
@@ -212,13 +229,12 @@ class ETagManagerTests: TestCase {
 
     func testResponseIsNotStoredIfResponseCodeIs500() {
         let eTag = "an_etag"
-        let url = urlForTest()
-        let request = URLRequest(url: url)
+        let request = URLRequest(url: Self.testURL)
         let responseObject = Data()
 
         let response = self.eTagManager.httpResultFromCacheOrBackend(
             with: self.responseForTest(
-                url: url,
+                url: Self.testURL,
                 body: responseObject,
                 eTag: eTag,
                 statusCode: .internalServerError
@@ -233,7 +249,7 @@ class ETagManagerTests: TestCase {
 
         expect(self.mockUserDefaults.setObjectForKeyCallCount) == 0
 
-        let cacheKey = url.absoluteString
+        let cacheKey = Self.testURL.absoluteString
         expect(self.mockUserDefaults.mockValues[cacheKey]).to(beNil())
     }
 
@@ -241,13 +257,12 @@ class ETagManagerTests: TestCase {
         self.eTagManager = try self.create(with: .informational)
 
         let eTag = "an_etag"
-        let url = self.urlForTest()
-        let request = URLRequest(url: url)
+        let request = URLRequest(url: Self.testURL)
         let responseObject = Data()
 
         let response = self.eTagManager.httpResultFromCacheOrBackend(
             with: self.responseForTest(
-                url: url,
+                url: Self.testURL,
                 body: responseObject,
                 eTag: eTag,
                 statusCode: .success,
@@ -259,20 +274,19 @@ class ETagManagerTests: TestCase {
 
         expect(response).toNot(beNil())
         expect(self.mockUserDefaults.setObjectForKeyCallCount) == 0
-        expect(self.mockUserDefaults.mockValues[url.absoluteString]).to(beNil())
+        expect(self.mockUserDefaults.mockValues[Self.testURL.absoluteString]).to(beNil())
     }
 
     func testResponseIsNotStoredIfVerificationFailedWithEnforcedMode() throws {
         try self.setEnforcedETagManager()
 
         let eTag = "an_etag"
-        let url = self.urlForTest()
-        let request = URLRequest(url: url)
+        let request = URLRequest(url: Self.testURL)
         let responseObject = Data()
 
         let response = self.eTagManager.httpResultFromCacheOrBackend(
             with: self.responseForTest(
-                url: url,
+                url: Self.testURL,
                 body: responseObject,
                 eTag: eTag,
                 statusCode: .success,
@@ -287,16 +301,15 @@ class ETagManagerTests: TestCase {
 
         expect(self.mockUserDefaults.setObjectForKeyCallCount) == 0
 
-        let cacheKey = url.absoluteString
+        let cacheKey = Self.testURL.absoluteString
         expect(self.mockUserDefaults.mockValues[cacheKey]).to(beNil())
     }
 
     func testClearCachesWorks() {
         let eTag = "an_etag"
-        let url = urlForTest()
-        _ = mockStoredETagResponse(for: url, statusCode: .success, eTag: eTag)
+        _ = self.mockStoredETagResponse(for: Self.testURL, statusCode: .success, eTag: eTag)
 
-        let cacheKey = url.absoluteString
+        let cacheKey = Self.testURL.absoluteString
         expect(self.mockUserDefaults.mockValues[cacheKey]).toNot(beNil())
 
         eTagManager.clearCaches()
@@ -320,9 +333,8 @@ class ETagManagerTests: TestCase {
         }
 
         let eTag = "the_etag"
-        let url = urlForTest()
-        let request = URLRequest(url: url)
-        let cacheKey = url.absoluteString
+        let request = URLRequest(url: Self.testURL)
+        let cacheKey = Self.testURL.absoluteString
 
         let actualResponse = "response".asData
 
@@ -334,7 +346,7 @@ class ETagManagerTests: TestCase {
         self.mockUserDefaults.mockValues[cacheKey] = wrapper.asData
 
         let response = self.eTagManager.httpResultFromCacheOrBackend(
-            with: self.responseForTest(url: url,
+            with: self.responseForTest(url: Self.testURL,
                                        body: actualResponse,
                                        eTag: eTag,
                                        statusCode: .notModified),
@@ -351,9 +363,8 @@ class ETagManagerTests: TestCase {
         try self.setEnforcedETagManager()
 
         let eTag = "the_etag"
-        let url = self.urlForTest()
-        let request = URLRequest(url: url)
-        let cacheKey = url.absoluteString
+        let request = URLRequest(url: Self.testURL)
+        let cacheKey = Self.testURL.absoluteString
 
         let actualResponse = "response".asData
 
@@ -374,9 +385,8 @@ class ETagManagerTests: TestCase {
         self.eTagManager = try self.create(with: .informational)
 
         let eTag = "the_etag"
-        let url = self.urlForTest()
-        let request = URLRequest(url: url)
-        let cacheKey = url.absoluteString
+        let request = URLRequest(url: Self.testURL)
+        let cacheKey = Self.testURL.absoluteString
 
         let actualResponse = "response".asData
 
@@ -395,9 +405,8 @@ class ETagManagerTests: TestCase {
 
     func testETagHeaderIsFoundIfItsMissingResponseVerificationAndVerificationIsDisabled() {
         let eTag = "the_etag"
-        let url = self.urlForTest()
-        let request = URLRequest(url: url)
-        let cacheKey = url.absoluteString
+        let request = URLRequest(url: Self.testURL)
+        let cacheKey = Self.testURL.absoluteString
 
         let actualResponse = "response".asData
 
@@ -418,9 +427,8 @@ class ETagManagerTests: TestCase {
         try self.setEnforcedETagManager()
 
         let eTag = "the_etag"
-        let url = self.urlForTest()
-        let request = URLRequest(url: url)
-        let cacheKey = url.absoluteString
+        let request = URLRequest(url: Self.testURL)
+        let cacheKey = Self.testURL.absoluteString
 
         let actualResponse = "response".asData
 
@@ -439,9 +447,8 @@ class ETagManagerTests: TestCase {
         self.eTagManager = try self.create(with: .informational)
 
         let eTag = "the_etag"
-        let url = self.urlForTest()
-        let request = URLRequest(url: url)
-        let cacheKey = url.absoluteString
+        let request = URLRequest(url: Self.testURL)
+        let cacheKey = Self.testURL.absoluteString
 
         let actualResponse = "response".asData
 
@@ -460,9 +467,8 @@ class ETagManagerTests: TestCase {
         self.eTagManager = try self.create(with: .informational)
 
         let eTag = "the_etag"
-        let url = self.urlForTest()
-        let request = URLRequest(url: url)
-        let cacheKey = url.absoluteString
+        let request = URLRequest(url: Self.testURL)
+        let cacheKey = Self.testURL.absoluteString
 
         let actualResponse = "response".asData
 
@@ -481,9 +487,8 @@ class ETagManagerTests: TestCase {
         try self.setEnforcedETagManager()
 
         let eTag = "the_etag"
-        let url = self.urlForTest()
-        let request = URLRequest(url: url)
-        let cacheKey = url.absoluteString
+        let request = URLRequest(url: Self.testURL)
+        let cacheKey = Self.testURL.absoluteString
 
         let actualResponse = "response".asData
 
@@ -500,9 +505,8 @@ class ETagManagerTests: TestCase {
 
     func testETagHeaderIsReturnedIfVerificationSucceded() {
         let eTag = "the_etag"
-        let url = self.urlForTest()
-        let request = URLRequest(url: url)
-        let cacheKey = url.absoluteString
+        let request = URLRequest(url: Self.testURL)
+        let cacheKey = Self.testURL.absoluteString
 
         let actualResponse = "response".asData
 
@@ -520,9 +524,8 @@ class ETagManagerTests: TestCase {
 
     func testETagHeaderIsReturnedIfVerificationWasNotRequested() {
         let eTag = "the_etag"
-        let url = self.urlForTest()
-        let request = URLRequest(url: url)
-        let cacheKey = url.absoluteString
+        let request = URLRequest(url: Self.testURL)
+        let cacheKey = Self.testURL.absoluteString
 
         let actualResponse = "response".asData
 
@@ -540,9 +543,8 @@ class ETagManagerTests: TestCase {
 
     func testETagHeaderContainsCreationTime() {
         let eTag = "the_etag"
-        let url = self.urlForTest()
-        let request = URLRequest(url: url)
-        let cacheKey = url.absoluteString
+        let request = URLRequest(url: Self.testURL)
+        let cacheKey = Self.testURL.absoluteString
         let creationTime = Date(timeIntervalSince1970: 800000)
 
         let actualResponse = "response".asData
@@ -564,9 +566,8 @@ class ETagManagerTests: TestCase {
 
     func testResponseReturnsRequestDateFromServer() {
         let eTag = "the_etag"
-        let url = self.urlForTest()
-        let request = URLRequest(url: url)
-        let cacheKey = url.absoluteString
+        let request = URLRequest(url: Self.testURL)
+        let cacheKey = Self.testURL.absoluteString
         let requestDate = Date().addingTimeInterval(-100000)
 
         let actualResponse = "response".asData
@@ -580,7 +581,7 @@ class ETagManagerTests: TestCase {
         """.asData
 
         let response = self.eTagManager.httpResultFromCacheOrBackend(
-            with: self.responseForTest(url: url,
+            with: self.responseForTest(url: Self.testURL,
                                        body: nil,
                                        eTag: eTag,
                                        statusCode: .notModified,
@@ -593,9 +594,8 @@ class ETagManagerTests: TestCase {
 
     func testCachedResponseWithNoVerificationResultIsNotIgnored() {
         let eTag = "the_etag"
-        let url = self.urlForTest()
-        let request = URLRequest(url: url)
-        let cacheKey = url.absoluteString
+        let request = URLRequest(url: Self.testURL)
+        let cacheKey = Self.testURL.absoluteString
 
         let actualResponse = "response".asData
 
@@ -608,7 +608,7 @@ class ETagManagerTests: TestCase {
         """.asData
 
         let response = self.eTagManager.httpResultFromCacheOrBackend(
-            with: self.responseForTest(url: url,
+            with: self.responseForTest(url: Self.testURL,
                                        body: nil,
                                        eTag: eTag,
                                        statusCode: .notModified),
@@ -621,9 +621,8 @@ class ETagManagerTests: TestCase {
 
     func testCachedResponseIsFoundIfVerificationWasNotRequested() {
         let eTag = "the_etag"
-        let url = self.urlForTest()
-        let request = URLRequest(url: url)
-        let cacheKey = url.absoluteString
+        let request = URLRequest(url: Self.testURL)
+        let cacheKey = Self.testURL.absoluteString
 
         let actualResponse = "response".asData
 
@@ -635,7 +634,7 @@ class ETagManagerTests: TestCase {
         ).asData()
 
         let response = self.eTagManager.httpResultFromCacheOrBackend(
-            with: self.responseForTest(url: url,
+            with: self.responseForTest(url: Self.testURL,
                                        body: nil,
                                        eTag: eTag,
                                        statusCode: .notModified),
@@ -650,9 +649,8 @@ class ETagManagerTests: TestCase {
 
     func testCachedResponseIsFoundIfVerificationSucceeded() {
         let eTag = "the_etag"
-        let url = self.urlForTest()
-        let request = URLRequest(url: url)
-        let cacheKey = url.absoluteString
+        let request = URLRequest(url: Self.testURL)
+        let cacheKey = Self.testURL.absoluteString
 
         let actualResponse = "response".asData
 
@@ -666,7 +664,7 @@ class ETagManagerTests: TestCase {
         """.asData
 
         let response = self.eTagManager.httpResultFromCacheOrBackend(
-            with: self.responseForTest(url: url,
+            with: self.responseForTest(url: Self.testURL,
                                        body: nil,
                                        eTag: eTag,
                                        statusCode: .notModified),
@@ -684,9 +682,8 @@ class ETagManagerTests: TestCase {
         // a response can't be stored if verification failed, but useful to test just in case.
 
         let eTag = "the_etag"
-        let url = self.urlForTest()
-        let request = URLRequest(url: url)
-        let cacheKey = url.absoluteString
+        let request = URLRequest(url: Self.testURL)
+        let cacheKey = Self.testURL.absoluteString
 
         let actualResponse = "response".asData
 
@@ -698,7 +695,7 @@ class ETagManagerTests: TestCase {
         ).asData()
 
         let response = self.eTagManager.httpResultFromCacheOrBackend(
-            with: self.responseForTest(url: url,
+            with: self.responseForTest(url: Self.testURL,
                                        body: nil,
                                        eTag: eTag,
                                        statusCode: .notModified),
@@ -762,6 +759,7 @@ private extension ETagManagerTests {
     func mockStoredETagResponse(for url: URL,
                                 statusCode: HTTPStatusCode = .success,
                                 eTag: String = "an_etag",
+                                lastUsed: Date = Date(),
                                 verificationResult: RevenueCat.VerificationResult = .defaultValue) -> Data {
         // swiftlint:disable:next force_try
         let data = try! JSONSerialization.data(withJSONObject: ["arg": "value"])
@@ -770,6 +768,7 @@ private extension ETagManagerTests {
             eTag: eTag,
             statusCode: statusCode,
             data: data,
+            lastUsed: lastUsed,
             verificationResult: verificationResult
         )
         let cacheKey = url.absoluteString
@@ -778,11 +777,9 @@ private extension ETagManagerTests {
         return data
     }
 
-    func urlForTest() -> URL {
-        guard let url: URL = URL(string: "/v1/subscribers/appUserID", relativeTo: baseURL) else {
-            fatalError("Error initializing URL")
-        }
-        return url
+    func getCachedResponse(url: URL) throws -> ETagManager.Response {
+        let cachedData = try XCTUnwrap(self.mockUserDefaults.mockValues[url.absoluteString] as? Data)
+        return try ETagManager.Response.with(cachedData)
     }
 
     func responseForTest(
@@ -799,6 +796,9 @@ private extension ETagManagerTests {
                      requestDate: requestDate,
                      verificationResult: verificationResult)
     }
+
+    private static let baseURL = URL(string: "https://api.revenuecat.com")!
+    private static let testURL = URL(string: "/v1/subscribers/appUserID", relativeTo: ETagManagerTests.baseURL)!
 
 }
 

--- a/Tests/UnitTests/Networking/ETagManagerTests.swift
+++ b/Tests/UnitTests/Networking/ETagManagerTests.swift
@@ -560,7 +560,7 @@ class ETagManagerTests: TestCase {
         let response = self.eTagManager.eTagHeader(for: request, withSignatureVerification: false)
         expect(response) == [
             ETagManager.eTagRequestHeaderName: eTag,
-            ETagManager.eTagCreationTimeRequestHeaderName: creationTime.millisecondsSince1970.description
+            ETagManager.eTagValidationTimeRequestHeaderName: creationTime.millisecondsSince1970.description
         ]
     }
 

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -501,11 +501,14 @@ final class HTTPClientTests: BaseHTTPClientTests {
         let request = HTTPRequest(method: .get, path: .mockPath)
         let responseData = "{\"message\": \"something is great up in the cloud\"}".asData
         let eTag = "etag"
+        let eTagCreation = Date(timeIntervalSince1970: 1234567)
 
-        self.eTagManager.stubResponseEtag(eTag)
+        self.eTagManager.stubResponseEtag(eTag, creationTime: eTagCreation)
 
         stub(condition: isPath(request.path)) { request in
             expect(request.allHTTPHeaderFields?[ETagManager.eTagRequestHeaderName]) == eTag
+            expect(request.allHTTPHeaderFields?[ETagManager.eTagCreationTimeRequestHeaderName])
+            == eTagCreation.millisecondsSince1970.description
 
             return HTTPStubsResponse(data: responseData,
                                      statusCode: .success,

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -507,7 +507,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
 
         stub(condition: isPath(request.path)) { request in
             expect(request.allHTTPHeaderFields?[ETagManager.eTagRequestHeaderName]) == eTag
-            expect(request.allHTTPHeaderFields?[ETagManager.eTagCreationTimeRequestHeaderName])
+            expect(request.allHTTPHeaderFields?[ETagManager.eTagValidationTimeRequestHeaderName])
             == eTagCreation.millisecondsSince1970.description
 
             return HTTPStubsResponse(data: responseData,

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -501,14 +501,14 @@ final class HTTPClientTests: BaseHTTPClientTests {
         let request = HTTPRequest(method: .get, path: .mockPath)
         let responseData = "{\"message\": \"something is great up in the cloud\"}".asData
         let eTag = "etag"
-        let eTagCreation = Date(timeIntervalSince1970: 1234567)
+        let eTagValidationTime = Date(timeIntervalSince1970: 1234567)
 
-        self.eTagManager.stubResponseEtag(eTag, creationTime: eTagCreation)
+        self.eTagManager.stubResponseEtag(eTag, validationTime: eTagValidationTime)
 
         stub(condition: isPath(request.path)) { request in
             expect(request.allHTTPHeaderFields?[ETagManager.eTagRequestHeaderName]) == eTag
             expect(request.allHTTPHeaderFields?[ETagManager.eTagValidationTimeRequestHeaderName])
-            == eTagCreation.millisecondsSince1970.description
+            == eTagValidationTime.millisecondsSince1970.description
 
             return HTTPStubsResponse(data: responseData,
                                      statusCode: .success,


### PR DESCRIPTION
Fixes SDK-3024 and SDK-3026.