### PR TITLE
`PurchaseTester`: fix memory leaks

### DIFF
--- a/Tests/TestingApps/PurchaseTester/PurchaseTester/CatsViewController.swift
+++ b/Tests/TestingApps/PurchaseTester/PurchaseTester/CatsViewController.swift
@@ -29,8 +29,10 @@ class CatsViewController: UIViewController {
         beginRefundButton.addTarget(self, action: #selector(beginRefundButtonTapped), for: .touchUpInside)
         restorePurchasesButton.addTarget(self, action: #selector(restorePurchasesButtonTapped), for: .touchUpInside)
 
-        self.customerInfoObservation = Task {
+        self.customerInfoObservation = Task { [weak self] in
             for await customerInfo in Purchases.shared.customerInfoStream {
+                guard let self else { return }
+
                 self.configureCatContentFor(customerInfo: customerInfo)
             }
         }


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- Please link to issues following this format: Resolves #999999 -->

Because memory leaks in `for await` loop.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes -->

Changed `self` to weak capture.
