### PR TITLE
Fixed `Catalyst` build with Xcode 15 beta 1

### DIFF
--- a/Sources/FoundationExtensions/UIApplication+RCExtensions.swift
+++ b/Sources/FoundationExtensions/UIApplication+RCExtensions.swift
@@ -18,6 +18,7 @@ import UIKit
 extension UIApplication {
 
     @available(iOS 13.0, *)
+    @available(macCatalystApplicationExtension 13.1, *)
     @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(watchOSApplicationExtension, unavailable)


### PR DESCRIPTION
Fixes this error:
> Property cannot be more available than enclosing scope
> Enclosing scope requires availability of application extensions for Mac Catalyst 13.1 or newer
