### PR TITLE
`Xcode 15`: handle `Locale.currencyCode` deprecation

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -211,6 +211,8 @@
 		4F54DF402A1D8C7500FD72BF /* MockStoreKit2TransactionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54DF3E2A1D8C7500FD72BF /* MockStoreKit2TransactionFetcher.swift */; };
 		4F54DF422A1D8D0700FD72BF /* MockTransactionPoster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54DF412A1D8D0700FD72BF /* MockTransactionPoster.swift */; };
 		4F54DF432A1D8D0700FD72BF /* MockTransactionPoster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F54DF412A1D8D0700FD72BF /* MockTransactionPoster.swift */; };
+		4F5C05BD2A43A21A00651C7D /* Locale+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5C05BC2A43A21A00651C7D /* Locale+Extensions.swift */; };
+		4F5C05BF2A43A2C500651C7D /* LocaleExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5C05BE2A43A2C500651C7D /* LocaleExtensionsTests.swift */; };
 		4F69EB092A14406E00ED6D4B /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F69EB082A14406E00ED6D4B /* Matchers.swift */; };
 		4F69EB0A2A14406E00ED6D4B /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F69EB082A14406E00ED6D4B /* Matchers.swift */; };
 		4F6BED592A26A14400CD9322 /* DebugView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6BED582A26A14400CD9322 /* DebugView.swift */; };
@@ -925,6 +927,8 @@
 		4F4FF3E02A3B731A0028018C /* ETagStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ETagStrings.swift; sourceTree = "<group>"; };
 		4F54DF3E2A1D8C7500FD72BF /* MockStoreKit2TransactionFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreKit2TransactionFetcher.swift; sourceTree = "<group>"; };
 		4F54DF412A1D8D0700FD72BF /* MockTransactionPoster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTransactionPoster.swift; sourceTree = "<group>"; };
+		4F5C05BC2A43A21A00651C7D /* Locale+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Locale+Extensions.swift"; sourceTree = "<group>"; };
+		4F5C05BE2A43A2C500651C7D /* LocaleExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleExtensionsTests.swift; sourceTree = "<group>"; };
 		4F69EB082A14406E00ED6D4B /* Matchers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Matchers.swift; sourceTree = "<group>"; };
 		4F6BED582A26A14400CD9322 /* DebugView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugView.swift; sourceTree = "<group>"; };
 		4F6BEDD82A26B55C00CD9322 /* DebugViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugViewModel.swift; sourceTree = "<group>"; };
@@ -1401,6 +1405,7 @@
 				2D9C7BB226D838FC006838BE /* UIApplication+RCExtensions.swift */,
 				57CD86D9291C1E2300768DE1 /* UserDefaults+Extensions.swift */,
 				578D798D2936ACF70042E434 /* ProcessInfo+Extensions.swift */,
+				4F5C05BC2A43A21A00651C7D /* Locale+Extensions.swift */,
 			);
 			path = FoundationExtensions;
 			sourceTree = "<group>";
@@ -2040,6 +2045,7 @@
 				57ACB13628184CF1000DCC9F /* DecoderExtensionTests.swift */,
 				2DD269162522A20A006AC4BC /* DictionaryExtensionsTests.swift */,
 				57910CB229C3889B006209D5 /* DispatchTimeIntervalExtensionsTests.swift */,
+				4F5C05BE2A43A2C500651C7D /* LocaleExtensionsTests.swift */,
 				37E35ABEE9FD79CCA64E4F8B /* NSData+RCExtensionsTests.swift */,
 				37E353AF2CAD3CEDE6D9B368 /* NSError+RCExtensionsTests.swift */,
 				5766AA41283C768600FA6091 /* OperatorExtensionsTests.swift */,
@@ -3312,6 +3318,7 @@
 				B39E811A268E849900D31189 /* AttributionNetwork.swift in Sources */,
 				57488C7629CB90F90000EE7E /* CustomerInfo+OfflineEntitlements.swift in Sources */,
 				37E35C8515C5E2D01B0AF5C1 /* Strings.swift in Sources */,
