### PR TITLE
`Integration Tests`: fixed flaky errors when loading offerings

### DIFF
--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -72,7 +72,7 @@ class BaseBackendIntegrationTests: XCTestCase {
         self.clearReceiptIfExists()
         self.configurePurchases(apiKey: apiKey, proxyURL: proxyURL)
         self.verifyPurchasesDoesNotLeak()
-        try await self.waitForAnonymousUser()
+        await self.waitForAnonymousUser()
     }
 
     // MARK: - Configuration
@@ -130,12 +130,17 @@ private extension BaseBackendIntegrationTests {
         }
     }
 
-    func waitForAnonymousUser() async throws {
+    func waitForAnonymousUser() async {
         // SDK initialization begins with an initial request to offerings,
         // which results in a get-create of the initial anonymous user.
         // To avoid race conditions with when this request finishes and make all tests deterministic
         // this waits for that request to finish.
-        _ = try await Purchases.shared.offerings()
+        //
+        // This ignores errors because this class does not set up `SKTestSession`,
+        // so subclasses would fail to load offerings if they don't set one up.
+        // However, it still serves the purpose of waiting for the anonymous user.
+        // If there is something broken when loading offerings, there is a dedicated test that would fail instead.
+        _ = try? await Purchases.shared.offerings()
     }
 
     private var dangerousSettings: DangerousSettings {


### PR DESCRIPTION
Follow up to #2381.
Fixes https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/10666/workflows/872136c8-5309-45de-958a-5957b5868ba5/jobs/63011

When #2381 was introduced, I didn't realize that `SubscriberAttributesManagerIntegrationTests` would be calling `offerings()` without an `SKTestSession`. Why that doesn't _always_ fail I don't understand (my only guess is that based on test order, which is random, sometimes a previously created session is still active in the background), but it _can_ fail due to products not being found.
This ignores those errors while still allowing the server to create the anonymous user.
