### PR TITLE
`DangerousSettings`: debug-only `forceServerErrors`

### DIFF
--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -19,6 +19,7 @@ import Foundation
         /// Whether `ReceiptFetcher` can retry fetching receipts.
         let enableReceiptFetchRetry: Bool
 
+        #if DEBUG
         /// Whether `HTTPClient` will fake server errors
         let forceServerErrors: Bool
 
@@ -26,6 +27,11 @@ import Foundation
             self.enableReceiptFetchRetry = enableReceiptFetchRetry
             self.forceServerErrors = forceServerErrors
         }
+        #else
+        init(enableReceiptFetchRetry: Bool = false) {
+            self.enableReceiptFetchRetry = enableReceiptFetchRetry
+        }
+        #endif
 
         static let `default`: Self = .init()
     }

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -172,6 +172,12 @@ class SystemInfo {
         return host.contains("apple.com")
     }
 
+    #if DEBUG
+
+    var forceServerErrors: Bool { self.dangerousSettings.internalSettings.forceServerErrors }
+
+    #endif
+
 }
 
 extension SystemInfo: SandboxEnvironmentDetector {}

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -61,7 +61,7 @@ class HTTPClient {
         completionHandler: Completion<Value>?
     ) {
         #if DEBUG
-        guard !self.systemInfo.dangerousSettings.internalSettings.forceServerErrors else {
+        guard !self.systemInfo.forceServerErrors else {
             completionHandler?(
                 .failure(.errorResponse(Self.serverErrorResponse, .internalServerError))
             )

--- a/Tests/UnitTests/Mocks/MockSystemInfo.swift
+++ b/Tests/UnitTests/Mocks/MockSystemInfo.swift
@@ -12,6 +12,7 @@ import Foundation
 // Note: this class is implicitly `@unchecked Sendable` through its parent
 // even though it's not actually thread safe.
 class MockSystemInfo: SystemInfo {
+
     var stubbedIsApplicationBackgrounded: Bool?
     var stubbedIsSandbox: Bool?
     var customEntitlementsComputation: Bool?
@@ -47,6 +48,12 @@ class MockSystemInfo: SystemInfo {
 
     override var isSandbox: Bool {
         return self.stubbedIsSandbox ?? super.isSandbox
+    }
+
+    var stubbedForceServerErrors: Bool?
+
+    override var forceServerErrors: Bool {
+        return self.stubbedForceServerErrors ?? super.forceServerErrors
     }
 
 }


### PR DESCRIPTION
Follow up to #2370. This removes `forceServerErrors` from release builds so it can't be accidentally used (even though `HTTPClient` was only checking it on `DEBUG` already).

Also allows changing the flag at runtime, so future integration tests can check the behavior when the server changes status throughout the lifetime of the app.
