### PR TITLE
`HTTPResponseTests`: fixed disabled test

### DIFF
--- a/Tests/UnitTests/Networking/HTTPResponseTests.swift
+++ b/Tests/UnitTests/Networking/HTTPResponseTests.swift
@@ -94,7 +94,7 @@ private extension HTTPResponse where Body == HTTPEmptyResponseBody {
 
 class HTTPResponseBodyTests: TestCase {
 
-    func copyWithNewRequestDateDefaultsToSameData() {
+    func testCopyWithNewRequestDateDefaultsToSameData() {
         struct Body: Equatable, Codable, HTTPResponseBody {
             var data: String
         }


### PR DESCRIPTION
This didn't start with `test` so it wasn't actually running!

_(I wish `XCTest` moved to some sort of macro like `@Test` in the future to avoid this)._
