### PR TITLE
`Xcode 14.3`: fixed compilation errors

### DIFF
--- a/Tests/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
+++ b/Tests/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
@@ -233,9 +233,9 @@ private extension BeginRefundRequestHelperTests {
                 "original_app_user_id": "app_user_id",
                 "original_application_version": "2083",
                 "first_seen": "2019-06-17T16:05:33Z",
-                "non_subscriptions": [:],
+                "non_subscriptions": [:] as [String: Any],
                 "subscriptions": [
-                    "onemonth_freetrial": [:]
+                    "onemonth_freetrial": [:] as [String: Any]
                 ],
                 "entitlements": [
                     "\(mockEntitlementID)": [
@@ -244,7 +244,7 @@ private extension BeginRefundRequestHelperTests {
                         "purchase_date": "2018-10-26T23:17:53Z"
                     ]
                 ]
-            ]
+            ] as [String: Any]
         ]
     }
 
@@ -255,10 +255,10 @@ private extension BeginRefundRequestHelperTests {
                 "original_app_user_id": "app_user_id",
                 "original_application_version": "2083",
                 "first_seen": "2019-06-17T16:05:33Z",
-                "non_subscriptions": [:],
+                "non_subscriptions": [:] as [String: Any],
                 "subscriptions": [
-                    "onemonth_freetrial": [:],
-                    "onemonth_freetrial2": [:]
+                    "onemonth_freetrial": [:] as [String: Any],
+                    "onemonth_freetrial2": [:] as [String: Any]
                 ],
                 "entitlements": [
                     "\(mockEntitlementID)": [
@@ -272,7 +272,7 @@ private extension BeginRefundRequestHelperTests {
                         "purchase_date": "2018-10-26T23:17:53Z"
                     ]
                 ]
-            ]
+            ] as [String: Any]
         ]
     }
 
@@ -283,8 +283,8 @@ private extension BeginRefundRequestHelperTests {
                 "original_app_user_id": "app_user_id",
                 "original_application_version": "2083",
                 "first_seen": "2019-06-17T16:05:33Z",
-                "non_subscriptions": [:],
-                "subscriptions": [:],
+                "non_subscriptions": [:] as [String: Any],
+                "subscriptions": [:] as [String: Any],
                 "entitlements": [
                     "\(mockEntitlementID)": [
                         "expires_date": "2000-08-30T02:40:36Z",
@@ -292,7 +292,7 @@ private extension BeginRefundRequestHelperTests {
                         "purchase_date": "2018-10-26T23:17:53Z"
                     ]
                 ]
-            ]
+            ] as [String: Any]
         ]
     }
 
@@ -303,8 +303,8 @@ private extension BeginRefundRequestHelperTests {
                 "original_app_user_id": "app_user_id",
                 "original_application_version": "2083",
                 "first_seen": "2019-06-17T16:05:33Z",
-                "non_subscriptions": [:],
-                "subscriptions": [:],
+                "non_subscriptions": [:] as [String: Any],
+                "subscriptions": [:] as [String: Any],
                 "entitlements": [
                     "pro": [
                         "expires_date": "2100-08-30T02:40:36Z",
@@ -312,7 +312,7 @@ private extension BeginRefundRequestHelperTests {
                         "purchase_date": "2018-10-26T23:17:53Z"
                     ]
                 ]
-            ]
+            ] as [String: Any]
         ]
     }
 

--- a/Tests/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
+++ b/Tests/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
@@ -30,10 +30,10 @@ class ManageSubscriptionsHelperTests: TestCase {
         "subscriber": [
             "original_app_user_id": "app_user_id",
             "first_seen": "2019-06-17T16:05:33Z",
-            "subscriptions": [:],
-            "other_purchases": [:],
+            "subscriptions": [:] as [String: Any],
+            "other_purchases": [:] as [String: Any],
             "original_application_version": NSNull()
-        ],
+        ] as [String: Any],
         "managementURL": NSNull()
     ]
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -388,14 +388,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         expect(transaction?.sk2Transaction) == mockTransaction
         expect(userCancelled) == false
 
-        let expectedCustomerInfo = try CustomerInfo(data: [
-            "request_date": "2019-08-16T10:30:42Z",
-            "subscriber": [
-                "first_seen": "2019-07-17T00:05:54Z",
-                "original_app_user_id": "",
-                "subscriptions": [:],
-                "other_purchases": [:]
-            ]])
+        let expectedCustomerInfo: CustomerInfo = .emptyInfo
         expect(customerInfo) == expectedCustomerInfo
     }
 
@@ -996,16 +989,6 @@ private extension PurchasesOrchestratorTests {
         return try await SK1StoreProduct(sk1Product: fetchSk1Product())
     }
 
-    var mockCustomerInfo: CustomerInfo {
-        // swiftlint:disable:next force_try
-        try! CustomerInfo(data: [
-            "request_date": "2019-08-16T10:30:42Z",
-            "subscriber": [
-                "first_seen": "2019-07-17T00:05:54Z",
-                "original_app_user_id": "",
-                "subscriptions": [:],
-                "other_purchases": [:]
-            ]])
-    }
+    var mockCustomerInfo: CustomerInfo { .emptyInfo }
 
 }

--- a/Tests/StoreKitUnitTests/StoreKit2TransactionListenerTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2TransactionListenerTests.swift
@@ -13,7 +13,7 @@
 
 import Nimble
 @testable import RevenueCat
-@preconcurrency import StoreKit // `PurchaseResult` is not `Sendable`
+import StoreKit
 import StoreKitTest
 import XCTest
 

--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitConfigTestCase+Extensions.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitConfigTestCase+Extensions.swift
@@ -13,7 +13,7 @@
 
 import Nimble
 @testable import RevenueCat
-@preconcurrency import StoreKit
+import StoreKit
 import XCTest
 
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)

--- a/Tests/UnitTests/FoundationExtensions/ArrayExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/ArrayExtensionsTests.swift
@@ -46,7 +46,7 @@ class ArrayExtensionsTests: TestCase {
     // MARK: - onlyElement
 
     func testOnlyElementWithEmptyArray() {
-        expect([].onlyElement).to(beNil())
+        expect([Any]().onlyElement).to(beNil())
     }
 
     func testOnlyElementWithMultipleElements() {

--- a/Tests/UnitTests/FoundationExtensions/DictionaryExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/DictionaryExtensionsTests.swift
@@ -235,7 +235,7 @@ class DictionaryExtensionsMapKeysTests: TestCase {
     }
 
     func testCompactMapDictionaryResultingInEmptyDictionary() {
-        expect([1: "test"].compactMapKeys { _ in nil }) == [:]
+        expect([1: "test"].compactMapKeys { _ in Optional<String>.none }).to(beEmpty())
     }
 
     func testCompactMapKeys() {

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -29,10 +29,11 @@ class BaseCustomerInfoManagerTests: TestCase {
             "subscriber": [
                 "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-06-17T16:05:33Z",
-                "subscriptions": [:],
-                "other_purchases": [:],
+                "subscriptions": [:]  as [String: Any],
+                "other_purchases": [:]  as [String: Any],
                 "original_application_version": NSNull()
-            ]])
+            ]  as [String: Any]
+        ])
 
         self.mockDeviceCache = MockDeviceCache(sandboxEnvironmentDetector: self.mockSystemInfo)
         self.customerInfoManagerChangesCallCount = 0
@@ -187,14 +188,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
     }
 
     func testSendCachedCustomerInfoIfAvailableForAppUserIDSendsIfNeverSent() throws {
-        let info = try CustomerInfo(data: [
-        "request_date": "2019-08-16T10:30:42Z",
-            "subscriber": [
-                "original_app_user_id": Self.appUserID,
-                "first_seen": "2019-06-17T16:05:33Z",
-                "subscriptions": [:],
-                "other_purchases": [:]
-            ]])
+        let info: CustomerInfo = .emptyInfo
 
         let object = try info.asJSONEncodedData()
         self.mockDeviceCache.cachedCustomerInfo[Self.appUserID] = object
@@ -205,14 +199,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
     }
 
     func testSendCachedCustomerInfoIfAvailableForAppUserIDSendsIfDifferent() throws {
-        let oldInfo = try CustomerInfo(data: [
-            "request_date": "2019-08-16T10:30:42Z",
-            "subscriber": [
-                "original_app_user_id": Self.appUserID,
-                "first_seen": "2019-06-17T16:05:33Z",
-                "subscriptions": [:],
-                "other_purchases": [:]
-            ]])
+        let oldInfo: CustomerInfo = .emptyInfo
 
         var object = try oldInfo.asJSONEncodedData()
 
@@ -226,8 +213,9 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                 "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-06-17T16:05:33Z",
                 "subscriptions": ["product_a": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]],
-                "other_purchases": [:]
-            ]])
+                "other_purchases": [:] as [String: Any]
+            ] as [String: Any]
+        ])
 
         object = try newInfo.asJSONEncodedData()
         mockDeviceCache.cachedCustomerInfo[Self.appUserID] = object
@@ -237,14 +225,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
     }
 
     func testSendCachedCustomerInfoIfAvailableForAppUserIDSendsOnMainThread() throws {
-        let oldInfo = try CustomerInfo(data: [
-            "request_date": "2019-08-16T10:30:42Z",
-            "subscriber": [
-                "original_app_user_id": Self.appUserID,
-                "first_seen": "2019-06-17T16:05:33Z",
-                "subscriptions": [:],
-                "other_purchases": [:]
-            ]])
+        let oldInfo: CustomerInfo = .emptyInfo
 
         let object = try oldInfo.asJSONEncodedData()
         mockDeviceCache.cachedCustomerInfo[Self.appUserID] = object
@@ -306,9 +287,10 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                     "ProductC": ["expires_date": "2098-05-27T06:24:50Z", "period_type": "normal"],
                     "Pro": ["expires_date": "2098-05-27T06:24:50Z", "period_type": "normal"],
                     "ProductD": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]
-                ],
-                "other_purchases": [:]
-            ]])
+                ]  as [String: Any],
+                "other_purchases": [:]  as [String: Any]
+            ]  as [String: Any]
+        ])
 
         let object = try info.asJSONEncodedData()
         self.mockDeviceCache.cachedCustomerInfo[Self.appUserID] = object
@@ -337,8 +319,9 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                 "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-06-17T16:05:33Z",
                 "subscriptions": ["product_a": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]],
-                "other_purchases": [:]
-            ]])
+                "other_purchases": [:]  as [String: Any]
+            ]  as [String: Any]
+        ])
 
         let object = try info.asJSONEncodedData()
         mockDeviceCache.cachedCustomerInfo["firstUser"] = object
@@ -365,8 +348,8 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                 "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-06-17T16:05:33Z",
                 "subscriptions": ["product_a": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]],
