### PR TITLE
`xrOS`: added support to `PurchaseTester`

### DIFF
--- a/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		4F1F5E9B2A18124C00C4EB88 /* ProxyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1F5E9A2A18124C00C4EB88 /* ProxyViewModel.swift */; };
 		4F1F5E9D2A1814EF00C4EB88 /* ProxyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1F5E9C2A1814EF00C4EB88 /* ProxyView.swift */; };
 		4F4F782F2A18542200689BAA /* LocalizedAlertError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F4F782E2A18542200689BAA /* LocalizedAlertError.swift */; };
+		4F942FA82A449156007D0346 /* AdaptiveStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F942FA72A449156007D0346 /* AdaptiveStack.swift */; };
 		4FDA13872A33DBE300C45CFE /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 4FDA13862A33DBE300C45CFE /* PrivacyInfo.xcprivacy */; };
 		575642A4290C7A2700719219 /* LoggerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575642A3290C7A2700719219 /* LoggerView.swift */; };
 		575642A6290C7D3100719219 /* Windows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575642A5290C7D3100719219 /* Windows.swift */; };
@@ -38,10 +39,10 @@
 		578DAA0C2947DD21001700FD /* PurchaseTesterWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578DAA0B2947DD21001700FD /* PurchaseTesterWatchApp.swift */; };
 		578DAA0E2947DD21001700FD /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578DAA0D2947DD21001700FD /* ContentView.swift */; };
 		578DAA102947DD21001700FD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 578DAA0F2947DD21001700FD /* Assets.xcassets */; };
-		578DAA162947DD21001700FD /* PurchaseTesterWatchOS.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 578DAA092947DD21001700FD /* PurchaseTesterWatchOS.app */; platformFilters = (watchos, ); settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		578DAA162947DD21001700FD /* PurchaseTesterWatchOS.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 578DAA092947DD21001700FD /* PurchaseTesterWatchOS.app */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		578DAA232947DD8C001700FD /* Core.h in Headers */ = {isa = PBXBuildFile; fileRef = 578DAA222947DD8C001700FD /* Core.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		578DAA262947DD8C001700FD /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 578DAA202947DD8C001700FD /* Core.framework */; platformFilters = (ios, maccatalyst, macos, ); };
-		578DAA272947DD8C001700FD /* Core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 578DAA202947DD8C001700FD /* Core.framework */; platformFilters = (ios, maccatalyst, macos, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		578DAA262947DD8C001700FD /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 578DAA202947DD8C001700FD /* Core.framework */; };
+		578DAA272947DD8C001700FD /* Core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 578DAA202947DD8C001700FD /* Core.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		578DAA2D2947DE37001700FD /* ConfiguredPurchases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57ED6A83290891AF009580C6 /* ConfiguredPurchases.swift */; };
 		578DAA2E2947DE59001700FD /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575642A1290C78DD00719219 /* Logger.swift */; };
 		578DAA2F2947DFA6001700FD /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CCAF2AB286232EB0004E2CA /* Constants.swift */; };
@@ -141,6 +142,7 @@
 		4F1F5E9A2A18124C00C4EB88 /* ProxyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyViewModel.swift; sourceTree = "<group>"; };
 		4F1F5E9C2A1814EF00C4EB88 /* ProxyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyView.swift; sourceTree = "<group>"; };
 		4F4F782E2A18542200689BAA /* LocalizedAlertError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedAlertError.swift; sourceTree = "<group>"; };
+		4F942FA72A449156007D0346 /* AdaptiveStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveStack.swift; sourceTree = "<group>"; };
 		4FDA13862A33DBE300C45CFE /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		575642A1290C78DD00719219 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		575642A3290C7A2700719219 /* LoggerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerView.swift; sourceTree = "<group>"; };
@@ -325,6 +327,7 @@
 				4F4F782E2A18542200689BAA /* LocalizedAlertError.swift */,
 				57B5795229536B8C003EAA40 /* ObserverModeManager.swift */,
 				57B5795329536B8C003EAA40 /* ProductFetcherSK1.swift */,
+				4F942FA72A449156007D0346 /* AdaptiveStack.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -514,6 +517,7 @@
 				4F1F5E992A18124500C4EB88 /* ProxyManager.swift in Sources */,
 				2C10F19A27AC32840078444D /* SubscriberAttributesView.swift in Sources */,
 				57B5795629536B8C003EAA40 /* ObserverModeManager.swift in Sources */,
+				4F942FA82A449156007D0346 /* AdaptiveStack.swift in Sources */,
 				2CD2C516278C9B02005D1CC2 /* PurchaseTesterApp.swift in Sources */,
 				575642A4290C7A2700719219 /* LoggerView.swift in Sources */,
 				2DD2CBB329831A22004A3A6A /* ReceiptVerifier.swift in Sources */,
@@ -556,19 +560,12 @@
 		};
 		578DAA152947DD21001700FD /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilters = (
-				watchos,
-			);
+			platformFilter = ios;
 			target = 578DAA082947DD21001700FD /* PurchaseTesterWatchOS */;
 			targetProxy = 578DAA142947DD21001700FD /* PBXContainerItemProxy */;
 		};
 		578DAA252947DD8C001700FD /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilters = (
-				ios,
-				maccatalyst,
-				macos,
-			);
 			target = 578DAA1F2947DD8C001700FD /* Core */;
 			targetProxy = 578DAA242947DD8C001700FD /* PBXContainerItemProxy */;
 		};
