### PR TITLE
Fix deadlock when sending notification center in customerInfoListener

### DIFF
--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 
+// swiftlint:disable file_length
 class DeviceCache {
 
     var cachedAppUserID: String? { return self._cachedAppUserID.value }

--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -14,7 +14,6 @@
 
 import Foundation
 
-// swiftlint:disable file_length type_body_length
 class DeviceCache {
 
     var cachedAppUserID: String? { return self._cachedAppUserID.value }

--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -23,7 +23,6 @@ class DeviceCache {
 
     private let sandboxEnvironmentDetector: SandboxEnvironmentDetector
     private let userDefaults: SynchronizedUserDefaults
-    private let notificationCenter: NotificationCenter
     private let offeringsCachedObject: InMemoryCachedObject<Offerings>
 
     private let _cachedAppUserID: Atomic<String?>
@@ -33,52 +32,18 @@ class DeviceCache {
 
     init(sandboxEnvironmentDetector: SandboxEnvironmentDetector,
          userDefaults: UserDefaults,
-         offeringsCachedObject: InMemoryCachedObject<Offerings> = .init(),
-         notificationCenter: NotificationCenter = .default) {
+         offeringsCachedObject: InMemoryCachedObject<Offerings> = .init()) {
         self.sandboxEnvironmentDetector = sandboxEnvironmentDetector
         self.offeringsCachedObject = offeringsCachedObject
-        self.notificationCenter = notificationCenter
         self.userDefaults = .init(userDefaults: userDefaults)
         self._cachedAppUserID = .init(userDefaults.string(forKey: .appUserDefaults))
         self._cachedLegacyAppUserID = .init(userDefaults.string(forKey: .legacyGeneratedAppUserDefaults))
 
         Logger.verbose(Strings.purchase.device_cache_init(self))
-
-        // Observe `UserDefaults` changes through `handleUserDefaultsChanged`
-        // to ensure that users don't remove the data from the SDK, which would
-        // leave it in an undetermined state. See https://rev.cat/userdefaults-crash
-        // If the user is not using a custom `UserDefaults`, we don't need to
-        // because they have no access to it.
-        if userDefaults !== UserDefaults.revenueCatSuite {
-            self.userDefaultsObserver = self.notificationCenter.addObserver(
-                forName: UserDefaults.didChangeNotification,
-                object: userDefaults,
-                queue: nil, // Run synchronously on the posting thread
-                using: { [weak self] notification in
-                    self?.handleUserDefaultsChanged(notification: notification)
-                }
-            )
-        }
-    }
-
-    @objc private func handleUserDefaultsChanged(notification: Notification) {
-        guard let userDefaults = notification.object as? UserDefaults else {
-            return
-        }
-
-        // Note: this should never use `self.userDefaults` directly because this method
-        // might be synchronized, and `Atomic` is not reentrant.
-        if self.cachedAppUserID != nil && Self.cachedAppUserID(userDefaults) == nil {
-            fatalError(Strings.purchase.cached_app_user_id_deleted.description)
-        }
     }
 
     deinit {
         Logger.verbose(Strings.purchase.device_cache_deinit(self))
-
-        if let observer = self.userDefaultsObserver {
-            self.notificationCenter.removeObserver(observer)
-        }
     }
 
     // MARK: - appUserID
@@ -372,7 +337,6 @@ class DeviceCache {
 
 // @unchecked because:
 // - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
-// - It contains `NotificationCenter`, which isn't thread-safe as of Swift 5.7.
 extension DeviceCache: @unchecked Sendable {}
 
 // MARK: - Private

--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -67,7 +67,6 @@ enum PurchaseStrings {
     case begin_refund_no_active_entitlement
     case begin_refund_multiple_active_entitlements
     case begin_refund_customer_info_error(entitlementID: String?)
-    case cached_app_user_id_deleted
     case missing_cached_customer_info
     case sk1_purchase_too_slow
     case sk2_purchase_too_slow
@@ -252,14 +251,6 @@ extension PurchaseStrings: CustomStringConvertible {
         case .begin_refund_customer_info_error(let entitlementID):
             return "Failed to get CustomerInfo to proceed with refund for " +
                 "\(entitlementID.flatMap { "entitlement with ID " + $0 } ?? "active entitlement")."
-        case .cached_app_user_id_deleted:
-            return """
-                [\(Logger.frameworkDescription)] - Cached appUserID has been deleted from user defaults.
-                This leaves the SDK in an undetermined state. Please make sure that RevenueCat
-                entries in user defaults don't get deleted by anything other than the SDK.
-                More info: https://rev.cat/userdefaults-crash
-                """
-
         case .missing_cached_customer_info:
             return "Requested a cached CustomerInfo but it's not available."
 

--- a/Tests/UnitTests/Caching/DeviceCacheTests.swift
+++ b/Tests/UnitTests/Caching/DeviceCacheTests.swift
@@ -244,95 +244,42 @@ class DeviceCacheTests: TestCase {
         expect(self.deviceCache.cachedOfferings) === expectedOfferings
     }
 
-    func testAssertionHappensWhenAppUserIDIsDeleted() {
-        let mockNotificationCenter = MockNotificationCenter()
-        mockUserDefaults.mockValues["com.revenuecat.userdefaults.appUserID.new"] = "Rage Against the Machine"
-
-        self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
-                                       userDefaults: self.mockUserDefaults,
-                                       notificationCenter: mockNotificationCenter)
-
-        expectNoFatalError { mockNotificationCenter.fireNotifications() }
-
-        mockUserDefaults.mockValues["com.revenuecat.userdefaults.appUserID.new"] = nil
-
-        // swiftlint:disable:next line_length
-        let expectedMessage = "[\(Logger.frameworkDescription)] - Cached appUserID has been deleted from user defaults.\n" +
-        "This leaves the SDK in an undetermined state. Please make sure that RevenueCat\n" +
-        "entries in user defaults don\'t get deleted by anything other than the SDK.\n" +
-        "More info: https://rev.cat/userdefaults-crash"
-        expectFatalError(expectedMessage: expectedMessage) { mockNotificationCenter.fireNotifications() }
-    }
-
-    func testDoesntCrashIfOtherSettingIsDeletedAndAppUserIDHadntBeenSet() {
-        let mockNotificationCenter = MockNotificationCenter()
-        mockUserDefaults.mockValues["com.revenuecat.userdefaults.appUserID.new"] = nil
-        self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
-                                       userDefaults: self.mockUserDefaults,
-                                       notificationCenter: mockNotificationCenter)
-
-        expectNoFatalError { mockNotificationCenter.fireNotifications() }
-    }
-
-    func testNoAssertionIfModifyingRevenueCatUserDefaultsSuite() {
-        let userDefaults: UserDefaults = .revenueCatSuite
-        let mockNotificationCenter = MockNotificationCenter()
-
-        userDefaults.set("User", forKey: "com.revenuecat.userdefaults.appUserID.new")
-
-        self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
-                                       userDefaults: userDefaults,
-                                       notificationCenter: mockNotificationCenter)
-
-        userDefaults.set(nil, forKey: "com.revenuecat.userdefaults.appUserID.new")
-
-        expectNoFatalError { mockNotificationCenter.fireNotifications() }
-    }
-
     func testNewDeviceCacheInstanceWithExistingValidCustomerInfoCacheIsntStale() {
-        let mockNotificationCenter = MockNotificationCenter()
         let appUserID = "myUser"
         let fourMinutesAgo = Calendar.current.date(byAdding: .minute, value: -4, to: Date())
         let cackeKey = "com.revenuecat.userdefaults.purchaserInfoLastUpdated.\(appUserID)"
         mockUserDefaults.mockValues[cackeKey] = fourMinutesAgo
         self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
-                                       userDefaults: self.mockUserDefaults,
-                                       notificationCenter: mockNotificationCenter)
+                                       userDefaults: self.mockUserDefaults)
 
         expect(self.deviceCache.isCustomerInfoCacheStale(appUserID: appUserID,
                                                          isAppBackgrounded: false)) == false
     }
 
     func testNewDeviceCacheInstanceWithExistingInvalidCustomerInfoCacheIsStale() {
-        let mockNotificationCenter = MockNotificationCenter()
         let appUserID = "myUser"
         let fourDaysAgo = Calendar.current.date(byAdding: .day, value: -4, to: Date())
         mockUserDefaults.mockValues["com.revenuecat.userdefaults.purchaserInfoLastUpdated.\(appUserID)"] = fourDaysAgo
         self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
-                                       userDefaults: self.mockUserDefaults,
-                                       notificationCenter: mockNotificationCenter)
+                                       userDefaults: self.mockUserDefaults)
 
         expect(self.deviceCache.isCustomerInfoCacheStale(appUserID: appUserID,
                                                          isAppBackgrounded: false)) == true
     }
 
     func testNewDeviceCacheInstanceWithNoCachedCustomerInfoCacheIsStale() {
-        let mockNotificationCenter = MockNotificationCenter()
         let appUserID = "myUser"
         self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
-                                       userDefaults: self.mockUserDefaults,
-                                       notificationCenter: mockNotificationCenter)
+                                       userDefaults: self.mockUserDefaults)
 
         expect(self.deviceCache.isCustomerInfoCacheStale(appUserID: appUserID,
                                                          isAppBackgrounded: false)) == true
     }
 
     func testIsCustomerInfoCacheStaleForBackground() {
-        let mockNotificationCenter = MockNotificationCenter()
         let appUserID = "myUser"
         self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
-                                       userDefaults: self.mockUserDefaults,
-                                       notificationCenter: mockNotificationCenter)
+                                       userDefaults: self.mockUserDefaults)
         let outdatedCacheDateForBackground = Calendar.current.date(byAdding: .hour, value: -25, to: Date())!
         self.deviceCache.setCustomerInfoCache(timestamp: outdatedCacheDateForBackground, appUserID: appUserID)
 
