### PR TITLE
Custom Entitlement Computation: re-enable `syncPurchases`/`restorePurchases`

### DIFF
--- a/Sources/Misc/Concurrency/Purchases+async.swift
+++ b/Sources/Misc/Concurrency/Purchases+async.swift
@@ -72,6 +72,22 @@ extension Purchases {
         }
     }
 
+    func syncPurchasesAsync() async throws -> CustomerInfo {
+        return try await withCheckedThrowingContinuation { continuation in
+            syncPurchases { customerInfo, error in
+                continuation.resume(with: Result(customerInfo, error))
+            }
+        }
+    }
+
+    func restorePurchasesAsync() async throws -> CustomerInfo {
+        return try await withCheckedThrowingContinuation { continuation in
+            restorePurchases { customerInfo, error in
+                continuation.resume(with: Result(customerInfo, error))
+            }
+        }
+    }
+
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
     func purchaseAsync(product: StoreProduct, promotionalOffer: PromotionalOffer) async throws -> PurchaseResultData {
@@ -97,22 +113,6 @@ extension Purchases {
     func customerInfoAsync(fetchPolicy: CacheFetchPolicy) async throws -> CustomerInfo {
         return try await withCheckedThrowingContinuation { continuation in
             getCustomerInfo(fetchPolicy: fetchPolicy) { customerInfo, error in
-                continuation.resume(with: Result(customerInfo, error))
-            }
-        }
-    }
-
-    func syncPurchasesAsync() async throws -> CustomerInfo {
-        return try await withCheckedThrowingContinuation { continuation in
-            syncPurchases { customerInfo, error in
-                continuation.resume(with: Result(customerInfo, error))
-            }
-        }
-    }
-
-    func restorePurchasesAsync() async throws -> CustomerInfo {
-        return try await withCheckedThrowingContinuation { continuation in
-            restorePurchases { customerInfo, error in
                 continuation.resume(with: Result(customerInfo, error))
             }
         }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -769,6 +769,28 @@ public extension Purchases {
         return try await purchaseAsync(package: package)
     }
 
+    @objc func syncPurchases(completion: ((CustomerInfo?, PublicError?) -> Void)?) {
+        self.purchasesOrchestrator.syncPurchases { @Sendable in
+            completion?($0.value, $0.error?.asPublicError)
+        }
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func syncPurchases() async throws -> CustomerInfo {
+        return try await syncPurchasesAsync()
+    }
+
+    @objc func restorePurchases(completion: ((CustomerInfo?, PublicError?) -> Void)? = nil) {
+        purchasesOrchestrator.restorePurchases { @Sendable in
+            completion?($0.value, $0.error?.asPublicError)
+        }
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func restorePurchases() async throws -> CustomerInfo {
+        return try await restorePurchasesAsync()
+    }
+
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
     @available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvOS 12.2, *)
@@ -799,28 +821,6 @@ public extension Purchases {
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func purchase(package: Package, promotionalOffer: PromotionalOffer) async throws -> PurchaseResultData {
         return try await purchaseAsync(package: package, promotionalOffer: promotionalOffer)
-    }
-
-    @objc func syncPurchases(completion: ((CustomerInfo?, PublicError?) -> Void)?) {
-        self.purchasesOrchestrator.syncPurchases { @Sendable in
-            completion?($0.value, $0.error?.asPublicError)
-        }
-    }
-
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func syncPurchases() async throws -> CustomerInfo {
-        return try await syncPurchasesAsync()
-    }
-
-    @objc func restorePurchases(completion: ((CustomerInfo?, PublicError?) -> Void)? = nil) {
-        purchasesOrchestrator.restorePurchases { @Sendable in
-            completion?($0.value, $0.error?.asPublicError)
-        }
-    }
-
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func restorePurchases() async throws -> CustomerInfo {
-        return try await restorePurchasesAsync()
     }
 
     @objc(checkTrialOrIntroDiscountEligibility:completion:)

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -340,6 +340,78 @@ public protocol PurchasesType: AnyObject {
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func purchase(package: Package) async throws -> PurchaseResultData
 
+    /**
+     * This method will post all purchases associated with the current App Store account to RevenueCat and become
+     * associated with the current ``appUserID``. If the receipt is being used by an existing user, the current
+     * ``appUserID`` will be aliased together with the ``appUserID`` of the existing user.
+     *  Going forward, either ``appUserID`` will be able to reference the same user.
+     *
+     * You shouldn't use this method if you have your own account system. In that case "restoration" is provided
+     * by your app passing the same ``appUserID`` used to purchase originally.
+     *
+     * - Note: This may force your users to enter the App Store password so should only be performed on request of
+     * the user. Typically with a button in settings or near your purchase UI. Use
+     * ``Purchases/syncPurchases(completion:)`` if you need to restore transactions programmatically.
+     *
+     * - Warning: Receiving a ``CustomerInfo`` instead of an error does not imply that the user has any
+     * entitlements, simply that the process was successful. You must verify the ``CustomerInfo/entitlements``
+     * to confirm that they are active.
+     */
+    func restorePurchases(completion: ((CustomerInfo?, PublicError?) -> Void)?)
+
+    /**
+     * This method will post all purchases associated with the current App Store account to RevenueCat and become
+     * associated with the current ``appUserID``. If the receipt is being used by an existing user, the current
+     * ``appUserID`` will be aliased together with the ``appUserID`` of the existing user.
+     *  Going forward, either ``appUserID`` will be able to reference the same user.
+     *
+     * You shouldn't use this method if you have your own account system. In that case "restoration" is provided
+     * by your app passing the same ``appUserID`` used to purchase originally.
+     *
+     * - Note: This may force your users to enter the App Store password so should only be performed on request of
+     * the user. Typically with a button in settings or near your purchase UI. Use
+     * ``Purchases/syncPurchases(completion:)`` if you need to restore transactions programmatically.
+     *
+     * - Warning: Receiving a ``CustomerInfo`` instead of an error does not imply that the user has any
+     * entitlements, simply that the process was successful. You must verify the ``CustomerInfo/entitlements``
+     * to confirm that they are active.
+     */
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func restorePurchases() async throws -> CustomerInfo
+
+    /**
+     * This method will post all purchases associated with the current App Store account to RevenueCat and
+     * become associated with the current ``appUserID``.
+     *
+     * If the receipt is being used by an existing user, the current ``appUserID`` will be aliased together with
+     * the ``appUserID`` of the existing user.
+     * Going forward, either ``appUserID`` will be able to reference the same user.
+     *
+     * - Warning: This function should only be called if you're not calling any purchase method.
+     *
+     * - Note: This method will not trigger a login prompt from App Store. However, if the receipt currently
+     * on the device does not contain subscriptions, but the user has made subscription purchases, this method
+     * won't be able to restore them. Use ``Purchases/restorePurchases(completion:)`` to cover those cases.
+     */
+    func syncPurchases(completion: ((CustomerInfo?, PublicError?) -> Void)?)
+
+    /**
+     * This method will post all purchases associated with the current App Store account to RevenueCat and
+     * become associated with the current ``appUserID``.
+     *
+     * If the receipt is being used by an existing user, the current ``appUserID`` will be aliased together with
+     * the ``appUserID`` of the existing user.
+     * Going forward, either ``appUserID`` will be able to reference the same user.
+     *
+     * - Warning: This function should only be called if you're not calling any purchase method.
+     *
+     * - Note: This method will not trigger a login prompt from App Store. However, if the receipt currently
+     * on the device does not contain subscriptions, but the user has made subscription purchases, this method
+     * won't be able to restore them. Use ``Purchases/restorePurchases(completion:)`` to cover those cases.
+     */
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func syncPurchases() async throws -> CustomerInfo
+
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
     /**
@@ -442,78 +514,6 @@ public protocol PurchasesType: AnyObject {
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func purchase(package: Package, promotionalOffer: PromotionalOffer) async throws -> PurchaseResultData
-
-    /**
-     * This method will post all purchases associated with the current App Store account to RevenueCat and become
-     * associated with the current ``appUserID``. If the receipt is being used by an existing user, the current
-     * ``appUserID`` will be aliased together with the ``appUserID`` of the existing user.
-     *  Going forward, either ``appUserID`` will be able to reference the same user.
-     *
-     * You shouldn't use this method if you have your own account system. In that case "restoration" is provided
-     * by your app passing the same ``appUserID`` used to purchase originally.
-     *
-     * - Note: This may force your users to enter the App Store password so should only be performed on request of
-     * the user. Typically with a button in settings or near your purchase UI. Use
-     * ``Purchases/syncPurchases(completion:)`` if you need to restore transactions programmatically.
-     *
-     * - Warning: Receiving a ``CustomerInfo`` instead of an error does not imply that the user has any
-     * entitlements, simply that the process was successful. You must verify the ``CustomerInfo/entitlements``
-     * to confirm that they are active.
-     */
-    func restorePurchases(completion: ((CustomerInfo?, PublicError?) -> Void)?)
-
-    /**
-     * This method will post all purchases associated with the current App Store account to RevenueCat and become
-     * associated with the current ``appUserID``. If the receipt is being used by an existing user, the current
-     * ``appUserID`` will be aliased together with the ``appUserID`` of the existing user.
-     *  Going forward, either ``appUserID`` will be able to reference the same user.
-     *
-     * You shouldn't use this method if you have your own account system. In that case "restoration" is provided
-     * by your app passing the same ``appUserID`` used to purchase originally.
-     *
-     * - Note: This may force your users to enter the App Store password so should only be performed on request of
-     * the user. Typically with a button in settings or near your purchase UI. Use
-     * ``Purchases/syncPurchases(completion:)`` if you need to restore transactions programmatically.
-     *
-     * - Warning: Receiving a ``CustomerInfo`` instead of an error does not imply that the user has any
-     * entitlements, simply that the process was successful. You must verify the ``CustomerInfo/entitlements``
-     * to confirm that they are active.
-     */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func restorePurchases() async throws -> CustomerInfo
-
-    /**
-     * This method will post all purchases associated with the current App Store account to RevenueCat and
-     * become associated with the current ``appUserID``.
-     *
-     * If the receipt is being used by an existing user, the current ``appUserID`` will be aliased together with
-     * the ``appUserID`` of the existing user.
-     * Going forward, either ``appUserID`` will be able to reference the same user.
-     *
-     * - Warning: This function should only be called if you're not calling any purchase method.
-     *
-     * - Note: This method will not trigger a login prompt from App Store. However, if the receipt currently
-     * on the device does not contain subscriptions, but the user has made subscription purchases, this method
-     * won't be able to restore them. Use ``Purchases/restorePurchases(completion:)`` to cover those cases.
-     */
-    func syncPurchases(completion: ((CustomerInfo?, PublicError?) -> Void)?)
-
-    /**
-     * This method will post all purchases associated with the current App Store account to RevenueCat and
-     * become associated with the current ``appUserID``.
-     *
-     * If the receipt is being used by an existing user, the current ``appUserID`` will be aliased together with
-     * the ``appUserID`` of the existing user.
-     * Going forward, either ``appUserID`` will be able to reference the same user.
-     *
-     * - Warning: This function should only be called if you're not calling any purchase method.
-     *
-     * - Note: This method will not trigger a login prompt from App Store. However, if the receipt currently
-     * on the device does not contain subscriptions, but the user has made subscription purchases, this method
-     * won't be able to restore them. Use ``Purchases/restorePurchases(completion:)`` to cover those cases.
-     */
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    func syncPurchases() async throws -> CustomerInfo
 
     /**
      * Computes whether or not a user is eligible for the introductory pricing period of a given product.


### PR DESCRIPTION
Follow up to #2442
