### PR TITLE
`debugRevenueCatOverlay`: added support for `macOS`

### DIFF
--- a/Sources/Support/DebugUI/DebugContentViews.swift
+++ b/Sources/Support/DebugUI/DebugContentViews.swift
@@ -11,12 +11,12 @@
 //
 //  Created by Nacho Soto on 5/30/23.
 
-#if DEBUG && os(iOS) && swift(>=5.8)
+#if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS))
 
 import StoreKit
 import SwiftUI
 
-@available(iOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, *)
 struct DebugSwiftUIRootView: View {
 
     @StateObject
@@ -56,7 +56,7 @@ private enum DebugViewPath: Hashable {
 
 }
 
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, *)
 internal struct DebugSummaryView: View {
 
     @ObservedObject
@@ -74,7 +74,9 @@ internal struct DebugSummaryView: View {
 
             self.offeringsSection
         }
+        #if os(iOS)
         .listStyle(.insetGrouped)
+        #endif
         .scrollContentBackground(.hidden)
         .navigationTitle("RevenueCat Debug")
     }
@@ -166,7 +168,7 @@ internal struct DebugSummaryView: View {
 
 }
 
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, *)
 private struct DebugOfferingView: View {
 
     @State private var showingSubscriptionSheet = false
@@ -268,7 +270,7 @@ private struct DebugOfferingView: View {
 
 }
 
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, *)
 private struct DebugPackageView: View {
 
     var package: Package
@@ -334,7 +336,7 @@ private struct DebugPackageView: View {
 
 }
 
-@available(iOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, *)
 extension DebugViewModel.Configuration: Transferable {
 
     static var transferRepresentation: some TransferRepresentation {
@@ -349,7 +351,7 @@ extension DebugViewModel.Configuration: Transferable {
 }
 
 #if swift(>=5.9)
-@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+@available(iOS 17.0, macOS 14.0, *)
 private struct ProductStyle: ProductViewStyle {
 
     func makeBody(configuration: ProductViewStyleConfiguration) -> some View {

--- a/Sources/Support/DebugUI/DebugView.swift
+++ b/Sources/Support/DebugUI/DebugView.swift
@@ -11,11 +11,11 @@
 //
 //  Created by Nacho Soto on 5/30/23.
 
-#if DEBUG && os(iOS) && swift(>=5.8)
+#if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS))
 
 import SwiftUI
 
-@available(iOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, *)
 public extension View {
 
     /// Adds a bottom sheet overlay to the current view which allows debugging the current SDK setup.
@@ -63,6 +63,9 @@ public extension View {
             cornerRadius: DebugSwiftUIRootView.cornerRadius,
             content: {
                 DebugSwiftUIRootView()
+                #if os(macOS)
+                    .frame(width: 500, height: 600)
+                #endif
             }
         )
     }

--- a/Sources/Support/DebugUI/DebugViewModel.swift
+++ b/Sources/Support/DebugUI/DebugViewModel.swift
@@ -13,12 +13,12 @@
 
 import Foundation
 
-#if DEBUG && os(iOS) && swift(>=5.8)
+#if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS))
 
 import SwiftUI
 
 @MainActor
-@available(iOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, *)
 final class DebugViewModel: ObservableObject {
 
     struct Configuration: Codable {
@@ -65,7 +65,7 @@ final class DebugViewModel: ObservableObject {
 
 }
 
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, *)
 extension DebugViewModel {
 
     var diagnosticsStatus: String {
@@ -116,7 +116,7 @@ extension LoadingState where Error == NSError {
 
 }
 
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, *)
 private extension DebugViewModel.Configuration {
 
     static func create(with purchases: Purchases = .shared) -> Self {

--- a/Sources/Support/DebugUI/DebugViewSheetPresentation.swift
+++ b/Sources/Support/DebugUI/DebugViewSheetPresentation.swift
@@ -11,11 +11,11 @@
 //
 //  Created by Nacho Soto on 5/30/23.
 
-#if DEBUG && os(iOS) && swift(>=5.8)
+#if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS))
 
 import SwiftUI
 
-@available(iOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, *)
 extension View {
 
     @ViewBuilder

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/OtherAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/OtherAPI.swift
@@ -11,9 +11,9 @@ import RevenueCat
 import StoreKit
 import SwiftUI
 
-#if DEBUG && os(iOS) && swift(>=5.8)
+#if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS))
 
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, *)
 struct AppView: View {
 
     @State private var debugOverlayVisible: Bool = false
@@ -26,7 +26,11 @@ struct AppView: View {
 
 }
 
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+#endif
+
+#if DEBUG && os(iOS) && swift(>=5.8)
+
+@available(iOS 16.0, *)
 func debugViewController() {
     let _: UIViewController = DebugViewController()
     UIViewController().presentDebugRevenueCatOverlay()
@@ -35,7 +39,7 @@ func debugViewController() {
 
 #endif
 
-#if os(iOS) && swift(>=5.9)
+#if swift(>=5.9)
 
 @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
 struct PaywallViews: View {


### PR DESCRIPTION
I wanted to support it to be able to look into #2558.

![image](https://github.com/RevenueCat/purchases-ios/assets/685609/cdba0488-965e-4887-bef0-ae151430889a)
