### PR TITLE
`IntegrationTests`: explicit `StoreKit 1` mode

### DIFF
--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -40,6 +40,8 @@ class OfflineStoreKit2IntegrationTests: OfflineStoreKit1IntegrationTests {
 
 class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
 
+    override class var storeKit2Setting: StoreKit2Setting { return .disabled }
+
     override func setUp() async throws {
         try await super.setUp()
 

--- a/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
@@ -63,6 +63,8 @@ class StoreKit2ObserverModeIntegrationTests: StoreKit1ObserverModeIntegrationTes
 
 class StoreKit1ObserverModeIntegrationTests: BaseStoreKitObserverModeIntegrationTests {
 
+    override class var storeKit2Setting: StoreKit2Setting { return .disabled }
+
     func testPurchaseOutsideTheAppPostsReceipt() async throws {
         try self.testSession.buyProduct(productIdentifier: Self.monthlyNoIntroProductID)
 
@@ -82,6 +84,8 @@ class StoreKit2ObserverModeWithExistingPurchasesTests: StoreKit1ObserverModeWith
 /// Purchases a product before configuring `Purchases` to verify behavior upon initialization in observer mode.
 @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
 class StoreKit1ObserverModeWithExistingPurchasesTests: BaseStoreKitObserverModeIntegrationTests {
+
+    override class var storeKit2Setting: StoreKit2Setting { return .disabled }
 
     // MARK: - Transactions observation
 


### PR DESCRIPTION
I noticed that `BaseBackendIntegrationTests` sets the `StoreKit2Setting` to `.default`, but in these `StoreKit 1` tests we weren't overriding that setting.

When the default changes to `StoreKit 2`, this would have unknowingly changed and we'd have stopped testing `StoreKit 1`.
