### PR TITLE
`StoreKitConfigTestCase`: set `continueAfterFailure` to `false`

### DIFF
--- a/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -42,6 +42,9 @@ class StoreKitConfigTestCase: TestCase {
 
         try AvailabilityChecks.iOS14APIAvailableOrSkipTest()
 
+        // Avoid continuing with potentially bad data after a failed assertion
+        self.continueAfterFailure = false
+
         self.testSession = try SKTestSession(configurationFileNamed: "UnitTestsConfiguration")
         self.testSession.resetToDefaultState()
         self.testSession.disableDialogs = true


### PR DESCRIPTION
We already do this in `BaseBackendIntegrationTests`. There is no point continuing tests if an assertion failed. In fact it can be dangerous because it might lead to a crash instead of a failure, which means it won't get retried, and it would lead to a failure in CI.
