### PR TITLE
`CircleCI`: specify device to run `backend_integration_tests`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -743,6 +743,9 @@ jobs:
       - run:
           name: Backend and LoadShedder integration tests
           command: bundle exec fastlane backend_integration_tests
+          no_output_timeout: 5m
+          environment:
+            SCAN_DEVICE: iPhone 14 (16.4)
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: BackendIntegrationTests


### PR DESCRIPTION
For consistency with the normal `backend-integration-tests` job, this updates `loadshedder-integration-tests`.
I noticed that it was running tests on iOS 15.

We've been getting more flaky failures on this job that this might resolve.