### PR TITLE
Re-enable subs attributes in custom entitlements mode

### DIFF
--- a/Examples/testCustomEntitlementsComputation/testCustomEntitlementsComputation/ContentView.swift
+++ b/Examples/testCustomEntitlementsComputation/testCustomEntitlementsComputation/ContentView.swift
@@ -152,6 +152,7 @@ struct ContentView: View {
         }
 
         do {
+            Purchases.shared.attribution.setAttributes(["originalPurchaserAppUserID": appUserID])
             let (transaction, customerInfo, _) = try await Purchases.shared.purchase(package: package)
             print(
                 """

--- a/Sources/Logging/Strings/AttributionStrings.swift
+++ b/Sources/Logging/Strings/AttributionStrings.swift
@@ -116,7 +116,8 @@ extension AttributionStrings: CustomStringConvertible {
 
         case .attribute_set_locally(let attribute):
             return "Attribute set locally: \(attribute). It will be synced to the backend" +
-            " when the app backgrounds/foregrounds or when a purchase is made."
+            " when the app backgrounds/foregrounds or when a purchase is made. \nWhen using Custom Entitlements " +
+            "Computation mode, it will be synced only when purchases are made."
 
         case .missing_advertiser_identifiers:
             return "Attribution error: identifierForAdvertisers is missing"

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -208,11 +208,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     /// Current version of the ``Purchases`` framework.
     @objc public static var frameworkVersion: String { SystemInfo.frameworkVersion }
 
-    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-
     @objc public let attribution: Attribution
-
-    #endif
 
     @objc public var finishTransactions: Bool {
         get { self.systemInfo.finishTransactions }
@@ -466,9 +462,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.userDefaults = userDefaults
         self.notificationCenter = notificationCenter
         self.systemInfo = systemInfo
-        #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
         self.attribution = subscriberAttributes
-        #endif
         self.operationDispatcher = operationDispatcher
         self.customerInfoManager = customerInfoManager
         self.productsManager = productsManager


### PR DESCRIPTION
We're currently assessing whether we need subscriber attributes to be usable in Custom Entitlements Computation mode. 

This PR adds them so that they get sent along with the receipt when posting receipts, but they don't automatically sync when backgrounding / foregrounding the app. 