### PR TITLE
`StoreTransaction`: implemented `description`

### DIFF
--- a/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
@@ -66,6 +66,17 @@ public typealias SK2Transaction = StoreKit.Transaction
         return hasher.finalize()
     }
 
+    public override var description: String {
+        return """
+            <\(String(describing: StoreTransaction.self)):
+                identifier="\(self.transactionIdentifier)"
+                product="\(self.productIdentifier)"
+                date="\(self.purchaseDate)"
+                quantity=\(self.quantity)
+            >
+            """
+    }
+
 }
 
 /// Information that represents the customer’s purchase of a product.


### PR DESCRIPTION
This improves an upcoming log from #2533:
```
DEBUG: ℹ️ Found unfinished transaction, will post receipt in lieu of fetching CustomerInfo:
<StoreTransaction:
    identifier="9CB3E6CE-A6F6-41EC-B25D-FE0CCE5783F6"
    product=""
    date="2023-05-26 21:07:55 +0000"
    quantity=1
>
```
