### PR TITLE
`getPromotionalOffer`: return `ErrorCode.ineligibleError` if receipt is not found

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -234,10 +234,15 @@ final class PurchasesOrchestrator {
             return
         }
 
-        receiptFetcher.receiptData(refreshPolicy: .onlyIfEmpty) { receiptData, receiptURL in
-            guard let receiptData = receiptData,
-                  !receiptData.isEmpty else {
-                completion(.failure(ErrorUtils.missingReceiptFileError(receiptURL)))
+        self.receiptFetcher.receiptData(refreshPolicy: .onlyIfEmpty) { receiptData, receiptURL in
+            guard let receiptData = receiptData, !receiptData.isEmpty else {
+                let underlyingError = ErrorUtils.missingReceiptFileError(receiptURL)
+
+                // Promotional offers require existing purchases.
+                // If no receipt is found, this is most likely in sandbox with no purchases,
+                // so producing an "ineligible" error is better.
+                completion(.failure(ErrorUtils.ineligibleError(error: underlyingError)))
+
                 return
             }
 

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -416,6 +416,17 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         try await subscribe()
     }
 
+    func testGetPromotionalOfferWithNoPurchasesReturnsIneligible() async throws {
+        let product = try await self.monthlyPackage.storeProduct
+        let discount = try XCTUnwrap(product.discounts.onlyElement)
+
+        do {
+            _ = try await Purchases.shared.promotionalOffer(forProductDiscount: discount, product: product)
+        } catch {
+            expect(error).to(matchError(ErrorCode.ineligibleError))
+        }
+    }
+
     func testUserHasNoEligibleOffersByDefault() async throws {
         let (_, created) = try await Purchases.shared.logIn(UUID().uuidString)
         expect(created) == true


### PR DESCRIPTION
Fixes #2580.

Promotional offers require a receipt. If there is none (like in sandbox), it means no purchases were found, which implies that the user is not eligible.
