### PR TITLE
`xrOS`: fixed compilation by disabling debug overlay

### DIFF
--- a/Sources/Support/DebugUI/DebugContentViews.swift
+++ b/Sources/Support/DebugUI/DebugContentViews.swift
@@ -11,7 +11,8 @@
 //
 //  Created by Nacho Soto on 5/30/23.
 
-#if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS)) && !(swift(>=5.9) && os(xrOS))
+#if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS))
+#if !(swift(>=5.9) && os(xrOS))
 
 import StoreKit
 import SwiftUI
@@ -412,4 +413,5 @@ private struct ProductStyle: ProductViewStyle {
 }
 #endif
 
+#endif
 #endif

--- a/Sources/Support/DebugUI/DebugContentViews.swift
+++ b/Sources/Support/DebugUI/DebugContentViews.swift
@@ -11,7 +11,7 @@
 //
 //  Created by Nacho Soto on 5/30/23.
 
-#if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS))
+#if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS)) && !(swift(>=5.9) && os(xrOS))
 
 import StoreKit
 import SwiftUI

--- a/Sources/Support/DebugUI/DebugView.swift
+++ b/Sources/Support/DebugUI/DebugView.swift
@@ -10,8 +10,8 @@
 //  DebugView.swift
 //
 //  Created by Nacho Soto on 5/30/23.
-
-#if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS))
+ 
+#if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS)) && !(swift(>=5.9) && os(xrOS))
 
 import SwiftUI
 

--- a/Sources/Support/DebugUI/DebugView.swift
+++ b/Sources/Support/DebugUI/DebugView.swift
@@ -10,8 +10,9 @@
 //  DebugView.swift
 //
 //  Created by Nacho Soto on 5/30/23.
- 
-#if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS)) && !(swift(>=5.9) && os(xrOS))
+
+#if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS))
+#if !(swift(>=5.9) && os(xrOS))
 
 import SwiftUI
 
@@ -72,4 +73,5 @@ public extension View {
 
 }
 
+#endif
 #endif

--- a/Sources/Support/DebugUI/DebugViewController.swift
+++ b/Sources/Support/DebugUI/DebugViewController.swift
@@ -13,7 +13,7 @@
 
 import Foundation
 
-#if DEBUG && os(iOS) && swift(>=5.8)
+#if DEBUG && os(iOS) && swift(>=5.8) && !(swift(>=5.9) && os(xrOS))
 
 import SwiftUI
 import UIKit

--- a/Sources/Support/DebugUI/DebugViewController.swift
+++ b/Sources/Support/DebugUI/DebugViewController.swift
@@ -13,7 +13,8 @@
 
 import Foundation
 
-#if DEBUG && os(iOS) && swift(>=5.8) && !(swift(>=5.9) && os(xrOS))
+#if DEBUG && os(iOS) && swift(>=5.8)
+#if !(swift(>=5.9) && os(xrOS))
 
 import SwiftUI
 import UIKit
@@ -85,4 +86,5 @@ extension UIViewController {
 
 }
 
+#endif
 #endif

--- a/Sources/Support/DebugUI/DebugViewModel.swift
+++ b/Sources/Support/DebugUI/DebugViewModel.swift
@@ -13,7 +13,8 @@
 
 import Foundation
 
-#if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS)) && !(swift(>=5.9) && os(xrOS))
+#if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS))
+#if !(swift(>=5.9) && os(xrOS))
 
 import SwiftUI
 
@@ -145,4 +146,5 @@ private extension Signing.ResponseVerificationMode {
 
 }
 
+#endif
 #endif

--- a/Sources/Support/DebugUI/DebugViewModel.swift
+++ b/Sources/Support/DebugUI/DebugViewModel.swift
@@ -13,7 +13,7 @@
 
 import Foundation
 
-#if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS))
+#if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS)) && !(swift(>=5.9) && os(xrOS))
 
 import SwiftUI
 

--- a/Sources/Support/DebugUI/DebugViewSheetPresentation.swift
+++ b/Sources/Support/DebugUI/DebugViewSheetPresentation.swift
@@ -11,7 +11,7 @@
 //
 //  Created by Nacho Soto on 5/30/23.
 
-#if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS))
+#if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS)) && !(swift(>=5.9) && os(xrOS))
 
 import SwiftUI
 

--- a/Sources/Support/DebugUI/DebugViewSheetPresentation.swift
+++ b/Sources/Support/DebugUI/DebugViewSheetPresentation.swift
@@ -11,7 +11,8 @@
 //
 //  Created by Nacho Soto on 5/30/23.
 
-#if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS)) && !(swift(>=5.9) && os(xrOS))
+#if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS))
+#if !(swift(>=5.9) && os(xrOS))
 
 import SwiftUI
 
@@ -45,4 +46,5 @@ extension View {
     }
 }
 
+#endif
 #endif

--- a/Sources/Support/PaywallExtensions.swift
+++ b/Sources/Support/PaywallExtensions.swift
@@ -85,6 +85,8 @@ extension SubscriptionStoreView {
 
 }
 
+#if !os(xrOS)
+
 @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
 extension SubscriptionStoreView where Content == AutomaticSubscriptionStoreMarketingContent {
 
@@ -97,6 +99,8 @@ extension SubscriptionStoreView where Content == AutomaticSubscriptionStoreMarke
     }
 
 }
+
+#endif
 
 // MARK: - Private
 

--- a/Sources/Support/PaywallExtensions.swift
+++ b/Sources/Support/PaywallExtensions.swift
@@ -85,8 +85,20 @@ extension SubscriptionStoreView {
 
 }
 
-#if !os(xrOS)
+#if os(xrOS)
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+extension SubscriptionStoreView where Content == DefaultSubscriptionStoreMarketingContent {
 
+    /// Creates a ``SubscriptionStoreView`` from an ``Offering``
+    /// that doesn't take a custom view to use for marketing content.
+    public static func forOffering(_ offering: Offering) -> some View {
+        return self
+            .init(productIDs: offering.subscriptionProductIdentifiers)
+            .handlePurchases(offering)
+    }
+
+}
+#else
 @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
 extension SubscriptionStoreView where Content == AutomaticSubscriptionStoreMarketingContent {
 
@@ -99,7 +111,6 @@ extension SubscriptionStoreView where Content == AutomaticSubscriptionStoreMarke
     }
 
 }
-
 #endif
 
 // MARK: - Private


### PR DESCRIPTION
We can look into making them work in the future, but for now this helps compile the SDK for `xrOS`.