### PR TITLE
`LoadShedderIntegrationTests`: verify requests are actually handled by load shedder

### DIFF
--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -34,6 +34,7 @@ enum NetworkStrings {
     case blocked_network(url: URL, newHost: String?)
     case api_request_redirect(from: URL, to: URL)
     case operation_state(NetworkOperation.Type, state: String)
+    case request_handled_by_load_shedder(HTTPRequest.Path)
 
     #if DEBUG
     case api_request_forcing_server_error(HTTPRequest)
@@ -102,6 +103,9 @@ extension NetworkStrings: LogMessage {
 
         case let .operation_state(operation, state):
             return "\(operation): \(state)"
+
+        case let .request_handled_by_load_shedder(path):
+            return "Request was handled by load shedder: \(path.description)"
 
         #if DEBUG
         case let .api_request_forcing_server_error(request):

--- a/Sources/Networking/HTTPClient/ETagManager.swift
+++ b/Sources/Networking/HTTPClient/ETagManager.swift
@@ -84,6 +84,8 @@ class ETagManager {
             .compactMapValues { $0 }
     }
 
+    /// - Returns: `response` if a cached response couldn't be fetched,
+    /// or the cached `HTTPResponse`, always including the headers in `response`.
     func httpResultFromCacheOrBackend(with response: HTTPResponse<Data?>,
                                       request: URLRequest,
                                       retried: Bool) -> HTTPResponse<Data>? {

--- a/Sources/Networking/HTTPClient/ETagManager.swift
+++ b/Sources/Networking/HTTPClient/ETagManager.swift
@@ -99,7 +99,8 @@ class ETagManager {
                 let newResponse = storedResponse.withUpdatedValidationTime()
 
                 self.storeIfPossible(newResponse, for: request)
-                return newResponse.asResponse(withRequestDate: response.requestDate)
+                return newResponse.asResponse(withRequestDate: response.requestDate,
+                                              headers: response.responseHeaders)
             }
             if retried {
                 Logger.warn(
@@ -146,10 +147,6 @@ private extension ETagManager {
 
             return nil
         }
-    }
-
-    func storedHTTPResponse(for request: URLRequest, withRequestDate requestDate: Date?) -> HTTPResponse<Data>? {
-        return self.storedETagAndResponse(for: request)?.asResponse(withRequestDate: requestDate)
     }
 
     func storeStatusCodeAndResponseIfNoError(for request: URLRequest,
@@ -246,10 +243,13 @@ extension ETagManager.Response {
         return try? JSONEncoder.default.encode(self)
     }
 
-    fileprivate func asResponse(withRequestDate requestDate: Date?) -> HTTPResponse<Data> {
+    fileprivate func asResponse(
+        withRequestDate requestDate: Date?,
+        headers: HTTPClient.ResponseHeaders
+    ) -> HTTPResponse<Data> {
         return HTTPResponse(
             statusCode: self.statusCode,
-            responseHeaders: [:],
+            responseHeaders: headers,
             body: self.data,
             requestDate: requestDate,
             verificationResult: self.verificationResult

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -112,6 +112,7 @@ extension HTTPClient {
         case signature = "X-Signature"
         case requestDate = "X-RevenueCat-Request-Time"
         case contentType = "Content-Type"
+        case isLoadShedder = "X-RevenueCat-Fortress"
 
     }
 
@@ -319,6 +320,11 @@ private extension HTTPClient {
                     // If that can't be extracted, get status code from the parsed response.
                     httpCode: urlResponse?.httpStatusCode ?? response.statusCode
                 ))
+
+                if response.isLoadShedder {
+                    Logger.debug(Strings.network.request_handled_by_load_shedder(request.httpRequest.path))
+                }
+
             case let .failure(error):
                 Logger.debug(Strings.network.api_request_failed(request.httpRequest,
                                                                 httpCode: urlResponse?.httpStatusCode,
@@ -528,6 +534,10 @@ private extension HTTPResponse {
         return self.mapBody {
             return $0.copy(with: requestDate)
         }
+    }
+
+    var isLoadShedder: Bool {
+        return self.value(forHeaderField: HTTPClient.ResponseHeader.isLoadShedder.rawValue) == "true"
     }
 
 }

--- a/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
@@ -32,6 +32,14 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
         try await Purchases.shared.healthRequest(signatureVerification: true)
     }
 
+    func testHandledByProductionServer() async throws {
+        let logger = TestLogHandler()
+
+        try await Purchases.shared.healthRequest(signatureVerification: false)
+
+        logger.verifyMessageWasNotLogged(Strings.network.request_handled_by_load_shedder(.health))
+    }
+
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testProductEntitlementMapping() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()

--- a/Tests/UnitTests/Networking/ETagManagerTests.swift
+++ b/Tests/UnitTests/Networking/ETagManagerTests.swift
@@ -45,17 +45,22 @@ class ETagManagerTests: TestCase {
         let request = URLRequest(url: Self.testURL)
         let cachedResponse = self.mockStoredETagResponse(for: Self.testURL, statusCode: .success, eTag: eTag)
 
-        let response = self.eTagManager.httpResultFromCacheOrBackend(
-            with: self.responseForTest(url: Self.testURL,
-                                       body: nil,
-                                       eTag: eTag,
-                                       statusCode: .notModified),
-            request: request,
-            retried: false
+        let response = try XCTUnwrap(
+            self.eTagManager.httpResultFromCacheOrBackend(
+                with: self.responseForTest(url: Self.testURL,
+                                           body: nil,
+                                           eTag: eTag,
+                                           statusCode: .notModified),
+                request: request,
+                retried: false
+            )
         )
-        expect(response).toNot(beNil())
-        expect(response?.statusCode) == .success
-        expect(response?.body) == cachedResponse
+
+        expect(response.statusCode) == .success
+        expect(response.body) == cachedResponse
+        expect(response.responseHeaders).toNot(beEmpty())
+        expect(Set(response.responseHeaders.keys.compactMap { $0 as? String }))
+        == Set(self.getHeaders(eTag: eTag).keys)
     }
 
     func testValidationTimeIsUpdatedWhenUsingStoredResponse() throws {


### PR DESCRIPTION
This is important to avoid false positives if the API key redirect stops working.