### PR TITLE
`ETagManager`: add API key to `ETag` content

### DIFF
--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -99,7 +99,6 @@ extension HTTPClient {
     enum RequestHeader: String {
 
         case authorization = "Authorization"
-        case location = "Location"
         case nonce = "X-Nonce"
         case eTag = "X-RevenueCat-ETag"
         case eTagValidationTime = "X-RC-Last-Refresh-Time"
@@ -109,6 +108,7 @@ extension HTTPClient {
     enum ResponseHeader: String {
 
         case eTag = "X-RevenueCat-ETag"
+        case location = "Location"
         case signature = "X-Signature"
         case requestDate = "X-RevenueCat-Request-Time"
         case contentType = "Content-Type"

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1388,7 +1388,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
                 data: .init(),
                 statusCode: .temporaryRedirect,
                 headers: [
-                    HTTPClient.RequestHeader.location.rawValue: pathB.url!.absoluteString
+                    HTTPClient.ResponseHeader.location.rawValue: pathB.url!.absoluteString
                 ]
             )
         }


### PR DESCRIPTION
This fixes the following scenario:

- User makes initial requests with invalid API key
- 401 response
- We store that response (`ErrorResponse`)
- User fixes the API key
- Server returns 304
- We return the cached body for the `ErrorResponse`

This is a proposed fix for COIN-595. Instead of this, we might want to ensure that 401 responses don't return etags.
