### PR TITLE
SwiftUI Sample Project: Refactor Package terms method to a computed property

### DIFF
--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/Helpers/Extensions.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/Helpers/Extensions.swift
@@ -12,12 +12,12 @@ import StoreKit
 /* Some methods to make displaying subscription terms easier */
 
 extension Package {
-    func terms(for package: Package) -> String {
-        if let intro = package.storeProduct.introductoryDiscount {
+    var terms: String {
+        if let intro = self.storeProduct.introductoryDiscount {
             if intro.price == 0 {
                 return "\(intro.subscriptionPeriod.periodTitle) free trial"
             } else {
-                return "\(package.localizedIntroductoryPriceString!) for \(intro.subscriptionPeriod.periodTitle)"
+                return "\(self.localizedIntroductoryPriceString!) for \(intro.subscriptionPeriod.periodTitle)"
             }
         } else {
             return "Unlocks Premium"

--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/Views/PaywallView.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/Views/PaywallView.swift
@@ -123,7 +123,7 @@ struct PackageCellView: View {
                     Spacer()
                 }
                 HStack {
-                    Text(package.terms(for: package))
+                    Text(package.terms)
                         .font(.subheadline)
                         .foregroundColor(.secondary)
                     Spacer()


### PR DESCRIPTION
Note: Not sure if PRs are wanted on Example code.

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for `purchases-android` and hybrids

### Motivation
Noticed that the terms func was just passing the same `package`.

### Description
Testing: Looks like there are no tests for sample code.

This pull request refactors the terms(for package: Package) method in the Package extension to a computed property terms. The change not only improves readability and simplifies access to the package terms, but also eliminates the need to pass a Package instance to a function that belongs to the same Package type, which didn't make sense.
By making these changes, we provide a more streamlined and intuitive approach for developers to access package terms, and eliminate the need for an explicit method call. 