### PR TITLE
`StoreKitConfigTestCase`: improved `waitForStoreKitTestIfNeeded`

### DIFF
--- a/Sources/Misc/Concurrency/Atomic.swift
+++ b/Sources/Misc/Concurrency/Atomic.swift
@@ -35,6 +35,9 @@ import Foundation
  *     $0.bar = 2
  *     $0.x = "new X"
  * }
+ *
+ * // write value and get previous value
+ * let oldValue = foo.getAndSet(newValue)
  * ```
  *
  * Or for single-line read/writes:
@@ -62,6 +65,14 @@ internal final class Atomic<T> {
     func modify<Result>(_ action: (inout T) throws -> Result) rethrows -> Result {
         return try lock.perform {
             try action(&_value)
+        }
+    }
+
+    @discardableResult
+    func getAndSet(_ newValue: T) -> T {
+        return self.modify { currentValue in
+            defer { currentValue = newValue }
+            return currentValue
         }
     }
 

--- a/Tests/UnitTests/Misc/AtomicTests.swift
+++ b/Tests/UnitTests/Misc/AtomicTests.swift
@@ -39,6 +39,14 @@ class AtomicTests: TestCase {
         expect(result) == false
     }
 
+    func testGetAndSet() {
+        let atomic = Atomic(false)
+        let oldValue = atomic.getAndSet(true)
+
+        expect(oldValue) == false
+        expect(atomic.value) == true
+    }
+
     func testWithValue() {
         let atomic = Atomic(10)
         let result: Int = atomic.withValue { $0 + 10 }


### PR DESCRIPTION
I did this in hopes that it would work around `FB11799675`, but alas it didn't. I still think it's a useful refactor.

### Changes:
- Combined `hasWaited` and `waitLock` into a single `Atomic`
- Replaced `Thread.sleep` with `Task.sleep` to avoid blocking the thread. This way if `StoreKitTestSession` needs to do anything on the main thread, it can since it's no longer blocked.
- Moved call to `waitForStoreKitTestIfNeeded` _before_ finishing transactions. I did this in hopes that by the time we call that method, these transactions are gone.
