### PR TITLE
`PurchaseTester`: fixed compilation for `internal` entitlement verification

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Core/ConfiguredPurchases.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Core/ConfiguredPurchases.swift
@@ -25,8 +25,9 @@ public final class ConfiguredPurchases {
         apiKey: String,
         proxyURL: String?,
         useStoreKit2: Bool,
-        observerMode: Bool,
-        entitlementVerificationMode: Configuration.EntitlementVerificationMode
+        observerMode: Bool
+        // Trusted Entitlements is internal until ready to be made public.
+        // entitlementVerificationMode: Configuration.EntitlementVerificationMode
     ) {
         Purchases.logLevel = .verbose
         Purchases.logHandler = Self.logger.logHandler
@@ -41,7 +42,8 @@ public final class ConfiguredPurchases {
             with: .builder(withAPIKey: apiKey)
                 .with(usesStoreKit2IfAvailable: useStoreKit2)
                 .with(observerMode: observerMode)
-                .with(entitlementVerificationMode: entitlementVerificationMode)
+                // Trusted Entitlements is internal until ready to be made public.
+                // .with(entitlementVerificationMode: entitlementVerificationMode)
                 .build()
         )
 

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Extensions/Extensions.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Extensions/Extensions.swift
@@ -47,6 +47,9 @@ extension CacheFetchPolicy: Identifiable {
 
 }
 
+// Trusted Entitlements is internal until ready to be made public.
+
+/*
 extension Configuration.EntitlementVerificationMode {
 
     var label: String {
@@ -84,3 +87,4 @@ extension VerificationResult: CustomStringConvertible {
     }
 
 }
+*/

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
@@ -94,8 +94,9 @@ struct PurchaseTesterApp: App {
                 apiKey: data.apiKey,
                 proxyURL: data.proxy.nonEmpty,
                 useStoreKit2: data.storeKit2Enabled,
-                observerMode: data.observerMode,
-                entitlementVerificationMode: data.verificationMode
+                observerMode: data.observerMode
+                // Trusted Entitlements is internal until ready to be made public.
+                // entitlementVerificationMode: data.verificationMode
             )
         }
     }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/ConfigurationView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/ConfigurationView.swift
@@ -17,7 +17,8 @@ struct ConfigurationView: View {
                                                                    with: "")
         var proxy: String = ""
         var storeKit2Enabled: Bool = true
-        var verificationMode: Configuration.EntitlementVerificationMode = .disabled
+        // Trusted Entitlements is internal until ready to be made public.
+        // var verificationMode: Configuration.EntitlementVerificationMode = .disabled
         var observerMode: Bool = false
     }
 
@@ -49,11 +50,14 @@ struct ConfigurationView: View {
             }
 
             Section(header: Text("Settings")) {
+                // Trusted Entitlements is internal until ready to be made public.
+                /*
                 Picker("Entitlement Verification", selection: self.$data.verificationMode) {
                     ForEach(Configuration.EntitlementVerificationMode.all) { mode in
                         Text(mode.label).tag(mode)
                     }
                 }
+                */
 
                 Toggle(isOn: self.$data.storeKit2Enabled) {
                     Text("StoreKit2 enabled")
@@ -132,7 +136,8 @@ struct ConfigurationView: View {
 
 }
 
-extension Configuration.EntitlementVerificationMode: Codable {}
+// Trusted Entitlements is internal until ready to be made public.
+//extension Configuration.EntitlementVerificationMode: Codable {}
 
 // MARK: -
 

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/CustomerInfoView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Customer/CustomerInfoView.swift
@@ -40,8 +40,9 @@ private extension CustomerInfoView {
             ("Original Application Version", self.customerInfo.originalApplicationVersion ?? "-"),
             ("Original Purchase Date", self.date(customerInfo.originalPurchaseDate) ?? "-"),
             ("Latest Expiration Date", self.date(customerInfo.latestExpirationDate) ?? "-"),
-            ("Request Date", self.date(customerInfo.requestDate) ?? "-"),
-            ("Entitlement Verification", self.customerInfo.entitlements.verification.description),
+            ("Request Date", self.date(customerInfo.requestDate) ?? "-")
+            // Trusted Entitlements is internal until ready to be made public.
+            // ("Entitlement Verification", self.customerInfo.entitlements.verification.description),
         ]
     }
 


### PR DESCRIPTION
Follow up to #2350. This fixes compilation until the API is made `public` again.
