### PR TITLE
`customEntitlementsComputation`: disable automatic sync of `attConsentStatus`

### DIFF
--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -37,7 +37,8 @@ class Backend {
         let config = BackendConfiguration(httpClient: httpClient,
                                           operationDispatcher: operationDispatcher,
                                           operationQueue: QueueProvider.createBackendQueue(),
-                                          dateProvider: dateProvider)
+                                          dateProvider: dateProvider,
+                                          systemInfo: systemInfo)
         self.init(backendConfig: config, attributionFetcher: attributionFetcher)
     }
 

--- a/Sources/Networking/BackendConfiguration.swift
+++ b/Sources/Networking/BackendConfiguration.swift
@@ -20,15 +20,18 @@ final class BackendConfiguration {
     let operationDispatcher: OperationDispatcher
     let operationQueue: OperationQueue
     let dateProvider: DateProvider
+    let systemInfo: SystemInfo
 
     init(httpClient: HTTPClient,
          operationDispatcher: OperationDispatcher,
          operationQueue: OperationQueue,
-         dateProvider: DateProvider = DateProvider()) {
+         dateProvider: DateProvider = DateProvider(),
+         systemInfo: SystemInfo) {
         self.httpClient = httpClient
         self.operationDispatcher = operationDispatcher
         self.operationQueue = operationQueue
         self.dateProvider = dateProvider
+        self.systemInfo = systemInfo
     }
 
     func clearCache() {

--- a/Sources/Networking/CustomerAPI.swift
+++ b/Sources/Networking/CustomerAPI.swift
@@ -91,18 +91,16 @@ final class CustomerAPI {
               initiationSource: ProductRequestData.InitiationSource,
               subscriberAttributes subscriberAttributesByKey: SubscriberAttribute.Dictionary?,
               completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
-        var subscriberAttributesToPost: SubscriberAttribute.Dictionary? = nil
+        var subscriberAttributesToPost: SubscriberAttribute.Dictionary?
 
         if !self.backendConfig.systemInfo.dangerousSettings.customEntitlementComputation {
             subscriberAttributesToPost = subscriberAttributesByKey ?? [:]
             let attributionStatus = self.attributionFetcher.authorizationStatus
-            let consentStatus = SubscriberAttribute(withKey: ReservedSubscriberAttribute.consentStatus.rawValue,
+            let consentStatus = SubscriberAttribute(attribute: ReservedSubscriberAttribute.consentStatus,
                                                     value: attributionStatus.description,
                                                     dateProvider: self.backendConfig.dateProvider)
             subscriberAttributesToPost?[ReservedSubscriberAttribute.consentStatus.key] = consentStatus
         }
-
-
 
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
                                                                 appUserID: appUserID)

--- a/Sources/Networking/CustomerAPI.swift
+++ b/Sources/Networking/CustomerAPI.swift
@@ -99,7 +99,7 @@ final class CustomerAPI {
             let consentStatus = SubscriberAttribute(attribute: ReservedSubscriberAttribute.consentStatus,
                                                     value: attributionStatus.description,
                                                     dateProvider: self.backendConfig.dateProvider)
-            subscriberAttributesToPost?[ReservedSubscriberAttribute.consentStatus.key] = consentStatus
+            subscriberAttributesToPost?[consentStatus.key] = consentStatus
         }
 
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,

--- a/Sources/SubscriberAttributes/SubscriberAttribute.swift
+++ b/Sources/SubscriberAttributes/SubscriberAttribute.swift
@@ -32,6 +32,10 @@ struct SubscriberAttribute {
         self.init(withKey: key, value: value, isSynced: false, setTime: dateProvider.now())
     }
 
+    init(attribute: ReservedSubscriberAttribute, value: String?, dateProvider: DateProvider = DateProvider()) {
+        self.init(withKey: attribute.rawValue, value: value, dateProvider: dateProvider)
+    }
+
 }
 
 extension SubscriberAttribute {

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -37,7 +37,8 @@ class MockBackend: Backend {
         let backendConfig = BackendConfiguration(httpClient: httpClient,
                                                  operationDispatcher: MockOperationDispatcher(),
                                                  operationQueue: QueueProvider.createBackendQueue(),
-                                                 dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
+                                                 dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate),
+                                                 systemInfo: systemInfo)
         let identity = MockIdentityAPI(backendConfig: backendConfig)
         let offerings = MockOfferingsAPI(backendConfig: backendConfig)
         let offlineEntitlements = MockOfflineEntitlementsAPI(backendConfig: backendConfig)

--- a/Tests/UnitTests/Mocks/MockIdentityAPI.swift
+++ b/Tests/UnitTests/Mocks/MockIdentityAPI.swift
@@ -27,7 +27,8 @@ class MockIdentityAPI: IdentityAPI {
         let backendConfig = BackendConfiguration(httpClient: httpClient,
                                                  operationDispatcher: MockOperationDispatcher(),
                                                  operationQueue: Backend.QueueProvider.createBackendQueue(),
-                                                 dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
+                                                 dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate),
+                                                 systemInfo: systemInfo)
         self.init(backendConfig: backendConfig)
     }
 

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -48,7 +48,8 @@ class BaseBackendTests: TestCase {
         let backendConfig = BackendConfiguration(httpClient: self.httpClient,
                                                  operationDispatcher: operationDispatcher,
                                                  operationQueue: MockBackend.QueueProvider.createBackendQueue(),
-                                                 dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
+                                                 dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate),
+                                                 systemInfo: self.systemInfo)
 
         let customer = CustomerAPI(backendConfig: backendConfig, attributionFetcher: attributionFetcher)
         self.identity = IdentityAPI(backendConfig: backendConfig)

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -38,7 +38,8 @@ class BaseBackendTests: TestCase {
         self.systemInfo = try SystemInfo(
             platformInfo: nil,
             finishTransactions: true,
-            responseVerificationMode: self.responseVerificationMode
+            responseVerificationMode: self.responseVerificationMode,
+            dangerousSettings: self.dangerousSettings
         )
         self.httpClient = self.createClient()
         self.operationDispatcher = MockOperationDispatcher()
@@ -67,6 +68,10 @@ class BaseBackendTests: TestCase {
 
     var verificationMode: Configuration.EntitlementVerificationMode {
         return .disabled
+    }
+
+    var dangerousSettings: DangerousSettings {
+        return .init()
     }
 
     func createClient() -> MockHTTPClient {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testDoesNotPostConsentStatus.1.json
@@ -1,0 +1,16 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "initiation_source" : "queue",
+      "is_restore" : false,
+      "observer_mode" : false
+    },
+    "method" : "POST",
+    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testDoesNotPostConsentStatus.1.json
@@ -1,0 +1,16 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "initiation_source" : "queue",
+      "is_restore" : false,
+      "observer_mode" : false
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testDoesNotPostConsentStatus.1.json
@@ -1,0 +1,16 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "initiation_source" : "queue",
+      "is_restore" : false,
+      "observer_mode" : false
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testDoesNotPostConsentStatus.1.json
@@ -1,0 +1,16 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "initiation_source" : "queue",
+      "is_restore" : false,
+      "observer_mode" : false
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesNotPostConsentStatus.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testDoesNotPostConsentStatus.1.json
@@ -1,0 +1,16 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "initiation_source" : "queue",
+      "is_restore" : false,
+      "observer_mode" : false
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -55,7 +55,8 @@ class BasePurchasesTests: TestCase {
         let config = BackendConfiguration(httpClient: httpClient,
                                           operationDispatcher: self.mockOperationDispatcher,
                                           operationQueue: MockBackend.QueueProvider.createBackendQueue(),
-                                          dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
+                                          dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate),
+                                          systemInfo: self.systemInfo)
         self.backend = MockBackend(backendConfig: config, attributionFetcher: self.attributionFetcher)
         self.subscriberAttributesManager = MockSubscriberAttributesManager(
             backend: self.backend,

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -58,7 +58,8 @@ class BackendSubscriberAttributesTests: TestCase {
         let config = BackendConfiguration(httpClient: mockHTTPClient,
                                           operationDispatcher: MockOperationDispatcher(),
                                           operationQueue: MockBackend.QueueProvider.createBackendQueue(),
-                                          dateProvider: dateProvider)
+                                          dateProvider: dateProvider,
+                                          systemInfo: self.systemInfo)
 
         self.backend = Backend(backendConfig: config, attributionFetcher: attributionFetcher)
 


### PR DESCRIPTION
Removed automatic syncing of attConsentStatus when sending  a POST /receipt for customEntitlementsComputation