-                "other_purchases": [:]
-            ]
+                "other_purchases": [:]  as [String: Any]
+            ] as [String: Any]
         ]
 
         let object = try JSONSerialization.data(withJSONObject: data, options: [])
@@ -386,8 +369,8 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                 "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-06-17T16:05:33Z",
                 "subscriptions": ["product_a": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]],
-                "other_purchases": [:]
-            ]
+                "other_purchases": [:]  as [String: Any]
+            ]  as [String: Any]
         ]
 
         let object = try JSONSerialization.data(withJSONObject: data, options: [])
@@ -447,10 +430,11 @@ class CustomerInfoManagerGetCustomerInfoTests: BaseCustomerInfoManagerTests {
             "subscriber": [
                 "original_app_user_id": Self.appUserID,
                 "first_seen": "2020-06-17T16:05:33Z",
-                "subscriptions": [:],
-                "other_purchases": [:],
+                "subscriptions": [:]  as [String: Any],
+                "other_purchases": [:]  as [String: Any],
                 "original_application_version": "1.0"
-            ]])
+            ]  as [String: Any]
+        ])
     }
 
     // MARK: - CacheFetchPolicy.fromCacheOnly

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -29,8 +29,8 @@ class BaseCustomerInfoManagerTests: TestCase {
             "subscriber": [
                 "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-06-17T16:05:33Z",
-                "subscriptions": [:]  as [String: Any],
-                "other_purchases": [:]  as [String: Any],
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any],
                 "original_application_version": NSNull()
             ]  as [String: Any]
         ])
@@ -288,7 +288,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                     "Pro": ["expires_date": "2098-05-27T06:24:50Z", "period_type": "normal"],
                     "ProductD": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]
                 ]  as [String: Any],
-                "other_purchases": [:]  as [String: Any]
+                "other_purchases": [:] as [String: Any]
             ]  as [String: Any]
         ])
 
@@ -319,7 +319,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                 "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-06-17T16:05:33Z",
                 "subscriptions": ["product_a": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]],
-                "other_purchases": [:]  as [String: Any]
+                "other_purchases": [:] as [String: Any]
             ]  as [String: Any]
         ])
 
@@ -348,7 +348,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                 "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-06-17T16:05:33Z",
                 "subscriptions": ["product_a": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]],
-                "other_purchases": [:]  as [String: Any]
+                "other_purchases": [:] as [String: Any]
             ] as [String: Any]
         ]
 
@@ -369,7 +369,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
                 "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-06-17T16:05:33Z",
                 "subscriptions": ["product_a": ["expires_date": "2018-05-27T06:24:50Z", "period_type": "normal"]],
-                "other_purchases": [:]  as [String: Any]
+                "other_purchases": [:] as [String: Any]
             ]  as [String: Any]
         ]
 
@@ -430,8 +430,8 @@ class CustomerInfoManagerGetCustomerInfoTests: BaseCustomerInfoManagerTests {
             "subscriber": [
                 "original_app_user_id": Self.appUserID,
                 "first_seen": "2020-06-17T16:05:33Z",
-                "subscriptions": [:]  as [String: Any],
-                "other_purchases": [:]  as [String: Any],
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any],
                 "original_application_version": "1.0"
             ]  as [String: Any]
         ])

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -31,14 +31,7 @@ class IdentityManagerTests: TestCase {
         try super.setUpWithError()
 
         self.mockIdentityAPI = try XCTUnwrap(mockBackend.identity as? MockIdentityAPI)
-        self.mockCustomerInfo = try CustomerInfo(data: [
-            "request_date": "2019-08-16T10:30:42Z",
-            "subscriber": [
-                "first_seen": "2019-07-17T00:05:54Z",
-                "original_app_user_id": "",
-                "subscriptions": [:],
-                "other_purchases": [:]
-            ]])
+        self.mockCustomerInfo = .emptyInfo
 
         let systemInfo = MockSystemInfo(finishTransactions: false)
 

--- a/Tests/UnitTests/Misc/AnyEncodableTests.swift
+++ b/Tests/UnitTests/Misc/AnyEncodableTests.swift
@@ -54,10 +54,10 @@ class AnyEncodableTests: TestCase {
                 "b2": [
                     "b21": 1,
                     "b22": URL(string: "https://google.com")!
-                ],
+                ] as [String: Any],
                 "b3": [20.2, 19.99, 5],
                 "b4": Date(timeIntervalSinceReferenceDate: 50000)
-            ],
+            ] as [String: Any],
             "c": "3",
             "d": nil
         ]

--- a/Tests/UnitTests/Misc/CustomerInfo+TestExtensions.swift
+++ b/Tests/UnitTests/Misc/CustomerInfo+TestExtensions.swift
@@ -38,6 +38,22 @@ extension CustomerInfo {
 
 extension CustomerInfo {
 
+    // swiftlint:disable:next force_try
+    static let emptyInfo: CustomerInfo = try! .init(data: [
+        "request_date": "2019-08-16T10:30:42Z",
+        "subscriber": [
+            "first_seen": "2019-07-17T00:05:54Z",
+            "original_app_user_id": "app_user_id",
+            "subscriptions": [:] as [String: Any],
+            "other_purchases": [:] as [String: Any],
+            "original_application_version": "1.0"
+        ] as [String: Any]
+    ])
+
+}
+
+extension CustomerInfo {
+
     func asData(withNewSchemaVersion version: Any?) throws -> Data {
         var dictionary = try XCTUnwrap(
             JSONSerialization.jsonObject(with: try self.asJSONEncodedData()) as? [String: Any]

--- a/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
+++ b/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
@@ -31,16 +31,7 @@ class PurchasesDiagnosticsTests: TestCase {
         self.diagnostics = .init(purchases: self.purchases)
 
         self.purchases.mockedHealthRequestResponse = .success(())
-        self.purchases.mockedCustomerInfoResponse = .success(
-            try CustomerInfo(data: [
-                "request_date": "2019-08-16T10:30:42Z",
-                "subscriber": [
-                    "first_seen": "2019-07-17T00:05:54Z",
-                    "original_app_user_id": "",
-                    "subscriptions": [:],
-                    "other_purchases": [:]
-                ]])
-        )
+        self.purchases.mockedCustomerInfoResponse = .success(.emptyInfo)
         self.purchases.mockedOfferingsResponse = .success(.init(offerings: [:], currentOfferingID: nil))
     }
 

--- a/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
@@ -128,8 +128,8 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "user",
-                "subscriptions": [:]
-            ]
+                "subscriptions": [:] as [String: Any]
+            ] as [String: Any]
         ]
         let path: HTTPRequest.Path = .getCustomerInfo(appUserID: Self.userID)
         let customerInfoResponse = MockHTTPClient.Response(statusCode: .success, response: customerResponse)

--- a/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
@@ -183,7 +183,7 @@ class BackendGetOfferingsTests: BaseBackendTests {
 private extension BackendGetOfferingsTests {
 
     static let noOfferingsResponse: [String: Any?] = [
-        "offerings": [],
+        "offerings": [] as [Any],
         "current_offering_id": nil
     ]
 
@@ -202,7 +202,7 @@ private extension BackendGetOfferingsTests {
                         "platform_product_identifier": "annual_freetrial"
                     ]
                 ]
-            ]
+            ] as [String: Any]
         ],
         "current_offering_id": "offering_a"
     ]

--- a/Tests/UnitTests/Networking/Backend/BackendLoginTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendLoginTests.swift
@@ -196,11 +196,11 @@ private extension BackendLoginTests {
     static let mockCustomerInfoData: [String: Any] = [
         "request_date": "2019-08-16T10:30:42Z",
         "subscriber": [
-            "subscriptions": [:],
+            "subscriptions": [:] as [String: Any],
             "first_seen": "2019-07-17T00:05:54Z",
             "original_app_user_id": "",
-            "other_purchases": [:]
-        ]
+            "other_purchases": [:] as [String: Any]
+        ] as [String: Any]
     ]
 
 }

--- a/Tests/UnitTests/Networking/Backend/BackendOfflineEntitlementsTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendOfflineEntitlementsTests.swift
@@ -63,7 +63,7 @@ class BackendOfflineEntitlementsTests: BaseBackendTests {
 private extension BackendOfflineEntitlementsTests {
 
     static let noProductsEntitlements: [String: Any?] = [
-        "products": []
+        "products": [] as [Any]
     ]
 
     static let productsEntitlements: [String: Any?] = [
@@ -73,14 +73,14 @@ private extension BackendOfflineEntitlementsTests {
                 "entitlements": [
                     "pro_1"
                 ]
-            ],
+            ] as [String: Any],
             [
                 "id": "com.revenuecat.foo_2",
                 "entitlements": [
                     "pro_1",
                     "pro_2"
                 ]
-            ]
+            ] as [String: Any]
         ]
     ]
 

--- a/Tests/UnitTests/Networking/Backend/BackendPostOfferForSigningTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostOfferForSigningTests.swift
@@ -34,9 +34,9 @@ class BackendPostOfferForSigningTests: BaseBackendTests {
                         "signature": "Base64 encoded signature",
                         "nonce": "A UUID",
                         "timestamp": Int64(123413232131)
-                    ],
+                    ]  as [String: Any],
                     "signature_error": nil
-                ]
+                ]  as [String: Any?]
             ]
         ]
 
@@ -91,7 +91,7 @@ class BackendPostOfferForSigningTests: BaseBackendTests {
 
     func testOfferForSigningEmptyOffersResponse() {
         let validSigningResponse: [String: Any] = [
-            "offers": []
+            "offers": [] as [Any]
         ]
 
         self.httpClient.mock(
@@ -132,8 +132,8 @@ class BackendPostOfferForSigningTests: BaseBackendTests {
                     "signature_error": [
                         "message": errorResponse.message!,
                         "code": errorResponse.code.rawValue
-                    ]
-                ]
+                    ] as [String: Any]
+                ] as [String: Any?]
             ]
         ]
 

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -376,7 +376,7 @@ class BackendPostReceiptDataTests: BaseBackendTests {
                         "expires_date": futureDateString
                     ]
                 ]
-            ]
+            ] as [String: Any]
         ]
 
         let validUpdatedCustomerResponse: [String: Any] = [
@@ -392,7 +392,7 @@ class BackendPostReceiptDataTests: BaseBackendTests {
                         "expires_date": futureDateString
                     ]
                 ]
-            ]
+            ] as [String: Any]
         ]
         let initialCustomerInfoResponse = MockHTTPClient.Response(statusCode: .success,
                                                                   response: validCustomerResponse)

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -113,7 +113,7 @@ extension BaseBackendTests {
                     "expires_date": "2017-08-30T02:40:36Z"
                 ]
             ]
