### PR TITLE
`StoreKitObserverModeIntegrationTests`: fixed and disabled SK2 `testPurchaseInDevicePostsReceipt`

### DIFF
--- a/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
@@ -47,8 +47,8 @@ class StoreKit2ObserverModeIntegrationTests: StoreKit1ObserverModeIntegrationTes
 
         try await asyncWait(
             until: {
-                let entitlement = try? await Purchases.shared
-                    .customerInfo(fetchPolicy: .fetchCurrent)
+                let entitlement = await self.purchasesDelegate
+                    .customerInfo?
                     .entitlements[Self.entitlementIdentifier]
 
                 return entitlement?.isActive == true

--- a/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
@@ -38,7 +38,12 @@ class StoreKit2ObserverModeIntegrationTests: StoreKit1ObserverModeIntegrationTes
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testPurchaseInDevicePostsReceipt() async throws {
-        try await self.purchaseProductFromStoreKit()
+        let result = try await self.purchaseProductFromStoreKit()
+        let transaction = try XCTUnwrap(result.verificationResult?.underlyingTransaction)
+
+        try self.testSession.disableAutoRenewForTransaction(identifier: UInt(transaction.id))
+
+        XCTExpectFailure("This test currently does not pass (see FB12231111)")
 
         try await asyncWait(
             until: {
@@ -48,8 +53,8 @@ class StoreKit2ObserverModeIntegrationTests: StoreKit1ObserverModeIntegrationTes
 
                 return entitlement?.isActive == true
             },
-            timeout: .seconds(60),
-            pollInterval: .seconds(2),
+            timeout: .seconds(5),
+            pollInterval: .milliseconds(500),
             description: "Entitlement didn't become active"
         )
     }


### PR DESCRIPTION
Turns out this test was only passing because it was waiting for the receipt to be posted during a renewal, not the initial purchase!
This updates the test to reflect the correct expectation (disabling renewals), and added the `XCTExpectFailure` so we can detect if it starts passing in a future iOS version.

Also changed the test to not use `customerInfo()` because of #2563.