### PR TITLE
Hide promotional offers APIs in custom entitlements computation package

### DIFF
--- a/Sources/Misc/Concurrency/Purchases+async.swift
+++ b/Sources/Misc/Concurrency/Purchases+async.swift
@@ -72,6 +72,8 @@ extension Purchases {
         }
     }
 
+    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+
     func purchaseAsync(product: StoreProduct, promotionalOffer: PromotionalOffer) async throws -> PurchaseResultData {
         return try await withCheckedThrowingContinuation { continuation in
             purchase(product: product,
@@ -91,8 +93,6 @@ extension Purchases {
             }
         }
     }
-
-    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
     func customerInfoAsync(fetchPolicy: CacheFetchPolicy) async throws -> CustomerInfo {
         return try await withCheckedThrowingContinuation { continuation in

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -769,6 +769,8 @@ public extension Purchases {
         return try await purchaseAsync(package: package)
     }
 
+    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+
     @available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvOS 12.2, *)
     @objc(purchaseProduct:withPromotionalOffer:completion:)
     func purchase(product: StoreProduct,
@@ -798,8 +800,6 @@ public extension Purchases {
     func purchase(package: Package, promotionalOffer: PromotionalOffer) async throws -> PurchaseResultData {
         return try await purchaseAsync(package: package, promotionalOffer: promotionalOffer)
     }
-
-    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
     @objc func syncPurchases(completion: ((CustomerInfo?, PublicError?) -> Void)?) {
         self.purchasesOrchestrator.syncPurchases { @Sendable in

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -340,6 +340,8 @@ public protocol PurchasesType: AnyObject {
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func purchase(package: Package) async throws -> PurchaseResultData
 
+    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+
     /**
      * Initiates a purchase of a ``StoreProduct`` with a ``PromotionalOffer``.
      *
@@ -440,8 +442,6 @@ public protocol PurchasesType: AnyObject {
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func purchase(package: Package, promotionalOffer: PromotionalOffer) async throws -> PurchaseResultData
-
-    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
     /**
      * This method will post all purchases associated with the current App Store account to RevenueCat and become


### PR DESCRIPTION
### Description
This will remove the `promotionaOffer` purchase methods from the API in the custom entitlement computation package

