### PR TITLE
`Offline Entitlements`: allow creating offline `CustomerInfo` with empty `ProductEntitlementMapping`

### DIFF
--- a/Sources/OfflineEntitlements/OfflineCustomerInfoCreator.swift
+++ b/Sources/OfflineEntitlements/OfflineCustomerInfoCreator.swift
@@ -63,8 +63,7 @@ class OfflineCustomerInfoCreator {
     func create(for userID: String) async throws -> CustomerInfo {
         Logger.info(Strings.offlineEntitlements.computing_offline_customer_info)
 
-        guard let mapping = self.productEntitlementMappingFetcher.productEntitlementMapping,
-              !mapping.entitlementsByProduct.isEmpty else {
+        guard let mapping = self.productEntitlementMappingFetcher.productEntitlementMapping else {
             Logger.warn(Strings.offlineEntitlements.computing_offline_customer_info_with_no_entitlement_mapping)
             throw Error.noEntitlementMappingAvailable
         }

--- a/Tests/StoreKitUnitTests/OfflineEntitlements/CustomerInfoOfflineEntitlementsStoreKitTest.swift
+++ b/Tests/StoreKitUnitTests/OfflineEntitlements/CustomerInfoOfflineEntitlementsStoreKitTest.swift
@@ -128,6 +128,18 @@ class CustomerInfoOfflineEntitlementsStoreKitTest: StoreKitConfigTestCase {
         expect(info.entitlements.all).to(beEmpty())
     }
 
+    func testEmptyMapping() async throws {
+        let transaction = try await self.createTransactionWithPurchase()
+        let mapping: ProductEntitlementMapping = .empty
+
+        let info = self.create(with: [transaction], mapping: mapping)
+
+        self.verifyInfo(info)
+        expect(info.activeSubscriptions) == [transaction.productID]
+        expect(info.nonSubscriptions).to(beEmpty())
+        expect(info.entitlements.all).to(beEmpty())
+    }
+
     func testMultiplePurchasedProducts() async throws {
         let product1 = try await self.fetchSk2Product(Self.productID)
         let product2 = try await self.fetchSk2Product("com.revenuecat.annual_39.99_no_trial")

--- a/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
+++ b/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
@@ -188,25 +188,6 @@ class OfflineCustomerInfoResponseHandlerTests: BaseCustomerInfoResponseHandlerTe
         )
     }
 
-    func testServerErrorFailsWhenCreatingOfflineCustomerInfoWithEmptyMapping() async {
-        self.fetcher.stubbedResult = .success([])
-        self.factory.stubbedResult = Self.offlineCustomerInfo
-
-        let error: NetworkError = .serverDown()
-        let logger = TestLogHandler()
-
-        let result = await self.handle(.failure(error), .empty)
-        expect(result).to(beFailure())
-        expect(result.error).to(matchError(BackendError.networkError(error)))
-
-        expect(self.factory.createRequested) == false
-
-        logger.verifyMessageWasLogged(
-            Strings.offlineEntitlements.computing_offline_customer_info_with_no_entitlement_mapping,
-            level: .warn
-        )
-    }
-
     func testServerErrorCreatesOfflineCustomerInfo() async {
         self.fetcher.stubbedResult = .success([
             Self.purchasedProduct
@@ -231,6 +212,19 @@ class OfflineCustomerInfoResponseHandlerTests: BaseCustomerInfoResponseHandlerTe
             Strings.offlineEntitlements.computed_offline_customer_info(Self.offlineCustomerInfo.entitlements),
             level: .info
         )
+    }
+
+    func testCreatesOfflineCustomerInfoWithEmptyMapping() async {
+        self.fetcher.stubbedResult = .success([])
+        self.factory.stubbedResult = Self.offlineCustomerInfo
+
+        let error: NetworkError = .serverDown()
+
+        let result = await self.handle(.failure(error), .empty)
+        expect(result).to(beSuccess())
+        expect(result.value) == Self.offlineCustomerInfo
+
+        expect(self.factory.createRequested) == true
     }
 
     func testServerErrorWithFailingPurchasedProductsFetcher() async {


### PR DESCRIPTION
This matches the behavior in Android. It still will fail if the mapping hasn't been fetched yet, but if it has and it's empty, it'll still create a `CustomerInfo`. This is useful for apps that don't use entitlements. They'll still be able to check the product ID in `activeSubscriptions`.