-        ]
+        ] as [String: Any]
     ]
 
 }

--- a/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
@@ -45,15 +45,15 @@ class BasicCustomerInfoTests: TestCase {
                         "original_purchase_date": "1990-08-30T02:40:36Z",
                         "purchase_date": "1990-08-30T02:40:36Z",
                         "store": "play_store"
-                    ]
+                    ] as [String: Any]
                 ]
-            ],
+            ] as [String: Any],
             "subscriptions": [
                 "onemonth_freetrial": [
                     "expires_date": "2100-08-30T02:40:36Z",
                     "period_type": "normal",
                     "is_sandbox": false
-                ],
+                ] as [String: Any],
                 "onemonth": [
                     "expires_date": BasicCustomerInfoTests.expiredSubscriptionDate,
                     "period_type": "normal",
@@ -87,7 +87,7 @@ class BasicCustomerInfoTests: TestCase {
                     "purchase_date": "1990-08-30T02:40:36Z"
                 ]
             ]
-        ]
+        ] as [String: Any]
     ]
 
     static let validTwoProductsJSON = "{" +
@@ -167,9 +167,10 @@ class BasicCustomerInfoTests: TestCase {
             "subscriber": [
                 "original_app_user_id": "app_user_id",
                 "first_seen": "2019-07-17T00:05:54Z",
-                "subscriptions": [:],
-                "other_purchases": [:]
-            ]])
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any]
+            ] as [String: Any]
+        ])
         expect(customerInfo.originalApplicationVersion).to(beNil())
     }
 
@@ -179,10 +180,11 @@ class BasicCustomerInfoTests: TestCase {
             "subscriber": [
                 "original_app_user_id": "app_user_id",
                 "first_seen": "2019-07-17T00:05:54Z",
-                "subscriptions": [:],
-                "other_purchases": [:],
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any],
                 "original_application_version": NSNull()
-            ]])
+            ] as [String: Any]
+        ])
         expect(customerInfo.originalApplicationVersion).to(beNil())
     }
 
@@ -193,9 +195,10 @@ class BasicCustomerInfoTests: TestCase {
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "app_user_id",
                 "original_application_version": "1.0",
-                "subscriptions": [:],
-                "other_purchases": [:]
-            ]])
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any]
+            ] as [String: Any]
+        ])
         expect(customerInfo.originalApplicationVersion) == "1.0"
     }
 
@@ -207,9 +210,10 @@ class BasicCustomerInfoTests: TestCase {
                 "original_application_version": "1.0",
                 "original_app_user_id": "app_user_id",
                 "original_purchase_date": "2018-10-26T23:17:53Z",
-                "subscriptions": [:],
-                "other_purchases": [:]
-            ]])
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any]
+            ] as [String: Any]
+        ])
         expect(customerInfo.originalPurchaseDate) == Date(timeIntervalSinceReferenceDate: 562288673)
     }
 
@@ -219,9 +223,10 @@ class BasicCustomerInfoTests: TestCase {
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "",
-                "subscriptions": [:],
-                "other_purchases": [:]
-            ]])
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any]
+            ] as [String: Any]
+        ])
         expect(customerInfo.managementURL).to(beNil())
     }
 
@@ -232,9 +237,10 @@ class BasicCustomerInfoTests: TestCase {
                 "first_seen": "2019-07-17T00:05:54Z",
                 "management_url": "https://apple.com/manage_subscription",
                 "original_app_user_id": "",
-                "subscriptions": [:],
-                "other_purchases": [:]
-            ]])
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any]
+            ] as [String: Any]
+        ])
         expect(customerInfo.managementURL?.absoluteString) == "https://apple.com/manage_subscription"
     }
 
@@ -244,10 +250,11 @@ class BasicCustomerInfoTests: TestCase {
             "subscriber": [
                 "management_url": "",
                 "first_seen": "2019-07-17T00:05:54Z",
-                "subscriptions": [:],
-                "other_purchases": [:],
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any],
                 "original_app_user_id": ""
-            ]])
+            ] as [String: Any]
+        ])
         expect(customerInfo.managementURL).to(beNil())
 
         customerInfo = try CustomerInfo(data: [
@@ -255,10 +262,11 @@ class BasicCustomerInfoTests: TestCase {
             "subscriber": [
                 "management_url": true,
                 "first_seen": "2019-07-17T00:05:54Z",
-                "subscriptions": [:],
-                "other_purchases": [:],
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any],
                 "original_app_user_id": ""
-            ]])
+            ] as [String: Any]
+        ])
         expect(customerInfo.managementURL).to(beNil())
 
         customerInfo = try CustomerInfo(data: [
@@ -266,10 +274,11 @@ class BasicCustomerInfoTests: TestCase {
             "subscriber": [
                 "management_url": nil,
                 "first_seen": "2019-07-17T00:05:54Z",
-                "subscriptions": [:],
-                "other_purchases": [:],
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any],
                 "original_app_user_id": ""
-            ]])
+            ] as [String: Any?]
+        ])
         expect(customerInfo.managementURL).to(beNil())
 
         customerInfo = try CustomerInfo(data: [
@@ -277,10 +286,11 @@ class BasicCustomerInfoTests: TestCase {
             "subscriber": [
                 "management_url": "this isnt' a URL!",
                 "first_seen": "2019-07-17T00:05:54Z",
-                "subscriptions": [:],
-                "other_purchases": [:],
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any],
                 "original_app_user_id": ""
-            ]])
+            ] as [String: Any]
+        ])
         expect(customerInfo.managementURL).to(beNil())
 
         customerInfo = try CustomerInfo(data: [
@@ -289,9 +299,10 @@ class BasicCustomerInfoTests: TestCase {
                 "management_url": 68546984,
                 "original_app_user_id": "",
                 "first_seen": "2019-07-17T00:05:54Z",
-                "subscriptions": [:],
-                "other_purchases": [:]
-            ]])
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any]
+            ] as [String: Any]
+        ])
         expect(customerInfo.managementURL).to(beNil())
 
     }
@@ -357,7 +368,7 @@ class BasicCustomerInfoTests: TestCase {
                             "purchase_date": "1990-08-30T02:40:36Z",
                             "is_sandbox": true,
                             "store": "play_store"
-                        ]
+                        ] as [String: Any]
                     ],
                     "pro.3": [
                         [
@@ -366,7 +377,7 @@ class BasicCustomerInfoTests: TestCase {
                             "purchase_date": "1990-08-30T02:40:36Z",
                             "is_sandbox": true,
                             "store": "play_store"
-                        ]
+                        ] as [String: Any]
                     ]
                 ],
                 "subscriptions": [
@@ -404,7 +415,7 @@ class BasicCustomerInfoTests: TestCase {
                         "purchase_date": "1990-08-30T02:40:36Z"
                     ]
                 ]
-            ]
+            ] as [String: Any]
         ] as [String: Any]
 
         let customerInfoWithoutRequestData = try CustomerInfo(data: response)
@@ -456,8 +467,8 @@ class BasicCustomerInfoTests: TestCase {
                         "product_identifier": "threemonth_freetrial",
                         "expires_date": nil
                     ]
-                ]
-            ]
+                ] as [String: Any]
+            ] as [String: Any]
         ] as [String: Any]
         let customerInfoWithoutRequestData = try CustomerInfo(data: response)
         let purchaseDate = customerInfoWithoutRequestData.purchaseDate(forEntitlement: "pro")
@@ -470,17 +481,19 @@ class BasicCustomerInfoTests: TestCase {
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "",
-                "subscriptions": [:],
-                "other_purchases": [:]
-            ]])
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any]
+            ] as [String: Any]
+        ])
         let info2 = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "",
-                "subscriptions": [:],
-                "other_purchases": [:]
-            ]])
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any]
+            ] as [String: Any]
+        ])
         expect(info1) == info2
     }
 
@@ -490,17 +503,19 @@ class BasicCustomerInfoTests: TestCase {
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "",
-                "subscriptions": [:],
-                "other_purchases": [:]
-            ]])
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any]
+            ] as [String: Any]
+        ])
         let info2 = try CustomerInfo(data: [
             "request_date": "2018-11-19T02:40:36Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "",
-                "subscriptions": [:],
-                "other_purchases": [:]
-            ]])
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any]
+            ] as [String: Any]
+        ])
         expect(info1) == info2
     }
 
@@ -514,14 +529,15 @@ class BasicCustomerInfoTests: TestCase {
                     "pro.1": [
                         "expires_date": "2018-12-19T02:40:36Z"
                     ]],
-                "other_purchases": [:],
+                "other_purchases": [:] as [String: Any],
                 "entitlements": [
                     "pro": [
                         "expires_date": "2018-12-19T02:40:36Z",
                         "product_identifier": "pro.1"
                     ]
                 ]
-            ]])
+            ] as [String: Any]
+        ])
         let info2 = try CustomerInfo(data: [
             "request_date": "2018-11-19T02:40:36Z",
             "subscriber": [
@@ -532,14 +548,15 @@ class BasicCustomerInfoTests: TestCase {
                         "expires_date": "2018-12-19T02:40:36Z"
                     ]
                 ],
-                "other_purchases": [:],
+                "other_purchases": [:] as [String: Any],
                 "entitlements": [
                     "pro": [
                         "expires_date": "2018-12-29T02:40:36Z",
                         "product_identifier": "pro.1"
                     ]
                 ]
-            ]])
+            ] as [String: Any]
+        ])
         expect(info1) != info2
     }
 
@@ -559,9 +576,9 @@ class BasicCustomerInfoTests: TestCase {
                         "purchase_date": "2019-07-26T23:45:40Z",
                         "store": "app_store",
                         "unsubscribe_detected_at": nil
-                    ]
+                    ] as [String: Any?]
                 ],
-                "non_subscriptions": [:],
+                "non_subscriptions": [:] as [String: Any],
                 "entitlements": [
                     "pro": [
                         "product_identifier": "monthly_freetrial",
@@ -569,7 +586,8 @@ class BasicCustomerInfoTests: TestCase {
                         "purchase_date": "2018-07-26T23:30:41Z"
                     ]
                 ]
-            ]])
+            ] as [String: Any]
+        ])
         let info2 = try CustomerInfo(data: [
             "request_date": "2018-12-20T02:40:36Z",
             "subscriber": [
@@ -585,9 +603,9 @@ class BasicCustomerInfoTests: TestCase {
                         "purchase_date": "2019-07-26T23:45:40Z",
                         "store": "app_store",
                         "unsubscribe_detected_at": nil
-                    ]
+                    ] as [String: Any?]
                 ],
-                "non_subscriptions": [:],
+                "non_subscriptions": [:] as [String: Any],
                 "entitlements": [
                     "pro": [
                         "product_identifier": "monthly_freetrial",
@@ -595,7 +613,8 @@ class BasicCustomerInfoTests: TestCase {
                         "purchase_date": "2018-07-26T23:30:41Z"
                     ]
                 ]
-            ]])
+            ] as [String: Any]
+        ])
         expect(info1) != info2
     }
 
