### PR TITLE
`PaywallExtensions`: fixed compilation

### DIFF
--- a/Sources/Support/PaywallExtensions.swift
+++ b/Sources/Support/PaywallExtensions.swift
@@ -99,10 +99,12 @@ private extension Offering {
             .map(\.product.productIdentifier)
     }
 
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     var allProductIdentifiers: [String] {
         return self.products.map(\.productIdentifier)
     }
 
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     private var products: some Sequence<StoreProduct> {
         return self.availablePackages.lazy.map(\.storeProduct)
     }


### PR DESCRIPTION
Not sure why I didn't notice this when compiling through Xcode, but just noticed this on CI in #2591.
Fixes:
```
❌ /Users/distiller/purchases-ios/Sources/Support/PaywallExtensions.swift:106:27: 'some' return types are only available in application extensions for iOS 13.0.0 or newer
    private var products: some Sequence<StoreProduct> {
```
