### PR TITLE
`CustomerInfoManager`: post all unfinished transactions

### DIFF
--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -324,11 +324,11 @@ private extension CustomerInfoManager {
                     let storefront = await Storefront.currentStorefront
                     var lastResult: Result<CustomerInfo, BackendError>?
 
-                    for transaction in transactions {
-                        Logger.debug(
-                            Strings.customerInfo.posting_transaction_in_lieu_of_fetching_customerinfo(transaction)
-                        )
+                    Logger.debug(
+                        Strings.customerInfo.posting_transactions_in_lieu_of_fetching_customerinfo(transactions)
+                    )
 
+                    for transaction in transactions {
                         lastResult = await self.transactionPoster.handlePurchasedTransaction(
                             transaction,
                             data: .init(appUserID: appUserID,

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -325,7 +325,9 @@ private extension CustomerInfoManager {
                     var lastResult: Result<CustomerInfo, BackendError>?
 
                     for transaction in transactions {
-                        Logger.debug(Strings.customerInfo.posting_transaction_in_lieu_of_fetching_customerinfo(transaction))
+                        Logger.debug(
+                            Strings.customerInfo.posting_transaction_in_lieu_of_fetching_customerinfo(transaction)
+                        )
 
                         lastResult = await self.transactionPoster.handlePurchasedTransaction(
                             transaction,

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -320,9 +320,10 @@ private extension CustomerInfoManager {
         if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
             _ = Task<Void, Never> {
                 let transactions = await self.transactionFetcher.unfinishedVerifiedTransactions
+
                 if !transactions.isEmpty {
+                    var lastResult: Result<CustomerInfo, BackendError> = .failure(.missingCachedCustomerInfo())
                     let storefront = await Storefront.currentStorefront
-                    var lastResult: Result<CustomerInfo, BackendError>?
 
                     Logger.debug(
                         Strings.customerInfo.posting_transactions_in_lieu_of_fetching_customerinfo(transactions)
@@ -339,7 +340,7 @@ private extension CustomerInfoManager {
                         )
                     }
 
-                    completion(lastResult!)
+                    completion(lastResult)
                 } else {
                     self.requestCustomerInfo(appUserID: appUserID,
                                              isAppBackgrounded: isAppBackgrounded,

--- a/Sources/Logging/Strings/CustomerInfoStrings.swift
+++ b/Sources/Logging/Strings/CustomerInfoStrings.swift
@@ -29,7 +29,7 @@ enum CustomerInfoStrings {
     case customerinfo_updated_from_network
     case customerinfo_updated_from_network_error(BackendError)
     case customerinfo_updated_offline
-    case posting_transaction_in_lieu_of_fetching_customerinfo(StoreTransaction)
+    case posting_transactions_in_lieu_of_fetching_customerinfo([StoreTransaction])
     case updating_request_date(CustomerInfo, Date)
     case sending_latest_customerinfo_to_delegate
     case sending_updated_customerinfo_to_delegate
@@ -73,9 +73,9 @@ extension CustomerInfoStrings: CustomStringConvertible {
         case .customerinfo_updated_offline:
             return "There was an error communicating with RevenueCat servers. " +
             "CustomerInfo was temporarily computed offline, and it will be posted again as soon as possible."
-        case let .posting_transaction_in_lieu_of_fetching_customerinfo(transaction):
-            return "Found unfinished transaction, will post receipt in lieu " +
-            "of fetching CustomerInfo:\n\(transaction.description)"
+        case let .posting_transactions_in_lieu_of_fetching_customerinfo(transactions):
+            return "Found unfinished transactions, will post receipt in lieu " +
+            "of fetching CustomerInfo:\n\(transactions)"
         case let .updating_request_date(info, newRequestDate):
             return "Updating CustomerInfo '\(info.originalAppUserId)' request date: \(newRequestDate)"
         case .sending_latest_customerinfo_to_delegate:

--- a/Sources/Purchasing/Purchases/TransactionPoster.swift
+++ b/Sources/Purchasing/Purchases/TransactionPoster.swift
@@ -121,6 +121,22 @@ final class TransactionPoster: TransactionPosterType {
 
 }
 
+/// Async extension
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+extension TransactionPosterType {
+
+    /// Starts a `PostReceiptDataOperation` for the transaction.
+    func handlePurchasedTransaction(
+        _ transaction: StoreTransaction,
+        data: PurchasedTransactionData
+    ) async -> Result<CustomerInfo, BackendError> {
+        await Async.call { completion in
+            self.handlePurchasedTransaction(transaction, data: data, completion: completion)
+        }
+    }
+
+}
+
 // MARK: - Implementation
 
 private extension TransactionPoster {

--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -315,9 +315,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
         do {
             try await self.purchaseConsumablePackage()
             fail("Consumable purchases should fail while offline")
-        } catch {
-
-        }
+        } catch {}
 
         logger.verifyMessageWasNotLogged("Finishing transaction")
 
@@ -337,7 +335,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
         // 6. Ensure transactions are finished
         logger.verifyMessageWasLogged("Finishing transaction", level: .info, expectedCount: 2)
     }
-    
+
 }
 
 class OfflineWithNoMappingStoreKitIntegrationTests: BaseOfflineStoreKitIntegrationTests {

--- a/Tests/UnitTests/Mocks/MockTransactionPoster.swift
+++ b/Tests/UnitTests/Mocks/MockTransactionPoster.swift
@@ -18,9 +18,11 @@ final class MockTransactionPoster: TransactionPosterType {
 
     private let operationDispatcher = OperationDispatcher()
 
-    let stubbedHandlePurchasedTransactionResult: Atomic<Swift.Result<CustomerInfo, BackendError>> = .init(
+    let stubbedHandlePurchasedTransactionResult: Atomic<Result<CustomerInfo, BackendError>> = .init(
         .failure(.missingCachedCustomerInfo())
     )
+    let stubbedHandlePurchasedTransactionResults: Atomic<[Result<CustomerInfo, BackendError>]> = .init([])
+
     let invokedHandlePurchasedTransaction: Atomic<Bool> = false
     let invokedHandlePurchasedTransactionCount: Atomic<Int> = .init(0)
     let invokedHandlePurchasedTransactionParameters: Atomic<(transaction: StoreTransactionType,
@@ -33,12 +35,19 @@ final class MockTransactionPoster: TransactionPosterType {
         data: PurchasedTransactionData,
         completion: @escaping CustomerAPI.CustomerInfoResponseHandler
     ) {
+        // Returns either the first of `stubbedHandlePurchasedTransactionResults`
+        // or `stubbedHandlePurchasedTransactionResult`
+        func result() -> Result<CustomerInfo, BackendError> {
+            return self.stubbedHandlePurchasedTransactionResults.value.popFirst()
+            ?? self.stubbedHandlePurchasedTransactionResult.value
+        }
+
         self.invokedHandlePurchasedTransaction.value = true
         self.invokedHandlePurchasedTransactionCount.value += 1
         self.invokedHandlePurchasedTransactionParameters.value = (transaction, data)
         self.invokedHandlePurchasedTransactionParameterList.value.append((transaction, data))
 
-        self.operationDispatcher.dispatchOnMainActor { [result = self.stubbedHandlePurchasedTransactionResult.value] in
+        self.operationDispatcher.dispatchOnMainActor { [result = result()] in
             completion(result)
         }
     }

--- a/Tests/UnitTests/Mocks/MockTransactionPoster.swift
+++ b/Tests/UnitTests/Mocks/MockTransactionPoster.swift
@@ -25,6 +25,8 @@ final class MockTransactionPoster: TransactionPosterType {
     let invokedHandlePurchasedTransactionCount: Atomic<Int> = .init(0)
     let invokedHandlePurchasedTransactionParameters: Atomic<(transaction: StoreTransactionType,
                                                              data: PurchasedTransactionData)?> = nil
+    let invokedHandlePurchasedTransactionParameterList: Atomic<[(transaction: StoreTransactionType,
+                                                                 data: PurchasedTransactionData)]> = .init([])
 
     func handlePurchasedTransaction(
         _ transaction: StoreTransactionType,
@@ -34,6 +36,7 @@ final class MockTransactionPoster: TransactionPosterType {
         self.invokedHandlePurchasedTransaction.value = true
         self.invokedHandlePurchasedTransactionCount.value += 1
         self.invokedHandlePurchasedTransactionParameters.value = (transaction, data)
+        self.invokedHandlePurchasedTransactionParameterList.value.append((transaction, data))
 
         self.operationDispatcher.dispatchOnMainActor { [result = self.stubbedHandlePurchasedTransactionResult.value] in
             completion(result)


### PR DESCRIPTION
This expands the logic added in #2533 to post not only the first transaction, but all of them.

This is important for cases where there might be a consumable transaction. By handling _all_ those, we ensure that we are able to process offline `CustomerInfo` later on, instead of potentially failing due to a consumable transaction still unfinished.