### PR TITLE
`copy(with: VerificationResult)`: optimization to avoid copies

### DIFF
--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -238,6 +238,8 @@ extension CustomerInfo {
 
     /// Creates a copy of this ``CustomerInfo`` modifying only the ``VerificationResult``.
     func copy(with entitlementVerification: VerificationResult) -> Self {
+        guard entitlementVerification != self.data.entitlementVerification else { return self }
+
         var copy = self.data
         copy.entitlementVerification = entitlementVerification
         return .init(data: copy)

--- a/Sources/Networking/HTTPClient/HTTPResponse.swift
+++ b/Sources/Networking/HTTPClient/HTTPResponse.swift
@@ -98,6 +98,8 @@ extension HTTPResponse {
     }
 
     func copy(with newVerificationResult: VerificationResult) -> Self {
+        guard newVerificationResult != self.verificationResult else { return self }
+
         return .init(
             statusCode: self.statusCode,
             responseHeaders: self.responseHeaders,

--- a/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
@@ -844,8 +844,7 @@ class BasicCustomerInfoTests: TestCase {
     }
 
     func testCopyWithSameVerificationResult() throws {
-        self.verifyCopy(of: self.customerInfo.copy(with: .verified),
-                        onlyModifiesEntitlementVerification: .verified)
+        expect(self.customerInfo.copy(with: .notRequested)) === self.customerInfo
     }
 
     func testCopyWithVerificationResultVerified() throws {

--- a/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
@@ -843,6 +843,11 @@ class BasicCustomerInfoTests: TestCase {
         == Set(["onemonth_freetrial", "twomonth_freetrial", "threemonth_freetrial"])
     }
 
+    func testCopyWithSameVerificationResult() throws {
+        self.verifyCopy(of: self.customerInfo.copy(with: .verified),
+                        onlyModifiesEntitlementVerification: .verified)
+    }
+
     func testCopyWithVerificationResultVerified() throws {
         self.verifyCopy(of: self.customerInfo,
                         onlyModifiesEntitlementVerification: .verified)


### PR DESCRIPTION
I noticed this could be improved while working on #2635.
