### PR TITLE
Extracted `TransactionPoster` from `PurchasesOrchestrator`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -206,6 +206,7 @@
 		4F69EB092A14406E00ED6D4B /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F69EB082A14406E00ED6D4B /* Matchers.swift */; };
 		4F69EB0A2A14406E00ED6D4B /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F69EB082A14406E00ED6D4B /* Matchers.swift */; };
 		4F7DBFBD2A1E986C00A2F511 /* StoreKit2TransactionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7DBFBC2A1E986C00A2F511 /* StoreKit2TransactionFetcher.swift */; };
+		4F8038332A1EA7C300D21039 /* TransactionPoster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8038322A1EA7C300D21039 /* TransactionPoster.swift */; };
 		4F8A58172A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */; };
 		4F8A58182A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */; };
 		4FA4C8DA2A168956007D2803 /* OfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA4C8D92A168956007D2803 /* OfflineCustomerInfoCreator.swift */; };
@@ -882,6 +883,7 @@
 		4F2017D42A15587F0061F6EF /* OfflineStoreKitIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineStoreKitIntegrationTests.swift; sourceTree = "<group>"; };
 		4F69EB082A14406E00ED6D4B /* Matchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Matchers.swift; sourceTree = "<group>"; };
 		4F7DBFBC2A1E986C00A2F511 /* StoreKit2TransactionFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2TransactionFetcher.swift; sourceTree = "<group>"; };
+		4F8038322A1EA7C300D21039 /* TransactionPoster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionPoster.swift; sourceTree = "<group>"; };
 		4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOfflineCustomerInfoCreator.swift; sourceTree = "<group>"; };
 		4FA4C8D92A168956007D2803 /* OfflineCustomerInfoCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineCustomerInfoCreator.swift; sourceTree = "<group>"; };
 		4FA4C9722A16D3AC007D2803 /* MockBackendConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackendConfiguration.swift; sourceTree = "<group>"; };
@@ -2397,6 +2399,7 @@
 				B35042C326CDB79A00905B95 /* Purchases.swift */,
 				B35042C526CDD3B100905B95 /* PurchasesDelegate.swift */,
 				2D9F4A5426C30CA800B07B43 /* PurchasesOrchestrator.swift */,
+				4F8038322A1EA7C300D21039 /* TransactionPoster.swift */,
 			);
 			path = Purchases;
 			sourceTree = "<group>";
@@ -3138,6 +3141,7 @@
 				2D971CC12744364C0093F35F /* SKError+Extensions.swift in Sources */,
 				57F2C60C29784C11009EE527 /* SwiftVersionCheck.swift in Sources */,
 				57EAE527274324C60060EB74 /* Lock.swift in Sources */,
+				4F8038332A1EA7C300D21039 /* TransactionPoster.swift in Sources */,
 				B32B74FF26868AEB005647BF /* Package.swift in Sources */,
 				578DAA482948EEAD001700FD /* Clock.swift in Sources */,
 				2DDF41B324F6F387005BC22D /* InAppPurchaseBuilder.swift in Sources */,

--- a/Sources/Misc/Concurrency/OperationDispatcher.swift
+++ b/Sources/Misc/Concurrency/OperationDispatcher.swift
@@ -68,7 +68,5 @@ extension OperationDispatcher {
 
 }
 
-#if swift(<5.8)
-// `DispatchQueue` is not `Sendable` as of Swift 5.7, but this class performs no mutations.
+// `DispatchQueue` is not `Sendable` as of Swift 5.8, but this class performs no mutations.
 extension OperationDispatcher: @unchecked Sendable {}
-#endif

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -353,6 +353,17 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         let beginRefundRequestHelper = BeginRefundRequestHelper(systemInfo: systemInfo,
                                                                 customerInfoManager: customerInfoManager,
                                                                 currentUserProvider: identityManager)
