### PR TITLE
`Xcode 15`: fixed all documentation warnings

### DIFF
--- a/Sources/DocCDocumentation/DocCDocumentation.docc/V4_API_Migration_guide.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/V4_API_Migration_guide.md
@@ -250,7 +250,7 @@ These types replace native StoreKit types in all public API methods that used th
 #### PurchasesDelegate
 | v3 | v4 |
 | ------------ | ------------------------------------- | 
-| purchases(_ purchases: Purchases, didReceiveUpdated purchaserInfo: PurchaserInfo) | ``PurchasesDelegate/purchases(_:receivedUpdated:)`` |
+| purchases(_ purchases: Purchases, didReceiveUpdated purchaserInfo: PurchaserInfo) | ``RevenueCat/PurchasesDelegate/purchases(_:receivedUpdated:)`` |
 
 ### Error handling
 
@@ -282,7 +282,7 @@ if let error = error as? RevenueCat.ErrorCode {
 - ``Purchases/beginRefundRequest(forProduct:)``: Use this method to begin a refund request for a purchase, specifying the product identifier.
 - ``Purchases/beginRefundRequest(forEntitlement:)``: Use this method to begin a refund request for a purchase, specifying the entitlement identifier.
 - You can now use ``Purchases/customerInfoStream`` to be notified whenever there's new ``CustomerInfo`` available, 
-as an alternative to ``PurchasesDelegate/purchases(_:receivedUpdated:)``.
+as an alternative to ``RevenueCat/PurchasesDelegate/purchases(_:receivedUpdated:)``.
 
 ## Reporting undocumented issues:
 

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -22,7 +22,7 @@ import Foundation
  * **Steps:**
  * 1. Call ``Configuration/builder(withAPIKey:)`` To obtain a ``Configuration/Builder`` object.
  * 2. Set this builder's properties using the "`with(`" functions.
- * 3. Call ``Builder/build()`` to obtain the `Configuration` object.
+ * 3. Call ``Configuration/Builder/build()`` to obtain the `Configuration` object.
  * 4. Pass the `Configuration` object into ``Purchases/configure(with:)-6oipy``.
  *
  * ```swift

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -54,8 +54,9 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
     /// Returns the already configured instance of ``Purchases``.
     /// - Warning: this method will crash with `fatalError` if ``Purchases`` has not been initialized through
-    /// ``configure(withAPIKey:)`` or one of its overloads. If there's a chance that may have not happened yet,
-    /// you can use ``isConfigured`` to check if it's safe to call.
+    /// ``Purchases/configure(withAPIKey:)`` or one of its overloads.
+    /// If there's a chance that may have not happened yet, you can use ``isConfigured`` to check if it's safe to call.
+    /// 
     /// ### Related symbols
     /// - ``isConfigured``
     @objc(sharedPurchases)
@@ -69,7 +70,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
 
     private static let purchases: Atomic<Purchases?> = nil
 
-    /// Returns `true` if RevenueCat has already been initialized through ``configure(withAPIKey:)``
+    /// Returns `true` if RevenueCat has already been initialized through ``Purchases/configure(withAPIKey:)``
     /// or one of is overloads.
     @objc public static var isConfigured: Bool { Self.purchases.value != nil }
 

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -69,8 +69,8 @@ public protocol PurchasesType: AnyObject {
      *
      * #### Related Articles
      * - [Identifying Users](https://docs.revenuecat.com/docs/user-ids)
-     * - ``logOut(completion:)``
-     * - ``isAnonymous``
+     * - ``Purchases/logOut(completion:)``
+     * - ``Purchases/isAnonymous``
      * - ``Purchases/appUserID``
      */
     func logIn(_ appUserID: String, completion: @escaping (CustomerInfo?, Bool, PublicError?) -> Void)
@@ -95,8 +95,8 @@ public protocol PurchasesType: AnyObject {
      *
      * #### Related Articles
      * - [Identifying Users](https://docs.revenuecat.com/docs/user-ids)
-     * - ``logOut()``
-     * - ``isAnonymous``
+     * - ``Purchases/logOut()``
+     * - ``Purchases/isAnonymous``
      * - ``Purchases/appUserID``
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
@@ -206,7 +206,7 @@ public protocol PurchasesType: AnyObject {
      * Fetches the ``StoreProduct``s for your IAPs for given `productIdentifiers`.
      *
      * Use this method if you aren't using ``Purchases/getOfferings(completion:)``.
-     * You should use ``getOfferings(completion:)`` though.
+     * You should use ``Purchases/getOfferings(completion:)`` though.
      *
      * - Note: `completion` may be called without ``StoreProduct``s that you are expecting. This is usually caused by
      * iTunesConnect configuration errors. Ensure your IAPs have the "Ready to Submit" status in iTunesConnect.
@@ -228,8 +228,8 @@ public protocol PurchasesType: AnyObject {
     /**
      * Fetches the ``StoreProduct``s for your IAPs for given `productIdentifiers`.
      *
-     * Use this method if you aren't using ``getOfferings(completion:)``.
-     * You should use ``getOfferings(completion:)`` though.
+     * Use this method if you aren't using ``Purchases/getOfferings(completion:)``.
+     * You should use ``Purchases/getOfferings(completion:)`` though.
      *
      * - Note: The result might not contain the ``StoreProduct``s that you are expecting. This is usually caused by
      * iTunesConnect configuration errors. Ensure your IAPs have the "Ready to Submit" status in iTunesConnect.
@@ -440,7 +440,7 @@ public protocol PurchasesType: AnyObject {
      * #### Related Symbols
      * - ``StoreProduct/discounts``
      * - ``StoreProduct/eligiblePromotionalOffers()``
-     * - ``promotionalOffer(forProductDiscount:product:)``
+     * - ``Purchases/promotionalOffer(forProductDiscount:product:)``
      */
     @available(iOS 12.2, macOS 10.14.4, watchOS 6.2, macCatalyst 13.0, tvOS 12.2, *)
     @objc(purchaseProduct:withPromotionalOffer:completion:)
@@ -535,7 +535,7 @@ public protocol PurchasesType: AnyObject {
      * - Parameter receiveEligibility: A block that receives a dictionary of `product_id` -> ``IntroEligibility``.
      *
      * ### Related symbols
-     * - ``checkTrialOrIntroDiscountEligibility(product:completion:)``
+     * - ``Purchases/checkTrialOrIntroDiscountEligibility(product:completion:)``
      */
     @objc(checkTrialOrIntroDiscountEligibility:completion:)
     func checkTrialOrIntroDiscountEligibility(
@@ -561,7 +561,7 @@ public protocol PurchasesType: AnyObject {
      * - Parameter productIdentifiers: Array of product identifiers for which you want to compute eligibility
      *
      * ### Related symbols
-     * - ``checkTrialOrIntroDiscountEligibility(product:)``
+     * - ``Purchases/checkTrialOrIntroDiscountEligibility(product:)``
      */
     @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
     func checkTrialOrIntroDiscountEligibility(productIdentifiers: [String]) async -> [String: IntroEligibility]
@@ -586,7 +586,7 @@ public protocol PurchasesType: AnyObject {
      * - Parameter completion: A block that receives an ``IntroEligibilityStatus``.
      *
      * ### Related symbols
-     * - ``checkTrialOrIntroDiscountEligibility(productIdentifiers:completion:)``
+     * - ``Purchases/checkTrialOrIntroDiscountEligibility(productIdentifiers:completion:)``
      */
     @objc(checkTrialOrIntroDiscountEligibilityForProduct:completion:)
     func checkTrialOrIntroDiscountEligibility(
@@ -613,14 +613,15 @@ public protocol PurchasesType: AnyObject {
      * - Parameter product: The ``StoreProduct``  for which you want to compute eligibility.
      *
      * ### Related symbols
-     * - ``checkTrialOrIntroDiscountEligibility(productIdentifiers:)``
+     * - ``Purchases/checkTrialOrIntroDiscountEligibility(productIdentifiers:)``
      */
     @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
     func checkTrialOrIntroDiscountEligibility(product: StoreProduct) async -> IntroEligibilityStatus
 
     /**
      * Use this method to fetch ``PromotionalOffer``
-     *  to use in ``purchase(package:promotionalOffer:)`` or ``purchase(product:promotionalOffer:)``.
+     *  to use in ``Purchases/purchase(package:promotionalOffer:)``
+     *  or ``Purchases/purchase(product:promotionalOffer:)``.
      * [iOS Promotional Offers](https://docs.revenuecat.com/docs/ios-subscription-offers#promotional-offers).
      * - Note: If you're looking to use free trials or Introductory Offers instead,
      * use ``Purchases/checkTrialOrIntroDiscountEligibility(productIdentifiers:completion:)``.
@@ -655,7 +656,7 @@ public protocol PurchasesType: AnyObject {
     /// - Note: if checking for eligibility for a `StoreProductDiscount` fails (for example, if network is down),
     ///   that discount will fail silently and be considered not eligible.
     /// #### Related Symbols
-    /// - ``promotionalOffer(forProductDiscount:product:)``
+    /// - ``Purchases/promotionalOffer(forProductDiscount:product:)``
     /// - ``StoreProduct/eligiblePromotionalOffers()``
     /// - ``StoreProduct/discounts``
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
@@ -723,8 +724,8 @@ public protocol PurchasesType: AnyObject {
      * or multiple active entitlements were found for the user, an `Error` will be thrown.
      *
      *- important: This method should only be used if your user can only
-     * have a single active entitlement at a given time.
-     * If a user could have more than one entitlement at a time, use ``beginRefundRequest(forEntitlement:)`` instead.
+     * have a single active entitlement at a given time. If a user could have more than one entitlement at a time,
+     * use ``Purchases/beginRefundRequest(forEntitlement:)`` instead.
      */
     @available(iOS 15.0, *)
     @available(macOS, unavailable)

--- a/Sources/Purchasing/StoreKitAbstractions/PromotionalOffer.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/PromotionalOffer.swift
@@ -31,7 +31,7 @@ public final class PromotionalOffer: NSObject {
 
     /// The ``StoreProductDiscount`` in this offer.
     @objc public let discount: StoreProductDiscount
-    /// The ``SignedData-swift.class`` provides information about the ``PromotionalOffer``'s signature.
+    /// The ``PromotionalOffer/SignedData-swift.class`` provides information about the ``PromotionalOffer``'s signature.
     @objc public let signedData: SignedData
 
     init(discount: StoreProductDiscountType, signedData: SignedData) {


### PR DESCRIPTION
These still work correctly when using Xcode 14 as well.
