### PR TITLE
`debugRevenueCatOverlay` improvements

### DIFF
--- a/Sources/Support/DebugUI/DebugContentViews.swift
+++ b/Sources/Support/DebugUI/DebugContentViews.swift
@@ -94,13 +94,19 @@ private struct DebugSummaryView: View {
                 Text("Loading...")
 
             case let .loaded(config):
-                LabeledContent("SDK version", value: SystemInfo.frameworkVersion)
+                LabeledContent("SDK version", value: config.sdkVersion)
                 LabeledContent("Observer mode", value: config.observerMode.description)
                 LabeledContent("Sandbox", value: config.sandbox.description)
                 LabeledContent("StoreKit 2", value: config.storeKit2Enabled ? "on" : "off")
                 LabeledContent("Offline Customer Info",
                                value: config.offlineCustomerInfoSupport ? "enabled" : "disabled")
-                LabeledContent("Entitlement Verification Mode", value: config.verificationMode.display)
+                LabeledContent("Entitlement Verification Mode", value: config.verificationMode)
+
+                ShareLink(item: config, preview: .init("Configuration")) {
+                    Label("Share", systemImage: "square.and.arrow.up")
+
+                }
+                .frame(maxWidth: .infinity)
             }
         }
     }
@@ -113,7 +119,8 @@ private struct DebugSummaryView: View {
                 Text("Loading...")
 
             case let .loaded(info):
-                LabeledContent("User ID", value: info.originalAppUserId)
+                LabeledContent("User ID", value: Purchases.shared.appUserID)
+                LabeledContent("Original User ID", value: info.originalAppUserId)
                 LabeledContent("Active Entitlements", value: info.entitlements.active.count.description)
 
                 if let latestExpiration = info.latestExpirationDate {
@@ -240,14 +247,16 @@ private struct DebugPackageView: View {
 
 }
 
-private extension Signing.ResponseVerificationMode {
+@available(iOS 16.0, *)
+extension DebugViewModel.Configuration: Transferable {
 
-    var display: String {
-        switch self {
-        case .disabled: return "disabled"
-        case .informational: return "informational"
-        case .enforced: return "enforced"
-        }
+    static var transferRepresentation: some TransferRepresentation {
+        return CodableRepresentation(
+            for: DebugViewModel.Configuration.self,
+            contentType: .plainText,
+            encoder: JSONEncoder.prettyPrinted,
+            decoder: JSONDecoder.default
+        )
     }
 
 }

--- a/Sources/Support/DebugUI/DebugViewModel.swift
+++ b/Sources/Support/DebugUI/DebugViewModel.swift
@@ -21,13 +21,14 @@ import SwiftUI
 @available(iOS 16.0, *)
 final class DebugViewModel: ObservableObject {
 
-    struct Configuration {
+    struct Configuration: Codable {
 
-        let observerMode: Bool
-        let sandbox: Bool
-        let storeKit2Enabled: Bool
-        let offlineCustomerInfoSupport: Bool
-        let verificationMode: Signing.ResponseVerificationMode
+        var sdkVersion: String = SystemInfo.frameworkVersion
+        var observerMode: Bool
+        var sandbox: Bool
+        var storeKit2Enabled: Bool
+        var offlineCustomerInfoSupport: Bool
+        var verificationMode: String
 
     }
 
@@ -121,8 +122,20 @@ private extension DebugViewModel.Configuration {
             sandbox: purchases.isSandbox,
             storeKit2Enabled: purchases.storeKit2Setting.isEnabledAndAvailable,
             offlineCustomerInfoSupport: purchases.offlineCustomerInfoEnabled,
-            verificationMode: purchases.responseVerificationMode
+            verificationMode: purchases.responseVerificationMode.display
         )
+    }
+
+}
+
+private extension Signing.ResponseVerificationMode {
+
+    var display: String {
+        switch self {
+        case .disabled: return "disabled"
+        case .informational: return "informational"
+        case .enforced: return "enforced"
+        }
     }
 
 }


### PR DESCRIPTION
### Changes:
- Separate `User ID` and `Original User ID`
- Share button to be able to copy / send configuration as pretty-printed JSON

Thanks to @codykerns for the suggestions.

<img width="417" alt="Screenshot 2023-06-07 at 11 25 05" src="https://github.com/RevenueCat/purchases-ios/assets/685609/a4852bee-b01c-4c4a-8770-0145fdb4a89a">
