### PR TITLE
`SubscriberAttributesManagerIntegrationTests`: fixed flaky failures

### DIFF
--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -64,6 +64,7 @@ class BaseBackendIntegrationTests: XCTestCase {
         self.clearReceiptIfExists()
         self.configurePurchases()
         self.verifyPurchasesDoesNotLeak()
+        try await self.waitForAnonymousUser()
     }
 
 }
@@ -113,6 +114,14 @@ private extension BaseBackendIntegrationTests {
             Purchases.shared.delegate = nil
             Purchases.clearSingleton()
         }
+    }
+
+    func waitForAnonymousUser() async throws {
+        // SDK initialization begins with an initial request to offerings,
+        // which results in a get-create of the initial anonymous user.
+        // To avoid race conditions with when this request finishes and make all tests deterministic
+        // this waits for that request to finish.
+        _ = try await Purchases.shared.offerings()
     }
 
     private var dangerousSettings: DangerousSettings {

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -32,12 +32,6 @@ class BaseStoreKitIntegrationTests: BaseBackendIntegrationTests {
         // (and transactions has been cleared), to avoid the SDK posting receipts from
         // a previous test.
         try await super.setUp()
-
-        // SDK initialization begins with an initial request to offerings
-        // Which results in a get-create of the initial anonymous user.
-        // To avoid race conditions with when this request finishes and make all tests deterministic
-        // this waits for that request to finish.
-        _ = try await Purchases.shared.offerings()
     }
 
     override func tearDown() {


### PR DESCRIPTION
Turns out we had already solved this race condition in #1492 that lead to flaky failures,
but it was only in `BaseStoreKitIntegrationTests`. This moves it up to `BaseBackendIntegrationTests` so that
`SubscriberAttributesManagerIntegrationTests` can use it too.

Fixes https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/10501/workflows/cb6dbf22-cda8-4c41-875b-04b489992631/jobs/61135
