### PR TITLE
`Offline Entitlements`: integration tests

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -199,6 +199,8 @@
 		37E3578711F5FDD5DC6458A8 /* AttributionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3521731D8DC16873F55F3 /* AttributionFetcher.swift */; };
 		37E35C8515C5E2D01B0AF5C1 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3507939634ED5A9280544 /* Strings.swift */; };
 		42F1DF385E3C1F9903A07FBF /* ProductsFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */; };
+		4F2017D52A15587F0061F6EF /* OfflineStoreKitIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2017D42A15587F0061F6EF /* OfflineStoreKitIntegrationTests.swift */; };
+		4F2018732A15797D0061F6EF /* TestLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57057FF728B0048900995F21 /* TestLogHandler.swift */; };
 		4F69EB092A14406E00ED6D4B /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F69EB082A14406E00ED6D4B /* Matchers.swift */; };
 		4F69EB0A2A14406E00ED6D4B /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F69EB082A14406E00ED6D4B /* Matchers.swift */; };
 		4F8A58172A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */; };
@@ -871,6 +873,7 @@
 		37E35EEE7783629CDE41B70C /* SystemInfoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemInfoTests.swift; sourceTree = "<group>"; };
 		37E35F783903362B65FB7AF3 /* MockProductsRequestFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockProductsRequestFactory.swift; sourceTree = "<group>"; };
 		37E35FDA0A44EA03EA12DAA2 /* DateFormatter+ExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DateFormatter+ExtensionsTests.swift"; sourceTree = "<group>"; };
+		4F2017D42A15587F0061F6EF /* OfflineStoreKitIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineStoreKitIntegrationTests.swift; sourceTree = "<group>"; };
 		4F69EB082A14406E00ED6D4B /* Matchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Matchers.swift; sourceTree = "<group>"; };
 		4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOfflineCustomerInfoCreator.swift; sourceTree = "<group>"; };
 		4FA4C8D92A168956007D2803 /* OfflineCustomerInfoCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineCustomerInfoCreator.swift; sourceTree = "<group>"; };
@@ -1707,6 +1710,7 @@
 				5753EE0F294B93CC00CBAB54 /* BaseStoreKitIntegrationTests.swift */,
 				5753EE0D294B938900CBAB54 /* StoreKitObserverModeIntegrationTests.swift */,
 				2DE20B6E264087FB004C597D /* StoreKitIntegrationTests.swift */,
+				4F2017D42A15587F0061F6EF /* OfflineStoreKitIntegrationTests.swift */,
 				579189FC28F4966500BF4963 /* OtherIntegrationTests.swift */,
 				57488AFE29CA58050000EE7E /* LoadShedderIntegrationTests.swift */,
 				579234E427F779FE00B39C68 /* SubscriberAttributesManagerIntegrationTests.swift */,
@@ -3382,6 +3386,7 @@
 				57DE80BE28077010008D6C6F /* XCTestCase+Extensions.swift in Sources */,
 				2D3BFAD426DEA49200370B11 /* SKProductSubscriptionDurationExtensions.swift in Sources */,
 				579234E327F7788900B39C68 /* BaseBackendIntegrationTests.swift in Sources */,
+				4F2017D52A15587F0061F6EF /* OfflineStoreKitIntegrationTests.swift in Sources */,
 				2DE20B6F264087FB004C597D /* StoreKitIntegrationTests.swift in Sources */,
 				4FCBA84F2A15391B004134BD /* SnapshotTesting+Extensions.swift in Sources */,
 				4FA696BD2A0020A000D228B1 /* MainThreadMonitor.swift in Sources */,
@@ -3390,6 +3395,7 @@
 				2DE61A84264190830021CEA0 /* Constants.swift in Sources */,
 				5753EE10294B93CC00CBAB54 /* BaseStoreKitIntegrationTests.swift in Sources */,
 				579234E527F779FE00B39C68 /* SubscriberAttributesManagerIntegrationTests.swift in Sources */,
+				4F2018732A15797D0061F6EF /* TestLogHandler.swift in Sources */,
 				2D3BFAD226DEA46600370B11 /* MockProductsRequest.swift in Sources */,
 				2D1015DB275A4EAE0086173F /* AvailabilityChecks.swift in Sources */,
 				5753EE0E294B938900CBAB54 /* StoreKitObserverModeIntegrationTests.swift in Sources */,

--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -35,6 +35,10 @@ enum NetworkStrings {
     case blocked_network(url: URL, newHost: String?)
     case api_request_redirect(from: URL, to: URL)
 
+    #if DEBUG
+    case api_request_forcing_server_error(HTTPRequest)
+    #endif
+
 }
 
 extension NetworkStrings: CustomStringConvertible {
@@ -98,6 +102,11 @@ extension NetworkStrings: CustomStringConvertible {
 
         case let .api_request_redirect(from, to):
             return "Performing redirect from '\(from.absoluteString)' to '\(to.absoluteString)'"
+
+        #if DEBUG
+        case let .api_request_forcing_server_error(request):
+            return "Returning fake HTTP 500 error for '\(request.description)'"
+        #endif
         }
     }
 

