### PR TITLE
Support `product_plan_identifier` for purchased subscriptions from `Google Play`

### DIFF
--- a/Sources/Identity/CustomerInfo+ActiveDates.swift
+++ b/Sources/Identity/CustomerInfo+ActiveDates.swift
@@ -55,6 +55,10 @@ extension CustomerInfo {
                         .map { productID, subscription in
                             let key: String
                             let value = subscription.expiresDate
+
+                            // Products purchased from Google Play will have a product plan identifier (base plan)
+                            // These products get mapped as "productId:productPlanIdentifier" in the Android SDK
+                            // so the same mapping needs to be handled here for cross platform purchases
                             if let productPlanIdentfier = subscription.productPlanIdentifier {
                                 key = "\(productID):\(productPlanIdentfier)"
                             } else {

--- a/Sources/Identity/CustomerInfo+ActiveDates.swift
+++ b/Sources/Identity/CustomerInfo+ActiveDates.swift
@@ -48,7 +48,17 @@ extension CustomerInfo {
     }
 
     static func extractExpirationDates(_ subscriber: CustomerInfoResponse.Subscriber) -> [String: Date?] {
-        return subscriber.subscriptions.mapValues { $0.expiresDate }
+        var map = [String: Date?]()
+
+        for (productId, subscription) in subscriber.subscriptions {
+            if let productPlanIdentfier = subscription.productPlanIdentifier {
+                map["\(productId):\(productPlanIdentfier)"] = subscription.expiresDate
+            } else {
+                map[productId] = subscription.expiresDate
+            }
+        }
+
+        return map
     }
 
     static func extractPurchaseDates(_ subscriber: CustomerInfoResponse.Subscriber) -> [String: Date?] {

--- a/Sources/Identity/CustomerInfo+ActiveDates.swift
+++ b/Sources/Identity/CustomerInfo+ActiveDates.swift
@@ -48,17 +48,21 @@ extension CustomerInfo {
     }
 
     static func extractExpirationDates(_ subscriber: CustomerInfoResponse.Subscriber) -> [String: Date?] {
-        var map = [String: Date?]()
-
-        for (productId, subscription) in subscriber.subscriptions {
-            if let productPlanIdentfier = subscription.productPlanIdentifier {
-                map["\(productId):\(productPlanIdentfier)"] = subscription.expiresDate
-            } else {
-                map[productId] = subscription.expiresDate
-            }
-        }
-
-        return map
+        return Dictionary(
+                    uniqueKeysWithValues: subscriber
+                        .subscriptions
+                        .lazy
+                        .map { productID, subscription in
+                            let key: String
+                            let value = subscription.expiresDate
+                            if let productPlanIdentfier = subscription.productPlanIdentifier {
+                                key = "\(productID):\(productPlanIdentfier)"
+                            } else {
+                                key = productID
+                            }
+                            return (key, value)
+                        }
+                )
     }
 
     static func extractPurchaseDates(_ subscriber: CustomerInfoResponse.Subscriber) -> [String: Date?] {

--- a/Sources/Networking/Responses/CustomerInfoResponse.swift
+++ b/Sources/Networking/Responses/CustomerInfoResponse.swift
@@ -60,6 +60,7 @@ extension CustomerInfoResponse {
         var billingIssuesDetectedAt: Date?
         @IgnoreDecodeErrors<PurchaseOwnershipType>
         var ownershipType: PurchaseOwnershipType
+        var productPlanIdentifier: String?
 
     }
 

--- a/Sources/Purchasing/EntitlementInfo.swift
+++ b/Sources/Purchasing/EntitlementInfo.swift
@@ -134,9 +134,9 @@ extension PeriodType: DefaultValueProvider {
     @objc public var productIdentifier: String { self.contents.productIdentifier }
 
     /**
-     The product plan identifier that unlocked this entitlement
+     The product plan identifier that unlocked this entitlement (usually for a Google Play purchase)
      */
-    @objc public var productPlanIdentifier: String? { self.contents.productPlanIdentifier }
+    @objc internal var productPlanIdentifier: String? { self.contents.productPlanIdentifier }
 
     /**
      False if this entitlement is unlocked via a production purchase

--- a/Sources/Purchasing/EntitlementInfo.swift
+++ b/Sources/Purchasing/EntitlementInfo.swift
@@ -134,6 +134,11 @@ extension PeriodType: DefaultValueProvider {
     @objc public var productIdentifier: String { self.contents.productIdentifier }
 
     /**
+     The product plan identifier that unlocked this entitlement
+     */
+    @objc public var productPlanIdentifier: String? { self.contents.productPlanIdentifier }
+
+    /**
      False if this entitlement is unlocked via a production purchase
      */
     @objc public var isSandbox: Bool { self.contents.isSandbox }
@@ -236,6 +241,7 @@ extension PeriodType: DefaultValueProvider {
             expirationDate: subscription.expiresDate,
             store: subscription.store,
             productIdentifier: entitlement.productIdentifier,
+            productPlanIdentifier: subscription.productPlanIdentifier,
             isSandbox: subscription.isSandbox,
             unsubscribeDetectedAt: subscription.unsubscribeDetectedAt,
             billingIssueDetectedAt: subscription.billingIssuesDetectedAt,
@@ -321,6 +327,7 @@ private extension EntitlementInfo {
         let expirationDate: Date?
         let store: Store
         let productIdentifier: String
+        let productPlanIdentifier: String?
         let isSandbox: Bool
         let unsubscribeDetectedAt: Date?
         let billingIssueDetectedAt: Date?

--- a/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
@@ -77,6 +77,11 @@ class BasicCustomerInfoTests: TestCase {
                     "product_identifier": "onemonth_freetrial",
                     "purchase_date": "2018-10-26T23:17:53Z"
                 ],
+                "pro_google_play": [
+                    "expires_date": "2100-08-30T02:40:36Z",
+                    "product_identifier": "onemonth_freetrial",
+                    "purchase_date": "2018-10-26T23:17:53Z"
+                ],
                 "expired_pro": [
                     "expires_date": BasicCustomerInfoTests.expiredSubscriptionDate,
                     "product_identifier": "onemonth",
@@ -876,13 +881,13 @@ class BasicCustomerInfoTests: TestCase {
 
     func testCopyWithNewRequestDateUpdatesEntitlements() throws {
         expect(self.customerInfo.activeSubscriptions).toNot(contain("onemonth"))
-        expect(self.customerInfo.entitlements.active).to(haveCount(2))
+        expect(self.customerInfo.entitlements.active).to(haveCount(3))
         expect(self.customerInfo.entitlements["expired_pro"]?.isActive) == false
 
         let newRequestTime = try Self.date(withDaysAgo: -2)
         let updatedCustomerInfo: CustomerInfo = self.customerInfo.copy(with: newRequestTime)
         expect(updatedCustomerInfo.activeSubscriptions).to(contain("onemonth"))
-        expect(updatedCustomerInfo.entitlements.active).to(haveCount(3))
+        expect(updatedCustomerInfo.entitlements.active).to(haveCount(4))
         expect(updatedCustomerInfo.entitlements["expired_pro"]?.isActive) == true
     }
 

--- a/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
@@ -54,6 +54,12 @@ class BasicCustomerInfoTests: TestCase {
                     "period_type": "normal",
                     "is_sandbox": false
                 ] as [String: Any],
+                "gold": [
+                    "expires_date": "2100-07-30T02:40:36Z",
+                    "period_type": "normal",
+                    "is_sandbox": false,
+                    "product_plan_identifier": "monthly"
+                ],
                 "onemonth": [
                     "expires_date": BasicCustomerInfoTests.expiredSubscriptionDate,
                     "period_type": "normal",
@@ -116,13 +122,14 @@ class BasicCustomerInfoTests: TestCase {
     }
 
     func testListActiveSubscriptions() {
-        expect(self.customerInfo.activeSubscriptions) == ["onemonth_freetrial"]
+        expect(self.customerInfo.activeSubscriptions) == ["onemonth_freetrial", "gold:monthly"]
     }
 
     func testAllPurchasedProductIdentifier() {
         let allPurchased = self.customerInfo.allPurchasedProductIdentifiers
 
-        expect(allPurchased) == ["onemonth", "onemonth_freetrial", "threemonth_freetrial", "onetime_purchase"]
+        expect(allPurchased) == ["onemonth", "onemonth_freetrial",
+                                 "threemonth_freetrial", "gold:monthly", "onetime_purchase"]
     }
 
     func testLatestExpirationDateHelper() {

--- a/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
+++ b/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
@@ -1354,6 +1354,28 @@ private extension EntitlementInfosTests {
         == (expectedEntitlementActive ? [identifier] : [])
     }
 
+    func verifyEntitlementActivePurchasedFromGooglePlay(
+        _ expectedEntitlementActive: Bool = true,
+        entitlement: String = "pro_cat",
+        productPlanIdentifier: String,
+        file: FileString = #file,
+        line: UInt = #line
+    ) throws {
+        let subscriberInfo = try CustomerInfo(data: self.response)
+        let proCat = try XCTUnwrap(subscriberInfo.entitlements[entitlement])
+
+        expect(file: file, line: line, proCat.identifier) == entitlement
+        expect(file: file, line: line, subscriberInfo.entitlements.all.keys.contains(entitlement)) == true
+        expect(file: file, line: line, subscriberInfo.entitlements.active.keys.contains(entitlement))
+        == expectedEntitlementActive
+        expect(file: file, line: line, proCat.isActive).to(
+            equal(expectedEntitlementActive),
+            description: expectedEntitlementActive
+            ? "Entitlement should be active"
+            : "Entitlement should not be active"
+        )
+    }
+
     func verifyRenewal(_ expectedWillRenew: Bool = true,
                        expectedUnsubscribeDetectedAt: Date? = nil,
                        expectedBillingIssueDetectedAt: Date? = nil,


### PR DESCRIPTION
### Motivation

Addresses https://github.com/RevenueCat/purchases-flutter/issues/692

### Description

Shows the product id as `<product>:<base_plan>` if the subscription was purchased from Google Play. This uses the `product_plan_identifier` that is returned with the subscription.
