### PR TITLE
Custom Entitlement Computation: mark `PurchaseResultData.userCancelled` as `unavailable`

### DIFF
--- a/Examples/testCustomEntitlementsComputation/testCustomEntitlementsComputation/ContentView.swift
+++ b/Examples/testCustomEntitlementsComputation/testCustomEntitlementsComputation/ContentView.swift
@@ -152,12 +152,12 @@ struct ContentView: View {
         }
 
         do {
-            let (transaction, customerInfo, _) = try await Purchases.shared.purchase(package: package)
+            let result = try await Purchases.shared.purchase(package: package)
             print(
                 """
                 Purchase finished:
-                Transaction: \(transaction.debugDescription)
-                CustomerInfo: \(customerInfo.debugDescription)
+                Transaction: \(result.transaction.debugDescription)
+                CustomerInfo: \(result.customerInfo.debugDescription)
                 """
             )
         } catch ErrorCode.purchaseCancelledError {

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 		57057FF928B0048900995F21 /* TestLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57057FF728B0048900995F21 /* TestLogHandler.swift */; };
 		57069A5428E3918400B86355 /* AsyncExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57069A5328E3918400B86355 /* AsyncExtensions.swift */; };
 		57069A5E28E398E100B86355 /* AsyncExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57069A5D28E398E100B86355 /* AsyncExtensionsTests.swift */; };
+		570EC37C29F994E50036A023 /* PurchaseResultData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570EC37B29F994E50036A023 /* PurchaseResultData.swift */; };
 		570FAF4B2864EC2300D3C769 /* NonSubscriptionTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570FAF4A2864EC2300D3C769 /* NonSubscriptionTransaction.swift */; };
 		5712BE9029241EB500A83F15 /* TimingUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5712BE8F29241EB500A83F15 /* TimingUtil.swift */; };
 		5712BE9229241F7900A83F15 /* TimingUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5712BE9129241F7900A83F15 /* TimingUtilTests.swift */; };
@@ -870,6 +871,7 @@
 		570896B527595C8100296F1C /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = UnitTests.xctestplan; path = Tests/TestPlans/UnitTests.xctestplan; sourceTree = "<group>"; };
 		570896B727596E8800296F1C /* SwiftAPITester.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SwiftAPITester.xcodeproj; path = Tests/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj; sourceTree = "<group>"; };
 		570896BD27596E8800296F1C /* ObjCAPITester.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ObjCAPITester.xcodeproj; path = Tests/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj; sourceTree = "<group>"; };
+		570EC37B29F994E50036A023 /* PurchaseResultData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseResultData.swift; sourceTree = "<group>"; };
 		570FAF4A2864EC2300D3C769 /* NonSubscriptionTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonSubscriptionTransaction.swift; sourceTree = "<group>"; };
 		5712BE8F29241EB500A83F15 /* TimingUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingUtil.swift; sourceTree = "<group>"; };
 		5712BE9129241F7900A83F15 /* TimingUtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingUtilTests.swift; sourceTree = "<group>"; };
@@ -2338,6 +2340,7 @@
 				B35042C326CDB79A00905B95 /* Purchases.swift */,
 				B35042C526CDD3B100905B95 /* PurchasesDelegate.swift */,
 				2D9F4A5426C30CA800B07B43 /* PurchasesOrchestrator.swift */,
+				570EC37B29F994E50036A023 /* PurchaseResultData.swift */,
 			);
 			path = Purchases;
 			sourceTree = "<group>";
@@ -3013,6 +3016,7 @@
 				579415D2293689DD00218FBC /* Codable+Extensions.swift in Sources */,
 				2DDF41B424F6F387005BC22D /* ASN1ContainerBuilder.swift in Sources */,
 				57F3C10529B7B22E0004FD7E /* CustomerInfo+ActiveDates.swift in Sources */,
+				570EC37C29F994E50036A023 /* PurchaseResultData.swift in Sources */,
 				B35F9E0926B4BEED00095C3F /* String+Extensions.swift in Sources */,
 				574A2EE7282C3F0800150D40 /* AnyDecodable.swift in Sources */,
 				57488B7F29CB70E50000EE7E /* ProductEntitlementMapping.swift in Sources */,

