### PR TITLE
`HTTPClient`: disable `URLSession` cache

### DIFF
--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -42,6 +42,7 @@ class HTTPClient {
         config.httpMaximumConnectionsPerHost = 1
         config.timeoutIntervalForRequest = requestTimeout
         config.timeoutIntervalForResource = requestTimeout
+        config.urlCache = nil // We implement our own caching with `ETagManager`.
         self.session = URLSession(configuration: config,
                                   delegate: RedirectLoggerSessionDelegate(),
                                   delegateQueue: nil)


### PR DESCRIPTION
Turns out this was breaking an HTTP 304 integration test in #2659. I'm very confused why we hadn't seen it before.

Possibly it didn't matter for normal requests, but it was breaking signature verification because the `nonce` was different on the new request, and therefore it wouldn't match the cached signature.
