### PR TITLE
`OfferingsManager`: return `Offerings` from new disk cache when server is down

### DIFF
--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -141,7 +141,7 @@ class DeviceCache {
 
     // MARK: - Offerings
 
-    func cachedOfferingsData(appUserID: String) -> Data? {
+    func cachedOfferingsResponseData(appUserID: String) -> Data? {
         return self.userDefaults.read {
             $0.data(forKey: CacheKey.offerings(appUserID))
         }

--- a/Sources/Logging/Strings/OfferingStrings.swift
+++ b/Sources/Logging/Strings/OfferingStrings.swift
@@ -20,6 +20,7 @@ enum OfferingStrings {
 
     case cannot_find_product_configuration_error(identifiers: Set<String>)
     case fetching_offerings_error(error: OfferingsManager.Error, underlyingError: Error?)
+    case fetching_offerings_failed_server_down
     case found_existing_product_request(identifiers: Set<String>)
     case no_cached_offerings_fetching_from_network
     case offerings_stale_updated_from_network
@@ -27,7 +28,8 @@ enum OfferingStrings {
     case offerings_stale_updating_in_foreground
     case products_already_cached(identifiers: Set<String>)
     case product_cache_invalid_for_storefront_change
-    case vending_offerings_cache
+    case vending_offerings_cache_from_memory
+    case vending_offerings_cache_from_disk
     case retrieved_products(products: [SKProduct])
     case list_products(productIdentifier: String, product: SKProduct)
     case invalid_product_identifiers(identifiers: Set<String>)
@@ -65,6 +67,9 @@ extension OfferingStrings: CustomStringConvertible {
 
             return result
 
+        case .fetching_offerings_failed_server_down:
+            return "Error fetching offerings: server appears down"
+
         case .found_existing_product_request(let identifiers):
             return "Found an existing request for products: \(identifiers), appending " +
                 "to completion"
@@ -90,8 +95,11 @@ extension OfferingStrings: CustomStringConvertible {
         case .product_cache_invalid_for_storefront_change:
             return "Storefront change detected. Invalidating and re-fetching product cache."
 
-        case .vending_offerings_cache:
-            return "Vending Offerings from cache"
+        case .vending_offerings_cache_from_memory:
+            return "Vending Offerings from memory cache"
+
+        case .vending_offerings_cache_from_disk:
+            return "Vending Offerings from disk cache"
 
         case .retrieved_products(let products):
             return "Retrieved SKProducts: \(products)"

--- a/Sources/Networking/Responses/OfferingsResponse.swift
+++ b/Sources/Networking/Responses/OfferingsResponse.swift
@@ -50,8 +50,8 @@ extension OfferingsResponse {
 
 }
 
-extension OfferingsResponse.Offering.Package: Decodable {}
-extension OfferingsResponse.Offering: Decodable {}
-extension OfferingsResponse: Decodable {}
+extension OfferingsResponse.Offering.Package: Codable, Equatable {}
+extension OfferingsResponse.Offering: Codable, Equatable {}
+extension OfferingsResponse: Codable, Equatable {}
 
 extension OfferingsResponse: HTTPResponseBody {}

--- a/Sources/Purchasing/Offerings.swift
+++ b/Sources/Purchasing/Offerings.swift
@@ -45,14 +45,32 @@ import Foundation
         return all[currentOfferingID]
     }
 
+    internal let response: OfferingsResponse
+
     private let currentOfferingID: String?
+
+    init(
+        offerings: [String: Offering],
+        currentOfferingID: String?,
+        response: OfferingsResponse
+    ) {
+        self.all = offerings
+        self.currentOfferingID = currentOfferingID
+        self.response = response
+    }
+
+}
+
+extension Offerings: Sendable {}
+
+public extension Offerings {
 
     /**
      Retrieves a specific offering by its identifier, use this to access additional offerings configured in the
      RevenueCat dashboard, e.g. `offerings.offering(identifier: "offering_id")` or `offerings[@"offering_id"]`.
      To access the current offering use ``Offerings/current``.
      */
-    @objc public func offering(identifier: String?) -> Offering? {
+    @objc func offering(identifier: String?) -> Offering? {
         guard let identifier = identifier else {
             return nil
         }
@@ -62,11 +80,11 @@ import Foundation
 
     /// #### Related Symbols
     /// - ``offering(identifier:)``
-    @objc public subscript(key: String) -> Offering? {
+    @objc subscript(key: String) -> Offering? {
         return offering(identifier: key)
     }
 
-    @objc public override var description: String {
+    @objc override var description: String {
         var description = "<Offerings {\n"
         for offering in all.values {
             description += "\t\(offering)\n"
@@ -75,11 +93,4 @@ import Foundation
         return description
     }
 
-    init(offerings: [String: Offering], currentOfferingID: String?) {
-        all = offerings
-        self.currentOfferingID = currentOfferingID
-    }
-
 }
-
-extension Offerings: Sendable {}

--- a/Sources/Purchasing/OfferingsFactory.swift
+++ b/Sources/Purchasing/OfferingsFactory.swift
@@ -29,7 +29,9 @@ class OfferingsFactory {
             return nil
         }
 
-        return Offerings(offerings: offerings, currentOfferingID: data.currentOfferingId)
+        return Offerings(offerings: offerings,
+                         currentOfferingID: data.currentOfferingId,
+                         response: data)
     }
 
     func createOffering(

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -132,7 +132,7 @@ private extension OfferingsManager {
         fetchPolicy: FetchPolicy,
         completion: (@escaping @Sendable (Offerings?) -> Void)
     ) {
-        guard let data = self.deviceCache.cachedOfferingsData(appUserID: appUserID),
+        guard let data = self.deviceCache.cachedOfferingsResponseData(appUserID: appUserID),
               let response: OfferingsResponse = try? JSONDecoder.default.decode(jsonData: data, logErrors: true) else {
             completion(nil)
             return

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -42,9 +42,10 @@ class OfferingsManager {
         fetchPolicy: FetchPolicy = .default,
         completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
     ) {
-        guard let cachedOfferings = self.deviceCache.cachedOfferings else {
+        guard let memoryCachedOfferings = self.deviceCache.cachedOfferings else {
             Logger.debug(Strings.offering.no_cached_offerings_fetching_from_network)
-            systemInfo.isApplicationBackgrounded { isAppBackgrounded in
+
+            self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
                 self.updateOfferingsCache(appUserID: appUserID,
                                           isAppBackgrounded: isAppBackgrounded,
                                           fetchPolicy: fetchPolicy,
@@ -53,10 +54,10 @@ class OfferingsManager {
             return
         }
 
-        Logger.debug(Strings.offering.vending_offerings_cache)
-        dispatchCompletionOnMainThreadIfPossible(completion, result: .success(cachedOfferings))
+        Logger.debug(Strings.offering.vending_offerings_cache_from_memory)
+        self.dispatchCompletionOnMainThreadIfPossible(completion, value: .success(memoryCachedOfferings))
 
-        systemInfo.isApplicationBackgrounded { isAppBackgrounded in
+        self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
             if self.deviceCache.isOfferingsCacheStale(isAppBackgrounded: isAppBackgrounded) {
                 self.updateOfferingsCache(appUserID: appUserID,
                                           isAppBackgrounded: isAppBackgrounded,
@@ -80,8 +81,23 @@ class OfferingsManager {
             switch result {
             case let .success(response):
                 self.handleOfferingsBackendResult(with: response,
+                                                  appUserID: appUserID,
                                                   fetchPolicy: fetchPolicy,
                                                   completion: completion)
+
+            case let .failure(.networkError(networkError)) where networkError.isServerDown:
+                Logger.warn(Strings.offering.fetching_offerings_failed_server_down)
+
+                // If unable to fetch offerings when server is down, attempt to load them from disk cache.
+                self.fetchCachedOfferingsFromDisk(appUserID: appUserID,
+                                                  fetchPolicy: fetchPolicy) { offerings in
+                    if let offerings = offerings {
+                        self.dispatchCompletionOnMainThreadIfPossible(completion, value: .success(offerings))
+                    } else {
+                        self.handleOfferingsUpdateError(.backendError(.networkError(networkError)),
+                                                        completion: completion)
+                    }
+                }
 
             case let .failure(error):
                 self.handleOfferingsUpdateError(.backendError(error), completion: completion)
@@ -100,7 +116,7 @@ class OfferingsManager {
 
     func invalidateAndReFetchCachedOfferingsIfAppropiate(appUserID: String) {
         let cachedOfferings = self.deviceCache.cachedOfferings
-        self.deviceCache.clearCachedOfferings()
+        self.deviceCache.clearOfferingsCache(appUserID: appUserID)
 
         if cachedOfferings != nil {
             self.offerings(appUserID: appUserID, fetchPolicy: .ignoreNotFoundProducts) { @Sendable _ in }
@@ -111,17 +127,45 @@ class OfferingsManager {
 
 private extension OfferingsManager {
 
-    func handleOfferingsBackendResult(
-        with response: OfferingsResponse,
+    func fetchCachedOfferingsFromDisk(
+        appUserID: String,
         fetchPolicy: FetchPolicy,
-        completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
+        completion: (@escaping @Sendable (Offerings?) -> Void)
+    ) {
+        guard let data = self.deviceCache.cachedOfferingsData(appUserID: appUserID),
+              let response: OfferingsResponse = try? JSONDecoder.default.decode(jsonData: data, logErrors: true) else {
+            completion(nil)
+            return
+        }
+
+        self.createOfferings(
+            from: response,
+            fetchPolicy: fetchPolicy,
+            completion: { [cache = self.deviceCache] result in
+                switch result {
+                case let .success(offerings):
+                    Logger.debug(Strings.offering.vending_offerings_cache_from_disk)
+
+                    cache.cacheInMemory(offerings: offerings)
+                    completion(offerings)
+
+                case .failure:
+                    completion(nil)
+                }
+            }
+        )
+    }
+
+    func createOfferings(
+        from response: OfferingsResponse,
+        fetchPolicy: FetchPolicy,
+        completion: @escaping (@Sendable (Result<Offerings, Error>) -> Void)
     ) {
         let productIdentifiers = response.productIdentifiers
 
         guard !productIdentifiers.isEmpty else {
             let errorMessage = Strings.offering.configuration_error_no_products_for_offering.description
-            self.handleOfferingsUpdateError(.configurationError(errorMessage, underlyingError: nil),
-                                            completion: completion)
+            completion(.failure(.configurationError(errorMessage, underlyingError: nil)))
             return
         }
 
@@ -129,7 +173,7 @@ private extension OfferingsManager {
             let products = result.value ?? []
 
             guard products.isEmpty == false else {
-                self.handleOfferingsUpdateError(Self.createErrorForEmptyResult(result.error), completion: completion)
+                completion(.failure(Self.createErrorForEmptyResult(result.error)))
                 return
             }
 
@@ -145,21 +189,35 @@ private extension OfferingsManager {
                     )
 
                 case .failIfProductsAreMissing:
-                    self.handleOfferingsUpdateError(
-                        .missingProducts(identifiers: missingProductIDs),
-                        completion: completion
-                    )
+                    completion(.failure(.missingProducts(identifiers: missingProductIDs)))
                     return
                 }
             }
 
             if let createdOfferings = self.offeringsFactory.createOfferings(from: productsByID, data: response) {
+                completion(.success(createdOfferings))
+            } else {
+                completion(.failure(.noOfferingsFound()))
+            }
+        }
+    }
+
+    func handleOfferingsBackendResult(
+        with response: OfferingsResponse,
+        appUserID: String,
+        fetchPolicy: FetchPolicy,
+        completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
+    ) {
+        self.createOfferings(from: response, fetchPolicy: fetchPolicy) { result in
+            switch result {
+            case let .success(offerings):
                 Logger.rcSuccess(Strings.offering.offerings_stale_updated_from_network)
 
-                self.deviceCache.cache(offerings: createdOfferings)
-                self.dispatchCompletionOnMainThreadIfPossible(completion, result: .success(createdOfferings))
-            } else {
-                self.handleOfferingsUpdateError(.noOfferingsFound(), completion: completion)
+                self.deviceCache.cache(offerings: offerings, appUserID: appUserID)
+                self.dispatchCompletionOnMainThreadIfPossible(completion, value: .success(offerings))
+
+            case let .failure(error):
+                self.handleOfferingsUpdateError(error, completion: completion)
             }
         }
     }
@@ -181,16 +239,16 @@ private extension OfferingsManager {
         Logger.appleError(Strings.offering.fetching_offerings_error(error: error,
                                                                     underlyingError: error.underlyingError))
         self.deviceCache.clearOfferingsCacheTimestamp()
-        self.dispatchCompletionOnMainThreadIfPossible(completion, result: .failure(error))
+        self.dispatchCompletionOnMainThreadIfPossible(completion, value: .failure(error))
     }
 
-    func dispatchCompletionOnMainThreadIfPossible(
-        _ completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?,
-        result: Result<Offerings, Error>
+    func dispatchCompletionOnMainThreadIfPossible<T>(
+        _ completion: (@MainActor @Sendable (T) -> Void)?,
+        value: T
     ) {
         if let completion = completion {
             self.operationDispatcher.dispatchOnMainActor {
-                completion(result)
+                completion(value)
             }
         }
     }

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -146,7 +146,10 @@ private extension OfferingsManager {
                 case let .success(offerings):
                     Logger.debug(Strings.offering.vending_offerings_cache_from_disk)
 
+                    // Cache in memory but as stale, so it can be re-updated when possible
                     cache.cacheInMemory(offerings: offerings)
+                    cache.clearOfferingsCacheTimestamp()
+
                     completion(offerings)
 
                 case .failure:

--- a/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
+++ b/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
@@ -32,7 +32,9 @@ class PurchasesDiagnosticsTests: TestCase {
 
         self.purchases.mockedHealthRequestResponse = .success(())
         self.purchases.mockedCustomerInfoResponse = .success(.emptyInfo)
-        self.purchases.mockedOfferingsResponse = .success(.init(offerings: [:], currentOfferingID: nil))
+        self.purchases.mockedOfferingsResponse = .success(.init(offerings: [:],
+                                                                currentOfferingID: nil,
+                                                                response: .init(currentOfferingId: nil, offerings: [])))
     }
 
     func testFailingHealthRequest() async throws {

--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -78,34 +78,43 @@ class MockDeviceCache: DeviceCache {
     // MARK: offerings
 
     var cacheOfferingsCount = 0
+    var cacheOfferingsInMemoryCount = 0
     var clearCachedOfferingsCount = 0
     var clearOfferingsCacheTimestampCount = 0
     var setOfferingsCacheTimestampToNowCount = 0
     var stubbedIsOfferingsCacheStale = false
     var stubbedOfferings: Offerings?
+    var stubbedCachedOfferingsData: Data?
 
     override var cachedOfferings: Offerings? {
         return stubbedOfferings
     }
 
-    override func cache(offerings: Offerings) {
-        cacheOfferingsCount += 1
+    override func cache(offerings: Offerings, appUserID: String) {
+        self.cacheOfferingsCount += 1
+    }
+    override func cacheInMemory(offerings: Offerings) {
+        self.cacheOfferingsInMemoryCount += 1
     }
 
     override func isOfferingsCacheStale(isAppBackgrounded: Bool) -> Bool {
-        return stubbedIsOfferingsCacheStale
+        return self.stubbedIsOfferingsCacheStale
     }
 
     override func clearOfferingsCacheTimestamp() {
-        clearOfferingsCacheTimestampCount += 1
+        self.clearOfferingsCacheTimestampCount += 1
     }
 
     override func setOfferingsCacheTimestampToNow() {
-        setOfferingsCacheTimestampToNowCount += 1
+        self.setOfferingsCacheTimestampToNowCount += 1
     }
 
-    override func clearCachedOfferings() {
-        clearCachedOfferingsCount += 1
+    override func clearOfferingsCache(appUserID: String) {
+        self.clearCachedOfferingsCount += 1
+    }
+
+    override func cachedOfferingsData(appUserID: String) -> Data? {
+        return self.stubbedCachedOfferingsData
     }
 
     // MARK: SubscriberAttributes

--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -113,7 +113,7 @@ class MockDeviceCache: DeviceCache {
         self.clearCachedOfferingsCount += 1
     }
 
-    override func cachedOfferingsData(appUserID: String) -> Data? {
+    override func cachedOfferingsResponseData(appUserID: String) -> Data? {
         return self.stubbedCachedOfferingsData
     }
 

--- a/Tests/UnitTests/Mocks/MockOfferingsFactory.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsFactory.swift
@@ -15,7 +15,9 @@ class MockOfferingsFactory: OfferingsFactory {
         data: OfferingsResponse
     ) -> Offerings? {
         if emptyOfferings {
-            return Offerings(offerings: [:], currentOfferingID: "base")
+            return Offerings(offerings: [:],
+                             currentOfferingID: "base",
+                             response: .init(currentOfferingId: "base", offerings: []))
         }
         if nilOfferings {
             return nil
@@ -35,6 +37,13 @@ class MockOfferingsFactory: OfferingsFactory {
                                 offeringIdentifier: "base")
                     ]
                 )],
-            currentOfferingID: "base")
+            currentOfferingID: "base",
+            response: .init(currentOfferingId: "base", offerings: [
+                .init(identifier: "base", description: "This is the base offering",
+                      packages: [
+                        .init(identifier: "", platformProductIdentifier: "$rc_monthly")
+                      ])
+            ])
+        )
     }
 }

--- a/Tests/UnitTests/Mocks/MockProductsManager.swift
+++ b/Tests/UnitTests/Mocks/MockProductsManager.swift
@@ -31,6 +31,8 @@ class MockProductsManager: ProductsManager {
                 completion(result)
             }
         } else {
+            Logger.debug("\(type(of: self)): no stubbed products, returning fake products for \(identifiers)")
+
             let products: [StoreProduct] = identifiers
                 .map { (identifier) -> MockSK1Product in
                     let product = MockSK1Product(mockProductIdentifier: identifier)

--- a/Tests/UnitTests/Networking/NetworkErrorTests.swift
+++ b/Tests/UnitTests/Networking/NetworkErrorTests.swift
@@ -323,3 +323,19 @@ class NetworkErrorTests: TestCase {
         )
     }
 }
+
+extension NetworkError {
+
+    static func serverDown(
+        file: String = #fileID, function: String = #function, line: UInt = #line
+    ) -> Self {
+        return .errorResponse(
+            .init(code: .internalServerError, originalCode: BackendErrorCode.internalServerError.rawValue),
+            .internalServerError,
+            file: file,
+            function: function,
+            line: line
+        )
+    }
+
+}

--- a/Tests/UnitTests/Networking/Responses/OfferingsDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/OfferingsDecodingTests.swift
@@ -60,4 +60,8 @@ class OfferingsDecodingTests: BaseHTTPResponseTest {
         expect(package.platformProductIdentifier) == "com.revenuecat.other_product"
     }
 
+    func testEncoding() throws {
+        expect(try self.response.encodeAndDecode()) == self.response
+    }
+
 }

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -433,6 +433,7 @@ extension OfferingsManagerTests {
         expect(self.mockOfferings.invokedGetOfferingsForAppUserID) == true
         expect(self.mockDeviceCache.cacheOfferingsCount) == 0
         expect(self.mockDeviceCache.cacheOfferingsInMemoryCount) == 1
+        expect(self.mockDeviceCache.clearOfferingsCacheTimestampCount) == 1
     }
 
     func testFailsToCreateOfferingsFromDiskCache() throws {


### PR DESCRIPTION
This new cache is used only when the server is down, so paywalls can continue to work in that case.

### Example:
```
- DEBUG: ℹ️ Configuring SDK using RevenueCat's UserDefaults suite.
- DEBUG: ℹ️ No cached Offerings, fetching from network
- DEBUG: ℹ️ Offerings cache is stale, updating from network in foreground
- WARN: ⚠️ Error fetching offerings: server appears down
- DEBUG: ℹ️ MockProductsManager: no stubbed products, returning fake products for ["monthly_freetrial"]
- DEBUG: ℹ️ Vending Offerings from disk cache
```