### PR TITLE
`StoreProductDiscount`: added `description`

### DIFF
--- a/Sources/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreProductDiscount.swift
@@ -96,6 +96,21 @@ public final class StoreProductDiscount: NSObject, StoreProductDiscountType {
         return Data(discount: self).hashValue
     }
 
+    public override var description: String {
+        return """
+            <\(String(describing: StoreProductDiscount.self)):
+                offerIdentifier: \(self.offerIdentifier ?? "")
+                currencyCode: \(self.currencyCode ?? "")
+                price: \(self.price)
+                localizedPriceString: \(self.localizedPriceString)
+                paymentMode: \(self.paymentMode)
+                subscriptionPeriod: \(self.subscriptionPeriod)
+                numberOfPeriods: \(self.numberOfPeriods)
+                type: \(self.type)
+            >
+            """
+    }
+
 }
 
 extension StoreProductDiscount: Sendable {}


### PR DESCRIPTION
A few tests are failing in iOS 17, so this makes it easier to see what's different in the discounts.
