### PR TITLE
Custom Entitlement Computation: disabled unnecessary APIs

### DIFF
--- a/Examples/testCustomEntitlementsComputation/testCustomEntitlementsComputation/ContentView.swift
+++ b/Examples/testCustomEntitlementsComputation/testCustomEntitlementsComputation/ContentView.swift
@@ -79,6 +79,7 @@ struct ContentView: View {
             .task {
                 Purchases.configureInCustomEntitlementsComputationMode(apiKey: Constants.apiKey,
                                                                        appUserID: appUserID)
+                subscribeToCustomerInfoStream()
                 do {
                     self.offerings = try await Purchases.shared.offerings()
                     print("offerings: \(String(describing: offerings))")
@@ -118,9 +119,6 @@ struct ContentView: View {
                                 .foregroundColor(.primary)
                         }
                     }
-                }
-                .task {
-                    subscribeToCustomerInfoStream()
                 }
             }
         }

--- a/Sources/Logging/Strings/ConfigureStrings.swift
+++ b/Sources/Logging/Strings/ConfigureStrings.swift
@@ -71,8 +71,6 @@ enum ConfigureStrings {
 
     case custom_entitlements_computation_enabled_but_no_app_user_id
 
-    case custom_entitlements_computation_only_feature(String)
-
 }
 
 extension ConfigureStrings: CustomStringConvertible {
@@ -169,9 +167,6 @@ extension ConfigureStrings: CustomStringConvertible {
             return "customEntitlementComputation mode is enabled, but appUserID is nil. " +
             "When using customEntitlementComputation, you must set the appUserID to prevent anonymous IDs from " +
             "being generated."
-
-        case let .custom_entitlements_computation_only_feature(feature):
-            return "\(feature) is only available in customEntitlementComputation mode"
         }
     }
 

--- a/Sources/Misc/Concurrency/Purchases+async.swift
+++ b/Sources/Misc/Concurrency/Purchases+async.swift
@@ -17,6 +17,8 @@ import Foundation
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 extension Purchases {
 
+    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+
     func logInAsync(_ appUserID: String) async throws -> (customerInfo: CustomerInfo, created: Bool) {
         return try await withCheckedThrowingContinuation { continuation in
             logIn(appUserID) { customerInfo, created, error in
@@ -34,18 +36,12 @@ extension Purchases {
         }
     }
 
+    #endif
+
     func offeringsAsync(fetchPolicy: OfferingsManager.FetchPolicy) async throws -> Offerings {
         return try await withCheckedThrowingContinuation { continuation in
             self.getOfferings(fetchPolicy: fetchPolicy) { offerings, error in
                 continuation.resume(with: Result(offerings, error))
-            }
-        }
-    }
-
-    func customerInfoAsync(fetchPolicy: CacheFetchPolicy) async throws -> CustomerInfo {
-        return try await withCheckedThrowingContinuation { continuation in
-            getCustomerInfo(fetchPolicy: fetchPolicy) { customerInfo, error in
-                continuation.resume(with: Result(customerInfo, error))
             }
         }
     }
@@ -92,6 +88,16 @@ extension Purchases {
                      promotionalOffer: promotionalOffer) { transaction, customerInfo, error, userCancelled in
                 continuation.resume(with: Result(customerInfo, error)
                                         .map { PurchaseResultData(transaction, $0, userCancelled) })
+            }
+        }
+    }
+
+    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+
+    func customerInfoAsync(fetchPolicy: CacheFetchPolicy) async throws -> CustomerInfo {
+        return try await withCheckedThrowingContinuation { continuation in
+            getCustomerInfo(fetchPolicy: fetchPolicy) { customerInfo, error in
+                continuation.resume(with: Result(customerInfo, error))
             }
         }
     }
@@ -175,6 +181,8 @@ extension Purchases {
             return result
         }
     }
+
+    #endif
 
 #if os(iOS) || os(macOS)
 

--- a/Sources/Misc/Concurrency/Purchases+async.swift
+++ b/Sources/Misc/Concurrency/Purchases+async.swift
@@ -72,6 +72,8 @@ extension Purchases {
         }
     }
 
+    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+
     func purchaseAsync(product: StoreProduct, promotionalOffer: PromotionalOffer) async throws -> PurchaseResultData {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(product: product,
@@ -91,8 +93,6 @@ extension Purchases {
             }
         }
     }