@@ -615,9 +634,9 @@ class BasicCustomerInfoTests: TestCase {
                         "purchase_date": "2019-07-26T23:45:40Z",
                         "store": "app_store",
                         "unsubscribe_detected_at": nil
-                    ]
+                    ] as [String: Any?]
                 ],
-                "non_subscriptions": [:],
+                "non_subscriptions": [:] as [String: Any],
                 "entitlements": [
                     "pro": [
                         "product_identifier": "monthly_freetrial",
@@ -625,7 +644,8 @@ class BasicCustomerInfoTests: TestCase {
                         "purchase_date": "2018-07-26T23:30:41Z"
                     ]
                 ]
-            ]])
+            ] as [String: Any]
+        ])
         let info2 = try CustomerInfo(data: [
             "request_date": "2018-12-20T02:40:36Z",
             "subscriber": [
@@ -641,9 +661,9 @@ class BasicCustomerInfoTests: TestCase {
                         "purchase_date": "2019-07-26T23:45:40Z",
                         "store": "app_store",
                         "unsubscribe_detected_at": nil
-                    ]
+                    ] as [String: Any?]
                 ],
-                "non_subscriptions": [:],
+                "non_subscriptions": [:] as [String: Any],
                 "entitlements": [
                     "pro": [
                         "product_identifier": "monthly_freetrial",
@@ -651,7 +671,8 @@ class BasicCustomerInfoTests: TestCase {
                         "purchase_date": "2018-07-26T23:30:41Z"
                     ]
                 ]
-            ]])
+            ] as [String: Any]
+        ])
         expect(info1) == info2
     }
 
@@ -662,9 +683,10 @@ class BasicCustomerInfoTests: TestCase {
                     "first_seen": "2019-07-17T00:05:54Z",
                     "management_url": "https://apple.com/manage_subscription",
                     "original_app_user_id": "",
-                    "subscriptions": [:],
-                    "other_purchases": [:]
-                ]])
+                    "subscriptions": [:] as [String: Any],
+                    "other_purchases": [:] as [String: Any]
+                ] as [String: Any]
+            ])
         ).to(throwError())
     }
 
@@ -675,9 +697,10 @@ class BasicCustomerInfoTests: TestCase {
                 "subscriber": [
                     "first_seen": "2019-07-17T00:05:54Z",
                     "management_url": "https://apple.com/manage_subscription",
-                    "subscriptions": [:],
-                    "other_purchases": [:]
-                ]])
+                    "subscriptions": [:] as [String: Any],
+                    "other_purchases": [:] as [String: Any]
+                ] as [String: Any]
+            ])
         ).to(throwError())
     }
 
@@ -696,9 +719,10 @@ class BasicCustomerInfoTests: TestCase {
                 "subscriber": [
                     "management_url": "https://apple.com/manage_subscription",
                     "original_app_user_id": "",
-                    "subscriptions": [:],
-                    "other_purchases": [:]
-                ]])
+                    "subscriptions": [:] as [String: Any],
+                    "other_purchases": [:] as [String: Any]
+                ] as [String: Any]
+            ])
         ).to(throwError())
     }
 
@@ -709,9 +733,10 @@ class BasicCustomerInfoTests: TestCase {
                 "subscriber": [
                     "original_app_user_id": "app_user_id",
                     "first_seen": "2019-07-17T00:05:54Z",
-                    "subscriptions": [:],
-                    "other_purchases": [:]
-                ]])
+                    "subscriptions": [:] as [String: Any],
+                    "other_purchases": [:] as [String: Any]
+                ] as [String: Any]
+            ])
         ).to(throwError())
     }
 
@@ -722,9 +747,10 @@ class BasicCustomerInfoTests: TestCase {
                 "subscriber": [
                     "original_app_user_id": "app_user_id",
                     "first_seen": "2019-07-",
-                    "subscriptions": [:],
-                    "other_purchases": [:]
-                ]])
+                    "subscriptions": [:] as [String: Any],
+                    "other_purchases": [:] as [String: Any]
+                ] as [String: Any]
+            ])
         ).to(throwError())
     }
 
@@ -735,7 +761,7 @@ class BasicCustomerInfoTests: TestCase {
                 "original_app_user_id": "app_user_id",
                 "original_application_version": "2083",
                 "first_seen": "2019-06-17T16:05:33Z",
-                "non_subscriptions": [:],
+                "non_subscriptions": [:] as [String: Any],
                 "subscriptions": [
                     "onemonth_freetrial": [
                         "expires_date": "2100-08-30T02:40:36Z",
@@ -765,7 +791,7 @@ class BasicCustomerInfoTests: TestCase {
                         "purchase_date": "1990-08-30T02:40:36Z"
                     ]
                 ]
-            ]
+            ] as [String: Any]
         ] as [String: Any]
 
         let info = try CustomerInfo(data: response)
@@ -779,7 +805,7 @@ class BasicCustomerInfoTests: TestCase {
                 "original_app_user_id": "app_user_id",
                 "original_application_version": "2083",
                 "first_seen": "2019-06-17T16:05:33Z",
-                "non_subscriptions": [:],
+                "non_subscriptions": [:] as [String: Any],
                 "subscriptions": [
                     "onemonth_freetrial": [
                         "expires_date": "2100-08-30T02:40:36Z",
@@ -809,7 +835,7 @@ class BasicCustomerInfoTests: TestCase {
                         "purchase_date": "1990-08-30T02:40:36Z"
                     ]
                 ]
-            ]
+            ] as [String: Any]
         ] as [String: Any]
 
         let info = try CustomerInfo(data: response)
@@ -914,9 +940,9 @@ private extension BasicCustomerInfoTests {
                     "purchase_date": "2019-07-26T23:45:40Z",
                     "store": "app_store",
                     "unsubscribe_detected_at": nil
-                ]
+                ] as [String: Any?]
             ],
-            "non_subscriptions": [:],
+            "non_subscriptions": [:] as [String: Any],
             "entitlements": [
                 "pro": [
                     "product_identifier": "monthly_freetrial",
@@ -924,7 +950,7 @@ private extension BasicCustomerInfoTests {
                     "purchase_date": "2018-07-26T23:30:41Z"
                 ]
             ]
-        ]
+        ] as [String: Any]
     ]
 
 }

--- a/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
+++ b/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
@@ -45,14 +45,14 @@ class EntitlementInfosTests: TestCase {
                         "original_purchase_date": "2019-07-26T22:10:27Z",
                         "purchase_date": "2019-07-26T22:10:27Z",
                         "store": "app_store"
-                    ],
+                    ] as [String: Any],
                     [
                         "id": "ea820afcc4",
                         "is_sandbox": false,
                         "original_purchase_date": "2019-07-26T23:45:40Z",
                         "purchase_date": "2019-07-26T23:45:40Z",
                         "store": "app_store"
-                    ]
+                    ] as [String: Any]
                 ]
             ],
             subscriptions: [
@@ -65,7 +65,7 @@ class EntitlementInfosTests: TestCase {
                     "purchase_date": "2019-07-26T23:45:40Z",
                     "store": "app_store",
                     "unsubscribe_detected_at": nil
-                ]
+                ] as [String: Any?]
             ]
         )
 
@@ -112,7 +112,7 @@ class EntitlementInfosTests: TestCase {
                     "purchase_date": "1999-07-26T23:30:41Z",
                     "store": "app_store",
                     "unsubscribe_detected_at": nil
-                ]
+                ] as [String: Any?]
             ]
         )
 
@@ -124,25 +124,25 @@ class EntitlementInfosTests: TestCase {
 
     func testSubscriptionIsActiveIfExpirationIsInFutureAndNoRequestDate() throws {
         self.stubResponse(
-                entitlements: [
-                    "pro_cat": [
-                        "expires_date": "2200-07-26T23:50:40Z",
-                        "product_identifier": "monthly_freetrial",
-                        "purchase_date": "1999-07-26T23:30:41Z"
-                    ]
-                ],
-                subscriptions: [
-                    "monthly_freetrial": [
-                        "billing_issues_detected_at": nil,
-                        "expires_date": "2200-07-26T23:50:40Z",
-                        "is_sandbox": false,
-                        "original_purchase_date": "1999-07-26T23:30:41Z",
-                        "period_type": "normal",
-                        "purchase_date": "1999-07-26T23:30:41Z",
-                        "store": "app_store",
-                        "unsubscribe_detected_at": nil
-                    ]
+            entitlements: [
+                "pro_cat": [
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "product_identifier": "monthly_freetrial",
+                    "purchase_date": "1999-07-26T23:30:41Z"
                 ]
+            ],
+            subscriptions: [
+                "monthly_freetrial": [
+                    "billing_issues_detected_at": nil,
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "is_sandbox": false,
+                    "original_purchase_date": "1999-07-26T23:30:41Z",
+                    "period_type": "normal",
+                    "purchase_date": "1999-07-26T23:30:41Z",
+                    "store": "app_store",
+                    "unsubscribe_detected_at": nil
+                ] as [String: Any?]
+            ]
         )
 
         try self.verifyEntitlementActive()
@@ -155,27 +155,27 @@ class EntitlementInfosTests: TestCase {
             from: Date().addingTimeInterval(CustomerInfo.requestDateGracePeriod.seconds / -2)
         )
         self.stubResponse(
-                entitlements: [
-                    "pro_cat": [
-                        "expires_date": expirationAndRequestDate,
-                        "product_identifier": "monthly_freetrial",
-                        "purchase_date": "1999-07-26T23:30:41Z"
-                    ]
-                ],
-                nonSubscriptions: [:],
-                subscriptions: [
-                    "monthly_freetrial": [
-                        "billing_issues_detected_at": nil,
-                        "expires_date": "2200-07-26T23:50:40Z",
-                        "is_sandbox": false,
-                        "original_purchase_date": "1999-07-26T23:30:41Z",
-                        "period_type": "normal",
-                        "purchase_date": "1999-07-26T23:30:41Z",
-                        "store": "app_store",
-                        "unsubscribe_detected_at": nil
-                    ]
-                ],
-                requestDate: expirationAndRequestDate
+            entitlements: [
+                "pro_cat": [
+                    "expires_date": expirationAndRequestDate,
+                    "product_identifier": "monthly_freetrial",
+                    "purchase_date": "1999-07-26T23:30:41Z"
+                ]
+            ],
+            nonSubscriptions: [:],
+            subscriptions: [
+                "monthly_freetrial": [
+                    "billing_issues_detected_at": nil,
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "is_sandbox": false,
+                    "original_purchase_date": "1999-07-26T23:30:41Z",
+                    "period_type": "normal",
+                    "purchase_date": "1999-07-26T23:30:41Z",
+                    "store": "app_store",
+                    "unsubscribe_detected_at": nil
+                ] as [String: Any?]
+            ],
+            requestDate: expirationAndRequestDate
         )
 
         try self.verifyEntitlementActive()
@@ -211,7 +211,7 @@ class EntitlementInfosTests: TestCase {
                     "purchase_date": "1999-07-26T23:30:41Z",
                     "store": "app_store",
                     "unsubscribe_detected_at": nil
-                ]
+                ] as [String: Any?]
             ],
             requestDate: Self.formatter.string(from: requestDate)
         )
