### PR TITLE
Removed `preventPurchasePopupCallFromTriggeringCacheRefresh`, update caches on `willEnterForeground`

### DIFF
--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -133,12 +133,6 @@ class DeviceCache {
         }
     }
 
-    func setCacheTimestampToNowToPreventConcurrentCustomerInfoUpdates(appUserID: String) {
-        self.userDefaults.write {
-            Self.setCustomerInfoCacheTimestampToNow($0, appUserID: appUserID)
-        }
-    }
-
     // MARK: - Offerings
 
     func cachedOfferingsResponseData(appUserID: String) -> Data? {
@@ -177,10 +171,6 @@ class DeviceCache {
 
     func clearOfferingsCacheTimestamp() {
         self.offeringsCachedObject.clearCacheTimestamp()
-    }
-
-    func setOfferingsCacheTimestampToNow() {
-        self.offeringsCachedObject.updateCacheTimestamp(date: Date())
     }
 
     // MARK: - subscriber attributes

--- a/Sources/Logging/Strings/ConfigureStrings.swift
+++ b/Sources/Logging/Strings/ConfigureStrings.swift
@@ -23,7 +23,7 @@ enum ConfigureStrings {
 
     case adsupport_not_imported
 
-    case application_active
+    case application_foregrounded
 
     case configuring_purchases_proxy_url_set(url: String)
 
@@ -87,8 +87,8 @@ extension ConfigureStrings: CustomStringConvertible {
             "\(Strings.objectDescription(purchases))"
         case .adsupport_not_imported:
             return "AdSupport framework not imported. Attribution data incomplete."
-        case .application_active:
-            return "applicationDidBecomeActive"
+        case .application_foregrounded:
+            return "applicationWillEnterForeground"
         case .configuring_purchases_proxy_url_set(let url):
             return "Purchases is being configured using a proxy for RevenueCat " +
                 "with URL: \(url)"

--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -26,6 +26,7 @@ enum PurchaseStrings {
     case purchases_orchestrator_init(PurchasesOrchestrator)
     case purchases_orchestrator_deinit(PurchasesOrchestrator)
     case updating_all_caches
+    case not_updating_caches_while_products_are_in_progress
     case cannot_purchase_product_appstore_configuration_error
     case entitlements_revoked_syncing_purchases(productIdentifiers: [String])
     case entitlement_expired_outside_grace_period(expiration: Date, reference: Date)
@@ -107,6 +108,9 @@ extension PurchaseStrings: CustomStringConvertible {
 
         case .updating_all_caches:
             return "Updating all caches"
+
+        case .not_updating_caches_while_products_are_in_progress:
+            return "Detected purchase in progress: will skip cache updates"
 
         case .cannot_purchase_product_appstore_configuration_error:
             return "Could not purchase SKProduct. " +

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -203,23 +203,23 @@ extension SystemInfo {
 
 extension SystemInfo {
 
-    static var applicationDidBecomeActiveNotification: Notification.Name {
+    static var applicationWillEnterForegroundNotification: Notification.Name {
         #if os(iOS) || os(tvOS)
-            UIApplication.didBecomeActiveNotification
+            UIApplication.willEnterForegroundNotification
         #elseif os(macOS)
-            NSApplication.didBecomeActiveNotification
+            NSApplication.willBecomeActiveNotification
         #elseif os(watchOS)
-            Notification.Name.NSExtensionHostDidBecomeActive
+            Notification.Name.NSExtensionHostWillEnterForeground
         #endif
     }
 
-    static var applicationWillResignActiveNotification: Notification.Name {
+    static var applicationDidEnterBackgroundNotification: Notification.Name {
         #if os(iOS) || os(tvOS)
-            UIApplication.willResignActiveNotification
+            UIApplication.didEnterBackgroundNotification
         #elseif os(macOS)
-            NSApplication.willResignActiveNotification
+            NSApplication.didResignActiveNotification
         #elseif os(watchOS)
-            Notification.Name.NSExtensionHostWillResignActive
+            Notification.Name.NSExtensionHostDidEnterBackground
         #endif
     }
 

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -361,7 +361,6 @@ final class PurchasesOrchestrator {
         }
 
         payment.applicationUsername = self.appUserID
-        self.preventPurchasePopupCallFromTriggeringCacheRefresh(appUserID: self.appUserID)
 
         self.cachePresentedOfferingIdentifier(package: package, productIdentifier: productIdentifier)
 
@@ -1054,11 +1053,6 @@ private extension PurchasesOrchestrator {
                 }
             }
         }
-    }
-
-    func preventPurchasePopupCallFromTriggeringCacheRefresh(appUserID: String) {
-        deviceCache.setCacheTimestampToNowToPreventConcurrentCustomerInfoUpdates(appUserID: appUserID)
-        deviceCache.setOfferingsCacheTimestampToNow()
     }
 
     func purchase(

--- a/Tests/UnitTests/Caching/DeviceCacheTests.swift
+++ b/Tests/UnitTests/Caching/DeviceCacheTests.swift
@@ -78,7 +78,6 @@ class DeviceCacheTests: TestCase {
 
     func testClearCachesForAppUserIDAndSaveNewUserIDClearsCachesTimestamp() {
         let appUserID = "cesar"
-        self.deviceCache.setCacheTimestampToNowToPreventConcurrentCustomerInfoUpdates(appUserID: appUserID)
         self.deviceCache.clearCaches(oldAppUserID: appUserID, andSaveWithNewUserID: "newUser")
         expect(self.deviceCache.isCustomerInfoCacheStale(appUserID: appUserID, isAppBackgrounded: false)).to(beTrue())
     }
@@ -136,29 +135,8 @@ class DeviceCacheTests: TestCase {
 
     }
 
-    func testSetCustomerInfoCacheTimestampToNow() {
-        let appUserID = "user"
-        let isBackgrounded = false
-
-        expect(self.deviceCache.isCustomerInfoCacheStale(appUserID: appUserID,
-                                                         isAppBackgrounded: isBackgrounded)) == true
-
-        self.deviceCache.setCacheTimestampToNowToPreventConcurrentCustomerInfoUpdates(appUserID: appUserID)
-
-        expect(self.deviceCache.isCustomerInfoCacheStale(appUserID: appUserID,
-                                                         isAppBackgrounded: isBackgrounded)) == false
-    }
-
     func testCustomerInfoCacheIsStaleIfNoCaches() {
         expect(self.deviceCache.isCustomerInfoCacheStale(appUserID: "user", isAppBackgrounded: false)).to(beTrue())
-    }
-
-    func testSetOfferingsCacheTimestampToNow() {
-        expect(self.deviceCache.isOfferingsCacheStale(isAppBackgrounded: false)).to(beTrue())
-        expect(self.deviceCache.isOfferingsCacheStale(isAppBackgrounded: true)).to(beTrue())
-        self.deviceCache.setOfferingsCacheTimestampToNow()
-        expect(self.deviceCache.isOfferingsCacheStale(isAppBackgrounded: false)).to(beFalse())
-        expect(self.deviceCache.isOfferingsCacheStale(isAppBackgrounded: true)).to(beFalse())
     }
 
     func testOfferingsCacheIsStaleIfNoCaches() {

--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -71,10 +71,6 @@ class MockDeviceCache: DeviceCache {
         clearCustomerInfoCacheTimestampCount += 1
     }
 
-    override func setCacheTimestampToNowToPreventConcurrentCustomerInfoUpdates(appUserID: String) {
-        setCustomerInfoCacheTimestampToNowCount += 1
-    }
-
     // MARK: offerings
 
     var cacheOfferingsCount = 0
@@ -103,10 +99,6 @@ class MockDeviceCache: DeviceCache {
 
     override func clearOfferingsCacheTimestamp() {
         self.clearOfferingsCacheTimestampCount += 1
-    }
-
-    override func setOfferingsCacheTimestampToNow() {
-        self.setOfferingsCacheTimestampToNowCount += 1
     }
 
     override func clearOfferingsCache(appUserID: String) {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDelegateTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDelegateTests.swift
@@ -35,11 +35,11 @@ class PurchasesDelegateTests: BasePurchasesTests {
         expect(self.storeKit1Wrapper.delegate).toNot(beNil())
     }
 
-    func testSubscribesToUIApplicationDidBecomeActive() throws {
+    func testSubscribesToUIApplicationWillEnterForeground() throws {
         expect(self.notificationCenter.observers).to(haveCount(2))
 
         let (_, _, name, _) = try XCTUnwrap(self.notificationCenter.observers.first)
-        expect(name) == SystemInfo.applicationDidBecomeActiveNotification
+        expect(name) == SystemInfo.applicationWillEnterForegroundNotification
     }
 
     func testTriggersCallToBackend() {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDelegateTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDelegateTests.swift
@@ -42,6 +42,19 @@ class PurchasesDelegateTests: BasePurchasesTests {
         expect(name) == SystemInfo.applicationWillEnterForegroundNotification
     }
 
+    #if os(iOS)
+
+    // We shouldn't use this notification because it's called when
+    // apps lose focus when presenting popups during a purchase.
+    func testDoesNotSubscribeToUIApplicationDidBecomeActive() throws {
+        expect(self.notificationCenter.observers)
+            .toNot(containElementSatisfying { _, _, name, _ in
+                name == UIApplication.didBecomeActiveNotification
+            })
+    }
+
+    #endif
+
     func testTriggersCallToBackend() {
         self.notificationCenter.fireNotifications()
         expect(self.backend.userID).toEventuallyNot(beNil())

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -224,7 +224,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
         expect(self.mockNotificationCenter.observers).toNot(beEmpty())
 
         expect(self.mockNotificationCenter.observers).to(containElementSatisfying {
-            $0.notificationName == SystemInfo.applicationDidBecomeActiveNotification
+            $0.notificationName == SystemInfo.applicationWillEnterForegroundNotification
         })
 
         self.mockNotificationCenter.fireNotifications()
@@ -237,7 +237,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
         expect(self.mockNotificationCenter.observers).toNot(beEmpty())
 
         expect(self.mockNotificationCenter.observers).to(containElementSatisfying {
-            $0.notificationName == SystemInfo.applicationWillResignActiveNotification
+            $0.notificationName == SystemInfo.applicationDidEnterBackgroundNotification
         })
 
         self.mockNotificationCenter.fireNotifications()


### PR DESCRIPTION
This method was a hack to deal with apps getting `didBecomeActive` notifications in the middle of a purchase when the popups were displayed.
This had several problems:
- It was only being used for StoreKit 1 purchases
- It wasn't used for StoreKit 2 purchases through the SDK
- It wasn't used for purchases initiated outside the SDK (like using the upcoming paywall screens)
- It updated the cache timestamp to "now", including offerings, despite not actually updating data
- It was an indirect and implicit way of solving a problem instead of an explicit one

This solves the same by observing `willEnterForeground`, which only happens when the app actually comes back from the background, and not when it simply loses focus.