@@ -751,9 +748,10 @@
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match Development com.revenuecat.sampleapp";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "match Development com.revenuecat.sampleapp macos";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=watchos*]" = "match Development com.revenuecat.sampleapp";
-				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator";
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
@@ -792,9 +790,10 @@
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.revenuecat.sampleapp";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "match AppStore com.revenuecat.sampleapp macos";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=watchos*]" = "match AppStore com.revenuecat.sampleapp";
-				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator";
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
@@ -884,10 +883,13 @@
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=watchos*]" = "";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos";
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,6,7";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -920,10 +922,13 @@
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=watchos*]" = "";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchsimulator watchos appletvsimulator appletvos";
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,6,7";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/AdaptiveStack.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/AdaptiveStack.swift
@@ -1,0 +1,36 @@
+//
+//  AdaptiveStack.swift
+//  PurchaseTester
+//
+//  Created by Nacho Soto on 6/22/23.
+//
+
+import SwiftUI
+
+struct AdaptiveStack<Content: View>: View {
+
+    let horizontalAlignment: HorizontalAlignment
+    let verticalAlignment: VerticalAlignment
+    let spacing: CGFloat?
+    let content: () -> Content
+
+    init(
+        horizontalAlignment: HorizontalAlignment = .center,
+        verticalAlignment: VerticalAlignment = .center,
+        spacing: CGFloat? = nil,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.horizontalAlignment = horizontalAlignment
+        self.verticalAlignment = verticalAlignment
+        self.spacing = spacing
+        self.content = content
+    }
+
+    var body: some View {
+        #if os(xrOS)
+        VStack(alignment: self.horizontalAlignment, spacing: self.spacing, content: self.content)
+        #else
+        HStack(alignment: self.verticalAlignment, spacing: spacing, content: self.content)
+        #endif
+    }
+}

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/ObserverModeManager.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/ObserverModeManager.swift
@@ -34,6 +34,7 @@ final class ObserverModeManager: ObservableObject {
         _ = await self.purchasesOrchestrator.purchase(sk1Product: sk1Product)
     }
 
+    #if !os(xrOS)
     func purchaseAsSK2Product(_ product: StoreProduct) async throws {
         guard let sk2Product = try await self.productFetcherSK2.products(with: [product.productIdentifier]).first else {
             print("Failed to find product")
@@ -42,5 +43,6 @@ final class ObserverModeManager: ObservableObject {
 
         try await self.purchasesOrchestrator.purchase(sk2Product: sk2Product)
     }
+    #endif
 
 }

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/PurchasesOrchestrator.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/PurchasesOrchestrator.swift
@@ -41,6 +41,8 @@ final class PurchasesOrchestrator: NSObject {
         self.paymentQueue.add(.init(product: product))
     }
 
+    // Fix-me: inject @Environment(\.product) to fix this
+    #if !os(xrOS)
     func purchase(sk2Product product: SK2Product) async throws {
         let result = try await product.purchase()
 
@@ -61,6 +63,7 @@ final class PurchasesOrchestrator: NSObject {
             fatalError()
         }
     }
+    #endif
 
 }
 

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
@@ -169,12 +169,16 @@ struct HomeView: View {
     }
 
     var body: some View {
+        #if !os(xrOS)
         if #available(iOS 16.0, macOS 13.0, *) {
             self.content
                 .debugRevenueCatOverlay(isPresented: self.$debugOverlayVisible)
         } else {
             self.content
         }
+        #else
+        self.content
+        #endif
     }
     
     private func fetchData() async {
@@ -238,7 +242,7 @@ private struct CustomerInfoHeaderView: View {
     }
     
     var body: some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: self.horizontalAlignment) {
             Text(appUserID ?? "... loading")
             if activeEntitlementInfos.isEmpty {
                 Text("No active entitlements")
@@ -246,7 +250,7 @@ private struct CustomerInfoHeaderView: View {
                 Text(activeEntitlementInfos.map(\.identifier).joined(separator: ", "))
             }
             
-            HStack {
+            AdaptiveStack {
                 Spacer()
 
                 if let customerInfo = self.revenueCatCustomerData.customerInfo {
@@ -311,6 +315,14 @@ private struct CustomerInfoHeaderView: View {
         }
     }
     
+    private var horizontalAlignment: HorizontalAlignment {
+        #if os(xrOS)
+        return .center
+        #else
+        return .leading
+        #endif
+    }
+
 }
 
 private struct OfferingItemView: View {

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Offerings/OfferingDetailView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Offerings/OfferingDetailView.swift
@@ -94,9 +94,11 @@ struct OfferingDetailView: View {
                         try await self.purchaseAsSK1Product()
                     }
 
+                    #if !os(xrOS)
                     self.button("Buy directly from SK2 (w/o RevenueCat)") {
                         try await self.purchaseAsSK2Product()
                     }
+                    #endif
 
                     Divider()
                 }
@@ -150,12 +152,14 @@ struct OfferingDetailView: View {
             try await self.observerModeManager.purchaseAsSK1Product(self.package.storeProduct)
         }
 
+        #if !os(xrOS)
         private func purchaseAsSK2Product() async throws {
             self.isPurchasing = true
             defer { self.isPurchasing = false }
 
             try await self.observerModeManager.purchaseAsSK2Product(self.package.storeProduct)
         }
+        #endif
 
         private func completedPurchase(_ data: PurchaseResultData) {
             print("🚀 Info 💁‍♂️ - Transaction: \(data.transaction?.description ?? "")")


### PR DESCRIPTION
![image](https://github.com/RevenueCat/purchases-ios/assets/685609/eeb5c7ea-55df-4d11-a06c-c660431c8c08)
![image](https://github.com/RevenueCat/purchases-ios/assets/685609/8435a62c-b14c-4be4-bd08-6d98c690c13d)
