### PR TITLE
`CircleCI`: save test archive on `loadshedder-integration-tests`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ commands:
       - run:
           name: Compress result bundle
           command: |
-             tar -czf xcresult.tar.gz << parameters.bundle_name >>.xcresult && \
+             tar -czf << parameters.bundle_name >>.xcresult.tar.gz << parameters.bundle_name >>.xcresult && \
              rm -r << parameters.bundle_name >>.xcresult
           working_directory: << parameters.directory >>
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -739,7 +739,7 @@ jobs:
           command: bundle exec fastlane v3_loadshedder_integration_tests
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
-          bundle_name: V3LoadShedderIntegrationTests
+          bundle_name: v3LoadShedderIntegration
       - run:
           name: Backend and LoadShedder integration tests
           command: bundle exec fastlane backend_integration_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -737,9 +737,20 @@ jobs:
       - run:
           name: V3 LoadShedder integration tests
           command: bundle exec fastlane v3_loadshedder_integration_tests
+      - compress_result_bundle:
+          directory: fastlane/test_output/xctest/ios
+          bundle_name: V3LoadShedderIntegrationTests
       - run:
           name: Backend and LoadShedder integration tests
           command: bundle exec fastlane backend_integration_tests
+      - compress_result_bundle:
+          directory: fastlane/test_output/xctest/ios
+          bundle_name: BackendIntegrationTests
+      - store_test_results:
+          path: fastlane/test_output
+      - store_artifacts:
+          path: fastlane/test_output/xctest
+          destination: scan-test-output
   
   deploy-purchase-tester:
     <<: *base-job


### PR DESCRIPTION
So we can better debug failures.

![Screenshot 2023-05-23 at 15 50 29](https://github.com/RevenueCat/purchases-ios/assets/685609/23cee9b0-3193-440f-b15d-d8b74efb3bb8)
