### PR TITLE
`ErrorUtils`: handle `PurchasesError` to avoid creating unknown errors

### DIFF
--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -286,7 +286,8 @@ enum ErrorUtils {
         switch error {
         case let skError as SKError:
             return skError.asPurchasesError
-
+        case let purchasesError as PurchasesError:
+            return purchasesError
         default:
             return ErrorUtils.unknownError(
                 error: error,
@@ -309,8 +310,10 @@ enum ErrorUtils {
         switch error {
         case let storeKitError as StoreKitError:
             return storeKitError.asPurchasesError
-        case let purchasesError as Product.PurchaseError:
-            return purchasesError.asPurchasesError
+        case let purchaseError as Product.PurchaseError:
+            return purchaseError.asPurchasesError
+        case let purchasesError as PurchasesError:
+            return purchasesError
         default:
             return ErrorUtils.unknownError(
                 error: error,

--- a/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
+++ b/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
@@ -133,6 +133,23 @@ class ErrorUtilsTests: TestCase {
             .to(matchError(expected))
     }
 
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testPurchasesErrorWithPurchasesErrorStoreKitError() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        let error = BackendError.missingAppUserID().asPurchasesError
+
+        expect(ErrorUtils.purchasesError(withStoreKitError: error))
+            .to(matchError(error))
+    }
+
+    func testPurchasesErrorWithPurchasesErrorSKError() {
+        let error = BackendError.missingAppUserID().asPurchasesError
+
+        expect(ErrorUtils.purchasesError(withSKError: error))
+            .to(matchError(error))
+    }
+
     func testPurchaseErrorsAreLoggedAsApppleErrors() {
         let underlyingError = NSError(domain: SKErrorDomain, code: SKError.Code.paymentInvalid.rawValue)
         let error = ErrorUtils.purchaseNotAllowedError(error: underlyingError)

--- a/Tests/UnitTests/StoreKitExtensions/SKErrorTests.swift
+++ b/Tests/UnitTests/StoreKitExtensions/SKErrorTests.swift
@@ -18,6 +18,14 @@ import XCTest
 
 class SKErrorTests: BaseErrorTests {
 
+    func testErrorUtilsCreation() {
+        let error: SKError = .init(.paymentNotAllowed)
+
+        expect(
+            ErrorUtils.purchasesError(withSKError: error).error
+        ) == .purchaseNotAllowedError
+    }
+
     func testStoreProblemError() {
         let error: SKError = .init(.cloudServiceNetworkConnectionFailed)
 

--- a/Tests/UnitTests/StoreKitExtensions/StoreKitErrorTests.swift
+++ b/Tests/UnitTests/StoreKitExtensions/StoreKitErrorTests.swift
@@ -25,6 +25,14 @@ class StoreKitErrorTests: BaseErrorTests {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
     }
 
+    func testErrorUtilsCreation() {
+        let error: StoreKitError = .userCancelled
+
+        expect(
+            ErrorUtils.purchasesError(withStoreKitError: error).error
+        ) == .purchaseCancelledError
+    }
+
     func testUserCancelledError() {
         let error: StoreKitError = .userCancelled
 


### PR DESCRIPTION
If we end up calling these methods with an existing `PurchasesError`, we'd end up creating an `.unknownError` instead of returning that.
This is actually needed for #2683, where the inside of the `do`/`catch` can throw a `PurchasesError`.
