### PR TITLE
`iOS 17`: added tests for simulating cancellations

### DIFF
--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -155,6 +155,21 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         }
     }
 
+    #if swift(>=5.9)
+    @available(iOS 17.0, tvOS 17.0, watchOS 10.0, macOS 14.0, *)
+    func testPurchaseCancellationsAreReportedCorrectly() async throws {
+        try AvailabilityChecks.iOS17APIAvailableOrSkipTest()
+
+        try await self.testSession.setSimulatedError(SKTestFailures.Purchase.generic(.userCancelled),
+                                                     forAPI: .purchase)
+
+        let (transaction, info, cancelled) = try await self.purchaseMonthlyOffering()
+        expect(transaction).to(beNil())
+        expect(info.entitlements.active).to(beEmpty())
+        expect(cancelled) == true
+    }
+    #endif
+
     func testPurchaseMadeBeforeLogInIsRetainedAfter() async throws {
         try await self.purchaseMonthlyOffering()
 

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -160,11 +160,9 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     func testPurchaseCancellationsAreReportedCorrectly() async throws {
         try AvailabilityChecks.iOS17APIAvailableOrSkipTest()
 
-        try await self.testSession.setSimulatedError(SKTestFailures.Purchase.generic(.userCancelled),
-                                                     forAPI: .purchase)
+        try await self.testSession.setSimulatedError(.generic(.userCancelled), forAPI: .purchase)
 
-        let (transaction, info, cancelled) = try await self.purchaseMonthlyOffering()
-        expect(transaction).to(beNil())
+        let (_, info, cancelled) = try await Purchases.shared.purchase(package: self.monthlyPackage)
         expect(info.entitlements.active).to(beEmpty())
         expect(cancelled) == true
     }

--- a/Tests/StoreKitUnitTests/TestHelpers/AvailabilityChecks.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/AvailabilityChecks.swift
@@ -55,6 +55,12 @@ enum AvailabilityChecks {
         }
     }
 
+    static func iOS17APIAvailableOrSkipTest() throws {
+        guard #available(iOS 17.0, tvOS 17.0, macOS 14.0, watchOS 10.0, *) else {
+            throw XCTSkip("Required API is not available for this test.")
+        }
+    }
+
     /// Opposite of `iOS15APIAvailableOrSkipTest`.
     static func iOS15APINotAvailableOrSkipTest() throws {
         if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionListener.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionListener.swift
@@ -30,6 +30,7 @@ class MockStoreKit2TransactionListener: StoreKit2TransactionListener {
     var invokedDelegateGetterCount = 0
     weak var stubbedDelegate: StoreKit2TransactionListenerDelegate!
 
+    var mockCancelled = false
     // `StoreKit.Transaction` can't be stored directly as a property.
     // See https://openradar.appspot.com/radar?id=4970535809187840 / https://bugs.swift.org/browse/SR-15825
     var mockTransaction: Box<StoreKit.Transaction?> = .init(nil)
@@ -66,11 +67,11 @@ class MockStoreKit2TransactionListener: StoreKit2TransactionListener {
     override func handle(
         purchaseResult: StoreKit.Product.PurchaseResult
     ) async throws -> ResultData {
-        invokedHandle = true
-        invokedHandleCount += 1
-        invokedHandleParameters = (.init(purchaseResult), ())
-        invokedHandleParametersList.append((.init(purchaseResult), ()))
+        self.invokedHandle = true
+        self.invokedHandleCount += 1
+        self.invokedHandleParameters = (.init(purchaseResult), ())
+        self.invokedHandleParametersList.append((.init(purchaseResult), ()))
 
-        return (false, mockTransaction.value)
+        return (self.mockCancelled, self.mockTransaction.value)
     }
 }


### PR DESCRIPTION
Prior to this it was not possible to simulate cancellations with `SKTestSession`.

Relying on the new [`SKTestSession.setSimulatedError`](https://developer.apple.com/documentation/storekittest/sktestsession/4196369-setsimulatederror) (see `FB10300403`)
