### PR TITLE
`PurchasedProductsFetcher`: don't throw errors if purchased products were found

### DIFF
--- a/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
+++ b/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
@@ -60,11 +60,17 @@ class PurchasedProductsFetcher: PurchasedProductsFetcherType {
             }
         }
 
-        if result.isEmpty, let error = syncError {
-            // Only throw errors when syncing with the store if there were no entitlements found
-            throw error
+        if let error = syncError {
+            if result.isEmpty {
+                // Only throw errors when syncing with the store if there were no entitlements found
+                throw error
+            } else {
+                Logger.appleError(error.localizedDescription)
+
+                // If there are any entitlements, ignore the error.
+                return result
+            }
         } else {
-            // If there are any entitlements, ignore the error.
             return result
         }
     }

--- a/Tests/StoreKitUnitTests/OfflineEntitlements/PurchasedProductsFetcherTests.swift
+++ b/Tests/StoreKitUnitTests/OfflineEntitlements/PurchasedProductsFetcherTests.swift
@@ -30,7 +30,7 @@ class BasePurchasedProductsFetcherTests: StoreKitConfigTestCase {
 
         self.sandboxDetector = MockSandboxEnvironmentDetector(isSandbox: .random())
         self.fetcher = PurchasedProductsFetcher(
-            appStoreSync: self.syncAppStore,
+            appStoreSync: { try await self.syncAppStore() },
             sandboxDetector: self.sandboxDetector
         )
     }
@@ -101,8 +101,8 @@ class FailingSyncPurchasedProductsFetcherTests: BasePurchasedProductsFetcherTest
 
     func testThrowsIfNoPurchasedProducts() async throws {
         do {
-            _ = try await self.fetcher.fetchPurchasedProducts()
-            fail("Expected error")
+            let result = try await self.fetcher.fetchPurchasedProducts()
+            fail("Expected error. Found \(result.count) products")
         } catch let error {
             expect(error).to(matchError(Self.error))
         }

--- a/Tests/StoreKitUnitTests/OfflineEntitlements/PurchasedProductsFetcherTests.swift
+++ b/Tests/StoreKitUnitTests/OfflineEntitlements/PurchasedProductsFetcherTests.swift
@@ -18,10 +18,10 @@ import XCTest
 @testable import RevenueCat
 
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-class PurchasedProductsFetcherTests: StoreKitConfigTestCase {
+class BasePurchasedProductsFetcherTests: StoreKitConfigTestCase {
 
-    private var sandboxDetector: SandboxEnvironmentDetector!
-    private var fetcher: PurchasedProductsFetcher!
+    fileprivate var sandboxDetector: SandboxEnvironmentDetector!
+    fileprivate var fetcher: PurchasedProductsFetcher!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -29,8 +29,20 @@ class PurchasedProductsFetcherTests: StoreKitConfigTestCase {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         self.sandboxDetector = MockSandboxEnvironmentDetector(isSandbox: .random())
-        self.fetcher = PurchasedProductsFetcher(sandboxDetector: self.sandboxDetector)
+        self.fetcher = PurchasedProductsFetcher(
+            appStoreSync: self.syncAppStore,
+            sandboxDetector: self.sandboxDetector
+        )
     }
+
+    fileprivate func syncAppStore() async throws {
+        try await PurchasedProductsFetcher.defaultAppStoreSync()
+    }
+
+}
+
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+class PurchasedProductsFetcherTests: BasePurchasedProductsFetcherTests {
 
     func testNoPurchasedProducts() async throws {
         let products = try await self.fetcher.fetchPurchasedProducts()
@@ -77,5 +89,33 @@ class PurchasedProductsFetcherTests: StoreKitConfigTestCase {
             product2.id
         ]))
     }
+
+}
+
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+class FailingSyncPurchasedProductsFetcherTests: BasePurchasedProductsFetcherTests {
+
+    override func syncAppStore() async throws {
+        throw Self.error
+    }
+
+    func testThrowsIfNoPurchasedProducts() async throws {
+        do {
+            _ = try await self.fetcher.fetchPurchasedProducts()
+            fail("Expected error")
+        } catch let error {
+            expect(error).to(matchError(Self.error))
+        }
+    }
+
+    func testReturnsProductsEvenIfSyncingFailed() async throws {
+        _ = try await self.createTransactionWithPurchase()
+
+        let products = try await self.fetcher.fetchPurchasedProducts()
+        expect(products).to(haveCount(1))
+
+    }
+
+    private static let error = ErrorUtils.storeProblemError()
 
 }


### PR DESCRIPTION
This is a best-effort implementation. We can still compute the offline `CustomerInfo` if we found some purchased products.
Extracted from #2368 and added tests.
