### PR TITLE
`Trusted Entitlements`: added debug log with `ResponseVerificationMode`

### DIFF
--- a/Sources/Logging/Strings/ConfigureStrings.swift
+++ b/Sources/Logging/Strings/ConfigureStrings.swift
@@ -33,6 +33,8 @@ enum ConfigureStrings {
 
     case observer_mode_enabled
 
+    case response_verification_mode(Signing.ResponseVerificationMode)
+
     case delegate_set
 
     case purchase_instance_already_set
@@ -98,6 +100,15 @@ extension ConfigureStrings: CustomStringConvertible {
             return "StoreKit 2 support enabled"
         case .observer_mode_enabled:
             return "Purchases is configured in observer mode"
+        case let .response_verification_mode(mode):
+            switch mode {
+            case .disabled:
+                return "Purchases is configured with response verification disabled"
+            case .informational:
+                return "Purchases is configured with informational response verification"
+            case .enforced:
+                return "Purchases is configured with enforced response verification"
+            }
         case .delegate_set:
             return "Delegate set"
         case .purchase_instance_already_set:

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -485,6 +485,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         Logger.debug(Strings.configure.system_version(SystemInfo.systemVersion), fileName: nil)
         Logger.debug(Strings.configure.is_simulator(SystemInfo.isRunningInSimulator), fileName: nil)
         Logger.user(Strings.configure.initial_app_user_id(isSet: appUserID != nil), fileName: nil)
+        Logger.debug(Strings.configure.response_verification_mode(systemInfo.responseVerificationMode), fileName: nil)
 
         self.requestFetcher = requestFetcher
         self.receiptFetcher = receiptFetcher


### PR DESCRIPTION
I was going through some logs, and realized I couldn't tell what mode was configured, and I thought it would be useful.