### PR TITLE
Add `Data.sha1`

### DIFF
--- a/Sources/FoundationExtensions/Data+Extensions.swift
+++ b/Sources/FoundationExtensions/Data+Extensions.swift
@@ -50,17 +50,19 @@ extension Data {
     var hashString: String {
         if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
             var sha256 = SHA256()
-            sha256.update(data: self)
-
-            return Self.hexString(sha256.finalize().makeIterator())
+            return self.hashString(with: &sha256)
         } else {
-            let hash = self.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) -> [UInt8] in
-                var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
-                CC_SHA256(bytes.baseAddress, CC_LONG(self.count), &hash)
-                return hash
-            }
+            return self.hashString(CC_SHA256, length: CC_SHA256_DIGEST_LENGTH)
+        }
+    }
 
-            return Self.hexString(hash.makeIterator())
+    /// - Returns: the SHA1 hash of the underlying bytes.
+    var sha1: Data {
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
+            var sha1 = Insecure.SHA1()
+            return self.hash(with: &sha1)
+        } else {
+            return Data(self.hash(CC_SHA1, length: CC_SHA1_DIGEST_LENGTH))
         }
     }
 
@@ -81,5 +83,46 @@ extension Data {
     }
 
     static let nonceLength = 12
+
+}
+
+// MARK: - Hashing
+
+private extension Data {
+
+    typealias HashingFunction = (
+        _ data: UnsafeRawPointer?,
+        _ len: CC_LONG,
+        _ md: UnsafeMutablePointer<UInt8>?
+    ) -> UnsafeMutablePointer<UInt8>?
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func hashString<T: HashFunction>(with digest: inout T) -> String {
+        digest.update(data: self)
+
+        return Self.hexString(digest.finalize().makeIterator())
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func hash<T: HashFunction>(with digest: inout T) -> Data {
+        digest.update(data: self)
+
+        return Data(digest.finalize())
+    }
+
+    func hash(_ hashingFunction: HashingFunction, length: Int32) -> [UInt8] {
+        return self.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) -> [UInt8] in
+            var hash = [UInt8](repeating: 0, count: Int(length))
+            _ = hashingFunction(bytes.baseAddress, CC_LONG(self.count), &hash)
+            return hash
+        }
+    }
+
+    func hashString(_ hashingFunction: HashingFunction, length: Int32) -> String {
+        return Self.hexString(
+            self.hash(hashingFunction, length: length)
+                .makeIterator()
+        )
+    }
 
 }

--- a/Tests/UnitTests/FoundationExtensions/DataExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/DataExtensionsTests.swift
@@ -48,6 +48,15 @@ class DataExtensionsTests: TestCase {
         != "a relatively long string that ends in 1".asData.hashString
     }
 
+    func testStringDataAsSha1() {
+        expect("sample string".asData.sha1.asString) == "243182b9d0b085c06005bf773212854bf7cd4694"
+    }
+
+    func testDataAsSha1HashesTheEntireData() {
+        expect("a relatively long string that ends in 0".asData.sha1)
+        != "a relatively long string that ends in 1".asData.sha1
+    }
+
     func testReceiptDataAsHashString() {
         let storedReceiptData = Self.sampleReceiptData(receiptName: Self.receiptFilename)
 


### PR DESCRIPTION
This also refactors the implementation to be able to share the same code.

This algorithm will be used for some of the components in the new signatures.