### PR TITLE
`@DefaultDecodable.Now`: fixed flaky test

### DIFF
--- a/Tests/UnitTests/FoundationExtensions/DecoderExtensionTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/DecoderExtensionTests.swift
@@ -175,7 +175,7 @@ class DecoderExtensionsDefaultDecodableTests: TestCase {
     }
 
     func testDecodesDateAsNow() throws {
-        expect(try Data.decodeEmptyData().date).to(beCloseTo(Date()))
+        expect(try Data.decodeEmptyData().date).to(beCloseTo(Date(), within: 1))
     }
 
     func testDoesNotIgnoreErrorsIfNotArray() throws {


### PR DESCRIPTION
`Date`s don't encode milliseconds, which meant that this test could fail.
See #2372.
