### PR TITLE
Changed tests to work around `URL` decoding differences in `iOS 17`

### DIFF
--- a/Tests/UnitTests/FoundationExtensions/DecoderExtensionTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/DecoderExtensionTests.swift
@@ -89,7 +89,7 @@ class DecoderExtensionsIgnoreErrorsTests: TestCase {
     }
 
     func testIgnoresErrors() throws {
-        let json = "{\"url\": \"not a! valid url@\"}"
+        let json = "{\"url\": 1}"
         let data = try Data.decode(json)
 
         expect(data.url).to(beNil())

--- a/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
@@ -284,7 +284,7 @@ class BasicCustomerInfoTests: TestCase {
         customerInfo = try CustomerInfo(data: [
             "request_date": "2019-08-16T10:30:42Z",
             "subscriber": [
-                "management_url": "this isnt' a URL!",
+                "management_url": 3, // Invalid URL
                 "first_seen": "2019-07-17T00:05:54Z",
                 "subscriptions": [:] as [String: Any],
                 "other_purchases": [:] as [String: Any],


### PR DESCRIPTION
The "invalid" test URLs we were using are no longer invalid on iOS 17. This fixes those tests by using an `Int` instead of a `String`.

<img width="775" alt="image" src="https://github.com/RevenueCat/purchases-ios/assets/685609/3ef5ec23-b17d-4ac1-9e4e-4dc48c97f5a9">
