### PR TITLE
Purchases.configure: log warning if attempting to use a static appUserID

### DIFF
--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -113,8 +113,16 @@ import Foundation
          *
          * - Important: Set this property if you have your own user identifiers that you manage.
          */
+        @_disfavoredOverload
         @objc public func with(appUserID: String?) -> Builder {
             self.appUserID = appUserID
+            return self
+        }
+
+        // swiftlint:disable:next missing_docs
+        public func with(appUserID: StaticString) -> Configuration.Builder {
+            Logger.warn(Strings.identity.logging_in_with_static_string)
+            self.appUserID = "\(appUserID)"
             return self
         }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -158,6 +158,29 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expect(purchases.appUserID) == Self.appUserID
     }
 
+    func testStaticUserIdSringLogsMessage() {
+        let logger = TestLogHandler()
+
+        _ = Purchases.configure(
+            with: .init(withAPIKey: "")
+                .with(appUserID: "Static string")
+        )
+
+        logger.verifyMessageWasLogged(Strings.identity.logging_in_with_static_string, level: .warn)
+    }
+
+    func testUserIdSringDoesNotLogMessage() {
+        let appUserID = "user ID"
+        let logger = TestLogHandler()
+
+        _ = Purchases.configure(
+            with: .init(withAPIKey: "")
+                .with(appUserID: appUserID)
+        )
+
+        logger.verifyMessageWasNotLogged(Strings.identity.logging_in_with_static_string, level: .warn)
+    }
+
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func testEntitlementVerificationModeDisabledDoesNotSetPublicKey() throws {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()


### PR DESCRIPTION
### Checklist
- [X] If applicable, unit tests
- [X] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation

Hardcoding the user id is not desirable in almost any scenario, so we want to warn the developer when that happens.

### Description

Following what we did for `Purchases.logIn` in https://github.com/RevenueCat/purchases-ios/pull/1958, detect when `Builder.with(appUserId:)` is called with a static string and log a warning.
