### PR TITLE
`ProductsManager`: improved display of underlying errors

### DIFF
--- a/Sources/Logging/Strings/StoreKitStrings.swift
+++ b/Sources/Logging/Strings/StoreKitStrings.swift
@@ -20,9 +20,9 @@ enum StoreKitStrings {
 
     case sk_receipt_request_finished
 
-    case skrequest_failed(error: Error)
+    case skrequest_failed(NSError)
 
-    case store_products_request_failed(error: Error)
+    case store_products_request_failed(NSError)
 
     case skproductsrequest_timed_out(after: Int)
 
@@ -66,10 +66,10 @@ extension StoreKitStrings: CustomStringConvertible {
             return "SKReceiptRefreshRequest finished"
 
         case .skrequest_failed(let error):
-            return "SKRequest failed: \(error.localizedDescription)"
+            return "SKRequest failed: \(error.description)"
 
         case .store_products_request_failed(let error):
-            return "Store products request failed! Error: \(error.localizedDescription)"
+            return "Store products request failed! Error: \(error.description)"
 
         case .skproductsrequest_timed_out(let afterTimeInSeconds):
             return "SKProductsRequest took longer than \(afterTimeInSeconds) seconds, " +

--- a/Sources/Purchasing/ProductsManager.swift
+++ b/Sources/Purchasing/ProductsManager.swift
@@ -101,8 +101,8 @@ class ProductsManager: NSObject, ProductsManagerType {
 
                 Logger.debug(Strings.storeKit.store_product_request_finished)
                 return Set(products)
-            } catch {
-                Logger.debug(Strings.storeKit.store_products_request_failed(error: error))
+            } catch let error as NSError {
+                Logger.debug(Strings.storeKit.store_products_request_failed(error))
                 throw ErrorUtils.storeProblemError(error: error)
             }
         }

--- a/Sources/Purchasing/StoreKit1/ProductsFetcherSK1.swift
+++ b/Sources/Purchasing/StoreKit1/ProductsFetcherSK1.swift
@@ -157,7 +157,7 @@ extension ProductsFetcherSK1: SKProductsRequestDelegate {
         }
 
         self.queue.async { [self] in
-            Logger.appleError(Strings.storeKit.store_products_request_failed(error: error))
+            Logger.appleError(Strings.storeKit.store_products_request_failed(error as NSError))
 
             guard let productRequest = self.productsByRequests[request] else {
                 Logger.error(Strings.purchase.requested_products_not_found(request: request))

--- a/Sources/Purchasing/StoreKit1/StoreKitRequestFetcher.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKitRequestFetcher.swift
@@ -67,7 +67,7 @@ extension StoreKitRequestFetcher: SKRequestDelegate {
     func request(_ request: SKRequest, didFailWithError error: Error) {
         guard request is SKReceiptRefreshRequest else { return }
 
-        Logger.appleError(Strings.storeKit.skrequest_failed(error: error))
+        Logger.appleError(Strings.storeKit.skrequest_failed(error as NSError))
         self.finishReceiptRequest(request)
         request.cancel()
     }


### PR DESCRIPTION
This goes from:
```
ERROR: 🍎‼️ Store products request failed! Error: UNKNOWN_ERROR
```
To:
```
ERROR: 🍎‼️ Store products request failed! Error: Error Domain=SKErrorDomain Code=0 "UNKNOWN_ERROR" UserInfo={NSLocalizedDescription=UNKNOWN_ERROR, NSUnderlyingError=0x600002b04cf0 {Error Domain=ASDErrorDomain Code=950 "Unhandled exception" UserInfo={NSLocalizedDescription=Unhandled exception, NSLocalizedFailureReason=An unknown error occurred}}}
```
