### PR TITLE
Documented `HTTPStatusCode.isSuccessfullySynced`

### DIFF
--- a/Sources/Networking/HTTPClient/HTTPStatusCode.swift
+++ b/Sources/Networking/HTTPClient/HTTPStatusCode.swift
@@ -22,6 +22,7 @@ enum HTTPStatusCode {
     case notModified
     case temporaryRedirect
     case invalidRequest
+    case unauthorized
     case notFoundError
     case internalServerError
     case networkConnectTimeoutError
@@ -35,6 +36,7 @@ enum HTTPStatusCode {
         .notModified,
         .temporaryRedirect,
         .invalidRequest,
+        .unauthorized,
         .notFoundError,
         .internalServerError,
         .networkConnectTimeoutError
@@ -56,6 +58,7 @@ extension HTTPStatusCode: RawRepresentable {
         case .notModified: return 304
         case .temporaryRedirect: return 307
         case .invalidRequest: return 400
+        case .unauthorized: return 401
         case .notFoundError: return 404
         case .internalServerError: return 500
         case .networkConnectTimeoutError: return 599
@@ -88,7 +91,12 @@ extension HTTPStatusCode {
         return 500...599 ~= self.rawValue
     }
 
+    /// Used to determine if we can consider subscriber attributes as synced.
+    /// - Note: whether to finish transactions is determined based on `isServerError` instead.
     var isSuccessfullySynced: Bool {
+        // Note: this means that all 4xx (except 404) are considered as successfully synced.
+        // The reason is because it's likely due to a client error, so continuing to retry
+        // won't yield any different results and instead kill pandas.
         return !(self.isServerError || self == .notFoundError)
     }
 

--- a/Tests/UnitTests/Networking/HTTPStatusCodeTests.swift
+++ b/Tests/UnitTests/Networking/HTTPStatusCodeTests.swift
@@ -57,6 +57,7 @@ class HTTPStatusCodeTests: TestCase {
 
     func testIsNotSuccessfulResponse() {
         expect(HTTPStatusCode.invalidRequest.isSuccessfulResponse) == false
+        expect(HTTPStatusCode.unauthorized.isSuccessfulResponse) == false
         expect(HTTPStatusCode.notFoundError.isSuccessfulResponse) == false
         expect(HTTPStatusCode.internalServerError.isSuccessfulResponse) == false
         expect(HTTPStatusCode.networkConnectTimeoutError.isSuccessfulResponse) == false
@@ -76,6 +77,7 @@ class HTTPStatusCodeTests: TestCase {
         expect(HTTPStatusCode.notModified.isServerError) == false
         expect(HTTPStatusCode.temporaryRedirect.isServerError) == false
         expect(HTTPStatusCode.invalidRequest.isServerError) == false
+        expect(HTTPStatusCode.unauthorized.isServerError) == false
         expect(HTTPStatusCode.notFoundError.isServerError) == false
         expect(status(100).isServerError) == false
         expect(status(202).isServerError) == false
@@ -91,6 +93,7 @@ class HTTPStatusCodeTests: TestCase {
         expect(HTTPStatusCode.notModified.isSuccessfullySynced) == true
         expect(HTTPStatusCode.temporaryRedirect.isSuccessfullySynced) == true
         expect(HTTPStatusCode.invalidRequest.isSuccessfullySynced) == true
+        expect(HTTPStatusCode.unauthorized.isSuccessfullySynced) == true
         expect(status(100).isSuccessfullySynced) == true
         expect(status(202).isSuccessfullySynced) == true
         expect(status(226).isSuccessfullySynced) == true

--- a/Tests/UnitTests/Networking/NetworkErrorTests.swift
+++ b/Tests/UnitTests/Networking/NetworkErrorTests.swift
@@ -167,6 +167,7 @@ class NetworkErrorTests: TestCase {
 
     func testSuccessfullySyncedTrue() {
         let errors = [
+            error(Self.responseError(.unauthorized)),
             error(Self.responseError(.invalidRequest)),
             error(Self.responseError(.notModified)),
             error(Self.responseError(.success))


### PR DESCRIPTION
Adding this new `HTTPStatusCode.unauthorized` has exposed the fact that we were treating all `4xx` as "successfully synced".
