### PR TITLE
`BackendError`/`NetworkError`: removed `Equatable` conformances

### DIFF
--- a/Sources/Error Handling/BackendError.swift
+++ b/Sources/Error Handling/BackendError.swift
@@ -16,7 +16,7 @@
 import Foundation
 
 /// An `Error` produced by ``Backend``.
-enum BackendError: Error, Equatable {
+enum BackendError: Error {
 
     case networkError(NetworkError)
     case missingAppUserID(Source)
@@ -179,7 +179,7 @@ extension BackendError {
 
 extension BackendError {
 
-    enum UnexpectedBackendResponseError: Error, Equatable {
+    enum UnexpectedBackendResponseError: Error {
 
         /// Login call failed due to a problem with the response.
         case loginResponseDecoding

--- a/Sources/Networking/HTTPClient/NetworkError.swift
+++ b/Sources/Networking/HTTPClient/NetworkError.swift
@@ -16,7 +16,7 @@
 import Foundation
 
 /// Represents an error created by `HTTPClient`.
-enum NetworkError: Swift.Error, Equatable {
+enum NetworkError: Swift.Error {
 
     case decoding(NSError, Source)
     case offlineConnection(Source)


### PR DESCRIPTION
This wasn't required, likely since the introduction of #1879, which added `matchError` as a much better way to check errors.
I noticed this when adding a new `case` with an associated value that wasn't `Equatable`.

Tiny change but should make compilation faster, and reduce the binary size.
