### PR TITLE
Fix iOS 12 compilation

### DIFF
--- a/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
+++ b/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
@@ -22,7 +22,7 @@ enum OfflineEntitlementsStrings {
     case product_entitlement_mapping_stale_updating
     case product_entitlement_mapping_updated_from_network
     case product_entitlement_mapping_fetching_error(BackendError)
-    case found_unverified_transactions_in_sk2(StoreKit.Transaction, Error)
+    case found_unverified_transactions_in_sk2(transactionID: UInt64, Error)
 
 }
 
@@ -40,12 +40,12 @@ extension OfflineEntitlementsStrings: CustomStringConvertible {
         case let .product_entitlement_mapping_fetching_error(error):
             return "Failed updating ProductEntitlementMapping from network: \(error.localizedDescription)"
 
-        case let .found_unverified_transactions_in_sk2(transaction, error):
+        case let .found_unverified_transactions_in_sk2(transactionID, error):
             return """
                 Found an unverified transaction. It will be ignored and will not be a part of CustomerInfo.
                 Details:
                 Error: \(error.localizedDescription)
-                Transaction: \(transaction.debugDescription)
+                Transaction ID: \(transactionID)
             """
 
         }

--- a/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
+++ b/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
@@ -31,9 +31,9 @@ class PurchasedProductsFetcher {
 
         for await transaction in StoreKit.Transaction.currentEntitlements {
             switch transaction {
-            case let .unverified(unverifiedTransaction, verificationError):
+            case let .unverified(transaction, verificationError):
                 Logger.appleWarning(
-                    Strings.offlineEntitlements.found_unverified_transactions_in_sk2(unverifiedTransaction,
+                    Strings.offlineEntitlements.found_unverified_transactions_in_sk2(transactionID: transaction.id,
                                                                                      verificationError)
                 )
             case let .verified(verifiedTransaction):


### PR DESCRIPTION
Broken by #2358. This is the same as https://github.com/apple/swift/issues/58099

Even though `OfflineEntitlementsStrings` isn't available on iOS 12, it can't contain types that aren't available at runtime on iOS 12.