### PR TITLE
Always initialize `StoreKit2TransactionListener` even on SK1 mode

### DIFF
--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -74,7 +74,7 @@ enum PurchaseStrings {
     case begin_refund_multiple_active_entitlements
     case begin_refund_customer_info_error(entitlementID: String?)
     case missing_cached_customer_info
-    case sk2_transactions_update_received_transaction(StoreTransaction)
+    case sk2_transactions_update_received_transaction(productID: String)
     case sk1_purchase_too_slow
     case sk2_purchase_too_slow
     case payment_queue_wrapper_delegate_call_sk1_enabled
@@ -282,8 +282,8 @@ extension PurchaseStrings: CustomStringConvertible {
         case .missing_cached_customer_info:
             return "Requested a cached CustomerInfo but it's not available."
 
-        case let .sk2_transactions_update_received_transaction(transaction):
-            return "StoreKit.Transaction.updates: received transaction for product '\(transaction.productIdentifier)'"
+        case let .sk2_transactions_update_received_transaction(productID):
+            return "StoreKit.Transaction.updates: received transaction for product '\(productID)'"
 
         case .sk1_purchase_too_slow:
             return "StoreKit 1 purchase took longer than expected"

--- a/Sources/Logging/Strings/StoreKitStrings.swift
+++ b/Sources/Logging/Strings/StoreKitStrings.swift
@@ -57,6 +57,8 @@ enum StoreKitStrings {
 
     case sk2_product_request_too_slow
 
+    case sk2_observing_transaction_updates
+
     #if DEBUG
 
     case sk1_wrapper_notifying_delegate_of_existing_transactions(count: Int)
@@ -139,6 +141,9 @@ extension StoreKitStrings: CustomStringConvertible {
 
         case .sk2_product_request_too_slow:
             return "StoreKit 2 product request took longer than expected"
+
+        case .sk2_observing_transaction_updates:
+            return "Observing StoreKit.Transaction.updates"
 
         #if DEBUG
         case let .sk1_wrapper_notifying_delegate_of_existing_transactions(count):

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -130,8 +130,9 @@ final class PurchasesOrchestrator {
         storeKit2TransactionListener.delegate = self
         storeKit2StorefrontListener.delegate = self
 
+        storeKit2TransactionListener.listenForTransactions()
+
         if systemInfo.storeKit2Setting == .enabledForCompatibleDevices {
-            storeKit2TransactionListener.listenForTransactions()
             storeKit2StorefrontListener.listenForStorefrontChanges()
         }
     }

--- a/Sources/Purchasing/StoreKit1/PaymentQueueWrapper.swift
+++ b/Sources/Purchasing/StoreKit1/PaymentQueueWrapper.swift
@@ -129,7 +129,7 @@ extension PaymentQueueWrapper: SKPaymentQueueDelegate {
 extension PaymentQueueWrapper: SKPaymentTransactionObserver {
 
     func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
-        // Ignored. Either `StoreKit1Wrapper` will handle this, or `StoreKit2TransactionListener` if `SK2` is enabled.
+        // Ignored. Either `StoreKit1Wrapper` or `StoreKit2TransactionListener` will handle this.
     }
 
     #if !os(watchOS)

--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
@@ -25,7 +25,7 @@ protocol StoreKit2TransactionListenerDelegate: AnyObject {
 }
 
 /// Observes `StoreKit.Transaction.updates`, which receives:
-/// - Updates from outside `Product.purchase()`, like renewals
+/// - Updates from outside `Product.purchase()`, like renewals and purchases made on other devices
 /// - Purchases from SwiftUI's paywalls.
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
 class StoreKit2TransactionListener {

--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
@@ -24,6 +24,9 @@ protocol StoreKit2TransactionListenerDelegate: AnyObject {
 
 }
 
+/// Observes `StoreKit.Transaction.updates`, which receives:
+/// - Updates from outside `Product.purchase()`, like renewals
+/// - Purchases from SwiftUI's paywalls.
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
 class StoreKit2TransactionListener {
 
@@ -31,6 +34,7 @@ class StoreKit2TransactionListener {
     typealias ResultData = (userCancelled: Bool, transaction: SK2Transaction?)
 
     private(set) var taskHandle: Task<Void, Never>?
+
     weak var delegate: StoreKit2TransactionListenerDelegate?
 
     init(delegate: StoreKit2TransactionListenerDelegate?) {
@@ -38,6 +42,8 @@ class StoreKit2TransactionListener {
     }
 
     func listenForTransactions() {
+        Logger.debug(Strings.storeKit.sk2_observing_transaction_updates)
+
         self.taskHandle?.cancel()
         self.taskHandle = Task(priority: .utility) { [weak self] in
             for await result in StoreKit.Transaction.updates {
@@ -103,13 +109,13 @@ private extension StoreKit2TransactionListener {
 
         case let .verified(verifiedTransaction):
             if fromTransactionUpdate, let delegate = self.delegate {
-                let transaction = StoreTransaction(sk2Transaction: verifiedTransaction)
-
-                Logger.debug(Strings.purchase.sk2_transactions_update_received_transaction(transaction))
+                Logger.debug(Strings.purchase.sk2_transactions_update_received_transaction(
+                    productID: verifiedTransaction.productID
+                ))
 
                 try await delegate.storeKit2TransactionListener(
                     self,
-                    updatedTransaction: transaction
+                    updatedTransaction: StoreTransaction(sk2Transaction: verifiedTransaction)
                 )
             }
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -967,7 +967,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    func testDoesNotListenForSK2TransactionsWithSK2Disabled() throws {
+    func testListensForSK2TransactionsWithSK2Disabled() throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         let transactionListener = MockStoreKit2TransactionListener()
@@ -977,11 +977,11 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         self.setUpOrchestrator(storeKit2TransactionListener: transactionListener,
                                storeKit2StorefrontListener: StoreKit2StorefrontListener(delegate: nil))
 
-        expect(transactionListener.invokedListenForTransactions) == false
+        expect(transactionListener.invokedListenForTransactions) == true
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    func testDoesNotListenForSK2TransactionsWithSK2EnabledOnlyForOptimizations() throws {
+    func testListensForSK2TransactionsWithSK2EnabledOnlyForOptimizations() throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         let transactionListener = MockStoreKit2TransactionListener()
@@ -991,7 +991,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         self.setUpOrchestrator(storeKit2TransactionListener: transactionListener,
                                storeKit2StorefrontListener: StoreKit2StorefrontListener(delegate: nil))
 
-        expect(transactionListener.invokedListenForTransactions) == false
+        expect(transactionListener.invokedListenForTransactions) == true
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionListenerDelegate.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionListenerDelegate.swift
@@ -19,8 +19,8 @@ final class MockStoreKit2TransactionListenerDelegate: StoreKit2TransactionListen
     var invokedTransactionUpdated: Bool { return self._invokedTransactionUpdated.value }
     var updatedTransactions: [StoreTransactionType] { return self._updatedTransactions.value }
 
-    private var _invokedTransactionUpdated: Atomic<Bool> = false
-    private var _updatedTransactions: Atomic<[StoreTransactionType]> = .init([])
+    private let _invokedTransactionUpdated: Atomic<Bool> = false
+    private let _updatedTransactions: Atomic<[StoreTransactionType]> = .init([])
 
     func storeKit2TransactionListener(
         _ listener: StoreKit2TransactionListener,
@@ -31,3 +31,6 @@ final class MockStoreKit2TransactionListenerDelegate: StoreKit2TransactionListen
     }
 
 }
+
+@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+extension MockStoreKit2TransactionListenerDelegate: Sendable {}


### PR DESCRIPTION
This is necessary for the new paywall screens to work.
Tests for this added in #2590.