### PR TITLE
`StoreKit2TransactionListener`: added log when receiving `Transactions.Updates`

### DIFF
--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -73,6 +73,7 @@ enum PurchaseStrings {
     case begin_refund_multiple_active_entitlements
     case begin_refund_customer_info_error(entitlementID: String?)
     case missing_cached_customer_info
+    case sk2_transactions_update_received_transaction(StoreTransaction)
     case sk1_purchase_too_slow
     case sk2_purchase_too_slow
 
@@ -272,6 +273,9 @@ extension PurchaseStrings: CustomStringConvertible {
                 "\(entitlementID.flatMap { "entitlement with ID " + $0 } ?? "active entitlement")."
         case .missing_cached_customer_info:
             return "Requested a cached CustomerInfo but it's not available."
+
+        case let .sk2_transactions_update_received_transaction(transaction):
+            return "StoreKit.Transaction.updates: received transaction for product '\(transaction.productIdentifier)'"
 
         case .sk1_purchase_too_slow:
             return "StoreKit 1 purchase took longer than expected"

--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
@@ -103,9 +103,13 @@ private extension StoreKit2TransactionListener {
 
         case let .verified(verifiedTransaction):
             if fromTransactionUpdate, let delegate = self.delegate {
+                let transaction = StoreTransaction(sk2Transaction: verifiedTransaction)
+
+                Logger.debug(Strings.purchase.sk2_transactions_update_received_transaction(transaction))
+
                 try await delegate.storeKit2TransactionListener(
                     self,
-                    updatedTransaction: StoreTransaction(sk2Transaction: verifiedTransaction)
+                    updatedTransaction: transaction
                 )
             }
 


### PR DESCRIPTION
I realized we currently don't log anything, and we go straight to posting the receipt. It would be useful for debugging if we know why receipts are being posted.