@@ -347,11 +294,9 @@ class DeviceCacheTests: TestCase {
     }
 
     func testIsCustomerInfoCacheStaleForForeground() {
-        let mockNotificationCenter = MockNotificationCenter()
         let appUserID = "myUser"
         self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
-                                       userDefaults: self.mockUserDefaults,
-                                       notificationCenter: mockNotificationCenter)
+                                       userDefaults: self.mockUserDefaults)
         let outdatedCacheDateForForeground = Calendar.current.date(byAdding: .minute, value: -25, to: Date())!
         self.deviceCache.setCustomerInfoCache(timestamp: outdatedCacheDateForForeground, appUserID: appUserID)
 
@@ -366,11 +311,9 @@ class DeviceCacheTests: TestCase {
     }
 
     func testIsCustomerInfoCacheWithCachedInfoButNoTimestamp() {
-        let mockNotificationCenter = MockNotificationCenter()
         let appUserID = "myUser"
         self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
-                                       userDefaults: self.mockUserDefaults,
-                                       notificationCenter: mockNotificationCenter)
+                                       userDefaults: self.mockUserDefaults)
 
         let data = Data()
         self.deviceCache.cache(customerInfo: data, appUserID: appUserID)
@@ -384,12 +327,10 @@ class DeviceCacheTests: TestCase {
     }
 
     func testIsCustomerInfoCacheStaleForDifferentAppUserID() {
-        let mockNotificationCenter = MockNotificationCenter()
         let otherAppUserID = "some other user"
         let currentAppUserID = "myUser"
         self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
-                                       userDefaults: self.mockUserDefaults,
-                                       notificationCenter: mockNotificationCenter)
+                                       userDefaults: self.mockUserDefaults)
         let validCacheDate = Calendar.current.date(byAdding: .minute, value: -3, to: Date())!
         self.deviceCache.setCustomerInfoCache(timestamp: validCacheDate, appUserID: otherAppUserID)
 
