### PR TITLE
`ETagManager.httpResultFromCacheOrBackend`: return response headers

### DIFF
--- a/Sources/Networking/HTTPClient/ETagManager.swift
+++ b/Sources/Networking/HTTPClient/ETagManager.swift
@@ -84,6 +84,8 @@ class ETagManager {
             .compactMapValues { $0 }
     }
 
+    /// - Returns: `response` if a cached response couldn't be fetched,
+    /// or the cached `HTTPResponse`, always including the headers in `response`.
     func httpResultFromCacheOrBackend(with response: HTTPResponse<Data?>,
                                       request: URLRequest,
                                       retried: Bool) -> HTTPResponse<Data>? {

--- a/Sources/Networking/HTTPClient/ETagManager.swift
+++ b/Sources/Networking/HTTPClient/ETagManager.swift
@@ -99,7 +99,8 @@ class ETagManager {
                 let newResponse = storedResponse.withUpdatedValidationTime()
 
                 self.storeIfPossible(newResponse, for: request)
-                return newResponse.asResponse(withRequestDate: response.requestDate)
+                return newResponse.asResponse(withRequestDate: response.requestDate,
+                                              headers: response.responseHeaders)
             }
             if retried {
                 Logger.warn(
@@ -146,10 +147,6 @@ private extension ETagManager {
 
             return nil
         }
-    }
-
-    func storedHTTPResponse(for request: URLRequest, withRequestDate requestDate: Date?) -> HTTPResponse<Data>? {
-        return self.storedETagAndResponse(for: request)?.asResponse(withRequestDate: requestDate)
     }
 
     func storeStatusCodeAndResponseIfNoError(for request: URLRequest,
@@ -246,10 +243,13 @@ extension ETagManager.Response {
         return try? JSONEncoder.default.encode(self)
     }
 
-    fileprivate func asResponse(withRequestDate requestDate: Date?) -> HTTPResponse<Data> {
+    fileprivate func asResponse(
+        withRequestDate requestDate: Date?,
+        headers: HTTPClient.ResponseHeaders
+    ) -> HTTPResponse<Data> {
         return HTTPResponse(
             statusCode: self.statusCode,
-            responseHeaders: [:],
+            responseHeaders: headers,
             body: self.data,
             requestDate: requestDate,
             verificationResult: self.verificationResult

--- a/Tests/UnitTests/Networking/ETagManagerTests.swift
+++ b/Tests/UnitTests/Networking/ETagManagerTests.swift
@@ -45,17 +45,22 @@ class ETagManagerTests: TestCase {
         let request = URLRequest(url: Self.testURL)
         let cachedResponse = self.mockStoredETagResponse(for: Self.testURL, statusCode: .success, eTag: eTag)
 
-        let response = self.eTagManager.httpResultFromCacheOrBackend(
-            with: self.responseForTest(url: Self.testURL,
-                                       body: nil,
-                                       eTag: eTag,
-                                       statusCode: .notModified),
-            request: request,
-            retried: false
+        let response = try XCTUnwrap(
+            self.eTagManager.httpResultFromCacheOrBackend(
+                with: self.responseForTest(url: Self.testURL,
+                                           body: nil,
+                                           eTag: eTag,
+                                           statusCode: .notModified),
+                request: request,
+                retried: false
+            )
         )
-        expect(response).toNot(beNil())
-        expect(response?.statusCode) == .success
-        expect(response?.body) == cachedResponse
+
+        expect(response.statusCode) == .success
+        expect(response.body) == cachedResponse
+        expect(response.responseHeaders).toNot(beEmpty())
+        expect(Set(response.responseHeaders.keys.compactMap { $0 as? String }))
+        == Set(self.getHeaders(eTag: eTag).keys)
     }
 
     func testValidationTimeIsUpdatedWhenUsingStoredResponse() throws {


### PR DESCRIPTION
When working on #2663, the new `isLoadShedder` was not getting the right value for 304 responses because we were returning `[:]`, since we don't store headers in `ETagManager`.
