### PR TITLE
`HTTPClient`: improved log for failed requests

### DIFF
--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -19,7 +19,7 @@ enum NetworkStrings {
 
     case api_request_started(HTTPRequest)
     case api_request_completed(_ request: HTTPRequest, httpCode: HTTPStatusCode)
-    case api_request_failed(_ request: HTTPRequest, error: NetworkError)
+    case api_request_failed(_ request: HTTPRequest, httpCode: HTTPStatusCode?, error: NetworkError)
     case reusing_existing_request_for_operation(CacheableNetworkOperation.Type, String)
     case creating_json_error(error: String)
     case json_data_received(dataString: String)
@@ -53,8 +53,9 @@ extension NetworkStrings: LogMessage {
         case let .api_request_completed(request, httpCode):
             return "API request completed: \(request.description) (\(httpCode.rawValue))"
 
-        case let .api_request_failed(request, error):
-            return "API request failed: \(request.description): \(error.description)"
+        case let .api_request_failed(request, statusCode, error):
+            return "API request failed: \(request.description) (\(statusCode?.rawValue.description ?? "<>")): " +
+            "\(error.description)"
 
         case let .reusing_existing_request_for_operation(operationType, cacheKey):
             return "Network operation '\(operationType)' found with the same cache key " +

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -320,7 +320,9 @@ private extension HTTPClient {
                     httpCode: urlResponse?.httpStatusCode ?? response.statusCode
                 ))
             case let .failure(error):
-                Logger.debug(Strings.network.api_request_failed(request.httpRequest, error: error))
+                Logger.debug(Strings.network.api_request_failed(request.httpRequest,
+                                                                httpCode: urlResponse?.httpStatusCode,
+                                                                error: error))
             }
 
             request.completionHandler?(response)


### PR DESCRIPTION
Changed this log:
```
[network] DEBUG: ℹ️ API request failed: GET /v1/subscribers/17571811-B0A4-49DC-B326-572E602BF195: Request failed signature verification.
```

To this:
```
[network] DEBUG: ℹ️ API request failed: GET /v1/subscribers/BD9F38FF-33C6-4A77-86F7-6AEA92E6717D (200): Request failed signature verification.
```

This was useful when debugging #2668 and #2659.