@@ -245,7 +245,7 @@ class EntitlementInfosTests: TestCase {
                     "purchase_date": "1999-07-26T23:30:41Z",
                     "store": "app_store",
                     "unsubscribe_detected_at": nil
-                ]
+                ] as [String: Any?]
             ],
             requestDate: Self.formatter.string(from: requestDate)
         )
@@ -260,25 +260,25 @@ class EntitlementInfosTests: TestCase {
 
     func testInactiveSubscription() throws {
         stubResponse(
-                entitlements: [
-                    "pro_cat": [
-                        "expires_date": "2000-07-26T23:50:40Z",
-                        "product_identifier": "monthly_freetrial",
-                        "purchase_date": "1999-07-26T23:30:41Z"
-                    ]
-                ],
-                subscriptions: [
-                    "monthly_freetrial": [
-                        "billing_issues_detected_at": nil,
-                        "expires_date": "2000-07-26T23:50:40Z",
-                        "is_sandbox": false,
-                        "original_purchase_date": "1999-07-26T23:30:41Z",
-                        "period_type": "normal",
-                        "purchase_date": "1999-07-26T23:30:41Z",
-                        "store": "app_store",
-                        "unsubscribe_detected_at": nil
-                    ]
+            entitlements: [
+                "pro_cat": [
+                    "expires_date": "2000-07-26T23:50:40Z",
+                    "product_identifier": "monthly_freetrial",
+                    "purchase_date": "1999-07-26T23:30:41Z"
                 ]
+            ],
+            subscriptions: [
+                "monthly_freetrial": [
+                    "billing_issues_detected_at": nil,
+                    "expires_date": "2000-07-26T23:50:40Z",
+                    "is_sandbox": false,
+                    "original_purchase_date": "1999-07-26T23:30:41Z",
+                    "period_type": "normal",
+                    "purchase_date": "1999-07-26T23:30:41Z",
+                    "store": "app_store",
+                    "unsubscribe_detected_at": nil
+                ]  as [String: Any?]
+            ]
         )
 
         try verifyEntitlementActive(false)
@@ -294,25 +294,26 @@ class EntitlementInfosTests: TestCase {
 
     func testCreatesEntitlementInfos() throws {
         stubResponse(
-                entitlements: [
-                    "pro_cat": [
-                        "expires_date": "2200-07-26T23:50:40Z",
-                        "product_identifier": "monthly_freetrial",
-                        "purchase_date": "2019-07-26T23:45:40Z"
-                    ]
-                ],
-                subscriptions: [
-                    "monthly_freetrial": [
-                        "billing_issues_detected_at": nil,
-                        "expires_date": "2200-07-26T23:50:40Z",
-                        "is_sandbox": false,
-                        "original_purchase_date": "2019-07-26T23:30:41Z",
-                        "period_type": "normal",
-                        "purchase_date": "2019-07-26T23:45:40Z",
-                        "store": "app_store",
-                        "unsubscribe_detected_at": nil
-                    ]
-                ])
+            entitlements: [
+                "pro_cat": [
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "product_identifier": "monthly_freetrial",
+                    "purchase_date": "2019-07-26T23:45:40Z"
+                ]
+            ],
+            subscriptions: [
+                "monthly_freetrial": [
+                    "billing_issues_detected_at": nil,
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "is_sandbox": false,
+                    "original_purchase_date": "2019-07-26T23:30:41Z",
+                    "period_type": "normal",
+                    "purchase_date": "2019-07-26T23:45:40Z",
+                    "store": "app_store",
+                    "unsubscribe_detected_at": nil
+                ] as [String: Any?]
+            ]
+        )
 
         try verifySubscriberInfo()
         try verifyEntitlementActive()
@@ -340,14 +341,14 @@ class EntitlementInfosTests: TestCase {
                             "original_purchase_date": "2019-07-26T22:10:27Z",
                             "purchase_date": "2019-07-26T22:10:27Z",
                             "store": "app_store"
-                        ],
+                        ] as [String: Any],
                         [
                             "id": "ea820afcc4",
                             "is_sandbox": false,
                             "original_purchase_date": "2019-07-26T23:45:40Z",
                             "purchase_date": "2019-07-26T23:45:40Z",
                             "store": "app_store"
-                        ]
+                        ] as [String: Any]
                     ]
                 ],
                 subscriptions: [
@@ -360,7 +361,7 @@ class EntitlementInfosTests: TestCase {
                         "purchase_date": "2019-07-26T23:45:40Z",
                         "store": "app_store",
                         "unsubscribe_detected_at": nil
-                    ]
+                    ] as [String: Any?]
                 ]
         )
 
@@ -395,7 +396,7 @@ class EntitlementInfosTests: TestCase {
                         "purchase_date": "2019-07-26T23:45:40Z",
                         "store": "app_store",
                         "unsubscribe_detected_at": nil
-                    ]
+                    ] as [String: Any?]
                 ])
 
         try verifySubscriberInfo()
@@ -409,25 +410,26 @@ class EntitlementInfosTests: TestCase {
 
     func testSubscriptionWontRenewBillingError() throws {
         stubResponse(
-                entitlements: [
-                    "pro_cat": [
-                        "expires_date": "2200-07-26T23:50:40Z",
-                        "product_identifier": "monthly_freetrial",
-                        "purchase_date": "2019-07-26T23:45:40Z"
-                    ]
-                ],
-                subscriptions: [
-                    "monthly_freetrial": [
-                        "billing_issues_detected_at": "2019-07-27T23:30:41Z",
-                        "expires_date": "2200-07-26T23:50:40Z",
-                        "is_sandbox": false,
-                        "original_purchase_date": "2019-07-26T23:30:41Z",
-                        "period_type": "normal",
-                        "purchase_date": "2019-07-26T23:45:40Z",
-                        "store": "app_store",
-                        "unsubscribe_detected_at": nil
-                    ]
-                ])
+            entitlements: [
+                "pro_cat": [
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "product_identifier": "monthly_freetrial",
+                    "purchase_date": "2019-07-26T23:45:40Z"
+                ]
+            ],
+            subscriptions: [
+                "monthly_freetrial": [
+                    "billing_issues_detected_at": "2019-07-27T23:30:41Z",
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "is_sandbox": false,
+                    "original_purchase_date": "2019-07-26T23:30:41Z",
+                    "period_type": "normal",
+                    "purchase_date": "2019-07-26T23:45:40Z",
+                    "store": "app_store",
+                    "unsubscribe_detected_at": nil
+                ] as [String: Any?]
+            ]
+        )
 
         try verifySubscriberInfo()
         try verifyEntitlementActive()
@@ -440,25 +442,26 @@ class EntitlementInfosTests: TestCase {
 
     func testSubscriptionWontRenewCancelled() throws {
         stubResponse(
-                entitlements: [
-                    "pro_cat": [
-                        "expires_date": "2200-07-26T23:50:40Z",
-                        "product_identifier": "monthly_freetrial",
-                        "purchase_date": "2019-07-26T23:45:40Z"
-                    ]
-                ],
-                subscriptions: [
-                    "monthly_freetrial": [
-                        "billing_issues_detected_at": nil,
-                        "expires_date": "2200-07-26T23:50:40Z",
-                        "is_sandbox": false,
-                        "original_purchase_date": "2019-07-26T23:30:41Z",
-                        "period_type": "normal",
-                        "purchase_date": "2019-07-26T23:45:40Z",
-                        "store": "app_store",
-                        "unsubscribe_detected_at": "2019-07-27T23:30:41Z"
-                    ]
-                ])
+            entitlements: [
+                "pro_cat": [
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "product_identifier": "monthly_freetrial",
+                    "purchase_date": "2019-07-26T23:45:40Z"
+                ]
+            ],
+            subscriptions: [
+                "monthly_freetrial": [
+                    "billing_issues_detected_at": nil,
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "is_sandbox": false,
+                    "original_purchase_date": "2019-07-26T23:30:41Z",
+                    "period_type": "normal",
+                    "purchase_date": "2019-07-26T23:45:40Z",
+                    "store": "app_store",
+                    "unsubscribe_detected_at": "2019-07-27T23:30:41Z"
+                ] as [String: Any?]
+            ]
+        )
 
         try verifySubscriberInfo()
         try verifyEntitlementActive()
@@ -471,25 +474,26 @@ class EntitlementInfosTests: TestCase {
 
     func testSubscriptionWontRenewBillingErrorAndCancelled() throws {
         stubResponse(
-                entitlements: [
-                    "pro_cat": [
-                        "expires_date": "2200-07-26T23:50:40Z",
-                        "product_identifier": "monthly_freetrial",
-                        "purchase_date": "2019-07-26T23:45:40Z"
-                    ]
-                ],
-                subscriptions: [
-                    "monthly_freetrial": [
-                        "billing_issues_detected_at": "2019-07-27T22:30:41Z",
-                        "expires_date": "2200-07-26T23:50:40Z",
-                        "is_sandbox": false,
-                        "original_purchase_date": "2019-07-26T23:30:41Z",
-                        "period_type": "normal",
-                        "purchase_date": "2019-07-26T23:45:40Z",
-                        "store": "app_store",
-                        "unsubscribe_detected_at": "2019-07-27T23:30:41Z"
-                    ]
-                ])
+            entitlements: [
+                "pro_cat": [
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "product_identifier": "monthly_freetrial",
+                    "purchase_date": "2019-07-26T23:45:40Z"
+                ]
+            ],
+            subscriptions: [
+                "monthly_freetrial": [
+                    "billing_issues_detected_at": "2019-07-27T22:30:41Z",
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "is_sandbox": false,
+                    "original_purchase_date": "2019-07-26T23:30:41Z",
+                    "period_type": "normal",
+                    "purchase_date": "2019-07-26T23:45:40Z",
+                    "store": "app_store",
+                    "unsubscribe_detected_at": "2019-07-27T23:30:41Z"
+                ] as [String: Any]
+            ]
+        )
 
         try verifySubscriberInfo()
         try verifyEntitlementActive()
@@ -506,25 +510,26 @@ class EntitlementInfosTests: TestCase {
 
     func testSubscriptionIsSandboxInteger() throws {
         stubResponse(
-                entitlements: [
-                    "pro_cat": [
-                        "expires_date": "2200-07-26T23:50:40Z",
-                        "product_identifier": "monthly_freetrial",
-                        "purchase_date": "2019-07-26T23:45:40Z"
-                    ]
-                ],
-                subscriptions: [
-                    "monthly_freetrial": [
-                        "billing_issues_detected_at": nil,
-                        "expires_date": "2200-07-26T23:50:40Z",
-                        "is_sandbox": true,
-                        "original_purchase_date": "2019-07-26T23:30:41Z",
-                        "period_type": "normal",
-                        "purchase_date": "2019-07-26T23:45:40Z",
-                        "store": "app_store",
-                        "unsubscribe_detected_at": nil
-                    ]
-                ])
+            entitlements: [
+                "pro_cat": [
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "product_identifier": "monthly_freetrial",
+                    "purchase_date": "2019-07-26T23:45:40Z"
+                ]
+            ],
+            subscriptions: [
+                "monthly_freetrial": [
+                    "billing_issues_detected_at": nil,
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "is_sandbox": true,
+                    "original_purchase_date": "2019-07-26T23:30:41Z",
+                    "period_type": "normal",
+                    "purchase_date": "2019-07-26T23:45:40Z",
+                    "store": "app_store",
+                    "unsubscribe_detected_at": nil
+                ] as [String: Any?]
+            ]
+        )
 
         try verifySubscriberInfo()
         try verifyEntitlementActive()
@@ -621,14 +626,14 @@ class EntitlementInfosTests: TestCase {
                             "original_purchase_date": "2019-07-26T22:10:27Z",
                             "purchase_date": "2019-07-26T22:10:27Z",
                             "store": "app_store"
-                        ],
+                        ] as [String: Any],
                         [
                             "id": "ea820afcc4",
                             "is_sandbox": false,
                             "original_purchase_date": "2019-07-26T23:45:40Z",
                             "purchase_date": "2019-07-26T23:45:40Z",
                             "store": "app_store"
-                        ]
+                        ] as [String: Any]
                     ]
                 ],
                 subscriptions: [:]
