### PR TITLE
`PurchaseTesterSwiftUI`: fixed macOS UI

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
@@ -127,13 +127,9 @@ struct HomeView: View {
                     #endif
                 }
             }
-            #if os(macOS)
-                .padding()
-            #endif
-                .task {
-                    await self.fetchData()
-                }
-
+            .task {
+                await self.fetchData()
+            }
         }
         .alert(
             isPresented: .init(get: { self.error != nil },


### PR DESCRIPTION
Not sure why this broke, but SwiftUI on Mac is incredibly brittle and ever changing.

### Before:
![Screenshot 2023-05-19 at 12 10 28 PM](https://github.com/RevenueCat/purchases-ios/assets/685609/35cd29f7-faf1-4e9a-8c5c-da70f8b67d38)

### After:
![Screenshot 2023-05-19 at 12 09 42 PM](https://github.com/RevenueCat/purchases-ios/assets/685609/c0d2768b-f8b2-430b-9f38-348e76b22bbc)

