### PR TITLE
`Offline Entitlements`: fixed iOS 12 tests

### DIFF
--- a/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
@@ -895,7 +895,11 @@ class BasicCustomerInfoTests: TestCase {
         expect(self.customerInfo.copy(with: .failed).isComputedOffline) == false
     }
 
-    func testIsComputedOffline() {
+    func testIsComputedOffline() throws {
+        // `CustomerInfo.entitlements.verification` isn't available in iOS 12,
+        // but offline CustomerInfo isn't supported anyway.
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
         expect(self.customerInfo.copy(with: .verifiedOnDevice).isComputedOffline) == true
     }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
@@ -149,6 +149,10 @@ class PurchasesPurchasingTests: BasePurchasesTests {
     }
 
     func testDoesntFinishTransactionIfComputingCustomerInfoOffline() throws {
+        // `CustomerInfo.entitlements.verification` isn't available in iOS 12,
+        // but offline CustomerInfo isn't supported anyway.
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
         var finished = false
 
         let productID = "com.product.id1"


### PR DESCRIPTION
These 2 tests should have been skipped on iOS 12.

Technically offline entitlements require iOS 15, but we can still run these tests before that, which doesn't hurt. However, in iOS 12, we can't even tell if the `CustomerInfo` was computed offline, so no point running them.