### PR TITLE
Improved `finishAllUnfinishedTransactions`

### DIFF
--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -86,13 +86,6 @@ class BaseBackendIntegrationTests: XCTestCase {
         self.mainThreadMonitor = .init()
         self.mainThreadMonitor.run()
 
-        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
-            // Despite calling `SKTestSession.clearTransactions` tests sometimes
-            // begin with leftover transactions. This ensures that we remove them
-            // to always start with a clean state.
-            await self.finishAllUnfinishedTransactions()
-        }
-
         self.userDefaults = UserDefaults(suiteName: Constants.userDefaultsSuiteName)
         self.userDefaults?.removePersistentDomain(forName: Constants.userDefaultsSuiteName)
         if !Constants.proxyURL.isEmpty {

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -33,6 +33,13 @@ class BaseStoreKitIntegrationTests: BaseBackendIntegrationTests {
             try self.configureTestSession()
         }
 
+        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            // Despite calling `SKTestSession.clearTransactions` tests sometimes
+            // begin with leftover transactions. This ensures that we remove them
+            // to always start with a clean state.
+            await self.deleteAllTransactions(session: self.testSession)
+        }
+
         // Initialize `Purchases` *after* the fresh new session has been created
         // (and transactions has been cleared), to avoid the SDK posting receipts from
         // a previous test.

--- a/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -48,7 +48,7 @@ class StoreKitConfigTestCase: TestCase {
         self.testSession.clearTransactions()
 
         if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
-            await self.finishAllUnfinishedTransactions()
+            await self.deleteAllTransactions(session: self.testSession)
         }
 
         self.waitForStoreKitTestIfNeeded()


### PR DESCRIPTION
Also hoping that this would work around `FB11799675`, but it still didn't. I still think it's useful to ensure a clean slate in tests.

This new implementation does 3 things:
- Delete transactions from `SKTestSession.allTransactions()` (those should be empty after `SKTestSession.clearTransactions()`, but this method further ensures that)
- Finish transactions from `StoreKit.Transaction.unfinished`
- Delete transactions in `StoreKit.Transaction.unfinished`

Because this new implementation requires an `SKTestSession`, it exposed the fact that we were calling this from `BaseBackendIntegrationTests`, which not all subclasses create an `SKTestSession`. Now it's in `BaseStoreKitIntegrationTests` where it belongs.
