### PR TITLE
Add message indicating tag doesn't exist

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -673,9 +673,10 @@ end
 def check_no_git_tag_exists(version_number)
   if git_tag_exists(tag: version_number, remote: true, remote_name: 'origin')
     raise "git tag with version #{version_number} already exists!"
+  else
+    UI.message("git tag with version #{version_number} doesn't exist")
   end
 end
-
 
 def check_no_github_release_exists(version_number)
   found_release_number = get_github_release(url: "revenuecat/purchases-ios", version: version_number)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -674,7 +674,7 @@ def check_no_git_tag_exists(version_number)
   if git_tag_exists(tag: version_number, remote: true, remote_name: 'origin')
     raise "git tag with version #{version_number} already exists!"
   else
-    UI.message("git tag with version #{version_number} doesn't exist")
+    UI.message("✅ git tag with version #{version_number} doesn't exist")
   end
 end
 


### PR DESCRIPTION
There's some confusion when checking if a tag exists since Fastlane prints a message in red if the tag doesn't exist.

<img width="1102" alt="Screenshot 2023-04-27 at 5 10 21 PM" src="https://user-images.githubusercontent.com/664544/235016026-6fe97f54-497b-4d0c-9988-ae7c2e2a6d5e.png">

I added a message if the tag doesn't exist, so it doesn't look like there's an error