--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -13,14 +13,11 @@ import Foundation
  */
 @objc(RCDangerousSettings) public final class DangerousSettings: NSObject {
 
-    /// Dangerous settings not exposed outside of the SDK.
-    internal struct InternalSettings {
+    internal struct Internal: InternalDangerousSettingsType {
 
-        /// Whether `ReceiptFetcher` can retry fetching receipts.
         let enableReceiptFetchRetry: Bool
 
         #if DEBUG
-        /// Whether `HTTPClient` will fake server errors
         let forceServerErrors: Bool
 
         init(enableReceiptFetchRetry: Bool = false, forceServerErrors: Bool = false) {
@@ -60,7 +57,7 @@ import Foundation
      */
     @objc public let customEntitlementComputation: Bool
 
-    internal let internalSettings: InternalSettings
+    internal let internalSettings: InternalDangerousSettingsType
 
     @objc public override convenience init() {
         self.init(autoSyncPurchases: true)
@@ -84,14 +81,14 @@ import Foundation
     @objc internal convenience init(autoSyncPurchases: Bool = true, customEntitlementComputation: Bool) {
         self.init(autoSyncPurchases: autoSyncPurchases,
                   customEntitlementComputation: customEntitlementComputation,
-                  internalSettings: .default)
+                  internalSettings: Internal.default)
 
     }
 
     /// Designated initializer
     internal init(autoSyncPurchases: Bool,
                   customEntitlementComputation: Bool = false,
-                  internalSettings: InternalSettings) {
+                  internalSettings: InternalDangerousSettingsType) {
         self.autoSyncPurchases = autoSyncPurchases
         self.internalSettings = internalSettings
         self.customEntitlementComputation = customEntitlementComputation
@@ -100,3 +97,16 @@ import Foundation
 }
 
 extension DangerousSettings: Sendable {}
+
+/// Dangerous settings not exposed outside of the SDK.
+internal protocol InternalDangerousSettingsType: Sendable {
+
+    /// Whether `ReceiptFetcher` can retry fetching receipts.
+    var enableReceiptFetchRetry: Bool { get }
+
+    #if DEBUG
+    /// Whether `HTTPClient` will fake server errors
+    var forceServerErrors: Bool { get }
+    #endif
+
+}

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -172,12 +172,6 @@ class SystemInfo {
         return host.contains("apple.com")
     }
 
-    #if DEBUG
-
-    var forceServerErrors: Bool { self.dangerousSettings.internalSettings.forceServerErrors }
-
-    #endif
-
 }
 
 extension SystemInfo: SandboxEnvironmentDetector {}

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -61,7 +61,8 @@ class HTTPClient {
         completionHandler: Completion<Value>?
     ) {
         #if DEBUG
-        guard !self.systemInfo.forceServerErrors else {
+        guard !self.systemInfo.dangerousSettings.internalSettings.forceServerErrors else {
+            Logger.warn(Strings.network.api_request_forcing_server_error(request))
             completionHandler?(
                 .failure(.errorResponse(Self.serverErrorResponse, .internalServerError))
             )

--- a/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
@@ -55,7 +55,7 @@ class StoreKit1Wrapper: NSObject {
     weak var delegate: StoreKit1WrapperDelegate? {
         didSet {
             if self.delegate != nil {
-                self.notifyDelegateOfExistingTransactions()
+                self.notifyDelegateOfExistingTransactionsIfNeeded()
 
                 self.paymentQueue.add(self)
             } else {
@@ -114,7 +114,7 @@ class StoreKit1Wrapper: NSObject {
         return payment
     }
 
-    private func notifyDelegateOfExistingTransactions() {
+    private func notifyDelegateOfExistingTransactionsIfNeeded() {
         // Here be dragons. Explanation:
         // When initializing the SDK after an app opens, `SKPaymentQueue` notifies its
         // transaction observers of _existing_ transactions, so this method is normally not required.

--- a/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKit1Wrapper.swift
@@ -55,6 +55,8 @@ class StoreKit1Wrapper: NSObject {
     weak var delegate: StoreKit1WrapperDelegate? {
         didSet {
             if self.delegate != nil {
+                self.notifyDelegateOfExistingTransactions()
+
                 self.paymentQueue.add(self)
             } else {
                 self.paymentQueue.remove(self)
@@ -110,6 +112,34 @@ class StoreKit1Wrapper: NSObject {
         let payment = self.payment(with: product)
         payment.paymentDiscount = discount
         return payment
+    }
+
+    private func notifyDelegateOfExistingTransactions() {
+        // Here be dragons. Explanation:
+        // When initializing the SDK after an app opens, `SKPaymentQueue` notifies its
+        // transaction observers of _existing_ transactions, so this method is normally not required.
+        //
+        // However: `BaseOfflineStoreKitIntegrationTests` simulates restarting apps.
+        // When it re-creates `Purchases` to do that, `StoreKit 1` doesn't know to re-notify
+        // its observers. This does so manually.
+        // This isn't required in StoreKit 2 because resubscribing to
+        // `StoreKit.Transaction.updates` does forward existing transactions.
+
+        #if DEBUG
+        guard ProcessInfo.isRunningIntegrationTests, let delegate = self.delegate else { return }
+
+        let transactions = self.paymentQueue.transactions
+        guard !transactions.isEmpty else { return }
+
+        Logger.appleWarning(
+            "StoreKit1Wrapper: sending delegate \(transactions.count) existing transactions " +
+            "for Integration Tests."
+        )
+
+        for transaction in transactions {
+            delegate.storeKit1Wrapper(self, updatedTransaction: transaction)
+        }
+        #endif
     }
 
 }

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -89,7 +89,7 @@ class BaseBackendIntegrationTests: XCTestCase {
     }
 
     /// Simulates closing the app and re-opening with a fresh instance of `Purchases`.
-    final func resetPurchases() async {
+    final func resetSingleton() async {
         Logger.warn("Resetting Purchases.shared")
 
         Purchases.clearSingleton()

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -15,15 +15,18 @@ import Nimble
 @testable import RevenueCat
 import XCTest
 
-final class TestPurchaseDelegate: NSObject, PurchasesDelegate {
+final class TestPurchaseDelegate: NSObject, PurchasesDelegate, Sendable {
 
-    var customerInfo: CustomerInfo?
-    var customerInfoUpdateCount = 0
+    private let _customerInfo: Atomic<CustomerInfo?> = nil
+    private let _customerInfoUpdateCount: Atomic<Int> = .init(0)
 
     func purchases(_ purchases: Purchases, receivedUpdated customerInfo: CustomerInfo) {
-        self.customerInfo = customerInfo
-        customerInfoUpdateCount += 1
+        self._customerInfo.value = customerInfo
+        self._customerInfoUpdateCount.value += 1
     }
+
+    var customerInfo: CustomerInfo? { return self._customerInfo.value }
+    var customerInfoUpdateCount: Int { return self._customerInfoUpdateCount.value }
 
 }
 
@@ -75,15 +78,22 @@ class BaseBackendIntegrationTests: XCTestCase {
         }
 
         self.clearReceiptIfExists()
-        self.configurePurchases(apiKey: apiKey, proxyURL: proxyURL)
+        await self.configurePurchases(apiKey: apiKey, proxyURL: proxyURL)
         self.verifyPurchasesDoesNotLeak()
-        await self.waitForAnonymousUser()
     }
 
     override func tearDown() {
         super.tearDown()
 
         self.mainThreadMonitor = nil
+    }
+
+    /// Simulates closing the app and re-opening with a fresh instance of `Purchases`.
+    final func resetPurchases() async {
+        Logger.warn("Resetting Purchases.shared")
+
+        Purchases.clearSingleton()
+        await self.createPurchases()
     }
 
     // MARK: - Configuration
@@ -108,13 +118,17 @@ private extension BaseBackendIntegrationTests {
         }
     }
 
-    func configurePurchases(apiKey: String, proxyURL: String?) {
+    func configurePurchases(apiKey: String, proxyURL: String?) async {
         self.purchasesDelegate = TestPurchaseDelegate()
 
         Purchases.proxyURL = proxyURL.flatMap(URL.init(string:))
         Purchases.logLevel = .verbose
 
-        Purchases.configure(withAPIKey: apiKey,
+        await self.createPurchases()
+    }
+
+    func createPurchases() async {
+        Purchases.configure(withAPIKey: self.apiKey,
                             appUserID: nil,
                             observerMode: Self.observerMode,
                             userDefaults: self.userDefaults,
@@ -125,6 +139,8 @@ private extension BaseBackendIntegrationTests {
                             networkTimeout: Configuration.networkTimeoutDefault,
                             dangerousSettings: self.dangerousSettings)
         Purchases.shared.delegate = self.purchasesDelegate
+
+        await self.waitForAnonymousUser()
     }
 
     func verifyPurchasesDoesNotLeak() {
@@ -156,7 +172,14 @@ private extension BaseBackendIntegrationTests {
 
     private var dangerousSettings: DangerousSettings {
         return .init(autoSyncPurchases: true,
-                     internalSettings: .init(enableReceiptFetchRetry: true))
+                     internalSettings: self)
     }
+
+}
+
+extension BaseBackendIntegrationTests: InternalDangerousSettingsType {
+
+    var enableReceiptFetchRetry: Bool { return true }
+    var forceServerErrors: Bool { return false }
 
 }

--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -124,12 +124,12 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
         self.serverDown()
         try await self.purchaseMonthlyProduct()
 
+        logger.verifyMessageWasNotLogged("Finishing transaction")
+
         // 2. "Re-open" the app after the server is back
         self.serverUp()
         Purchases.shared.invalidateCustomerInfoCache()
         await self.resetSingleton()
-
-        logger.verifyMessageWasNotLogged("Finishing transaction")
 
         // 3. Ensure delegate is notified of subscription
         try await asyncWait(

--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -1,0 +1,169 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  OfflineStoreKitIntegrationTests.swift
+//
+//  Created by Nacho Soto on 5/17/23.
+
+import Nimble
+@testable import RevenueCat
+import StoreKit
+import XCTest
+
+class OfflineStoreKit2IntegrationTests: OfflineStoreKit1IntegrationTests {
+
+    override class var storeKit2Setting: StoreKit2Setting { return .enabledForCompatibleDevices }
+
+}
+
+class OfflineStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
+
+    var serverIsDown: Bool = false
+    override var forceServerErrors: Bool { return self.serverIsDown }
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        await self.waitForPendingCustomerInfoRequests()
+        if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
+            try await self.ensureEntitlementMappingIsAvailable()
+        }
+    }
+
+    func testOfferingsAreCachedInMemory() async throws {
+        let onlineOfferings = try await Purchases.shared.offerings()
+        expect(onlineOfferings.all).toNot(beEmpty())
+
+        self.serverDown()
+
+        let offlineOfferings = try await Purchases.shared.offerings()
+        expect(offlineOfferings) === onlineOfferings
+    }
+
+    func testOfferingsAreCachedOnDisk() async throws {
+        let onlineOfferings = try await Purchases.shared.offerings()
+        expect(onlineOfferings.all).toNot(beEmpty())
+
+        self.serverDown()
+        await self.resetPurchases()
+
+        let offlineOfferings = try await Purchases.shared.offerings()
+        expect(offlineOfferings.response) == onlineOfferings.response
+
+        let offering = try XCTUnwrap(offlineOfferings.current)
+        expect(offering.availablePackages.count) == onlineOfferings.current?.availablePackages.count
+        expect(offering.monthly?.storeProduct.productIdentifier) == "com.revenuecat.monthly_4.99.1_week_intro"
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testOfflineCustomerInfoWithNoPurchases() async throws {
+        Purchases.shared.invalidateCustomerInfoCache()
+
+        self.serverDown()
+
+        let info = try await Purchases.shared.customerInfo()
+        expect(info.entitlements.all).to(beEmpty())
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testOfflineCustomerInfoWithOnePurchase() async throws {
+        try await self.purchaseMonthlyProduct()
+
+        Purchases.shared.invalidateCustomerInfoCache()
+        self.serverDown()
+
+        let info = try await Purchases.shared.customerInfo()
+        expect(info.entitlements.all).toNot(beEmpty())
+        try await self.verifyEntitlementWentThrough(info)
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testPurchaseWhileServerIsDownSucceedsButDoesNotFinishTransaction() async throws {
+        let logger = TestLogHandler()
+
+        self.serverDown()
+        try await self.purchaseMonthlyProduct()
+
+        logger.verifyMessageWasLogged(Strings.offlineEntitlements.computing_offline_customer_info, level: .info)
+        logger.verifyMessageWasNotLogged("Finishing transaction")
+    }
+
+    @available(iOS 15.2, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testPurchaseWhileServerIsDownPostsReceiptAfterServerComesBack() async throws {
+        let logger = TestLogHandler()
+
+        // 1. Purchase while server is down
+        self.serverDown()
+        try await self.purchaseMonthlyProduct()
+
+        // 2. "Re-open" the app after the server is back
+        self.serverUp()
+        Purchases.shared.invalidateCustomerInfoCache()
+        await self.resetPurchases()
+
+        logger.verifyMessageWasNotLogged("Finishing transaction")
+
+        // 3. Ensure delegate is notified of subscription
+        await asyncWait(
+            until: { [delegate = self.purchasesDelegate] in
+                delegate?.customerInfo?.activeSubscriptions.isEmpty == false
+            },
+            timeout: .seconds(5),
+            pollInterval: .milliseconds(200),
+            description: "Subscription never became active"
+        )
+
+        // 4. Ensure transaction is eventually finished
+        await logger.verifyMessageIsEventuallyLogged(
+            "Finishing transaction",
+            level: .info,
+            timeout: .seconds(5),
+            pollInterval: .milliseconds(100)
+        )
+
+        // 5. Restart app again
+        Purchases.shared.invalidateCustomerInfoCache()
+        await self.resetPurchases()
+
+        // 6. To ensure (with a clean cache) that the receipt was posted
+        let info = try await Purchases.shared.customerInfo()
+        try await self.verifyEntitlementWentThrough(info)
+    }
+
+    @available(iOS 15.2, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testReopeningAppWithOfflineEntitlementsDoesNotReturnStaleCache() async throws {
+        // 1. Purchase while server is down
+        self.serverDown()
+        try await self.purchaseMonthlyProduct()
+
+        // 2. "Re-open" the app
+        await self.resetPurchases()
+
+        // 3. `CustomerInfo` should contain offline purchase
+        let info = try await Purchases.shared.customerInfo()
+        try await self.verifyEntitlementWentThrough(info)
+    }
+
+}
+
+private extension OfflineStoreKit1IntegrationTests {
+
+    final func serverDown() { self.serverIsDown = true }
+    final func serverUp() { self.serverIsDown = false }
+
+    private func waitForPendingCustomerInfoRequests() async {
+        _ = try? await Purchases.shared.customerInfo()
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    private func ensureEntitlementMappingIsAvailable() async throws {
+        _ = try await Purchases.shared.productEntitlementMapping()
+    }
+
+}

--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -241,9 +241,13 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
 
 class OfflineWithNoMappingStoreKitIntegrationTests: BaseOfflineStoreKitIntegrationTests {
 
+    override var forceServerErrors: Bool { return true }
+
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testOfflineCustomerInfoFailsIfNoEntitlementMapping() async throws {
-        self.serverDown()
+        let logger = TestLogHandler()
+
+        Purchases.shared.invalidateCustomerInfoCache()
 
         do {
             _ = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
@@ -253,6 +257,10 @@ class OfflineWithNoMappingStoreKitIntegrationTests: BaseOfflineStoreKitIntegrati
         } catch let error {
             fail("Unexpected error: \(error)")
         }
+
+        logger.verifyMessageWasLogged(
+            Strings.offlineEntitlements.computing_offline_customer_info_with_no_entitlement_mapping
+        )
     }
 
 }

--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -24,10 +24,12 @@ class OfflineStoreKit2IntegrationTests: OfflineStoreKit1IntegrationTests {
 
 class OfflineStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
-    var serverIsDown: Bool = false
+    private var serverIsDown: Bool = false
     override var forceServerErrors: Bool { return self.serverIsDown }
 
     override func setUp() async throws {
+        self.serverIsDown = false
+
         try await super.setUp()
 
         await self.waitForPendingCustomerInfoRequests()
@@ -94,7 +96,7 @@ class OfflineStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         logger.verifyMessageWasNotLogged("Finishing transaction")
     }
 
-    @available(iOS 15.2, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testPurchaseWhileServerIsDownPostsReceiptAfterServerComesBack() async throws {
         let logger = TestLogHandler()
 
@@ -110,7 +112,7 @@ class OfflineStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         logger.verifyMessageWasNotLogged("Finishing transaction")
 
         // 3. Ensure delegate is notified of subscription
-        await asyncWait(
+        try await asyncWait(
             until: { [delegate = self.purchasesDelegate] in
                 delegate?.customerInfo?.activeSubscriptions.isEmpty == false
             },
@@ -120,7 +122,7 @@ class OfflineStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         )
 
         // 4. Ensure transaction is eventually finished
-        await logger.verifyMessageIsEventuallyLogged(
+        try await logger.verifyMessageIsEventuallyLogged(
             "Finishing transaction",
             level: .info,
             timeout: .seconds(5),
@@ -136,7 +138,7 @@ class OfflineStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         try await self.verifyEntitlementWentThrough(info)
     }
 
-    @available(iOS 15.2, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testReopeningAppWithOfflineEntitlementsDoesNotReturnStaleCache() async throws {
         // 1. Purchase while server is down
         self.serverDown()

--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -53,7 +53,7 @@ class OfflineStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         expect(onlineOfferings.all).toNot(beEmpty())
 
         self.serverDown()
-        await self.resetPurchases()
+        await self.resetSingleton()
 
         let offlineOfferings = try await Purchases.shared.offerings()
         expect(offlineOfferings.response) == onlineOfferings.response
@@ -107,7 +107,7 @@ class OfflineStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         // 2. "Re-open" the app after the server is back
         self.serverUp()
         Purchases.shared.invalidateCustomerInfoCache()
-        await self.resetPurchases()
+        await self.resetSingleton()
 
         logger.verifyMessageWasNotLogged("Finishing transaction")
 
@@ -131,7 +131,7 @@ class OfflineStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
         // 5. Restart app again
         Purchases.shared.invalidateCustomerInfoCache()
-        await self.resetPurchases()
+        await self.resetSingleton()
 
         // 6. To ensure (with a clean cache) that the receipt was posted
         let info = try await Purchases.shared.customerInfo()
@@ -145,7 +145,7 @@ class OfflineStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         try await self.purchaseMonthlyProduct()
 
         // 2. "Re-open" the app
-        await self.resetPurchases()
+        await self.resetSingleton()
 
         // 3. `CustomerInfo` should contain offline purchase
         let info = try await Purchases.shared.customerInfo()

--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -95,7 +95,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testOfflineCustomerInfoWithOnePurchase() async throws {
-        try await self.purchaseMonthlyProduct()
+        try await self.purchaseMonthlyOffering()
 
         Purchases.shared.invalidateCustomerInfoCache()
         self.serverDown()
@@ -170,6 +170,22 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
         // 3. `CustomerInfo` should contain offline purchase
         let info = try await Purchases.shared.customerInfo()
         try await self.verifyEntitlementWentThrough(info)
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testPurchasingTwoProductsWhileOffline() async throws {
+        self.serverDown()
+        let product1 = try await self.monthlyPackage.storeProduct
+        let product2 = try await self.annualPackage.storeProduct
+
+        _ = try await Purchases.shared.purchase(product: product1)
+        let info = try await Purchases.shared.purchase(product: product2).customerInfo
+
+        try await self.verifyEntitlementWentThrough(info)
+        expect(info.allPurchasedProductIdentifiers) == [
+            product1.productIdentifier,
+            product2.productIdentifier
+        ]
     }
 
 }

--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -48,16 +48,6 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
         }
     }
 
-    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    func testOfflineCustomerInfoFailsIfNoEntitlementMapping() async throws {
-        Purchases.shared.invalidateCustomerInfoCache()
-
-        self.serverDown()
-
-        let info = try await Purchases.shared.customerInfo()
-        expect(info.entitlements.all).to(beEmpty())
-    }
-
     func testOfferingsAreCachedInMemory() async throws {
         let onlineOfferings = try await Purchases.shared.offerings()
         expect(onlineOfferings.all).toNot(beEmpty())

--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -94,6 +94,17 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testReturnsCachedCustomerInfo() async throws {
+        let logger = TestLogHandler()
+
+        self.serverDown()
+
+       _ = try await Purchases.shared.customerInfo()
+
+        logger.verifyMessageWasNotLogged(Strings.customerInfo.customerinfo_updated_offline)
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testOfflineCustomerInfoWithOnePurchase() async throws {
         try await self.purchaseMonthlyOffering()
 

--- a/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
@@ -40,7 +40,7 @@ class StoreKit2ObserverModeIntegrationTests: StoreKit1ObserverModeIntegrationTes
     func testPurchaseInDevicePostsReceipt() async throws {
         try await self.purchaseProductFromStoreKit()
 
-        await asyncWait(
+        try await asyncWait(
             until: {
                 let entitlement = try? await Purchases.shared
                     .customerInfo(fetchPolicy: .fetchCurrent)

--- a/Tests/StoreKitUnitTests/OfferingsManagerStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/OfferingsManagerStoreKitTests.swift
@@ -64,7 +64,7 @@ extension OfferingsManagerStoreKitTests {
         expect(receivedProduct.currencyCode) == "USD"
 
         testSession.locale = Locale(identifier: "es_ES")
-        await changeStorefront("ESP")
+        try await changeStorefront("ESP")
 
         fetchedStoreProduct = try await fetchSk2StoreProduct()
         storeProduct = StoreProduct(sk2Product: fetchedStoreProduct.underlyingSK2Product)

--- a/Tests/StoreKitUnitTests/PriceFormatterProviderTests.swift
+++ b/Tests/StoreKitUnitTests/PriceFormatterProviderTests.swift
@@ -51,7 +51,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
 
     func testSk1PriceFormatterUsesCurrentStorefront() async throws {
         self.testSession.locale = Locale(identifier: "es_ES")
-        await self.changeStorefront("ESP")
+        try await self.changeStorefront("ESP")
 
         let sk1Fetcher = ProductsFetcherSK1(requestTimeout: Configuration.storeKitRequestTimeoutDefault)
 
@@ -61,7 +61,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
         expect(priceFormatter.currencyCode) == "EUR"
 
         self.testSession.locale = Locale(identifier: "en_EN")
-        await self.changeStorefront("USA")
+        try await self.changeStorefront("USA")
 
         // Note: this test passes only because the cache is manually
         // cleared. `ProductsFetcherSK1` does not detect Storefront
@@ -80,7 +80,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         self.testSession.locale = Locale(identifier: "es_ES")
-        await self.changeStorefront("ESP")
+        try await self.changeStorefront("ESP")
 
         let sk2Fetcher = ProductsFetcherSK2()
 
@@ -90,7 +90,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
         expect(priceFormatter.currencyCode) == "EUR"
 
         self.testSession.locale = Locale(identifier: "en_EN")
-        await self.changeStorefront("USA")
+        try await self.changeStorefront("USA")
 
         storeProduct = try await sk2Fetcher.product(withIdentifier: Self.productID)
 

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -68,7 +68,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         expect(unwrappedFirstProduct.currencyCode) == "USD"
 
         testSession.locale = Locale(identifier: "es_ES")
-        await changeStorefront("ESP")
+        try await changeStorefront("ESP")
 
         // Note: this test passes only because the method `clearCache`
         // is manually executed. `ProductsManager` does not detect Storefront changes to invalidate the
@@ -98,7 +98,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         expect(unwrappedFirstProduct.currencyCode) == "USD"
 
         testSession.locale = Locale(identifier: "es_ES")
-        await changeStorefront("ESP")
+        try await changeStorefront("ESP")
 
         // Note: this test passes only because the method `clearCache`
         // is manually executed. `ProductsManager` does not detect Storefront changes to invalidate the

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -499,7 +499,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
             finishTransactions: false,
             storeKit2Setting: .enabledForCompatibleDevices,
             dangerousSettings: .init(autoSyncPurchases: true,
-                                     internalSettings: .init(enableReceiptFetchRetry: true))
+                                     internalSettings: DangerousSettings.Internal(enableReceiptFetchRetry: true))
         )
 
         self.setUpOrchestrator()

--- a/Tests/StoreKitUnitTests/StoreProductTests.swift
+++ b/Tests/StoreKitUnitTests/StoreProductTests.swift
@@ -224,7 +224,7 @@ class StoreProductTests: StoreKitConfigTestCase {
 
     func testSk1PriceFormatterUsesCurrentStorefront() async throws {
         testSession.locale = Locale(identifier: "es_ES")
-        await self.changeStorefront("ESP")
+        try await self.changeStorefront("ESP")
 
         let sk1Fetcher = ProductsFetcherSK1(requestTimeout: Configuration.storeKitRequestTimeoutDefault)
 
@@ -241,7 +241,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(storeProduct.currencyCode) == "EUR"
 
         testSession.locale = Locale(identifier: "en_EN")
-        await self.changeStorefront("USA")
+        try await self.changeStorefront("USA")
 
         // Note: this test passes only because the cache is manually
         // cleared. `ProductsFetcherSK1` does not detect Storefront
@@ -265,7 +265,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         testSession.locale = Locale(identifier: "es_ES")
-        await self.changeStorefront("ESP")
+        try await self.changeStorefront("ESP")
 
         let sk2Fetcher = ProductsFetcherSK2()
 
@@ -282,7 +282,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(storeProduct.currencyCode) == "EUR"
 
         testSession.locale = Locale(identifier: "en_EN")
-        await self.changeStorefront("USA")
+        try await self.changeStorefront("USA")
 
         storeProduct = try await sk2Fetcher.product(withIdentifier: Self.productID)
 

--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitConfigTestCase+Extensions.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitConfigTestCase+Extensions.swift
@@ -73,10 +73,10 @@ extension StoreKitConfigTestCase {
         _ new: String,
         file: FileString = #fileID,
         line: UInt = #line
-    ) async {
+    ) async throws {
         self.testSession.storefront = new
 
-        await asyncWait(
+        try await asyncWait(
             until: { await Storefront.currentStorefront?.countryCode == new },
             timeout: .seconds(1),
             pollInterval: .milliseconds(100),

--- a/Tests/UnitTests/Mocks/MockOfflineEntitlementsManager.swift
+++ b/Tests/UnitTests/Mocks/MockOfflineEntitlementsManager.swift
@@ -7,7 +7,7 @@
 //
 //      https://opensource.org/licenses/MIT
 //
-//  MockOfflineEntitlementsManager.swiftz
+//  MockOfflineEntitlementsManager.swift
 //
 //  Created by Nacho Soto on 3/22/23.
 

--- a/Tests/UnitTests/Mocks/MockSystemInfo.swift
+++ b/Tests/UnitTests/Mocks/MockSystemInfo.swift
@@ -50,12 +50,6 @@ class MockSystemInfo: SystemInfo {
         return self.stubbedIsSandbox ?? super.isSandbox
     }
 
-    var stubbedForceServerErrors: Bool?
-
-    override var forceServerErrors: Bool {
-        return self.stubbedForceServerErrors ?? super.forceServerErrors
-    }
-
 }
 
 extension OperatingSystemVersion: Comparable {

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1349,7 +1349,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
             finishTransactions: false,
             dangerousSettings: .init(
                 autoSyncPurchases: true,
-                internalSettings: .init(forceServerErrors: true)
+                internalSettings: DangerousSettings.Internal(forceServerErrors: true)
             )
         )
         self.client = self.createClient()

--- a/Tests/UnitTests/TestHelpers/AsyncTestHelpers.swift
+++ b/Tests/UnitTests/TestHelpers/AsyncTestHelpers.swift
@@ -65,8 +65,8 @@ func waitUntilValue<Value>(
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 func asyncWait(
     until condition: @Sendable () async -> Bool,
-    timeout: DispatchTimeInterval,
-    pollInterval: DispatchTimeInterval,
+    timeout: DispatchTimeInterval = AsyncDefaults.timeout,
+    pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval,
     description: String? = nil,
     file: FileString = #fileID,
     line: UInt = #line

--- a/Tests/UnitTests/TestHelpers/AsyncTestHelpers.swift
+++ b/Tests/UnitTests/TestHelpers/AsyncTestHelpers.swift
@@ -70,7 +70,7 @@ func asyncWait(
     description: String? = nil,
     file: FileString = #fileID,
     line: UInt = #line
-) async {
+) async throws {
     let start = Date()
     var foundCorrectValue = false
 
@@ -90,4 +90,13 @@ func asyncWait(
         line: line,
         foundCorrectValue
     ).to(beTrue(), description: description)
+
+    if !foundCorrectValue {
+        struct ConditionFailedError: Error {}
+
+        // Because this method is `async`, for some reason Swift is continuing execution of the test
+        // despite the expectation failing, so we throw to ensure this doesn't happen
+        // leading to an inconsistent state.
+        throw ConditionFailedError()
+    }
 }

--- a/Tests/UnitTests/TestHelpers/TestLogHandler.swift
+++ b/Tests/UnitTests/TestHelpers/TestLogHandler.swift
@@ -111,10 +111,10 @@ extension TestLogHandler {
         pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval,
         file: FileString = #file,
         line: UInt = #line
-    ) async {
+    ) async throws {
         let condition = Self.entryCondition(message: message, level: level)
 
-        await asyncWait(
+        try await asyncWait(
             until: { self.messages.contains(where: condition) },
             timeout: timeout, pollInterval: pollInterval,
             description: "Message '\(message)' not found. Logged messages: \(self.messages)",

--- a/Tests/UnitTests/TestHelpers/TestLogHandler.swift
+++ b/Tests/UnitTests/TestHelpers/TestLogHandler.swift
@@ -103,6 +103,26 @@ extension TestLogHandler {
         )
     }
 
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func verifyMessageIsEventuallyLogged(
+        _ message: String,
+        level: LogLevel? = nil,
+        timeout: DispatchTimeInterval = AsyncDefaults.timeout,
+        pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval,
+        file: FileString = #file,
+        line: UInt = #line
+    ) async {
+        let condition = Self.entryCondition(message: message, level: level)
+
+        await asyncWait(
+            until: { self.messages.contains(where: condition) },
+            timeout: timeout, pollInterval: pollInterval,
+            description: "Message '\(message)' not found. Logged messages: \(self.messages)",
+            file: file,
+            line: line
+        )
+    }
+
     func verifyMessageWasNotLogged(
         _ message: CustomStringConvertible,
         level: LogLevel? = nil,
@@ -117,7 +137,9 @@ extension TestLogHandler {
         .toNot(containElementSatisfying(Self.entryCondition(message: message, level: level)))
     }
 
-    private static func entryCondition(message: CustomStringConvertible, level: LogLevel?) -> (MessageData) -> Bool {
+    private static func entryCondition(
+        message: CustomStringConvertible, level: LogLevel?
+    ) -> @Sendable (MessageData) -> Bool {
         return { entry in
             guard entry.message.contains(message.description) else {
                 return false


### PR DESCRIPTION
## Example tests:
```swift
func testOfferingsAreCachedInMemory() async throws {
    let onlineOfferings = try await Purchases.shared.offerings()
    expect(onlineOfferings.all).toNot(beEmpty())

    self.serverDown()

    let offlineOfferings = try await Purchases.shared.offerings()
    expect(offlineOfferings) === onlineOfferings
}

func testOfferingsAreCachedOnDisk() async throws {
    let onlineOfferings = try await Purchases.shared.offerings()
    expect(onlineOfferings.all).toNot(beEmpty())

    self.serverDown()
    await self.resetPurchases()

    let offlineOfferings = try await Purchases.shared.offerings()
    expect(offlineOfferings.response) == onlineOfferings.response

    let offering = try XCTUnwrap(offlineOfferings.current)
    expect(offering.availablePackages.count) == onlineOfferings.current?.availablePackages.count
    expect(offering.monthly?.storeProduct.productIdentifier) == "com.revenuecat.monthly_4.99.1_week_intro"
}
```