### PR TITLE
`SwiftLint`: fixed lint with new 0.51.0 version

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -18,6 +18,7 @@ opt_in_rules:
 
 disabled_rules:
   - orphaned_doc_comment
+  - blanket_disable_command
 
 custom_rules:
   xctestcase_superclass:


### PR DESCRIPTION
See https://github.com/realm/SwiftLint/releases/tag/0.51.0

This new rule warns when rules are disabled without being enabled before the end of the file.
We take advantage of that in many places, so it's better to disable it here.
