### PR TITLE
`DispatchTimeInterval`: fixed Xcode 14.3 compilation

### DIFF
--- a/Sources/FoundationExtensions/DispatchTimeInterval+Extensions.swift
+++ b/Sources/FoundationExtensions/DispatchTimeInterval+Extensions.swift
@@ -101,8 +101,9 @@ extension DispatchTimeInterval: Comparable {
 
 }
 
-#if swift(<5.8)
-// `DispatchTimeInterval` is not `Sendable` as of Swift 5.7.
+#if swift(<5.9)
+// `DispatchTimeInterval` is not `Sendable` as of Swift 5.8.
 // Its conformance is safe since it only represents data
+// See https://github.com/apple/swift/issues/65044
 extension DispatchTimeInterval: @unchecked Sendable {}
 #endif


### PR DESCRIPTION
I expected it to be marked `Sendable` in the next version of Swift, but it still hasn't so I filed https://github.com/apple/swift/issues/65044.

`DispatchTimeInterval` is a value type, so it's safe to do this. I don't want to remove the `#if swift` version check because I expect it to be marked `Sendable` in a future version.
