### PR TITLE
`GetCustomerInfo` posts receipts if there are pending transactions

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -204,6 +204,11 @@
 		4F0BBAAC2A1D253D000E75AB /* OfflineCustomerInfoCreatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0BBAAB2A1D253D000E75AB /* OfflineCustomerInfoCreatorTests.swift */; };
 		4F2017D52A15587F0061F6EF /* OfflineStoreKitIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2017D42A15587F0061F6EF /* OfflineStoreKitIntegrationTests.swift */; };
 		4F2018732A15797D0061F6EF /* TestLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57057FF728B0048900995F21 /* TestLogHandler.swift */; };
+		4F3D56632A1E66A10070105A /* CustomerInfoManagerPostReceiptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F3D56622A1E66A10070105A /* CustomerInfoManagerPostReceiptTests.swift */; };
+		4F54DF3F2A1D8C7500FD72BF /* MockStoreKit2TransactionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54DF3E2A1D8C7500FD72BF /* MockStoreKit2TransactionFetcher.swift */; };
+		4F54DF402A1D8C7500FD72BF /* MockStoreKit2TransactionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54DF3E2A1D8C7500FD72BF /* MockStoreKit2TransactionFetcher.swift */; };
+		4F54DF422A1D8D0700FD72BF /* MockTransactionPoster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54DF412A1D8D0700FD72BF /* MockTransactionPoster.swift */; };
+		4F54DF432A1D8D0700FD72BF /* MockTransactionPoster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54DF412A1D8D0700FD72BF /* MockTransactionPoster.swift */; };
 		4F69EB092A14406E00ED6D4B /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F69EB082A14406E00ED6D4B /* Matchers.swift */; };
 		4F69EB0A2A14406E00ED6D4B /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F69EB082A14406E00ED6D4B /* Matchers.swift */; };
 		4F7DBFBD2A1E986C00A2F511 /* StoreKit2TransactionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7DBFBC2A1E986C00A2F511 /* StoreKit2TransactionFetcher.swift */; };
@@ -882,6 +887,9 @@
 		4F0BBA802A1D0524000E75AB /* DefaultDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultDecodable.swift; sourceTree = "<group>"; };
 		4F0BBAAB2A1D253D000E75AB /* OfflineCustomerInfoCreatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineCustomerInfoCreatorTests.swift; sourceTree = "<group>"; };
 		4F2017D42A15587F0061F6EF /* OfflineStoreKitIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineStoreKitIntegrationTests.swift; sourceTree = "<group>"; };
+		4F3D56622A1E66A10070105A /* CustomerInfoManagerPostReceiptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoManagerPostReceiptTests.swift; sourceTree = "<group>"; };
+		4F54DF3E2A1D8C7500FD72BF /* MockStoreKit2TransactionFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreKit2TransactionFetcher.swift; sourceTree = "<group>"; };
+		4F54DF412A1D8D0700FD72BF /* MockTransactionPoster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTransactionPoster.swift; sourceTree = "<group>"; };
 		4F69EB082A14406E00ED6D4B /* Matchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Matchers.swift; sourceTree = "<group>"; };
 		4F7DBFBC2A1E986C00A2F511 /* StoreKit2TransactionFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2TransactionFetcher.swift; sourceTree = "<group>"; };
 		4F8038322A1EA7C300D21039 /* TransactionPoster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionPoster.swift; sourceTree = "<group>"; };
@@ -1695,11 +1703,13 @@
 				351B514226D449C100BD2BD7 /* MockSubscriberAttributesManager.swift */,
 				351B514626D44A0D00BD2BD7 /* MockSystemInfo.swift */,
 				F591492726B9956C00D32E58 /* MockTransaction.swift */,
+				4F54DF412A1D8D0700FD72BF /* MockTransactionPoster.swift */,
 				F55FFA5927634C3F00995146 /* MockTransactionsManager.swift */,
 				35F8B8F926E02AE1003C3363 /* MockTrialOrIntroPriceEligibilityChecker.swift */,
 				37E357D16038F07915D7825D /* MockUserDefaults.swift */,
 				2DDF41E924F6F844005BC22D /* SKProductSubscriptionDurationExtensions.swift */,
 				5793397128E77A6E00C1232C /* MockPaymentQueue.swift */,
+				4F54DF3E2A1D8C7500FD72BF /* MockStoreKit2TransactionFetcher.swift */,
 				575A8EE42922C9F300936709 /* MockStoreKit2TransactionListenerDelegate.swift */,
 				57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */,
 				578DAA492948EF4F001700FD /* TestClock.swift */,