--- a/Sources/Purchasing/Purchases/PurchaseResultData.swift
+++ b/Sources/Purchasing/Purchases/PurchaseResultData.swift
@@ -1,0 +1,61 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PurchaseResultData.swift
+//
+//  Created by Nacho Soto on 4/26/23.
+
+import Foundation
+
+/// Result for ``Purchases/purchase(product:)``.
+/// Counterpart of `PurchaseCompletedBlock` for `async` APIs.
+public struct PurchaseResultData {
+
+    /// The transaction from this purchase.
+    public let transaction: StoreTransaction?
+    /// The ``CustomerInfo`` with updated entitlements after a purchase.
+    public let customerInfo: CustomerInfo
+
+    // swiftlint:disable:next identifier_name
+    internal let _userCancelled: Bool
+
+    // swiftlint:disable:next missing_docs
+    public init(transaction: StoreTransaction?, customerInfo: CustomerInfo, userCancelled: Bool) {
+        self.init(transaction, customerInfo, userCancelled)
+    }
+
+}
+
+extension PurchaseResultData {
+
+    internal init(_ transaction: StoreTransaction?, _ customerInfo: CustomerInfo, _ userCancelled: Bool) {
+        self.transaction = transaction
+        self.customerInfo = customerInfo
+        self._userCancelled = userCancelled
+    }
+
+}
+
+public extension PurchaseResultData {
+
+    #if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+    @available(
+        *, unavailable,
+        message: "To detect cancellations, you need to catch `ErrorCode.purchaseCancelledError instead"
+    )
+    // swiftlint:disable:next missing_docs
+    var userCancelled: Bool { self._userCancelled }
+    #else
+    /// Whether the user cancelled the purchase.
+    var userCancelled: Bool { self._userCancelled }
+    #endif
+
+}
+
+extension PurchaseResultData: Sendable {}

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -23,14 +23,6 @@ import StoreKit
 // MARK: Block definitions
 
 /**
- Result for ``Purchases/purchase(product:)``.
- Counterpart of `PurchaseCompletedBlock` for `async` APIs.
- */
-public typealias PurchaseResultData = (transaction: StoreTransaction?,
-                                       customerInfo: CustomerInfo,
-                                       userCancelled: Bool)
-
-/**
  Completion block for ``Purchases/purchase(product:completion:)``
  */
 public typealias PurchaseCompletedBlock = @MainActor @Sendable (StoreTransaction?,

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -395,7 +395,7 @@ final class PurchasesOrchestrator {
                                                                          package: package,
                                                                          promotionalOffer: promotionalOffer)
 
-                if !result.userCancelled {
+                if !result._userCancelled {
                     Logger.rcPurchaseSuccess(Strings.purchase.purchased_product(
                         productIdentifier: product.id
                     ))
@@ -405,8 +405,8 @@ final class PurchasesOrchestrator {
                     completion(result.transaction,
                                result.customerInfo,
                                // Forward an error if purchase was cancelled to match SK1 behavior.
-                               result.userCancelled ? ErrorUtils.purchaseCancelledError().asPublicError : nil,
-                               result.userCancelled)
+                               result._userCancelled ? ErrorUtils.purchaseCancelledError().asPublicError : nil,
+                               result._userCancelled)
                 }
             } catch let error {
                 Logger.rcPurchaseError(Strings.purchase.product_purchase_failed(
@@ -455,7 +455,7 @@ final class PurchasesOrchestrator {
                 throw ErrorUtils.purchaseCancelledError()
             }
 
-            return (
+            return .init(
                 transaction: nil,
                 customerInfo: try await self.customerInfoManager.customerInfo(appUserID: self.appUserID,
                                                                               fetchPolicy: .cachedOrFetched),
@@ -489,7 +489,7 @@ final class PurchasesOrchestrator {
                                                                            fetchPolicy: .cachedOrFetched)
         }
 
-        return (transaction, customerInfo, userCancelled)
+        return .init(transaction, customerInfo, userCancelled)
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -266,35 +266,10 @@ public protocol PurchasesType: AnyObject {
      * If the purchase was successful there will be a ``StoreTransaction`` and a ``CustomerInfo``.
      *
      * If the purchase was not successful, there will be an `NSError`.
-     *
      * If the user cancelled, `userCancelled` will be `true`.
      */
     @objc(purchaseProduct:withCompletion:)
     func purchase(product: StoreProduct, completion: @escaping PurchaseCompletedBlock)
-
-    /**
-     * Initiates a purchase of a ``StoreProduct``.
-     *
-     * Use this function if you are not using the ``Offerings`` system to purchase a ``StoreProduct``.
-     * If you are using the ``Offerings`` system, use ``Purchases/purchase(package:completion:)`` instead.
-     *
-     * - Important: Call this method when a user has decided to purchase a product.
-     * Only call this in direct response to user input.
-     *
-     * From here ``Purchases`` will handle the purchase with `StoreKit` and return ``PurchaseResultData``.
-     *
-     * - Note: You do not need to finish the transaction yourself after this, ``Purchases`` will
-     * handle this for you.
-     *
-     * - Parameter product: The ``StoreProduct`` the user intends to purchase.
-     *
-     * - Throws: An error of type ``ErrorCode`` is thrown if a failure occurs while purchasing
-     *
-     * - Returns: A tuple with ``StoreTransaction`` and a ``CustomerInfo`` if the purchase was successful.
-     * If the user cancelled the purchase, `userCancelled` will be `true`.
-     */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func purchase(product: StoreProduct) async throws -> PurchaseResultData
 
     /**
      * Initiates a purchase of a ``Package``.
@@ -311,34 +286,11 @@ public protocol PurchasesType: AnyObject {
      * - Parameter completion: A completion block that is called when the purchase completes.
      *
      * If the purchase was successful there will be a ``StoreTransaction`` and a ``CustomerInfo``.
-     *
      * If the purchase was not successful, there will be an `NSError`.
-     *
      * If the user cancelled, `userCancelled` will be `true`.
      */
     @objc(purchasePackage:withCompletion:)
     func purchase(package: Package, completion: @escaping PurchaseCompletedBlock)
-
-    /**
-     * Initiates a purchase of a ``Package``.
-     *
-     * - Important: Call this method when a user has decided to purchase a product.
-     * Only call this in direct response to user input.
-     *
-     * From here ``Purchases`` will handle the purchase with `StoreKit` and return ``PurchaseResultData``.
-     *
-     * - Note: You do not need to finish the transaction yourself after this, Purchases will
-     * handle this for you.
-     *
-     * - Parameter package: The ``Package`` the user intends to purchase
-     *
-     * - Throws: An error of type ``ErrorCode`` is thrown if a failure occurs while purchasing
-     *
-     * - Returns: A tuple with ``StoreTransaction`` and a ``CustomerInfo`` if the purchase was successful.
-     * If the user cancelled the purchase, `userCancelled` will be `true`.
-     */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func purchase(package: Package) async throws -> PurchaseResultData
 
     /**
      * This method will post all purchases associated with the current App Store account to RevenueCat and become
@@ -449,30 +401,6 @@ public protocol PurchasesType: AnyObject {
                   completion: @escaping PurchaseCompletedBlock)
 
     /**
-     * Use this function if you are not using the Offerings system to purchase a ``StoreProduct`` with an
-     * applied ``PromotionalOffer``.
-     * If you are using the Offerings system, use ``Purchases/purchase(package:promotionalOffer:completion:)`` instead.
-     *
-     * Call this method when a user has decided to purchase a product with an applied discount.
-     * Only call this in direct response to user input.
-     *
-     * From here ``Purchases`` will handle the purchase with `StoreKit` and return ``PurchaseResultData``.
-     *
-     * - Note: You do not need to finish the transaction yourself after this, Purchases will handle
-     * this for you.
-     *
-     * - Parameter product: The ``StoreProduct`` the user intends to purchase
-     * - Parameter promotionalOffer: The ``PromotionalOffer`` to apply to the purchase
-     *
-     * - Throws: An error of type ``ErrorCode`` is thrown if a failure occurs while purchasing
-     *
-     * - Returns: A tuple with ``StoreTransaction`` and a ``CustomerInfo`` if the purchase was successful.
-     * If the user cancelled the purchase, `userCancelled` will be `true`.
-     */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func purchase(product: StoreProduct, promotionalOffer: PromotionalOffer) async throws -> PurchaseResultData
-
-    /**
      * Purchase the passed ``Package``.
      * Call this method when a user has decided to purchase a product with an applied discount. Only call this in
      * direct response to user input. From here ``Purchases`` will handle the purchase with `StoreKit` and call the
@@ -494,27 +422,6 @@ public protocol PurchasesType: AnyObject {
     func purchase(package: Package,
                   promotionalOffer: PromotionalOffer,
                   completion: @escaping PurchaseCompletedBlock)
-
-    /**
-     * Purchase the passed ``Package``.
-     * Call this method when a user has decided to purchase a product with an applied discount. Only call this in
-     * direct response to user input. From here ``Purchases`` will handle the purchase with `StoreKit` and return
-     * ``PurchaseResultData``.
-     *
-     * - Note: You do not need to finish the transaction yourself after this, Purchases will handle
-     * this for you.
-     *
-     * - Parameter package: The ``Package`` the user intends to purchase
-     * - Parameter promotionalOffer: The ``PromotionalOffer`` to apply to the purchase
-     *
-     * - Throws: An error of type ``ErrorCode`` is thrown if a failure occurs while purchasing
-     *
-     * - Returns: A tuple with ``StoreTransaction`` and a ``CustomerInfo`` if the purchase was successful.
-     * If the user cancelled the purchase, `userCancelled` will be `true`.
-     */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func purchase(package: Package, promotionalOffer: PromotionalOffer) async throws -> PurchaseResultData
-
     /**
      * Computes whether or not a user is eligible for the introductory pricing period of a given product.
      * You should use this method to determine whether or not you show the user the normal product price or
@@ -619,9 +526,11 @@ public protocol PurchasesType: AnyObject {
     func checkTrialOrIntroDiscountEligibility(product: StoreProduct) async -> IntroEligibilityStatus
 
     /**
-     * Use this method to fetch ``PromotionalOffer``
-     *  to use in ``purchase(package:promotionalOffer:)`` or ``purchase(product:promotionalOffer:)``.
+     * Use this method to fetch ``PromotionalOffer`` to use in ``purchase(package:promotionalOffer:completion:)``
+     * or ``purchase(product:promotionalOffer:completion:)``.
+     *
      * [iOS Promotional Offers](https://docs.revenuecat.com/docs/ios-subscription-offers#promotional-offers).
+     * 
      * - Note: If you're looking to use free trials or Introductory Offers instead,
      * use ``Purchases/checkTrialOrIntroDiscountEligibility(productIdentifiers:completion:)``.
      *
@@ -908,6 +817,91 @@ public protocol PurchasesSwiftType: AnyObject {
     /// - Important: this method is not thread-safe.
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     var customerInfoStream: AsyncStream<CustomerInfo> { get }
+
+    /**
+     * Initiates a purchase of a ``StoreProduct``.
+     *
+     * Use this function if you are not using the ``Offerings`` system to purchase a ``StoreProduct``.
+     * If you are using the ``Offerings`` system, use ``Purchases/purchase(package:completion:)`` instead.
+     *
+     * - Important: Call this method when a user has decided to purchase a product.
+     * Only call this in direct response to user input.
+     *
+     * From here ``Purchases`` will handle the purchase with `StoreKit` and return ``PurchaseResultData``.
+     *
+     * - Note: You do not need to finish the transaction yourself after this, ``Purchases`` will
+     * handle this for you.
+     *
+     * - Parameter product: The ``StoreProduct`` the user intends to purchase.
+     *
+     * - Throws: An error of type ``ErrorCode`` is thrown if a failure occurs while purchasing
+     * - Returns: A tuple with ``StoreTransaction`` and a ``CustomerInfo`` if the purchase was successful.
+     */
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func purchase(product: StoreProduct) async throws -> PurchaseResultData
+
+    /**
+     * Initiates a purchase of a ``Package``.
+     *
+     * - Important: Call this method when a user has decided to purchase a product.
+     * Only call this in direct response to user input.
+     *
+     * From here ``Purchases`` will handle the purchase with `StoreKit` and return ``PurchaseResultData``.
+     *
+     * - Note: You do not need to finish the transaction yourself after this, Purchases will
+     * handle this for you.
+     *
+     * - Parameter package: The ``Package`` the user intends to purchase
+     *
+     * - Throws: An error of type ``ErrorCode`` is thrown if a failure occurs while purchasing
+     * - Returns: A tuple with ``StoreTransaction`` and a ``CustomerInfo`` if the purchase was successful.
+     */
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func purchase(package: Package) async throws -> PurchaseResultData
+
+    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+
+    /**
+     * Use this function if you are not using the Offerings system to purchase a ``StoreProduct`` with an
+     * applied ``PromotionalOffer``.
+     * If you are using the Offerings system, use ``Purchases/purchase(package:promotionalOffer:completion:)`` instead.
+     *
+     * Call this method when a user has decided to purchase a product with an applied discount.
+     * Only call this in direct response to user input.
+     *
+     * From here ``Purchases`` will handle the purchase with `StoreKit` and return ``PurchaseResultData``.
+     *
+     * - Note: You do not need to finish the transaction yourself after this, Purchases will handle
+     * this for you.
+     *
+     * - Parameter product: The ``StoreProduct`` the user intends to purchase
+     * - Parameter promotionalOffer: The ``PromotionalOffer`` to apply to the purchase
+     *
+     * - Throws: An error of type ``ErrorCode`` is thrown if a failure occurs while purchasing
+     * - Returns: A tuple with ``StoreTransaction`` and a ``CustomerInfo`` if the purchase was successful.
+     */
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func purchase(product: StoreProduct, promotionalOffer: PromotionalOffer) async throws -> PurchaseResultData
+
+    /**
+     * Purchase the passed ``Package``.
+     * Call this method when a user has decided to purchase a product with an applied discount. Only call this in
+     * direct response to user input. From here ``Purchases`` will handle the purchase with `StoreKit` and return
+     * ``PurchaseResultData``.
+     *
+     * - Note: You do not need to finish the transaction yourself after this, Purchases will handle
+     * this for you.
+     *
+     * - Parameter package: The ``Package`` the user intends to purchase
+     * - Parameter promotionalOffer: The ``PromotionalOffer`` to apply to the purchase
+     *
+     * - Throws: An error of type ``ErrorCode`` is thrown if a failure occurs while purchasing
+     * - Returns: A tuple with ``StoreTransaction`` and a ``CustomerInfo`` if the purchase was successful.
+     */
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func purchase(package: Package, promotionalOffer: PromotionalOffer) async throws -> PurchaseResultData
+
+    #endif
 
     #if os(iOS)
 

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -98,9 +98,13 @@ private func checkTypealiases(
     customerInfo: CustomerInfo,
     userCancelled: Bool
 ) {
-    let purchaseResultData: PurchaseResultData = (transaction: transaction,
-                                                  customerInfo: customerInfo,
-                                                  userCancelled: userCancelled)
+    let purchaseResultData = PurchaseResultData(transaction: transaction,
+                                                customerInfo: customerInfo,
+                                                userCancelled: userCancelled)
+
+    let _: StoreTransaction? = purchaseResultData.transaction
+    let _: CustomerInfo = purchaseResultData.customerInfo
+    let _: Bool = purchaseResultData.userCancelled
 
     // swiftlint:disable:next line_length
     let purchaseCompletedBlock: PurchaseCompletedBlock = { (_: StoreTransaction?, _: CustomerInfo?, _: Error?, _: Bool) -> Void in }
@@ -220,12 +224,12 @@ private func checkAsyncMethods(purchases: Purchases) async {
         let _: Offerings = try await purchases.offerings()
 
         let _: [StoreProduct] = await purchases.products([])
-        let _: (StoreTransaction?, CustomerInfo, Bool) = try await purchases.purchase(package: pack)
-        let _: (StoreTransaction?, CustomerInfo, Bool) = try await purchases.purchase(package: pack,
-                                                                                      promotionalOffer: offer)
-        let _: (StoreTransaction?, CustomerInfo, Bool) = try await purchases.purchase(product: stp)
-        let _: (StoreTransaction?, CustomerInfo, Bool) = try await purchases.purchase(product: stp,
-                                                                                      promotionalOffer: offer)
+        let _: PurchaseResultData = try await purchases.purchase(package: pack)
+        let _: PurchaseResultData = try await purchases.purchase(package: pack,
+                                                                 promotionalOffer: offer)
+        let _: PurchaseResultData = try await purchases.purchase(product: stp)
+        let _: PurchaseResultData = try await purchases.purchase(product: stp,
+                                                                 promotionalOffer: offer)
         let _: CustomerInfo = try await purchases.customerInfo()
         let _: CustomerInfo = try await purchases.customerInfo(fetchPolicy: .default)
         let _: CustomerInfo = try await purchases.restorePurchases()

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -382,15 +382,15 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                               storeProduct: StoreProduct(sk2Product: product),
                               offeringIdentifier: "offering")
 
-        let (transaction, customerInfo, userCancelled) = try await orchestrator.purchase(sk2Product: product,
-                                                                                         package: package,
-                                                                                         promotionalOffer: nil)
+        let result = try await orchestrator.purchase(sk2Product: product,
+                                                     package: package,
+                                                     promotionalOffer: nil)
 
-        expect(transaction?.sk2Transaction) == mockTransaction
-        expect(userCancelled) == false
+        expect(result.transaction?.sk2Transaction) == mockTransaction
+        expect(result.userCancelled) == false
 
         let expectedCustomerInfo: CustomerInfo = .emptyInfo
-        expect(customerInfo) == expectedCustomerInfo
+        expect(result.customerInfo) == expectedCustomerInfo
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
@@ -590,13 +590,13 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         let product = try await self.fetchSk2Product()
 
-        let (transaction, customerInfo, cancelled) = try await self.orchestrator.purchase(sk2Product: product,
-                                                                                          package: nil,
-                                                                                          promotionalOffer: nil)
+        let result = try await self.orchestrator.purchase(sk2Product: product,
+                                                          package: nil,
+                                                          promotionalOffer: nil)
 
-        expect(transaction).to(beNil())
-        expect(customerInfo) == self.mockCustomerInfo
-        expect(cancelled) == false
+        expect(result.transaction).to(beNil())
+        expect(result.customerInfo) == self.mockCustomerInfo
+        expect(result.userCancelled) == false
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)


### PR DESCRIPTION
Follow up to #2449.
This is step 2 of 3 towards getting rid of `userCancelled` in purchase results.

After #2449, `ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION` builds no longer send `userCancelled` `true` for cancellations, and instead throw `ErrorCode.purchaseCancelledError`.
To avoid users detecting cancellations looking at this property, this marks it `unavailable` with a message.

### How?

To achieve that, I converted the `tuple` into a `struct`. This also required moving the affected `purchase` methods from `PurchasesType` to `PurchasesSwiftType`, but that's an implementation detail.

The public API remains _mostly_ unchanged, with the only caveat that it's no longer possible to destructure the result tuple, so:
```swift
let (transaction, customerInfo, cancelled) = Purchases.shared.purchase(...)
```
Needs to become:
```swift
let result = Purchases.shared.purchase(...)
```

I updated the API tester to reflect that, as well as checking the properties of `PurchaseResultData`.

### Completion block API

As it's documented in #1910, completion block APIs already did send both `userCancelled` and the `error`, so we don't need to change those.

### Future changes

This paves the future for a full deprecation, where we mark it `deprecated` for normal builds as well, and change the behavior regardless of the `DangerousSettings`.
