### PR TITLE
Fixed `HTTPResponse.description`

### DIFF
--- a/Sources/Networking/HTTPClient/HTTPResponse.swift
+++ b/Sources/Networking/HTTPClient/HTTPResponse.swift
@@ -41,10 +41,10 @@ extension HTTPResponse: CustomStringConvertible {
         }()
 
         return """
-        HTTPResponse(" +
-        statusCode: \(self.statusCode.rawValue),
-        body: \(body),
-        verification: \(self.verificationResult)
+        HTTPResponse(
+            statusCode: \(self.statusCode.rawValue),
+            body: \(body),
+            verification: \(self.verificationResult)
         )
         """
     }


### PR DESCRIPTION
Probably a bad conversion to multiline string. It had a leftover `" +`
