### PR TITLE
Custom Entitlement Computation: avoid `getCustomerInfo` requests for cancelled purchases

### DIFF
--- a/Examples/testCustomEntitlementsComputation/testCustomEntitlementsComputation/ContentView.swift
+++ b/Examples/testCustomEntitlementsComputation/testCustomEntitlementsComputation/ContentView.swift
@@ -154,9 +154,16 @@ struct ContentView: View {
         }
 
         do {
-            let (transaction, customerInfo, userCancelled) = try await Purchases.shared.purchase(package: package)
-            print("Purchase finished. Result: \nUser Cancelled: \(userCancelled)\n" +
-                  "transaction: \(transaction.debugDescription), customerInfo: \(customerInfo.debugDescription)")
+            let (transaction, customerInfo, _) = try await Purchases.shared.purchase(package: package)
+            print(
+                """
+                Purchase finished:
+                Transaction: \(transaction.debugDescription)
+                CustomerInfo: \(customerInfo.debugDescription)
+                """
+            )
+        } catch ErrorCode.purchaseCancelledError {
+            print("Purchase was cancelled")
         } catch {
             print("FAILED TO PURCHASE: \(error.localizedDescription)")
         }

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -413,9 +413,11 @@ final class PurchasesOrchestrator {
                     productIdentifier: product.id,
                     error: error
                 ))
+                let publicError = ErrorUtils.purchasesError(withUntypedError: error).asPublicError
+                let userCancelled = publicError.isCancelledError
 
                 DispatchQueue.main.async {
-                    completion(nil, nil, ErrorUtils.purchasesError(withUntypedError: error).asPublicError, false)
+                    completion(nil, nil, publicError, userCancelled)
                 }
             }
         }
@@ -449,6 +451,10 @@ final class PurchasesOrchestrator {
                     return try await sk2Product.purchase(options: options)
                 }
         } catch StoreKitError.userCancelled {
+            guard !self.systemInfo.dangerousSettings.customEntitlementComputation else {
+                throw ErrorUtils.purchaseCancelledError()
+            }
+
             return (
                 transaction: nil,
                 customerInfo: try await self.customerInfoManager.customerInfo(appUserID: self.appUserID,
@@ -466,6 +472,11 @@ final class PurchasesOrchestrator {
         // This detects if `Product.PurchaseResult.userCancelled` is true.
         let (userCancelled, sk2Transaction) = try await self.storeKit2TransactionListener
             .handle(purchaseResult: result)
+
+        if userCancelled, self.systemInfo.dangerousSettings.customEntitlementComputation {
+            throw ErrorUtils.purchaseCancelledError()
+        }
+
         let transaction = sk2Transaction.map(StoreTransaction.init(sk2Transaction:))
         let customerInfo: CustomerInfo
 
@@ -746,13 +757,22 @@ private extension PurchasesOrchestrator {
             let isCancelled = purchasesError.isCancelledError
 
             if isCancelled {
-                self.customerInfoManager.customerInfo(appUserID: self.appUserID,
-                                                      fetchPolicy: .cachedOrFetched) { @Sendable customerInfo in
+                if self.systemInfo.dangerousSettings.customEntitlementComputation {
                     self.operationDispatcher.dispatchOnMainActor {
                         completion(storeTransaction,
-                                   customerInfo.value,
+                                   nil,
                                    purchasesError.asPublicError,
                                    true)
+                    }
+                } else {
+                    self.customerInfoManager.customerInfo(appUserID: self.appUserID,
+                                                          fetchPolicy: .cachedOrFetched) { @Sendable customerInfo in
+                        self.operationDispatcher.dispatchOnMainActor {
+                            completion(storeTransaction,
+                                       customerInfo.value,
+                                       purchasesError.asPublicError,
+                                       true)
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
Fixes SDK-3088
Supersedes #2447

Thanks to @tonidero for doing most of this.

Note that it's currently impossible to test this for SK2, so we only have SK1 tests (we have a Radar for that).

The next step will be to deprecate the current API to remove the `userCancelled` property and make this the new behavior.
See also #1910 for an explanation of the different return values of the purchase APIs.
