### PR TITLE
`Tests`: fixed crash on iOS 13

### DIFF
--- a/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -63,10 +63,13 @@ class StoreKitConfigTestCase: TestCase {
     override func tearDown() async throws {
         self.clearReceiptIfExists()
 
-        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
-            await self.deleteAllTransactions(session: self.testSession)
+        // `SKTestSession` might have not been initialized if the test was skipped.
+        if let session = self.testSession {
+            if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+                await self.deleteAllTransactions(session: session)
+            }
+            session.clearTransactions()
         }
-        self.testSession.clearTransactions()
 
         try await super.tearDown()
     }


### PR DESCRIPTION
This broke in #2616 because `SKTestSession` is `nil` when the tests are skipped.

Fixes https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/11773/workflows/c554f77d-7ea3-447c-ae54-099117eb1797/jobs/76416