### PR TITLE
`HTTPClient`: log actual response status code

### DIFF
--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -309,7 +309,10 @@ private extension HTTPClient {
         if let response = response {
             switch response {
             case let .success(response):
-                Logger.debug(Strings.network.api_request_completed(request.httpRequest, httpCode: response.statusCode))
+                Logger.debug(Strings.network.api_request_completed(
+                    request.httpRequest,
+                    httpCode: urlResponse?.httpStatusCode ?? response.statusCode
+                ))
             case let .failure(error):
                 Logger.debug(Strings.network.api_request_failed(request.httpRequest, error: error))
             }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -311,6 +311,8 @@ private extension HTTPClient {
             case let .success(response):
                 Logger.debug(Strings.network.api_request_completed(
                     request.httpRequest,
+                    // Getting status code from the original response to detect 304s
+                    // If that can't be extracted, get status code from the parsed response.
                     httpCode: urlResponse?.httpStatusCode ?? response.statusCode
                 ))
             case let .failure(error):

--- a/Sources/Networking/HTTPClient/HTTPStatusCode.swift
+++ b/Sources/Networking/HTTPClient/HTTPStatusCode.swift
@@ -93,3 +93,13 @@ extension HTTPStatusCode {
     }
 
 }
+
+extension URLResponse {
+
+    var httpStatusCode: HTTPStatusCode? {
+        guard let response = self as? HTTPURLResponse else { return nil }
+
+        return .init(rawValue: response.statusCode)
+    }
+
+}


### PR DESCRIPTION
We were currently logging the status code retrieved from `ETagManager`, which made it seem like etags weren't working.

Example:
> API request completed: GET /v1/subscribers/identify (200)

With this change, we now log the actual response status code so we can verify the server is returning the correct status code:
> API request completed: GET /v1/subscribers/identify (304)
