### PR TITLE
`PurchaseTesterSwiftUI`: added `ProxyView` to `iOS`

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Proxy/ProxyManager.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Proxy/ProxyManager.swift
@@ -7,8 +7,6 @@
 
 import Foundation
 
-#if os(macOS) || targetEnvironment(macCatalyst)
-
 enum ProxyStatus {
 
     enum Mode: String, Decodable, CaseIterable {
@@ -105,5 +103,3 @@ private struct ProxyChangeModeResponse: Decodable {
     let mode: ProxyStatus.Mode
 
 }
-
-#endif

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Proxy/ProxyView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Proxy/ProxyView.swift
@@ -8,8 +8,6 @@
 import Foundation
 import SwiftUI
 
-#if os(macOS) || targetEnvironment(macCatalyst)
-
 struct ProxyView: View {
 
     @StateObject
@@ -53,9 +51,8 @@ struct ProxyView: View {
         } label: {
             Text(mode.description)
         }
+        .buttonStyle(.borderedProminent)
         .disabled(self.changingMode)
     }
 
 }
-
-#endif

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Proxy/ProxyViewModel.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Proxy/ProxyViewModel.swift
@@ -7,8 +7,6 @@
 
 import Foundation
 
-#if os(macOS) || targetEnvironment(macCatalyst)
-
 @MainActor
 final class ProxyViewModel: NSObject, ObservableObject {
 
@@ -30,5 +28,3 @@ final class ProxyViewModel: NSObject, ObservableObject {
     }
 
 }
-
-#endif

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/PurchaseTesterApp.swift
@@ -112,18 +112,35 @@ struct PurchaseTesterApp: App {
         ContentView(configuration: configuration)
             .environmentObject(self.revenueCatCustomerData)
             .toolbar {
-                ToolbarItem(placement: .principal) {
+                ToolbarItemGroup(placement: Self.toolbarPlacement) {
                     Button {
                         self.configuration = nil
                     } label: {
                         Text("Reconfigure")
                     }
+
+                    #if os(iOS)
+                    NavigationLink {
+                        ProxyView(proxyURL: self.configuration?.proxyURL)
+                            .navigationTitle("Proxy Status")
+                    } label: {
+                        Text("Proxy")
+                    }
+                    #endif
                 }
             }
     }
 
     private var isConfigured: Bool {
         return self.configuration != nil
+    }
+
+    private static var toolbarPlacement: ToolbarItemPlacement {
+        #if os(iOS)
+        return .navigation
+        #else
+        return .principal
+        #endif
     }
 
 }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
@@ -78,7 +78,13 @@ struct HomeView: View {
                                 Text(policy.label).tag(policy)
                             }
                         }
+                        #if os(iOS)
+                        .pickerStyle(WheelPickerStyle())
+                        .frame(height: 80)
+                        #endif
                         
+                        Spacer()
+
                         Button {
                             Task<Void, Never> {
                                 do {


### PR DESCRIPTION
Follow up to #2518.

Also fixed the `CustomerInfo` `Picker`, which wasn't working on iOS due to its design.
