### PR TITLE
`ImageSnapshot`: fixed Xcode 15 compilation

### DIFF
--- a/Tests/UnitTests/TestHelpers/ImageSnapshot.swift
+++ b/Tests/UnitTests/TestHelpers/ImageSnapshot.swift
@@ -25,8 +25,8 @@ func haveValidSnapshot<Value>(
     timeout: TimeInterval = 5,
     file: StaticString = #file,
     line: UInt = #line
-) -> Predicate<Value> {
-    return Predicate { actualExpression in
+) -> Nimble.Predicate<Value> {
+    return Nimble.Predicate { actualExpression in
         guard let value = try actualExpression.evaluate() else {
             return PredicateResult(status: .fail, message: .fail("have valid snapshot"))
         }


### PR DESCRIPTION
Same as #2602, but didn't notice this in #2630, and since we don't have iOS 17 tests in CI yet, it went unnoticed.
