### PR TITLE
`Trusted Entitlements`: update handling of 304 responses

### DIFF
--- a/Sources/Logging/Strings/ETagStrings.swift
+++ b/Sources/Logging/Strings/ETagStrings.swift
@@ -21,7 +21,7 @@ enum ETagStrings {
     case found_no_etag(URLRequest)
     case could_not_find_cached_response_in_already_retried(response: String)
     case storing_response(URLRequest, ETagManager.Response)
-    case not_storing_etag(HTTPResponse<Data?>)
+    case not_storing_etag(VerifiedHTTPResponse<Data?>)
     case using_etag(URLRequest, String, Date?)
     case not_using_etag(URLRequest,
                         VerificationResult,

--- a/Sources/Logging/Strings/SigningStrings.swift
+++ b/Sources/Logging/Strings/SigningStrings.swift
@@ -33,8 +33,8 @@ enum SigningStrings {
                              parameters: Signing.SignatureParameters,
                              salt: Data,
                              payload: Data,
-                             message: Data)
-    case invalid_signature_data(HTTPRequest, Data, HTTPClient.ResponseHeaders, HTTPStatusCode)
+                             message: Data?)
+    case invalid_signature_data(HTTPRequest, Data?, HTTPClient.ResponseHeaders, HTTPStatusCode)
     #endif
 
 }
