### PR TITLE
Changed `Logger` to use `os_log`

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -4474,7 +4474,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/RevenueCat/purchases-ios";
 			requirement = {
-				branch = "os-log";
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -235,6 +235,8 @@
 		4F8038332A1EA7C300D21039 /* TransactionPoster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8038322A1EA7C300D21039 /* TransactionPoster.swift */; };
 		4F8A58172A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */; };
 		4F8A58182A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */; };
+		4F90AFCB2A3915340047E63F /* TestMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F90AFCA2A3915340047E63F /* TestMessage.swift */; };
+		4F90AFCC2A3915BC0047E63F /* TestMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F90AFCA2A3915340047E63F /* TestMessage.swift */; };
 		4FA4C8DA2A168956007D2803 /* OfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA4C8D92A168956007D2803 /* OfflineCustomerInfoCreator.swift */; };
 		4FA4C9732A16D3AC007D2803 /* MockBackendConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA4C9722A16D3AC007D2803 /* MockBackendConfiguration.swift */; };
 		4FA4C9742A16D3AC007D2803 /* MockBackendConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA4C9722A16D3AC007D2803 /* MockBackendConfiguration.swift */; };
@@ -932,6 +934,7 @@
 		4F7DBFBC2A1E986C00A2F511 /* StoreKit2TransactionFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2TransactionFetcher.swift; sourceTree = "<group>"; };
 		4F8038322A1EA7C300D21039 /* TransactionPoster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionPoster.swift; sourceTree = "<group>"; };
 		4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOfflineCustomerInfoCreator.swift; sourceTree = "<group>"; };
+		4F90AFCA2A3915340047E63F /* TestMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestMessage.swift; sourceTree = "<group>"; };
 		4FA4C8D92A168956007D2803 /* OfflineCustomerInfoCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineCustomerInfoCreator.swift; sourceTree = "<group>"; };
 		4FA4C9722A16D3AC007D2803 /* MockBackendConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackendConfiguration.swift; sourceTree = "<group>"; };
 		4FA696A329FC43C600D228B1 /* ReceiptParserTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ReceiptParserTests-Info.plist"; sourceTree = "<group>"; };
@@ -1777,6 +1780,7 @@
 		2DE20B6D264087FB004C597D /* BackendIntegrationTests */ = {
 			isa = PBXGroup;
 			children = (
+				4F90AFC92A39152A0047E63F /* Helpers */,
 				4FCBA8522A1539D0004134BD /* __Snapshots__ */,
 				579234E127F777EE00B39C68 /* BaseBackendIntegrationTests.swift */,
 				5753EE0F294B93CC00CBAB54 /* BaseStoreKitIntegrationTests.swift */,
@@ -2122,6 +2126,14 @@
 				4FCEEA5D2A379B80002C2112 /* DebugViewController.swift */,
 			);
 			path = DebugUI;
+			sourceTree = "<group>";
+		};
+		4F90AFC92A39152A0047E63F /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				4F90AFCA2A3915340047E63F /* TestMessage.swift */,
+			);
+			path = Helpers;
 			sourceTree = "<group>";
 		};
 		4FCEEA5F2A379CD6002C2112 /* Support */ = {
@@ -3555,6 +3567,7 @@
 				5753EE10294B93CC00CBAB54 /* BaseStoreKitIntegrationTests.swift in Sources */,
 				579234E527F779FE00B39C68 /* SubscriberAttributesManagerIntegrationTests.swift in Sources */,
 				4F2018732A15797D0061F6EF /* TestLogHandler.swift in Sources */,
+				4F90AFCB2A3915340047E63F /* TestMessage.swift in Sources */,
 				2D3BFAD226DEA46600370B11 /* MockProductsRequest.swift in Sources */,
 				2D1015DB275A4EAE0086173F /* AvailabilityChecks.swift in Sources */,
 				5753EE0E294B938900CBAB54 /* StoreKitObserverModeIntegrationTests.swift in Sources */,
@@ -3590,6 +3603,7 @@
 				4F7C37E62A27F14B001E17D3 /* XCTestCase+Extensions.swift in Sources */,
 				4F7C37E52A27EFF7001E17D3 /* BaseStoreKitIntegrationTests.swift in Sources */,
 				4F6BEE3C2A27B45900CD9322 /* Constants.swift in Sources */,
+				4F90AFCC2A3915BC0047E63F /* TestMessage.swift in Sources */,
 				4F7C37E42A27EFE1001E17D3 /* BaseBackendIntegrationTests.swift in Sources */,
 				4F6BEE882A27E16B00CD9322 /* TestLogHandler.swift in Sources */,
 			);
