### PR TITLE
`PurchaseTesterSwiftUI`: added visual feedback for purchase success/failure

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		2CF428692863EEAC007E6A78 /* Package+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF428682863EEAC007E6A78 /* Package+Extensions.swift */; };
 		2DD2CBB129831A09004A3A6A /* ReceiptInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD2CBB029831A09004A3A6A /* ReceiptInspector.swift */; };
 		2DD2CBB329831A22004A3A6A /* ReceiptVerifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD2CBB229831A22004A3A6A /* ReceiptVerifier.swift */; };
+		4F4F782F2A18542200689BAA /* LocalizedAlertError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4F782E2A18542200689BAA /* LocalizedAlertError.swift */; };
 		575642A4290C7A2700719219 /* LoggerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575642A3290C7A2700719219 /* LoggerView.swift */; };
 		575642A6290C7D3100719219 /* Windows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575642A5290C7D3100719219 /* Windows.swift */; };
 		5759B472296F9B3B002472D5 /* LocalReceiptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5759B471296F9B3B002472D5 /* LocalReceiptView.swift */; };
@@ -132,6 +133,7 @@
 		2CF428682863EEAC007E6A78 /* Package+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Package+Extensions.swift"; sourceTree = "<group>"; };
 		2DD2CBB029831A09004A3A6A /* ReceiptInspector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReceiptInspector.swift; sourceTree = "<group>"; };
 		2DD2CBB229831A22004A3A6A /* ReceiptVerifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReceiptVerifier.swift; sourceTree = "<group>"; };
+		4F4F782E2A18542200689BAA /* LocalizedAlertError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedAlertError.swift; sourceTree = "<group>"; };
 		575642A1290C78DD00719219 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		575642A3290C7A2700719219 /* LoggerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerView.swift; sourceTree = "<group>"; };
 		575642A5290C7D3100719219 /* Windows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Windows.swift; sourceTree = "<group>"; };
@@ -300,6 +302,7 @@
 			children = (
 				57B5795029536B8C003EAA40 /* PurchasesOrchestrator.swift */,
 				57B5795129536B8C003EAA40 /* ProductFetcherSK2.swift */,
+				4F4F782E2A18542200689BAA /* LocalizedAlertError.swift */,
 				57B5795229536B8C003EAA40 /* ObserverModeManager.swift */,
 				57B5795329536B8C003EAA40 /* ProductFetcherSK1.swift */,
 			);
@@ -478,6 +481,7 @@
 				2C10F18E27AAD1F00078444D /* TextFieldAlert.swift in Sources */,
 				2CD2C518278C9B02005D1CC2 /* ContentView.swift in Sources */,
 				2CF428692863EEAC007E6A78 /* Package+Extensions.swift in Sources */,
+				4F4F782F2A18542200689BAA /* LocalizedAlertError.swift in Sources */,
 				2C10F17F27A993EA0078444D /* OfferingDetailView.swift in Sources */,
 				57B5795529536B8C003EAA40 /* ProductFetcherSK2.swift in Sources */,
 				2C10F18527A995150078444D /* HomeView.swift in Sources */,

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/LocalizedAlertError.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/LocalizedAlertError.swift
@@ -1,0 +1,29 @@
+//
+//  LocalizedAlertError.swift
+//  PurchaseTester
+//
+//  Created by Nacho Soto on 5/19/23.
+//
+
+import Foundation
+
+struct LocalizedAlertError: LocalizedError {
+
+    private let underlyingError: NSError
+
+    var errorDescription: String? { self.title }
+    var recoverySuggestion: String? { self.underlyingError.localizedRecoverySuggestion }
+
+    init(_ error: Error) {
+        self.underlyingError = error as NSError
+    }
+
+    var title: String {
+        return "\(self.underlyingError.domain) \(self.underlyingError.code)"
+    }
+
+    var subtitle: String {
+        return self.underlyingError.localizedDescription
+    }
+
+}

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
@@ -300,27 +300,6 @@ private struct OfferingItemView: View {
     }
 }
 
-private struct LocalizedAlertError: LocalizedError {
-
-    private let underlyingError: NSError
-
-    var errorDescription: String? { self.title }
-    var recoverySuggestion: String? { self.underlyingError.localizedRecoverySuggestion }
-
-    init(_ error: Error) {
-        self.underlyingError = error as NSError
-    }
-
-    var title: String {
-        return "\(self.underlyingError.domain) \(self.underlyingError.code)"
-    }
-
-    var subtitle: String {
-        return self.underlyingError.localizedDescription
-    }
-
-}
-
 #if targetEnvironment(macCatalyst) || os(macOS)
 @available(macCatalyst 16.0, *)
 private struct OpenWindowButton: View {


### PR DESCRIPTION
Currently we were only printing that on the console. This will show an alert after the purchase either fails or succeeds.

![Screenshot 2023-05-19 at 6 06 51 PM](https://github.com/RevenueCat/purchases-ios/assets/685609/d2232119-5321-4139-8657-2a717929edaa)
