### PR TITLE
`CustomerInfoManager`: don't cache offline `CustomerInfo`

### DIFF
--- a/Sources/Logging/Strings/CustomerInfoStrings.swift
+++ b/Sources/Logging/Strings/CustomerInfoStrings.swift
@@ -23,6 +23,7 @@ enum CustomerInfoStrings {
     case checking_intro_eligibility_locally_from_receipt(AppleReceipt)
     case invalidating_customerinfo_cache
     case no_cached_customerinfo
+    case not_caching_offline_customer_info
     case customerinfo_stale_updating_in_background
     case customerinfo_stale_updating_in_foreground
     case customerinfo_updated_from_network
@@ -51,6 +52,8 @@ extension CustomerInfoStrings: CustomStringConvertible {
             return "Invalidating CustomerInfo cache."
         case .no_cached_customerinfo:
             return "No cached CustomerInfo, fetching from network."
+        case .not_caching_offline_customer_info:
+            return "CustomerInfo was computed offline. Won't be stored in cache."
         case .customerinfo_stale_updating_in_background:
             return "CustomerInfo cache is stale, updating from network in background."
         case .customerinfo_stale_updating_in_foreground:

--- a/Sources/OfflineEntitlements/CustomerInfo+OfflineEntitlements.swift
+++ b/Sources/OfflineEntitlements/CustomerInfo+OfflineEntitlements.swift
@@ -84,7 +84,7 @@ extension CustomerInfo {
     }
 
     /// Purchases are verified with StoreKit 2.
-    private static let verification: VerificationResult = .verified
+    private static let verification: VerificationResult = .verifiedOnDevice
 
     static let defaultManagementURL = URL(string: "https://apps.apple.com/account/subscriptions")!
 

--- a/Tests/StoreKitUnitTests/OfflineEntitlements/CustomerInfoOfflineEntitlementsStoreKitTest.swift
+++ b/Tests/StoreKitUnitTests/OfflineEntitlements/CustomerInfoOfflineEntitlementsStoreKitTest.swift
@@ -251,7 +251,7 @@ private extension CustomerInfoOfflineEntitlementsStoreKitTest {
         expect(entitlement.periodType) == periodType
         expect(entitlement.store) == .appStore
         expect(entitlement.unsubscribeDetectedAt).to(beNil())
-        expect(entitlement.verification) == .verified
+        expect(entitlement.verification) == .verifiedOnDevice
     }
 
 }


### PR DESCRIPTION
This is meant to be a temporary `CustomerInfo` while the backend is offline.
See also #2368.