### PR TITLE
`xrOS`: fixed runtime warning

### DIFF
--- a/Sources/FoundationExtensions/UIApplication+RCExtensions.swift
+++ b/Sources/FoundationExtensions/UIApplication+RCExtensions.swift
@@ -22,6 +22,7 @@ extension UIApplication {
     @available(watchOS, unavailable)
     @available(watchOSApplicationExtension, unavailable)
     @available(tvOS, unavailable)
+    @MainActor
     var currentWindowScene: UIWindowScene? {
         var scenes = self
             .connectedScenes

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -187,6 +187,7 @@ extension SystemInfo {
     @available(watchOS, unavailable)
     @available(watchOSApplicationExtension, unavailable)
     @available(tvOS, unavailable)
+    @MainActor
     var currentWindowScene: UIWindowScene {
         get throws {
             let scene = self.sharedUIApplication?.currentWindowScene


### PR DESCRIPTION
This was missing in #2683, these methods need to be invoked from the `@MainActor`.

![image](https://github.com/RevenueCat/purchases-ios/assets/685609/9ff6a004-618e-4e0d-b8ff-3b2f52276008)
