### PR TITLE
`Xcode`: fixed `.storekit` file references in schemes

### DIFF
--- a/RevenueCat.xcodeproj/xcshareddata/xcschemes/BackendIntegrationTests.xcscheme
+++ b/RevenueCat.xcodeproj/xcshareddata/xcschemes/BackendIntegrationTests.xcscheme
@@ -71,7 +71,7 @@
          </BuildableReference>
       </BuildableProductRunnable>
       <StoreKitConfigurationFileReference
-         identifier = "../../Tests/TestingApps/PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit">
+         identifier = "../Tests/TestingApps/PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit">
       </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction

--- a/Tests/v3LoadShedderIntegration/v3LoadShedderIntegration.xcodeproj/xcshareddata/xcschemes/v3LoadShedderIntegration.xcscheme
+++ b/Tests/v3LoadShedderIntegration/v3LoadShedderIntegration.xcodeproj/xcshareddata/xcschemes/v3LoadShedderIntegration.xcscheme
@@ -62,7 +62,7 @@
          </BuildableReference>
       </BuildableProductRunnable>
       <StoreKitConfigurationFileReference
-         identifier = "../../Tests/v3LoadShedderIntegration/v3LoadShedderIntegrationTests/v3LoadShedderIntegrationTestsConfiguration.storekit">
+         identifier = "../Tests/v3LoadShedderIntegration/v3LoadShedderIntegrationTests/V3LoadShedderIntegrationTestsConfiguration.storekit">
       </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction


### PR DESCRIPTION
For some reason this has been giving a warning:
![Screenshot 2023-05-18 at 10 15 14 AM](https://github.com/RevenueCat/purchases-ios/assets/685609/1974bc2a-d5df-49f6-a1f1-7979738e4b8e)
