### PR TITLE
Update offerings cache when switchUser(to:) is called

### DIFF
--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -92,7 +92,7 @@ class IdentityManager: CurrentUserProvider {
     }
 
     func switchUser(to newAppUserID: String) {
-        Logger.debug(Strings.identity.switching_user(newUserId: newAppUserID))
+        Logger.debug(Strings.identity.switching_user(newUserID: newAppUserID))
         self.resetCacheAndSave(newUserID: newAppUserID)
     }
 

--- a/Sources/Logging/Strings/IdentityStrings.swift
+++ b/Sources/Logging/Strings/IdentityStrings.swift
@@ -36,7 +36,9 @@ enum IdentityStrings {
 
     case invalidating_cached_customer_info
 
-    case switching_user(newUserId: String)
+    case switching_user(newUserID: String)
+
+    case switching_user_same_app_user_id(newUserID: String)
 
 }
 
@@ -68,8 +70,11 @@ extension IdentityStrings: CustomStringConvertible {
             return "Attempt to delete attributes for user, but there were none to delete"
         case .invalidating_cached_customer_info:
             return "Detected unverified cached CustomerInfo but verification is enabled. Invalidating cache."
-        case let .switching_user(newUserId):
-            return "Switching to user '\(newUserId)'."
+        case let .switching_user(newUserID):
+            return "Switching to user '\(newUserID)'."
+        case let .switching_user_same_app_user_id(newUserID):
+            return "switchUser(to:) called with the same appUserID as the current user (\(newUserID)). " +
+            "This has no effect."
         }
     }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -695,7 +695,18 @@ public extension Purchases {
     ///
     @objc(switchUserToNewAppUserID:)
     func switchUser(to newAppUserID: String) {
+        guard self.identityManager.currentAppUserID != newAppUserID else {
+            self.logger.warn(Strings.identity.switching_user_same_app_user_id(newUserID: newAppUserID))
+            return
+        }
+
         self.identityManager.switchUser(to: newAppUserID)
+
+        self.systemInfo.isApplicationBackgrounded { isBackgrounded in
+            self.offeringsManager.updateOfferingsCache(appUserID: self.appUserID,
+                                                       isAppBackgrounded: isBackgrounded,
+                                                       completion: nil)
+        }
     }
 
 }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -696,7 +696,7 @@ extension Purchases {
     ///
     @objc(switchUserToNewAppUserID:)
     public func switchUser(to newAppUserID: String) {
-       internalSwitchUser(to: newAppUserID)
+        self.internalSwitchUser(to: newAppUserID)
     }
 #endif
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -681,12 +681,13 @@ public extension Purchases {
 
 }
 
-#else
+#endif
 
 // - MARK: - Custom entitlement computation API
 
-public extension Purchases {
+extension Purchases {
 
+#if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
     ///
     /// Updates the current appUserID to a new one, without associating the two.
     /// - Important: This method is **only available** in Custom Entitlements Computation mode.
@@ -694,7 +695,12 @@ public extension Purchases {
     /// with the newAppUserID.
     ///
     @objc(switchUserToNewAppUserID:)
-    func switchUser(to newAppUserID: String) {
+    public func switchUser(to newAppUserID: String) {
+       internalSwitchUser(to: newAppUserID)
+    }
+#endif
+
+    internal func internalSwitchUser(to newAppUserID: String) {
         guard self.identityManager.currentAppUserID != newAppUserID else {
             Logger.warn(Strings.identity.switching_user_same_app_user_id(newUserID: newAppUserID))
             return
@@ -710,8 +716,6 @@ public extension Purchases {
     }
 
 }
-
-#endif
 
 // MARK: Purchasing
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -696,7 +696,7 @@ public extension Purchases {
     @objc(switchUserToNewAppUserID:)
     func switchUser(to newAppUserID: String) {
         guard self.identityManager.currentAppUserID != newAppUserID else {
-            self.logger.warn(Strings.identity.switching_user_same_app_user_id(newUserID: newAppUserID))
+            Logger.warn(Strings.identity.switching_user_same_app_user_id(newUserID: newAppUserID))
             return
         }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -687,7 +687,7 @@ public extension Purchases {
 
 extension Purchases {
 
-#if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+#if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
     ///
     /// Updates the current appUserID to a new one, without associating the two.
     /// - Important: This method is **only available** in Custom Entitlements Computation mode.

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -102,7 +102,7 @@ class PurchasesLogInTests: BasePurchasesTests {
 
     #if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
 
-    func testSwitchUser() {
+    func testSwitchUserSwitchesUser() {
         self.systemInfo = MockSystemInfo(finishTransactions: true, customEntitlementsComputation: true)
         Purchases.clearSingleton()
         self.initializePurchasesInstance(appUserId: "old-test-user-id")
@@ -111,6 +111,30 @@ class PurchasesLogInTests: BasePurchasesTests {
 
         expect(self.identityManager.invokedSwitchUser) == true
         expect(self.identityManager.invokedSwitchUserParametersList) == ["test-user-id"]
+    }
+
+    func testRefreshesOfferingsCache() {
+        expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount) == 0
+
+        self.systemInfo = MockSystemInfo(finishTransactions: true, customEntitlementsComputation: true)
+        Purchases.clearSingleton()
+        self.initializePurchasesInstance(appUserId: "old-test-user-id")
+
+        self.purchases.switchUser(to: "test-user-id")
+
+        expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount).toEventually(equal(1))
+    }
+
+    func testSwitchUserNoOpIfAppUserIDIsSameAsCurrent() {
+        self.systemInfo = MockSystemInfo(finishTransactions: true, customEntitlementsComputation: true)
+        Purchases.clearSingleton()
+        let appUserId = "test-user-id"
+        self.initializePurchasesInstance(appUserId: appUserId)
+
+        self.purchases.switchUser(to: appUserId)
+
+        expect(self.identityManager.invokedSwitchUser) == false
+        expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount).toEventually(equal(0))
     }
 
     #endif

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -134,7 +134,7 @@ class PurchasesLogInTests: BasePurchasesTests {
         self.purchases.switchUser(to: appUserId)
 
         expect(self.identityManager.invokedSwitchUser) == false
-        expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount).toEventually(equal(0))
+        expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount).toNever(equal(1))
     }
 
     #endif

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -120,8 +120,7 @@ class PurchasesLogInTests: BasePurchasesTests {
 
         self.purchases.internalSwitchUser(to: "test-user-id")
 
-        expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount)
-            .toEventually(equal(baselineOfferingsCallCount + 1))
+        expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount) == baselineOfferingsCallCount + 1
     }
 
     func testSwitchUserNoOpIfAppUserIDIsSameAsCurrent() {
@@ -136,8 +135,7 @@ class PurchasesLogInTests: BasePurchasesTests {
         self.purchases.internalSwitchUser(to: appUserId)
 
         expect(self.identityManager.invokedSwitchUser) == false
-        expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount)
-            .toNever(equal(baselineOfferingsCallCount + 1))
+        expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount) == baselineOfferingsCallCount
     }
 
     // MARK: - Update offerings cache


### PR DESCRIPTION
Added updating of offerings cache when `switchUser(to:)` is called. 
Also added checking that the new appUserID != the current one and no-op if it is. 