### PR TITLE
`PostReceiptDataOperation`: clean up cache key

### DIFF
--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -70,7 +70,7 @@ final class PostReceiptDataOperation: CacheableNetworkOperation {
         \(configuration.appUserID)-\(postData.isRestore)-\(postData.receiptData.hashString)
         -\(postData.productData?.cacheKey ?? "")
         -\(postData.presentedOfferingIdentifier ?? "")-\(postData.observerMode)
-        -\(postData.subscriberAttributesByKey?.debugDescription ?? "")"
+        -\(postData.subscriberAttributesByKey?.debugDescription ?? "")
         """
 
         return .init({ cacheKey in


### PR DESCRIPTION
This does not change any behavior, but I was debugging this and was confused about the trailing `"`.
Likely from when this was changed to use `"""`.
