### PR TITLE
`MainThreadMonitor`: fixed flakiness in CI

### DIFF
--- a/Tests/BackendIntegrationTests/MainThreadMonitor.swift
+++ b/Tests/BackendIntegrationTests/MainThreadMonitor.swift
@@ -52,7 +52,7 @@ final class MainThreadMonitor {
         }
     }
 
-    private static let threshold: DispatchTimeInterval = .seconds(1)
+    private static let threshold: DispatchTimeInterval = .seconds(5)
 
 }
 


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/11230/workflows/78444bf6-22b8-40fc-ad92-1f29279377d0/jobs/69663
This is meant to detect deadlocks. 1 second is unfortunately too low for CI with limited resources.
