### PR TITLE
`HTTPClient`: don't assume error responses are JSON

### DIFF
--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -528,7 +528,7 @@ private extension HTTPResponse {
 
 }
 
-private extension HTTPResponse<Data> {
+private extension HTTPResponse where Body == Data {
 
     func parseUnsuccessfulResponse() -> NetworkError {
         let isJSON = self.value(forHeaderField: HTTPClient.ResponseHeader.contentType.rawValue) == "application/json"

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -111,6 +111,7 @@ extension HTTPClient {
         case eTag = "X-RevenueCat-ETag"
         case signature = "X-Signature"
         case requestDate = "X-RevenueCat-Request-Time"
+        case contentType = "Content-Type"
 
     }
 
@@ -494,12 +495,7 @@ extension Result where Success == HTTPResponse<Data>, Failure == NetworkError {
         return self.flatMap { response in
             response.statusCode.isSuccessfulResponse
             ? .success(response)
-            : .failure(
-                .errorResponse(
-                    ErrorResponse.from(response.body),
-                    response.statusCode
-                )
-            )
+            : .failure(response.parseUnsuccessfulResponse())
         }
     }
 
@@ -519,15 +515,30 @@ extension Result where Success == HTTPResponse<Data>, Failure == NetworkError {
 
 }
 
-extension HTTPResponse {
+private extension HTTPResponse {
 
-    fileprivate func copyWithNewRequestDate() -> Self {
+    func copyWithNewRequestDate() -> Self {
         // Update request time from server unless it failed verification.
         guard self.verificationResult != .failed, let requestDate = self.requestDate else { return self }
 
         return self.mapBody {
             return $0.copy(with: requestDate)
         }
+    }
+
+}
+
+private extension HTTPResponse<Data> {
+
+    func parseUnsuccessfulResponse() -> NetworkError {
+        let isJSON = self.value(forHeaderField: HTTPClient.ResponseHeader.contentType.rawValue) == "application/json"
+
+        return .errorResponse(
+            isJSON
+                ? .from(self.body)
+                : .defaultResponse,
+            self.statusCode
+        )
     }
 
 }

--- a/Sources/Networking/HTTPClient/HTTPResponse.swift
+++ b/Sources/Networking/HTTPClient/HTTPResponse.swift
@@ -243,8 +243,8 @@ extension ErrorResponse {
         }
     }
 
-    private static let defaultResponse: Self = .init(code: .unknownError,
-                                                     originalCode: BackendErrorCode.unknownError.rawValue,
-                                                     message: nil)
+    static let defaultResponse: Self = .init(code: .unknownError,
+                                             originalCode: BackendErrorCode.unknownError.rawValue,
+                                             message: nil)
 
 }

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -322,7 +322,9 @@ final class HTTPClientTests: BaseHTTPClientTests {
             return HTTPStubsResponse(
                 data: json.data(using: String.Encoding.utf8)!,
                 statusCode: Int32(errorCode),
-                headers: nil
+                headers: [
+                    HTTPClient.ResponseHeader.contentType.rawValue: "application/json"
+                ]
             )
         }
 
@@ -356,7 +358,9 @@ final class HTTPClientTests: BaseHTTPClientTests {
             return HTTPStubsResponse(
                 data: json.asData,
                 statusCode: Int32(errorCode),
-                headers: nil
+                headers: [
+                    HTTPClient.ResponseHeader.contentType.rawValue: "application/json"
+                ]
             )
         }
 
@@ -382,6 +386,8 @@ final class HTTPClientTests: BaseHTTPClientTests {
     }
 
     func testServerSide500sWithUnknownBody() throws {
+        let logger = TestLogHandler()
+
         let request = HTTPRequest(method: .get, path: .mockPath)
         let errorCode = 500 + Int.random(in: 0..<50)
 
@@ -413,6 +419,8 @@ final class HTTPClientTests: BaseHTTPClientTests {
         expect(error.isServerDown) == true
 
         expect(MockSigning.requests).to(beEmpty())
+
+        logger.verifyMessageWasNotLogged("Couldn't decode data from json")
     }
 
     func testInvalidJSONAsDataDoesNotFail() {

--- a/Tests/UnitTests/TestHelpers/TestLogHandler.swift
+++ b/Tests/UnitTests/TestHelpers/TestLogHandler.swift
@@ -134,7 +134,10 @@ extension TestLogHandler {
             line: line,
             self.messages
         )
-        .toNot(containElementSatisfying(Self.entryCondition(message: message, level: level)))
+        .toNot(
+            containElementSatisfying(Self.entryCondition(message: message, level: level)),
+            description: "Message '\(message)' should not have been logged"
+        )
     }
 
     private static func entryCondition(


### PR DESCRIPTION
When receiving 500 responses, `HTTPClient` was always calling `ErrorResponse.from(_ data: Data)`, which tried to decode the content as if it was JSON.
However, if the response had something completely different, it would fail to decode.

This wasn't really a bug because `HTTPClient` was still forwarding the right result, but now it will do so without even trying to parse it.
