### PR TITLE
`PurchaseTesterSwiftUI`: added new window on Mac to manage proxy

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Core/ConfiguredPurchases.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Core/ConfiguredPurchases.swift
@@ -12,10 +12,12 @@ import RevenueCat
 public final class ConfiguredPurchases {
 
     public let purchases: Purchases
+    public let proxyURL: URL?
     private let delegate: Delegate
 
-    public init(purchases: Purchases) {
+    public init(purchases: Purchases, proxyURL: URL?) {
         self.purchases = purchases
+        self.proxyURL = proxyURL
         self.delegate = Delegate()
 
         self.purchases.delegate = self.delegate
@@ -47,7 +49,7 @@ public final class ConfiguredPurchases {
                 .build()
         )
 
-        self.init(purchases: purchases)
+        self.init(purchases: purchases, proxyURL: Purchases.proxyURL)
     }
 
     // MARK: -

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		2DD2CBB129831A09004A3A6A /* ReceiptInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD2CBB029831A09004A3A6A /* ReceiptInspector.swift */; };
 		2DD2CBB329831A22004A3A6A /* ReceiptVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD2CBB229831A22004A3A6A /* ReceiptVerifier.swift */; };
 		4F4F782F2A18542200689BAA /* LocalizedAlertError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4F782E2A18542200689BAA /* LocalizedAlertError.swift */; };
+		4F1F5E992A18124500C4EB88 /* ProxyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1F5E982A18124500C4EB88 /* ProxyManager.swift */; };
+		4F1F5E9B2A18124C00C4EB88 /* ProxyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1F5E9A2A18124C00C4EB88 /* ProxyViewModel.swift */; };
+		4F1F5E9D2A1814EF00C4EB88 /* ProxyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1F5E9C2A1814EF00C4EB88 /* ProxyView.swift */; };
 		575642A4290C7A2700719219 /* LoggerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575642A3290C7A2700719219 /* LoggerView.swift */; };
 		575642A6290C7D3100719219 /* Windows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575642A5290C7D3100719219 /* Windows.swift */; };
 		5759B472296F9B3B002472D5 /* LocalReceiptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5759B471296F9B3B002472D5 /* LocalReceiptView.swift */; };
@@ -134,6 +137,9 @@
 		2DD2CBB029831A09004A3A6A /* ReceiptInspector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReceiptInspector.swift; sourceTree = "<group>"; };
 		2DD2CBB229831A22004A3A6A /* ReceiptVerifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReceiptVerifier.swift; sourceTree = "<group>"; };
 		4F4F782E2A18542200689BAA /* LocalizedAlertError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedAlertError.swift; sourceTree = "<group>"; };
+		4F1F5E982A18124500C4EB88 /* ProxyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyManager.swift; sourceTree = "<group>"; };
+		4F1F5E9A2A18124C00C4EB88 /* ProxyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyViewModel.swift; sourceTree = "<group>"; };
+		4F1F5E9C2A1814EF00C4EB88 /* ProxyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyView.swift; sourceTree = "<group>"; };
 		575642A1290C78DD00719219 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		575642A3290C7A2700719219 /* LoggerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerView.swift; sourceTree = "<group>"; };
 		575642A5290C7D3100719219 /* Windows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Windows.swift; sourceTree = "<group>"; };
@@ -251,6 +257,7 @@
 				2CF428672863EE9D007E6A78 /* Extensions */,
 				57B5794F29536B8C003EAA40 /* Helpers */,
 				2C10F18727A9952B0078444D /* Views */,
+				4F1F5E902A18123300C4EB88 /* Proxy */,
 				2CD2C4F0278C9B02005D1CC2 /* Assets.xcassets */,
 			);
 			path = Shared;
