### PR TITLE
`TimingUtil`: removed slow purchase logs

### DIFF
--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -77,8 +77,6 @@ enum PurchaseStrings {
     case sk2_transactions_update_received_transaction(productID: String)
     case transaction_poster_handling_transaction(productID: String, offeringID: String?)
     case caching_presented_offering_identifier(offeringID: String, productID: String)
-    case sk1_purchase_too_slow
-    case sk2_purchase_too_slow
     case payment_queue_wrapper_delegate_call_sk1_enabled
     case restorepurchases_called_with_allow_sharing_appstore_account_false
 
@@ -296,12 +294,6 @@ extension PurchaseStrings: LogMessage {
 
         case let .caching_presented_offering_identifier(offeringID, productID):
             return "Caching presented offering identifier '\(offeringID)' for product '\(productID)'"
-
-        case .sk1_purchase_too_slow:
-            return "StoreKit 1 purchase took longer than expected"
-
-        case .sk2_purchase_too_slow:
-            return "StoreKit 2 purchase took longer than expected"
 
         case .payment_queue_wrapper_delegate_call_sk1_enabled:
             return "Unexpectedly received PaymentQueueWrapperDelegate call with SK1 enabled"

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -297,7 +297,6 @@ extension Configuration {
     internal enum TimingThreshold: TimingUtil.Duration {
 
         case productRequest = 3
-        case purchase = 7
         case introEligibility = 2
         case purchasedProducts = 1
 

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -440,24 +440,20 @@ final class PurchasesOrchestrator {
         let result: Product.PurchaseResult
 
         do {
-            result = try await TimingUtil.measureAndLogIfTooSlow(
-                threshold: .purchase,
-                message: Strings.purchase.sk2_purchase_too_slow.description) {
-                    var options: Set<Product.PurchaseOption> = [
-                        .simulatesAskToBuyInSandbox(Purchases.simulatesAskToBuyInSandbox)
-                    ]
+            var options: Set<Product.PurchaseOption> = [
+                .simulatesAskToBuyInSandbox(Purchases.simulatesAskToBuyInSandbox)
+            ]
 
-                    if let signedData = promotionalOffer {
-                        Logger.debug(
-                            Strings.storeKit.sk2_purchasing_added_promotional_offer_option(signedData.identifier)
-                        )
-                        options.insert(try signedData.sk2PurchaseOption)
-                    }
+            if let signedData = promotionalOffer {
+                Logger.debug(
+                    Strings.storeKit.sk2_purchasing_added_promotional_offer_option(signedData.identifier)
+                )
+                options.insert(try signedData.sk2PurchaseOption)
+            }
 
-                    self.cachePresentedOfferingIdentifier(package: package, productIdentifier: sk2Product.id)
+            self.cachePresentedOfferingIdentifier(package: package, productIdentifier: sk2Product.id)
 
-                    return try await sk2Product.purchase(options: options)
-                }
+            result = try await sk2Product.purchase(options: options)
         } catch StoreKitError.userCancelled {
             guard !self.systemInfo.dangerousSettings.customEntitlementComputation else {
                 throw ErrorUtils.purchaseCancelledError()


### PR DESCRIPTION
This includes the time the user takes to go through the dialogs (including potentially signing in, etc), so it doesn't make a lot of sense.
