### PR TITLE
[WIP] `Documentation`: added reference to new `View.debugRevenueCatOverlay`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,6 +346,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-darwin-22
   x86_64-linux
 

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ var dependencies: [Package.Dependency] = [
     .package(url: "git@github.com:Quick/Nimble.git", from: "10.0.0")
 ]
 if shouldIncludeDocCPlugin {
-    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
+    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.2.0"))
 }
 
 let package = Package(

--- a/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
@@ -25,6 +25,7 @@ Most features require configuring the SDK before using it.
 - ``Purchases/configure(withAPIKey:)``
 - ``Purchases/configure(with:)-6oipy``
 - ``PurchasesDiagnostics``
+- ``SwiftUI/View/debugRevenueCatOverlay()``
 
 ### Displaying Products
 - ``Purchases/offerings()``

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -501,7 +501,7 @@ platform :ios do
     )
   end
 
-  private_lane :build_symbols_for_docs do
+  lane :build_symbols_for_docs do
     ios_version = ENV['DOCS_IOS_VERSION'] || "16.1"
 
     sh("swift",
@@ -531,8 +531,6 @@ platform :ios do
          "preview-documentation",
          "--target",
          "RevenueCat",
-         "--configuration",
-         "debug", # Necessary for debug-only symbols
          "--platform",
          "name=iOS,version=#{ios_version}",
          "--transform-for-static-hosting",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -507,12 +507,14 @@ platform :ios do
     sh("swift",
        "build",
        "--target", "RevenueCat",
+       "--configuration", "debug", # Necessary for debug-only symbols
        # Build for iOS instead of the default macOS. This ensures that iOS-only symbols are included in the docs.
        "-Xswiftc", "-sdk", "-Xswiftc", sh("xcrun", "--sdk", "iphonesimulator", "--show-sdk-path").strip!,
        "-Xswiftc", "-target", "-Xswiftc", "x86_64-apple-ios#{ios_version}-simulator",
        "-Xswiftc", "-emit-symbol-graph",
        "-Xswiftc", "-emit-symbol-graph-dir",
-       "-Xswiftc", ".build")
+       "-Xswiftc", ".build",
+       "-Xswiftc", "-emit-extension-block-symbols")
   end
 
   desc "Preview docs"
@@ -529,10 +531,14 @@ platform :ios do
          "preview-documentation",
          "--target",
          "RevenueCat",
+         "--configuration",
+         "debug", # Necessary for debug-only symbols
          "--platform",
          "name=iOS,version=#{ios_version}",
          "--transform-for-static-hosting",
          "--enable-inherited-docs",
+         # Note: this is becoming the default on Swift 5.9: https://github.com/apple/swift-docc-plugin/commit/26ac5758409154cc448d7ab82389c520fa8a8247
+         "--include-extended-types",
          "--additional-symbol-graph-dir", ".build")
     end
   end
@@ -566,6 +572,8 @@ platform :ios do
            "generate-documentation",
            "--target",
            "RevenueCat",
+           "--configuration",
+           "debug", # Necessary for debug-only symbols
            "--disable-indexing", # Produces a DocC archive that is best-suited for hosting online but incompatible with Xcode.
            "--platform",
            "name=iOS,version=#{ios_version}",
@@ -575,6 +583,8 @@ platform :ios do
            hosting_base_path,
            "--transform-for-static-hosting",
            "--enable-inherited-docs",
+           # Note: this is becoming the default on Swift 5.9: https://github.com/apple/swift-docc-plugin/commit/26ac5758409154cc448d7ab82389c520fa8a8247
+           "--include-extended-types",
            "--additional-symbol-graph-dir", ".build")
            
         docs_index_path = File.join(Dir.pwd, "scripts/docs/index.html")

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -242,6 +242,14 @@ Run LoadShedder tests
 
 Update swift package commit
 
+### ios build_symbols_for_docs
+
+```sh
+[bundle exec] fastlane ios build_symbols_for_docs
+```
+
+
+
 ### ios preview_docs
 
 ```sh


### PR DESCRIPTION
See #2567.

This requires a new flag `include-extended-types` (see https://apple.github.io/swift-docc-plugin/documentation/swiftdoccplugin/generating-documentation-for-extended-types/).

This is fixed in Xcode 15 🎉 
![Screenshot 2023-06-06 at 09 42 06](https://github.com/RevenueCat/purchases-ios/assets/685609/65020433-dfd5-4a29-af7c-f2c89784d556)
