### PR TITLE
`PurchaseTesterSwiftUI`: fixed iOS compilation

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
@@ -24,23 +24,21 @@ struct PurchaseTesterApp: App {
         WindowGroup(id: Windows.default.rawValue) {
             Group {
                 if let configuration {
-                    NavigationSplitView {
-                        ContentView(configuration: configuration)
-                            .environmentObject(self.revenueCatCustomerData)
-                            .toolbar {
-                                ToolbarItem(placement: .principal) {
-                                    Button {
-                                        self.configuration = nil
-                                    } label: {
-                                        Text("Reconfigure")
-                                    }
-                                }
-                            }
-                    } detail: {
-                        DynamicCustomerView(customerInfo: self.$revenueCatCustomerData.customerInfo)
+                    Group {
+                        #if os(macOS)
+                        NavigationSplitView {
+                            self.content(configuration)
+                        } detail: {
+                            DynamicCustomerView(customerInfo: self.$revenueCatCustomerData.customerInfo)
+                        }
+                        .navigationSplitViewStyle(.balanced)
+                        .navigationSplitViewColumnWidth(100)
+                        #else
+                        NavigationView {
+                            self.content(configuration)
+                        }
+                        #endif
                     }
-                    .navigationSplitViewStyle(.balanced)
-                    .navigationSplitViewColumnWidth(100)
                     .task(id: self.configuration?.purchases) {
                         self.revenueCatCustomerData.customerInfo = nil
 
@@ -100,6 +98,20 @@ struct PurchaseTesterApp: App {
                 entitlementVerificationMode: data.verificationMode
             )
         }
+    }
+
+    private func content(_ configuration: ConfiguredPurchases) -> some View {
+        ContentView(configuration: configuration)
+            .environmentObject(self.revenueCatCustomerData)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Button {
+                        self.configuration = nil
+                    } label: {
+                        Text("Reconfigure")
+                    }
+                }
+            }
     }
 
     private var isConfigured: Bool {

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
@@ -127,7 +127,9 @@ struct HomeView: View {
                     #endif
                 }
             }
+            #if os(macOS)
                 .padding()
+            #endif
                 .task {
                     await self.fetchData()
                 }
@@ -232,8 +234,10 @@ private struct CustomerInfoHeaderView: View {
             HStack {
                 Spacer()
 
-                NavigationLink(value: self.revenueCatCustomerData.customerInfo) {
-                    Text("View Info")
+                if let customerInfo = self.revenueCatCustomerData.customerInfo {
+                    NavigationLink(destination: CustomerView(customerInfo: customerInfo)) {
+                        Text("View Info")
+                    }
                 }
                 
                 Spacer()
@@ -279,9 +283,6 @@ private struct CustomerInfoHeaderView: View {
                 Spacer()
 
             }.padding(.top, 20)
-        }
-        .navigationDestination(for: CustomerInfo.self) {
-            CustomerView(customerInfo: $0)
         }
     }
     


### PR DESCRIPTION
Fixes from #2345.

The changes were made to make `macOS` work better, but they're only available in iOS 16+.
This brings back the previous `NavigationView` and `NavigationLink` APIs that are backwards compatible.
