### PR TITLE
`PostReceiptOperation`: added ability to also post `AdServices` token

### DIFF
--- a/Sources/Logging/Strings/AttributionStrings.swift
+++ b/Sources/Logging/Strings/AttributionStrings.swift
@@ -42,6 +42,7 @@ enum AttributionStrings {
     case adservices_token_fetch_failed(error: Error)
     case adservices_token_post_failed(error: BackendError)
     case adservices_token_post_succeeded
+    case adservices_marking_as_synced(appUserID: String)
     case adservices_token_unavailable_in_simulator
     case latest_attribution_sent_user_defaults_invalid(networkKey: String)
     case copying_attributes(oldAppUserID: String, newAppUserID: String)
@@ -133,6 +134,9 @@ extension AttributionStrings: CustomStringConvertible {
 
         case .adservices_token_post_succeeded:
             return "AdServices attribution token successfully posted"
+
+        case let .adservices_marking_as_synced(userID):
+            return "Marking AdServices attribution token as synced for App User ID: \(userID)"
 
         case .adservices_token_unavailable_in_simulator:
             return "AdServices attribution token is not available in the simulator"

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -111,6 +111,7 @@ class Backend {
               observerMode: Bool,
               initiationSource: ProductRequestData.InitiationSource,
               subscriberAttributes subscriberAttributesByKey: SubscriberAttribute.Dictionary?,
+              aadAttributionToken: String? = nil,
               completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
         self.customer.post(receiptData: receiptData,
                            appUserID: appUserID,
@@ -120,6 +121,7 @@ class Backend {
                            observerMode: observerMode,
                            initiationSource: initiationSource,
                            subscriberAttributes: subscriberAttributesByKey,
+                           aadAttributionToken: aadAttributionToken,
                            completion: completion)
     }
 

--- a/Sources/Networking/CustomerAPI.swift
+++ b/Sources/Networking/CustomerAPI.swift
@@ -90,6 +90,7 @@ final class CustomerAPI {
               observerMode: Bool,
               initiationSource: ProductRequestData.InitiationSource,
               subscriberAttributes subscriberAttributesByKey: SubscriberAttribute.Dictionary?,
+              aadAttributionToken: String?,
               completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
         var subscriberAttributesToPost: SubscriberAttribute.Dictionary?
 
@@ -112,7 +113,8 @@ final class CustomerAPI {
                                                          presentedOfferingIdentifier: offeringIdentifier,
                                                          observerMode: observerMode,
                                                          initiationSource: initiationSource,
-                                                         subscriberAttributesByKey: subscriberAttributesToPost)
+                                                         subscriberAttributesByKey: subscriberAttributesToPost,
+                                                         aadAttributionToken: aadAttributionToken)
         let factory = PostReceiptDataOperation.createFactory(configuration: config,
                                                              postData: postData,
                                                              customerInfoCallbackCache: self.customerInfoCallbackCache)

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -25,6 +25,7 @@ final class PostReceiptDataOperation: CacheableNetworkOperation {
         let observerMode: Bool
         let initiationSource: ProductRequestData.InitiationSource
         let subscriberAttributesByKey: SubscriberAttribute.Dictionary?
+        let aadAttributionToken: String?
 
     }
 
@@ -145,6 +146,7 @@ extension PostReceiptDataOperation.PostData: Encodable {
         case observerMode
         case initiationSource
         case attributes
+        case aadAttributionToken
         case presentedOfferingIdentifier
 
     }
@@ -171,6 +173,8 @@ extension PostReceiptDataOperation.PostData: Encodable {
                 .map(AnyEncodable.init),
             forKey: .attributes
         )
+
+        try container.encodeIfPresent(self.aadAttributionToken, forKey: .aadAttributionToken)
     }
 
 }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -208,11 +208,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     /// Current version of the ``Purchases`` framework.
     @objc public static var frameworkVersion: String { SystemInfo.frameworkVersion }
 
-    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
-
     @objc public let attribution: Attribution
-
-    #endif
 
     @objc public var finishTransactions: Bool {
         get { self.systemInfo.finishTransactions }
@@ -313,7 +309,8 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                                                   subscriberAttributesManager: subscriberAttributesManager)
         let subscriberAttributes = Attribution(subscriberAttributesManager: subscriberAttributesManager,
                                                currentUserProvider: identityManager,
-                                               attributionPoster: attributionPoster)
+                                               attributionPoster: attributionPoster,
+                                               systemInfo: systemInfo)
         let productsRequestFactory = ProductsRequestFactory()
         let productsManager = CachingProductsManager(
             manager: ProductsManager(productsRequestFactory: productsRequestFactory,
@@ -466,9 +463,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.userDefaults = userDefaults
         self.notificationCenter = notificationCenter
         self.systemInfo = systemInfo
-        #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
         self.attribution = subscriberAttributes
-        #endif
         self.operationDispatcher = operationDispatcher
         self.customerInfoManager = customerInfoManager
         self.productsManager = productsManager

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/CustomEntitlementComputationSwiftAPITester.xcodeproj/project.pbxproj
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/CustomEntitlementComputationSwiftAPITester.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		2DD778ED270E23460079CBD4 /* OfferingAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C726EBE7EA007DDB75 /* OfferingAPI.swift */; };
 		2DD778EE270E23460079CBD4 /* EntitlementInfosAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C526EBE7EA007DDB75 /* EntitlementInfosAPI.swift */; };
 		2DD778EF270E23460079CBD4 /* EntitlementInfoAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C826EBE7EA007DDB75 /* EntitlementInfoAPI.swift */; };
