### PR TITLE
Performance: `CustomerInfoManager.fetchAndCacheCustomerInfoIfStale` no longer fetches data if stale

### DIFF
--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -62,12 +62,11 @@ class CustomerInfoManager {
     func fetchAndCacheCustomerInfoIfStale(appUserID: String,
                                           isAppBackgrounded: Bool,
                                           completion: CustomerInfoCompletion?) {
-        let cachedCustomerInfo = self.cachedCustomerInfo(appUserID: appUserID)
         let isCacheStale = self.withData {
             $0.deviceCache.isCustomerInfoCacheStale(appUserID: appUserID, isAppBackgrounded: isAppBackgrounded)
         }
 
-        guard !isCacheStale, let customerInfo = cachedCustomerInfo else {
+        guard !isCacheStale, let customerInfo = self.cachedCustomerInfo(appUserID: appUserID) else {
             Logger.debug(isAppBackgrounded
                             ? Strings.customerInfo.customerinfo_stale_updating_in_background
                             : Strings.customerInfo.customerinfo_stale_updating_in_foreground)


### PR DESCRIPTION
Just a small performance optimization. No point calling `cachedCustomerInfo` if `isCacheStale`.
