### PR TITLE
`customEntitlementComputation`: new `X-Custom-Entitlement-Computation` header

### DIFF
--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -168,7 +168,7 @@ private extension HTTPClient {
         }
 
         if systemInfo.dangerousSettings.customEntitlementComputation {
-            headers["X-Custom-Entitlements-Enabled"] = "\(true)"
+            headers["X-Custom-Entitlements-Computation"] = "\(true)"
         }
 
         return headers

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -166,6 +166,11 @@ private extension HTTPClient {
         if let idfv = systemInfo.identifierForVendor {
             headers["X-Apple-Device-Identifier"] = idfv
         }
+
+        if systemInfo.dangerousSettings.customEntitlementComputation {
+            headers["X-Custom-Entitlements-Enabled"] = "\(true)"
+        }
+
         return headers
     }
 

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -757,8 +757,8 @@ class HTTPClientTests: TestCase {
 
         stub(condition: isPath(request.path)) { request in
             let headers =  request.allHTTPHeaderFields ?? [:]
-            headerPresent = headers["X-Custom-Entitlements-Enabled"] != nil
-                && headers["X-Custom-Entitlements-Enabled"] == "true"
+            headerPresent = headers["X-Custom-Entitlements-Computation"] != nil
+                && headers["X-Custom-Entitlements-Computation"] == "true"
             return .emptySuccessResponse()
         }
 
@@ -783,7 +783,7 @@ class HTTPClientTests: TestCase {
 
         stub(condition: isPath(request.path)) { request in
             let headers =  request.allHTTPHeaderFields ?? [:]
-            headerPresent = headers["X-Custom-Entitlements-Enabled"] != nil
+            headerPresent = headers["X-Custom-Entitlements-Computation"] != nil
             return .emptySuccessResponse()
         }
 

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -18,7 +18,7 @@ class HTTPClientTests: TestCase {
     private typealias EmptyResponse = HTTPResponse<HTTPEmptyResponseBody>.Result
 
     private let apiKey = "MockAPIKey"
-    private let systemInfo = MockSystemInfo(finishTransactions: true)
+    private var systemInfo: MockSystemInfo!
     private var client: HTTPClient!
     private var userDefaults: UserDefaults!
     private var eTagManager: MockETagManager!
@@ -32,6 +32,7 @@ class HTTPClientTests: TestCase {
         try XCTSkipIf(true, "OHHTTPStubs does not currently support watchOS")
         #endif
 
+        self.systemInfo = MockSystemInfo(finishTransactions: true)
         self.userDefaults = MockUserDefaults()
         self.eTagManager = MockETagManager(userDefaults: self.userDefaults)
         self.operationDispatcher = OperationDispatcher()
@@ -740,6 +741,57 @@ class HTTPClientTests: TestCase {
         }
 
         expect(headerPresent.value) == true
+    }
+
+    func testRequestsWithCustomEntitlementsSendHeader() {
+        self.systemInfo = MockSystemInfo(finishTransactions: true, customEntitlementsComputation: true)
+        self.client = HTTPClient(apiKey: self.apiKey,
+                                 systemInfo: self.systemInfo,
+                                 eTagManager: self.eTagManager,
+                                 dnsChecker: MockDNSChecker.self,
+                                 requestTimeout: 3)
+
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
+
+        var headerPresent = false
+
+        stub(condition: isPath(request.path)) { request in
+            let headers =  request.allHTTPHeaderFields ?? [:]
+            headerPresent = headers["X-Custom-Entitlements-Enabled"] != nil
+                && headers["X-Custom-Entitlements-Enabled"] == "true"
+            return .emptySuccessResponse()
+        }
+
+        waitUntil { completion in
+            self.client.perform(request) { (_: HTTPResponse<Data>.Result) in completion() }
+        }
+
+        expect(headerPresent) == true
+    }
+
+    func testRequestsWithoutCustomEntitlementsSendHeader() {
+        self.systemInfo = MockSystemInfo(finishTransactions: true, customEntitlementsComputation: false)
+        self.client = HTTPClient(apiKey: self.apiKey,
+                                 systemInfo: self.systemInfo,
+                                 eTagManager: self.eTagManager,
+                                 dnsChecker: MockDNSChecker.self,
+                                 requestTimeout: 3)
+
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
+
+        var headerPresent = false
+
+        stub(condition: isPath(request.path)) { request in
+            let headers =  request.allHTTPHeaderFields ?? [:]
+            headerPresent = headers["X-Custom-Entitlements-Enabled"] != nil
+            return .emptySuccessResponse()
+        }
+
+        waitUntil { completion in
+            self.client.perform(request) { (_: HTTPResponse<Data>.Result) in completion() }
+        }
+
+        expect(headerPresent) == false
     }
 
     func testPassesObserverModeHeaderCorrectlyWhenDisabled() throws {

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -745,11 +745,7 @@ class HTTPClientTests: TestCase {
 
     func testRequestsWithCustomEntitlementsSendHeader() {
         self.systemInfo = MockSystemInfo(finishTransactions: true, customEntitlementsComputation: true)
-        self.client = HTTPClient(apiKey: self.apiKey,
-                                 systemInfo: self.systemInfo,
-                                 eTagManager: self.eTagManager,
-                                 dnsChecker: MockDNSChecker.self,
-                                 requestTimeout: 3)
+        self.client = HTTPClient(apiKey: self.apiKey, systemInfo: systemInfo, eTagManager: self.eTagManager)
 
         let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
@@ -769,13 +765,9 @@ class HTTPClientTests: TestCase {
         expect(headerPresent) == true
     }
 
-    func testRequestsWithoutCustomEntitlementsSendHeader() {
+    func testRequestsWithoutCustomEntitlementsDoNotSendHeader() {
         self.systemInfo = MockSystemInfo(finishTransactions: true, customEntitlementsComputation: false)
-        self.client = HTTPClient(apiKey: self.apiKey,
-                                 systemInfo: self.systemInfo,
-                                 eTagManager: self.eTagManager,
-                                 dnsChecker: MockDNSChecker.self,
-                                 requestTimeout: 3)
+        self.client = HTTPClient(apiKey: self.apiKey, systemInfo: systemInfo, eTagManager: self.eTagManager)
 
         let request = HTTPRequest(method: .post([:]), path: .mockPath)
 


### PR DESCRIPTION
Added a new header in httpClient, which is sent only if the customEntitlementsComputation (#2416) setting is enabled. 