+		4F592A502A1FDC6F00851F36 /* AttributionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F592A4F2A1FDC6F00851F36 /* AttributionAPI.swift */; };
 		570EC3B229F9A0830036A023 /* RevenueCat_CustomEntitlementComputation in Frameworks */ = {isa = PBXBuildFile; productRef = 570EC3B129F9A0830036A023 /* RevenueCat_CustomEntitlementComputation */; };
 		570FAF562864EE1D00D3C769 /* NonSubscriptionTransactionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570FAF552864EE1D00D3C769 /* NonSubscriptionTransactionAPI.swift */; };
 		5738F40C27866DD00096D623 /* StoreProductDiscountAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5738F40B27866DD00096D623 /* StoreProductDiscountAPI.swift */; };
@@ -50,6 +51,7 @@
 /* Begin PBXFileReference section */
 		2C396F5B281C64AF00669657 /* AdServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdServices.framework; path = System/Library/Frameworks/AdServices.framework; sourceTree = SDKROOT; };
 		2DD778D0270E233F0079CBD4 /* SwiftAPITester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftAPITester.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		4F592A4F2A1FDC6F00851F36 /* AttributionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributionAPI.swift; sourceTree = "<group>"; };
 		570FAF552864EE1D00D3C769 /* NonSubscriptionTransactionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonSubscriptionTransactionAPI.swift; sourceTree = "<group>"; };
 		5738F40B27866DD00096D623 /* StoreProductDiscountAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProductDiscountAPI.swift; sourceTree = "<group>"; };
 		5738F429278673A80096D623 /* SubscriptionPeriodAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionPeriodAPI.swift; sourceTree = "<group>"; };
@@ -116,6 +118,7 @@
 		A55F62B726EAFFD200A1B466 /* SwiftAPITester */ = {
 			isa = PBXGroup;
 			children = (
+				4F592A4F2A1FDC6F00851F36 /* AttributionAPI.swift */,
 				B32554412825E5EA00DA62EA /* ConfigurationAPI.swift */,
 				A5D614C426EBE7EA007DDB75 /* CustomerInfoAPI.swift */,
 				A5D614C826EBE7EA007DDB75 /* EntitlementInfoAPI.swift */,
@@ -238,6 +241,7 @@
 				B32554422825E5EA00DA62EA /* ConfigurationAPI.swift in Sources */,
 				5738F40C27866DD00096D623 /* StoreProductDiscountAPI.swift in Sources */,
 				5740FCD52996D7B800E049F9 /* VerificationResultAPI.swift in Sources */,
+				4F592A502A1FDC6F00851F36 /* AttributionAPI.swift in Sources */,
 				5758EE582786542200B3B703 /* StoreTransactionAPI.swift in Sources */,
 				B3A4C834280DE72600D4AE17 /* PromotionalOfferAPI.swift in Sources */,
 				5738F42A278673A80096D623 /* SubscriptionPeriodAPI.swift in Sources */,

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/AttributionAPI.swift
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/AttributionAPI.swift
@@ -1,0 +1,14 @@
+//
+//  AttributionAPI.swift
+//  SwiftAPITester
+//
+//  Created by Nacho Soto on 5/25/23.
+//
+
+import RevenueCat_CustomEntitlementComputation
+
+private var attribution: Attribution!
+
+func checkAttributionAPI() {
+    attribution.enableAdServicesAttributionTokenCollection()
+}

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -31,6 +31,8 @@ func checkPurchasesAPI() {
     checkPurchasesPurchasingAPI(purchases: purch)
     checkPurchasesSupportAPI(purchases: purch)
 
+    let _: Attribution = purch.attribution
+
     if #available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *) {
         _ = Task<Void, Never> {
             await checkAsyncMethods(purchases: purch)

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/main.swift
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/main.swift
@@ -14,6 +14,8 @@
 import Foundation
 
 func main() -> Int {
+    checkAttributionAPI()
+
     checkEntitlementInfoAPI()
     checkEntitlementInfoEnums()
     checkEntitlementInfosAPI()

--- a/Tests/StoreKitUnitTests/TestHelpers/AvailabilityChecks.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/AvailabilityChecks.swift
@@ -37,6 +37,12 @@ enum AvailabilityChecks {
         }
     }
 
+    static func iOS14_3APIAvailableOrSkipTest() throws {
+        guard #available(iOS 14.3, tvOS 14.3, macOS 11.1, *) else {
+            throw XCTSkip("Required API is not available for this test.")
+        }
+    }
+
     static func iOS15APIAvailableOrSkipTest() throws {
         guard #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) else {
             throw XCTSkip("Required API is not available for this test.")
@@ -48,6 +54,12 @@ enum AvailabilityChecks {
         if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
             throw XCTSkip("Test only for older devices")
         }
+    }
+
+    static func skipIfTVOrWatchOS() throws {
+        #if os(watchOS) || os(tvOS)
+        throw XCTSkip("Test not for watchOS or tvOS")
+        #endif
     }
 
 }

--- a/Tests/UnitTests/Attribution/AttributionPosterTests.swift
+++ b/Tests/UnitTests/Attribution/AttributionPosterTests.swift
@@ -306,6 +306,16 @@ class AdServicesAttributionPosterTests: BaseAttributionPosterTests {
         try AvailabilityChecks.iOS14APIAvailableOrSkipTest()
     }
 
+    func testAdServicesTokenToPostIfNeededReturnsNilIfAlreadySent() {
+        self.backend.stubbedPostAdServicesTokenCompletionResult = .success(())
+
+        expect(self.attributionPoster.adServicesTokenToPostIfNeeded).toNot(beNil())
+
+        self.attributionPoster.postAdServicesTokenIfNeeded()
+
+        expect(self.attributionPoster.adServicesTokenToPostIfNeeded).to(beNil())
+    }
+
     func testPostAdServicesTokenIfNeededSkipsIfAlreadySent() {
         backend.stubbedPostAdServicesTokenCompletionResult = .success(())
 

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -16,6 +16,7 @@ class MockBackend: Backend {
                                        observerMode: Bool,
                                        initiationSource: ProductRequestData.InitiationSource,
                                        subscriberAttributesByKey: [String: SubscriberAttribute]?,
+                                       aadAttributionToken: String?,
                                        completion: CustomerAPI.CustomerInfoResponseHandler?)
 
     var invokedPostReceiptData = false
@@ -61,6 +62,7 @@ class MockBackend: Backend {
                        observerMode: Bool,
                        initiationSource: ProductRequestData.InitiationSource,
                        subscriberAttributes subscriberAttributesByKey: SubscriberAttribute.Dictionary?,
+                       aadAttributionToken: String? = nil,
                        completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
         invokedPostReceiptData = true
         invokedPostReceiptDataCount += 1
@@ -72,6 +74,7 @@ class MockBackend: Backend {
                                             observerMode,
                                             initiationSource,
                                             subscriberAttributesByKey,
+                                            aadAttributionToken: aadAttributionToken,
                                             completion)
         invokedPostReceiptDataParametersList.append((receiptData,
                                                      appUserID,
@@ -81,6 +84,7 @@ class MockBackend: Backend {
                                                      observerMode,
                                                      initiationSource,
                                                      subscriberAttributesByKey,
+                                                     aadAttributionToken,
                                                      completion))
 
         self.onPostReceipt?()

--- a/Tests/UnitTests/Mocks/MockSystemInfo.swift
+++ b/Tests/UnitTests/Mocks/MockSystemInfo.swift
@@ -14,7 +14,6 @@ import Foundation
 class MockSystemInfo: SystemInfo {
     var stubbedIsApplicationBackgrounded: Bool?
     var stubbedIsSandbox: Bool?
-    var customEntitlementsComputation: Bool?
 
     convenience init(finishTransactions: Bool,
                      storeKit2Setting: StoreKit2Setting = .default,

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -72,7 +72,8 @@ class BasePurchasesTests: TestCase {
                                                    subscriberAttributesManager: self.subscriberAttributesManager)
         self.attribution = Attribution(subscriberAttributesManager: self.subscriberAttributesManager,
                                        currentUserProvider: self.identityManager,
-                                       attributionPoster: self.attributionPoster)
+                                       attributionPoster: self.attributionPoster,
+                                       systemInfo: self.systemInfo)
         self.customerInfoManager = CustomerInfoManager(operationDispatcher: self.mockOperationDispatcher,
                                                        deviceCache: self.deviceCache,
                                                        backend: self.backend,
@@ -428,6 +429,7 @@ extension BasePurchasesTests {
                            observerMode: Bool,
                            initiationSource: ProductRequestData.InitiationSource,
                            subscriberAttributes: [String: SubscriberAttribute]?,
+                           aadAttributionToken: String? = nil,
                            completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
             self.postReceiptDataCalled = true
             self.postedReceiptData = receiptData

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -99,6 +99,26 @@ class BackendSubscriberAttributesTests: TestCase {
         expect(self.mockHTTPClient.calls).toEventually(haveCount(1))
     }
 
+    func testPostReceiptWithAdServicesToken() throws {
+        let token = "token"
+
+        waitUntil { completion in
+            self.backend.post(receiptData: self.receiptData,
+                              appUserID: self.appUserID,
+                              isRestore: false,
+                              productData: nil,
+                              presentedOfferingIdentifier: nil,
+                              observerMode: false,
+                              initiationSource: .restore,
+                              subscriberAttributes: [:],
+                              aadAttributionToken: token) { _ in
+                completion()
+            }
+        }
+
+        expect(self.mockHTTPClient.calls).to(haveCount(1))
+    }
+
     func testPostReceiptWithSubscriberAttributesReturnsBadJson() throws {
         let subscriberAttributesByKey: [String: SubscriberAttribute] = [
             subscriberAttribute1.key: subscriberAttribute1,

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -103,7 +103,8 @@ class PurchasesSubscriberAttributesTests: TestCase {
                                                        subscriberAttributesManager: mockSubscriberAttributesManager)
         self.attribution = Attribution(subscriberAttributesManager: self.mockSubscriberAttributesManager,
                                        currentUserProvider: self.mockIdentityManager,
-                                       attributionPoster: self.mockAttributionPoster)
+                                       attributionPoster: self.mockAttributionPoster,
+                                       systemInfo: self.systemInfo)
         self.customerInfoManager = CustomerInfoManager(operationDispatcher: mockOperationDispatcher,
                                                        deviceCache: mockDeviceCache,
                                                        backend: mockBackend,
@@ -724,6 +725,42 @@ class PurchasesSubscriberAttributesTests: TestCase {
         expect(self.mockSubscriberAttributesManager.invokedMarkAttributesParameters?.syncedAttributes) == mockAttributes
         expect(self.mockSubscriberAttributesManager.invokedMarkAttributesParameters?.appUserID) ==
         mockIdentityManager.currentAppUserID
+    }
+
+    @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    func testPostReceiptMarksAdServicesTokenSyncedIfBackendSuccessfullySynced() throws {
+        try AvailabilityChecks.iOS14_3APIAvailableOrSkipTest()
+        try AvailabilityChecks.skipIfTVOrWatchOS()
+
+        self.setupPurchases()
+
+        let token = "token"
+
+        self.mockAttributionFetcher.adServicesTokenToReturn = token
+        self.attribution.enableAdServicesAttributionTokenCollection()
+
+        let product = StoreProduct(sk1Product: MockSK1Product(mockProductIdentifier: "com.product.id1"))
+        self.purchases.purchase(product: product) { (_, _, _, _) in }
+
+        let transaction = MockTransaction()
+        transaction.mockPayment = self.mockStoreKit1Wrapper.payment!
+        transaction.mockState = .purchasing
+
+        self.mockStoreKit1Wrapper.delegate?.storeKit1Wrapper(self.mockStoreKit1Wrapper, updatedTransaction: transaction)
+
+        self.mockBackend.stubbedPostReceiptResult = .success(try CustomerInfo(data: self.emptyCustomerInfoData))
+
+        transaction.mockState = .purchased
+        self.mockStoreKit1Wrapper.delegate?.storeKit1Wrapper(self.mockStoreKit1Wrapper, updatedTransaction: transaction)
+
+        expect(self.mockBackend.invokedPostReceiptData).toEventually(equal(true))
+        expect(self.mockDeviceCache.invokedSetLatestNetworkAndAdvertisingIdsSent) == true
+        expect(self.mockDeviceCache.invokedSetLatestNetworkAndAdvertisingIdsSentCount) == 1
+        expect(self.mockDeviceCache.invokedSetLatestNetworkAndAdvertisingIdsSentParameters) == (
+            [.adServices: token], self.mockIdentityManager.currentAppUserID
+        )
     }
 
     @available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvOS 12.2, *)

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -437,7 +437,7 @@ class SubscriberAttributesManagerTests: TestCase {
         expect(self.mockDeviceCache.invokedStoreSubscriberAttributesCount) == 0
     }
 
-    // mark - sync attributes for all users
+    // MARK: - sync attributes for all users
 
     func testSyncAttributesForAllUsersSyncsForEveryUserWithUnsyncedAttributes() {
         let userID1 = "userID1"

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS16-testPostReceiptWithAdServicesToken.1.json
@@ -1,0 +1,23 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer the api key"
+  },
+  "request" : {
+    "body" : {
+      "aad_attribution_token" : "token",
+      "app_user_id" : "abc123",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "initiation_source" : "restore",
+      "is_restore" : false,
+      "observer_mode" : false
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}


### PR DESCRIPTION
### Changes:
- Added `aadAttributionToken` to `PostReceiptDataOperation`
- Exposed `AttributionPoster.adServicesTokenToPostIfNeeded`
- Added snapshot test to verify it's sent
- Added `PurchasesOrchestrator` tests (SK1/SK2) for sending the attribution token
- Added missing `PurchasesOrchestrator` tests for sending attributes
- Added log when marking `AdServices` token as synced
- Exposed `Purchases.attribution` for custom entitlement computation framework (and added to API tester)
- Exposed `Purchases.enableAdServicesAttributionTokenCollection`  for custom entitlement computation framework (and added to API tester)