### PR TITLE
`AppleReceipt.debugDescription`: don't pretty-print JSON

### DIFF
--- a/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
+++ b/Sources/LocalReceiptParsing/BasicTypes/AppleReceipt.swift
@@ -120,7 +120,7 @@ extension AppleReceipt: CustomDebugStringConvertible {
 
     /// swiftlint:disable:next missing_docs
     public var debugDescription: String {
-        return (try? self.prettyPrintedJSON) ?? "<null>"
+        return (try? self.encodedJSON) ?? "<null>"
     }
 
 }

--- a/Sources/LocalReceiptParsing/DataConverters/Codable+Extensions.swift
+++ b/Sources/LocalReceiptParsing/DataConverters/Codable+Extensions.swift
@@ -23,9 +23,25 @@ extension Encodable {
         }
     }
 
+    /// - Throws: if encoding failed
+    /// - Returns: `nil` if the encoded `Data` can't be serialized into a `String`.
+    var encodedJSON: String? {
+        get throws {
+            return String(data: try self.jsonEncodedData, encoding: .utf8)
+        }
+    }
+
+    // MARK: -
+
     var prettyPrintedData: Data {
         get throws {
             return try JSONEncoder.prettyPrinted.encode(self)
+        }
+    }
+
+    var jsonEncodedData: Data {
+        get throws {
+            return try JSONEncoder.default.encode(self)
         }
     }
 

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -386,7 +386,7 @@ private extension HTTPClient {
         urlRequest.allHTTPHeaderFields = self.headers(for: request, urlRequest: urlRequest)
 
         do {
-            urlRequest.httpBody = try request.httpRequest.requestBody?.asData()
+            urlRequest.httpBody = try request.httpRequest.requestBody?.jsonEncodedData
         } catch {
             Logger.error(Strings.network.creating_json_error(error: error.localizedDescription))
             return nil
@@ -456,14 +456,6 @@ extension HTTPRequest.Path {
     }
 
     private static let pathPrefix: String = "/v1"
-
-}
-
-private extension Encodable {
-
-    func asData() throws -> Data {
-        return try JSONEncoder.default.encode(self)
-    }
 
 }
 

--- a/Tests/UnitTests/Caching/DeviceCacheTests.swift
+++ b/Tests/UnitTests/Caching/DeviceCacheTests.swift
@@ -217,7 +217,7 @@ class DeviceCacheTests: TestCase {
 
         expect(self.deviceCache.cachedOfferings) === expectedOfferings
         try expect(self.mockUserDefaults.mockValues["com.revenuecat.userdefaults.offerings.user"] as? Data)
-        == expectedOfferings.response.asJSONEncodedData()
+        == expectedOfferings.response.jsonEncodedData
     }
 
     func testCacheOfferingsInMemory() throws {

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -189,7 +189,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
     func testSendCachedCustomerInfoIfAvailableForAppUserIDSendsIfNeverSent() throws {
         let info: CustomerInfo = .emptyInfo
 
-        let object = try info.asJSONEncodedData()
+        let object = try info.jsonEncodedData
         self.mockDeviceCache.cachedCustomerInfo[Self.appUserID] = object
 
         customerInfoManager.sendCachedCustomerInfoIfAvailable(appUserID: Self.appUserID)
@@ -200,7 +200,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
     func testSendCachedCustomerInfoIfAvailableForAppUserIDSendsIfDifferent() throws {
         let oldInfo: CustomerInfo = .emptyInfo
 
-        var object = try oldInfo.asJSONEncodedData()
+        var object = try oldInfo.jsonEncodedData
 
         mockDeviceCache.cachedCustomerInfo[Self.appUserID] = object
 
@@ -216,7 +216,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
             ] as [String: Any]
         ])
 
-        object = try newInfo.asJSONEncodedData()
+        object = try newInfo.jsonEncodedData
         mockDeviceCache.cachedCustomerInfo[Self.appUserID] = object
 
         customerInfoManager.sendCachedCustomerInfoIfAvailable(appUserID: Self.appUserID)
@@ -226,7 +226,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
     func testSendCachedCustomerInfoIfAvailableForAppUserIDSendsOnMainThread() throws {
         let oldInfo: CustomerInfo = .emptyInfo
 
-        let object = try oldInfo.asJSONEncodedData()
+        let object = try oldInfo.jsonEncodedData
         mockDeviceCache.cachedCustomerInfo[Self.appUserID] = object
 
         customerInfoManager.sendCachedCustomerInfoIfAvailable(appUserID: Self.appUserID)
@@ -291,7 +291,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
             ]  as [String: Any]
         ])
 