@@ -2026,6 +2036,7 @@
 			isa = PBXGroup;
 			children = (
 				37E35E992F1916C7F3911E7B /* CustomerInfoManagerTests.swift */,
+				4F3D56622A1E66A10070105A /* CustomerInfoManagerPostReceiptTests.swift */,
 				37E35294EBC1E5A879C95540 /* IdentityManagerTests.swift */,
 			);
 			path = Identity;
@@ -2935,8 +2946,10 @@
 				57488C0129CB85BE0000EE7E /* MockOfflineEntitlementsAPI.swift in Sources */,
 				2D90F8C026FD20DF009B9142 /* MockAttributionDataMigrator.swift in Sources */,
 				57488B2B29CA803F0000EE7E /* MockSandboxEnvironmentDetector.swift in Sources */,
+				4F54DF402A1D8C7500FD72BF /* MockStoreKit2TransactionFetcher.swift in Sources */,
 				F55FFA5D27634E1900995146 /* MockTransactionsManager.swift in Sources */,
 				4FA4C9742A16D3AC007D2803 /* MockBackendConfiguration.swift in Sources */,
+				4F54DF432A1D8D0700FD72BF /* MockTransactionPoster.swift in Sources */,
 				4F8A58182A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift in Sources */,
 				57554CC2282AE1E3009A7E58 /* TestCase.swift in Sources */,
 				2D90F8B826FD20AA009B9142 /* MockReceiptFetcher.swift in Sources */,
@@ -3306,6 +3319,7 @@
 				F591492826B9956C00D32E58 /* MockTransaction.swift in Sources */,
 				5796A39427D6BD6900653165 /* BackendGetOfferingsTests.swift in Sources */,
 				5766AA42283C768600FA6091 /* OperatorExtensionsTests.swift in Sources */,
+				4F54DF3F2A1D8C7500FD72BF /* MockStoreKit2TransactionFetcher.swift in Sources */,
 				351B516A26D44CB300BD2BD7 /* ISOPeriodFormatterTests.swift in Sources */,
 				57DC9F4A27CD37BA00DA6AF9 /* HTTPStatusCodeTests.swift in Sources */,
 				2DDF41DE24F6F527005BC22D /* MockAppleReceiptBuilder.swift in Sources */,
@@ -3321,12 +3335,14 @@
 				2D22BF6826F3CC6D001AE2F9 /* XCTestCase+Extensions.swift in Sources */,
 				579189E928F47E8D00BF4963 /* PurchasesDiagnosticsTests.swift in Sources */,
 				351B51B626D450E800BD2BD7 /* ReceiptFetcherTests.swift in Sources */,
+				4F3D56632A1E66A10070105A /* CustomerInfoManagerPostReceiptTests.swift in Sources */,
 				5796A3C027D7D64500653165 /* ResultExtensionsTests.swift in Sources */,
 				351B51A726D450D400BD2BD7 /* SystemInfoTests.swift in Sources */,
 				5733B1A827FFBCC800EC2045 /* BackendErrorTests.swift in Sources */,
 				351B515626D44B2300BD2BD7 /* MockNotificationCenter.swift in Sources */,
 				351B515226D44AF000BD2BD7 /* MockReceiptFetcher.swift in Sources */,
 				351B51C226D450E800BD2BD7 /* ProductRequestDataTests.swift in Sources */,
+				4F54DF422A1D8D0700FD72BF /* MockTransactionPoster.swift in Sources */,
 				351B51BE26D450E800BD2BD7 /* CustomerInfoTests.swift in Sources */,
 				35272E1B26D0029300F22C3B /* DeviceCacheSubscriberAttributesTests.swift in Sources */,
 				5796A39627D6BDAB00653165 /* BackendPostOfferForSigningTests.swift in Sources */,

