### PR TITLE
`ETagManager`: refactored e-tag creation and tests

### DIFF
--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -100,7 +100,6 @@ extension HTTPClient {
     enum RequestHeader: String {
 
         case authorization = "Authorization"
-        case location = "Location"
         case nonce = "X-Nonce"
         case eTag = "X-RevenueCat-ETag"
         case eTagValidationTime = "X-RC-Last-Refresh-Time"
@@ -110,6 +109,7 @@ extension HTTPClient {
     enum ResponseHeader: String {
 
         case eTag = "X-RevenueCat-ETag"
+        case location = "Location"
         case signature = "X-Signature"
         case requestDate = "X-RevenueCat-Request-Time"
         case contentType = "Content-Type"

--- a/Tests/UnitTests/Networking/ETagManagerTests.swift
+++ b/Tests/UnitTests/Networking/ETagManagerTests.swift
@@ -209,7 +209,7 @@ class ETagManagerTests: TestCase {
     func testResponseIsStoredIfResponseCodeIs200AndVerificationSucceded() throws {
         let request = URLRequest(url: Self.testURL)
         let cacheKey = try request.cacheKey
-        
+
         let responseObject = try JSONSerialization.data(withJSONObject: ["a": "response"])
         let response = self.eTagManager.httpResultFromCacheOrBackend(
             with: self.responseForTest(
@@ -781,8 +781,7 @@ private extension ETagManagerTests {
                                 statusCode: HTTPStatusCode = .success,
                                 validationTime: Date? = nil,
                                 verificationResult: RevenueCat.VerificationResult = .defaultValue) throws -> Data {
-        // swiftlint:disable:next force_try
-        let data = try! JSONSerialization.data(withJSONObject: ["arg": "value"])
+        let data = try JSONSerialization.data(withJSONObject: ["arg": "value"])
 
         let etagAndResponse = ETagManager.Response(
             eTag: Self.testETag,
@@ -791,7 +790,7 @@ private extension ETagManagerTests {
             validationTime: validationTime,
             verificationResult: verificationResult
         )
-        self.mockUserDefaults.mockValues[try request.cacheKey] = etagAndResponse.asData()!
+        self.mockUserDefaults.mockValues[try request.cacheKey] = try XCTUnwrap(etagAndResponse.asData())
 
         return data
     }

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1394,7 +1394,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
                 data: .init(),
                 statusCode: .temporaryRedirect,
                 headers: [
-                    HTTPClient.RequestHeader.location.rawValue: pathB.url!.absoluteString
+                    HTTPClient.ResponseHeader.location.rawValue: pathB.url!.absoluteString
                 ]
             )
         }


### PR DESCRIPTION
We had lots of different parts of the code doing `request.url?.absoluteString` and also using different values for e-tags.
This refactor combines all that to use a single `eTag(for:)` method.

I did this as part of #2665, which is getting closed, but it will still be useful if we ever decide to change the content of e-tags.