@@ -666,7 +671,7 @@ class EntitlementInfosTests: TestCase {
                         "purchase_date": "2019-07-26T23:45:40Z",
                         "store": "app_store",
                         "unsubscribe_detected_at": nil
-                    ]
+                    ] as [String: Any?]
                 ])
 
         try verifyStore(.appStore)
@@ -689,7 +694,7 @@ class EntitlementInfosTests: TestCase {
                     "purchase_date": "2019-07-26T23:45:40Z",
                     "store": "mac_app_store",
                     "unsubscribe_detected_at": nil
-                ]
+                ] as [String: Any?]
             ])
         try verifyStore(.macAppStore)
 
@@ -711,7 +716,7 @@ class EntitlementInfosTests: TestCase {
                     "purchase_date": "2019-07-26T23:45:40Z",
                     "store": "play_store",
                     "unsubscribe_detected_at": nil
-                ]
+                ] as [String: Any?]
             ])
         try verifyStore(.playStore)
 
@@ -733,7 +738,7 @@ class EntitlementInfosTests: TestCase {
                     "purchase_date": "2019-07-26T23:45:40Z",
                     "store": "promotional",
                     "unsubscribe_detected_at": nil
-                ]
+                ] as [String: Any?]
             ])
         try verifyStore(.promotional)
 
@@ -755,7 +760,7 @@ class EntitlementInfosTests: TestCase {
                     "purchase_date": "2019-07-26T23:45:40Z",
                     "store": "stripe",
                     "unsubscribe_detected_at": nil
-                ]
+                ] as [String: Any?]
             ])
         try verifyStore(.stripe)
 
@@ -777,7 +782,7 @@ class EntitlementInfosTests: TestCase {
                     "purchase_date": "2019-07-26T23:45:40Z",
                     "store": "amazon",
                     "unsubscribe_detected_at": nil
-                ]
+                ] as [String: Any?]
             ])
         try verifyStore(.amazon)
 
@@ -799,7 +804,7 @@ class EntitlementInfosTests: TestCase {
                     "purchase_date": "2019-07-26T23:45:40Z",
                     "store": "tienda",
                     "unsubscribe_detected_at": nil
-                ]
+                ] as [String: Any?]
             ])
         try verifyStore(.unknownStore)
     }
@@ -821,14 +826,14 @@ class EntitlementInfosTests: TestCase {
                             "original_purchase_date": "2019-07-26T22:10:27Z",
                             "purchase_date": "2019-07-26T22:10:27Z",
                             "store": "app_store"
-                        ],
+                        ] as [String: Any],
                         [
                             "id": "ea820afcc4",
                             "is_sandbox": false,
                             "original_purchase_date": "2019-07-26T23:45:40Z",
                             "purchase_date": "2019-07-26T23:45:40Z",
                             "store": "app_store"
-                        ]
+                        ] as [String: Any]
                     ]
                 ],
                 subscriptions: [:]
@@ -851,14 +856,14 @@ class EntitlementInfosTests: TestCase {
                             "original_purchase_date": "2019-07-26T22:10:27Z",
                             "purchase_date": "2019-07-26T22:10:27Z",
                             "store": "app_store"
-                        ],
+                        ] as [String: Any],
                         [
                             "id": "ea820afcc4",
                             "is_sandbox": false,
                             "original_purchase_date": "2019-07-26T23:45:40Z",
                             "purchase_date": "2019-07-26T23:45:40Z",
                             "store": "mac_app_store"
-                        ]
+                        ] as [String: Any]
                     ]
                 ],
                 subscriptions: [:]
@@ -881,14 +886,14 @@ class EntitlementInfosTests: TestCase {
                             "original_purchase_date": "2019-07-26T22:10:27Z",
                             "purchase_date": "2019-07-26T22:10:27Z",
                             "store": "app_store"
-                        ],
+                        ] as [String: Any],
                         [
                             "id": "ea820afcc4",
                             "is_sandbox": false,
                             "original_purchase_date": "2019-07-26T23:45:40Z",
                             "purchase_date": "2019-07-26T23:45:40Z",
                             "store": "play_store"
-                        ]
+                        ] as [String: Any]
                     ]
                 ],
                 subscriptions: [:]
@@ -911,14 +916,14 @@ class EntitlementInfosTests: TestCase {
                             "original_purchase_date": "2019-07-26T22:10:27Z",
                             "purchase_date": "2019-07-26T22:10:27Z",
                             "store": "app_store"
-                        ],
+                        ] as [String: Any],
                         [
                             "id": "ea820afcc4",
                             "is_sandbox": false,
                             "original_purchase_date": "2019-07-26T23:45:40Z",
                             "purchase_date": "2019-07-26T23:45:40Z",
                             "store": "promotional"
-                        ]
+                        ] as [String: Any]
                     ]
                 ],
                 subscriptions: [:]
@@ -941,14 +946,14 @@ class EntitlementInfosTests: TestCase {
                             "original_purchase_date": "2019-07-26T22:10:27Z",
                             "purchase_date": "2019-07-26T22:10:27Z",
                             "store": "app_store"
-                        ],
+                        ] as [String: Any],
                         [
                             "id": "ea820afcc4",
                             "is_sandbox": false,
                             "original_purchase_date": "2019-07-26T23:45:40Z",
                             "purchase_date": "2019-07-26T23:45:40Z",
                             "store": "stripe"
-                        ]
+                        ] as [String: Any]
                     ]
                 ],
                 subscriptions: [:]
@@ -971,14 +976,14 @@ class EntitlementInfosTests: TestCase {
                             "original_purchase_date": "2019-07-26T22:10:27Z",
                             "purchase_date": "2019-07-26T22:10:27Z",
                             "store": "app_store"
-                        ],
+                        ] as [String: Any],
                         [
                             "id": "ea820afcc4",
                             "is_sandbox": false,
                             "original_purchase_date": "2019-07-26T23:45:40Z",
                             "purchase_date": "2019-07-26T23:45:40Z",
                             "store": "amazon"
-                        ]
+                        ] as [String: Any]
                     ]
                 ],
                 subscriptions: [:]
@@ -1001,14 +1006,14 @@ class EntitlementInfosTests: TestCase {
                             "original_purchase_date": "2019-07-26T22:10:27Z",
                             "purchase_date": "2019-07-26T22:10:27Z",
                             "store": "app_store"
-                        ],
+                        ] as [String: Any],
                         [
                             "id": "ea820afcc4",
                             "is_sandbox": false,
                             "original_purchase_date": "2019-07-26T23:45:40Z",
                             "purchase_date": "2019-07-26T23:45:40Z",
                             "store": "tienda"
-                        ]
+                        ] as [String: Any]
                     ]
                 ],
                 subscriptions: [:]
