### PR TITLE
Temporarily disable entitlement mapping

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1316,10 +1316,11 @@ private extension Purchases {
                                                            completion: nil)
             }
 
-            self.offlineEntitlementsManager.updateProductsEntitlementsCacheIfStale(
-                isAppBackgrounded: isAppBackgrounded,
-                completion: nil
-            )
+//            disabled temporarily, until the backend side is ready
+//            self.offlineEntitlementsManager.updateProductsEntitlementsCacheIfStale(
+//                isAppBackgrounded: isAppBackgrounded,
+//                completion: nil
+//            )
         }
     }
 
@@ -1345,10 +1346,11 @@ private extension Purchases {
                                                    isAppBackgrounded: isAppBackgrounded,
                                                    completion: nil)
 
-        self.offlineEntitlementsManager.updateProductsEntitlementsCacheIfStale(
-            isAppBackgrounded: isAppBackgrounded,
-            completion: nil
-        )
+//            disabled temporarily, until the backend side is ready
+//        self.offlineEntitlementsManager.updateProductsEntitlementsCacheIfStale(
+//            isAppBackgrounded: isAppBackgrounded,
+//            completion: nil
+//        )
     }
 
     // Used when delegate is being set

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
@@ -30,8 +30,11 @@ class PurchasesGetOfferingsTests: BasePurchasesTests {
         self.systemInfo.stubbedIsApplicationBackgrounded = false
         self.setupPurchases()
 
+//        temporarily disabled until the backend side is ready
+//        expect(self.mockOfflineEntitlementsManager.invokedUpdateProductsEntitlementsCacheIfStaleCount)
+//            .toEventually(equal(1))
         expect(self.mockOfflineEntitlementsManager.invokedUpdateProductsEntitlementsCacheIfStaleCount)
-            .toEventually(equal(1))
+            .toEventually(equal(0))
     }
 
     func testFirstInitializationDoesntFetchOfferingsOrOfflineEntitlementsIfAppBackgrounded() {


### PR DESCRIPTION
Temporarily disabled entitlement mapping cache, until the backend is ready for it. 