### PR TITLE
Add lane for running iOS v3 load shedder integration tests

### DIFF
--- a/Tests/v3LoadShedderIntegration/v3LoadShedderIntegrationTests/V3LoadShedderIntegrationTests.swift
+++ b/Tests/v3LoadShedderIntegration/v3LoadShedderIntegrationTests/V3LoadShedderIntegrationTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 // swiftlint:disable xctestcase_superclass
 final class V3LoadShedderIntegrationTests: XCTestCase {
-    let apiKey = "API_KEY"
+    let apiKey = "REVENUECAT_LOAD_SHEDDER_API_KEY"
 
     let skConfigFileName = "V3LoadShedderIntegrationTestsConfiguration"
     let entitlementIdentifier = "premium"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -252,7 +252,8 @@ platform :ios do
       previous_text: "REVENUECAT_LOAD_SHEDDER_API_KEY",
       new_text: ENV["REVENUECAT_LOAD_SHEDDER_API_KEY"],
       paths_of_files_to_update: [
-        './Tests/BackendIntegrationTests/Constants.swift'
+        './Tests/BackendIntegrationTests/Constants.swift',
+        './Tests/v3LoadShedderIntegration/v3LoadShedderIntegrationTests/V3LoadShedderIntegrationTests.swift'
       ]
     )
 
@@ -385,6 +386,24 @@ platform :ios do
       output_directory: "fastlane/test_output/xctest/ios"
     )
   end
+
+  desc "Run LoadShedder tests"
+  lane :v3_loadshedder_integration_tests do |options|
+    replace_api_key_integration_tests
+    scan(
+      project: "./Tests/v3LoadShedderIntegration/v3LoadShedderIntegration.xcodeproj",
+      scheme: "v3LoadShedderIntegration",
+      derived_data_path: "scan_derived_data",
+      output_types: 'junit',
+      output_style: 'raw',
+      number_of_retries: 3,
+      result_bundle: true,
+      testplan: "CI-BackendIntegration",
+      configuration: 'Debug',
+      output_directory: "fastlane/test_output/xctest/ios"
+    )
+  end
+  
 
   desc "Update swift package commit"
   lane :update_swift_package_commit do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -396,9 +396,7 @@ platform :ios do
       derived_data_path: "scan_derived_data",
       output_types: 'junit',
       output_style: 'raw',
-      number_of_retries: 3,
       result_bundle: true,
-      testplan: "CI-BackendIntegration",
       configuration: 'Debug',
       output_directory: "fastlane/test_output/xctest/ios"
     )

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -82,6 +82,14 @@ Runs all the iOS tests
 
 Runs all the tvOS tests
 
+### ios test_watchos
+
+```sh
+[bundle exec] fastlane ios test_watchos
+```
+
+Runs all the watchOS tests
+
 ### ios release_checks
 
 ```sh
@@ -201,6 +209,14 @@ Export XCFramework
 ```
 
 Run BackendIntegrationTests
+
+### ios v3_loadshedder_integration_tests
+
+```sh
+[bundle exec] fastlane ios v3_loadshedder_integration_tests
+```
+
+Run LoadShedder tests
 
 ### ios update_swift_package_commit
 


### PR DESCRIPTION
This adds a fastlane lane to execute load shedder integration tests. 
In a follow-up PR I'll call this lane automatically from CircleCI, on a schedule. 

It won't be a part of regular integration tests, since this logic is tied to v3 and static. So only the load shedder itself is getting tested here. 