### PR TITLE
`CI`: changed `Codecov` to `informational`

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        informational: true


### PR DESCRIPTION
For some PRs where we only change a few lines, we sometimes get failures (example: #2668).
It's extra noise, since we're only using coverage data as information.

See documentation: https://docs.codecov.com/docs/codecovyml-reference
