### PR TITLE
`CustomerInfoManager`: fixed deadlock caused by reading `CustomerInfo` inside of observer

### DIFF
--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -249,7 +249,10 @@ class CustomerInfoManager {
             }
 
             $0.lastSentCustomerInfo = customerInfo
-            self.operationDispatcher.dispatchOnMainThread { [observers = $0.customerInfoObserversByIdentifier] in
+
+            // This must be async to prevent deadlocks if the observer calls a method that ends up reading
+            // this class' data. By making it async, the closure is invoked outside of the lock.
+            self.operationDispatcher.dispatchAsyncOnMainThread { [observers = $0.customerInfoObserversByIdentifier] in
                 for closure in observers.values {
                     closure(customerInfo)
                 }

--- a/Sources/Misc/Concurrency/OperationDispatcher.swift
+++ b/Sources/Misc/Concurrency/OperationDispatcher.swift
@@ -22,12 +22,19 @@ class OperationDispatcher {
 
     static let `default`: OperationDispatcher = .init()
 
+    /// Invokes `block` on the main thread asynchronously
+    /// or synchronously if called from the main thread.
     func dispatchOnMainThread(_ block: @escaping @Sendable () -> Void) {
         if Thread.isMainThread {
             block()
         } else {
             self.mainQueue.async(execute: block)
         }
+    }
+
+    /// Dispatch block on main thread asynchronously.
+    func dispatchAsyncOnMainThread(_ block: @escaping @Sendable () -> Void) {
+        self.mainQueue.async(execute: block)
     }
 
     func dispatchOnMainActor(_ block: @MainActor @escaping @Sendable () -> Void) {

--- a/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
+++ b/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
@@ -25,6 +25,16 @@ class MockOperationDispatcher: OperationDispatcher {
         }
     }
 
+    var invokedDispatchAsyncOnMainThread = false
+    var invokedDispatchAsyncOnMainThreadCount = 0
+
+    override func dispatchAsyncOnMainThread(_ block: @escaping @Sendable () -> Void) {
+        self.invokedDispatchAsyncOnMainThread = true
+        self.invokedDispatchAsyncOnMainThreadCount += 1
+
+        super.dispatchAsyncOnMainThread(block)
+    }
+
     override func dispatchOnMainActor(_ block: @escaping @Sendable @MainActor () -> Void) {
         self.invokedDispatchOnMainThread = true
         self.invokedDispatchOnMainThreadCount += 1

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -205,7 +205,7 @@ class PurchasesLogInTests: BasePurchasesTests {
             self.purchases.logIn(Self.appUserID) { _, _, _ in completed() }
         }
 
-        expect(self.cachingTrialOrIntroPriceEligibilityChecker.invokedClearCache) == true
+        expect(self.cachingTrialOrIntroPriceEligibilityChecker.invokedClearCache).toEventually(beTrue())
         expect(self.cachingTrialOrIntroPriceEligibilityChecker.invokedClearCacheCount) == 1
     }
 


### PR DESCRIPTION
Fixes #2410 and https://github.com/RevenueCat/react-native-purchases/issues/579.

This adds 2 previously failing tests that reproduce this issue: one directly on `CustomerInfoManager` and another one utilizing `PurchasesDelegate`.
These illustrate the issue: if the observer (through `CustomerInfoManager.monitorChanges` or `PurchasesDelegate`) called a method that ended up reading `CustomerInfoManager`'s data inside of the observation, the SDK would deadlock.

This is because we were invoking the observers while inside the lock. This was unnecessary, so this fixes the issue by ensuring that the observers receive updates after the lock is released, using a new `OperationDispatcher.dispatchAsyncOnMainThread`.
