### PR TITLE
`PaywallExtensions`: post purchases with `Offering` identifier

### DIFF
--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -75,12 +75,11 @@ enum PurchaseStrings {
     case begin_refund_customer_info_error(entitlementID: String?)
     case missing_cached_customer_info
     case sk2_transactions_update_received_transaction(productID: String)
-    case transaction_poster_handling_transaction(productID: String)
+    case transaction_poster_handling_transaction(productID: String, offeringID: String?)
+    case caching_presented_offering_identifier(offeringID: String, productID: String)
     case sk1_purchase_too_slow
     case sk2_purchase_too_slow
     case payment_queue_wrapper_delegate_call_sk1_enabled
-
-    // swiftlint:disable:next identifier_name
     case restorepurchases_called_with_allow_sharing_appstore_account_false
 
 }
@@ -286,8 +285,17 @@ extension PurchaseStrings: CustomStringConvertible {
         case let .sk2_transactions_update_received_transaction(productID):
             return "StoreKit.Transaction.updates: received transaction for product '\(productID)'"
 
-        case let .transaction_poster_handling_transaction(productID):
-            return "TransactionPoster: handling transaction for product '\(productID)'"
+        case let .transaction_poster_handling_transaction(productID, offeringID):
+            let prefix = "TransactionPoster: handling transaction for product '\(productID)'"
+
+            if let offeringIdentifier = offeringID {
+                return prefix + " in Offering '\(offeringIdentifier)'"
+            } else {
+                return prefix
+            }
+
+        case let .caching_presented_offering_identifier(offeringID, productID):
+            return "Caching presented offering identifier '\(offeringID)' for product '\(productID)'"
 
         case .sk1_purchase_too_slow:
             return "StoreKit 1 purchase took longer than expected"

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1330,6 +1330,21 @@ extension Purchases: @unchecked Sendable {}
 
 // MARK: Internal
 
+extension Purchases {
+
+    /// Used when purchasing through `SwiftUI` paywalls.
+    func cachePresentedOfferingIdentifier(_ identifier: String, productIdentifier: String) {
+        Logger.debug(Strings.purchase.caching_presented_offering_identifier(offeringID: identifier,
+                                                                            productID: productIdentifier))
+
+        self.purchasesOrchestrator.cachePresentedOfferingIdentifier(
+            identifier,
+            productIdentifier: productIdentifier
+        )
+    }
+
+}
+
 extension Purchases: InternalPurchasesType {
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -512,6 +512,10 @@ final class PurchasesOrchestrator {
         }
     }
 
+    func cachePresentedOfferingIdentifier(_ identifier: String, productIdentifier: String) {
+        self.presentedOfferingIDsByProductID.modify { $0[productIdentifier] = identifier }
+    }
+
 #if os(iOS) || os(macOS)
 
     @available(watchOS, unavailable)
@@ -1083,7 +1087,7 @@ private extension PurchasesOrchestrator {
 
     func cachePresentedOfferingIdentifier(package: Package?, productIdentifier: String) {
         if let package = package {
-            self.presentedOfferingIDsByProductID.modify { $0[productIdentifier] = package.offeringIdentifier }
+            self.cachePresentedOfferingIdentifier(package.offeringIdentifier, productIdentifier: productIdentifier)
         }
     }
 

--- a/Sources/Purchasing/Purchases/TransactionPoster.swift
+++ b/Sources/Purchasing/Purchases/TransactionPoster.swift
@@ -82,7 +82,8 @@ final class TransactionPoster: TransactionPosterType {
                                     data: PurchasedTransactionData,
                                     completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
         Logger.debug(Strings.purchase.transaction_poster_handling_transaction(
-            productID: transaction.productIdentifier
+            productID: transaction.productIdentifier,
+            offeringID: data.presentedOfferingID
         ))
 
         self.receiptFetcher.receiptData(

--- a/Sources/Support/DebugUI/DebugContentViews.swift
+++ b/Sources/Support/DebugUI/DebugContentViews.swift
@@ -228,7 +228,7 @@ private struct DebugOfferingView: View {
         }
         .sheet(isPresented: self.$showingStoreSheet) {
             if #available(iOS 17.0, macOS 14.0, tvOS 17.0, *) {
-                StoreView(offering: self.offering)
+                StoreView.forOffering(self.offering)
             }
         }
         #endif
@@ -237,7 +237,7 @@ private struct DebugOfferingView: View {
     #if swift(>=5.9)
     @available(iOS 17.0, macOS 14.0, tvOS 17.0, *)
     private var subscriptionStoreView: some View {
-        SubscriptionStoreView(offering: self.offering) {
+        SubscriptionStoreView.forOffering(self.offering) {
             VStack {
                 VStack {
                     Text("🐈")

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/OtherAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/OtherAPI.swift
@@ -43,18 +43,18 @@ struct PaywallViews: View {
     let offering: Offering
 
     var body: some View {
-        StoreView(offering: self.offering)
-        StoreView(offering: self.offering, prefersPromotionalIcon: true)
+        StoreView.forOffering(self.offering)
+        StoreView.forOffering(self.offering, prefersPromotionalIcon: true)
 
-        StoreView(
-            offering: self.offering,
+        StoreView.forOffering(
+            self.offering,
             prefersPromotionalIcon: true,
             icon: { (_: Product) in Text("") },
             placeholderIcon: { Text("") }
         )
 
-        SubscriptionStoreView(offering: self.offering)
-        SubscriptionStoreView(offering: self.offering) {
+        SubscriptionStoreView.forOffering(self.offering)
+        SubscriptionStoreView.forOffering(self.offering) {
             Text("Marketing content")
         }
     }

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -46,11 +46,41 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     }
 
     func testCanPurchasePackage() async throws {
+        let logger = TestLogHandler()
+
+        let package = try await self.monthlyPackage
         try await self.purchaseMonthlyOffering()
+
+        logger.verifyMessageWasLogged(
+            Strings.purchase.transaction_poster_handling_transaction(
+                productID: package.storeProduct.productIdentifier,
+                offeringID: package.offeringIdentifier
+            )
+        )
     }
 
     func testCanPurchaseProduct() async throws {
         try await self.purchaseMonthlyProduct()
+    }
+
+    func testPurchasingPackageWithPresentedOfferingIdentifier() async throws {
+        let package = try await self.monthlyPackage
+
+        let logger = TestLogHandler()
+
+        Purchases.shared.cachePresentedOfferingIdentifier(
+            package.offeringIdentifier,
+            productIdentifier: package.storeProduct.productIdentifier
+        )
+
+        try await self.purchaseMonthlyProduct()
+
+        logger.verifyMessageWasLogged(
+            Strings.purchase.transaction_poster_handling_transaction(
+                productID: package.storeProduct.productIdentifier,
+                offeringID: package.offeringIdentifier
+            )
+        )
     }
 
     func testCanPurchaseConsumable() async throws {


### PR DESCRIPTION
### Changes:

- Exposed `internal`-only `Purchases.cachePresentedOfferingIdentifier`
- Changed `SwiftUI` extensions to `static` methods: this is required to be able to call an instance method on them
- Added integration test to verify this offering identifier is used

Technically this is an API change, but these APIs are implicitly beta because they're only available in Xcode 15 beta.
