### PR TITLE
`Encodable.jsonEncodedData`: fixed tests on iOS 17 due to inconsistent key ordering

### DIFF
--- a/Sources/LocalReceiptParsing/DataConverters/Codable+Extensions.swift
+++ b/Sources/LocalReceiptParsing/DataConverters/Codable+Extensions.swift
@@ -39,6 +39,8 @@ extension Encodable {
         }
     }
 
+    /// - Note: beginning with iOS 17, the output of this is not guaranteed to be consistent due to key ordering.
+    /// For tests, it's better to compare `prettyPrintedData` which does sort keys.
     var jsonEncodedData: Data {
         get throws {
             return try JSONEncoder.default.encode(self)

--- a/Sources/LocalReceiptParsing/DataConverters/Codable+Extensions.swift
+++ b/Sources/LocalReceiptParsing/DataConverters/Codable+Extensions.swift
@@ -53,7 +53,6 @@ extension JSONEncoder {
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
         encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = .sortedKeys
 
         return encoder
     }()

--- a/Sources/LocalReceiptParsing/DataConverters/Codable+Extensions.swift
+++ b/Sources/LocalReceiptParsing/DataConverters/Codable+Extensions.swift
@@ -53,6 +53,7 @@ extension JSONEncoder {
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
         encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = .sortedKeys
 
         return encoder
     }()
@@ -61,7 +62,7 @@ extension JSONEncoder {
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
         encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = .prettyPrinted
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
 
         return encoder
     }()

--- a/Tests/UnitTests/Caching/DeviceCacheTests.swift
+++ b/Tests/UnitTests/Caching/DeviceCacheTests.swift
@@ -216,8 +216,12 @@ class DeviceCacheTests: TestCase {
         self.deviceCache.cache(offerings: expectedOfferings, appUserID: "user")
 
         expect(self.deviceCache.cachedOfferings) === expectedOfferings
-        try expect(self.mockUserDefaults.mockValues["com.revenuecat.userdefaults.offerings.user"] as? Data)
-        == expectedOfferings.response.jsonEncodedData
+
+        let storedData = try XCTUnwrap(
+            self.mockUserDefaults.mockValues["com.revenuecat.userdefaults.offerings.user"] as? Data
+        )
+        let offerings = try JSONDecoder.default.decode(OfferingsResponse.self, from: storedData)
+        expect(offerings) == expectedOfferings.response
     }
 
     func testCacheOfferingsInMemory() throws {

--- a/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
@@ -130,11 +130,8 @@ class CustomerInfoDecodingTests: BaseHTTPResponseTest {
         expect(parsedData) == ["is_included": "in_raw_data"]
     }
 
-    func testReencoding() throws {
-        let reEncoded = try self.customerInfo.encodeAndDecode()
-
-        expect(reEncoded) == self.customerInfo
-        try expect(reEncoded.jsonEncodedData) == self.customerInfo.jsonEncodedData
+    func testReencoding() {
+        expect(try self.customerInfo.encodeAndDecode()) == self.customerInfo
     }
 
     func testFailsToDecode() {
@@ -220,11 +217,8 @@ class CustomerInfoVersion2DecodingTests: BaseHTTPResponseTest {
         expect(entitlement.purchaseDate) == dateFormatter.date(from: "2023-01-12T20:29:44Z")
     }
 
-    func testReencoding() throws {
-        let reEncoded = try self.customerInfo.encodeAndDecode()
-
-        expect(reEncoded) == self.customerInfo
-        try expect(reEncoded.jsonEncodedData) == self.customerInfo.jsonEncodedData
+    func testReencoding() {
+        expect(try self.customerInfo.encodeAndDecode()) == self.customerInfo
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)

--- a/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/CustomerInfoDecodingTests.swift
@@ -130,8 +130,11 @@ class CustomerInfoDecodingTests: BaseHTTPResponseTest {
         expect(parsedData) == ["is_included": "in_raw_data"]
     }
 
-    func testReencoding() {
-        expect(try self.customerInfo.encodeAndDecode()) == self.customerInfo
+    func testReencoding() throws {
+        let reEncoded = try self.customerInfo.encodeAndDecode()
+
+        expect(reEncoded) == self.customerInfo
+        try expect(reEncoded.jsonEncodedData) == self.customerInfo.jsonEncodedData
     }
 
     func testFailsToDecode() {
@@ -217,8 +220,11 @@ class CustomerInfoVersion2DecodingTests: BaseHTTPResponseTest {
         expect(entitlement.purchaseDate) == dateFormatter.date(from: "2023-01-12T20:29:44Z")
     }
 
-    func testReencoding() {
-        expect(try self.customerInfo.encodeAndDecode()) == self.customerInfo
+    func testReencoding() throws {
+        let reEncoded = try self.customerInfo.encodeAndDecode()
+
+        expect(reEncoded) == self.customerInfo
+        try expect(reEncoded.jsonEncodedData) == self.customerInfo.jsonEncodedData
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)


### PR DESCRIPTION
A bunch of tests were failing on Xcode 15 due to [a change in Swift](https://github.com/apple/swift/issues/66466), because we relying on being able to verify that the encoded `Data` saved to caches is consistent.
Starting on Swift 5.9 `JSONEncoder` has optimizations that mean we can't rely on it.

To fix this, this PR does 2 things:
- Changed `JSONEncoder.prettyPrinted` to have `.sortedKeys`
- Changed test to verify the decoded response `struct`, not the raw encoded `Data`

Note that I didn't make `JSONEncoder.default` use `.sortedKeys` because of the potential performance impact. `Encodable.prettyPrintedData` is used in tests like `ReceiptFetcherTests` (which this PR fixes) and for debug purposes, but `Encodable.encodedJSON` is used everywhere.