### PR TITLE
Added new `VerificationResult.verifiedOnDevice`

### DIFF
--- a/Sources/Security/VerificationResult.swift
+++ b/Sources/Security/VerificationResult.swift
@@ -54,6 +54,9 @@ internal enum VerificationResult: Int {
     /// Entitlements were verified with our server.
     case verified = 1
 
+    /// Entitlements were created and verified on device through `StoreKit 2`.
+    case verifiedOnDevice = 3
+
     /// Entitlement verification failed, possibly due to a MiTM attack.
     /// ### Related Symbols
     /// - ``ErrorCode/signatureVerificationFailed``
@@ -77,20 +80,23 @@ extension VerificationResult {
         switch (cachedResult, responseResult) {
         case (.notRequested, .notRequested),
             (.verified, .verified),
+            (.verifiedOnDevice, .verifiedOnDevice),
             (.failed, .failed):
             return cachedResult
 
-        case (.verified, .notRequested): return .notRequested
-        case (.verified, .failed): return .failed
+        case (.verified, .notRequested), (.verifiedOnDevice, .notRequested): return .notRequested
+        case (.verified, .failed), (.verifiedOnDevice, .failed): return .failed
 
-        case (.notRequested, .verified): return .verified
+        case (.notRequested, .verified), (.notRequested, .verifiedOnDevice): return responseResult
         case (.notRequested, .failed): return .failed
 
         case (.failed, .notRequested): return .notRequested
         // If the cache verification failed, the etag won't be used
         // so the response would only be a 200 and not 304.
         // Therefore the cache verification error can be ignored
-        case (.failed, .verified): return .verified
+        case (.failed, .verified), (.failed, .verifiedOnDevice): return responseResult
+
+        case (.verifiedOnDevice, .verified), (.verified, .verifiedOnDevice): return responseResult
         }
     }
 

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCVerificationResultAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCVerificationResultAPI.m
@@ -17,6 +17,7 @@
     switch (result) {
         case RCVerificationResultNotRequested:
         case RCVerificationResultVerified:
+        case RCVerificationResultVerifiedOnDevice:
         case RCVerificationResultFailed:
             break;
     }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/VerificationResultAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/VerificationResultAPI.swift
@@ -24,6 +24,7 @@ func checkVerificationResultAPI(_ mode: EntitlementVerificationMode = .disabled,
     switch result {
     case .notRequested,
             .verified,
+            .verifiedOnDevice,
             .failed:
         break
 

--- a/Tests/UnitTests/Security/SigningTests.swift
+++ b/Tests/UnitTests/Security/SigningTests.swift
@@ -297,6 +297,7 @@ class SigningTests: TestCase {
     func testVerificationResultWithSameCachedAndResponseResult() {
         expect(VerificationResult.from(cache: .notRequested, response: .notRequested)) == .notRequested
         expect(VerificationResult.from(cache: .verified, response: .verified)) == .verified
+        expect(VerificationResult.from(cache: .verifiedOnDevice, response: .verifiedOnDevice)) == .verifiedOnDevice
         expect(VerificationResult.from(cache: .failed, response: .failed)) == .failed
     }
 
@@ -304,13 +305,19 @@ class SigningTests: TestCase {
         expect(VerificationResult.from(cache: .notRequested,
                                        response: .verified)) == .verified
         expect(VerificationResult.from(cache: .notRequested,
+                                       response: .verifiedOnDevice)) == .verifiedOnDevice
+        expect(VerificationResult.from(cache: .notRequested,
                                        response: .failed)) == .failed
     }
 
     func testVerifiedCachedResult() {
         expect(VerificationResult.from(cache: .verified,
                                        response: .notRequested)) == .notRequested
+        expect(VerificationResult.from(cache: .verifiedOnDevice,
+                                       response: .notRequested)) == .notRequested
         expect(VerificationResult.from(cache: .verified,
+                                       response: .failed)) == .failed
+        expect(VerificationResult.from(cache: .verifiedOnDevice,
                                        response: .failed)) == .failed
     }
 
@@ -319,6 +326,8 @@ class SigningTests: TestCase {
                                        response: .notRequested)) == .notRequested
         expect(VerificationResult.from(cache: .failed,
                                        response: .verified)) == .verified
+        expect(VerificationResult.from(cache: .failed,
+                                       response: .verifiedOnDevice)) == .verifiedOnDevice
     }
 
 }


### PR DESCRIPTION
This will be used to represent data that has been created and verified locally.