### PR TITLE
`SubscriberAttributesManagerIntegrationTests`: fixed potential race condition

### DIFF
--- a/Tests/BackendIntegrationTests/SubscriberAttributesManagerIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/SubscriberAttributesManagerIntegrationTests.swift
@@ -233,10 +233,12 @@ private extension SubscriberAttributesManagerIntegrationTests {
     }
 
     func syncAttributes() async -> [Error?] {
+        let purchases = Purchases.shared
+
         return await withCheckedContinuation { continuation in
             let errors: Atomic<[Error?]> = .init([])
 
-            Purchases.shared.syncSubscriberAttributes(
+            purchases.syncSubscriberAttributes(
                 syncedAttribute: { error in errors.modify { $0.append(error) } },
                 completion: { continuation.resume(returning: errors.value) }
             )


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/10484/workflows/453cb381-e2b4-4549-93fd-4bb7e0e03485/jobs/60959
I'm not quite sure why, but for some reason sometimes, the `tearDown` handle for these tests was running before this `continunation` finished, leading to a crash:
```swift
fatalError(Strings.purchase.purchases_nil.description)
```

This simple change saves `Purchases.shared` before creating a new `Task` to fix that.
