### PR TITLE
`MainThreadMonitor`: don't monitor thread if debugger is attached

### DIFF
--- a/Tests/BackendIntegrationTests/MainThreadMonitor.swift
+++ b/Tests/BackendIntegrationTests/MainThreadMonitor.swift
@@ -29,6 +29,11 @@ final class MainThreadMonitor {
     }
 
     func run() {
+        guard !Self.debuggerIsAttached else {
+            Logger.verbose("Debugger is attached, ignoring")
+            return
+        }
+
         self.queue.async { [weak self] in
             while self != nil {
                 let semaphore = DispatchSemaphore(value: 0)
@@ -48,5 +53,24 @@ final class MainThreadMonitor {
     }
 
     private static let threshold: DispatchTimeInterval = .seconds(1)
+
+}
+
+private extension MainThreadMonitor {
+
+    // From https://stackoverflow.com/a/33177600/401024
+    static var debuggerIsAttached: Bool {
+        // Buffer for "sysctl(...)" call's result.
+        var info = kinfo_proc()
+        // Counts buffer's size in bytes (like C/C++'s `sizeof`).
+        var size = MemoryLayout.stride(ofValue: info)
+        // Tells we want info about own process.
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()]
+        // Call the API (and assert success).
+        let junk = sysctl(&mib, UInt32(mib.count), &info, &size, nil, 0)
+        assert(junk == 0, "sysctl failed")
+        // Finally, checks if debugger's flag is present yet.
+        return (info.kp_proc.p_flag & P_TRACED) != 0
+    }
 
 }


### PR DESCRIPTION
See #2463.
If you're actively debugging and interrupt the main thread, it'll end up asserting, which isn't very convenient.

Copied the logic from https://stackoverflow.com/a/33177600/401024. It's not the safest code, but this only runs in tests.
