### PR TITLE
`PurchasesOrchestrator`: also get `Storefront` from SK1

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -824,7 +824,7 @@ extension PurchasesOrchestrator: StoreKit2TransactionListenerDelegate {
         _ listener: StoreKit2TransactionListener,
         updatedTransaction transaction: StoreTransactionType
     ) async throws {
-        let storefront = await transaction.storefrontOrCurrent
+        let storefront = await self.storefront(from: transaction)
 
         _ = try await Async.call { completed in
             self.transactionPoster.handlePurchasedTransaction(
@@ -843,6 +843,12 @@ extension PurchasesOrchestrator: StoreKit2TransactionListenerDelegate {
                 completed(result.mapError(\.asPurchasesError))
             }
         }
+    }
+
+    private func storefront(from transaction: StoreTransactionType) async -> StorefrontType? {
+        return await transaction.storefrontOrCurrent
+        // If we couldn't determine storefront from SK2, try SK1:
+        ?? self.paymentQueueWrapper.sk1Wrapper?.currentStorefront
     }
 
 }


### PR DESCRIPTION
Looks like `Storefront.current` is usually `nil` during tests.
After #2612, it's important than renewals posted from SK1 and SK2 end up with equivalent cache keys. This will be ensured by a test in #2590, which breaks unless we do this.
Example cache keys between SK1 and SK2:
```
PostReceiptDataOperation $RCAnonymousID:9d38b05059d442b082f915011041bbcb-true-77c15e6fad291c0ff9bf8a4efdfa21eca7cdd74e7a0a4a1bdcf320e8ddcfc2d5\n-com.revenuecat.monthly_4.99.no_intro-0.99-USD-USA--1-0-7096FF06-P1M---1-com.revenuecat.monthly_4.99.1_free_week\n--true\n-[\"$attConsentStatus\": [SubscriberAttribute] key: $attConsentStatus value: notDetermined setTime: 2023-06-12 22:31:56 +0000]
PostReceiptDataOperation $RCAnonymousID:9d38b05059d442b082f915011041bbcb-true-77c15e6fad291c0ff9bf8a4efdfa21eca7cdd74e7a0a4a1bdcf320e8ddcfc2d5\n-com.revenuecat.monthly_4.99.no_intro-0.99-USD---1-0-7096FF06-P1M---1-com.revenuecat.monthly_4.99.1_free_week\n--true\n-["$attConsentStatus": [SubscriberAttribute] key: $attConsentStatus value: notDetermined setTime: 2023-06-12 22:31:56 +0000]
```

Notice `USA` is missing on the SK2 posted product.
