### PR TITLE
`customEntitlementsComputation`: new method to switch users

### DIFF
--- a/Examples/testCustomEntitlementsComputation/testCustomEntitlementsComputation/ContentView.swift
+++ b/Examples/testCustomEntitlementsComputation/testCustomEntitlementsComputation/ContentView.swift
@@ -133,10 +133,7 @@ struct ContentView: View {
     }
 
     func logIn(_ appUserID: String) {
-        print("Switching to user: \(appUserID)")
-        Task {
-            Purchases.shared.switchUser(newAppUserID: appUserID)
-        }
+        Purchases.shared.switchUser(to: appUserID)
     }
 
     func subscribeToCustomerInfoStream() {

--- a/Examples/testCustomEntitlementsComputation/testCustomEntitlementsComputation/ContentView.swift
+++ b/Examples/testCustomEntitlementsComputation/testCustomEntitlementsComputation/ContentView.swift
@@ -135,7 +135,7 @@ struct ContentView: View {
     func logIn(_ appUserID: String) {
         print("Switching to user: \(appUserID)")
         Task {
-            try await Purchases.shared.logIn(appUserID)
+            Purchases.shared.switchUser(newAppUserID: appUserID)
         }
     }
 

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -91,8 +91,9 @@ class IdentityManager: CurrentUserProvider {
         }
     }
 
-    func switchUser(newAppUserID: String) {
-        self.resetCacheAndSaveNewUserID(newUserID: newAppUserID)
+    func switchUser(to newAppUserID: String) {
+        Logger.debug(Strings.identity.switching_user(newUserId: newAppUserID))
+        self.resetCacheAndSave(newUserID: newAppUserID)
     }
 
     static func generateRandomID() -> String {
@@ -153,7 +154,7 @@ private extension IdentityManager {
             return
         }
 
-        self.resetCacheAndSaveNewUserID(newUserID: Self.generateRandomID())
+        self.resetCacheAndSave(newUserID: Self.generateRandomID())
         Logger.info(Strings.identity.log_out_success)
         completion(nil)
     }
@@ -167,8 +168,8 @@ extension IdentityManager: @unchecked Sendable {}
 
 private extension IdentityManager {
 
-    func resetCacheAndSaveNewUserID(newUserID: String) {
-        self.deviceCache.clearCaches(oldAppUserID: currentAppUserID, andSaveWithNewUserID: Self.generateRandomID())
+    func resetCacheAndSave(newUserID: String) {
+        self.deviceCache.clearCaches(oldAppUserID: currentAppUserID, andSaveWithNewUserID: newUserID)
         self.deviceCache.clearLatestNetworkAndAdvertisingIdsSent(appUserID: currentAppUserID)
         self.backend.clearHTTPClientCaches()
     }

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -149,7 +149,7 @@ private extension IdentityManager {
             return
         }
 
-        self.resetUserIDCache()
+        self.resetCacheAndSaveNewUserID(newUserID: Self.generateRandomID())
         Logger.info(Strings.identity.log_out_success)
         completion(nil)
     }
@@ -163,10 +163,9 @@ extension IdentityManager: @unchecked Sendable {}
 
 private extension IdentityManager {
 
-    func resetUserIDCache() {
-        self.deviceCache.clearCaches(oldAppUserID: self.currentAppUserID,
-                                     andSaveWithNewUserID: Self.generateRandomID())
-        self.deviceCache.clearLatestNetworkAndAdvertisingIdsSent(appUserID: self.currentAppUserID)
+    func resetCacheAndSaveNewUserID(newUserID: String) {
+        self.deviceCache.clearCaches(oldAppUserID: currentAppUserID, andSaveWithNewUserID: Self.generateRandomID())
+        self.deviceCache.clearLatestNetworkAndAdvertisingIdsSent(appUserID: currentAppUserID)
         self.backend.clearHTTPClientCaches()
     }
 

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -91,6 +91,10 @@ class IdentityManager: CurrentUserProvider {
         }
     }
 
+    func switchUser(newAppUserID: String) {
+        self.resetCacheAndSaveNewUserID(newUserID: newAppUserID)
+    }
+
     static func generateRandomID() -> String {
         "$RCAnonymousID:\(UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased())"
     }

--- a/Sources/Logging/Strings/ConfigureStrings.swift
+++ b/Sources/Logging/Strings/ConfigureStrings.swift
@@ -71,7 +71,7 @@ enum ConfigureStrings {
 
     case custom_entitlements_computation_enabled_but_no_app_user_id
 
-    case custom_entitlements_computation_only_feature(feature: String)
+    case custom_entitlements_computation_only_feature(String)
 
 }
 
@@ -166,12 +166,12 @@ extension ConfigureStrings: CustomStringConvertible {
             "getCustomerInfo is called or logIn is called."
 
         case .custom_entitlements_computation_enabled_but_no_app_user_id:
-            return "ERROR: customEntitlementComputation mode is enabled, but appUserID is nil. " +
+            return "customEntitlementComputation mode is enabled, but appUserID is nil. " +
             "When using customEntitlementComputation, you must set the appUserID to prevent anonymous IDs from " +
             "being generated."
 
         case let .custom_entitlements_computation_only_feature(feature):
-            return "ERROR: \(feature) is only available in customEntitlementComputation mode"
+            return "\(feature) is only available in customEntitlementComputation mode"
         }
     }
 

--- a/Sources/Logging/Strings/ConfigureStrings.swift
+++ b/Sources/Logging/Strings/ConfigureStrings.swift
@@ -71,6 +71,8 @@ enum ConfigureStrings {
 
     case custom_entitlements_computation_enabled_but_no_app_user_id
 
+    case custom_entitlements_computation_only_feature(feature: String)
+
 }
 
 extension ConfigureStrings: CustomStringConvertible {
@@ -167,6 +169,9 @@ extension ConfigureStrings: CustomStringConvertible {
             return "ERROR: customEntitlementComputation mode is enabled, but appUserID is nil. " +
             "When using customEntitlementComputation, you must set the appUserID to prevent anonymous IDs from " +
             "being generated."
+
+        case let .custom_entitlements_computation_only_feature(feature):
+            return "ERROR: \(feature) is only available in customEntitlementComputation mode"
         }
     }
 

--- a/Sources/Logging/Strings/IdentityStrings.swift
+++ b/Sources/Logging/Strings/IdentityStrings.swift
@@ -36,6 +36,8 @@ enum IdentityStrings {
 
     case invalidating_cached_customer_info
 
+    case switching_user(newUserId: String)
+
 }
 
 extension IdentityStrings: CustomStringConvertible {
@@ -66,6 +68,8 @@ extension IdentityStrings: CustomStringConvertible {
             return "Attempt to delete attributes for user, but there were none to delete"
         case .invalidating_cached_customer_info:
             return "Detected unverified cached CustomerInfo but verification is enabled. Invalidating cache."
+        case let .switching_user(newUserId):
+            return "Switching to user '\(newUserId)'."
         }
     }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -641,6 +641,20 @@ public extension Purchases {
         return try await logOutAsync()
     }
 
+    ///
+    /// Updates the current appUserID to a new one, without associating the two.
+    /// This method is **only available** in Custom Entitlements Computation mode.
+    /// Receipts posted by the SDK to the RevenueCat backend after calling this method will be sent
+    /// with the newAppUserID.
+    /// 
+    func switchUser(newAppUserID: String) {
+        guard self.systemInfo.dangerousSettings.customEntitlementComputation else {
+            return
+        }
+
+        self.identityManager.switchUser(newAppUserID: newAppUserID)
+    }
+
     @objc func getOfferings(completion: @escaping (Offerings?, PublicError?) -> Void) {
         self.getOfferings(fetchPolicy: .default, completion: completion)
     }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -650,7 +650,7 @@ public extension Purchases {
     @objc(switchUserTo:)
     func switchUser(to newAppUserID: String) {
         guard self.systemInfo.dangerousSettings.customEntitlementComputation else {
-            Logger.error(Strings.configure.custom_entitlements_computation_only_feature(feature: "Switch users"))
+            Logger.error(Strings.configure.custom_entitlements_computation_only_feature("Switch users"))
             return
         }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -643,16 +643,18 @@ public extension Purchases {
 
     ///
     /// Updates the current appUserID to a new one, without associating the two.
-    /// This method is **only available** in Custom Entitlements Computation mode.
+    /// - Important: This method is **only available** in Custom Entitlements Computation mode.
     /// Receipts posted by the SDK to the RevenueCat backend after calling this method will be sent
     /// with the newAppUserID.
-    /// 
-    func switchUser(newAppUserID: String) {
+    ///
+    @objc(switchUserTo:)
+    func switchUser(to newAppUserID: String) {
         guard self.systemInfo.dangerousSettings.customEntitlementComputation else {
+            Logger.error(Strings.configure.custom_entitlements_computation_only_feature(feature: "Switch users"))
             return
         }
 
-        self.identityManager.switchUser(newAppUserID: newAppUserID)
+        self.identityManager.switchUser(to: newAppUserID)
     }
 
     @objc func getOfferings(completion: @escaping (Offerings?, PublicError?) -> Void) {

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -647,7 +647,7 @@ public extension Purchases {
     /// Receipts posted by the SDK to the RevenueCat backend after calling this method will be sent
     /// with the newAppUserID.
     ///
-    @objc(switchUserTo:)
+    @objc(switchUserToNewAppUserID:)
     func switchUser(to newAppUserID: String) {
         guard self.systemInfo.dangerousSettings.customEntitlementComputation else {
             Logger.error(Strings.configure.custom_entitlements_computation_only_feature("Switch users"))

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -175,6 +175,7 @@ BOOL isAnonymous;
     [p purchasePackage:pack withPromotionalOffer:pro completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];
     
     [p logIn:@"" completion:^(RCCustomerInfo *i, BOOL created, NSError *e) { }];
+    [p switchUserTo:@""];
     [p logOutWithCompletion:^(RCCustomerInfo *i, NSError *e) { }];
 
     [p.delegate purchases:p receivedUpdatedCustomerInfo:pi];

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -175,7 +175,7 @@ BOOL isAnonymous;
     [p purchasePackage:pack withPromotionalOffer:pro completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];
     
     [p logIn:@"" completion:^(RCCustomerInfo *i, BOOL created, NSError *e) { }];
-    [p switchUserTo:@""];
+    [p switchUserToNewAppUserID:@""];
     [p logOutWithCompletion:^(RCCustomerInfo *i, NSError *e) { }];
 
     [p.delegate purchases:p receivedUpdatedCustomerInfo:pi];

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -157,6 +157,7 @@ private func checkPurchasesPurchasingAPI(purchases: Purchases) {
 private func checkIdentity(purchases: Purchases) {
     purchases.logOut { (_: CustomerInfo?, _: Error?) in }
     purchases.logIn("") { (_: CustomerInfo?, _: Bool, _: Error?) in }
+    purchases.switchUser(to: "")
 }
 
 private func checkPurchasesSupportAPI(purchases: Purchases) {

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -375,6 +375,21 @@ class IdentityManagerTests: TestCase {
 
         expect(self.mockDeviceCache.invokedCopySubscriberAttributes) == false
     }
+
+    // MARK: - Switch user
+
+    func testSwitchUserResetsAllCaches() {
+        let manager = self.create(appUserID: "old-test-user-id")
+
+        manager.switchUser(to: "test-user-id")
+
+        expect(self.mockDeviceCache.clearCachesCalledOldUserID) == "old-test-user-id"
+        expect(self.mockDeviceCache.clearCachesCalleNewUserID) == "test-user-id"
+        expect(self.mockDeviceCache.invokedClearLatestNetworkAndAdvertisingIdsSentCount) == 1
+        expect(self.mockDeviceCache
+            .invokedClearLatestNetworkAndAdvertisingIdsSentParameters?.appUserID) == "test-user-id"
+        expect(self.mockBackend.invokedClearHTTPClientCachesCount) == 1
+    }
 }
 
 private extension IdentityManagerTests {

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -182,14 +182,6 @@ class MockBackend: Backend {
         let appUserID: String?
     }
 
-    var invokedClearHTTPClientCaches = false
-    var invokedClearHTTPClientCachesCount = 0
-
-    override func clearHTTPClientCaches() {
-        self.invokedClearHTTPClientCaches = true
-        self.invokedClearHTTPClientCachesCount += 1
-    }
-
     var stubbedSignatureVerificationEnabled: Bool?
 
     override var signatureVerificationEnabled: Bool {

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -170,6 +170,13 @@ class MockBackend: Backend {
         }
     }
 
+    var invokedClearHTTPClientCaches = false
+    var invokedClearHTTPClientCachesCount = 0
+    override func clearHTTPClientCaches() {
+        self.invokedClearHTTPClientCaches = true
+        self.invokedClearHTTPClientCachesCount += 1
+    }
+
     struct InvokedPostSubscriberAttributesParams: Equatable {
         let subscriberAttributes: [String: SubscriberAttribute]?
         let appUserID: String?

--- a/Tests/UnitTests/Mocks/MockIdentityManager.swift
+++ b/Tests/UnitTests/Mocks/MockIdentityManager.swift
@@ -75,4 +75,13 @@ class MockIdentityManager: IdentityManager {
         completion(self.mockLogOutError)
     }
 
+    var invokedSwitchUser = false
+    var invokedSwitchUserCount = 0
+    var invokedSwitchUserParametersList: [String] = []
+    override func switchUser(to newAppUserID: String) {
+        self.invokedSwitchUser = true
+        self.invokedSwitchUserCount += 1
+        self.invokedSwitchUserParametersList.append(newAppUserID)
+    }
+
 }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -98,6 +98,29 @@ class PurchasesLogInTests: BasePurchasesTests {
         expect(self.identityManager.invokedLogOutCount) == 1
     }
 
+    // MARK: - Switch user
+
+    func testSwitchUserWontDoAnythingIfNotOnCustomEntitlementComputationMode() {
+        self.systemInfo = MockSystemInfo(finishTransactions: true, customEntitlementsComputation: false)
+        Purchases.clearSingleton()
+        self.initializePurchasesInstance(appUserId: "old-test-user-id")
+
+        self.purchases.switchUser(to: "test-user-id")
+
+        expect(self.identityManager.invokedSwitchUser) == false
+    }
+
+    func testSwitchUserWillSwitchUserIfOnCustomEntitlementComputationMode() {
+        self.systemInfo = MockSystemInfo(finishTransactions: true, customEntitlementsComputation: true)
+        Purchases.clearSingleton()
+        self.initializePurchasesInstance(appUserId: "old-test-user-id")
+
+        self.purchases.switchUser(to: "test-user-id")
+
+        expect(self.identityManager.invokedSwitchUser) == true
+        expect(self.identityManager.invokedSwitchUserParametersList) == ["test-user-id"]
+    }
+
     // MARK: - Update offerings cache
 
     func testLogInUpdatesOfferingsCache() throws {


### PR DESCRIPTION
Adds a new method to switch users without posting to the backend for Custom Entitlements Computation mode. 