+        let transactionPoster = TransactionPoster(
+            productsManager: productsManager,
+            receiptFetcher: receiptFetcher,
+            currentUserProvider: identityManager,
+            attribution: subscriberAttributes,
+            backend: backend,
+            paymentQueueWrapper: paymentQueueWrapper,
+            systemInfo: systemInfo,
+            operationDispatcher: operationDispatcher
+        )
+
         let purchasesOrchestrator: PurchasesOrchestrator = {
             if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
                 return .init(
@@ -365,6 +376,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                     receiptParser: receiptParser,
                     customerInfoManager: customerInfoManager,
                     backend: backend,
+                    transactionPoster: transactionPoster,
                     currentUserProvider: identityManager,
                     transactionsManager: transactionsManager,
                     deviceCache: deviceCache,
@@ -385,6 +397,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                     receiptParser: receiptParser,
                     customerInfoManager: customerInfoManager,
                     backend: backend,
+                    transactionPoster: transactionPoster,
                     currentUserProvider: identityManager,
                     transactionsManager: transactionsManager,
                     deviceCache: deviceCache,

--- a/Sources/Purchasing/Purchases/TransactionPoster.swift
+++ b/Sources/Purchasing/Purchases/TransactionPoster.swift
@@ -1,0 +1,306 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  TransactionPoster.swift
+//
+//  Created by Nacho Soto on 5/24/23.
+
+import Foundation
+
+/// Determines what triggered a purchase and whether it comes from a restore.
+struct PurchaseSource {
+
+    let isRestore: Bool
+    let initiationSource: ProductRequestData.InitiationSource
+
+}
+
+/// A type that can post receipts as a result of a purchased transaction.
+protocol TransactionPosterType: AnyObject, Sendable {
+
+    /// Starts a `PostReceiptDataOperation` for the transaction.
+    func handlePurchasedTransaction(
+        _ transaction: StoreTransaction,
+        presentedOfferingID: String?,
+        storefront: StorefrontType?,
+        source: PurchaseSource,
+        completion: @escaping PurchaseCompletedBlock
+    )
+
+    /// Finishes the transaction if not in observer mode.
+    /// - Note: `handlePurchasedTransaction` calls this automatically,
+    /// this is only required for failed transactions.
+    func finishTransactionIfNeeded(
+        _ transaction: StoreTransactionType,
+        completion: @escaping @Sendable @MainActor () -> Void
+    )
+
+    func markSyncedIfNeeded(
+        subscriberAttributes: SubscriberAttribute.Dictionary?,
+        error: BackendError?
+    )
+
+}
+
+// swiftlint:disable function_parameter_count
+
+final class TransactionPoster: TransactionPosterType {
+
+    private let productsManager: ProductsManagerType
+    private let receiptFetcher: ReceiptFetcher
+    private let currentUserProvider: CurrentUserProvider
+    private let attribution: Attribution
+    private let backend: Backend
+    private let paymentQueueWrapper: EitherPaymentQueueWrapper
+    private let systemInfo: SystemInfo
+    private let operationDispatcher: OperationDispatcher
+
+    init(
+        productsManager: ProductsManagerType,
+        receiptFetcher: ReceiptFetcher,
+        currentUserProvider: CurrentUserProvider,
+        attribution: Attribution,
+        backend: Backend,
+        paymentQueueWrapper: EitherPaymentQueueWrapper,
+        systemInfo: SystemInfo,
+        operationDispatcher: OperationDispatcher
+    ) {
+        self.productsManager = productsManager
+        self.receiptFetcher = receiptFetcher
+        self.currentUserProvider = currentUserProvider
+        self.attribution = attribution
+        self.backend = backend
+        self.paymentQueueWrapper = paymentQueueWrapper
+        self.systemInfo = systemInfo
+        self.operationDispatcher = operationDispatcher
+    }
+
+    func handlePurchasedTransaction(_ transaction: StoreTransaction,
+                                    presentedOfferingID: String?,
+                                    storefront: StorefrontType?,
+                                    source: PurchaseSource,
+                                    completion: @escaping PurchaseCompletedBlock) {
+        self.receiptFetcher.receiptData(
+            refreshPolicy: self.refreshRequestPolicy(forProductIdentifier: transaction.productIdentifier)
+        ) { receiptData in
+            if let receiptData = receiptData, !receiptData.isEmpty {
+                self.fetchProductsAndPostReceipt(
+                    withTransaction: transaction,
+                    receiptData: receiptData,
+                    source: source,
+                    storefront: storefront,
+                    presentedOfferingID: presentedOfferingID,
+                    completion: completion
+                )
+            } else {
+                self.handleReceiptPost(withTransaction: transaction,
+                                       result: .failure(.missingReceiptFile()),
+                                       subscriberAttributes: nil,
+                                       completion: completion)
+            }
+        }
+    }
+
+    func finishTransactionIfNeeded(
+        _ transaction: StoreTransactionType,
+        completion: @escaping @Sendable @MainActor () -> Void
+    ) {
+        @Sendable
+        func complete() {
+            self.operationDispatcher.dispatchOnMainActor(completion)
+        }
+
+        guard self.finishTransactions else {
+            complete()
+            return
+        }
+
+        Logger.purchase(Strings.purchase.finishing_transaction(transaction))
+
+        transaction.finish(self.paymentQueueWrapper.paymentQueueWrapperType, completion: complete)
+    }
+
+    func markSyncedIfNeeded(
+        subscriberAttributes: SubscriberAttribute.Dictionary?,
+        error: BackendError?
+    ) {
+        if let error = error {
+            guard error.successfullySynced else { return }
+
+            if let attributeErrors = (error as NSError).subscriberAttributesErrors, !attributeErrors.isEmpty {
+                Logger.error(Strings.attribution.subscriber_attributes_error(
+                    errors: attributeErrors
+                ))
+            }
+        }
+
+        self.attribution.markAttributesAsSynced(subscriberAttributes, appUserID: self.appUserID)
+    }
+
+}
+
+// MARK: - Implementation
+
+private extension TransactionPoster {
+
+    /// Called as a result a purchase.
+    func fetchProductsAndPostReceipt(
+        withTransaction transaction: StoreTransaction,
+        receiptData: Data,
+        source: PurchaseSource,
+        storefront: StorefrontType?,
+        presentedOfferingID: String?,
+        completion: @escaping PurchaseCompletedBlock
+    ) {
+        if let productIdentifier = transaction.productIdentifier.notEmpty {
+            self.product(with: productIdentifier) { products in
+                self.postReceipt(withTransaction: transaction,
+                                 receiptData: receiptData,
+                                 product: products,
+                                 source: source,
+                                 storefront: storefront,
+                                 presentedOfferingID: presentedOfferingID,
+                                 completion: completion)
+            }
+        } else {
+            self.handleReceiptPost(withTransaction: transaction,
+                                   result: .failure(.missingTransactionProductIdentifier()),
+                                   subscriberAttributes: nil,
+                                   completion: completion)
+        }
+    }
+
+    func handleReceiptPost(withTransaction transaction: StoreTransaction,
+                           result: Result<CustomerInfo, BackendError>,
+                           subscriberAttributes: SubscriberAttribute.Dictionary?,
+                           completion: @escaping PurchaseCompletedBlock) {
+        self.operationDispatcher.dispatchOnMainActor {
+            self.markSyncedIfNeeded(subscriberAttributes: subscriberAttributes,
+                                    error: result.error)
+
+            switch result {
+            case let .success(customerInfo):
+                if customerInfo.isComputedOffline {
+                    completion(transaction, customerInfo, nil, false)
+                } else {
+                    self.finishTransactionIfNeeded(transaction) {
+                        completion(transaction, customerInfo, nil, false)
+                    }
+                }
+
+            case let .failure(error):
+                let publicError = error.asPublicError
+
+                if error.finishable {
+                    self.finishTransactionIfNeeded(transaction) {
+                        completion(transaction, nil, publicError, false)
+                    }
+                } else {
+                    completion(transaction, nil, publicError, false)
+                }
+            }
+        }
+    }
+
+    func postReceipt(withTransaction transaction: StoreTransaction,
+                     receiptData: Data,
+                     product: StoreProduct?,
+                     source: PurchaseSource,
+                     storefront: StorefrontType?,
+                     presentedOfferingID: String?,
+                     completion: @escaping PurchaseCompletedBlock) {
+        let productData = product.map { ProductRequestData(with: $0, storefront: storefront) }
+        let unsyncedAttributes = self.unsyncedAttributes
+
+        self.backend.post(receiptData: receiptData,
+                          appUserID: self.appUserID,
+                          isRestore: source.isRestore,
+                          productData: productData,
+                          presentedOfferingIdentifier: presentedOfferingID,
+                          observerMode: self.observerMode,
+                          initiationSource: source.initiationSource,
+                          subscriberAttributes: unsyncedAttributes) { result in
+            self.handleReceiptPost(withTransaction: transaction,
+                                   result: result,
+                                   subscriberAttributes: unsyncedAttributes,
+                                   completion: completion)
+        }
+    }
+
+}
+
+// MARK: - Properties
+
+private extension TransactionPoster {
+
+    private var appUserID: String {
+        self.currentUserProvider.currentAppUserID
+    }
+
+    var unsyncedAttributes: SubscriberAttribute.Dictionary {
+        self.attribution.unsyncedAttributesByKey(appUserID: self.appUserID)
+    }
+
+    var observerMode: Bool {
+        self.systemInfo.observerMode
+    }
+
+    var finishTransactions: Bool {
+        self.systemInfo.finishTransactions
+    }
+
+}
+
+// MARK: - Receipt refreshing
+
+extension TransactionPoster {
+
+    private func refreshRequestPolicy(forProductIdentifier productIdentifier: String) -> ReceiptRefreshPolicy {
+        if self.systemInfo.dangerousSettings.internalSettings.enableReceiptFetchRetry {
+            return .retryUntilProductIsFound(productIdentifier: productIdentifier,
+                                             maximumRetries: Self.receiptRetryCount,
+                                             sleepDuration: Self.receiptRetrySleepDuration)
+        } else {
+            // See https://github.com/RevenueCat/purchases-ios/pull/2245 and
+            // https://github.com/RevenueCat/purchases-ios/issues/2260
+            // - Release or production builds:
+            //      We don't _want_ to always refresh receipts to avoid throttling errors
+            //      We don't _need_ to because the receipt will be refreshed by the backend using /verifyReceipt
+            // - Debug and sandbox builds (potentially using StoreKit config files):
+            //      We need to always refresh the receipt because the backend does not use /verifyReceipt
+            //          when it was generated locally with SK config files.
+
+            #if DEBUG
+            return self.systemInfo.isSandbox
+            ? .always
+            : .onlyIfEmpty
+            #else
+            return .onlyIfEmpty
+            #endif
+        }
+    }
+
+    static let receiptRetryCount: Int = 3
+    static let receiptRetrySleepDuration: DispatchTimeInterval = .seconds(5)
+
+}
+
+// MARK: - Products
+
+private extension TransactionPoster {
+
+    func product(with identifier: String, completion: @escaping (StoreProduct?) -> Void) {
+        self.productsManager.products(withIdentifiers: [identifier]) { products in
+            self.operationDispatcher.dispatchOnMainThread {
+                completion(products.value?.first)
+            }
+        }
+    }
+
+}

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -199,6 +199,16 @@ class BasePurchasesTests: TestCase {
             receiptParser: self.mockReceiptParser,
             customerInfoManager: self.customerInfoManager,
             backend: self.backend,
+            transactionPoster: .init(
+                productsManager: self.mockProductsManager,
+                receiptFetcher: self.receiptFetcher,
+                currentUserProvider: self.identityManager,
+                attribution: self.attribution,
+                backend: self.backend,
+                paymentQueueWrapper: paymentQueueWrapper,
+                systemInfo: self.systemInfo,
+                operationDispatcher: self.mockOperationDispatcher
+            ),
             currentUserProvider: self.identityManager,
             transactionsManager: self.mockTransactionsManager,
             deviceCache: self.deviceCache,

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -145,8 +145,10 @@ class PurchasesSubscriberAttributesTests: TestCase {
         Purchases.deprecated.automaticAppleSearchAdsAttributionCollection = automaticCollection
 
         self.mockIdentityManager.mockIsAnonymous = false
+
+        let paymentQueueWrapper: EitherPaymentQueueWrapper = .left(self.mockStoreKit1Wrapper)
         let purchasesOrchestrator = PurchasesOrchestrator(productsManager: self.mockProductsManager,
-                                                          paymentQueueWrapper: .left(self.mockStoreKit1Wrapper),
+                                                          paymentQueueWrapper: paymentQueueWrapper,
                                                           systemInfo: self.systemInfo,
                                                           subscriberAttributes: self.attribution,
                                                           operationDispatcher: self.mockOperationDispatcher,
@@ -154,6 +156,16 @@ class PurchasesSubscriberAttributesTests: TestCase {
                                                           receiptParser: self.mockReceiptParser,
                                                           customerInfoManager: self.customerInfoManager,
                                                           backend: self.mockBackend,
+                                                          transactionPoster: .init(
+                                                            productsManager: self.mockProductsManager,
+                                                            receiptFetcher: self.mockReceiptFetcher,
+                                                            currentUserProvider: self.mockIdentityManager,
+                                                            attribution: self.attribution,
+                                                            backend: self.mockBackend,
+                                                            paymentQueueWrapper: paymentQueueWrapper,
+                                                            systemInfo: self.systemInfo,
+                                                            operationDispatcher: self.mockOperationDispatcher
+                                                          ),
                                                           currentUserProvider: self.mockIdentityManager,
                                                           transactionsManager: self.mockTransactionsManager,
                                                           deviceCache: self.mockDeviceCache,


### PR DESCRIPTION
Necessary refactor for #2533. This allows `CustomerInfoManager` to have an instance of `TransactionPosterType` instead of the whole `PurchasesOrchestrator`.

Essentially this becomes the hierarchy now:
![IMG_B8C56C11B7E5-1](https://github.com/RevenueCat/purchases-ios/assets/685609/36f5c30b-fc82-4590-b574-ce6d95eef13f)

### Changes:
- Created stateless `TransactionPoster`
- Extracted `handlePurchasedTransaction` into `TransactionPoster`
- The new implementation there is _mostly_ the same, with the one difference that it's stateless. Instead of holding `purchaseCompleteCallbacksByProductID`, that's done by `PurchasesOrchestrator`. The methods there all take a callback, so they're easier to use and don't require keeping a callback around.
- Created `PurchaseSource` to abstract the combo of `isRestore` and `InitiationSource`. This is still messy using the deprecated `allowSharingAppStoreAccount`, but at least that's abstracted out and the new `TransactionPoster` won't deal with that deprecated property.
- I didn't mock `TransactionPoster`, which means that all existing tests that check `PurchasesOrchestrator` continue working the same way. This was on purpose to keep this refactor as simple as possible.
- This supersedes #2536: the change made there was now possible here without any integration test failures, thanks to the fact that we can process transactions independently without messing with the `purchaseCompleteCallbacksByProductID` state now.

### Future improvements
This is just a start, there's a lot more than can be done to simplify the `PurchasesOrchestrator` monster. The main thing would be to remove all the custom code for `restorePurchases`, which is largely the same as what's in `TransactionPoster` now.

### Notes:
Just posting this here for posteriority. I had to trace the call hierarchy for both SK1 and SK2. This "block" is what's now in `TransactionPoster`:
![IMG_C60274393F7F-1](https://github.com/RevenueCat/purchases-ios/assets/685609/5a7377f0-8301-474f-a774-a90b6e232bc3)
