### PR TITLE
`PurchasesOrchestrator`: simplified `StoreKit2TransactionListenerDelegate` transaction handling

### DIFF
--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -199,6 +199,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         expect(self.backend.invokedPostReceiptDataCount) == 1
         expect(self.backend.invokedPostReceiptDataParameters?.productData).toNot(beNil())
         expect(self.backend.invokedPostReceiptDataParameters?.offeringIdentifier) == "offering"
+        expect(self.backend.invokedPostReceiptDataParameters?.isRestore) == false
         expect(self.backend.invokedPostReceiptDataParameters?.initiationSource) == .purchase
     }
 
@@ -725,7 +726,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         expect(transaction.finishInvoked) == false
         expect(self.backend.invokedPostReceiptData) == true
-        expect(self.backend.invokedPostReceiptDataParameters?.isRestore) == true
+        expect(self.backend.invokedPostReceiptDataParameters?.isRestore) == false
         expect(self.backend.invokedPostReceiptDataParameters?.initiationSource) == .queue
     }
 


### PR DESCRIPTION
While working on #2533 I noticed that the implementation for `StoreKit2TransactionListenerDelegate` was unnecessarily complex:
```swift
@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
extension PurchasesOrchestrator: StoreKit2TransactionListenerDelegate {
    func storeKit2TransactionListener(
        _ listener: StoreKit2TransactionListener,
        updatedTransaction transaction: StoreTransactionType
    ) async throws {
        let isRestore = self.systemInfo.observerMode

        _ = try await self.syncPurchases(receiptRefreshPolicy: .always,
                                         isRestore: isRestore,
                                         initiationSource: .queue)

        await Async.call { completion in
            self.finishTransactionIfNeeded(transaction) { @MainActor in
                completion(())
            }
        }
    }
}
```

Instead of only posting the one transaction, we were calling `syncPurchases`, which is inconsistent with how we handle SK1 transactions.
The new logic in #2533 will also make use of this single-transaction handling code, so it makes sense to unify this as well.

Note that since #1704, **this method is only invoked for transactions detected outside of a manual purchase flow**.

This only required an overload to specify the `InitiationSource`, which uncovered one incorrect `isRestore` parameter in one of our tests.
I verified that this is expected based on other tests, and the implementation of `initiationSource(for productIdentifier:restored:)`, as well as checking with @antoniobg.
