### PR TITLE
Removed unnecessary `Strings.trimmedOrError`

### DIFF
--- a/Sources/FoundationExtensions/String+Extensions.swift
+++ b/Sources/FoundationExtensions/String+Extensions.swift
@@ -19,7 +19,6 @@ extension String {
     enum Error: Swift.Error {
 
         case escapingEmptyString
-        case trimmingEmptyString
 
     }
 
@@ -38,17 +37,6 @@ extension String {
         }
 
         return trimmedAndEscaped
-    }
-
-    func trimmedOrError() throws -> String {
-        let trimmed = self.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        guard trimmed.count > 0 else {
-            Logger.warn("Attempting to trim an empty string")
-            throw Error.trimmingEmptyString
-        }
-
-        return trimmed
     }
 
     /// Returns `nil` if `self` is an empty string.

--- a/Sources/Networking/Operations/LogInOperation.swift
+++ b/Sources/Networking/Operations/LogInOperation.swift
@@ -56,7 +56,9 @@ final class LogInOperation: CacheableNetworkOperation {
 private extension LogInOperation {
 
     func logIn(completion: @escaping () -> Void) {
-        guard let newAppUserID = try? self.newAppUserID.trimmedOrError() else {
+        guard let newAppUserID = self.newAppUserID
+            .trimmingWhitespacesAndNewLines
+            .notEmpty else {
             self.loginCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 callback.completion(.failure(.missingAppUserID()))
             }


### PR DESCRIPTION
This was duplicated code, we can simply use `notEmpty` to be able to detect it. That warning was also unnecessary.