@@ -1018,92 +1023,96 @@ class EntitlementInfosTests: TestCase {
 
     func testParsePeriod() throws {
         stubResponse(
-                entitlements: [
-                    "pro_cat": [
-                        "expires_date": "2200-07-26T23:50:40Z",
-                        "product_identifier": "monthly_freetrial",
-                        "purchase_date": "2019-07-26T23:45:40Z"
-                    ]
-                ],
-                subscriptions: [
-                    "monthly_freetrial": [
-                        "billing_issues_detected_at": nil,
-                        "expires_date": "2200-07-26T23:50:40Z",
-                        "is_sandbox": false,
-                        "original_purchase_date": "2019-07-26T23:30:41Z",
-                        "period_type": "normal",
-                        "purchase_date": "2019-07-26T23:45:40Z",
-                        "store": "app_store",
-                        "unsubscribe_detected_at": nil
-                    ]
-                ])
+            entitlements: [
+                "pro_cat": [
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "product_identifier": "monthly_freetrial",
+                    "purchase_date": "2019-07-26T23:45:40Z"
+                ]
+            ],
+            subscriptions: [
+                "monthly_freetrial": [
+                    "billing_issues_detected_at": nil,
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "is_sandbox": false,
+                    "original_purchase_date": "2019-07-26T23:30:41Z",
+                    "period_type": "normal",
+                    "purchase_date": "2019-07-26T23:45:40Z",
+                    "store": "app_store",
+                    "unsubscribe_detected_at": nil
+                ] as [String: Any?]
+            ]
+        )
 
         try verifyPeriodType(.normal)
 
         stubResponse(
-                entitlements: [
-                    "pro_cat": [
-                        "expires_date": "2200-07-26T23:50:40Z",
-                        "product_identifier": "monthly_freetrial",
-                        "purchase_date": "2019-07-26T23:45:40Z"
-                    ]
-                ],
-                subscriptions: [
-                    "monthly_freetrial": [
-                        "billing_issues_detected_at": nil,
-                        "expires_date": "2200-07-26T23:50:40Z",
-                        "is_sandbox": false,
-                        "original_purchase_date": "2019-07-26T23:30:41Z",
-                        "period_type": "intro",
-                        "purchase_date": "2019-07-26T23:45:40Z",
-                        "store": "app_store",
-                        "unsubscribe_detected_at": nil
-                    ]
-                ])
+            entitlements: [
+                "pro_cat": [
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "product_identifier": "monthly_freetrial",
+                    "purchase_date": "2019-07-26T23:45:40Z"
+                ]
+            ],
+            subscriptions: [
+                "monthly_freetrial": [
+                    "billing_issues_detected_at": nil,
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "is_sandbox": false,
+                    "original_purchase_date": "2019-07-26T23:30:41Z",
+                    "period_type": "intro",
+                    "purchase_date": "2019-07-26T23:45:40Z",
+                    "store": "app_store",
+                    "unsubscribe_detected_at": nil
+                ] as [String: Any?]
+            ]
+        )
         try verifyPeriodType(.intro)
 
         stubResponse(
-                entitlements: [
-                    "pro_cat": [
-                        "expires_date": "2200-07-26T23:50:40Z",
-                        "product_identifier": "monthly_freetrial",
-                        "purchase_date": "2019-07-26T23:45:40Z"
-                    ]
-                ],
-                subscriptions: [
-                    "monthly_freetrial": [
-                        "billing_issues_detected_at": nil,
-                        "expires_date": "2200-07-26T23:50:40Z",
-                        "is_sandbox": false,
-                        "original_purchase_date": "2019-07-26T23:30:41Z",
-                        "period_type": "trial",
-                        "purchase_date": "2019-07-26T23:45:40Z",
-                        "store": "app_store",
-                        "unsubscribe_detected_at": nil
-                    ]
-                ])
+            entitlements: [
+                "pro_cat": [
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "product_identifier": "monthly_freetrial",
+                    "purchase_date": "2019-07-26T23:45:40Z"
+                ]
+            ],
+            subscriptions: [
+                "monthly_freetrial": [
+                    "billing_issues_detected_at": nil,
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "is_sandbox": false,
+                    "original_purchase_date": "2019-07-26T23:30:41Z",
+                    "period_type": "trial",
+                    "purchase_date": "2019-07-26T23:45:40Z",
+                    "store": "app_store",
+                    "unsubscribe_detected_at": nil
+                ] as [String: Any?]
+            ]
+        )
         try verifyPeriodType(.trial)
 
         stubResponse(
-                entitlements: [
-                    "pro_cat": [
-                        "expires_date": "2200-07-26T23:50:40Z",
-                        "product_identifier": "monthly_freetrial",
-                        "purchase_date": "2019-07-26T23:45:40Z"
-                    ]
-                ],
-                subscriptions: [
-                    "monthly_freetrial": [
-                        "billing_issues_detected_at": nil,
-                        "expires_date": "2200-07-26T23:50:40Z",
-                        "is_sandbox": false,
-                        "original_purchase_date": "2019-07-26T23:30:41Z",
-                        "period_type": "period",
-                        "purchase_date": "2019-07-26T23:45:40Z",
-                        "store": "app_store",
-                        "unsubscribe_detected_at": nil
-                    ]
-                ])
+            entitlements: [
+                "pro_cat": [
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "product_identifier": "monthly_freetrial",
+                    "purchase_date": "2019-07-26T23:45:40Z"
+                ]
+            ],
+            subscriptions: [
+                "monthly_freetrial": [
+                    "billing_issues_detected_at": nil,
+                    "expires_date": "2200-07-26T23:50:40Z",
+                    "is_sandbox": false,
+                    "original_purchase_date": "2019-07-26T23:30:41Z",
+                    "period_type": "period",
+                    "purchase_date": "2019-07-26T23:45:40Z",
+                    "store": "app_store",
+                    "unsubscribe_detected_at": nil
+                ] as [String: Any?]
+            ]
+        )
         try verifyPeriodType(.normal)
     }
 
@@ -1124,42 +1133,43 @@ class EntitlementInfosTests: TestCase {
                         "original_purchase_date": "2019-07-26T22:10:27Z",
                         "purchase_date": "2019-07-26T22:10:27Z",
                         "store": "app_store"
-                    ],
+                    ] as [String: Any],
                     [
                         "id": "ea820afcc4",
                         "is_sandbox": false,
                         "original_purchase_date": "2019-07-26T23:45:40Z",
                         "purchase_date": "2019-07-26T23:45:40Z",
                         "store": "app_store"
-                    ]
+                    ] as [String: Any]
                 ]
             ],
-            subscriptions: [:]
+            subscriptions: [:] as [String: Any]
         )
         try verifyPeriodType(.normal)
     }
 
     func testPromoWillRenew() throws {
         stubResponse(
-                entitlements: [
-                    "pro_cat": [
-                        "expires_date": "2221-01-10T02:35:25Z",
-                        "product_identifier": "rc_promo_pro_cat_lifetime",
-                        "purchase_date": "2021-02-27T02:35:25Z"
-                    ]
-                ],
-                subscriptions: [
-                    "rc_promo_pro_cat_lifetime": [
-                        "billing_issues_detected_at": nil,
-                        "expires_date": "2221-01-10T02:35:25Z",
-                        "is_sandbox": false,
-                        "original_purchase_date": "2021-02-27T02:35:25Z",
-                        "period_type": "normal",
-                        "purchase_date": "2021-02-27T02:35:25Z",
-                        "store": "promotional",
-                        "unsubscribe_detected_at": nil
-                    ]
-                ])
+            entitlements: [
+                "pro_cat": [
+                    "expires_date": "2221-01-10T02:35:25Z",
+                    "product_identifier": "rc_promo_pro_cat_lifetime",
+                    "purchase_date": "2021-02-27T02:35:25Z"
+                ]
+            ],
+            subscriptions: [
+                "rc_promo_pro_cat_lifetime": [
+                    "billing_issues_detected_at": nil,
+                    "expires_date": "2221-01-10T02:35:25Z",
+                    "is_sandbox": false,
+                    "original_purchase_date": "2021-02-27T02:35:25Z",
+                    "period_type": "normal",
+                    "purchase_date": "2021-02-27T02:35:25Z",
+                    "store": "promotional",
+                    "unsubscribe_detected_at": nil
+                ] as [String: Any?]
+            ]
+        )
 
         try verifyRenewal(false)
     }
@@ -1190,8 +1200,9 @@ class EntitlementInfosTests: TestCase {
                     "purchase_date": "2021-02-27T02:35:25Z",
                     "store": "promotional",
                     "unsubscribe_detected_at": nil
-                ]
-            ])
+                ] as [String: Any?]
+            ]
+        )
     }
 
     func testActiveInAnyEnvironmentIncludesSandboxInSandbox() throws {
@@ -1261,7 +1272,7 @@ private extension EntitlementInfosTests {
                 "original_app_user_id": "cesarsandbox1",
                 "original_application_version": "1.0",
                 "subscriptions": subscriptions
-            ]
+            ] as [String: Any]
         ]
     }
 

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -308,10 +308,10 @@ extension BasePurchasesTests {
         "subscriber": [
             "first_seen": "2019-07-17T00:05:54Z",
             "original_app_user_id": BasePurchasesTests.appUserID,
-            "subscriptions": [:],
-            "other_purchases": [:],
+            "subscriptions": [:] as [String: Any],
+            "other_purchases": [:] as [String: Any],
             "original_application_version": NSNull()
-        ]
+        ] as [String: Any]
     ]
 
 }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetCustomerInfoTests.swift
@@ -23,10 +23,10 @@ class PurchasesGetCustomerInfoTests: BasePurchasesTests {
         "subscriber": [
             "first_seen": "2020-07-17T00:05:54Z",
             "original_app_user_id": BasePurchasesTests.appUserID,
-            "subscriptions": [:],
-            "other_purchases": [:],
+            "subscriptions": [:] as [String: Any],
+            "other_purchases": [:] as [String: Any],
             "original_application_version": "1.0"
-        ]
+        ] as [String: Any]
     ]
 
     func testCachedCustomerInfoHasSchemaVersion() throws {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -225,10 +225,10 @@ private extension PurchasesLogInTests {
         "subscriber": [
             "first_seen": "2019-07-17T00:05:54Z",
             "original_app_user_id": "user",
-            "subscriptions": [:],
-            "other_purchases": [:],
+            "subscriptions": [:] as [String: Any],
+            "other_purchases": [:] as [String: Any],
             "original_application_version": NSNull()
-        ]
+        ] as [String: Any]
     ]
 
     private static let loggedOutCustomerInfoData: [String: Any] = [
@@ -236,10 +236,10 @@ private extension PurchasesLogInTests {
         "subscriber": [
             "first_seen": "2019-07-17T00:05:54Z",
             "original_app_user_id": "$RCAnonymousID:5b6fdbad3a0c4f879e43d269ecdf9ba1",
-            "subscriptions": [:],
-            "other_purchases": [:],
+            "subscriptions": [:] as [String: Any],
+            "other_purchases": [:] as [String: Any],
             "original_application_version": NSNull()
-        ]
+        ] as [String: Any]
     ]
 
     /// Converts the result of `Purchases.logIn` into `LogInResult`

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
@@ -574,17 +574,19 @@ class PurchasesPurchasingTests: BasePurchasesTests {
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "app_user_id",
-                "subscriptions": [:],
-                "non_subscriptions": [:]
-            ]])
+                "subscriptions": [:] as [String: Any],
+                "non_subscriptions": [:] as [String: Any]
+            ] as [String: Any]
+        ])
         let customerInfoAfterPurchase = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "app_user_id",
-                "subscriptions": [:],
-                "non_subscriptions": [product.productIdentifier: []]
-            ]])
+                "subscriptions": [:] as [String: Any],
+                "non_subscriptions": [product.productIdentifier: [] as [Any]]
+            ] as [String: Any]
+        ])
         self.backend.overrideCustomerInfoResult = .success(customerInfoBeforePurchase)
         self.backend.postReceiptResult = .success(customerInfoAfterPurchase)
 
