### PR TITLE
[WIP] `Configuration`: added parameter to allow overriding `Bundle`

### DIFF
--- a/Sources/Logging/Strings/ConfigureStrings.swift
+++ b/Sources/Logging/Strings/ConfigureStrings.swift
@@ -59,6 +59,8 @@ enum ConfigureStrings {
 
     case using_custom_user_defaults
 
+    case using_custom_bundle
+
     case using_user_defaults_standard
 
     case using_user_defaults_suite_name
@@ -154,6 +156,9 @@ extension ConfigureStrings: LogMessage {
 
         case .using_custom_user_defaults:
             return "Configuring SDK using provided UserDefaults."
+
+        case .using_custom_bundle:
+            return "Configuring SDK using provided Bundle."
 
         case .using_user_defaults_standard:
             return "Configuring SDK using UserDefaults.standard because we found existing data in it."

--- a/Sources/Misc/Deprecations.swift
+++ b/Sources/Misc/Deprecations.swift
@@ -116,6 +116,7 @@ public extension Purchases {
             appUserID: appUserID,
             observerMode: observerMode,
             userDefaults: userDefaults,
+            bundle: nil,
             platformInfo: nil,
             responseVerificationMode: .default,
             storeKit2Setting: .init(useStoreKit2IfAvailable: useStoreKit2IfAvailable),

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -113,14 +113,14 @@ class SystemInfo {
     init(platformInfo: Purchases.PlatformInfo?,
          finishTransactions: Bool,
          operationDispatcher: OperationDispatcher = .default,
-         bundle: Bundle = .main,
+         bundle: Bundle? = nil,
          sandboxEnvironmentDetector: SandboxEnvironmentDetector = BundleSandboxEnvironmentDetector.default,
          storeKit2Setting: StoreKit2Setting = .default,
          responseVerificationMode: Signing.ResponseVerificationMode = .default,
          dangerousSettings: DangerousSettings? = nil) throws {
         self.platformFlavor = platformInfo?.flavor ?? "native"
         self.platformFlavorVersion = platformInfo?.version
-        self._bundle = .init(bundle)
+        self._bundle = .init(bundle ?? .main)
 
         self._finishTransactions = .init(finishTransactions)
         self.operationDispatcher = operationDispatcher

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -44,6 +44,7 @@ import Foundation
     let appUserID: String?
     let observerMode: Bool
     let userDefaults: UserDefaults?
+    let bundle: Bundle?
     let storeKit2Setting: StoreKit2Setting
     let dangerousSettings: DangerousSettings?
     let networkTimeout: TimeInterval
@@ -58,6 +59,7 @@ import Foundation
         self.appUserID = builder.appUserID
         self.observerMode = builder.observerMode
         self.userDefaults = builder.userDefaults
+        self.bundle = builder.bundle
         self.storeKit2Setting = builder.storeKit2Setting
         self.dangerousSettings = builder.dangerousSettings
         self.storeKit1Timeout = builder.storeKit1Timeout
@@ -81,6 +83,7 @@ import Foundation
 
         private(set) var apiKey: String
         private(set) var appUserID: String?
+        private(set) var bundle: Bundle?
         private(set) var observerMode: Bool = false
         private(set) var userDefaults: UserDefaults?
         private(set) var dangerousSettings: DangerousSettings?
@@ -141,6 +144,17 @@ import Foundation
          */
         @objc public func with(userDefaults: UserDefaults) -> Builder {
             self.userDefaults = userDefaults
+            return self
+        }
+
+        /**
+         * Set the app `bundle` to configure the SDK with.
+         * - Note: This should only be overriden if you're configuring the SDK from a different target
+         * than the one containing the App Store receipt.
+         * For example, when configuring the SDK from a Safari extension.
+         */
+        @objc public func with(bundle: Bundle) -> Builder {
+            self.bundle = bundle
             return self
         }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -253,6 +253,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     convenience init(apiKey: String,
                      appUserID: String?,
                      userDefaults: UserDefaults? = nil,
+                     bundle: Bundle? = nil,
                      observerMode: Bool = false,
                      platformInfo: PlatformInfo? = Purchases.platformInfo,
                      responseVerificationMode: Signing.ResponseVerificationMode,
@@ -264,6 +265,10 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             Logger.debug(Strings.configure.using_custom_user_defaults)
         }
 
+        if bundle != nil {
+            Logger.debug(Strings.configure.using_custom_bundle)
+        }
+
         let operationDispatcher: OperationDispatcher = .default
         let receiptRefreshRequestFactory = ReceiptRefreshRequestFactory()
         let fetcher = StoreKitRequestFetcher(requestFactory: receiptRefreshRequestFactory,
@@ -273,6 +278,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             systemInfo = try SystemInfo(platformInfo: platformInfo,
                                         finishTransactions: !observerMode,
                                         operationDispatcher: operationDispatcher,
+                                        bundle: bundle,
                                         storeKit2Setting: storeKit2Setting,
                                         responseVerificationMode: responseVerificationMode,
                                         dangerousSettings: dangerousSettings)
@@ -1042,6 +1048,7 @@ public extension Purchases {
                   appUserID: configuration.appUserID,
                   observerMode: configuration.observerMode,
                   userDefaults: configuration.userDefaults,
+                  bundle: configuration.bundle,
                   platformInfo: configuration.platformInfo,
                   responseVerificationMode: configuration.responseVerificationMode,
                   storeKit2Setting: configuration.storeKit2Setting,
@@ -1207,6 +1214,7 @@ public extension Purchases {
         appUserID: String?,
         observerMode: Bool,
         userDefaults: UserDefaults?,
+        bundle: Bundle?,
         platformInfo: PlatformInfo?,
         responseVerificationMode: Signing.ResponseVerificationMode,
         storeKit2Setting: StoreKit2Setting,
@@ -1218,6 +1226,7 @@ public extension Purchases {
             .init(apiKey: apiKey,
                   appUserID: appUserID,
                   userDefaults: userDefaults,
+                  bundle: bundle,
                   observerMode: observerMode,
                   platformInfo: platformInfo,
                   responseVerificationMode: responseVerificationMode,

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCConfigurationAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCConfigurationAPI.m
@@ -13,16 +13,17 @@
 
 + (void)checkAPI {
     RCConfigurationBuilder *builder = [RCConfiguration builderWithAPIKey:@""];
-    RCConfiguration *config __unused = [[[[[[[[[[[builder withApiKey:@""]
-                                         withObserverMode:false]
-                                        withUserDefaults:NSUserDefaults.standardUserDefaults]
-                                       withAppUserID:@""]
-                                      withAppUserID:nil]
-                                     withDangerousSettings:[[RCDangerousSettings alloc] init]]
-                                    withNetworkTimeout:1]
-                                   withStoreKit1Timeout: 1]
-                                  withPlatformInfo:[[RCPlatformInfo alloc] initWithFlavor:@"" version:@""]]
-                                withUsesStoreKit2IfAvailable:false] build];
+    RCConfiguration *config __unused = [[[[[[[[[[[[builder withApiKey:@""]
+                                                  withObserverMode:false]
+                                                 withUserDefaults:NSUserDefaults.standardUserDefaults]
+                                                withBundle:NSBundle.mainBundle]
+                                               withAppUserID:@""]
+                                              withAppUserID:nil]
+                                             withDangerousSettings:[[RCDangerousSettings alloc] init]]
+                                            withNetworkTimeout:1]
+                                           withStoreKit1Timeout: 1]
+                                          withPlatformInfo:[[RCPlatformInfo alloc] initWithFlavor:@"" version:@""]]
+                                         withUsesStoreKit2IfAvailable:false] build];
 
     if (@available(iOS 13.0, *)) {
         RCConfiguration *config __unused = [[builder withEntitlementVerificationMode:RCEntitlementVerificationModeEnforced]

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/ConfigurationAPI.swift
@@ -16,6 +16,7 @@ func checkConfigurationAPI() {
         .with(appUserID: nil)
         .with(observerMode: false)
         .with(userDefaults: UserDefaults.standard)
+        .with(bundle: Bundle.main)
         .with(dangerousSettings: DangerousSettings())
         .with(dangerousSettings: DangerousSettings(autoSyncPurchases: true))
         .with(networkTimeout: 1)

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -60,6 +60,7 @@ class BaseBackendIntegrationTests: XCTestCase {
                             appUserID: nil,
                             observerMode: Self.observerMode,
                             userDefaults: self.userDefaults,
+                            bundle: nil,
                             platformInfo: nil,
                             responseVerificationMode: Self.responseVerificationMode,
                             storeKit2Setting: Self.storeKit2Setting,


### PR DESCRIPTION
This is necessary for app extensions that require configuring the SDK from outside the main bundle where the App Store receipt lives.

Example:
```swift
Purchases.configure(
    with: .init(withAPIKey: "api key")
        .with(bundle: Bundle(identifier: "com.your_main.app_bundle"))
)
```