@@ -4460,7 +4474,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/RevenueCat/purchases-ios";
 			requirement = {
-				branch = main;
+				branch = "os-log";
 				kind = branch;
 			};
 		};

--- a/Sources/LocalReceiptParsing/Helpers/LoggerType.swift
+++ b/Sources/LocalReceiptParsing/Helpers/LoggerType.swift
@@ -40,6 +40,7 @@ protocol LoggerType {
 
 }
 
+/// Contains a message that can be output by ``os.Logger``.
 protocol LogMessage: CustomStringConvertible {
 
     var description: String { get }
@@ -74,6 +75,7 @@ protocol LogMessage: CustomStringConvertible {
     // swiftlint:enable missing_docs
 }
 
+/// An in-memory cache of ``os.Logger`` instances based on their category.
 @available(iOS 14.0.0, tvOS 14.0.0, macOS 11.0.0, *)
 final class LoggerStore {
 

--- a/Sources/LocalReceiptParsing/Helpers/LoggerType.swift
+++ b/Sources/LocalReceiptParsing/Helpers/LoggerType.swift
@@ -88,6 +88,7 @@ final class LoggerStore {
     }
 
     private static let subsystem = Bundle.main.bundleIdentifier ?? "com.revenuecat.Purchases"
+
 }
 
 @available(iOS 14.0.0, tvOS 14.0.0, macOS 11.0.0, *)

--- a/Sources/LocalReceiptParsing/Helpers/LoggerType.swift
+++ b/Sources/LocalReceiptParsing/Helpers/LoggerType.swift
@@ -42,7 +42,6 @@ protocol LoggerType {
 
 protocol LogMessage: CustomStringConvertible {
 
-    // TODO: OSLogMessage
     var description: String { get }
     var category: String { get }
 
@@ -100,7 +99,7 @@ func defaultLogHandler(
     verbose: Bool,
     level: LogLevel,
     category: String,
-    message: String, // TODO: OSLogMessage (iOS 14?)
+    message: String,
     file: String?,
     function: String?,
     line: UInt

--- a/Sources/LocalReceiptParsing/Helpers/LoggerType.swift
+++ b/Sources/LocalReceiptParsing/Helpers/LoggerType.swift
@@ -76,7 +76,7 @@ protocol LogMessage: CustomStringConvertible {
 }
 
 /// An in-memory cache of ``os.Logger`` instances based on their category.
-@available(iOS 14.0.0, tvOS 14.0.0, macOS 11.0.0, *)
+@available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
 final class LoggerStore {
 
     private var loggersByCategory: [String: os.Logger] = [:]
@@ -93,7 +93,7 @@ final class LoggerStore {
 
 }
 
-@available(iOS 14.0.0, tvOS 14.0.0, macOS 11.0.0, *)
+@available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
 private let store = LoggerStore()
 
 // swiftlint:disable:next function_parameter_count

--- a/Sources/LocalReceiptParsing/Helpers/ReceiptParserLogger.swift
+++ b/Sources/LocalReceiptParsing/Helpers/ReceiptParserLogger.swift
@@ -16,7 +16,7 @@ import Foundation
 final class ReceiptParserLogger: LoggerType {
 
     func verbose(
-        _ message: @autoclosure () -> CustomStringConvertible,
+        _ message: @autoclosure () -> LogMessage,
         fileName: String?,
         functionName: String?,
         line: UInt
@@ -31,7 +31,7 @@ final class ReceiptParserLogger: LoggerType {
     }
 
     func debug(
-        _ message: @autoclosure () -> CustomStringConvertible,
+        _ message: @autoclosure () -> LogMessage,
         fileName: String?,
         functionName: String?,
         line: UInt
@@ -46,7 +46,7 @@ final class ReceiptParserLogger: LoggerType {
     }
 
     func info(
-        _ message: @autoclosure () -> CustomStringConvertible,
+        _ message: @autoclosure () -> LogMessage,
         fileName: String?,
         functionName: String?,
         line: UInt
@@ -61,7 +61,7 @@ final class ReceiptParserLogger: LoggerType {
     }
 
     func warn(
-        _ message: @autoclosure () -> CustomStringConvertible,
+        _ message: @autoclosure () -> LogMessage,
         fileName: String?,
         functionName: String?,
         line: UInt
@@ -76,7 +76,7 @@ final class ReceiptParserLogger: LoggerType {
     }
 
     func error(
-        _ message: @autoclosure () -> CustomStringConvertible,
+        _ message: @autoclosure () -> LogMessage,
         fileName: String,
         functionName: String,
         line: UInt
@@ -91,15 +91,18 @@ final class ReceiptParserLogger: LoggerType {
     }
 
     private static func log(level: LogLevel,
-                            message: @autoclosure () -> CustomStringConvertible,
+                            message: @autoclosure () -> LogMessage,
                             fileName: String? = #fileID,
                             functionName: String? = #function,
                             line: UInt = #line) {
+        let message = message()
+
         defaultLogHandler(
             framework: Self.framework,
             verbose: false,
             level: level,
-            message: message().description,
+            category: message.category,
+            message: message.description,
             file: fileName,
             function: functionName,
             line: line

--- a/Sources/LocalReceiptParsing/Helpers/ReceiptStrings.swift
+++ b/Sources/LocalReceiptParsing/Helpers/ReceiptStrings.swift
@@ -113,4 +113,5 @@ extension ReceiptStrings: LogMessage {
     }
 
     var category: String { return "receipt" }
+
 }

--- a/Sources/LocalReceiptParsing/Helpers/ReceiptStrings.swift
+++ b/Sources/LocalReceiptParsing/Helpers/ReceiptStrings.swift
@@ -40,7 +40,7 @@ enum ReceiptStrings {
 
 }
 
-extension ReceiptStrings: CustomStringConvertible {
+extension ReceiptStrings: LogMessage {
 
     var description: String {
         switch self {
@@ -112,4 +112,5 @@ extension ReceiptStrings: CustomStringConvertible {
         }
     }
 
+    var category: String { return "receipt" }
 }

--- a/Sources/Logging/Logger.swift
+++ b/Sources/Logging/Logger.swift
@@ -26,7 +26,7 @@ public typealias LogHandler = (_ level: LogLevel,
                                _ message: String) -> Void
 
 internal typealias InternalLogHandler = (_ level: LogLevel,
-                                         _ message: String, // TODO: interpolation
+                                         _ message: String,
                                          _ category: String,
                                          _ file: String?,
                                          _ function: String?,

--- a/Sources/Logging/Strings/AttributionStrings.swift
+++ b/Sources/Logging/Strings/AttributionStrings.swift
@@ -50,7 +50,7 @@ enum AttributionStrings {
 
 }
 
-extension AttributionStrings: CustomStringConvertible {
+extension AttributionStrings: LogMessage {
 
     var description: String {
         switch self {
@@ -153,5 +153,7 @@ extension AttributionStrings: CustomStringConvertible {
 
         }
     }
+
+    var category: String { return "attribution" }
 
 }

--- a/Sources/Logging/Strings/BackendErrorStrings.swift
+++ b/Sources/Logging/Strings/BackendErrorStrings.swift
@@ -27,7 +27,7 @@ enum BackendErrorStrings {
 
 }
 
-extension BackendErrorStrings: CustomStringConvertible {
+extension BackendErrorStrings: LogMessage {
 
     var description: String {
         switch self {
@@ -43,5 +43,7 @@ extension BackendErrorStrings: CustomStringConvertible {
             return "Missing 'signatureData' or its structure changed:\n\(String(describing: signatureDataString))"
         }
     }
+
+    var category: String { return "backend" }
 
 }

--- a/Sources/Logging/Strings/CodableStrings.swift
+++ b/Sources/Logging/Strings/CodableStrings.swift
@@ -27,7 +27,7 @@ enum CodableStrings {
 
 }
 
-extension CodableStrings: CustomStringConvertible {
+extension CodableStrings: LogMessage {
 
     var description: String {
         switch self {
@@ -60,5 +60,7 @@ extension CodableStrings: CustomStringConvertible {
             return "Type '\(type)' mismatch, codingPath:\(context.codingPath), description:\n\(description)"
         }
     }
+
+    var category: String { return "codable" }
 
 }

--- a/Sources/Logging/Strings/ConfigureStrings.swift
+++ b/Sources/Logging/Strings/ConfigureStrings.swift
@@ -77,7 +77,7 @@ enum ConfigureStrings {
 
 }
 
-extension ConfigureStrings: CustomStringConvertible {
+extension ConfigureStrings: LogMessage {
 
     var description: String {
         switch self {
@@ -188,5 +188,7 @@ extension ConfigureStrings: CustomStringConvertible {
                     """
         }
     }
+
+    var category: String { return "configure" }
 
 }

--- a/Sources/Logging/Strings/CustomerInfoStrings.swift
+++ b/Sources/Logging/Strings/CustomerInfoStrings.swift
@@ -38,7 +38,7 @@ enum CustomerInfoStrings {
 
 }
 
-extension CustomerInfoStrings: CustomStringConvertible {
+extension CustomerInfoStrings: LogMessage {
 
     var description: String {
         switch self {
@@ -89,5 +89,7 @@ extension CustomerInfoStrings: CustomStringConvertible {
         }
 
     }
+
+    var category: String { return "customer" }
 
 }

--- a/Sources/Logging/Strings/DiagnosticsStrings.swift
+++ b/Sources/Logging/Strings/DiagnosticsStrings.swift
@@ -21,7 +21,7 @@ enum DiagnosticsStrings {
 
 }
 
-extension DiagnosticsStrings: CustomStringConvertible {
+extension DiagnosticsStrings: LogMessage {
 
     var description: String {
         switch self {
@@ -30,5 +30,7 @@ extension DiagnosticsStrings: CustomStringConvertible {
             return String(format: "%@ (%.2f seconds)", message.description, roundedDuration)
         }
     }
+
+    var category: String { return "diagnostics" }
 
 }

--- a/Sources/Logging/Strings/EligibilityStrings.swift
+++ b/Sources/Logging/Strings/EligibilityStrings.swift
@@ -26,7 +26,7 @@ enum EligibilityStrings {
     case sk2_intro_eligibility_too_slow
 }
 
-extension EligibilityStrings: CustomStringConvertible {
+extension EligibilityStrings: LogMessage {
 
     var description: String {
         switch self {
@@ -54,5 +54,7 @@ extension EligibilityStrings: CustomStringConvertible {
             return "StoreKit 2 intro eligibility took longer than expected to determine"
         }
     }
+
+    var category: String { return "eligibility" }
 
 }

--- a/Sources/Logging/Strings/IdentityStrings.swift
+++ b/Sources/Logging/Strings/IdentityStrings.swift
@@ -42,7 +42,7 @@ enum IdentityStrings {
 
 }
 
-extension IdentityStrings: CustomStringConvertible {
+extension IdentityStrings: LogMessage {
 
     var description: String {
         switch self {
@@ -77,5 +77,7 @@ extension IdentityStrings: CustomStringConvertible {
             "This has no effect."
         }
     }
+
+    var category: String { return "identity" }
 
 }

--- a/Sources/Logging/Strings/ManageSubscriptionsStrings.swift
+++ b/Sources/Logging/Strings/ManageSubscriptionsStrings.swift
@@ -30,7 +30,7 @@ extension ManageSubscriptionsHelper {
 
 }
 
-extension ManageSubscriptionsHelper.Strings: CustomStringConvertible {
+extension ManageSubscriptionsHelper.Strings: LogMessage {
 
     var description: String {
         switch self {
@@ -48,5 +48,7 @@ extension ManageSubscriptionsHelper.Strings: CustomStringConvertible {
             return "tried to call AppStore.showManageSubscriptions in a platform that doesn't support it!"
         }
     }
+
+    var category: String { return "manage_subscriptions" }
 
 }

--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -43,7 +43,7 @@ enum NetworkStrings {
 
 }
 
-extension NetworkStrings: CustomStringConvertible {
+extension NetworkStrings: LogMessage {
 
     var description: String {
         switch self {
@@ -117,6 +117,8 @@ extension NetworkStrings: CustomStringConvertible {
         #endif
         }
     }
+
+    var category: String { return "network" }
 
 }
 

--- a/Sources/Logging/Strings/OfferingStrings.swift
+++ b/Sources/Logging/Strings/OfferingStrings.swift
@@ -46,7 +46,7 @@ enum OfferingStrings {
 
 }
 
-extension OfferingStrings: CustomStringConvertible {
+extension OfferingStrings: LogMessage {
 
     var description: String {
         switch self {
@@ -157,5 +157,7 @@ extension OfferingStrings: CustomStringConvertible {
             return "Package: \(old) already exists, overwriting with: \(new)"
         }
     }
+
+    var category: String { return "offering" }
 
 }

--- a/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
+++ b/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
@@ -39,7 +39,7 @@ enum OfflineEntitlementsStrings {
 
 }
 
-extension OfflineEntitlementsStrings: CustomStringConvertible {
+extension OfflineEntitlementsStrings: LogMessage {
 
     var description: String {
         switch self {
@@ -95,5 +95,7 @@ extension OfflineEntitlementsStrings: CustomStringConvertible {
             return "PurchasedProductsFetcher: invalidating cache"
         }
     }
+
+    var category: String { return "offline_entitlements" }
 
 }

--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -85,7 +85,7 @@ enum PurchaseStrings {
 
 }
 
-extension PurchaseStrings: CustomStringConvertible {
+extension PurchaseStrings: LogMessage {
 
     var description: String {
         switch self {
@@ -303,6 +303,8 @@ extension PurchaseStrings: CustomStringConvertible {
             "Are you sure you want to do this?"
         }
     }
+
+    var category: String { return "purchases" }
 
 }
 

--- a/Sources/Logging/Strings/SigningStrings.swift
+++ b/Sources/Logging/Strings/SigningStrings.swift
@@ -28,7 +28,7 @@ enum SigningStrings {
 
 }
 
-extension SigningStrings: CustomStringConvertible {
+extension SigningStrings: LogMessage {
 
     var description: String {
         switch self {
@@ -50,5 +50,7 @@ extension SigningStrings: CustomStringConvertible {
             "This will be reported as a verification failure."
         }
     }
+
+    var category: String { return "signing" }
 
 }

--- a/Sources/Logging/Strings/StoreKitStrings.swift
+++ b/Sources/Logging/Strings/StoreKitStrings.swift
@@ -67,7 +67,7 @@ enum StoreKitStrings {
 
 }
 
-extension StoreKitStrings: CustomStringConvertible {
+extension StoreKitStrings: LogMessage {
 
     var description: String {
         switch self {
@@ -153,5 +153,7 @@ extension StoreKitStrings: CustomStringConvertible {
 
         }
     }
+
+    var category: String { return "storeKit" }
 
 }

--- a/Sources/Logging/Strings/StoreKitStrings.swift
+++ b/Sources/Logging/Strings/StoreKitStrings.swift
@@ -154,6 +154,6 @@ extension StoreKitStrings: LogMessage {
         }
     }
 
-    var category: String { return "storeKit" }
+    var category: String { return "store_kit" }
 
 }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -191,8 +191,17 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
      * - ``logLevel``
      */
     @objc public static var verboseLogHandler: VerboseLogHandler {
-        get { Logger.logHandler }
-        set { Logger.logHandler = newValue }
+        get {
+            return { level, message, file, function, line in
+                Logger.internalLogHandler(level, message, "", file, function, line)
+            }
+        }
+
+        set {
+            Logger.internalLogHandler = { level, message, _, file, function, line in
+                newValue(level, message, file, function, line)
+            }
+        }
     }
 
     /**

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -105,7 +105,7 @@ class BaseBackendIntegrationTests: XCTestCase {
 
     /// Simulates closing the app and re-opening with a fresh instance of `Purchases`.
     final func resetSingleton() async {
-        Logger.warn("Resetting Purchases.shared")
+        Logger.warn(TestMessage.resetting_purchases_singleton)
 
         Purchases.clearSingleton()
         await self.createPurchases()
@@ -121,10 +121,10 @@ private extension BaseBackendIntegrationTests {
         guard let url = Bundle.main.appStoreReceiptURL, manager.fileExists(atPath: url.path) else { return }
 
         do {
-            Logger.info("Removing receipt from url: \(url)")
+            Logger.info(TestMessage.removing_receipt(url))
             try manager.removeItem(at: url)
         } catch {
-            Logger.appleWarning("Error attempting to remove receipt URL '\(url)': \(error)")
+            Logger.appleWarning(TestMessage.error_removing_url(url, error))
         }
     }
 

--- a/Tests/BackendIntegrationTests/Helpers/TestMessage.swift
+++ b/Tests/BackendIntegrationTests/Helpers/TestMessage.swift
@@ -1,0 +1,82 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Messages.swift
+//
+//  Created by Nacho Soto on 6/13/23.
+
+import Foundation
+
+#if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+@testable import RevenueCat_CustomEntitlementComputation
+#else
+@testable import RevenueCat
+#endif
+
+// swiftlint:disable identifier_name
+
+enum TestMessage: LogMessage {
+
+    case expiring_subscription(productID: String)
+    case expire_subscription_failed(Error)
+    case finished_waiting_for_expiration
+    case sleeping_to_force_expiration(seconds: Int)
+
+    case resetting_purchases_singleton
+    case removing_receipt(URL)
+    case error_removing_url(URL, Error)
+    case receipt_content(String)
+    case unable_parse_receipt_without_sdk
+    case error_parsing_receipt(Error)
+
+}
+
+extension TestMessage {
+
+    var description: String {
+        switch self {
+        case let .expiring_subscription(productID):
+            return "Expiring subscription for product '\(productID)'"
+
+        case let .expire_subscription_failed(error):
+            return """
+                Failed testSession.expireSubscription, this is probably an Xcode bug.
+                Test will now wait for expiration instead of triggering it.
+                Error: \(error.localizedDescription)
+                """
+
+        case .finished_waiting_for_expiration:
+            return "Done waiting for subscription expiration, continuing test."
+
+        case let .sleeping_to_force_expiration(seconds):
+            return "Sleeping for \(seconds) seconds to force expiration"
+
+        case .resetting_purchases_singleton:
+            return "Resetting Purchases.shared"
+
+        case let .removing_receipt(url):
+            return "Removing receipt from url: \(url)"
+
+        case let .error_removing_url(url, error):
+            return "Error attempting to remove receipt URL '\(url)': \(error)"
+
+        case let .receipt_content(receipt):
+            return "Receipt content:\n\(receipt)"
+
+        case .unable_parse_receipt_without_sdk:
+            return "Can't print receipt when purchases isn't configured"
+
+        case let .error_parsing_receipt(error):
+            return "Error parsing local receipt: \(error)"
+        }
+    }
+
+    var category: String { return "IntegrationTests" }
+
+}

--- a/Tests/BackendIntegrationTests/MainThreadMonitor.swift
+++ b/Tests/BackendIntegrationTests/MainThreadMonitor.swift
@@ -75,6 +75,8 @@ private extension MainThreadMonitor {
 
 }
 
+// MARK: - logs
+
 // swiftlint:disable identifier_name
 
 private enum Message: LogMessage {
@@ -96,8 +98,8 @@ private enum Message: LogMessage {
         }
     }
 
-    var category: String { return "MainThreadMonitor" }
+    var category: String { return Self.name }
 
-    private static let name: String = "\(type(of: MainThreadMonitor.self))"
+    private static let name: String = "\(MainThreadMonitor.self)"
 
 }

--- a/Tests/BackendIntegrationTests/MainThreadMonitor.swift
+++ b/Tests/BackendIntegrationTests/MainThreadMonitor.swift
@@ -21,16 +21,16 @@ final class MainThreadMonitor {
 
     init() {
         self.queue = .init(label: "com.revenuecat.MainThreadMonitor")
-        Logger.verbose("Initializing \(type(of: self)) with a threshold of \(Self.threshold.seconds) seconds")
+        Logger.verbose(Message.initializing_main_thread_monitor(threshold: Self.threshold))
     }
 
     deinit {
-        Logger.verbose("Stopping \(type(of: self))")
+        Logger.verbose(Message.stopping)
     }
 
     func run() {
         guard !Self.debuggerIsAttached else {
-            Logger.verbose("\(type(of: self)): debugger is attached, ignoring")
+            Logger.verbose(Message.ignoring)
             return
         }
 
@@ -72,5 +72,32 @@ private extension MainThreadMonitor {
         // Finally, checks if debugger's flag is present yet.
         return (info.kp_proc.p_flag & P_TRACED) != 0
     }
+
+}
+
+// swiftlint:disable identifier_name
+
+private enum Message: LogMessage {
+
+    case initializing_main_thread_monitor(threshold: DispatchTimeInterval)
+    case stopping
+    case ignoring
+
+    var description: String {
+        switch self {
+        case let .initializing_main_thread_monitor(threshold):
+            return "Initializing \(Self.name) with a threshold of \(threshold.seconds) seconds"
+
+        case .stopping:
+            return "Stopping \(Self.name)"
+
+        case .ignoring:
+            return "\(Self.name): debugger is attached, ignoring"
+        }
+    }
+
+    var category: String { return "MainThreadMonitor" }
+
+    private static let name: String = "\(type(of: MainThreadMonitor.self))"
 
 }

--- a/Tests/StoreKitUnitTests/LoggerTests.swift
+++ b/Tests/StoreKitUnitTests/LoggerTests.swift
@@ -55,37 +55,51 @@ class LoggerTests: TestCase {
 
     func testLoggerLogsMessagesWithHigherLevel() {
         Logger.logLevel = .info
-        Logger.warn(Self.logMessage)
+        Logger.warn(Message.test1)
 
-        self.logger.verifyMessageWasLogged(Self.logMessage, level: .warn)
+        self.logger.verifyMessageWasLogged(Message.test1, level: .warn)
     }
 
     func testLoggerLogsMessagesWithHigherLevelThanVerbose() {
         Logger.logLevel = .verbose
-        Logger.info(Self.logMessage)
+        Logger.info(Message.test1)
 
-        self.logger.verifyMessageWasLogged(Self.logMessage, level: .info)
+        self.logger.verifyMessageWasLogged(Message.test1, level: .info)
     }
 
     func testLoggerLogsMessagesWithSameLevel() {
         Logger.logLevel = .info
-        Logger.info(Self.logMessage)
+        Logger.info(Message.test1)
 
-        self.logger.verifyMessageWasLogged(Self.logMessage, level: .info)
+        self.logger.verifyMessageWasLogged(Message.test1, level: .info)
     }
 
     func testLoggerDoesNotLogMessagesWithLowerLevel() {
         Logger.logLevel = .info
-        Logger.debug(Self.logMessage)
-        Logger.info("Other message")
+        Logger.debug(Message.test1)
+        Logger.info(Message.test2)
 
-        self.logger.verifyMessageWasNotLogged(Self.logMessage)
+        self.logger.verifyMessageWasNotLogged(Message.test1)
     }
 
 }
 
 private extension LoggerTests {
 
-    static let logMessage = "Log message"
+    enum Message: LogMessage {
+
+        case test1
+        case test2
+
+        var description: String {
+            switch self {
+            case .test1: return "Log message 1"
+            case .test2: return "Log message 2"
+            }
+        }
+
+        var category: String { return "debug_logs" }
+
+    }
 
 }

--- a/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -124,27 +124,3 @@ private extension StoreKitConfigTestCase {
     }
 
 }
-
-enum StoreKitTestMessage: LogMessage {
-
-    case delayingTest(TimeInterval)
-    case errorRemovingReceipt(URL, Error)
-    case deletingTransactions(count: Int)
-    case finishingTransactions(count: Int)
-
-    var description: String {
-        switch self {
-        case let .delayingTest(waitTime):
-            return "Delaying tests for \(waitTime) seconds for StoreKit initialization..."
-        case let .errorRemovingReceipt(url, error):
-            return "Error attempting to remove receipt URL '\(url)': \(error)"
-        case let .deletingTransactions(count):
-            return "Deleting \(count) transactions"
-        case let .finishingTransactions(count):
-            return "Finishing \(count) transactions"
-        }
-    }
-
-    var category: String { return "StoreKitConfigTestCase" }
-
-}

--- a/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -106,7 +106,7 @@ private extension StoreKitConfigTestCase {
         guard let waitTime = Self.waitTimeInSeconds else { return }
         guard !Self.hasWaited.getAndSet(true) else { return }
 
-        Logger.warn("Delaying tests for \(waitTime) seconds for StoreKit initialization...")
+        Logger.warn(StoreKitTestMessage.delayingTest(waitTime))
 
         try? await Task.sleep(nanoseconds: DispatchTimeInterval(waitTime).nanoseconds)
     }
@@ -119,8 +119,32 @@ private extension StoreKitConfigTestCase {
         do {
             try manager.removeItem(at: url)
         } catch {
-            Logger.appleWarning("Error attempting to remove receipt URL '\(url)': \(error)")
+            Logger.appleWarning(StoreKitTestMessage.errorRemovingReceipt(url, error))
         }
     }
+
+}
+
+enum StoreKitTestMessage: LogMessage {
+
+    case delayingTest(TimeInterval)
+    case errorRemovingReceipt(URL, Error)
+    case deletingTransactions(count: Int)
+    case finishingTransactions(count: Int)
+
+    var description: String {
+        switch self {
+        case let .delayingTest(waitTime):
+            return "Delaying tests for \(waitTime) seconds for StoreKit initialization..."
+        case let .errorRemovingReceipt(url, error):
+            return "Error attempting to remove receipt URL '\(url)': \(error)"
+        case let .deletingTransactions(count):
+            return "Deleting \(count) transactions"
+        case let .finishingTransactions(count):
+            return "Finishing \(count) transactions"
+        }
+    }
+
+    var category: String { return "StoreKitConfigTestCase" }
 
 }

--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
@@ -87,3 +87,27 @@ extension Product.PurchaseResult {
     }
 
 }
+
+enum StoreKitTestMessage: LogMessage {
+
+    case delayingTest(TimeInterval)
+    case errorRemovingReceipt(URL, Error)
+    case deletingTransactions(count: Int)
+    case finishingTransactions(count: Int)
+
+    var description: String {
+        switch self {
+        case let .delayingTest(waitTime):
+            return "Delaying tests for \(waitTime) seconds for StoreKit initialization..."
+        case let .errorRemovingReceipt(url, error):
+            return "Error attempting to remove receipt URL '\(url)': \(error)"
+        case let .deletingTransactions(count):
+            return "Deleting \(count) transactions"
+        case let .finishingTransactions(count):
+            return "Finishing \(count) transactions"
+        }
+    }
+
+    var category: String { return "StoreKitConfigTestCase" }
+
+}

--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
@@ -50,7 +50,7 @@ extension XCTestCase {
     func deleteAllTransactions(session: SKTestSession) async {
         let sk1Transactions = session.allTransactions()
         if !sk1Transactions.isEmpty {
-            Logger.debug("Deleting \(sk1Transactions.count) transactions")
+            Logger.debug(StoreKitTestMessage.deletingTransactions(count: sk1Transactions.count))
 
             for transaction in sk1Transactions {
                 try? session.deleteTransaction(identifier: transaction.identifier)
@@ -59,7 +59,7 @@ extension XCTestCase {
 
         let sk2Transactions = await self.unfinishedTransactions
         if !sk2Transactions.isEmpty {
-            Logger.debug("Finishing \(sk2Transactions.count) transactions")
+            Logger.debug(StoreKitTestMessage.finishingTransactions(count: sk2Transactions.count))
 
             for transaction in sk2Transactions.map(\.underlyingTransaction) {
                 await transaction.finish()

--- a/Tests/UnitTests/Mocks/MockProductsManager.swift
+++ b/Tests/UnitTests/Mocks/MockProductsManager.swift
@@ -31,7 +31,7 @@ class MockProductsManager: ProductsManager {
                 completion(result)
             }
         } else {
-            Logger.debug("\(type(of: self)): no stubbed products, returning fake products for \(identifiers)")
+            Logger.error("\(type(of: self)): no stubbed products, returning fake products for \(identifiers)")
 
             let products: [StoreProduct] = identifiers
                 .map { (identifier) -> MockSK1Product in

--- a/Tests/UnitTests/TestHelpers/TestLogHandler.swift
+++ b/Tests/UnitTests/TestHelpers/TestLogHandler.swift
@@ -229,19 +229,19 @@ extension TestLogHandler: LogMessageObserver {
 private final class SharedTestLogHandler {
 
     private let observers: Atomic<[WeakBox<LogMessageObserver>]>
-    private let logHandler: VerboseLogHandler
+    private let logHandler: InternalLogHandler
 
     init() {
         self.observers = .init([])
-        self.logHandler = { [observers] level, message, file, function, line in
-            Logger.defaultLogHandler(level, message, file, function, line)
+        self.logHandler = { [observers] level, message, category, file, function, line in
+            Logger.defaultLogHandler(level, message, category, file, function, line)
 
             Self.notify(observers: observers.value, message: message, level: level)
         }
     }
 
     func install() {
-        Purchases.verboseLogHandler = self.logHandler
+        Logger.internalLogHandler = self.logHandler
     }
 
     func add(observer: LogMessageObserver) {


### PR DESCRIPTION
Fixes SDK-3173.

### Motivation
`os_log` (and the new `Logger.log`) is the canonical way of logging in Apple platforms, replacing the old `NSLog`. This was made even more useful with the [updates to log printing in Xcode 15](https://developer.apple.com/videos/play/wwdc2023/10226/).
Additionally, this allows us in the future to log `OSLogMessage` (using `OSLogInterpolation`), and therefore being able to mark certain parts of logs as `privacy: .private`.

### Changes:
- Introduced `LogMessage` to ensure every logged message has a `category`
- Created `LoggerStore` to abstract `os.Logger` creation
- Changed `Logger` to use `os.Logger` if available (defaulting to the old `NSLog` otherwise)
- Updated tests to always use `LogMessage` instances (same as #2600)

With these new categories, log provide extra context. Example
```
[storeKit] DEBUG: 😻 Store products request received response
[storeKit] DEBUG: ℹ️ Store products request finished
[offering] DEBUG: 😻 Offerings updated from network.
[offering] DEBUG: 😻 Offerings updated from network.
[network] DEBUG: ℹ️ API request completed: GET /v1/product_entitlement_mapping (200)
[offline_entitlements] DEBUG: ℹ️ ProductEntitlementMapping cache updated from network.
[network] DEBUG: ℹ️ GetProductEntitlementMappingOperation: Finished
[network] DEBUG: ℹ️ Serial request done: GET product_entitlement_mapping, 0 requests left in the queue
[network] DEBUG: ℹ️ GetCustomerInfoOperation: Started
[network] DEBUG: ℹ️ There are no requests currently running, starting request GET subscribers/$RCAnonymousID%3A7f0e7d8de70745ada839e66a66ec2d86
[network] DEBUG: ℹ️ API request started: GET /v1/subscribers/$RCAnonymousID:7f0e7d8de70745ada839e66a66ec2d86
[network] DEBUG: ℹ️ API request completed: GET /v1/subscribers/$RCAnonymousID:7f0e7d8de70745ada839e66a66ec2d86 (201)
[customer] VERBOSE: Updating CustomerInfo '$RCAnonymousID:7f0e7d8de70745ada839e66a66ec2d86' request date: 2023-06-13 21:33:34 +0000
[customer] DEBUG: ℹ️ Sending latest CustomerInfo to delegate.
[customer] DEBUG: 😻 CustomerInfo updated from network.
[eligibility] DEBUG: ℹ️ Detected active subscriptions changed. Clearing trial or intro eligibility cache.
```

These also look much better on Xcode 15:
![Screenshot 2023-06-13 at 14 52 57](https://github.com/RevenueCat/purchases-ios/assets/685609/d546035e-3eec-4dbd-956b-960634b680f9)
And even allow users to filter out specific categories:
![Screenshot 2023-06-13 at 14 53 09](https://github.com/RevenueCat/purchases-ios/assets/685609/2ee55884-007a-465c-aef9-a5333354a77c)
