### PR TITLE
`ErrorResponse`: drastically improved error messages, no more "unknown error"s

### DIFF
--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -20,6 +20,7 @@ enum NetworkStrings {
     case api_request_started(HTTPRequest)
     case api_request_completed(_ request: HTTPRequest, httpCode: HTTPStatusCode)
     case api_request_failed(_ request: HTTPRequest, httpCode: HTTPStatusCode?, error: NetworkError)
+    case api_request_failed_status_code(HTTPStatusCode)
     case reusing_existing_request_for_operation(CacheableNetworkOperation.Type, String)
     case creating_json_error(error: String)
     case json_data_received(dataString: String)
@@ -54,6 +55,9 @@ extension NetworkStrings: LogMessage {
         case let .api_request_failed(request, statusCode, error):
             return "API request failed: \(request.description) (\(statusCode?.rawValue.description ?? "<>")): " +
             "\(error.description)"
+
+        case let .api_request_failed_status_code(statusCode):
+            return "API request failed with status code \(statusCode.rawValue)"
 
         case let .reusing_existing_request_for_operation(operationType, cacheKey):
             return "Network operation '\(operationType)' found with the same cache key " +

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -358,11 +358,10 @@ private extension HTTPClient {
         let urlRequest = self.convert(request: request.adding(defaultHeaders: self.defaultHeaders))
 
         guard let urlRequest = urlRequest else {
-            Logger.error("Could not create request to \(request.path)")
+            let error: NetworkError = .unableToCreateRequest(request.httpRequest.path)
 
-            request.completionHandler?(
-                .failure(.unableToCreateRequest(request.httpRequest.path))
-            )
+            Logger.error(error.description)
+            request.completionHandler?(.failure(error))
             return
         }
 

--- a/Sources/Networking/HTTPClient/HTTPResponse.swift
+++ b/Sources/Networking/HTTPClient/HTTPResponse.swift
@@ -140,10 +140,13 @@ extension ErrorResponse {
             userInfo[.attributeErrors] = self.attributeErrors as NSDictionary
         }
 
+        // If the backend didn't provide a message we default to showing the status code.
+        let errorMessage = self.message ?? Strings.network.api_request_failed_status_code(statusCode).description
+
         let message: String? = self.code != .unknownBackendError
-            ? self.message
+            ? errorMessage
             : [
-                self.message,
+                errorMessage,
                 // Append original error code if we couldn't map it to a value.
                 "(\(self.originalCode))"
             ]

--- a/Sources/Networking/HTTPClient/NetworkError.swift
+++ b/Sources/Networking/HTTPClient/NetworkError.swift
@@ -176,7 +176,47 @@ extension NetworkError: PurchasesErrorConvertible {
 
 }
 
-extension NetworkError: DescribableError {}
+extension NetworkError: DescribableError {
+
+    var description: String {
+        switch self {
+        case let .decoding(error, _):
+            return error.localizedDescription
+
+        case .offlineConnection:
+            return ErrorCode.offlineConnectionError.description
+
+        case let .networkError(error, _):
+            return error.localizedDescription
+
+        case let .dnsError(failedURL, resolvedHost, _):
+            return NetworkStrings.blocked_network(url: failedURL, newHost: resolvedHost).description
+
+        case let .unableToCreateRequest(path, _):
+            return "Could not create request to \(path)"
+
+        case let .unexpectedResponse(response, _):
+            return "Unexpected response type: \(response.debugDescription)"
+
+        case .errorResponse:
+            return self.asPurchasesError.localizedDescription
+
+        case .signatureVerificationFailed:
+            return self.asPurchasesError.localizedDescription
+        }
+    }
+
+}
+
+extension NetworkError: CustomNSError {
+
+    var errorUserInfo: [String: Any] {
+        return [
+            NSLocalizedDescriptionKey: self.description
+        ]
+    }
+
+}
 
 extension NetworkError {
 

--- a/Tests/UnitTests/Networking/BaseErrorTests.swift
+++ b/Tests/UnitTests/Networking/BaseErrorTests.swift
@@ -26,6 +26,7 @@ class BaseErrorTests: TestCase {
         expectedCode: ErrorCode,
         underlyingError: Error? = nil,
         userInfoKeys: [NSError.UserInfoKey]? = nil,
+        localizedDescription: String? = nil,
         file: FileString = #file, line: UInt = #line
     ) {
         let nsError = error.asPurchasesError as NSError
@@ -53,7 +54,20 @@ class BaseErrorTests: TestCase {
         }
 
         if let userInfoKeys = userInfoKeys {
-            expect(nsError.userInfo.keys).to(contain(userInfoKeys as [String]))
+            expect(
+                file: file, line: line,
+                nsError.userInfo.keys
+            ).to(contain(userInfoKeys as [String]))
+        }
+
+        if let localizedDescription = localizedDescription {
+            expect(
+                file: file, line: line,
+                // Testing description of the error directly.
+                // This ensures that converting `error as NSError` also produces a good description
+                // and not just "The operation couldn’t be completed."
+                error.localizedDescription
+            ) == localizedDescription
         }
     }
 


### PR DESCRIPTION
## Description:

We've gotten several reports with error messages that aren't very helpful, like #2390.

Turns out that whenever the API returned a non-successful response but without an error code, we always produced _"unknown error"_.
This improves the behavior to default to showing the status code. One example that was very obvious is setting up the SDK with an invalid API key.

## Examples:

### `OfferingsManager.Error`:

- Before:
```
[Purchases] - ERROR: 🍎‼️ Error fetching offerings - The operation couldn’t be completed. (RevenueCat.OfferingsManager.Error error 0.)
Underlying error: The operation couldn’t be completed. (RevenueCat.NetworkError error 6.)
```

- After:
```
[Purchases] - ERROR: 🍎‼️ Error fetching offerings - The operation couldn’t be completed. (RevenueCat.OfferingsManager.Error error 0.)
Underlying error: Unknown error. API request failed with status code 401
```

### `BackendError`:
- Before:
```
[Purchases] - ERROR: 😿‼️ Unknown error.
```

- After:
```
[Purchases] - ERROR: 😿‼️ Unknown error. API request failed with status code 401
```

### Request debug logs:
- Before:
```
[Purchases] - DEBUG: ℹ️ API request failed: GET /v1/subscribers/$RCAnonymousID:988f9b85609b4a57af255750bec1fbb2/offerings: Unknown error.
```
- After:
```
[Purchases] - DEBUG: ℹ️ API request failed: GET /v1/subscribers/$RCAnonymousID:988f9b85609b4a57af255750bec1fbb2/offerings: Unknown error. API request failed with status code 401
```

### `CustomerInfoManager`:
- Before:
```
[Purchases] - WARN: ⚠️ Attempt to update CustomerInfo from network failed.
The operation couldn’t be completed. (RevenueCat.BackendError error 0.)
Underlying error: Unknown error
```

- After:
```
[Purchases] - WARN: ⚠️ Attempt to update CustomerInfo from network failed.
The operation couldn’t be completed. (RevenueCat.BackendError error 0.)
Underlying error: Unknown error. API request failed with status code 401
```