### PR TITLE
`BasePurchasesTests`: fixed leak detection

### DIFF
--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -23,6 +23,8 @@ enum PurchaseStrings {
     case storekit1_wrapper_deinit(StoreKit1Wrapper)
     case device_cache_init(DeviceCache)
     case device_cache_deinit(DeviceCache)
+    case purchases_orchestrator_init(PurchasesOrchestrator)
+    case purchases_orchestrator_deinit(PurchasesOrchestrator)
     case updating_all_caches
     case cannot_purchase_product_appstore_configuration_error
     case entitlements_revoked_syncing_purchases(productIdentifiers: [String])
@@ -91,6 +93,12 @@ extension PurchaseStrings: CustomStringConvertible {
 
         case let .device_cache_deinit(instance):
             return "DeviceCache.deinit: \(Strings.objectDescription(instance))"
+
+        case let .purchases_orchestrator_init(instance):
+            return "PurchasesOrchestrator.init: \(Strings.objectDescription(instance))"
+
+        case let .purchases_orchestrator_deinit(instance):
+            return "PurchasesOrchestrator.deinit: \(Strings.objectDescription(instance))"
 
         case .updating_all_caches:
             return "Updating all caches"

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -166,6 +166,12 @@ final class PurchasesOrchestrator {
         self.offeringsManager = offeringsManager
         self.manageSubscriptionsHelper = manageSubscriptionsHelper
         self.beginRefundRequestHelper = beginRefundRequestHelper
+
+        Logger.verbose(Strings.purchase.purchases_orchestrator_init(self))
+    }
+
+    deinit {
+        Logger.verbose(Strings.purchase.purchases_orchestrator_deinit(self))
     }
 
     func restorePurchases(completion: (@Sendable (Result<CustomerInfo, PurchasesError>) -> Void)?) {

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -101,54 +101,20 @@ class BasePurchasesTests: TestCase {
         // this level it should be moved to `StoreKitUnitTests`, which runs serially.
         Purchases.logLevel = .verbose
 
-        // See `addTeardownBlock` docs:
-        // - These run *before* `tearDown`.
-        // - They run in LIFO order.
         self.addTeardownBlock {
-            expect { [weak purchases = self.purchases] in purchases }
-                .toEventually(beNil(), description: "Purchases has leaked")
-        }
-        self.addTeardownBlock {
-            expect { [weak orchestrator = self.purchasesOrchestrator] in orchestrator }
-                .toEventually(beNil(), description: "PurchasesOrchestrator has leaked")
-        }
-        self.addTeardownBlock {
-            expect { [weak deviceCache = self.deviceCache] in deviceCache }
-                .toEventually(beNil(), description: "DeviceCache has leaked: \(self)")
-        }
+            weak var purchases = self.purchases
+            weak var orchestrator = self.purchasesOrchestrator
+            weak var deviceCache = self.deviceCache
 
-        self.addTeardownBlock {
             Purchases.clearSingleton()
+            self.clearReferences()
 
-            self.mockOperationDispatcher = nil
-            self.paymentQueueWrapper = nil
-            self.requestFetcher = nil
-            self.receiptFetcher = nil
-            self.mockProductsManager = nil
-            self.mockIntroEligibilityCalculator = nil
-            self.mockTransactionsManager = nil
-            self.backend = nil
-            self.attributionFetcher = nil
-            self.purchasesDelegate.makeDeferredPurchase = nil
-            self.purchasesDelegate = nil
-            self.storeKit1Wrapper.delegate = nil
-            self.storeKit1Wrapper = nil
-            self.systemInfo = nil
-            self.notificationCenter = nil
-            self.subscriberAttributesManager = nil
-            self.trialOrIntroPriceEligibilityChecker = nil
-            self.attributionPoster = nil
-            self.attribution = nil
-            self.customerInfoManager = nil
-            self.identityManager = nil
-            self.mockOfferingsManager = nil
-            self.mockOfflineEntitlementsManager = nil
-            self.mockPurchasedProductsFetcher = nil
-            self.mockManageSubsHelper = nil
-            self.mockBeginRefundRequestHelper = nil
-            self.purchasesOrchestrator = nil
-            self.deviceCache = nil
-            self.purchases = nil
+            expect(purchases)
+                .toEventually(beNil(), description: "Purchases has leaked")
+            expect(orchestrator)
+                .toEventually(beNil(), description: "PurchasesOrchestrator has leaked")
+            expect(deviceCache)
+                .toEventually(beNil(), description: "DeviceCache has leaked: \(self)")
         }
     }
 
@@ -496,5 +462,41 @@ extension OfferingsResponse {
                   ])
         ]
     )
