### PR TITLE
`Integration Tests`: avoid crashes when printing receipt

### DIFF
--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -271,7 +271,13 @@ extension BaseStoreKitIntegrationTests {
 
 extension BaseStoreKitIntegrationTests {
 
+    @MainActor
     func printReceiptContent() async {
+        guard Purchases.isConfigured else {
+            Logger.error("Can't print receipt when purchases isn't configured")
+            return
+        }
+
         do {
             let receipt = try await Purchases.shared.fetchReceipt(.always)
             let description = receipt.map { $0.debugDescription } ?? "<null>"


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/11501/workflows/b978f26f-ce2d-4040-ac40-96e121c4407f/jobs/72997/steps

Same as #2532, this prevents test crashes when this function is called after `Purchases` has been reset.
Test crashes are inconvenient because it makes the entire test run fail, instead of allowing retries.