@@ -398,13 +339,11 @@ class DeviceCacheTests: TestCase {
     }
 
     func testIsOfferingsCacheStaleDifferentCacheLengthsForBackgroundAndForeground() {
-        let mockNotificationCenter = MockNotificationCenter()
         let mockCachedObject = InMemoryCachedObject<Offerings>()
 
         self.deviceCache = DeviceCache(sandboxEnvironmentDetector: self.sandboxEnvironmentDetector,
                                        userDefaults: self.mockUserDefaults,
-                                       offeringsCachedObject: mockCachedObject,
-                                       notificationCenter: mockNotificationCenter)
+                                       offeringsCachedObject: mockCachedObject)
 
         let outdatedCacheDate = Calendar.current.date(byAdding: .hour, value: -25, to: Date())!
         mockCachedObject.updateCacheTimestamp(date: outdatedCacheDate)


### PR DESCRIPTION
Fixes an issue where a deadlock could happen if you fire a notification in the customerInfoListener. 

The issue stems from our usage of NotificationCenter to detect deletion of userDefaults. 

Since we've changed the default UserDefaults anyway, I don't feel like this adds much value anymore, and we've spent wayyyy too much time dealing with race conditions caused by it, so I'm just getting rid of it. 

I couldn't get it to reproduce on my device, but @codykerns was able to get a consistent repro and confirmed the fix with this branch. 