### PR TITLE
`NetworkError.signatureVerificationFailed`: added status code to error `userInfo`

### DIFF
--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -64,13 +64,15 @@ enum ErrorUtils {
      */
     static func signatureVerificationFailedError(
         path: HTTPRequest.Path,
+        code: HTTPStatusCode,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
     ) -> PurchasesError {
         return error(
             with: .signatureVerificationFailed,
             message: "Request to \(path.relativePath) failed verification",
             extraUserInfo: [
-                "request_path": path.relativePath
+                "request_path": path.relativePath,
+                "status_code": code.rawValue
             ],
             fileName: fileName, functionName: functionName, line: line
         )

--- a/Sources/Networking/HTTPClient/NetworkError.swift
+++ b/Sources/Networking/HTTPClient/NetworkError.swift
@@ -25,7 +25,7 @@ enum NetworkError: Swift.Error, Equatable {
     case unableToCreateRequest(HTTPRequest.Path, Source)
     case unexpectedResponse(URLResponse?, Source)
     case errorResponse(ErrorResponse, HTTPStatusCode, Source)
-    case signatureVerificationFailed(HTTPRequest.Path, Source)
+    case signatureVerificationFailed(HTTPRequest.Path, HTTPStatusCode, Source)
 
 }
 
@@ -89,10 +89,12 @@ extension NetworkError {
 
     static func signatureVerificationFailed(
         path: HTTPRequest.Path,
+        code: HTTPStatusCode,
         file: String = #fileID, function: String = #function, line: UInt = #line
     ) -> Self {
         return .signatureVerificationFailed(
             path,
+            code,
             .init(file: file, function: function, line: line)
         )
     }
@@ -161,9 +163,10 @@ extension NetworkError: PurchasesErrorConvertible {
                                            function: source.function,
                                            line: source.line)
 
-        case let .signatureVerificationFailed(path, source):
+        case let .signatureVerificationFailed(path, code, source):
             return ErrorUtils.signatureVerificationFailedError(
                 path: path,
+                code: code,
                 fileName: source.file,
                 functionName: source.function,
                 line: source.line

--- a/Sources/Security/Signing+ResponseVerification.swift
+++ b/Sources/Security/Signing+ResponseVerification.swift
@@ -126,7 +126,7 @@ extension Result where Success == Data?, Failure == NetworkError {
             )
 
             if response.verificationResult == .failed, case .enforced = verificationMode {
-                return .failure(.signatureVerificationFailed(path: request.path))
+                return .failure(.signatureVerificationFailed(path: request.path, code: response.statusCode))
             } else {
                 return .success(response.mapBody(Optional.some))
             }

--- a/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
+++ b/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
@@ -85,7 +85,7 @@ class PurchasesDiagnosticsTests: TestCase {
     }
 
     func testFailingSignatureVerification() async throws {
-        let expectedError = ErrorUtils.signatureVerificationFailedError(path: .health)
+        let expectedError = ErrorUtils.signatureVerificationFailedError(path: .health, code: .success)
         self.purchases.mockedHealthRequestWithSignatureVerificationResponse = .failure(expectedError.asPublicError)
 
         do {

--- a/Tests/UnitTests/Networking/Backend/BackendSignatureVerificationTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendSignatureVerificationTests.swift
@@ -41,16 +41,18 @@ class BackendSignatureVerificationTests: BaseBackendTests {
     }
 
     func testRequestFailsIfSignatureVerificationFails() throws {
+        let expectedError: NetworkError = .signatureVerificationFailed(path: .health, code: .success)
+
         self.httpClient.mock(
             requestPath: .health,
-            response: .init(error: .signatureVerificationFailed(path: .health))
+            response: .init(error: expectedError)
         )
 
         let error = waitUntilValue { completed in
             self.internalAPI.healthRequest(signatureVerification: true, completion: completed)
         }
 
-        expect(error).to(matchError(BackendError.networkError(.signatureVerificationFailed(path: .health))))
+        expect(error).to(matchError(BackendError.networkError(expectedError)))
     }
 
 }

--- a/Tests/UnitTests/Networking/NetworkErrorTests.swift
+++ b/Tests/UnitTests/Networking/NetworkErrorTests.swift
@@ -312,7 +312,8 @@ class NetworkErrorTests: TestCase {
 
     private static let unexpectedResponseError: NetworkError = .unexpectedResponse(nil)
 
-    private static let signatureVerificationFailed: NetworkError = .signatureVerificationFailed(path: .health)
+    private static let signatureVerificationFailed: NetworkError = .signatureVerificationFailed(path: .health,
+                                                                                                code: .success)
 
     private static func responseError(_ statusCode: HTTPStatusCode) -> NetworkError {
         return .errorResponse(

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -533,7 +533,8 @@ final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificat
         }
 
         expect(response).to(beFailure())
-        expect(response?.error).to(matchError(NetworkError.signatureVerificationFailed(path: Self.path)))
+        expect(response?.error)
+            .to(matchError(NetworkError.signatureVerificationFailed(path: Self.path, code: .success)))
     }
 
     func testPerformRequestOverridesIt() throws {
@@ -548,7 +549,8 @@ final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificat
         }
 
         expect(response).to(beFailure())
-        expect(response?.error).to(matchError(NetworkError.signatureVerificationFailed(path: Self.path)))
+        expect(response?.error)
+            .to(matchError(NetworkError.signatureVerificationFailed(path: Self.path, code: .success)))
     }
 
     func testPerformRequestWithDisabledModeOverridesIt() throws {
@@ -576,7 +578,7 @@ final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificat
         }
 
         expect(response).to(beFailure())
-        expect(response?.error) == NetworkError.signatureVerificationFailed(path: Self.path)
+        expect(response?.error) == NetworkError.signatureVerificationFailed(path: Self.path, code: .success)
     }
 
     func testFakeSignatureFailuresInInformationalMode() throws {


### PR DESCRIPTION
I'm debugging a potential issue with signatures, so knowing whether the signature was invalid on a 200 or a 304 was important.
