### PR TITLE
`enableAdServicesAttributionTokenCollection`: added integration test

### DIFF
--- a/Sources/Attribution/AttributionFetcher.swift
+++ b/Sources/Attribution/AttributionFetcher.swift
@@ -85,6 +85,13 @@ class AttributionFetcher {
 #if canImport(AdServices)
         do {
             #if targetEnvironment(simulator)
+            #if DEBUG
+            if let mockToken = ProcessInfo.mockAdServicesToken {
+                Logger.warn(Strings.attribution.adservices_mocking_token(mockToken))
+                return mockToken
+            }
+            #endif
+
                 // See https://github.com/RevenueCat/purchases-ios/issues/2121
                 Logger.appleWarning(Strings.attribution.adservices_token_unavailable_in_simulator)
                 return nil

--- a/Sources/FoundationExtensions/ProcessInfo+Extensions.swift
+++ b/Sources/FoundationExtensions/ProcessInfo+Extensions.swift
@@ -13,11 +13,14 @@
 
 import Foundation
 
+#if DEBUG
+
 enum EnvironmentKey: String {
 
     case XCTestConfigurationFile = "XCTestConfigurationFilePath"
     case RCRunningTests = "RCRunningTests"
     case RCRunningIntegrationTests = "RCRunningIntegrationTests"
+    case RCMockAdServicesToken = "RCMockAdServicesToken"
 
 }
 
@@ -28,8 +31,6 @@ extension ProcessInfo {
     }
 
 }
-
-#if DEBUG
 
 extension ProcessInfo {
 
@@ -45,6 +46,10 @@ extension ProcessInfo {
     /// `true` when running integration tests (configured in .xctestplan files).
     static var isRunningIntegrationTests: Bool {
         return self[.RCRunningIntegrationTests] == "1"
+    }
+
+    static var mockAdServicesToken: String? {
+        return self[.RCMockAdServicesToken]?.notEmptyOrWhitespaces
     }
 
 }

--- a/Sources/Logging/Strings/AttributionStrings.swift
+++ b/Sources/Logging/Strings/AttributionStrings.swift
@@ -39,6 +39,7 @@ enum AttributionStrings {
     case attribute_set_locally(attribute: String)
     case missing_advertiser_identifiers
     case adservices_not_supported
+    case adservices_mocking_token(String)
     case adservices_token_fetch_failed(error: Error)
     case adservices_token_post_failed(error: BackendError)
     case adservices_token_post_succeeded
@@ -124,6 +125,9 @@ extension AttributionStrings: CustomStringConvertible {
         case .adservices_not_supported:
             return "Tried to fetch AdServices attribution token on device without " +
                 "AdServices support."
+
+        case let .adservices_mocking_token(token):
+            return "AdServices: mocking token: \(token) for tests"
 
         case .adservices_token_fetch_failed(let error):
             return "Fetching AdServices attribution token failed with error: \(error.localizedDescription)"

--- a/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
@@ -36,4 +36,16 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
         expect(result.entitlementsByProduct["com.revenuecat.intro_test.monthly.1_week_intro"]).to(beEmpty())
     }
 
+    @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
+    func testEnableAdServicesAttributionTokenCollection() async throws {
+        let logger = TestLogHandler()
+
+        Purchases.shared.attribution.enableAdServicesAttributionTokenCollection()
+
+        try await logger.verifyMessageIsEventuallyLogged(
+            Strings.attribution.adservices_token_post_succeeded.description,
+            level: .debug
+        )
+    }
+
 }

--- a/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
@@ -44,7 +44,9 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
 
         try await logger.verifyMessageIsEventuallyLogged(
             Strings.attribution.adservices_token_post_succeeded.description,
-            level: .debug
+            level: .debug,
+            timeout: .seconds(3),
+            pollInterval: .milliseconds(200)
         )
     }
 

--- a/Tests/TestPlans/BackendIntegrationTests.xctestplan
+++ b/Tests/TestPlans/BackendIntegrationTests.xctestplan
@@ -16,6 +16,10 @@
         "value" : "1"
       },
       {
+        "key" : "RCMockAdServicesToken",
+        "value" : "G9i5hC8lQJeGOfmS+MFycll"
+      },
+      {
         "key" : "RCRunningIntegrationTests",
         "value" : "1"
       }

--- a/Tests/TestPlans/CI-BackendIntegration.xctestplan
+++ b/Tests/TestPlans/CI-BackendIntegration.xctestplan
@@ -12,6 +12,10 @@
     "codeCoverage" : false,
     "environmentVariableEntries" : [
       {
+        "key" : "RCMockAdServicesToken",
+        "value" : "G9i5hC8lQJeGOfmS+MFycll"
+      },
+      {
         "key" : "RCRunningTests",
         "value" : "1"
       },


### PR DESCRIPTION
Because `AAAttribution.attributionToken()` isn't available on simulators, we currently had no coverage for this entire part of the codebase.
By mocking the token (on simulator + debug + integration tests only), we can verify posting to the server works correctly.

As a follow-up, we can also verify that posting it as part of the receipt with #2549 works correctly as well.