-
-    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
     func customerInfoAsync(fetchPolicy: CacheFetchPolicy) async throws -> CustomerInfo {
         return try await withCheckedThrowingContinuation { continuation in

--- a/Sources/Misc/Deprecations.swift
+++ b/Sources/Misc/Deprecations.swift
@@ -16,6 +16,8 @@ import StoreKit
 
 // swiftlint:disable line_length missing_docs file_length
 
+#if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+
 public extension Purchases {
 
     @available(iOS, deprecated: 1, renamed: "checkTrialOrIntroDiscountEligibility(productIdentifiers:)")
@@ -345,6 +347,8 @@ public extension StoreProduct {
     }
 
 }
+
+#endif
 
 extension CustomerInfo {
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -769,6 +769,8 @@ public extension Purchases {
         return try await purchaseAsync(package: package)
     }
 
+    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+
     @available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvOS 12.2, *)
     @objc(purchaseProduct:withPromotionalOffer:completion:)
     func purchase(product: StoreProduct,
@@ -798,8 +800,6 @@ public extension Purchases {
     func purchase(package: Package, promotionalOffer: PromotionalOffer) async throws -> PurchaseResultData {
         return try await purchaseAsync(package: package, promotionalOffer: promotionalOffer)
     }
-
-    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
     @objc func syncPurchases(completion: ((CustomerInfo?, PublicError?) -> Void)?) {
         self.purchasesOrchestrator.syncPurchases { @Sendable in

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -340,6 +340,8 @@ public protocol PurchasesType: AnyObject {
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func purchase(package: Package) async throws -> PurchaseResultData
 
+    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+
     /**
      * Initiates a purchase of a ``StoreProduct`` with a ``PromotionalOffer``.
      *
@@ -440,8 +442,6 @@ public protocol PurchasesType: AnyObject {
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func purchase(package: Package, promotionalOffer: PromotionalOffer) async throws -> PurchaseResultData
-
-    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
     /**
      * This method will post all purchases associated with the current App Store account to RevenueCat and become

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -46,6 +46,8 @@ public protocol PurchasesType: AnyObject {
      */
     var delegate: PurchasesDelegate? { get set }
 
+    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+
     /**
      * This function will log in the current user with an ``appUserID``.
      *
@@ -165,6 +167,8 @@ public protocol PurchasesType: AnyObject {
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func customerInfo(fetchPolicy: CacheFetchPolicy) async throws -> CustomerInfo
+
+    #endif
 
     /**
      * Fetch the configured ``Offerings`` for this user.
@@ -437,6 +441,8 @@ public protocol PurchasesType: AnyObject {
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func purchase(package: Package, promotionalOffer: PromotionalOffer) async throws -> PurchaseResultData
 
+    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+
     /**
      * This method will post all purchases associated with the current App Store account to RevenueCat and become
      * associated with the current ``appUserID``. If the receipt is being used by an existing user, the current
@@ -655,6 +661,8 @@ public protocol PurchasesType: AnyObject {
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func eligiblePromotionalOffers(forProduct product: StoreProduct) async -> [PromotionalOffer]
 
+    #endif
+
     /**
      * Invalidates the cache for customer information.
      *
@@ -804,6 +812,8 @@ public protocol PurchasesType: AnyObject {
 
     #endif
 
+    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+
     /**
      * ``Attribution`` object that is responsible for all explicit attribution APIs
      * as well as subscriber attributes that RevenueCat offers.
@@ -870,6 +880,8 @@ public protocol PurchasesType: AnyObject {
     func collectDeviceIdentifiers()
 
     // swiftlint:enable missing_docs
+
+    #endif
 
 }
 

--- a/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -228,6 +228,7 @@ public extension StoreProduct {
 
 }
 
+#if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 public extension StoreProduct {
     /// Finds the subset of ``discounts`` that's eligible for the current user.
@@ -240,6 +241,7 @@ public extension StoreProduct {
         return await Purchases.shared.eligiblePromotionalOffers(forProduct: self)
     }
 }
+#endif
 
 // MARK: - Wrapper constructors / getters
 

--- a/Sources/Support/PurchasesDiagnostics.swift
+++ b/Sources/Support/PurchasesDiagnostics.swift
@@ -79,7 +79,9 @@ extension PurchasesDiagnostics {
     public func testSDKHealth() async throws {
         do {
             try await self.unauthenticatedRequest()
+            #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
             try await self.authenticatedRequest()
+            #endif
             try await self.offeringsRequest()
             try await self.signatureVerification()
         } catch let error as Error {
@@ -106,6 +108,7 @@ private extension PurchasesDiagnostics {
         }
     }
 
+    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
     func authenticatedRequest() async throws {
         do {
             _ = try await self.purchases.customerInfo()
@@ -115,6 +118,7 @@ private extension PurchasesDiagnostics {
             throw Error.unknown(error)
         }
     }
+    #endif
 
     func offeringsRequest() async throws {
         do {

--- a/Tests/InstallationTests/SPMCustomEntitlementComputationInstallation/InstallationTests.swift
+++ b/Tests/InstallationTests/SPMCustomEntitlementComputationInstallation/InstallationTests.swift
@@ -25,10 +25,6 @@ class InstallationTests: XCTestCase {
                                                                appUserID: "Integration Tests")
     }
 
-    func testCanFetchCustomerInfo() async throws {
-        _ = try await Purchases.shared.customerInfo()
-    }
-
     func testCanSwitchUser() throws {
         let userID = "new_user_ID"
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -102,17 +102,7 @@ class PurchasesLogInTests: BasePurchasesTests {
 
     #if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
-    func testSwitchUserWontDoAnythingIfNotOnCustomEntitlementComputationMode() {
-        self.systemInfo = MockSystemInfo(finishTransactions: true, customEntitlementsComputation: false)
-        Purchases.clearSingleton()
-        self.initializePurchasesInstance(appUserId: "old-test-user-id")
-
-        self.purchases.switchUser(to: "test-user-id")
-
-        expect(self.identityManager.invokedSwitchUser) == false
-    }
-
-    func testSwitchUserWillSwitchUserIfOnCustomEntitlementComputationMode() {
+    func testSwitchUser() {
         self.systemInfo = MockSystemInfo(finishTransactions: true, customEntitlementsComputation: true)
         Purchases.clearSingleton()
         self.initializePurchasesInstance(appUserId: "old-test-user-id")


### PR DESCRIPTION
## Disabled API:

- `getCustomerInfo`
- `logIn`
- `logOut`
- `Purchases.attribution`
- `syncPurchases`
- `restorePurchases`
- Trial eligibility
- Promotional purchases
- `async` counterparts