### PR TITLE
`PurchasesOrchestrator`: update `CustomerInfoManager` cache after processing transactions

### DIFF
--- a/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
@@ -91,6 +91,22 @@ class StoreKit1ObserverModeIntegrationTests: BaseStoreKitObserverModeIntegration
         try await self.verifyEntitlementWentThrough(info)
     }
 
+    func testPurchaseOutsideTheAppUpdatesCustomerInfoDelegate() async throws {
+        try self.testSession.buyProduct(productIdentifier: Self.monthlyNoIntroProductID)
+
+        try await asyncWait(
+            until: {
+                await self.purchasesDelegate.customerInfo?.entitlements.active.isEmpty == false
+            },
+            timeout: .seconds(4),
+            pollInterval: .milliseconds(100),
+            description: "Delegate should be notified"
+        )
+
+        let customerInfo = try XCTUnwrap(self.purchasesDelegate.customerInfo)
+        try await self.verifyEntitlementWentThrough(customerInfo)
+    }
+
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testSK2RenewalsPostReceiptOnlyOnceWhenSK1IsEnabled() async throws {
         try XCTSkipIf(Self.storeKit2Setting.isEnabledAndAvailable, "Test only for SK1")

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -836,6 +836,9 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         expect(self.backend.invokedPostReceiptData) == true
         expect(self.backend.invokedPostReceiptDataParameters?.transactionData.source.isRestore) == false
         expect(self.backend.invokedPostReceiptDataParameters?.transactionData.source.initiationSource) == .queue
+        expect(self.customerInfoManager.invokedCacheCustomerInfo) == true
+        expect(self.customerInfoManager.invokedCacheCustomerInfoParameters?.appUserID) == Self.mockUserID
+        expect(self.customerInfoManager.invokedCacheCustomerInfoParameters?.info) === self.mockCustomerInfo
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
@@ -858,7 +861,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
             )
             fail("Expected error")
         } catch {
-            expect(error).to(matchError(expectedError.asPurchasesError))
+            expect(error).to(matchError(expectedError))
         }
 
         expect(transaction.finishInvoked) == false


### PR DESCRIPTION
This is the last piece needed after #2612. Transactions handled from `StoreKit.Transaction.updates` were ignoring the result `CustomerInfo`.
On example where this was noticed is when redeeming promo codes: we posted the transaction, but `PurchasesDelegate` was not notified of the change.