--- a/Sources/Logging/Strings/CustomerInfoStrings.swift
+++ b/Sources/Logging/Strings/CustomerInfoStrings.swift
@@ -29,6 +29,7 @@ enum CustomerInfoStrings {
     case customerinfo_updated_from_network
     case customerinfo_updated_from_network_error(BackendError)
     case customerinfo_updated_offline
+    case posting_transaction_in_lieu_of_fetching_customerinfo(StoreTransaction)
     case updating_request_date(CustomerInfo, Date)
     case sending_latest_customerinfo_to_delegate
     case sending_updated_customerinfo_to_delegate
@@ -71,6 +72,9 @@ extension CustomerInfoStrings: CustomStringConvertible {
             return result
         case .customerinfo_updated_offline:
             return "CustomerInfo computed offline."
+        case let .posting_transaction_in_lieu_of_fetching_customerinfo(transaction):
+            return "Found unfinished transaction, will post receipt in lieu " +
+            "of fetching CustomerInfo:\n\(transaction.description)"
         case let .updating_request_date(info, newRequestDate):
             return "Updating CustomerInfo '\(info.originalAppUserId)' request date: \(newRequestDate)"
         case .sending_latest_customerinfo_to_delegate:

--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionFetcher.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionFetcher.swift
@@ -24,9 +24,9 @@ protocol StoreKit2TransactionFetcherType: Sendable {
 
 }
 
-@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
 final class StoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
 
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     var unfinishedVerifiedTransactions: [StoreTransaction] {
         get async {
             return await StoreKit.Transaction
@@ -37,6 +37,7 @@ final class StoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
         }
     }
 
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     var hasPendingConsumablePurchase: Bool {
         get async {
             return await StoreKit.Transaction

--- a/Tests/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
+++ b/Tests/StoreKitUnitTests/BeginRefundRequestHelperTests.swift
@@ -50,6 +50,8 @@ class BeginRefundRequestHelperTests: TestCase {
             operationDispatcher: MockOperationDispatcher(),
             deviceCache: MockDeviceCache(sandboxEnvironmentDetector: self.systemInfo),
             backend: MockBackend(),
+            transactionFetcher: MockStoreKit2TransactionFetcher(),
+            transactionPoster: MockTransactionPoster(),
             systemInfo: self.systemInfo
         )
         self.currentUserProvider = MockCurrentUserProvider(mockAppUserID: "appUserID")

--- a/Tests/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
+++ b/Tests/StoreKitUnitTests/ManageSubscriptionsHelperTests.swift
@@ -46,6 +46,8 @@ class ManageSubscriptionsHelperTests: TestCase {
             operationDispatcher: MockOperationDispatcher(),
             deviceCache: MockDeviceCache(sandboxEnvironmentDetector: self.systemInfo),
             backend: MockBackend(),
+            transactionFetcher: MockStoreKit2TransactionFetcher(),
+            transactionPoster: MockTransactionPoster(),
             systemInfo: self.systemInfo
         )
         self.currentUserProvider = MockCurrentUserProvider(mockAppUserID: "appUserID")

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -38,7 +38,6 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     private var mockManageSubsHelper: MockManageSubscriptionsHelper!
     private var mockBeginRefundRequestHelper: MockBeginRefundRequestHelper!
     private var mockOfferingsManager: MockOfferingsManager!
-    private var transactionPoster: TransactionPoster!
 
     private var orchestrator: PurchasesOrchestrator!
 
@@ -64,15 +63,6 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                                                          offeringsFactory: OfferingsFactory(),
                                                          productsManager: self.productsManager)
         self.setUpStoreKit1Wrapper()
-
-        self.transactionPoster = .init(
-            productsManager: self.productsManager,
-            receiptFetcher: self.receiptFetcher,
-            backend: self.backend,
-            paymentQueueWrapper: self.paymentQueueWrapper,
-            systemInfo: self.systemInfo,
-            operationDispatcher: self.operationDispatcher
-        )
 
         self.customerInfoManager = MockCustomerInfoManager(
             offlineEntitlementsManager: MockOfflineEntitlementsManager(),
@@ -186,6 +176,17 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                                                   storeKit2TransactionListener: storeKit2TransactionListener,
                                                   storeKit2StorefrontListener: storeKit2StorefrontListener)
         self.storeKit1Wrapper.delegate = self.orchestrator
+    }
+
+    private var transactionPoster: TransactionPoster {
+        return .init(
+            productsManager: self.productsManager,
+            receiptFetcher: self.receiptFetcher,
+            backend: self.backend,
+            paymentQueueWrapper: self.paymentQueueWrapper,
+            systemInfo: self.systemInfo,
+            operationDispatcher: self.operationDispatcher
+        )
     }
 
     // MARK: - tests

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -63,12 +63,26 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                                                          backend: self.backend,
                                                          offeringsFactory: OfferingsFactory(),
                                                          productsManager: self.productsManager)
+        self.setUpStoreKit1Wrapper()
 
-        self.customerInfoManager = MockCustomerInfoManager(offlineEntitlementsManager: MockOfflineEntitlementsManager(),
-                                                           operationDispatcher: OperationDispatcher(),
-                                                           deviceCache: self.deviceCache,
-                                                           backend: self.backend,
-                                                           systemInfo: self.systemInfo)
+        self.transactionPoster = .init(
+            productsManager: self.productsManager,
+            receiptFetcher: self.receiptFetcher,
+            backend: self.backend,
+            paymentQueueWrapper: self.paymentQueueWrapper,
+            systemInfo: self.systemInfo,
+            operationDispatcher: self.operationDispatcher
+        )
+
+        self.customerInfoManager = MockCustomerInfoManager(
+            offlineEntitlementsManager: MockOfflineEntitlementsManager(),
+            operationDispatcher: OperationDispatcher(),
+            deviceCache: self.deviceCache,
+            backend: self.backend,
+            transactionFetcher: MockStoreKit2TransactionFetcher(),
+            transactionPoster: self.transactionPoster,
+            systemInfo: self.systemInfo
+        )
         self.currentUserProvider = MockCurrentUserProvider(mockAppUserID: mockUserID)
         self.transactionsManager = MockTransactionsManager(receiptParser: MockReceiptParser())
         let attributionFetcher = MockAttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
@@ -93,7 +107,6 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         self.mockBeginRefundRequestHelper = MockBeginRefundRequestHelper(systemInfo: self.systemInfo,
                                                                          customerInfoManager: self.customerInfoManager,
                                                                          currentUserProvider: self.currentUserProvider)
-        self.setUpStoreKit1Wrapper()
         self.setUpOrchestrator()
         self.setUpStoreKit2Listener()
     }