+				4F5C05BD2A43A21A00651C7D /* Locale+Extensions.swift in Sources */,
 				2D9F4A5526C30CA800B07B43 /* PurchasesOrchestrator.swift in Sources */,
 				57C2931528BFEF4F0054EDFC /* PurchasesError.swift in Sources */,
 				57FD7B1528DA4037009CA4E4 /* PurchasesType.swift in Sources */,
@@ -3397,6 +3404,7 @@
 				A56DFDF3286673CE00EF2E32 /* BackendPostAttributionDataTests.swift in Sources */,
 				351B514B26D44A4A00BD2BD7 /* MockOperationDispatcher.swift in Sources */,
 				351B514926D44A2F00BD2BD7 /* MockCustomerInfoManager.swift in Sources */,
+				4F5C05BF2A43A2C500651C7D /* LocaleExtensionsTests.swift in Sources */,
 				5766AAC9283E88CF00FA6091 /* PurchasesGetCustomerInfoTests.swift in Sources */,
 				351B517426D44F4B00BD2BD7 /* MockPaymentDiscount.swift in Sources */,
 				57488B8B29CB756A0000EE7E /* ProductEntitlementMappingTests.swift in Sources */,

--- a/Sources/FoundationExtensions/Locale+Extensions.swift
+++ b/Sources/FoundationExtensions/Locale+Extensions.swift
@@ -1,0 +1,32 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Locale+Extensions.swift
+//
+//  Created by Nacho Soto on 6/21/23.
+
+import Foundation
+
+extension Locale {
+
+    // swiftlint:disable:next identifier_name
+    var rc_currencyCode: String? {
+        #if swift(>=5.9)
+        // `Locale.currencyCode` is deprecated
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, xrOS 1.0, *) {
+            return self.currency?.identifier
+        } else {
+            return self.currencyCode
+        }
+        #else
+        return self.currencyCode
+        #endif
+    }
+
+}

--- a/Sources/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
@@ -40,7 +40,7 @@ internal struct SK1StoreProduct: StoreProductType {
 
     var localizedDescription: String { return underlyingSK1Product.localizedDescription }
 
-    var currencyCode: String? { return underlyingSK1Product.priceLocale.currencyCode }
+    var currencyCode: String? { return underlyingSK1Product.priceLocale.rc_currencyCode }
 
     var price: Decimal { return underlyingSK1Product.price as Decimal }
 

--- a/Sources/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
@@ -29,7 +29,7 @@ internal struct SK1StoreProductDiscount: StoreProductDiscountType {
         } else {
             self.offerIdentifier = nil
         }
-        self.currencyCode = sk1Discount.optionalLocale?.currencyCode
+        self.currencyCode = sk1Discount.optionalLocale?.rc_currencyCode
         self.price = sk1Discount.price as Decimal
         self.paymentMode = paymentMode
         self.subscriptionPeriod = subscriptionPeriod

--- a/Tests/UnitTests/FoundationExtensions/LocaleExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/LocaleExtensionsTests.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  LocaleExtensionsTests.swift
+//
+//  Created by Nacho Soto on 6/21/23.
+
+import Nimble
+import XCTest
+
+@testable import RevenueCat
+
+class LocaleExtensionsTests: TestCase {
+
+    func testCurrencyCode() {
+        let locale = Locale(identifier: "en_US")
+        expect(locale.rc_currencyCode) == "USD"
+    }
+
+}

--- a/Tests/UnitTests/FoundationExtensions/LocaleExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/LocaleExtensionsTests.swift
@@ -19,8 +19,11 @@ import XCTest
 class LocaleExtensionsTests: TestCase {
 
     func testCurrencyCode() {
-        let locale = Locale(identifier: "en_US")
-        expect(locale.rc_currencyCode) == "USD"
+        expect(Locale(identifier: "en_US").rc_currencyCode) == "USD"
+    }
+
+    func testMissingCurrenctCode() {
+        expect(Locale(identifier: "").rc_currencyCode).to(beNil())
     }
 
 }


### PR DESCRIPTION
This is required to compile for `xrOS`.