-        let object = try info.asJSONEncodedData()
+        let object = try info.jsonEncodedData
         self.mockDeviceCache.cachedCustomerInfo[Self.appUserID] = object
 
         let receivedCustomerInfo = try XCTUnwrap(self.customerInfoManager.cachedCustomerInfo(appUserID: Self.appUserID))
@@ -322,7 +322,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
             ]  as [String: Any]
         ])
 
-        let object = try info.asJSONEncodedData()
+        let object = try info.jsonEncodedData
         mockDeviceCache.cachedCustomerInfo["firstUser"] = object
 
         let receivedCustomerInfo = customerInfoManager.cachedCustomerInfo(appUserID: "secondUser")

--- a/Tests/UnitTests/Misc/CustomerInfo+TestExtensions.swift
+++ b/Tests/UnitTests/Misc/CustomerInfo+TestExtensions.swift
@@ -14,14 +14,6 @@
 @testable import RevenueCat
 import XCTest
 
-extension Encodable {
-
-    func asJSONEncodedData() throws -> Data {
-        return try JSONEncoder.default.encode(self)
-    }
-
-}
-
 extension CustomerInfo {
 
     /// Initializes the customer with a dictionary
@@ -56,7 +48,7 @@ extension CustomerInfo {
 
     func asData(withNewSchemaVersion version: Any?) throws -> Data {
         var dictionary = try XCTUnwrap(
-            JSONSerialization.jsonObject(with: try self.asJSONEncodedData()) as? [String: Any]
+            JSONSerialization.jsonObject(with: try self.jsonEncodedData) as? [String: Any]
         )
 
         if let version = version {

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1285,7 +1285,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
     func testResponseFromServerUpdatesRequestDate() throws {
         let path: HTTPRequest.Path = .mockPath
         let mockedResponse = BodyWithDate(data: "test", requestDate: Date().addingTimeInterval(-3000000))
-        let encodedResponse = try mockedResponse.asJSONEncodedData()
+        let encodedResponse = try mockedResponse.jsonEncodedData
         let requestDate = Date().addingTimeInterval(-100000)
 
         stub(condition: isPath(path)) { _ in
@@ -1310,7 +1310,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         let path: HTTPRequest.Path = .mockPath
         let eTag = "etag"
         let mockedResponse = BodyWithDate(data: "test", requestDate: Date().addingTimeInterval(-30000000))
-        let encodedResponse = try mockedResponse.asJSONEncodedData()
+        let encodedResponse = try mockedResponse.jsonEncodedData
         let requestDate = Date().addingTimeInterval(-1000000)
 
         self.eTagManager.stubResponseEtag(eTag)

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -625,7 +625,7 @@ private extension BaseSignatureVerificationHTTPClientTests {
             responseHeaders: [
                 HTTPClient.ResponseHeader.requestDate.rawValue: String(requestDate.millisecondsSince1970)
             ],
-            body: try response.asJSONEncodedData(),
+            body: try response.jsonEncodedData,
             verificationResult: verificationResult
         )
     }

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -418,7 +418,7 @@ extension OfferingsManagerTests {
     func testReturnsOfferingsFromDiskCacheIfNetworkRequestWithServerDown() throws {
         self.mockDeviceCache.stubbedOfferings = nil
         self.mockOfferings.stubbedGetOfferingsCompletionResult = .failure(.networkError(.serverDown()))
-        self.mockDeviceCache.stubbedCachedOfferingsData = try MockData.anyBackendOfferingsResponse.asJSONEncodedData()
+        self.mockDeviceCache.stubbedCachedOfferingsData = try MockData.anyBackendOfferingsResponse.jsonEncodedData
 
         let result: Result<Offerings, OfferingsManager.Error>? = waitUntilValue { completed in
             self.offeringsManager.offerings(appUserID: MockData.anyAppUserID) { result in
@@ -441,7 +441,7 @@ extension OfferingsManagerTests {
 
         self.mockDeviceCache.stubbedOfferings = nil
         self.mockOfferings.stubbedGetOfferingsCompletionResult = .failure(error)
-        self.mockDeviceCache.stubbedCachedOfferingsData = try MockData.anyBackendOfferingsResponse.asJSONEncodedData()
+        self.mockDeviceCache.stubbedCachedOfferingsData = try MockData.anyBackendOfferingsResponse.jsonEncodedData
         self.mockOfferingsFactory.nilOfferings = true
 
         let result: Result<Offerings, OfferingsManager.Error>? = waitUntilValue { completed in

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -238,7 +238,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         self.systemInfo.stubbedIsApplicationBackgrounded = true
 
         let info = try CustomerInfo(data: Self.emptyCustomerInfoData)
-        let object = try info.asJSONEncodedData()
+        let object = try info.jsonEncodedData
 
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
 
@@ -250,7 +250,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
 
     func testSettingTheDelegateAfterInitializationSendsCachedCustomerInfo() throws {
         let info = try CustomerInfo(data: Self.emptyCustomerInfoData)
-        let object = try info.asJSONEncodedData()
+        let object = try info.jsonEncodedData
 
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
 
@@ -264,7 +264,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
 
     func testSettingTheDelegateLaterPastInitializationSendsCachedCustomerInfo() throws {
         let info = try CustomerInfo(data: Self.emptyCustomerInfoData)
-        let object = try info.asJSONEncodedData()
+        let object = try info.jsonEncodedData
 
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetCustomerInfoTests.swift
@@ -32,7 +32,7 @@ class PurchasesGetCustomerInfoTests: BasePurchasesTests {
     func testCachedCustomerInfoHasSchemaVersion() throws {
         let info = try CustomerInfo(data: Self.emptyCustomerInfoData)
 
-        let object = try info.asJSONEncodedData()
+        let object = try info.jsonEncodedData
         self.deviceCache.cachedCustomerInfo[self.identityManager.currentAppUserID] = object
 
         self.setupPurchases()
@@ -68,7 +68,7 @@ class PurchasesGetCustomerInfoTests: BasePurchasesTests {
     func testSendsCachedCustomerInfoToGetter() throws {
         let info = try CustomerInfo(data: Self.emptyCustomerInfoData)
 
-        self.deviceCache.cachedCustomerInfo[self.identityManager.currentAppUserID] = try info.asJSONEncodedData()
+        self.deviceCache.cachedCustomerInfo[self.identityManager.currentAppUserID] = try info.jsonEncodedData
 
         self.setupPurchases()
 
@@ -83,7 +83,7 @@ class PurchasesGetCustomerInfoTests: BasePurchasesTests {
     func testCustomerInfoCompletionBlockCalledExactlyOnceWhenInfoCached() throws {
         let info = try CustomerInfo(data: Self.emptyCustomerInfoData)
 
-        self.deviceCache.cachedCustomerInfo[self.identityManager.currentAppUserID] = try info.asJSONEncodedData()
+        self.deviceCache.cachedCustomerInfo[self.identityManager.currentAppUserID] = try info.jsonEncodedData
         self.deviceCache.stubbedIsCustomerInfoCacheStale = true
 
         self.setupPurchases()

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesRestoreTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesRestoreTests.swift
@@ -66,7 +66,7 @@ class PurchasesRestoreTests: BasePurchasesTests {
     func testRestoringPurchasesPostsIfReceiptHasTransactionsAndCustomerInfoLoaded() throws {
         let info = try CustomerInfo(data: Self.emptyCustomerInfoData)
 
-        let object = try info.asJSONEncodedData()
+        let object = try info.jsonEncodedData
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
 
         self.mockTransactionsManager.stubbedCustomerHasTransactionsCompletionParameter = true
@@ -260,7 +260,7 @@ class PurchasesRestoreNoSetupTests: BasePurchasesTests {
             ] as [String: Any]
         ])
 
-        let object = try info.asJSONEncodedData()
+        let object = try info.jsonEncodedData
 
         self.deviceCache.cachedCustomerInfo[self.identityManager.currentAppUserID] = object
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncPurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncPurchasesTests.swift
@@ -44,7 +44,7 @@ class PurchasesSyncPurchasesTests: BasePurchasesTests {
             ] as [String: Any]
         ])
 
-        let object = try info.asJSONEncodedData()
+        let object = try info.jsonEncodedData
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
 
         self.mockTransactionsManager.stubbedCustomerHasTransactionsCompletionParameter = false
@@ -65,7 +65,7 @@ class PurchasesSyncPurchasesTests: BasePurchasesTests {
     func testSyncPurchasesPostsIfReceiptHasTransactionsAndCustomerInfoLoaded() throws {
         let info: CustomerInfo = .emptyInfo
 
-        let object = try info.asJSONEncodedData()
+        let object = try info.jsonEncodedData
         self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
 
         self.mockTransactionsManager.stubbedCustomerHasTransactionsCompletionParameter = true


### PR DESCRIPTION
Xcode seems to limit logs to some amount of lines, so we were always missing the end of receipts.

This also removes duplicated implementations of `Encodable.jsonEncodedData`.
