### PR TITLE
`CI`: disable iOS 17 for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -848,8 +848,9 @@ workflows:
   generate-snapshot:
     when: << pipeline.parameters.generate_snapshots >>
     jobs:
-      - run-test-ios-17:
-          xcode_version: '15.0.0'
+      # Disabled until we drop support for iOS 11
+      # - run-test-ios-17:
+      #     xcode_version: '15.0.0'
       - run-test-ios-16:
           xcode_version: '14.3.0'
       - run-test-ios-15:
@@ -878,8 +879,9 @@ workflows:
           xcode_version: '14.3.0'
       - spm-receipt-parser:
           xcode_version: '14.3.0'
-      - run-test-ios-17:
-          xcode_version: '15.0.0'
+      # Disabled until we drop support for iOS 11
+      # - run-test-ios-17:
+      #     xcode_version: '15.0.0'
       - run-test-ios-16:
           xcode_version: '14.3.0'
       - run-test-ios-15:


### PR DESCRIPTION
Basically disabling #2591. I didn't realize that we can't even run them because of the iOS 11 issue (I had tested changing that locally).
I filed SDK-3184 to drop support in the short term, but for now this disables those tests.
