### PR TITLE
re-enable entitlement mapping integration test

### DIFF
--- a/Sources/Networking/HTTPClient/HTTPRequest.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequest.swift
@@ -206,7 +206,7 @@ extension HTTPRequest.Path: CustomStringConvertible {
             return "health"
 
         case .getProductEntitlementMapping:
-            return "products_entitlements"
+            return "product_entitlement_mapping"
         }
     }
 

--- a/Sources/Networking/Responses/ProductEntitlementMappingResponse.swift
+++ b/Sources/Networking/Responses/ProductEntitlementMappingResponse.swift
@@ -17,7 +17,11 @@ import Foundation
 /// - Seealso: `ProductEntitlementMapping`
 struct ProductEntitlementMappingResponse {
 
-    var products: [Product]
+    var productEntitlementMapping: [String: Product]
+
+    private enum CodingKeys: String, CodingKey {
+        case productEntitlementMapping = "product_entitlement_mapping"
+    }
 
 }
 
@@ -33,12 +37,11 @@ extension ProductEntitlementMappingResponse {
 }
 
 // MARK: - Codable
-
 extension ProductEntitlementMappingResponse.Product: Codable {
 
     private enum CodingKeys: String, CodingKey {
 
-        case identifier = "id"
+        case identifier = "product_identifier"
         case entitlements
 
     }

--- a/Tests/BackendIntegrationTests/LoadShedderIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/LoadShedderIntegrationTests.swift
@@ -51,8 +51,6 @@ class LoadShedderStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     func testProductEntitlementMapping() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        XCTExpectFailure("Endpoint is not available yet")
-
         let result = try await Purchases.shared.productEntitlementMapping()
         expect(result.entitlementsByProduct).toNot(beEmpty())
     }


### PR DESCRIPTION
Re-enables the entitlement mapping integration test on iOS. 

Note that it currently **doesn't work**, I'm not entirely sure why. 

We need to fix it before shipping. 