@@ -677,14 +679,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
     func testCachesCustomerInfoOnPurchase() throws {
         expect(self.deviceCache.cachedCustomerInfo.count).toEventually(equal(1))
 
-        self.backend.postReceiptResult = .success(try CustomerInfo(data: [
-            "request_date": "2019-08-16T10:30:42Z",
-            "subscriber": [
-                "first_seen": "2019-07-17T00:05:54Z",
-                "original_app_user_id": "app_user_id",
-                "subscriptions": [:],
-                "other_purchases": [:]
-            ]]))
+        self.backend.postReceiptResult = .success(.emptyInfo)
 
         let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
         self.purchases.purchase(product: product) { (_, _, _, _) in }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesRestoreTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesRestoreTests.swift
@@ -224,11 +224,11 @@ class PurchasesRestoreTests: BasePurchasesTests {
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": Self.appUserID,
-                "subscriptions": [:],
-                "other_purchases": [:],
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any],
                 "original_application_version": "1.0",
                 "original_purchase_date": "2018-10-26T23:17:53Z"
-            ]
+            ] as [String: Any]
         ]))
 
         let receivedCustomerInfo = waitUntilValue { completed in
@@ -253,11 +253,12 @@ class PurchasesRestoreNoSetupTests: BasePurchasesTests {
             "subscriber": [
                 "original_app_user_id": Self.appUserID,
                 "first_seen": "2019-07-17T00:05:54Z",
-                "subscriptions": [:],
-                "other_purchases": [:],
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any],
                 "original_application_version": "1.0",
                 "original_purchase_date": "2018-10-26T23:17:53Z"
-            ]])
+            ] as [String: Any]
+        ])
 
         let object = try info.asJSONEncodedData()
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncPurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncPurchasesTests.swift
@@ -37,11 +37,12 @@ class PurchasesSyncPurchasesTests: BasePurchasesTests {
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "app_user_id",
-                "subscriptions": [:],
-                "other_purchases": [:],
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any],
                 "original_application_version": "1.0",
                 "original_purchase_date": "2018-10-26T23:17:53Z"
-            ]])
+            ] as [String: Any]
+        ])
 
         let object = try info.asJSONEncodedData()
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
@@ -62,16 +63,7 @@ class PurchasesSyncPurchasesTests: BasePurchasesTests {
     }
 
     func testSyncPurchasesPostsIfReceiptHasTransactionsAndCustomerInfoLoaded() throws {
-        let info = try CustomerInfo(data: [
-            "request_date": "2019-08-16T10:30:42Z",
-            "subscriber": [
-                "first_seen": "2019-07-17T00:05:54Z",
-                "original_app_user_id": "app_user_id",
-                "subscriptions": [:],
-                "other_purchases": [:],
-                "original_application_version": "1.0",
-                "original_purchase_date": "2018-10-26T23:17:53Z"
-            ]])
+        let info: CustomerInfo = .emptyInfo
 
         let object = try info.asJSONEncodedData()
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesTransactionHandlingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesTransactionHandlingTests.swift
@@ -46,17 +46,19 @@ class PurchasesTransactionHandlingTests: BasePurchasesTests {
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "app_user_id",
-                "subscriptions": [:],
-                "non_subscriptions": [:]
-            ]])
+                "subscriptions": [:] as [String: Any],
+                "non_subscriptions": [:] as [String: Any]
+            ] as [String: Any]
+        ])
         let customerInfoAfterPurchase = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "app_user_id",
-                "subscriptions": [:],
-                "non_subscriptions": [self.product.mockProductIdentifier: []]
-            ]])
+                "subscriptions": [:] as [String: Any],
+                "non_subscriptions": [self.product.mockProductIdentifier: [] as [Any]]
+            ] as [String: Any]
+        ])
         self.backend.overrideCustomerInfoResult = .success(customerInfoBeforePurchase)
         self.backend.postReceiptResult = .success(customerInfoAfterPurchase)
 
@@ -75,16 +77,7 @@ class PurchasesTransactionHandlingTests: BasePurchasesTests {
     }
 
     func testDelegateIsOnlyCalledOnceIfCustomerInfoTheSame() throws {
-        let customerInfo1 = try CustomerInfo(data: [
-            "request_date": "2019-08-16T10:30:42Z",
-            "subscriber": [
-                "first_seen": "2019-07-17T00:05:54Z",
-                "original_app_user_id": "app_user_id",
-                "subscriptions": [:],
-                "other_purchases": [:],
-                "original_application_version": "1.0"
-            ]
-        ])
+        let customerInfo1: CustomerInfo = .emptyInfo
 
         let customerInfo2 = customerInfo1
 
@@ -114,10 +107,10 @@ class PurchasesTransactionHandlingTests: BasePurchasesTests {
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "app_user_id",
-                "subscriptions": [:],
-                "other_purchases": [:],
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any],
                 "original_application_version": "1.0"
-            ]
+            ] as [String: Any]
         ])
 
         let customerInfo2 = try CustomerInfo(data: [
@@ -125,10 +118,10 @@ class PurchasesTransactionHandlingTests: BasePurchasesTests {
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "app_user_id",
-                "subscriptions": [:],
-                "other_purchases": [:],
+                "subscriptions": [:] as [String: Any],
+                "other_purchases": [:] as [String: Any],
                 "original_application_version": "2.0"
-            ]
+            ] as [String: Any]
         ])
 
         let payment = SKPayment(product: self.product)
@@ -174,17 +167,19 @@ class PurchasesTransactionHandlingTests: BasePurchasesTests {
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "app_user_id",
-                "subscriptions": [:],
-                "non_subscriptions": [:]
-            ]])
+                "subscriptions": [:] as [String: Any],
+                "non_subscriptions": [:] as [String: Any]
+            ] as [String: Any]
+        ])
         let customerInfoAfterPurchase = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
                 "first_seen": "2019-07-17T00:05:54Z",
                 "original_app_user_id": "app_user_id",
-                "subscriptions": [:],
-                "non_subscriptions": [self.product.mockProductIdentifier: []]
-            ]])
+                "subscriptions": [:] as [String: Any],
+                "non_subscriptions": [self.product.mockProductIdentifier: [] as [Any]]
+            ] as [String: Any]
+        ])
         self.backend.overrideCustomerInfoResult = .success(customerInfoBeforePurchase)
         self.backend.postReceiptResult = .success(customerInfoAfterPurchase)
 

--- a/Tests/UnitTests/Purchasing/TransactionsFactoryTests.swift
+++ b/Tests/UnitTests/Purchasing/TransactionsFactoryTests.swift
@@ -44,7 +44,7 @@ class TransactionsFactoryTests: TestCase {
 
 private extension TransactionsFactoryTests {
 
-    static let sampleTransactions = [
+    static let sampleTransactions: [String: [[String: Any]]] = [
         "100_coins": [
             [
                 "id": "72c26cc69c",
@@ -52,13 +52,15 @@ private extension TransactionsFactoryTests {
                 "original_purchase_date": "1990-08-30T02:40:36Z",
                 "purchase_date": "2019-07-11T18:36:20Z",
                 "store": "app_store"
-            ], [
+            ],
+            [
                 "id": "6229b0bef1",
                 "is_sandbox": true,
                 "original_purchase_date": "2019-11-06T03:26:15Z",
                 "purchase_date": "2019-11-06T03:26:15Z",
                 "store": "play_store"
-            ]],
+            ]
+        ],
         "500_coins": [
             [
                 "id": "d6c007ba74",
@@ -66,13 +68,15 @@ private extension TransactionsFactoryTests {
                 "original_purchase_date": "2019-07-11T18:36:20Z",
                 "purchase_date": "2019-07-11T18:36:20Z",
                 "store": "play_store"
-            ], [
+            ],
+            [
                 "id": "5b9ba226bc",
                 "is_sandbox": true,
                 "original_purchase_date": "2019-07-26T22:10:27Z",
                 "purchase_date": "2019-07-26T22:10:27Z",
                 "store": "app_store"
-            ]],
+            ]
+        ],
         "lifetime_access": [
             [
                 "id": "d6c097ba74",
@@ -80,7 +84,8 @@ private extension TransactionsFactoryTests {
                 "original_purchase_date": "2018-07-11T18:36:20Z",
                 "purchase_date": "2018-07-11T18:36:20Z",
                 "store": "app_store"
-            ]]
+            ]
+        ]
     ]
 
 }

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -43,7 +43,7 @@ class BackendSubscriberAttributesTests: TestCase {
                     "expires_date": "2017-08-30T02:40:36Z"
                 ]
             ]
-        ]
+        ] as [String: Any]
     ]
 
     // swiftlint:disable:next force_try

--- a/Tests/UnitTests/SubscriberAttributes/DeviceCacheSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/DeviceCacheSubscriberAttributesTests.swift
@@ -351,7 +351,7 @@ class DeviceCacheSubscriberAttributesTests: TestCase {
                 userID2: userID2Attributes
             ],
             appUserIDKey: userID1
-        ] as [String: AnyObject]
+        ] as [String: Any]
         mockUserDefaults.mockValues = valuesBeforeMigration
 
         deviceCache.cleanupSubscriberAttributes()

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -49,10 +49,11 @@ class PurchasesSubscriberAttributesTests: TestCase {
         "subscriber": [
             "first_seen": "2019-07-17T00:05:54Z",
             "original_app_user_id": "",
-            "subscriptions": [:],
-            "other_purchases": [:],
+            "subscriptions": [:] as [String: Any],
+            "other_purchases": [:] as [String: Any],
             "original_application_version": NSNull()
-        ]]
+        ] as [String: Any]
+    ]
 
     var mockOfferingsManager: MockOfferingsManager!
     var mockOfflineEntitlementsManager: MockOfflineEntitlementsManager!
@@ -224,21 +225,9 @@ class PurchasesSubscriberAttributesTests: TestCase {
     }
 
     func testSubscriberAttributesSyncIsPerformedAfterCustomerInfoSync() throws {
-        mockBackend.stubbedGetCustomerInfoResult = .success(
-            try CustomerInfo(data: [
-                "request_date": "2019-08-16T10:30:42Z",
-                "subscriber": [
-                    "first_seen": "2019-07-17T00:05:54Z",
-                    "original_app_user_id": "app_user_id",
-                    "subscriptions": [:],
-                    "other_purchases": [:],
-                    "original_application_version": "1.0",
-                    "original_purchase_date": "2018-10-26T23:17:53Z"
-                ]
-            ])
-        )
+        self.mockBackend.stubbedGetCustomerInfoResult = .success(.emptyInfo)
 
-        setupPurchases()
+        self.setupPurchases()
 
         expect(self.mockBackend.invokedGetSubscriberDataCount) == 1
         expect(self.mockDeviceCache.cacheCustomerInfoCount) == 1


### PR DESCRIPTION
See also #2397.
Xcode 14.3 introduced the following error:
> Heterogeneous collection literal could only be inferred to '[String : Any]'; add explicit type annotation if this is intentional

### Changes:
- Added explicit types to fix this new error
- Removed unnecessary `@preconcurrency` imports
- Added new `CustomerInfo.emptyInfo` to reduce duplication of same fake `CustomerInfo` creation
