### PR TITLE
`StoreTransaction`: read `Storefront` from `StoreKit.Transaction`

### DIFF
--- a/Sources/Misc/Deprecations.swift
+++ b/Sources/Misc/Deprecations.swift
@@ -376,6 +376,7 @@ extension CustomerInfo {
         let purchaseDate: Date
         let transactionIdentifier: String
         let quantity: Int
+        var storefront: Storefront? { return nil }
 
         init(with transaction: NonSubscriptionTransaction) {
             self.productIdentifier = transaction.productIdentifier

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -824,7 +824,7 @@ extension PurchasesOrchestrator: StoreKit2TransactionListenerDelegate {
         _ listener: StoreKit2TransactionListener,
         updatedTransaction transaction: StoreTransactionType
     ) async throws {
-        let storefront = await Storefront.currentStorefront
+        let storefront = await transaction.storefront ??? (await Storefront.currentStorefront)
 
         _ = try await Async.call { completed in
             self.transactionPoster.handlePurchasedTransaction(

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -824,7 +824,7 @@ extension PurchasesOrchestrator: StoreKit2TransactionListenerDelegate {
         _ listener: StoreKit2TransactionListener,
         updatedTransaction transaction: StoreTransactionType
     ) async throws {
-        let storefront = await transaction.storefront ??? (await Storefront.currentStorefront)
+        let storefront = await transaction.storefrontOrCurrent
 
         _ = try await Async.call { completed in
             self.transactionPoster.handlePurchasedTransaction(

--- a/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
@@ -31,6 +31,11 @@ internal struct SK1StoreTransaction: StoreTransactionType {
     let transactionIdentifier: String
     let quantity: Int
 
+    var storefront: Storefront? {
+        // This is only available on StoreKit 2 transactions.
+        return nil
+    }
+
     func finish(_ wrapper: PaymentQueueWrapperType, completion: @escaping @Sendable () -> Void) {
         wrapper.finishTransaction(self.underlyingSK1Transaction, completion: completion)
     }

--- a/Sources/Purchasing/StoreKitAbstractions/SK2StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK2StoreTransaction.swift
@@ -23,6 +23,16 @@ internal struct SK2StoreTransaction: StoreTransactionType {
         self.purchaseDate = sk2Transaction.purchaseDate
         self.transactionIdentifier = String(sk2Transaction.id)
         self.quantity = sk2Transaction.purchasedQuantity
+
+        #if swift(>=5.9)
+        if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
+            self.storefront = .init(sk2Storefront: sk2Transaction.storefront)
+        } else {
+            self.storefront = nil
+        }
+        #else
+        self.storefront = nil
+        #endif
     }
 
     let underlyingSK2Transaction: SK2Transaction
@@ -31,6 +41,7 @@ internal struct SK2StoreTransaction: StoreTransactionType {
     let purchaseDate: Date
     let transactionIdentifier: String
     let quantity: Int
+    let storefront: Storefront?
 
     func finish(_ wrapper: PaymentQueueWrapperType, completion: @escaping @Sendable () -> Void) {
         Async.call(with: completion) {

--- a/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
@@ -133,6 +133,18 @@ extension StoreTransaction {
 
 }
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+extension StoreTransactionType {
+
+    /// - Returns: the `Storefront` associated to this transaction, or `Storefront.currentStorefront` if not available.
+    var storefrontOrCurrent: Storefront? {
+        get async {
+            return await self.storefront ??? (await Storefront.currentStorefront)
+        }
+    }
+
+}
+
 extension StoreTransaction: Identifiable {
 
     /// The stable identity of the entity associated with this instance.

--- a/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
@@ -41,6 +41,7 @@ public typealias SK2Transaction = StoreKit.Transaction
     @objc public var purchaseDate: Date { self.transaction.purchaseDate }
     @objc public var transactionIdentifier: String { self.transaction.transactionIdentifier }
     @objc public var quantity: Int { self.transaction.quantity }
+    @objc public var storefront: Storefront? { self.transaction.storefront }
 
     func finish(_ wrapper: PaymentQueueWrapperType, completion: @escaping @Sendable () -> Void) {
         self.transaction.finish(wrapper, completion: completion)
@@ -95,6 +96,10 @@ internal protocol StoreTransactionType: Sendable {
     /// The number of consumable products purchased.
     /// - Note: multi-quantity purchases aren't currently supported.
     var quantity: Int { get }
+
+    /// The App Store storefront associated with the transaction.
+    /// - Note: this is only available for StoreKit 2 transactions starting with iOS 17.
+    var storefront: Storefront? { get }
 
     /// Indicates to the App Store that the app delivered the purchased content
     /// or enabled the service to finish the transaction.

--- a/Tests/StoreKitUnitTests/StoreTransactionTests.swift
+++ b/Tests/StoreKitUnitTests/StoreTransactionTests.swift
@@ -36,6 +36,7 @@ class StoreTransactionTests: StoreKitConfigTestCase {
         expect(transaction.purchaseDate) == sk1Transaction.mockTransactionDate
         expect(transaction.transactionIdentifier) == sk1Transaction.mockTransactionIdentifier
         expect(transaction.quantity) == payment.quantity
+        expect(transaction.storefront).to(beNil())
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -53,6 +54,13 @@ class StoreTransactionTests: StoreKitConfigTestCase {
         expect(transaction.purchaseDate.timeIntervalSinceNow) <= 5
         expect(transaction.transactionIdentifier) == String(sk2Transaction.id)
         expect(transaction.quantity) == sk2Transaction.purchasedQuantity
+
+        if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
+            let expected = await Storefront.currentStorefront
+            expect(transaction.storefront) == expected
+        } else {
+            expect(transaction.storefront).to(beNil())
+        }
     }
 
     func testSk1TransactionDateBecomesAnInvalidDateIfNoDate() {

--- a/Tests/UnitTests/Mocks/MockStoreTransaction.swift
+++ b/Tests/UnitTests/Mocks/MockStoreTransaction.swift
@@ -20,12 +20,14 @@ final class MockStoreTransaction: StoreTransactionType {
     let purchaseDate: Date
     let transactionIdentifier: String
     let quantity: Int
+    let storefront: RevenueCat.Storefront?
 
     init() {
         self.productIdentifier = UUID().uuidString
         self.purchaseDate = Date()
         self.transactionIdentifier = UUID().uuidString
         self.quantity = 1
+        self.storefront = nil
     }
 
     private let _finishInvoked: Atomic<Bool> = false


### PR DESCRIPTION
This was added in iOS 17, and it's potentially more accurate than reading `Storefront.currentStorefront` later.
