### PR TITLE
`PurchasedProductsFetcher`: cache current entitlements

### DIFF
--- a/Sources/FoundationExtensions/DispatchTimeInterval+Extensions.swift
+++ b/Sources/FoundationExtensions/DispatchTimeInterval+Extensions.swift
@@ -21,6 +21,12 @@ extension DispatchTimeInterval {
         self = .milliseconds(Int(timeInterval * 1000))
     }
 
+    static func minutes(_ minutes: Int) -> Self {
+        precondition(minutes >= 0, "Minutes must be positive: \(minutes)")
+
+        return .seconds(minutes * 60)
+    }
+
     static func hours(_ hours: Int) -> Self {
         precondition(hours >= 0, "Hours must be positive: \(hours)")
 

--- a/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
+++ b/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
@@ -30,6 +30,10 @@ enum OfflineEntitlementsStrings {
     case computing_offline_customer_info_failed(Error)
     case computed_offline_customer_info(EntitlementInfos)
 
+    case purchased_products_fetching
+    case purchased_products_returning_cache(count: Int)
+    case purchased_products_invalidating_cache
+
 }
 
 extension OfflineEntitlementsStrings: CustomStringConvertible {
@@ -68,6 +72,14 @@ extension OfflineEntitlementsStrings: CustomStringConvertible {
 
         case let .computed_offline_customer_info(entitlements):
             return "Computed offline CustomerInfo with \(entitlements.active.count) active entitlements."
+        case .purchased_products_fetching:
+            return "PurchasedProductsFetcher: fetching products from StoreKit"
+
+        case let .purchased_products_returning_cache(count):
+            return "PurchasedProductsFetcher: returning \(count) cached products"
+
+        case .purchased_products_invalidating_cache:
+            return "PurchasedProductsFetcher: invalidating cache"
         }
     }
 

--- a/Sources/OfflineEntitlements/OfflineCustomerInfoCreator.swift
+++ b/Sources/OfflineEntitlements/OfflineCustomerInfoCreator.swift
@@ -24,18 +24,25 @@ class OfflineCustomerInfoCreator {
     private let productEntitlementMappingFetcher: ProductEntitlementMappingFetcher
     private let creator: Creator
 
-    static func createDefault(
+    static func createPurchasedProductsFetcherIfAvailable() -> PurchasedProductsFetcherType? {
+        if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
+            return PurchasedProductsFetcher()
+        } else {
+            return nil
+        }
+    }
+
+    static func createIfAvailable(
+        with purchasedProductsFetcher: PurchasedProductsFetcherType?,
         productEntitlementMappingFetcher: ProductEntitlementMappingFetcher
     ) -> OfflineCustomerInfoCreator? {
-        if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
-            return .init(
-                purchasedProductsFetcher: PurchasedProductsFetcher(),
-                productEntitlementMappingFetcher: productEntitlementMappingFetcher
-            )
-        } else {
+        guard let fetcher = purchasedProductsFetcher else {
             Logger.debug(Strings.offlineEntitlements.offline_entitlements_not_available)
             return nil
         }
+
+        return .init(purchasedProductsFetcher: fetcher,
+                     productEntitlementMappingFetcher: productEntitlementMappingFetcher)
     }
 
     convenience init(purchasedProductsFetcher: PurchasedProductsFetcherType,

--- a/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
+++ b/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
@@ -25,8 +25,12 @@ protocol PurchasedProductsFetcherType {
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 class PurchasedProductsFetcher: PurchasedProductsFetcherType {
 
+    private typealias Transactions = [StoreKit.VerificationResult<StoreKit.Transaction>]
+
     private let appStoreSync: () async throws -> Void
     private let sandboxDetector: SandboxEnvironmentDetector
+    private let cache: InMemoryCachedObject<Transactions>
+    private let updatesObservation: Task<Void, Never>
 
     init(
         appStoreSync: @escaping () async throws -> Void = PurchasedProductsFetcher.defaultAppStoreSync,
@@ -34,6 +38,18 @@ class PurchasedProductsFetcher: PurchasedProductsFetcherType {
     ) {
         self.appStoreSync = appStoreSync
         self.sandboxDetector = sandboxDetector
+        self.cache = .init()
+
+        self.updatesObservation = Task<Void, Never>(priority: .utility) { [cache = self.cache] in
+            for await _ in StoreKit.Transaction.updates where cache.cachedInstance != nil {
+                Logger.debug(Strings.offlineEntitlements.purchased_products_invalidating_cache)
+                cache.clearCache()
+            }
+        }
+    }
+
+    deinit {
+        self.updatesObservation.cancel()
     }
 
     func fetchPurchasedProducts() async throws -> [PurchasedSK2Product] {
@@ -47,7 +63,7 @@ class PurchasedProductsFetcher: PurchasedProductsFetcherType {
             syncError = error
         }
 
-        for await transaction in StoreKit.Transaction.currentEntitlements {
+        for transaction in await self.transactions {
             switch transaction {
             case let .unverified(transaction, verificationError):
                 Logger.appleWarning(
@@ -76,5 +92,28 @@ class PurchasedProductsFetcher: PurchasedProductsFetcherType {
     }
 
     static let defaultAppStoreSync = AppStore.sync
+
+    private static let cacheDuration: DispatchTimeInterval = .minutes(5)
+
+    private var transactions: Transactions {
+        get async {
+            if !self.cache.isCacheStale(durationInSeconds: Self.cacheDuration.seconds),
+               let cache = self.cache.cachedInstance, !cache.isEmpty {
+                Logger.debug(Strings.offlineEntitlements.purchased_products_returning_cache(count: cache.count))
+                return cache
+            }
+
+            var result: Transactions = []
+
+            Logger.debug(Strings.offlineEntitlements.purchased_products_fetching)
+
+            for await transaction in StoreKit.Transaction.currentEntitlements {
+                result.append(transaction)
+            }
+
+            self.cache.cache(instance: result)
+            return result
+        }
+    }
 
 }

--- a/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
+++ b/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
@@ -19,6 +19,8 @@ protocol PurchasedProductsFetcherType {
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func fetchPurchasedProducts() async throws -> [PurchasedSK2Product]
 
+    func clearCache()
+
 }
 
 /// A type that can fetch purchased products from StoreKit 2.
@@ -30,7 +32,6 @@ class PurchasedProductsFetcher: PurchasedProductsFetcherType {
     private let appStoreSync: () async throws -> Void
     private let sandboxDetector: SandboxEnvironmentDetector
     private let cache: InMemoryCachedObject<Transactions>
-    private let updatesObservation: Task<Void, Never>
 
     init(
         appStoreSync: @escaping () async throws -> Void = PurchasedProductsFetcher.defaultAppStoreSync,
@@ -39,17 +40,6 @@ class PurchasedProductsFetcher: PurchasedProductsFetcherType {
         self.appStoreSync = appStoreSync
         self.sandboxDetector = sandboxDetector
         self.cache = .init()
-
-        self.updatesObservation = Task<Void, Never>(priority: .utility) { [cache = self.cache] in
-            for await _ in StoreKit.Transaction.updates where cache.cachedInstance != nil {
-                Logger.debug(Strings.offlineEntitlements.purchased_products_invalidating_cache)
-                cache.clearCache()
-            }
-        }
-    }
-
-    deinit {
-        self.updatesObservation.cancel()
     }
 
     func fetchPurchasedProducts() async throws -> [PurchasedSK2Product] {
@@ -89,6 +79,12 @@ class PurchasedProductsFetcher: PurchasedProductsFetcherType {
         } else {
             return result
         }
+    }
+
+    func clearCache() {
+        Logger.debug(Strings.offlineEntitlements.purchased_products_invalidating_cache)
+
+        self.cache.clearCache()
     }
 
     static let defaultAppStoreSync = AppStore.sync

--- a/Tests/StoreKitUnitTests/OfflineEntitlements/PurchasedProductsFetcherTests.swift
+++ b/Tests/StoreKitUnitTests/OfflineEntitlements/PurchasedProductsFetcherTests.swift
@@ -90,7 +90,7 @@ class PurchasedProductsFetcherTests: BasePurchasedProductsFetcherTests {
         ]))
     }
 
-    func testCacheIsInvalidatedAfterPurchasing() async throws {
+    func testCacheIsInvalidated() async throws {
         let product1 = try await self.fetchSk2Product(Self.productID)
         _ = try await self.createTransactionWithPurchase(product: product1)
 
@@ -99,6 +99,8 @@ class PurchasedProductsFetcherTests: BasePurchasedProductsFetcherTests {
 
         let product2 = try await self.fetchSk2Product("com.revenuecat.annual_39.99_no_trial")
         _ = try await self.createTransactionWithPurchase(product: product2)
+
+        self.fetcher.clearCache()
 
         let products2 = try await self.fetcher.fetchPurchasedProducts()
         expect(products2).to(haveCount(2))

--- a/Tests/StoreKitUnitTests/OfflineEntitlements/PurchasedProductsFetcherTests.swift
+++ b/Tests/StoreKitUnitTests/OfflineEntitlements/PurchasedProductsFetcherTests.swift
@@ -90,6 +90,24 @@ class PurchasedProductsFetcherTests: BasePurchasedProductsFetcherTests {
         ]))
     }
 
+    func testCacheIsInvalidatedAfterPurchasing() async throws {
+        let product1 = try await self.fetchSk2Product(Self.productID)
+        _ = try await self.createTransactionWithPurchase(product: product1)
+
+        let products1 = try await self.fetcher.fetchPurchasedProducts()
+        expect(products1).to(haveCount(1))
+
+        let product2 = try await self.fetchSk2Product("com.revenuecat.annual_39.99_no_trial")
+        _ = try await self.createTransactionWithPurchase(product: product2)
+
+        let products2 = try await self.fetcher.fetchPurchasedProducts()
+        expect(products2).to(haveCount(2))
+        expect(products2.map(\.productIdentifier)).to(contain([
+            product1.id,
+            product2.id
+        ]))
+    }
+
 }
 
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)

--- a/Tests/UnitTests/FoundationExtensions/DispatchTimeIntervalExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/DispatchTimeIntervalExtensionsTests.swift
@@ -20,6 +20,12 @@ import XCTest
 
 class DispatchTimeIntervalExtensionsTests: TestCase {
 
+    func testMinutes() {
+        expect(DispatchTimeInterval.minutes(0)) == .seconds(0)
+        expect(DispatchTimeInterval.minutes(1)) == .seconds(60)
+        expect(DispatchTimeInterval.minutes(5)) == .seconds(60 * 5)
+    }
+
     func testHours() {
         expect(DispatchTimeInterval.hours(0)) == .seconds(0)
         expect(DispatchTimeInterval.hours(1)) == .seconds(3600)

--- a/Tests/UnitTests/Mocks/MockPurchasedProductsFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockPurchasedProductsFetcher.swift
@@ -29,4 +29,12 @@ final class MockPurchasedProductsFetcher: PurchasedProductsFetcherType {
         return try self.stubbedResult.get()
     }
 
+    var invokedClearCache = false
+    var invokedClearCacheCount = 0
+
+    func clearCache() {
+        self.invokedClearCache = true
+        self.invokedClearCacheCount += 1
+    }
+
 }

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -271,6 +271,7 @@ class BasePurchasesTests: TestCase {
                                    offeringsManager: self.mockOfferingsManager,
                                    offlineEntitlementsManager: self.mockOfflineEntitlementsManager,
                                    purchasesOrchestrator: self.purchasesOrchestrator,
+                                   purchasedProductsFetcher: self.mockPurchasedProductsFetcher,
                                    trialOrIntroPriceEligibilityChecker: self.cachingTrialOrIntroPriceEligibilityChecker)
 
         self.purchasesOrchestrator.delegate = self.purchases

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -249,6 +249,19 @@ class PurchasesLogInTests: BasePurchasesTests {
         expect(self.cachingTrialOrIntroPriceEligibilityChecker.invokedClearCacheCount) == 1
     }
 
+    func testLogInClearsPurchasedProductsFetcherCache() {
+        expect(self.mockPurchasedProductsFetcher.invokedClearCache) == false
+
+        self.identityManager.mockLogInResult = .success((Self.mockLoggedInInfo, true))
+
+        waitUntil { completed in
+            self.purchases.logIn(Self.appUserID) { _, _, _ in completed() }
+        }
+
+        expect(self.mockPurchasedProductsFetcher.invokedClearCache).toEventually(beTrue())
+        expect(self.mockPurchasedProductsFetcher.invokedClearCacheCount) == 1
+    }
+
 }
 
 // MARK: -

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -57,6 +57,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
 
     var mockOfferingsManager: MockOfferingsManager!
     var mockOfflineEntitlementsManager: MockOfflineEntitlementsManager!
+    var mockPurchasedProductsFetcher: MockPurchasedProductsFetcher!
     var mockManageSubsHelper: MockManageSubscriptionsHelper!
     var mockBeginRefundRequestHelper: MockBeginRefundRequestHelper!
 
@@ -105,6 +106,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
                                        currentUserProvider: self.mockIdentityManager,
                                        attributionPoster: self.mockAttributionPoster)
         self.mockOfflineEntitlementsManager = MockOfflineEntitlementsManager()
+        self.mockPurchasedProductsFetcher = MockPurchasedProductsFetcher()
         self.customerInfoManager = CustomerInfoManager(offlineEntitlementsManager: self.mockOfflineEntitlementsManager,
                                                        operationDispatcher: self.mockOperationDispatcher,
                                                        deviceCache: self.mockDeviceCache,
@@ -187,6 +189,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
                               offeringsManager: mockOfferingsManager,
                               offlineEntitlementsManager: mockOfflineEntitlementsManager,
                               purchasesOrchestrator: purchasesOrchestrator,
+                              purchasedProductsFetcher: mockPurchasedProductsFetcher,
                               trialOrIntroPriceEligibilityChecker: trialOrIntroductoryPriceEligibilityChecker)
         purchasesOrchestrator.delegate = purchases
         purchases!.delegate = purchasesDelegate


### PR DESCRIPTION
To optimize potentially computing offline `CustomerInfo`, this caches what's likely the most expensive part.