### PR TITLE
customEntitlementsComputation part 4: create convenience configuration method

### DIFF
--- a/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
@@ -108,6 +108,7 @@ Most features require configuring the SDK before using it.
 - ``Purchases/setOnesignalID(_:)``
 
 ### Advanced Configuration
+- ``Purchases/configureInCustomEntitlementsComputationMode(apiKey:appUserID:)``
 - ``Purchases/finishTransactions``
 - ``Purchases/invalidateCustomerInfoCache()``
 - ``Purchases/forceUniversalAppStore``

--- a/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md
@@ -58,6 +58,9 @@ Or browse our iOS sample apps:
 - ``Purchases/configure(with:)-6oipy``
 - ``PurchasesDiagnostics``
 
+### Advanced Configuration
+- ``Purchases/configureInCustomEntitlementsComputationMode(apiKey:appUserID:)``
+
 ### Displaying Products
 - ``Offerings``
 - ``Offering``

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1008,6 +1008,49 @@ public extension Purchases {
     }
 
     /**
+     * Configures an instance of the Purchases SDK with a specified API key and
+     * app user ID in Custom Entitlements Computation mode.
+
+     * - Warning: Configuring in Custom Entitlements Computation mode should only be enabled after
+     * being instructed to do so by the RevenueCat team.
+     * Apps configured in this mode will not have anonymous IDs, will not be able to use logOut methods,
+     * and will not have their CustomerInfo cache refreshed automatically.
+     *
+     * ## Custom Entitlements Computation mode
+     * This mode is intended for apps that will use RevenueCat to manage payment flows,
+     * but **will not** use RevenueCat's SDK to compute entitlements.
+     * Apps using this mode will instead rely on webhooks to get notified when purchases go through
+     * and to merge information between RevenueCat's servers
+     * and their own.
+     *
+     * In this mode, the RevenueCat SDK will never generate anonymous IDs. Instead, it can only be configured
+     * with a known appUserID, and the logOut methods
+     * will return an error if called. To change users, call ``logIn(_:)-arja``.
+     *
+     * The instance will be set as a singleton.
+     * You should access the singleton instance using ``Purchases/shared``.
+     *
+     * - Note: Best practice is to use a salted hash of your unique app user ids.
+     *
+     * - Parameter apiKey: The API Key generated for your app from https://app.revenuecat.com/
+     *
+     * - Parameter appUserID: The unique app user id for this user. This user id will allow users to share their
+     * purchases and subscriptions across devices. Pass `nil` or an empty string if you want ``Purchases``
+     * to generate this for you.
+     *
+     * - Returns: An instantiated ``Purchases`` object that has been set as a singleton.
+     */
+    @objc(configureInCustomEntitlementsModeWithApiKey:appUserID:)
+    @discardableResult static func configureInCustomEntitlementsComputationMode(apiKey: String,
+                                                                                appUserID: String) -> Purchases {
+        Self.configure(
+            with: .builder(withAPIKey: apiKey)
+                .with(appUserID: appUserID)
+                .with(dangerousSettings: DangerousSettings(customEntitlementComputation: true))
+                .build())
+    }
+
+    /**
      * Configures an instance of the Purchases SDK with a custom `UserDefaults`.
      *
      * Use this constructor if you want to

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -65,6 +65,10 @@ BOOL isAnonymous;
               useStoreKit2IfAvailable:true
                     dangerousSettings:[[RCDangerousSettings alloc] initWithAutoSyncPurchases:NO
                                                                 customEntitlementComputation:NO]];
+
+    [RCPurchases configureInCustomEntitlementsModeWithApiKey:@""
+                                                   appUserID:@""];
+
     
     [RCPurchases setLogHandler:^(RCLogLevel l, NSString *i) {}];
     canI = [RCPurchases canMakePayments];

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -259,6 +259,7 @@ private func checkConfigure() -> Purchases! {
 
     Purchases.configure(withAPIKey: "", appUserID: "", observerMode: false)
     Purchases.configure(withAPIKey: "", appUserID: nil, observerMode: true)
+    Purchases.configureInCustomEntitlementsComputationMode(apiKey: "", appUserID: "")
 
     return nil
 }


### PR DESCRIPTION
Adds a new configuration method that's meant as a convenience for enabling customEntitlementsComputation. 

Syntax using this method is just: 

```swift
Purchases.configureInCustomEntitlementsComputationMode(apiKey: "<api_key>", appUserID: "<app_user_id>")
```