### PR TITLE
`APITesters`: available since iOS 11

### DIFF
--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj/project.pbxproj
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester.xcodeproj/project.pbxproj
@@ -322,7 +322,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -359,7 +359,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCConfigurationAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCConfigurationAPI.m
@@ -13,7 +13,7 @@
 
 + (void)checkAPI {
     RCConfigurationBuilder *builder = [RCConfiguration builderWithAPIKey:@""];
-    RCConfiguration *config = [[[[[[[[[[[[builder withApiKey:@""]
+    RCConfiguration *config __unused = [[[[[[[[[[[builder withApiKey:@""]
                                          withObserverMode:false]
                                         withUserDefaults:NSUserDefaults.standardUserDefaults]
                                        withAppUserID:@""]
@@ -22,9 +22,12 @@
                                     withNetworkTimeout:1]
                                    withStoreKit1Timeout: 1]
                                   withPlatformInfo:[[RCPlatformInfo alloc] initWithFlavor:@"" version:@""]]
-                                 withEntitlementVerificationMode:RCEntitlementVerificationModeEnforced]
                                 withUsesStoreKit2IfAvailable:false] build];
-    NSLog(@"%@", config);
+
+    if (@available(iOS 13.0, *)) {
+        RCConfiguration *config __unused = [[builder withEntitlementVerificationMode:RCEntitlementVerificationModeEnforced]
+                                   build];
+    }
 }
 
 @end

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCEntitlementInfoAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCEntitlementInfoAPI.m
@@ -29,10 +29,13 @@
     NSDate *uda = [ri unsubscribeDetectedAt];
     NSDate *bida = [ri billingIssueDetectedAt];
     RCPurchaseOwnershipType ot = [ri ownershipType];
-    RCVerificationResult ver = [ri verification];
     NSDictionary<NSString *, id> *rawData = [ri rawData];
 
-    NSLog(i, ia, iaae, iace, ri, wr, pt, lpd, opd, ed, s, pi, is, uda, bida, ot, ver, rawData);
+    if (@available(iOS 13.0, *)) {
+        RCVerificationResult ver __unused = [ri verification];
+    }
+
+    NSLog(i, ia, iaae, iace, ri, wr, pt, lpd, opd, ed, s, pi, is, uda, bida, ot, rawData);
 }
 
 + (void)checkEnums {

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -163,12 +163,13 @@ BOOL isAnonymous;
     
     [p checkTrialOrIntroDiscountEligibilityForProduct:storeProduct completion:^(RCIntroEligibilityStatus status) { }];
     [p checkTrialOrIntroDiscountEligibility:@[@""] completion:^(NSDictionary<NSString *,RCIntroEligibility *> *d) { }];
-    [p getPromotionalOfferForProductDiscount:stpd
-                                 withProduct:storeProduct
-                              withCompletion:^(RCPromotionalOffer *offer, NSError *error) { }];
-    
-    [p purchaseProduct:storeProduct withPromotionalOffer:pro completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];
-    [p purchasePackage:pack withPromotionalOffer:pro completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];
+    if (@available(iOS 12.2, *)) {
+        [p getPromotionalOfferForProductDiscount:stpd
+                                     withProduct:storeProduct
+                                  withCompletion:^(RCPromotionalOffer *offer, NSError *error) { }];
+        [p purchaseProduct:storeProduct withPromotionalOffer:pro completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];
+        [p purchasePackage:pack withPromotionalOffer:pro completion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];
+    }
     
     [p logIn:@"" completion:^(RCCustomerInfo *i, BOOL created, NSError *e) { }];
     [p logOutWithCompletion:^(RCCustomerInfo *i, NSError *e) { }];
@@ -184,15 +185,22 @@ BOOL isAnonymous;
     }];
 
 #if (TARGET_OS_IPHONE || TARGET_OS_MACCATALYST) && !TARGET_OS_TV && !TARGET_OS_WATCH
-    [p beginRefundRequestForProduct:@"1234" completion:^(RCRefundRequestStatus s, NSError * _Nullable e) { }];
-    [p beginRefundRequestForEntitlement:@"" completion:^(RCRefundRequestStatus s, NSError * _Nullable e) { }];
-    [p beginRefundRequestForActiveEntitlementWithCompletion:^(RCRefundRequestStatus s, NSError * _Nullable e) { }];
-    [p showPriceConsentIfNeeded];
-    BOOL consent __unused = [p.delegate shouldShowPriceConsent];
+    if (@available(iOS 15.0, *)) {
+        [p beginRefundRequestForProduct:@"1234" completion:^(RCRefundRequestStatus s, NSError * _Nullable e) { }];
+        [p beginRefundRequestForEntitlement:@"" completion:^(RCRefundRequestStatus s, NSError * _Nullable e) { }];
+        [p beginRefundRequestForActiveEntitlementWithCompletion:^(RCRefundRequestStatus s, NSError * _Nullable e) { }];
+    }
+
+    if (@available(iOS 13.4, *)) {
+        [p showPriceConsentIfNeeded];
+        BOOL consent __unused = [p.delegate shouldShowPriceConsent];
+    }
 #endif
 
 #if TARGET_OS_IPHONE && !TARGET_OS_TV && !TARGET_OS_WATCH
-    [p presentCodeRedemptionSheet];
+    if (@available(iOS 14.0, *)) {
+        [p presentCodeRedemptionSheet];
+    }
 #endif
 }
 

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesDiagnosticsAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesDiagnosticsAPI.m
@@ -12,9 +12,10 @@
 @implementation RCPurchasesDiagnosticsAPI
 
 + (void)checkAPI {
-    RCPurchasesDiagnostics *diagnostics = [RCPurchasesDiagnostics default];
-
-    [diagnostics testSDKHealthWithCompletion:^(NSError * _Nullable error) {}];
+    if (@available(iOS 13.0, *)) {
+        RCPurchasesDiagnostics *diagnostics = [RCPurchasesDiagnostics default];
+        [diagnostics testSDKHealthWithCompletion:^(NSError * _Nullable error) {}];
+    }
 }
 
 @end

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCStoreProductAPI.m
@@ -14,43 +14,34 @@
 + (void)checkAPI {
     RCStoreProduct *product;
 
-    NSString *localizedDescription = product.localizedDescription;
-    NSString *localizedTitle = product.localizedTitle;
-    NSString *currencyCode = product.currencyCode;
-    NSDecimalNumber *price = product.price;
-    NSString *localizedPriceString = product.localizedPriceString;
-    NSString *productIdentifier = product.productIdentifier;
-    BOOL isFamilyShareable = product.isFamilyShareable;
-    NSString *subscriptionGroupIdentifier = product.subscriptionGroupIdentifier;
-    NSNumberFormatter *priceFormatter = product.priceFormatter;
-    RCSubscriptionPeriod *subscriptionPeriod = product.subscriptionPeriod;
-    RCStoreProductDiscount *introductoryPrice = product.introductoryDiscount;
-    NSArray<RCStoreProductDiscount *> *discounts = product.discounts;
-    NSDecimalNumber *pricePerMonth = product.pricePerMonth;
-    NSDecimalNumber *pricePerYear = product.pricePerYear;
-    NSString *localizedIntroductoryPriceString = product.localizedIntroductoryPriceString;
+    NSString *localizedDescription __unused = product.localizedDescription;
+    NSString *localizedTitle __unused = product.localizedTitle;
+    NSString *currencyCode __unused = product.currencyCode;
+    NSDecimalNumber *price __unused = product.price;
+    NSString *localizedPriceString __unused = product.localizedPriceString;
+    NSString *productIdentifier __unused = product.productIdentifier;
+    if (@available(iOS 14.0, *)) {
+        BOOL isFamilyShareable  __unused = product.isFamilyShareable;
+    }
+    if (@available(iOS 12.0, *)) {
+        NSString *subscriptionGroupIdentifier  __unused = product.subscriptionGroupIdentifier;
+    }
+    NSNumberFormatter *priceFormatter  __unused = product.priceFormatter;
 
-    SKProduct *sk1 = product.sk1Product;
+    if (@available(iOS 11.2, *)) {
+        RCSubscriptionPeriod *subscriptionPeriod __unused = product.subscriptionPeriod;
+        RCStoreProductDiscount *introductoryPrice __unused = product.introductoryDiscount;
+        NSDecimalNumber *pricePerMonth __unused = product.pricePerMonth;
+        NSDecimalNumber *pricePerYear __unused = product.pricePerYear;
+    }
 
-    NSLog(
-          product,
-          localizedDescription,
-          localizedTitle,
-          currencyCode,
-          price,
-          localizedPriceString,
-          productIdentifier,
-          isFamilyShareable,
-          subscriptionGroupIdentifier,
-          priceFormatter,
-          subscriptionPeriod,
-          introductoryPrice,
-          discounts,
-          pricePerMonth,
-          pricePerYear,
-          localizedIntroductoryPriceString,
-          sk1
-      );
+    NSString *localizedIntroductoryPriceString __unused = product.localizedIntroductoryPriceString;
+
+    if (@available(iOS 12.2, *)) {
+        NSArray<RCStoreProductDiscount *> *discounts __unused = product.discounts;
+    }
+
+    SKProduct *sk1 __unused = product.sk1Product;
 }
 
 + (void)checkConstructors {

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCStorefrontAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCStorefrontAPI.m
@@ -17,11 +17,13 @@
     NSString *identifier = storefront.identifier;
     NSString *countryCode = storefront.countryCode;
 
-    SKStorefront *sk1storefront = storefront.sk1Storefront;
+    if (@available(iOS 13.0, *)) {
+        SKStorefront *sk1storefront = storefront.sk1Storefront;
 
-    RCStorefront *currentStorefront = [RCStorefront sk1CurrentStorefront];
+        RCStorefront *currentStorefront = [RCStorefront sk1CurrentStorefront];
 
-    NSLog(identifier, countryCode, sk1storefront, currentStorefront);
+        NSLog(identifier, countryCode, sk1storefront, currentStorefront);
+    }
 }
 
 @end

--- a/Tests/APITesters/ReceiptParserAPITester/ReceiptParserAPITester.xcodeproj/project.pbxproj
+++ b/Tests/APITesters/ReceiptParserAPITester/ReceiptParserAPITester.xcodeproj/project.pbxproj
@@ -186,7 +186,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -219,7 +219,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj/project.pbxproj
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj/project.pbxproj
@@ -274,7 +274,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -307,7 +307,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/AttributionAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/AttributionAPI.swift
@@ -73,6 +73,8 @@ func checkAttributionAPI() {
     attribution.collectDeviceIdentifiers()
 
     #if !os(tvOS) && !os(watchOS)
-    attribution.enableAdServicesAttributionTokenCollection()
+    if #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) {
+        attribution.enableAdServicesAttributionTokenCollection()
+    }
     #endif
 }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PromotionalOfferAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PromotionalOfferAPI.swift
@@ -11,17 +11,20 @@ import StoreKit
 
 var offer: PromotionalOffer!
 func checkPromotionalOfferAPI() {
-    let discount: StoreProductDiscount = offer.discount
-    let sk1Discount = offer.discount.sk1Discount
-    let sk2Discount = offer.discount.sk2Discount
+    let _: StoreProductDiscount = offer.discount
 
-    let signedData = offer.signedData
+    if #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *) {
+        let _: SK1ProductDiscount? = offer.discount.sk1Discount
+    }
+    if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
+        let _: SK2ProductDiscount? = offer.discount.sk2Discount
+    }
+
+    let signedData: PromotionalOffer.SignedData = offer.signedData
 
     let _: String = signedData.identifier
     let _: String = signedData.keyIdentifier
     let _: UUID = signedData.nonce
     let _: String = signedData.signature
     let _: Int = signedData.timestamp
-
-    print(discount, sk1Discount!, sk2Discount!)
 }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesDiagnosticsAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesDiagnosticsAPI.swift
@@ -8,14 +8,17 @@
 import Foundation
 import RevenueCat
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 func checkPurchasesDiagnostics() {
     let _: PurchasesDiagnostics = .default
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 private func checkPurchasesDiagnosticsAsync(_ diagnostics: PurchasesDiagnostics) async {
     _ = try? await diagnostics.testSDKHealth()
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 func checkDiagnosticsErrors(_ error: PurchasesDiagnostics.Error) {
     switch error {
     case let .failedConnectingToAPI(error):

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/StoreProductAPI.swift
@@ -10,66 +10,55 @@ import RevenueCat
 var product: StoreProduct!
 
 func checkStoreProductAPI() {
-    let category: StoreProduct.ProductCategory = product.productCategory
-    let productType: StoreProduct.ProductType = product.productType
-    let localizedDescription: String = product.localizedDescription
-    let localizedTitle: String = product.localizedTitle
-    let currencyCode: String? = product.currencyCode
-    let price: Decimal = product.price
+    let _: StoreProduct.ProductCategory = product.productCategory
+    let _: StoreProduct.ProductType = product.productType
+    let _: String = product.localizedDescription
+    let _: String = product.localizedTitle
+    let _: String? = product.currencyCode
+    let _: Decimal = product.price
     // This is mainly for Objective-C
-    let decimalPrice: NSDecimalNumber = product.priceDecimalNumber
-    let localizedPriceString: String = product.localizedPriceString
-    let productIdentifier: String = product.productIdentifier
-    let isFamilyShareable: Bool = product.isFamilyShareable
-    let subscriptionGroupIdentifier: String? = product.subscriptionGroupIdentifier
-    let priceFormatter: NumberFormatter? = product.priceFormatter
-    let subscriptionPeriod: SubscriptionPeriod? = product.subscriptionPeriod
-    let introductoryPrice: StoreProductDiscount? = product.introductoryDiscount
-    let discounts: [StoreProductDiscount] = product.discounts
+    let _: NSDecimalNumber = product.priceDecimalNumber
+    let _: String = product.localizedPriceString
+    let _: String = product.productIdentifier
+    if #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *) {
+        let _: Bool = product.isFamilyShareable
+    }
+    if #available(iOS 12.0, macCatalyst 13.0, tvOS 12.0, macOS 10.14, watchOS 6.2, *) {
+        let _: String? = product.subscriptionGroupIdentifier
+    }
+    let _: NumberFormatter? = product.priceFormatter
+    if #available(iOS 11.2, macOS 10.13.2, tvOS 11.2, watchOS 6.2, *) {
+        let _: SubscriptionPeriod? = product.subscriptionPeriod
+        let _: StoreProductDiscount? = product.introductoryDiscount
+        let _: NSDecimalNumber? = product.pricePerMonth
+        let _: NSDecimalNumber? = product.pricePerYear
+    }
+    if #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *) {
+        let _: [StoreProductDiscount] = product.discounts
+    }
 
-    let pricePerMonth: NSDecimalNumber? = product.pricePerMonth
-    let pricePerYear: NSDecimalNumber? = product.pricePerYear
-    let localizedIntroductoryPriceString: String? = product.localizedIntroductoryPriceString
-    let sk1Product: SK1Product? = product.sk1Product
-    let sk2Product: SK2Product? = product.sk2Product
+    let _: String? = product.localizedIntroductoryPriceString
+    let _: SK1Product? = product.sk1Product
+
+    if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
+        let _: SK2Product? = product.sk2Product
+    }
 
     if #available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *) {
         _ = Task<Void, Never> {
             await checkStoreProductAsyncAPI()
         }
     }
-
-    print(
-        product!,
-        category,
-        productType,
-        localizedDescription,
-        localizedTitle,
-        currencyCode!,
-        price,
-        decimalPrice,
-        localizedPriceString,
-        productIdentifier,
-        isFamilyShareable,
-        subscriptionGroupIdentifier!,
-        priceFormatter!,
-        subscriptionPeriod!,
-        introductoryPrice!,
-        discounts,
-        pricePerMonth!,
-        pricePerYear!,
-        localizedIntroductoryPriceString!,
-        sk1Product!,
-        sk2Product!
-    )
 }
 
 func checkConstructors() {
     let sk1Product: SK1Product! = nil
-    let sk2Product: SK2Product! = nil
-
     _ = StoreProduct(sk1Product: sk1Product!)
-    _ = StoreProduct(sk2Product: sk2Product!)
+
+    if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
+        let sk2Product: SK2Product! = nil
+        _ = StoreProduct(sk2Product: sk2Product!)
+    }
 }
 
 func checkProductCategory(_ category: StoreProduct.ProductCategory) {
@@ -90,10 +79,12 @@ func checkProductType(_ type: StoreProduct.ProductType) {
     }
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 func checkStoreProductAsyncAPI() async {
     let _: [PromotionalOffer] = await product.eligiblePromotionalOffers()
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 @available(*, deprecated) // Ignore deprecation warnings
 func checkDeprecatedAsyncAPI() async {
     let _: [PromotionalOffer] = await product.getEligiblePromotionalOffers()

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/StoreProductDiscountAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/StoreProductDiscountAPI.swift
@@ -20,8 +20,13 @@ func checkStoreProductDiscountAPI() {
     let priceFormatter: NumberFormatter? = product.priceFormatter
     let subscriptionPeriod: SubscriptionPeriod = discount.subscriptionPeriod
 
-    let sk1Discount: SK1ProductDiscount = discount.sk1Discount!
-    let sk2Discount: SK2ProductDiscount = discount.sk2Discount!
+    if #available(iOS 12.2, macOS 10.14.4, tvOS 12.2, watchOS 6.2, *) {
+        let _: SK1ProductDiscount = discount.sk1Discount!
+    }
+
+    if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
+        let _: SK2ProductDiscount = discount.sk2Discount!
+    }
 
     print(
         offerIdentifier!,
@@ -31,9 +36,7 @@ func checkStoreProductDiscountAPI() {
         localizedPriceString,
         paymentMode,
         priceFormatter!,
-        subscriptionPeriod,
-        sk1Discount,
-        sk2Discount
+        subscriptionPeriod
     )
 }
 

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/StoreTransactionAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/StoreTransactionAPI.swift
@@ -9,7 +9,7 @@ import StoreKit
 
 import RevenueCat
 
-private  var transaction: StoreTransaction!
+private var transaction: StoreTransaction!
 func checkStoreTransactionAPI() {
     let productIdentifier: String = transaction.productIdentifier
     let purchaseDate: Date = transaction.purchaseDate
@@ -17,14 +17,16 @@ func checkStoreTransactionAPI() {
     let quantity: Int = transaction.quantity
 
     let sk1: SKPaymentTransaction? = transaction.sk1Transaction
-    let sk2: StoreKit.Transaction? = transaction.sk2Transaction
+
+    if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
+        let _: StoreKit.Transaction? = transaction.sk2Transaction
+    }
 
     print(
         productIdentifier,
         purchaseDate,
         transactionIdentifier,
         quantity,
-        sk1!,
-        sk2!
+        sk1!
     )
 }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/StorefrontAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/StorefrontAPI.swift
@@ -11,18 +11,20 @@ import StoreKit
 var storefront: RevenueCat.Storefront!
 
 func checkStorefrontAPI() {
-    let identifier: String = storefront.identifier
-    let countryCode: String = storefront.countryCode
+    let _: String = storefront.identifier
+    let _: String = storefront.countryCode
 
-    let sk1Storefront: SKStorefront? = storefront.sk1Storefront
-    let sk2Storefront: StoreKit.Storefront? = storefront.sk2Storefront
-
-    _ = Task<Void, Never> {
-        let _: RevenueCat.Storefront? = await Storefront.currentStorefront
+    if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, macCatalyst 13.1, *) {
+        let _: SKStorefront? = storefront.sk1Storefront
     }
 
-    print(identifier,
-          countryCode,
-          sk1Storefront!,
-          sk2Storefront!)
+    if #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) {
+        let _: StoreKit.Storefront? = storefront.sk2Storefront
+    }
+
+    if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, macCatalyst 13.1, *) {
+        _ = Task<Void, Never> {
+            let _: RevenueCat.Storefront? = await Storefront.currentStorefront
+        }
+    }
 }


### PR DESCRIPTION
Turns out we weren't compiling these beyond iOS 15.