### PR TITLE
`Package.swift` fix warning for unrecognized `Info.plist`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,6 +43,8 @@ let package = Package(
                 swiftSettings: [.define("ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION")]),
         .target(name: "ReceiptParser",
                 path: "LocalReceiptParsing"),
-        .testTarget(name: "ReceiptParserTests", dependencies: ["ReceiptParser", "Nimble"])
+        .testTarget(name: "ReceiptParserTests",
+                    dependencies: ["ReceiptParser", "Nimble"],
+                    exclude: ["ReceiptParserTests-Info.plist"])
     ]
 )


### PR DESCRIPTION
Fixes this warning:
> warning: 'purchases-ios': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
> purchases-ios/Tests/ReceiptParserTests/ReceiptParserTests-Info.plist
