### PR TITLE
`PostReceiptDataOperation` / `GetCustomerInfoOperation`: only invoke response handlers once

### DIFF
--- a/Sources/Networking/Operations/GetCustomerInfoOperation.swift
+++ b/Sources/Networking/Operations/GetCustomerInfoOperation.swift
@@ -68,10 +68,11 @@ private extension GetCustomerInfoOperation {
         let request = HTTPRequest(method: .get,
                                   path: .getCustomerInfo(appUserID: appUserID))
 
-        httpClient.perform(request) { (response: HTTPResponse<CustomerInfoResponseHandler.Response>.Result) in
-            self.customerInfoCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
-                self.customerInfoResponseHandler.handle(customerInfoResponse: response,
-                                                        completion: callback.completion)
+        self.httpClient.perform(request) { (response: HTTPResponse<CustomerInfoResponseHandler.Response>.Result) in
+            self.customerInfoResponseHandler.handle(customerInfoResponse: response) { result in
+                self.customerInfoCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
+                    callback.completion(result)
+                }
             }
 
             completion()

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -94,10 +94,13 @@ final class PostReceiptDataOperation: CacheableNetworkOperation {
     private func post(completion: @escaping () -> Void) {
         let request = HTTPRequest(method: .post(self.postData), path: .postReceiptData)
 
-        httpClient.perform(request) { (response: HTTPResponse<CustomerInfoResponseHandler.Response>.Result) in
-            self.customerInfoCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callbackObject in
-                self.customerInfoResponseHandler.handle(customerInfoResponse: response,
-                                                        completion: callbackObject.completion)
+        self.httpClient.perform(request) { (response: HTTPResponse<CustomerInfoResponseHandler.Response>.Result) in
+            self.customerInfoResponseHandler.handle(customerInfoResponse: response) { result in
+                self.customerInfoCallbackCache.performOnAllItemsAndRemoveFromCache(
+                    withCacheable: self
+                ) { callbackObject in
+                    callbackObject.completion(result)
+                }
             }
 
             completion()


### PR DESCRIPTION
After #2368, `CustomerInfoResponseHandler` is going to perform more tasks. This ensures that if there are multiple callbacks, that's only done once.
