### PR TITLE
`Integration Tests`: removed `@preconcurrency import`

### DIFF
--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -13,7 +13,7 @@
 
 import Nimble
 @testable import RevenueCat
-@preconcurrency import StoreKit // `PurchaseResult` is not `Sendable`
+import StoreKit
 import StoreKitTest
 import UniformTypeIdentifiers
 import XCTest


### PR DESCRIPTION
It's no longer required with Xcode 14.3.
