### PR TITLE
`Offline Entitlements`: disable for custom entitlements mode

### DIFF
--- a/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
+++ b/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
@@ -22,6 +22,7 @@ enum OfflineEntitlementsStrings {
 
     case product_entitlement_mapping_stale_updating
     case product_entitlement_mapping_updated_from_network
+    case product_entitlement_mapping_unavailable
     case product_entitlement_mapping_fetching_error(BackendError)
     case found_unverified_transactions_in_sk2(transactionID: UInt64, Error)
 
@@ -44,6 +45,9 @@ extension OfflineEntitlementsStrings: CustomStringConvertible {
 
         case .product_entitlement_mapping_updated_from_network:
             return "ProductEntitlementMapping cache updated from network."
+
+        case .product_entitlement_mapping_unavailable:
+            return "Offline entitlements aren't available, won't fetch ProductEntitlementMapping."
 
         case let .product_entitlement_mapping_fetching_error(error):
             return "Failed updating ProductEntitlementMapping from network: \(error.localizedDescription)"

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -297,7 +297,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
         let offlineEntitlementsManager = OfflineEntitlementsManager(deviceCache: deviceCache,
                                                                     operationDispatcher: operationDispatcher,
-                                                                    api: backend.offlineEntitlements)
+                                                                    api: backend.offlineEntitlements,
+                                                                    systemInfo: systemInfo)
         let customerInfoManager = CustomerInfoManager(offlineEntitlementsManager: offlineEntitlementsManager,
                                                       operationDispatcher: operationDispatcher,
                                                       deviceCache: deviceCache,

--- a/Tests/UnitTests/Mocks/MockOfflineEntitlementsManager.swift
+++ b/Tests/UnitTests/Mocks/MockOfflineEntitlementsManager.swift
@@ -19,7 +19,8 @@ class MockOfflineEntitlementsManager: OfflineEntitlementsManager {
     init() {
         super.init(deviceCache: MockDeviceCache(),
                    operationDispatcher: MockOperationDispatcher(),
-                   api: MockOfflineEntitlementsAPI())
+                   api: MockOfflineEntitlementsAPI(),
+                   systemInfo: MockSystemInfo(finishTransactions: false))
     }
 
     var invokedUpdateProductsEntitlementsCacheIfStale = false

--- a/Tests/UnitTests/Mocks/MockSystemInfo.swift
+++ b/Tests/UnitTests/Mocks/MockSystemInfo.swift
@@ -15,7 +15,6 @@ class MockSystemInfo: SystemInfo {
 
     var stubbedIsApplicationBackgrounded: Bool?
     var stubbedIsSandbox: Bool?
-    var customEntitlementsComputation: Bool?
 
     convenience init(finishTransactions: Bool,
                      storeKit2Setting: StoreKit2Setting = .default,


### PR DESCRIPTION
This disables fetching `ProductEntitlementMapping` for `RevenueCat_CustomEntitlementComputation`, which essentially disables offline entitlements.