### PR TITLE
clarify reasoning for disfavoredOverload in logIn

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -562,7 +562,10 @@ public extension Purchases {
         self.logIn("\(appUserID)", completion: completion)
     }
 
-    @_disfavoredOverload // Favor `StaticString` overload (`String` is not convertible to `StaticString`).
+    // Favor `StaticString` overload (`String` is not convertible to `StaticString`).
+    // This allows us to provide a compile-time warning to developers who accidentally 
+    // call logIn with hardcoded user ids in their app
+    @_disfavoredOverload
     @objc(logIn:completion:)
     func logIn(_ appUserID: String, completion: @escaping (CustomerInfo?, Bool, PublicError?) -> Void) {
         self.identityManager.logIn(appUserID: appUserID) { result in
@@ -590,7 +593,10 @@ public extension Purchases {
         return try await self.logIn("\(appUserID)")
     }
 
-    @_disfavoredOverload // Favor `StaticString` overload (`String` is not convertible to `StaticString`).
+    // Favor `StaticString` overload (`String` is not convertible to `StaticString`).
+    // This allows us to provide a compile-time warning to developers who accidentally 
+    // call logIn with hardcoded user ids in their app
+    @_disfavoredOverload
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func logIn(_ appUserID: String) async throws -> (customerInfo: CustomerInfo, created: Bool) {
         return try await self.logInAsync(appUserID)


### PR DESCRIPTION
I just came across this code and realized that I knew why it was there just because I was there when we added it, but reading the comment it wouldn't have been that clear to me why we were disfavoring what should be the preferred way of calling `logIn`.
