### PR TITLE
`PurchaseTester`: make CI job always point to current version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -764,6 +764,7 @@ jobs:
       - setup-git-credentials
       - trust-github-key
       - install-dependencies
+      - update-spm-installation-commit
       - run:
           name: Submit Purchase Tester
           working_directory: "Tests/TestingApps/PurchaseTesterSwiftUI"

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
@@ -971,8 +971,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/RevenueCat/purchases-ios";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.17.0;
+				branch = main;
+				kind = branch;
 			};
 		};
 		577E0E3B29159A8B0071E063 /* XCRemoteSwiftPackageReference "purchases-ios" */ = {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -477,6 +477,7 @@ platform :ios do
       './Tests/InstallationTests/SPMCustomEntitlementComputationInstallation/SPMInstallation.xcodeproj/project.pbxproj',
       './Tests/InstallationTests/ReceiptParserInstallation/ReceiptParserInstallation.xcodeproj/project.pbxproj',
       './Tests/APITesters/CustomEntitlementComputationSwiftAPITester/CustomEntitlementComputationSwiftAPITester.xcodeproj/project.pbxproj',
+      './Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj',
       './Examples/MagicWeather/MagicWeather.xcodeproj/project.pbxproj',
       './RevenueCat.xcodeproj/project.pbxproj'
     ]


### PR DESCRIPTION
Not sure how we didn't notice this before, but the build we were submitting wasn't being updated! It was stuck at 4.17.0 🤦🏻 