@@ -70,9 +70,8 @@ extension SigningStrings: LogMessage {
             INVALID SIGNATURE DETECTED:
             Request: \(request.method.httpMethod) \(request.path)
             Response: \(statusCode.rawValue)
-            \(responseHeaders.stringRepresentation)
             Headers: \(responseHeaders.map { "\($0.key.base): \($0.value)" })
-            Body (length: \(data.count)): \(data.hashString)
+            Body (length: \(data?.count ?? 0)): \(data?.hashString ?? "<>")
             """
 
         case let .verifying_signature(
@@ -87,7 +86,7 @@ extension SigningStrings: LogMessage {
             Parameters: \(parameters),
             Salt: \(salt.base64EncodedString()),
             Payload: \(payload.base64EncodedString()),
-            Message: \(message.base64EncodedString())
+            Message: \(message?.base64EncodedString() ?? "")
             """
 
         #endif

--- a/Sources/Networking/HTTPClient/ETagManager.swift
+++ b/Sources/Networking/HTTPClient/ETagManager.swift
@@ -246,7 +246,7 @@ extension ETagManager.Response: Codable {}
 extension ETagManager.Response {
 
     func asData() -> Data? {
-        return try? JSONEncoder.default.encode(self)
+        return try? self.jsonEncodedData
     }
 
     /// - Parameter responseVerificationResult: the result of the 304 response

--- a/Sources/Networking/HTTPClient/ETagManager.swift
+++ b/Sources/Networking/HTTPClient/ETagManager.swift
@@ -147,6 +147,7 @@ private extension ETagManager {
         switch response.verificationResult {
         case .verified: return true
         case .notRequested: return !withSignatureVerification
+        // This is theoretically impossible since we won't store these responses anyway.
         case .failed, .verifiedOnDevice: return false
         }
     }

--- a/Sources/Networking/InternalAPI.swift
+++ b/Sources/Networking/InternalAPI.swift
@@ -88,12 +88,12 @@ private final class HealthOperation: CacheableNetworkOperation {
         self.httpClient.perform(
             request,
             with: self.verificationMode
-        ) { (response: HTTPResponse<HTTPEmptyResponseBody>.Result) in
+        ) { (response: VerifiedHTTPResponse<HTTPEmptyResponseBody>.Result) in
             self.finish(with: response, completion: completion)
         }
     }
 
-    private func finish(with response: HTTPResponse<HTTPEmptyResponseBody>.Result,
+    private func finish(with response: VerifiedHTTPResponse<HTTPEmptyResponseBody>.Result,
                         completion: () -> Void) {
         self.callbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
             callback.completion(

--- a/Sources/Networking/Operations/GetCustomerInfoOperation.swift
+++ b/Sources/Networking/Operations/GetCustomerInfoOperation.swift
@@ -82,7 +82,9 @@ private extension GetCustomerInfoOperation {
         let request = HTTPRequest(method: .get,
                                   path: .getCustomerInfo(appUserID: appUserID))
 
-        self.httpClient.perform(request) { (response: HTTPResponse<CustomerInfoResponseHandler.Response>.Result) in
+        self.httpClient.perform(
+            request
+        ) { (response: VerifiedHTTPResponse<CustomerInfoResponseHandler.Response>.Result) in
             self.customerInfoResponseHandler.handle(customerInfoResponse: response) { result in
                 self.customerInfoCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                     callback.completion(result)

--- a/Sources/Networking/Operations/GetIntroEligibilityOperation.swift
+++ b/Sources/Networking/Operations/GetIntroEligibilityOperation.swift
@@ -76,7 +76,7 @@ private extension GetIntroEligibilityOperation {
 
         httpClient.perform(
             request
-        ) { (response: HTTPResponse<GetIntroEligibilityResponse>.Result) in
+        ) { (response: VerifiedHTTPResponse<GetIntroEligibilityResponse>.Result) in
             self.handleIntroEligibility(result: response,
                                         productIdentifiers: self.productIdentifiers,
                                         completion: self.responseHandler)
@@ -85,7 +85,7 @@ private extension GetIntroEligibilityOperation {
     }
 
     func handleIntroEligibility(
-        result: Result<HTTPResponse<GetIntroEligibilityResponse>, NetworkError>,
+        result: VerifiedHTTPResponse<GetIntroEligibilityResponse>.Result,
         productIdentifiers: [String],
         completion: OfferingsAPI.IntroEligibilityResponseHandler
     ) {

--- a/Sources/Networking/Operations/GetOfferingsOperation.swift
+++ b/Sources/Networking/Operations/GetOfferingsOperation.swift
@@ -61,7 +61,7 @@ private extension GetOfferingsOperation {
 
         let request = HTTPRequest(method: .get, path: .getOfferings(appUserID: appUserID))
 
-        httpClient.perform(request) { (response: HTTPResponse<OfferingsResponse>.Result) in
+        httpClient.perform(request) { (response: VerifiedHTTPResponse<OfferingsResponse>.Result) in
             defer {
                 completion()
             }

--- a/Sources/Networking/Operations/GetProductEntitlementMappingOperation.swift
+++ b/Sources/Networking/Operations/GetProductEntitlementMappingOperation.swift
@@ -49,7 +49,7 @@ private extension GetProductEntitlementMappingOperation {
     func getResponse(completion: @escaping () -> Void) {
         let request = HTTPRequest(method: .get, path: .getProductEntitlementMapping)
 
-        self.httpClient.perform(request) { (response: HTTPResponse<ProductEntitlementMappingResponse>.Result) in
+        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<ProductEntitlementMappingResponse>.Result) in
             defer {
                 completion()
             }

--- a/Sources/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
+++ b/Sources/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
@@ -24,7 +24,7 @@ class CustomerInfoResponseHandler {
         self.userID = userID
     }
 
-    func handle(customerInfoResponse response: HTTPResponse<Response>.Result,
+    func handle(customerInfoResponse response: VerifiedHTTPResponse<Response>.Result,
                 completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
         let result: Result<CustomerInfo, BackendError> = response
             .map { response in

--- a/Sources/Networking/Operations/LogInOperation.swift
+++ b/Sources/Networking/Operations/LogInOperation.swift
@@ -71,7 +71,7 @@ private extension LogInOperation {
                                                      newAppUserID: newAppUserID)),
                                   path: .logIn)
 
-        self.httpClient.perform(request) { (response: HTTPResponse<CustomerInfo>.Result) in
+        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<CustomerInfo>.Result) in
             self.loginCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callbackObject in
                 self.handleLogin(response, completion: callbackObject.completion)
             }
@@ -80,7 +80,7 @@ private extension LogInOperation {
         }
     }
 
-    func handleLogin(_ result: HTTPResponse<CustomerInfo>.Result,
+    func handleLogin(_ result: VerifiedHTTPResponse<CustomerInfo>.Result,
                      completion: IdentityAPI.LogInResponseHandler) {
         let result: Result<(info: CustomerInfo, created: Bool), BackendError> = result
             .map { response in

--- a/Sources/Networking/Operations/PostAdServicesTokenOperation.swift
+++ b/Sources/Networking/Operations/PostAdServicesTokenOperation.swift
@@ -43,7 +43,7 @@ class PostAdServicesTokenOperation: NetworkOperation {
         let request = HTTPRequest(method: .post(Body(aadAttributionToken: self.token)),
                                   path: .postAdServicesToken(appUserID: appUserID))
 
-        self.httpClient.perform(request) { (response: HTTPResponse<HTTPEmptyResponseBody>.Result) in
+        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<HTTPEmptyResponseBody>.Result) in
             defer {
                 completion()
             }

--- a/Sources/Networking/Operations/PostAttributionDataOperation.swift
+++ b/Sources/Networking/Operations/PostAttributionDataOperation.swift
@@ -47,7 +47,7 @@ class PostAttributionDataOperation: NetworkOperation {
         let request = HTTPRequest(method: .post(Body(network: self.network, attributionData: self.attributionData)),
                                   path: .postAttributionData(appUserID: appUserID))
 
-        self.httpClient.perform(request) { (response: HTTPResponse<HTTPEmptyResponseBody>.Result) in
+        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<HTTPEmptyResponseBody>.Result) in
             defer {
                 completion()
             }

--- a/Sources/Networking/Operations/PostOfferForSigningOperation.swift
+++ b/Sources/Networking/Operations/PostOfferForSigningOperation.swift
@@ -50,7 +50,7 @@ class PostOfferForSigningOperation: NetworkOperation {
             path: .postOfferForSigning
         )
 
-        self.httpClient.perform(request) { (response: HTTPResponse<PostOfferResponse>.Result) in
+        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<PostOfferResponse>.Result) in
             let result: Result<PostOfferForSigningOperation.SigningData, BackendError> = response
                 .mapError { error -> BackendError in
                     if case .decoding = error {

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -112,7 +112,9 @@ final class PostReceiptDataOperation: CacheableNetworkOperation {
     private func post(completion: @escaping () -> Void) {
         let request = HTTPRequest(method: .post(self.postData), path: .postReceiptData)
 
-        self.httpClient.perform(request) { (response: HTTPResponse<CustomerInfoResponseHandler.Response>.Result) in
+        self.httpClient.perform(
+            request
+        ) { (response: VerifiedHTTPResponse<CustomerInfoResponseHandler.Response>.Result) in
             self.customerInfoResponseHandler.handle(customerInfoResponse: response) { result in
                 self.customerInfoCallbackCache.performOnAllItemsAndRemoveFromCache(
                     withCacheable: self

--- a/Sources/Networking/Operations/PostSubscriberAttributesOperation.swift
+++ b/Sources/Networking/Operations/PostSubscriberAttributesOperation.swift
@@ -51,7 +51,7 @@ class PostSubscriberAttributesOperation: NetworkOperation {
         let request = HTTPRequest(method: .post(Body(self.subscriberAttributes)),
                                   path: .postSubscriberAttributes(appUserID: appUserID))
 
-        httpClient.perform(request) { (response: HTTPResponse<HTTPEmptyResponseBody>.Result) in
+        self.httpClient.perform(request) { (response: VerifiedHTTPResponse<HTTPEmptyResponseBody>.Result) in
             defer {
                 completion()
             }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -286,7 +286,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         }
 
         let receiptFetcher = ReceiptFetcher(requestFetcher: fetcher, systemInfo: systemInfo)
-        let eTagManager = ETagManager(verificationMode: systemInfo.responseVerificationMode)
+        let eTagManager = ETagManager()
         let attributionTypeFactory = AttributionTypeFactory()
         let attributionFetcher = AttributionFetcher(attributionFactory: attributionTypeFactory, systemInfo: systemInfo)
         let userDefaults = userDefaults ?? UserDefaults.computeDefault()

--- a/Sources/Security/Signing+ResponseVerification.swift
+++ b/Sources/Security/Signing+ResponseVerification.swift
@@ -13,7 +13,7 @@
 
 import Foundation
 
-extension HTTPResponse where Body == Data {
+extension HTTPResponse where Body == Data? {
 
     func verify(
         request: HTTPRequest,
@@ -46,7 +46,7 @@ extension HTTPResponse where Body == Data {
 
     // swiftlint:disable:next function_parameter_count
     private static func verificationResult(
-        body: Data,
+        body: Data?,
         statusCode: HTTPStatusCode,
         headers: HTTPClient.ResponseHeaders,
         requestDate: Date?,

--- a/Sources/Security/Signing.swift
+++ b/Sources/Security/Signing.swift
@@ -34,7 +34,7 @@ enum Signing: SigningType {
     /// Parameters used for signature creation / verification.
     struct SignatureParameters {
 
-        let message: Data
+        let message: Data?
         let nonce: Data?
         let etag: String?
         let requestDate: UInt64
@@ -229,7 +229,7 @@ extension Signing.SignatureParameters {
             (self.nonce ?? .init()) +
             String(self.requestDate).asData +
             (self.etag ?? "").asData +
-            self.message
+            (self.message ?? .init())
         )
     }
 

--- a/Sources/Security/VerificationResult.swift
+++ b/Sources/Security/VerificationResult.swift
@@ -87,32 +87,3 @@ extension VerificationResult: CustomDebugStringConvertible {
 
 }
 
-extension VerificationResult {
-
-    /// - Returns: the most restrictive ``VerificationResult`` based on the cached verification and
-    /// the response verification.
-    static func from(cache cachedResult: Self, response responseResult: Self) -> Self {
-        switch (cachedResult, responseResult) {
-        case (.notRequested, .notRequested),
-            (.verified, .verified),
-            (.verifiedOnDevice, .verifiedOnDevice),
-            (.failed, .failed):
-            return cachedResult
-
-        case (.verified, .notRequested), (.verifiedOnDevice, .notRequested): return .notRequested
-        case (.verified, .failed), (.verifiedOnDevice, .failed): return .failed
-
-        case (.notRequested, .verified), (.notRequested, .verifiedOnDevice): return responseResult
-        case (.notRequested, .failed): return .failed
-
-        case (.failed, .notRequested): return .notRequested
-        // If the cache verification failed, the etag won't be used
-        // so the response would only be a 200 and not 304.
-        // Therefore the cache verification error can be ignored
-        case (.failed, .verified), (.failed, .verifiedOnDevice): return responseResult
-
-        case (.verifiedOnDevice, .verified), (.verified, .verifiedOnDevice): return responseResult
-        }
-    }
-
-}

--- a/Sources/Security/VerificationResult.swift
+++ b/Sources/Security/VerificationResult.swift
@@ -86,4 +86,3 @@ extension VerificationResult: CustomDebugStringConvertible {
     }
 
 }
-

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -15,10 +15,10 @@ class MockHTTPClient: HTTPClient {
 
     struct Response {
 
-        let response: HTTPResponse<Data>.Result
+        let response: VerifiedHTTPResponse<Data>.Result
         let delay: DispatchTimeInterval
 
-        private init(response: HTTPResponse<Data>.Result, delay: DispatchTimeInterval) {
+        private init(response: VerifiedHTTPResponse<Data>.Result, delay: DispatchTimeInterval) {
             self.response = response
             self.delay = delay
         }
@@ -33,10 +33,12 @@ class MockHTTPClient: HTTPClient {
             // swiftlint:disable:next force_try
             let data = try! JSONSerialization.data(withJSONObject: response)
 
-            let response = HTTPResponse(
-                statusCode: statusCode,
-                responseHeaders: responseHeaders,
-                body: data,
+            let response = VerifiedHTTPResponse(
+                response: .init(
+                    statusCode: statusCode,
+                    responseHeaders: responseHeaders,
+                    body: data
+                ),
                 verificationResult: verificationResult
             )
 
@@ -92,7 +94,7 @@ class MockHTTPClient: HTTPClient {
             let mock = self.mocks[request.path] ?? .init(statusCode: .success)
 
             if let completionHandler = completionHandler {
-                let response: HTTPResponse<Value>.Result = mock.response.parseResponse()
+                let response: VerifiedHTTPResponse<Value>.Result = mock.response.parseResponse()
 
                 if mock.delay != .never {
                     DispatchQueue.main.asyncAfter(deadline: .now() + mock.delay) {

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -517,8 +517,8 @@ final class HTTPClientTests: BaseHTTPClientTests {
         self.eTagManager.stubResponseEtag(eTag, validationTime: eTagValidationTime)
 
         stub(condition: isPath(request.path)) { request in
-            expect(request.allHTTPHeaderFields?[ETagManager.eTagRequestHeaderName]) == eTag
-            expect(request.allHTTPHeaderFields?[ETagManager.eTagValidationTimeRequestHeaderName])
+            expect(request.allHTTPHeaderFields?[ETagManager.eTagRequestHeader.rawValue]) == eTag
+            expect(request.allHTTPHeaderFields?[ETagManager.eTagValidationTimeRequestHeader.rawValue])
             == eTagValidationTime.millisecondsSince1970.description
 
             return HTTPStubsResponse(data: responseData,
@@ -577,7 +577,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         self.eTagManager.stubResponseEtag(eTag)
 
         stub(condition: isPath(request.path)) { request in
-            headerPresent.value = request.allHTTPHeaderFields?[ETagManager.eTagRequestHeaderName] == eTag
+            headerPresent.value = request.allHTTPHeaderFields?[ETagManager.eTagRequestHeader.rawValue] == eTag
             return .emptySuccessResponse()
         }
 
@@ -594,7 +594,9 @@ final class HTTPClientTests: BaseHTTPClientTests {
         let headerPresent: Atomic<Bool?> = nil
 
         stub(condition: isPath(request.path)) { request in
-            headerPresent.value = request.allHTTPHeaderFields?.keys.contains(ETagManager.eTagRequestHeaderName) == true
+            headerPresent.value = request.allHTTPHeaderFields?.keys.contains(
+                ETagManager.eTagRequestHeader.rawValue
+            ) == true
             return .emptySuccessResponse()
         }
 
@@ -1080,11 +1082,12 @@ final class HTTPClientTests: BaseHTTPClientTests {
         self.eTagManager.stubbedHTTPResultFromCacheOrBackendResult = .init(
             statusCode: .success,
             responseHeaders: headers,
-            body: mockedCachedResponse
+            body: mockedCachedResponse,
+            verificationResult: .verified
         )
 
         stub(condition: isPath(path)) { response in
-            expect(response.allHTTPHeaderFields?[ETagManager.eTagRequestHeaderName]) == eTag
+            expect(response.allHTTPHeaderFields?[ETagManager.eTagRequestHeader.rawValue]) == eTag
 
             return .init(data: Data(),
                          statusCode: .notModified,
@@ -1323,7 +1326,8 @@ final class HTTPClientTests: BaseHTTPClientTests {
             statusCode: .success,
             responseHeaders: [:],
             body: encodedResponse,
-            requestDate: requestDate
+            requestDate: requestDate,
+            verificationResult: .notRequested
         )
 
         stub(condition: isPath(path)) { _ in

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -15,7 +15,9 @@ import XCTest
 
 class BaseHTTPClientTests: TestCase {
 
-    typealias EmptyResponse = HTTPResponse<HTTPEmptyResponseBody>.Result
+    typealias EmptyResponse = VerifiedHTTPResponse<HTTPEmptyResponseBody>.Result
+    typealias DataResponse = VerifiedHTTPResponse<Data>.Result
+    typealias BodyWithDateResponse = VerifiedHTTPResponse<BodyWithDate>.Result
 
     var systemInfo: MockSystemInfo!
     var client: HTTPClient!
@@ -329,7 +331,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         let result = waitUntilValue { completion in
-            self.client.perform(request) { (response: HTTPResponse<Data>.Result) in
+            self.client.perform(request) { (response: DataResponse) in
                 completion(response)
             }
         }
@@ -365,7 +367,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         let result = waitUntilValue { completion in
-            self.client.perform(request) { (response: HTTPResponse<Data>.Result) in
+            self.client.perform(request) { (response: DataResponse) in
                 completion(response)
             }
         }
@@ -401,7 +403,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         let result = waitUntilValue { completion in
-            self.client.perform(request) { (response: HTTPResponse<Data>.Result) in
+            self.client.perform(request) { (response: DataResponse) in
                 completion(response)
             }
         }
@@ -438,7 +440,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         let result = waitUntilValue { completion in
-            self.client.perform(request) { (response: HTTPResponse<Data>.Result) in
+            self.client.perform(request) { (response: DataResponse) in
                 completion(response)
             }
         }
@@ -466,7 +468,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         let result = waitUntilValue { completion in
-            self.client.perform(request) { (response: HTTPResponse<CustomResponse>.Result) in
+            self.client.perform(request) { (response: VerifiedHTTPResponse<CustomResponse>.Result) in
                 completion(response)
             }
         }
@@ -496,7 +498,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         let result = waitUntilValue { completion in
-            self.client.perform(request) { (response: HTTPResponse<Data>.Result) in
+            self.client.perform(request) { (response: DataResponse) in
                 completion(response)
             }
         }
@@ -525,7 +527,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         let result = waitUntilValue { completion in
-            self.client.perform(request) { (response: HTTPResponse<Data>.Result) in
+            self.client.perform(request) { (response: DataResponse) in
                 completion(response)
             }
         }
@@ -555,7 +557,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         let result = waitUntilValue { completion in
-            self.client.perform(request) { (response: HTTPResponse<CustomResponse>.Result) in
+            self.client.perform(request) { (response: VerifiedHTTPResponse<CustomResponse>.Result) in
                 completion(response)
             }
         }
@@ -580,7 +582,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         waitUntil { completion in
-            self.client.perform(request) { (_: HTTPResponse<Data>.Result) in completion() }
+            self.client.perform(request) { (_: DataResponse) in completion() }
         }
 
         expect(headerPresent.value) == true
@@ -597,7 +599,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         waitUntil { completion in
-            self.client.perform(request) { (_: HTTPResponse<Data>.Result) in completion() }
+            self.client.perform(request) { (_: DataResponse) in completion() }
         }
 
         expect(headerPresent.value) == false
@@ -617,7 +619,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         waitUntil { completion in
-            self.client.perform(request) { (_: HTTPResponse<Data>.Result) in completion() }
+            self.client.perform(request) { (_: DataResponse) in completion() }
         }
 
         expect(headerPresent.value) == true
@@ -636,7 +638,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         waitUntil { completion in
-            self.client.perform(request) { (_: HTTPResponse<Data>.Result) in completion() }
+            self.client.perform(request) { (_: DataResponse) in completion() }
         }
 
         expect(headerPresent.value) == true
@@ -655,7 +657,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         waitUntil { completion in
-            self.client.perform(request) { (_: HTTPResponse<Data>.Result) in completion() }
+            self.client.perform(request) { (_: DataResponse) in completion() }
         }
 
         expect(headerPresent.value) == true
@@ -675,7 +677,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         waitUntil { completion in
-            self.client.perform(request) { (_: HTTPResponse<Data>.Result) in completion() }
+            self.client.perform(request) { (_: DataResponse) in completion() }
         }
 
         expect(headerPresent.value) == true
@@ -696,7 +698,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         waitUntil { completion in
-            self.client.perform(request) { (_: HTTPResponse<Data>.Result) in completion() }
+            self.client.perform(request) { (_: DataResponse) in completion() }
         }
 
         expect(headerPresent.value) == true
@@ -723,7 +725,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         waitUntil { completion in
-            self.client.perform(request) { (_: HTTPResponse<Data>.Result) in completion() }
+            self.client.perform(request) { (_: DataResponse) in completion() }
         }
 
         expect(headerPresent.value) == true
@@ -741,7 +743,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         waitUntil { completion in
-            self.client.perform(request) { (_: HTTPResponse<Data>.Result) in completion() }
+            self.client.perform(request) { (_: DataResponse) in completion() }
         }
 
         expect(headerPresent.value) == true
@@ -763,7 +765,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         self.client = HTTPClient(apiKey: self.apiKey, systemInfo: systemInfo, eTagManager: self.eTagManager)
 
         waitUntil { completion in
-            self.client.perform(request) { (_: HTTPResponse<Data>.Result) in completion() }
+            self.client.perform(request) { (_: DataResponse) in completion() }
         }
 
         expect(headerPresent.value) == true
@@ -784,7 +786,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         self.client = HTTPClient(apiKey: self.apiKey, systemInfo: systemInfo, eTagManager: self.eTagManager)
 
         waitUntil { completion in
-            self.client.perform(request) { (_: HTTPResponse<Data>.Result) in completion() }
+            self.client.perform(request) { (_: DataResponse) in completion() }
         }
 
         expect(headerPresent.value) == true
@@ -803,7 +805,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         self.client = HTTPClient(apiKey: self.apiKey, systemInfo: systemInfo, eTagManager: self.eTagManager)
 
         waitUntil { completion in
-            self.client.perform(request) { (_: HTTPResponse<Data>.Result) in completion() }
+            self.client.perform(request) { (_: DataResponse) in completion() }
         }
 
         expect(headerPresent.value) == true
@@ -825,7 +827,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         waitUntil { completion in
-            self.client.perform(request) { (_: HTTPResponse<Data>.Result) in completion() }
+            self.client.perform(request) { (_: DataResponse) in completion() }
         }
 
         expect(headerPresent) == true
@@ -846,7 +848,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         waitUntil { completion in
-            self.client.perform(request) { (_: HTTPResponse<Data>.Result) in completion() }
+            self.client.perform(request) { (_: DataResponse) in completion() }
         }
 
         expect(headerPresent) == false
@@ -865,7 +867,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         self.client = HTTPClient(apiKey: self.apiKey, systemInfo: systemInfo, eTagManager: self.eTagManager)
 
         waitUntil { completion in
-            self.client.perform(request) { (_: HTTPResponse<Data>.Result) in completion() }
+            self.client.perform(request) { (_: DataResponse) in completion() }
         }
 
         expect(headerPresent.value) == true
@@ -891,7 +893,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         for requestNumber in 0..<serialRequests {
             let expectation = self.expectation(description: "Request \(requestNumber)")
 
-            client.perform(.init(method: .requestNumber(requestNumber), path: path)) { (_: HTTPResponse<Data>.Result) in
+            client.perform(.init(method: .requestNumber(requestNumber), path: path)) { (_: DataResponse) in
                 completionCallCount.value += 1
                 expectation.fulfill()
             }
@@ -926,12 +928,12 @@ final class HTTPClientTests: BaseHTTPClientTests {
             self.expectation(description: "Request 2")
         ]
 
-        self.client.perform(.init(method: .requestNumber(1), path: path)) { (_: HTTPResponse<Data>.Result) in
+        self.client.perform(.init(method: .requestNumber(1), path: path)) { (_: DataResponse) in
             firstRequestFinished.value = true
             expectations[0].fulfill()
         }
 
-        self.client.perform(.init(method: .requestNumber(2), path: path)) { (_: HTTPResponse<Data>.Result) in
+        self.client.perform(.init(method: .requestNumber(2), path: path)) { (_: DataResponse) in
             secondRequestFinished.value = true
             expectations[1].fulfill()
         }
@@ -978,17 +980,17 @@ final class HTTPClientTests: BaseHTTPClientTests {
             self.expectation(description: "Request 3")
         ]
 
-        self.client.perform(.init(method: .requestNumber(1), path: path)) { (_: HTTPResponse<Data>.Result) in
+        self.client.perform(.init(method: .requestNumber(1), path: path)) { (_: DataResponse) in
             firstRequestFinished.value = true
             expectations[0].fulfill()
         }
 
-        self.client.perform(.init(method: .requestNumber(2), path: path)) { (_: HTTPResponse<Data>.Result) in
+        self.client.perform(.init(method: .requestNumber(2), path: path)) { (_: DataResponse) in
             secondRequestFinished.value = true
             expectations[1].fulfill()
         }
 
-        self.client.perform(.init(method: .requestNumber(3), path: path)) { (_: HTTPResponse<Data>.Result) in
+        self.client.perform(.init(method: .requestNumber(3), path: path)) { (_: DataResponse) in
             thirdRequestFinished.value = true
             expectations[2].fulfill()
         }
@@ -1002,7 +1004,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
 
     func testPerformRequestExitsWithErrorIfBodyCouldntBeParsedIntoJSON() throws {
         let response = waitUntilValue { completion in
-            self.client.perform(.init(method: .invalidBody(), path: .mockPath)) { (result: HTTPResponse<Data>.Result) in
+            self.client.perform(.init(method: .invalidBody(), path: .mockPath)) { (result: DataResponse) in
                 completion(result)
             }
         }
@@ -1022,7 +1024,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         waitUntil { completion in
-            self.client.perform(.init(method: .invalidBody(), path: path)) { (_: HTTPResponse<Data>.Result) in
+            self.client.perform(.init(method: .invalidBody(), path: path)) { (_: DataResponse) in
                 completion()
             }
         }
@@ -1048,7 +1050,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         self.eTagManager.shouldReturnResultFromBackend = false
         self.eTagManager.stubbedHTTPResultFromCacheOrBackendResult = nil
 
-        let result: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+        let result: DataResponse? = waitUntilValue { completion in
             self.client.perform(.init(method: .get, path: path)) {
                 completion($0)
             }
@@ -1069,7 +1071,8 @@ final class HTTPClientTests: BaseHTTPClientTests {
 
         let headers: [String: String] = [
             HTTPClient.ResponseHeader.contentType.rawValue: "application/json",
-            HTTPClient.ResponseHeader.signature.rawValue: UUID().uuidString
+            HTTPClient.ResponseHeader.signature.rawValue: UUID().uuidString,
+            HTTPClient.ResponseHeader.requestDate.rawValue: String(requestDate.millisecondsSince1970)
         ]
 
         self.eTagManager.stubResponseEtag(eTag)
@@ -1077,9 +1080,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         self.eTagManager.stubbedHTTPResultFromCacheOrBackendResult = .init(
             statusCode: .success,
             responseHeaders: headers,
-            body: mockedCachedResponse,
-            requestDate: requestDate,
-            verificationResult: .notRequested
+            body: mockedCachedResponse
         )
 
         stub(condition: isPath(path)) { response in
@@ -1090,8 +1091,8 @@ final class HTTPClientTests: BaseHTTPClientTests {
                          headers: headers)
         }
 
-        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
-            self.client.perform(.init(method: .get, path: path)) { (result: HTTPResponse<Data>.Result) in
+        let response: DataResponse? = waitUntilValue { completion in
+            self.client.perform(.init(method: .get, path: path)) { (result: DataResponse) in
                 completion(result)
             }
         }
@@ -1099,12 +1100,11 @@ final class HTTPClientTests: BaseHTTPClientTests {
         expect(response).toNot(beNil())
         expect(response?.value?.statusCode) == .success
         expect(response?.value?.body) == mockedCachedResponse
-        expect(response?.value?.requestDate) == requestDate
+        expect(response?.value?.requestDate).to(beCloseToDate(requestDate))
         expect(response?.value?.verificationResult) == .notRequested
-        expect(response?.value?.responseHeaders).to(haveCount(headers.count))
+        expect(response?.value?.responseHeaders.keys).to(contain(Array(headers.keys.map(AnyHashable.init))))
 
         expect(self.eTagManager.invokedETagHeaderParametersList).to(haveCount(1))
-        expect(self.eTagManager.invokedETagHeaderParameters?.withSignatureVerification) == false
     }
 
     func testDNSCheckerIsCalledWhenGETRequestFailedWithUnknownError() {
@@ -1120,7 +1120,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         waitUntil { completion in
-            self.client.perform(.init(method: .get, path: path)) { (_: HTTPResponse<Data>.Result) in
+            self.client.perform(.init(method: .get, path: path)) { (_: DataResponse) in
                 completion()
             }
         }
@@ -1142,7 +1142,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         waitUntil { completion in
-            self.client.perform(.init(method: .post([:]), path: path)) { (_: HTTPResponse<Data>.Result) in
+            self.client.perform(.init(method: .post([:]), path: path)) { (_: DataResponse) in
                 completion()
             }
         }
@@ -1168,7 +1168,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         waitUntil { completion in
-            self.client.perform(.init(method: .post([:]), path: path)) { (_: HTTPResponse<Data>.Result) in
+            self.client.perform(.init(method: .post([:]), path: path)) { (_: DataResponse) in
                 completion()
             }
         }
@@ -1193,7 +1193,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
             return response
         }
         waitUntil { completion in
-            self.client.perform(.init(method: .get, path: path)) { (_: HTTPResponse<Data>.Result) in
+            self.client.perform(.init(method: .get, path: path)) { (_: DataResponse) in
                 completion()
             }
         }
@@ -1214,7 +1214,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         let obtainedError: NetworkError? = waitUntilValue { completion in
-            self.client.perform(.init(method: .get, path: path)) { (result: HTTPResponse<Data>.Result) in
+            self.client.perform(.init(method: .get, path: path)) { (result: DataResponse) in
                 completion(result.error)
             }
         }
@@ -1244,7 +1244,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         let obtainedError: NetworkError? = waitUntilValue { completion in
-            self.client.perform(.init(method: .get, path: path)) { (result: HTTPResponse<Data>.Result) in
+            self.client.perform(.init(method: .get, path: path)) { (result: DataResponse) in
                 completion(result.error)
             }
         }
@@ -1275,7 +1275,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         }
 
         waitUntil { completion in
-            self.client.perform(.init(method: .get, path: path)) { (_: HTTPResponse<Data>.Result) in
+            self.client.perform(.init(method: .get, path: path)) { (_: DataResponse) in
                 completion()
             }
         }
@@ -1302,7 +1302,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
             )
         }
 
-        let response: HTTPResponse<BodyWithDate>.Result? = waitUntilValue { completion in
+        let response: BodyWithDateResponse? = waitUntilValue { completion in
             self.client.perform(.init(method: .get, path: path), completionHandler: completion)
         }
 
@@ -1323,8 +1323,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
             statusCode: .success,
             responseHeaders: [:],
             body: encodedResponse,
-            requestDate: requestDate,
-            verificationResult: .notRequested
+            requestDate: requestDate
         )
 
         stub(condition: isPath(path)) { _ in
@@ -1337,7 +1336,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
             )
         }
 
-        let response: HTTPResponse<BodyWithDate>.Result? = waitUntilValue { completion in
+        let response: BodyWithDateResponse? = waitUntilValue { completion in
             self.client.perform(.init(method: .get, path: path), completionHandler: completion)
         }
 
@@ -1366,7 +1365,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
         )
         self.client = self.createClient()
 
-        let response: HTTPResponse<BodyWithDate>.Result? = waitUntilValue { completion in
+        let response: BodyWithDateResponse? = waitUntilValue { completion in
             self.client.perform(.init(method: .get, path: path), completionHandler: completion)
         }
 
@@ -1406,7 +1405,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
 
         let logger = TestLogHandler()
 
-        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+        let response: DataResponse? = waitUntilValue { completion in
             self.client.perform(.init(method: .get, path: pathA), completionHandler: completion)
         }
 
@@ -1432,7 +1431,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
 
         let logger = TestLogHandler()
 
-        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+        let response: DataResponse? = waitUntilValue { completion in
             self.client.perform(.init(method: .get, path: path), completionHandler: completion)
         }
         expect(response).to(beSuccess())
@@ -1455,7 +1454,7 @@ final class HTTPClientTests: BaseHTTPClientTests {
 
         let logger = TestLogHandler()
 
-        let response: HTTPResponse<Data>.Result? = waitUntilValue { completion in
+        let response: DataResponse? = waitUntilValue { completion in
             self.client.perform(.init(method: .get, path: path), completionHandler: completion)
         }
         expect(response).to(beSuccess())

--- a/Tests/UnitTests/Networking/HTTPResponseTests.swift
+++ b/Tests/UnitTests/Networking/HTTPResponseTests.swift
@@ -21,7 +21,7 @@ class HTTPResponseTests: TestCase {
 
     func testResponseVerificationNotRequestedWithNoPublicKey() {
         let request = HTTPRequest(method: .get, path: .health)
-        let response = HTTPResponse(
+        let response = HTTPResponse<Data?>(
             statusCode: .success,
             responseHeaders: [:],
             body: Data()
@@ -38,7 +38,7 @@ class HTTPResponseTests: TestCase {
         let key = Curve25519.Signing.PrivateKey().publicKey
 
         let request = HTTPRequest(method: .get, path: .health)
-        let response = HTTPResponse(
+        let response = HTTPResponse<Data?>(
             statusCode: .success,
             responseHeaders: [:],
             body: Data()
@@ -49,15 +49,17 @@ class HTTPResponseTests: TestCase {
     }
 
     func testValueForHeaderFieldWithNonExistingField() {
-        expect(HTTPResponse.create([:]).value(forHeaderField: "test")).to(beNil())
+        expect(HTTPResponse.create([:]).value(forHeaderField: HTTPClient.ResponseHeader.contentType)).to(beNil())
     }
 
     func testValueForHeaderFieldWithCaseSensitiveFieldName() {
-        expect(HTTPResponse.create(["TeSt": "test"]).value(forHeaderField: "TeSt")) == "test"
+        let header = HTTPClient.ResponseHeader.contentType
+        expect(HTTPResponse.create([header.rawValue: "test"]).value(forHeaderField: header)) == "test"
     }
 
     func testValueForHeaderFieldIsCaseInsensitive() {
-        expect(HTTPResponse.create(["x-signature": "test"]).value(forHeaderField: "X-Signature")) == "test"
+        let header = HTTPClient.ResponseHeader.contentType
+        expect(HTTPResponse.create([header.rawValue.lowercased(): "test"]).value(forHeaderField: header)) == "test"
     }
 
     func testRequestDate() {

--- a/Tests/UnitTests/Networking/HTTPResponseTests.swift
+++ b/Tests/UnitTests/Networking/HTTPResponseTests.swift
@@ -21,13 +21,14 @@ class HTTPResponseTests: TestCase {
 
     func testResponseVerificationNotRequestedWithNoPublicKey() {
         let request = HTTPRequest(method: .get, path: .health)
-        let response = HTTPResponse.create(with: Data(),
-                                           statusCode: .success,
-                                           headers: [:],
-                                           request: request,
-                                           publicKey: nil)
+        let response = HTTPResponse(
+            statusCode: .success,
+            responseHeaders: [:],
+            body: Data()
+        )
+        let verifiedResponse = response.verify(request: request, publicKey: nil)
 
-        expect(response.verificationResult) == .notRequested
+        expect(verifiedResponse.verificationResult) == .notRequested
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
@@ -37,13 +38,14 @@ class HTTPResponseTests: TestCase {
         let key = Curve25519.Signing.PrivateKey().publicKey
 
         let request = HTTPRequest(method: .get, path: .health)
-        let response = HTTPResponse.create(with: Data(),
-                                           statusCode: .success,
-                                           headers: [:],
-                                           request: request,
-                                           publicKey: key)
+        let response = HTTPResponse(
+            statusCode: .success,
+            responseHeaders: [:],
+            body: Data()
+        )
+        let verifiedResponse = response.verify(request: request, publicKey: key)
 
-        expect(response.verificationResult) == .notRequested
+        expect(verifiedResponse.verificationResult) == .notRequested
     }
 
     func testValueForHeaderFieldWithNonExistingField() {
@@ -77,39 +79,7 @@ class HTTPResponseTests: TestCase {
         expect(response.requestDate).to(beNil())
     }
 
-    func testCopyWithSameVerificationResult() throws {
-        self.verifyCopy(of: try Self.sampleResponse.copy(with: .verified),
-                        onlyModifiesEntitlementVerification: .verified)
-    }
-
-    func testCopyWithVerificationResultVerified() throws {
-        self.verifyCopy(of: try Self.sampleResponse,
-                        onlyModifiesEntitlementVerification: .verified)
-    }
-
-    func testCopyWithVerificationResultFailedVerified() throws {
-        self.verifyCopy(of: try Self.sampleResponse,
-                        onlyModifiesEntitlementVerification: .failed)
-    }
-
-    func testCopyWithVerificationResultNotRequested() throws {
-        self.verifyCopy(of: try Self.sampleResponse.copy(with: .verified),
-                        onlyModifiesEntitlementVerification: .notRequested)
-    }
-
     // MARK: -
-
-    private func verifyCopy<T: Equatable>(
-        of response: HTTPResponse<T>,
-        onlyModifiesEntitlementVerification newVerification: VerificationResult
-    ) {
-        let copy = response.copy(with: newVerification)
-        expect(copy.verificationResult) == newVerification
-        expect(copy.statusCode) == response.statusCode
-        expect(copy.responseHeaders).to(haveCount(response.responseHeaders.count))
-        expect(copy.body) == response.body
-        expect(copy.requestDate) == response.requestDate
-    }
 
     private static var sampleResponse: HTTPResponse<Data> {
         get throws {
@@ -121,6 +91,11 @@ class HTTPResponseTests: TestCase {
             )
         }
     }
+    private static var sampleVerifiedResponse: VerifiedHTTPResponse<Data> {
+        get throws {
+            return .init(response: try Self.sampleResponse, verificationResult: .notRequested)
+        }
+    }
 
 }
 
@@ -129,8 +104,7 @@ private extension HTTPResponse where Body == HTTPEmptyResponseBody {
     static func create(_ headers: HTTPResponse.Headers) -> Self {
         return .init(statusCode: .success,
                      responseHeaders: headers,
-                     body: .init(),
-                     verificationResult: .notRequested)
+                     body: .init())
     }
 
 }
@@ -141,8 +115,7 @@ private extension HTTPResponse where Body == Data {
         return .init(statusCode: .success,
                      responseHeaders: headers,
                      body: body,
-                     requestDate: Date(),
-                     verificationResult: .notRequested)
+                     requestDate: Date())
     }
 
 }

--- a/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
+++ b/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
@@ -266,7 +266,7 @@ private extension BaseCustomerInfoResponseHandlerTests {
     }
 
     func handle(
-        _ response: HTTPResponse<CustomerInfoResponseHandler.Response>.Result,
+        _ response: VerifiedHTTPResponse<CustomerInfoResponseHandler.Response>.Result,
         _ mapping: ProductEntitlementMapping?
     ) async -> Result<CustomerInfo, BackendError> {
         let handler = self.create(mapping)


### PR DESCRIPTION
### Changes:
- `ETagManager` no longer stores the verification mode
- Created new `VerifiedHTTPResponse`, which has the `VerificationResult`, extracted from `HTTPResponse`
- Removed `VerificationResult.from(cache:response:)`
- Changed `SignatureVerificationHTTPClientTests` to test using the real `ETagManager`, so they become more "end to end" unit tests. A lot of them were relying on implementation details of the mock instead of the real `ETagManager`.
- Removed several `HTTPClient` tests that were checking a behavior that was impossible (for example, no verification result despite it being enabled), or that checked behavior based on the cached `VerificationResult`

Depends on #2679 and #2697.

