### PR TITLE
`PurchaseOrchestrator`: fix incorrect `InitiationSource` for SK1 queue transactions

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -570,7 +570,9 @@ extension PurchasesOrchestrator: StoreKit1WrapperDelegate {
         let storeTransaction = StoreTransaction(sk1Transaction: transaction)
 
         switch transaction.transactionState {
-        case .restored: // for observer mode
+        // For observer mode. Should only come from calls to `restoreCompletedTransactions`,
+        // which the SDK does not currently use.
+        case .restored:
             self.handlePurchasedTransaction(storeTransaction,
                                             storefront: storeKit1Wrapper.currentStorefront,
                                             restored: true)

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -813,6 +813,8 @@ private extension PurchasesOrchestrator {
         for productIdentifier: String,
         restored: Bool
     ) -> ProductRequestData.InitiationSource {
+        // Having a purchase completed callback implies that the transation comes from an explicit call
+        // to `purchase()` instead of a StoreKit transaction notification.
         let hasPurchaseCallback = self.purchaseCompleteCallbacksByProductID.value.keys.contains(productIdentifier)
 
         switch (hasPurchaseCallback, restored) {

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -811,6 +811,7 @@ private extension PurchasesOrchestrator {
         }
     }
 
+    /// - Parameter restored: whether the transaction state was `.restored` instead of `.`purchased`.
     private func initiationSource(
         for productIdentifier: String,
         restored: Bool
@@ -821,6 +822,8 @@ private extension PurchasesOrchestrator {
 
         switch (hasPurchaseCallback, restored) {
         case (true, false): return .purchase
+        // Note that restores initiated through the SDK with `restorePurchases`
+        // won't use this method since those set the initiation source explicitly.
         case (true, true): return .restore
         case (false, _): return .queue
         }

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -198,6 +198,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         expect(self.backend.invokedPostReceiptDataCount) == 1
         expect(self.backend.invokedPostReceiptDataParameters?.productData).toNot(beNil())
         expect(self.backend.invokedPostReceiptDataParameters?.offeringIdentifier) == "offering"
+        expect(self.backend.invokedPostReceiptDataParameters?.initiationSource) == .purchase
     }
 
     func testSK1PurchaseDoesNotAlwaysRefreshReceiptInProduction() async throws {
@@ -436,6 +437,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         expect(self.backend.invokedPostReceiptDataCount) == 1
         expect(self.backend.invokedPostReceiptDataParameters?.productData).toNot(beNil())
         expect(self.backend.invokedPostReceiptDataParameters?.offeringIdentifier).to(beNil())
+        expect(self.backend.invokedPostReceiptDataParameters?.initiationSource) == .purchase
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
@@ -639,6 +641,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         expect(transaction.finishInvoked) == true
         expect(self.backend.invokedPostReceiptData) == true
         expect(self.backend.invokedPostReceiptDataParameters?.isRestore) == false
+        expect(self.backend.invokedPostReceiptDataParameters?.initiationSource) == .queue
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
@@ -722,6 +725,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         expect(transaction.finishInvoked) == false
         expect(self.backend.invokedPostReceiptData) == true
         expect(self.backend.invokedPostReceiptDataParameters?.isRestore) == true
+        expect(self.backend.invokedPostReceiptDataParameters?.initiationSource) == .queue
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
@@ -32,14 +32,15 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         let transaction = MockTransaction()
         transaction.mockPayment = try XCTUnwrap(self.storeKit1Wrapper.payment)
 
-        transaction.mockState = SKPaymentTransactionState.purchasing
+        transaction.mockState = .purchasing
         self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
-        transaction.mockState = SKPaymentTransactionState.purchased
+        transaction.mockState = .purchased
         self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
         expect(self.backend.postedIsRestore) == false
+        expect(self.backend.postedInitiationSource) == .purchase
         expect(self.purchasesDelegate.customerInfoReceivedCount).toEventually(equal(1))
     }
 
@@ -68,13 +69,14 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         let transaction = MockTransaction()
         transaction.mockPayment = try XCTUnwrap(self.storeKit1Wrapper.payment)
 
-        transaction.mockState = SKPaymentTransactionState.purchasing
+        transaction.mockState = .purchasing
         self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
-        transaction.mockState = SKPaymentTransactionState.purchased
+        transaction.mockState = .purchased
         self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
+        expect(self.backend.postedInitiationSource) == .purchase
         expect(self.backend.postedIsRestore) == false
     }
 
@@ -86,11 +88,11 @@ class PurchasesPurchasingTests: BasePurchasesTests {
 
         let transaction = MockTransaction()
         transaction.mockPayment = try XCTUnwrap(self.storeKit1Wrapper.payment)
+        transaction.mockState = .purchasing
 
-        transaction.mockState = SKPaymentTransactionState.purchasing
         self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
-        transaction.mockState = SKPaymentTransactionState.purchased
+        transaction.mockState = .purchased
         self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
@@ -944,10 +946,10 @@ class PurchasesPurchasingCustomSetupTests: BasePurchasesTests {
         let transaction = MockTransaction()
         transaction.mockPayment = try XCTUnwrap(self.storeKit1Wrapper.payment)
 
-        transaction.mockState = SKPaymentTransactionState.purchasing
+        transaction.mockState = .purchasing
         self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
-        transaction.mockState = SKPaymentTransactionState.purchased
+        transaction.mockState = .purchased
         self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
@@ -963,10 +965,11 @@ class PurchasesPurchasingCustomSetupTests: BasePurchasesTests {
         let transaction = MockTransaction()
         transaction.mockPayment = try XCTUnwrap(self.storeKit1Wrapper.payment)
 
-        transaction.mockState = SKPaymentTransactionState.restored
+        transaction.mockState = .restored
         self.storeKit1Wrapper.delegate?.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
         expect(self.backend.postReceiptDataCalled) == true
+        expect(self.backend.postedInitiationSource) == .restore
         expect(self.storeKit1Wrapper.finishCalled).toEventually(beFalse())
     }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesTransactionHandlingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesTransactionHandlingTests.swift
@@ -194,7 +194,8 @@ class PurchasesTransactionHandlingTests: BasePurchasesTests {
         transaction.mockState = .purchased
         try self.delegate.storeKit1Wrapper(self.storeKit1Wrapper, updatedTransaction: transaction)
 
-        expect(self.backend.postReceiptDataCalled).to(beTrue())
+        expect(self.backend.postReceiptDataCalled) == true
+        expect(self.backend.postedInitiationSource) == .queue
         expect(self.purchasesDelegate.customerInfoReceivedCount).toEventually(equal(2))
     }
 


### PR DESCRIPTION
All StoreKit 1 transactions were being sent with `InitiationSource.purchased`.
#1957 introduced this, but it was only set correctly for SK2.

The consequence of this is that users might see "invalid receipt" errors when posting receipts due to updated transactions from the queue, which can only happen for `InitiationSource.purchased`.