### PR TITLE
`Signature Verification`: added test-only log for debugging invalid signatures

### DIFF
--- a/Sources/Logging/Strings/SigningStrings.swift
+++ b/Sources/Logging/Strings/SigningStrings.swift
@@ -26,6 +26,10 @@ enum SigningStrings {
 
     case request_date_missing_from_headers(HTTPRequest)
 
+    #if DEBUG
+    case invalid_signature_data(HTTPRequest, Data, HTTPClient.ResponseHeaders, HTTPStatusCode)
+    #endif
+
 }
 
 extension SigningStrings: LogMessage {
@@ -48,6 +52,19 @@ extension SigningStrings: LogMessage {
         case let .signature_was_requested_but_not_provided(request):
             return "Request to '\(request.path)' required a signature but none was provided. " +
             "This will be reported as a verification failure."
+
+        #if DEBUG
+        case let .invalid_signature_data(request, data, responseHeaders, statusCode):
+            return """
+            INVALID SIGNATURE DETECTED:
+            Request: \(request.method.httpMethod) \(request.path)
+            Response: \(statusCode.rawValue)
+            \(responseHeaders.stringRepresentation)
+            Headers: \(responseHeaders.map { "\($0.key.base): \($0.value)" })
+            Body (length: \(data.count)): \(data.hashString)
+            """
+
+        #endif
         }
     }
 

--- a/Sources/Security/Signing+ResponseVerification.swift
+++ b/Sources/Security/Signing+ResponseVerification.swift
@@ -35,21 +35,28 @@ extension HTTPResponse where Body == Data {
                        publicKey: Signing.PublicKey?,
                        signing: SigningType.Type = Signing.self) -> Self {
         let requestDate = Self.parseRequestDate(headers: headers)
+        let verificationResult = Self.verificationResult(
+            body: body,
+            statusCode: statusCode,
+            headers: headers,
+            requestDate: requestDate,
+            request: request,
+            publicKey: publicKey,
+            signing: signing
+        )
+
+        #if DEBUG
+        if verificationResult == .failed, ProcessInfo.isRunningRevenueCatTests {
+            Logger.warn(Strings.signing.invalid_signature_data(request, body, headers, statusCode))
+        }
+        #endif
 
         return .init(
             statusCode: statusCode,
             responseHeaders: headers,
             body: body,
             requestDate: requestDate,
-            verificationResult: Self.verificationResult(
-                body: body,
-                statusCode: statusCode,
-                headers: headers,
-                requestDate: requestDate,
-                request: request,
-                publicKey: publicKey,
-                signing: signing
-            )
+            verificationResult: verificationResult
         )
     }
 


### PR DESCRIPTION
I've been debugging a signature problem in an integration test, and this has been helpful.
