### PR TITLE
`StoreKit1Wrapper`: added debug log when transaction is removed but no callbacks to notify

### DIFF
--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -30,10 +30,12 @@ enum PurchaseStrings {
     case finishing_transaction(StoreTransactionType)
     case purchasing_with_observer_mode_and_finish_transactions_false_warning
     case paymentqueue_revoked_entitlements_for_product_identifiers(productIdentifiers: [String])
-    case paymentqueue_removed_transaction(_ observer: SKPaymentTransactionObserver,
-                                          _ transaction: SKPaymentTransaction)
-    case paymentqueue_updated_transaction(_ observer: SKPaymentTransactionObserver,
-                                          _ transaction: SKPaymentTransaction)
+    case paymentqueue_removed_transaction(SKPaymentTransactionObserver,
+                                          SKPaymentTransaction)
+    case paymentqueue_removed_transaction_no_callbacks_found(SKPaymentTransactionObserver,
+                                                             SKPaymentTransaction)
+    case paymentqueue_updated_transaction(SKPaymentTransactionObserver,
+                                          SKPaymentTransaction)
     case presenting_code_redemption_sheet
     case unable_to_present_redemption_sheet
     case purchases_synced
@@ -130,6 +132,10 @@ extension PurchaseStrings: CustomStringConvertible {
             ]
                 .compactMap { $0 }
                 .joined(separator: " ")
+
+        case let .paymentqueue_removed_transaction_no_callbacks_found(observer, transaction):
+            return "\(observer.debugName) removedTransaction for (\(transaction.payment.productIdentifier) " +
+            "but not callbacks to notify"
 
         case let .paymentqueue_updated_transaction(observer, transaction):
             return "\(observer.debugName) updatedTransaction: \(transaction.payment.productIdentifier) " +

--- a/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
@@ -174,8 +174,12 @@ extension StoreKit1Wrapper: SKPaymentTransactionObserver {
                 Logger.debug(Strings.purchase.paymentqueue_removed_transaction(self, transaction))
                 delegate.storeKit1Wrapper(self, removedTransaction: transaction)
 
-                if let callbacks = self.finishedTransactionCallbacks.value.removeValue(forKey: transaction) {
+                if let callbacks = self.finishedTransactionCallbacks.value.removeValue(forKey: transaction),
+                    !callbacks.isEmpty {
                     callbacks.forEach { $0() }
+                } else {
+                    Logger.debug(Strings.purchase.paymentqueue_removed_transaction_no_callbacks_found(self,
+                                                                                                      transaction))
                 }
             }
         }


### PR DESCRIPTION
This would make issues like #2415 easier to debug.