+
+}
+
+private extension BasePurchasesTests {
+
+    func clearReferences() {
+        self.mockOperationDispatcher = nil
+        self.paymentQueueWrapper = nil
+        self.requestFetcher = nil
+        self.receiptFetcher = nil
+        self.mockProductsManager = nil
+        self.mockIntroEligibilityCalculator = nil
+        self.mockTransactionsManager = nil
+        self.backend = nil
+        self.attributionFetcher = nil
+        self.purchasesDelegate.makeDeferredPurchase = nil
+        self.purchasesDelegate = nil
+        self.storeKit1Wrapper.delegate = nil
+        self.storeKit1Wrapper = nil
+        self.systemInfo = nil
+        self.notificationCenter = nil
+        self.subscriberAttributesManager = nil
+        self.trialOrIntroPriceEligibilityChecker = nil
+        self.attributionPoster = nil
+        self.attribution = nil
+        self.customerInfoManager = nil
+        self.identityManager = nil
+        self.mockOfferingsManager = nil
+        self.mockOfflineEntitlementsManager = nil
+        self.mockPurchasedProductsFetcher = nil
+        self.mockManageSubsHelper = nil
+        self.mockBeginRefundRequestHelper = nil
+        self.purchasesOrchestrator = nil
+        self.deviceCache = nil
+        self.purchases = nil
+    }
 
 }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -408,13 +408,15 @@ class PurchasesConfiguringTests: BasePurchasesTests {
     }
 
     func testConfigureWithCustomEntitlementComputationFatalErrorIfNoAppUserID() throws {
-        self.systemInfo = MockSystemInfo(finishTransactions: true,
-                                         customEntitlementsComputation: true)
-
         let expectedMessage = Strings.configure.custom_entitlements_computation_enabled_but_no_app_user_id.description
 
         expectFatalError(expectedMessage: expectedMessage) {
-            self.setupAnonPurchases()
+            _ = Purchases(apiKey: "",
+                          appUserID: nil,
+                          userDefaults: .init(suiteName: UUID().uuidString)!,
+                          observerMode: false,
+                          responseVerificationMode: .default,
+                          dangerousSettings: .init(customEntitlementComputation: true))
         }
     }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -110,7 +110,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         let purchases = Purchases.configure(
             with: .init(withAPIKey: "")
                 // This test requires no previously stored user
-                .with(userDefaults: .init(suiteName: UUID().uuidString)!)
+                .with(userDefaults: .emptyNewUserDefaults())
                 .with(appUserID: "")
         )
         expect(purchases.appUserID).toNot(beEmpty())
@@ -120,7 +120,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
 
     func testUserIdOverridesPreviouslyConfiguredUser() {
         // This test requires no previously stored user
-        let userDefaults: UserDefaults = .init(suiteName: UUID().uuidString)!
+        let userDefaults: UserDefaults = .emptyNewUserDefaults()
 
         let newUserID = Self.appUserID + "_new"
 
@@ -141,7 +141,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
 
     func testNilUserIdIsIgnoredIfPreviousUserExists() {
         // This test requires no previously stored user
-        let userDefaults: UserDefaults = .init(suiteName: UUID().uuidString)!
+        let userDefaults: UserDefaults = .emptyNewUserDefaults()
 
         _ = Purchases.configure(
             with: .init(withAPIKey: "")
@@ -413,7 +413,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expectFatalError(expectedMessage: expectedMessage) {
             _ = Purchases(apiKey: "",
                           appUserID: nil,
-                          userDefaults: .init(suiteName: UUID().uuidString)!,
+                          userDefaults: .emptyNewUserDefaults(),
                           observerMode: false,
                           responseVerificationMode: .default,
                           dangerousSettings: .init(customEntitlementComputation: true))
@@ -498,5 +498,13 @@ class PurchasesConfiguringTests: BasePurchasesTests {
     }
 
     private static let customUserDefaults: UserDefaults = .init(suiteName: "com.revenuecat.testing_user_defaults")!
+
+}
+
+private extension UserDefaults {
+
+    static func emptyNewUserDefaults() -> Self {
+        return .init(suiteName: UUID().uuidString)!
+    }
 
 }


### PR DESCRIPTION
While working on #2533, I knew that my proof of concept had a retain cycle. I however was very confused when it wasn't detected by this mechanism introduced first introduced in #2104.

Turns out that this had been wrong the whole time: the current implementation, as explained by the comment, was executing those blocks in LIFO order, which meant that the references were being set to `nil` before the assertions could be created.
This meant that by the time the `except { [weak purchases = self.purchases] ... }` lines were called, `self.purchases` itself was `nil`, so nothing was being checked.

This simplifies the implementation by inlining the checks, and saving a `weak` reference before clearing the singleton and all the local references.

Luckily there was only one failing test that had to do with how `Purchases` was being created, and implementation details of `expectFatalError`. To avoid this, I changed the test to use the `Purchases.init` method directly.
