### PR TITLE
`Purchases`: avoid double-log when setting `delegate` to `nil`

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -86,7 +86,10 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             }
 
             self.privateDelegate = newValue
-            Logger.debug(Strings.configure.delegate_set)
+
+            if newValue != nil {
+                Logger.debug(Strings.configure.delegate_set)
+            }
 
             if !self.systemInfo.dangerousSettings.customEntitlementComputation {
                 // Sends cached customer info (if exists) to delegate as latest


### PR DESCRIPTION
Minor thing, but it creates extra noise when trying to debug the flow of the SDK through logs.
It removes this extra log:
```
- INFO: ℹ️ Purchases delegate is being set to nil, you probably don't want to do this.
- DEBUG: ℹ️ Delegate set
```

With this change, we'll only log the second line if the `delegate` is set to anything other than `nil`