@@ -130,15 +143,6 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     }
 
     fileprivate func setUpOrchestrator() {
-        self.transactionPoster = .init(
-            productsManager: self.productsManager,
-            receiptFetcher: self.receiptFetcher,
-            backend: self.backend,
-            paymentQueueWrapper: paymentQueueWrapper,
-            systemInfo: self.systemInfo,
-            operationDispatcher: self.operationDispatcher
-        )
-
         self.orchestrator = PurchasesOrchestrator(productsManager: self.productsManager,
                                                   paymentQueueWrapper: self.paymentQueueWrapper,
                                                   systemInfo: self.systemInfo,

--- a/Tests/UnitTests/Identity/CustomerInfoManagerPostReceiptTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerPostReceiptTests.swift
@@ -1,0 +1,45 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CustomerInfoManagerFetchInfoAndPostReceiptTests.swift
+//
+//  Created by Nacho Soto on 5/24/23.
+
+import Foundation
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+class CustomerInfoManagerPostReceiptTests: BaseCustomerInfoManagerTests {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+    }
+
+    func testDoesNotTryToPostUnfinishedTransactionIfThereIsNoHandler() async throws {
+        self.mockTransationFetcher.stubbedUnfinishedTransactions = [Self.createTransaction()]
+        self.mockBackend.stubbedGetCustomerInfoResult = .success(self.mockCustomerInfo)
+
+        let result = try await self.customerInfoManager.fetchAndCacheCustomerInfo(appUserID: "user",
+                                                                                  isAppBackgrounded: false)
+
+        expect(result) === self.mockCustomerInfo
+
+        expect(self.mockTransactionPoster.invokedHandlePurchasedTransaction.value) == false
+    }
+
+    private static func createTransaction() -> StoreTransaction {
+        return .init(sk1Transaction: MockTransaction())
+    }
+
+}

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -257,18 +257,19 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
     }
 
     func testCustomerInfoReturnsFromCacheAndRefreshesIfStale() {
-        mockDeviceCache.stubbedIsCustomerInfoCacheStale = true
-        mockBackend.stubbedGetCustomerInfoResult = .success(mockCustomerInfo)
+        self.mockDeviceCache.stubbedIsCustomerInfoCacheStale = true
+        self.mockBackend.stubbedGetCustomerInfoResult = .success(self.mockCustomerInfo)
 
-        customerInfoManager.cache(customerInfo: mockCustomerInfo, appUserID: Self.appUserID)
+        self.customerInfoManager.cache(customerInfo: self.mockCustomerInfo, appUserID: Self.appUserID)
 
-        waitUntil { completed in
-            self.customerInfoManager.customerInfo(appUserID: Self.appUserID, fetchPolicy: .default) { _ in
-                completed()
+        let info = waitUntilValue { completed in
+            self.customerInfoManager.customerInfo(appUserID: Self.appUserID, fetchPolicy: .default) {
+                completed($0.value)
             }
         }
 
-        expect(self.mockBackend.invokedGetSubscriberDataCount) == 1
+        expect(info) == self.mockCustomerInfo
+        expect(self.mockBackend.invokedGetSubscriberDataCount).toEventually(equal(1))
     }
 
     func testCustomerInfoFetchesIfNoCache() {

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -5,17 +5,19 @@ import XCTest
 
 @MainActor
 class BaseCustomerInfoManagerTests: TestCase {
-    fileprivate static let appUserID = "app_user_id"
+    static let appUserID = "app_user_id"
 
-    fileprivate var mockOfflineEntitlementsManager: MockOfflineEntitlementsManager!
-    fileprivate var mockBackend = MockBackend()
-    fileprivate var mockOperationDispatcher = MockOperationDispatcher()
-    fileprivate var mockDeviceCache: MockDeviceCache!
-    fileprivate var mockSystemInfo = MockSystemInfo(finishTransactions: true)
+    var mockOfflineEntitlementsManager: MockOfflineEntitlementsManager!
+    var mockBackend = MockBackend()
+    var mockOperationDispatcher = MockOperationDispatcher()
+    var mockDeviceCache: MockDeviceCache!
+    var mockSystemInfo = MockSystemInfo(finishTransactions: true)
+    var mockTransationFetcher: MockStoreKit2TransactionFetcher!
+    var mockTransactionPoster: MockTransactionPoster!
 
-    fileprivate var mockCustomerInfo: CustomerInfo!
+    var mockCustomerInfo: CustomerInfo!
 
-    fileprivate var customerInfoManager: CustomerInfoManager!
+    var customerInfoManager: CustomerInfoManager!
 
     fileprivate var customerInfoManagerChangesCallCount = 0
     fileprivate var customerInfoManagerLastCustomerInfo: CustomerInfo?
@@ -38,13 +40,21 @@ class BaseCustomerInfoManagerTests: TestCase {
 
         self.mockOfflineEntitlementsManager = MockOfflineEntitlementsManager()
         self.mockDeviceCache = MockDeviceCache(sandboxEnvironmentDetector: self.mockSystemInfo)
+        self.mockTransationFetcher = MockStoreKit2TransactionFetcher()
+        self.mockTransactionPoster = MockTransactionPoster()
+
         self.customerInfoManagerChangesCallCount = 0
         self.customerInfoManagerLastCustomerInfo = nil
-        self.customerInfoManager = CustomerInfoManager(offlineEntitlementsManager: self.mockOfflineEntitlementsManager,
-                                                       operationDispatcher: self.mockOperationDispatcher,
-                                                       deviceCache: self.mockDeviceCache,
-                                                       backend: self.mockBackend,
-                                                       systemInfo: self.mockSystemInfo)
+
+        self.customerInfoManager = CustomerInfoManager(
+            offlineEntitlementsManager: self.mockOfflineEntitlementsManager,
+            operationDispatcher: self.mockOperationDispatcher,
+            deviceCache: self.mockDeviceCache,
+            backend: self.mockBackend,
+            transactionFetcher: self.mockTransationFetcher,
+            transactionPoster: self.mockTransactionPoster,
+            systemInfo: self.mockSystemInfo
+        )
     }
 
     @discardableResult

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -41,6 +41,8 @@ class IdentityManagerTests: TestCase {
             operationDispatcher: MockOperationDispatcher(),
             deviceCache: self.mockDeviceCache,
             backend: MockBackend(),
+            transactionFetcher: MockStoreKit2TransactionFetcher(),
+            transactionPoster: MockTransactionPoster(),
             systemInfo: systemInfo
         )
         self.mockAttributeSyncing = MockAttributeSyncing()

--- a/Tests/UnitTests/Mocks/MockIdentityManager.swift
+++ b/Tests/UnitTests/Mocks/MockIdentityManager.swift
@@ -32,6 +32,8 @@ class MockIdentityManager: IdentityManager {
                     operationDispatcher: MockOperationDispatcher(),
                     deviceCache: mockDeviceCache,
                     backend: mockBackend,
+                    transactionFetcher: MockStoreKit2TransactionFetcher(),
+                    transactionPoster: MockTransactionPoster(),
                     systemInfo: mockSystemInfo
                    ),
                    attributeSyncing: self.mockAttributeSyncing,

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionFetcher.swift
@@ -1,0 +1,45 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockStoreKit2TransactionFetcher.swift
+//
+//  Created by Nacho Soto on 5/23/23.
+
+import Foundation
+@testable import RevenueCat
+
+final class MockStoreKit2TransactionFetcher: StoreKit2TransactionFetcherType {
+
+    private let _stubbedUnfinishedTransactions: Atomic<[StoreTransaction]> = .init([])
+    private let _stubbedHasPendingConsumablePurchase: Atomic<Bool> = false
+
+    var stubbedUnfinishedTransactions: [StoreTransaction] {
+        get { return self._stubbedUnfinishedTransactions.value }
+        set { self._stubbedUnfinishedTransactions.value = newValue }
+    }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    var unfinishedVerifiedTransactions: [StoreTransaction] {
+        get async {
+            return self.stubbedUnfinishedTransactions
+        }
+    }
+
+    // MARK: -
+
+    var stubbedHasPendingConsumablePurchase: Bool {
+        get { return self._stubbedHasPendingConsumablePurchase.value }
+        set { self._stubbedHasPendingConsumablePurchase.value = newValue }
+    }
+
+    var hasPendingConsumablePurchase: Bool {
+        return self.stubbedHasPendingConsumablePurchase
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockTransactionPoster.swift
+++ b/Tests/UnitTests/Mocks/MockTransactionPoster.swift
@@ -1,0 +1,70 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockTransactionPoster.swift
+//
+//  Created by Nacho Soto on 5/23/23.
+
+import Foundation
+@testable import RevenueCat
+
+final class MockTransactionPoster: TransactionPosterType {
+
+    private let operationDispatcher = OperationDispatcher()
+
+    let stubbedHandlePurchasedTransactionResult: Atomic<Swift.Result<CustomerInfo, BackendError>> = .init(
+        .failure(.missingCachedCustomerInfo())
+    )
+    let invokedHandlePurchasedTransaction: Atomic<Bool> = false
+    let invokedHandlePurchasedTransactionCount: Atomic<Int> = .init(0)
+    let invokedHandlePurchasedTransactionParameters: Atomic<(StoreTransaction, PurchasedTransactionData)?> = nil
+
+    func handlePurchasedTransaction(
+        _ transaction: StoreTransaction,
+        data: PurchasedTransactionData,
+        completion: @escaping CustomerAPI.CustomerInfoResponseHandler
+    ) {
+        self.invokedHandlePurchasedTransaction.value = true
+        self.invokedHandlePurchasedTransactionCount.value += 1
+        self.invokedHandlePurchasedTransactionParameters.value = (transaction, data)
+
+        self.operationDispatcher.dispatchOnMainActor { [result = self.stubbedHandlePurchasedTransactionResult.value] in
+            completion(result)
+        }
+    }
+
+    let invokedFinishTransactionIfNeeded: Atomic<Bool> = false
+    let invokedFinishTransactionIfNeededCount: Atomic<Int> = .init(0)
+    let invokedFinishTransactionIfNeededTransaction: Atomic<StoreTransactionType?> = nil
+
+    func finishTransactionIfNeeded(
+        _ transaction: StoreTransactionType,
+        completion: @escaping @MainActor () -> Void
+    ) {
+        self.invokedFinishTransactionIfNeeded.value = true
+        self.invokedFinishTransactionIfNeededCount.value += 1
+        self.invokedFinishTransactionIfNeededTransaction.value = transaction
+
+        self.operationDispatcher.dispatchOnMainActor {
+            completion()
+        }
+    }
+
+    let invokedMarkSyncIfNeeded: Atomic<Bool> = false
+    let invokedMarkSyncIfNeededCount: Atomic<Int> = .init(0)
+
+    func markSyncedIfNeeded(
+        subscriberAttributes: SubscriberAttribute.Dictionary?,
+        error: BackendError?
+    ) {
+        self.invokedMarkSyncIfNeeded.value = true
+        self.invokedMarkSyncIfNeededCount.value += 1
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockTransactionPoster.swift
+++ b/Tests/UnitTests/Mocks/MockTransactionPoster.swift
@@ -23,7 +23,8 @@ final class MockTransactionPoster: TransactionPosterType {
     )
     let invokedHandlePurchasedTransaction: Atomic<Bool> = false
     let invokedHandlePurchasedTransactionCount: Atomic<Int> = .init(0)
-    let invokedHandlePurchasedTransactionParameters: Atomic<(StoreTransaction, PurchasedTransactionData)?> = nil
+    let invokedHandlePurchasedTransactionParameters: Atomic<(transaction: StoreTransaction,
+                                                             data: PurchasedTransactionData)?> = nil
 
     func handlePurchasedTransaction(
         _ transaction: StoreTransaction,
@@ -45,7 +46,7 @@ final class MockTransactionPoster: TransactionPosterType {
 
     func finishTransactionIfNeeded(
         _ transaction: StoreTransactionType,
-        completion: @escaping @MainActor () -> Void
+        completion: @escaping @Sendable @MainActor () -> Void
     ) {
         self.invokedFinishTransactionIfNeeded.value = true
         self.invokedFinishTransactionIfNeededCount.value += 1
@@ -54,17 +55,6 @@ final class MockTransactionPoster: TransactionPosterType {
         self.operationDispatcher.dispatchOnMainActor {
             completion()
         }
-    }
-
-    let invokedMarkSyncIfNeeded: Atomic<Bool> = false
-    let invokedMarkSyncIfNeededCount: Atomic<Int> = .init(0)
-
-    func markSyncedIfNeeded(
-        subscriberAttributes: SubscriberAttribute.Dictionary?,
-        error: BackendError?
-    ) {
-        self.invokedMarkSyncIfNeeded.value = true
-        self.invokedMarkSyncIfNeededCount.value += 1
     }
 
 }

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -78,14 +78,6 @@ class BasePurchasesTests: TestCase {
                                        currentUserProvider: self.identityManager,
                                        attributionPoster: self.attributionPoster)
         self.mockOfflineEntitlementsManager = MockOfflineEntitlementsManager()
-        self.transactionPoster = TransactionPoster(
-            productsManager: self.mockProductsManager,
-            receiptFetcher: self.receiptFetcher,
-            backend: self.backend,
-            paymentQueueWrapper: self.paymentQueueWrapper,
-            systemInfo: self.systemInfo,
-            operationDispatcher: self.mockOperationDispatcher
-        )
         self.customerInfoManager = CustomerInfoManager(offlineEntitlementsManager: self.mockOfflineEntitlementsManager,
                                                        operationDispatcher: self.mockOperationDispatcher,
                                                        deviceCache: self.deviceCache,
@@ -161,7 +153,6 @@ class BasePurchasesTests: TestCase {
     var mockProductEntitlementMappingFetcher: MockProductEntitlementMappingFetcher!
     var mockPurchasedProductsFetcher: MockPurchasedProductsFetcher!
     var mockTransactionFetcher: MockStoreKit2TransactionFetcher!
-    var transactionPoster: TransactionPoster!
     var purchasesOrchestrator: PurchasesOrchestrator!
     var trialOrIntroPriceEligibilityChecker: MockTrialOrIntroPriceEligibilityChecker!
     var cachingTrialOrIntroPriceEligibilityChecker: MockCachingTrialOrIntroPriceEligibilityChecker!
@@ -178,6 +169,17 @@ class BasePurchasesTests: TestCase {
         return self.systemInfo.storeKit2Setting.shouldOnlyUseStoreKit2
             ? .right(self.mockPaymentQueueWrapper)
             : .left(self.storeKit1Wrapper)
+    }
+
+    private var transactionPoster: TransactionPoster {
+        return .init(
+            productsManager: self.mockProductsManager,
+            receiptFetcher: self.receiptFetcher,
+            backend: self.backend,
+            paymentQueueWrapper: self.paymentQueueWrapper,
+            systemInfo: self.systemInfo,
+            operationDispatcher: self.mockOperationDispatcher
+        )
     }
 
     func setupPurchases(automaticCollection: Bool = false, withDelegate: Bool = true) {
@@ -508,7 +510,6 @@ private extension BasePurchasesTests {
         self.mockTransactionFetcher = nil
         self.mockManageSubsHelper = nil
         self.mockBeginRefundRequestHelper = nil
-        self.transactionPoster = nil
         self.purchasesOrchestrator = nil
         self.deviceCache = nil
         self.purchases = nil

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -376,7 +376,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
 
         self.setupPurchases()
 
-        expect(self.paymentQueueWrapper.delegate).to(beNil())
+        expect(self.mockPaymentQueueWrapper.delegate).to(beNil())
     }
 
     func testSetsPaymentQueueWrapperDelegateToPaymentQueueWrapperIfSK1IsNotEnabled() throws {
@@ -387,7 +387,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
 
         self.setupPurchases()
 
-        expect(self.paymentQueueWrapper.delegate) === self.purchasesOrchestrator
+        expect(self.mockPaymentQueueWrapper.delegate) === self.purchasesOrchestrator
     }
 
     // MARK: - Custom Entitlement Computation

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDeferredPurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDeferredPurchasesTests.swift
@@ -151,7 +151,7 @@ class PurchaseDeferredPurchasesSK2Tests: BasePurchasesTests {
 
     private var paymentQueueWrapperDelegate: PaymentQueueWrapperDelegate {
         get throws {
-            return try XCTUnwrap(self.paymentQueueWrapper.delegate)
+            return try XCTUnwrap(self.mockPaymentQueueWrapper.delegate)
         }
     }
     private var product: MockSK1Product!
@@ -174,7 +174,7 @@ class PurchaseDeferredPurchasesSK2Tests: BasePurchasesTests {
         let payment = SKPayment(product: self.product)
 
         _ = try self.paymentQueueWrapperDelegate.paymentQueueWrapper(
-            self.paymentQueueWrapper,
+            self.mockPaymentQueueWrapper,
             shouldAddStorePayment: payment,
             for: self.product
         )

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetCustomerInfoTests.swift
@@ -141,7 +141,9 @@ class PurchasesGetCustomerInfoTests: BasePurchasesTests {
 
         self.deviceCache.cachedCustomerInfo = [:]
 
-        self.purchases.getCustomerInfo { (_, _) in }
+        waitUntil { completion in
+            self.purchases.getCustomerInfo { (_, _) in completion() }
+        }
 
         expect(self.backend.getSubscriberCallCount) == 2
     }

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -249,7 +249,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
         self.setupPurchases()
 
         expect(self.mockBackend.invokedGetSubscriberDataCount) == 1
-        expect(self.mockDeviceCache.cacheCustomerInfoCount) == 1
+        expect(self.mockDeviceCache.cacheCustomerInfoCount).toEventually(equal(1))
         expect(self.mockDeviceCache.cachedCustomerInfo.count) == 1
         expect(self.mockSubscriberAttributesManager.invokedSyncAttributesForAllUsersCount) == 0
 

--- a/Tests/UnitTests/TestHelpers/TestLogHandler.swift
+++ b/Tests/UnitTests/TestHelpers/TestLogHandler.swift
@@ -89,18 +89,35 @@ extension TestLogHandler {
     func verifyMessageWasLogged(
         _ message: CustomStringConvertible,
         level: LogLevel? = nil,
+        expectedCount: Int? = nil,
         file: FileString = #file,
         line: UInt = #line
     ) {
+        precondition(expectedCount == nil || expectedCount! > 0)
+
+        let condition = Self.entryCondition(message: message, level: level)
+
         expect(
             file: file,
             line: line,
             self.messages
         )
         .to(
-            containElementSatisfying(Self.entryCondition(message: message, level: level)),
+            containElementSatisfying(condition),
             description: "Message '\(message)' not found. Logged messages: \(self.messages)"
         )
+
+        if let expectedCount = expectedCount {
+            expect(
+                file: file,
+                line: line,
+                self.messages.lazy.filter(condition).count
+            )
+            .to(
+                equal(expectedCount),
+                description: "Message '\(message)' expected \(expectedCount) times"
+            )
+        }
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)


### PR DESCRIPTION
This fixes the last edge-case for offline entitlements. Solves the following scenario:
```swift
func testPurchaseWhileServerIsDownPostsReceiptWhenForegroundingApp() async throws {
    let logger = TestLogHandler()

    // 1. Purchase while server is down
    self.serverDown()
    try await self.purchaseMonthlyProduct()

    logger.verifyMessageWasNotLogged("Finishing transaction")

    // 2. Server is back
    self.serverUp()

    // 3. Request current CustomerInfo
    let info1 = try await Purchases.shared.customerInfo()
    try await self.verifyEntitlementWentThrough(info1)

    // 4. Ensure transaction is finished
    logger.verifyMessageWasLogged("Finishing transaction", level: .info)

    // 5. Restart app
    Purchases.shared.invalidateCustomerInfoCache()
    await self.resetSingleton()

    // 6. To ensure (with a clean cache) that the receipt was posted
    let info2 = try await Purchases.shared.customerInfo()
    try await self.verifyEntitlementWentThrough(info2)
}
```

This race condition happened when fetching `CustomerInfo` after we had computed an offline `CustomerInfo` with a purchase: if the server is still not aware of the purchase, then we lose that until some arbitrary amount of time when `StoreKit` might decide to send the pending transactions in the queue.
For that reason, instead of waiting, we proactively check now whenever `CustomerInfoManager` fetches new info.

The refactors #2540 and #2542 where required to break a retain cycle.
Also thanks to #2534 we know for sure that there aren't any cycles.

Note that this is an iOS 15.0+ only feature. It would be useful to better ensure consistency in older versions, but it's not strictly required, as those versions don't support offline entitlements either.