### PR TITLE
`MainThreadMonitor`: increased threshold

### DIFF
--- a/Tests/BackendIntegrationTests/MainThreadMonitor.swift
+++ b/Tests/BackendIntegrationTests/MainThreadMonitor.swift
@@ -52,7 +52,7 @@ final class MainThreadMonitor {
         }
     }
 
-    private static let threshold: DispatchTimeInterval = .seconds(5)
+    private static let threshold: DispatchTimeInterval = .seconds(30)
 
 }
 


### PR DESCRIPTION
See also #2517.

We keep getting flaky failures with this in CI, which is annoying because it marks the whole test run as failed and it doesn't retry.
The reason for that is because we have to use `fatalError` and can't use `fail()` because this detection has to happen outside the main thread.
If the main thread is blocked, well, we can't rely `XCTest` to run in the main thread.

Ultimately, we can't guarantee that CI machines will be fast enough to ensure they don't get blocked.
The purpose of this class was to detect deadlocks. By increasing it to 30 seconds, we pretty much avoid flaky failures for slow CI machines, but still have the ability to detect if the main thread is deadlocked due to a locking issue.