@@ -274,6 +281,16 @@
 				57ED6A85290893B6009580C6 /* Extensions.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		4F1F5E902A18123300C4EB88 /* Proxy */ = {
+			isa = PBXGroup;
+			children = (
+				4F1F5E982A18124500C4EB88 /* ProxyManager.swift */,
+				4F1F5E9A2A18124C00C4EB88 /* ProxyViewModel.swift */,
+				4F1F5E9C2A1814EF00C4EB88 /* ProxyView.swift */,
+			);
+			path = Proxy;
 			sourceTree = "<group>";
 		};
 		578DAA0A2947DD21001700FD /* PurchaseTesterWatchOS */ = {
@@ -483,12 +500,14 @@
 				2CF428692863EEAC007E6A78 /* Package+Extensions.swift in Sources */,
 				4F4F782F2A18542200689BAA /* LocalizedAlertError.swift in Sources */,
 				2C10F17F27A993EA0078444D /* OfferingDetailView.swift in Sources */,
+				4F1F5E9D2A1814EF00C4EB88 /* ProxyView.swift in Sources */,
 				57B5795529536B8C003EAA40 /* ProductFetcherSK2.swift in Sources */,
 				2C10F18527A995150078444D /* HomeView.swift in Sources */,
 				2C10F19127AC31610078444D /* TransactionsView.swift in Sources */,
 				57B5795429536B8C003EAA40 /* PurchasesOrchestrator.swift in Sources */,
 				2C10F18B27A997570078444D /* CustomerView.swift in Sources */,
 				5759B472296F9B3B002472D5 /* LocalReceiptView.swift in Sources */,
+				4F1F5E992A18124500C4EB88 /* ProxyManager.swift in Sources */,
 				2C10F19A27AC32840078444D /* SubscriberAttributesView.swift in Sources */,
 				57B5795629536B8C003EAA40 /* ObserverModeManager.swift in Sources */,
 				2CD2C516278C9B02005D1CC2 /* PurchaseTesterApp.swift in Sources */,
@@ -501,6 +520,7 @@
 				2C10F19727AC31B80078444D /* CustomerInfoView.swift in Sources */,
 				57ED6A86290893B6009580C6 /* Extensions.swift in Sources */,
 				57ED6A8229089111009580C6 /* Identifiable.swift in Sources */,
+				4F1F5E9B2A18124C00C4EB88 /* ProxyViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Proxy/ProxyManager.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Proxy/ProxyManager.swift
@@ -1,0 +1,109 @@
+//
+//  ProxyManager.swift
+//  PurchaseTester
+//
+//  Created by Nacho Soto on 5/19/23.
+//
+
+import Foundation
+
+#if os(macOS) || targetEnvironment(macCatalyst)
+
+enum ProxyStatus {
+
+    enum Mode: String, Decodable, CaseIterable {
+
+        case disabled               = "OFF"
+        case serverDown             = "SERVER_DOWN"
+        case overrideEntitlements   = "OVERRIDE_ENTITLEMENTS"
+
+    }
+
+    case disabled
+    case enabled(Mode)
+
+}
+
+final class ProxyManager {
+
+    static func fetchProxyStatus(proxyURL: URL) async -> ProxyStatus {
+        do {
+            let response: ProxyStatusResponse = try await URLSession.shared
+                .fetch(proxyURL: proxyURL,
+                       path: "status")
+
+            return .enabled(response.mode)
+        } catch {
+            print("Error fetching proxy status: \(error.localizedDescription)")
+            return .disabled
+        }
+    }
+
+    /// Throws if mode failed to change
+    static func changeMode(proxyURL: URL, to newMode: ProxyStatus.Mode) async throws {
+        let _: ProxyChangeModeResponse = try await URLSession.shared
+            .fetch(proxyURL: proxyURL, path: newMode.pathToChange)
+    }
+
+}
+
+extension ProxyStatus.Mode: CustomStringConvertible {
+
+    var description: String {
+        switch self {
+        case .disabled: return "Disabled"
+        case .serverDown: return "Server down"
+        case .overrideEntitlements: return "Fake entitlements"
+        }
+    }
+
+    fileprivate var pathToChange: String {
+        switch self {
+        case .disabled: return "off"
+        case .serverDown: return "server_down"
+        case .overrideEntitlements: return "entitlements"
+        }
+    }
+
+}
+
+extension ProxyStatus: CustomStringConvertible {
+
+    var description: String {
+        switch self {
+        case .disabled: return "Disabled"
+        case let .enabled(mode): return "Running (\(mode.description))"
+        }
+    }
+
+}
+
+// MARK: -
+
+private extension URLSession {
+
+    func fetch<T: Decodable>(proxyURL: URL, path: String) async throws -> T {
+        let (data, _) = try await self.data(from: URL(string: path, relativeTo: proxyURL)!)
+        let decoder = JSONDecoder()
+
+        return try decoder.decode(T.self, from: data)
+    }
+
+}
+
+// MARK: - Responses
+
+private struct ProxyStatusResponse: Decodable {
+
+    let mode: ProxyStatus.Mode
+
+}
+
+private struct ProxyChangeModeResponse: Decodable {
+
+    let result: String
+    let mode: ProxyStatus.Mode
+
+}
+
+#endif

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Proxy/ProxyView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Proxy/ProxyView.swift
@@ -1,0 +1,61 @@
+//
+//  ProxyView.swift
+//  PurchaseTester
+//
+//  Created by Nacho Soto on 5/19/23.
+//
+
+import Foundation
+import SwiftUI
+
+#if os(macOS) || targetEnvironment(macCatalyst)
+
+struct ProxyView: View {
+
+    @StateObject
+    private var viewModel: ProxyViewModel = .init()
+    @State
+    private var changingMode: Bool = false
+
+    let proxyURL: URL?
+
+    var body: some View {
+        if let proxyURL {
+            VStack {
+                Text(verbatim: "Proxy status: \(self.viewModel.proxyStatus?.description ?? "loading...")")
+                    .task(id: proxyURL) {
+                        await self.viewModel.refreshStatus(proxyURL: proxyURL)
+                    }
+
+
+                HStack(spacing: 5) {
+                    ForEach(ProxyStatus.Mode.allCases, id: \.self) { mode in
+                        self.modeButton(mode, proxyURL: proxyURL)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+            }
+        } else {
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private func modeButton(_ mode: ProxyStatus.Mode, proxyURL: URL) -> some View {
+        Button {
+            self.changingMode = true
+
+            Task<Void, Never> {
+                await self.viewModel.changeMode(to: mode, proxyURL: proxyURL)
+
+                self.changingMode = false
+            }
+        } label: {
+            Text(mode.description)
+        }
+        .disabled(self.changingMode)
+    }
+
+}
+
+#endif

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Proxy/ProxyView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Proxy/ProxyView.swift
@@ -22,7 +22,7 @@ struct ProxyView: View {
     var body: some View {
         if let proxyURL {
             VStack {
-                Text(verbatim: "Proxy status: \(self.viewModel.proxyStatus?.description ?? "loading...")")
+                Text(verbatim: "\(self.viewModel.proxyStatus?.description ?? "loading...")")
                     .task(id: proxyURL) {
                         await self.viewModel.refreshStatus(proxyURL: proxyURL)
                     }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Proxy/ProxyViewModel.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Proxy/ProxyViewModel.swift
@@ -1,0 +1,34 @@
+//
+//  ProxyViewModel.swift
+//  PurchaseTester
+//
+//  Created by Nacho Soto on 5/19/23.
+//
+
+import Foundation
+
+#if os(macOS) || targetEnvironment(macCatalyst)
+
+@MainActor
+final class ProxyViewModel: NSObject, ObservableObject {
+
+    @Published var proxyStatus: ProxyStatus?
+
+    override init() {}
+
+    func refreshStatus(proxyURL: URL) async {
+        self.proxyStatus = await ProxyManager.fetchProxyStatus(proxyURL: proxyURL)
+    }
+
+    func changeMode(to newMode: ProxyStatus.Mode, proxyURL: URL) async {
+        do {
+            try await ProxyManager.changeMode(proxyURL: proxyURL, to: newMode)
+            self.proxyStatus = .enabled(newMode)
+        } catch {
+            print("Failed changing mode: \(error.localizedDescription)")
+        }
+    }
+
+}
+
+#endif

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
@@ -68,6 +68,13 @@ struct PurchaseTesterApp: App {
             LoggerView(logger: ConfiguredPurchases.logger)
         }
 
+        #if os(macOS) || targetEnvironment(macCatalyst)
+        WindowGroup(id: Windows.proxy.rawValue) {
+            ProxyView(proxyURL: self.configuration?.proxyURL)
+                .navigationTitle("Proxy Status")
+        }
+        #endif
+
         #if os(macOS)
         MenuBarExtra("ReceiptParser", systemImage: "doc.text.magnifyingglass") {
             VStack {

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
@@ -269,6 +269,8 @@ private struct CustomerInfoHeaderView: View {
                 #if targetEnvironment(macCatalyst) || os(macOS)
                 if #available(macCatalyst 16.0, *) {
                     OpenWindowButton()
+
+                    OpenProxyWindowButton()
                 }
                 #else
                 NavigationLink(destination: LoggerView(logger: ConfiguredPurchases.logger)) {
@@ -309,5 +311,19 @@ private struct OpenWindowButton: View {
         }
     }
     
+}
+
+@available(macCatalyst 16.0, *)
+private struct OpenProxyWindowButton: View {
+
+    @Environment(\.openWindow)
+    private var openWindow
+
+    var body: some View {
+        Button("Proxy") {
+            self.openWindow(id: Windows.proxy.rawValue)
+        }
+    }
+
 }
 #endif

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Windows.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Windows.swift
@@ -11,5 +11,6 @@ enum Windows: String {
 
     case `default`
     case logs
+    case proxy
 
 }


### PR DESCRIPTION
This allows managing the proxy at runtime through the UI:
![Screenshot 2023-05-19 at 2 07 18 PM](https://github.com/RevenueCat/purchases-ios/assets/685609/279828d9-7c7b-4217-b0aa-19a1475e6bf9)

See also https://github.com/RevenueCat/khepri-mitm-proxy/pull/6
