### PR TITLE
`Purchases.restoreLogHandler`

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -204,6 +204,11 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         }
     }
 
+    /// Useful for tests that override the log handler.
+    internal static func restoreLogHandler() {
+        Logger.internalLogHandler = Logger.defaultLogHandler
+    }
+
     /**
      * Setting this to `true` adds additional information to the default log handler:
      *  Filename, line, and method data.

--- a/Tests/StoreKitUnitTests/LoggerTests.swift
+++ b/Tests/StoreKitUnitTests/LoggerTests.swift
@@ -82,6 +82,22 @@ class LoggerTests: TestCase {
         self.logger.verifyMessageWasNotLogged(Message.test1)
     }
 
+    func testPurchasesLogHandler() {
+        defer { Purchases.restoreLogHandler() }
+
+        var messages: [LoggedMessage] = []
+
+        Purchases.logHandler = { messages.append(.init($0, $1)) }
+
+        Logger.info(Message.test1)
+        Logger.warn(Message.test2)
+
+        expect(messages) == [
+            .init(.info, "\(LogIntent.info.prefix) \(Message.test1.description)"),
+            .init(.warn, "\(LogIntent.warning.prefix) \(Message.test2.description)")
+        ]
+    }
+
 }
 
 private extension LoggerTests {
@@ -99,6 +115,18 @@ private extension LoggerTests {
         }
 
         var category: String { return "debug_logs" }
+
+    }
+
+    struct LoggedMessage: Equatable {
+
+        var level: LogLevel
+        var message: String
+
+        init(_ level: LogLevel, _ message: String) {
+            self.level = level
+            self.message = message
+        }
 
     }
 

--- a/Tests/StoreKitUnitTests/LoggerTests.swift
+++ b/Tests/StoreKitUnitTests/LoggerTests.swift
@@ -83,7 +83,10 @@ class LoggerTests: TestCase {
     }
 
     func testPurchasesLogHandler() {
-        defer { Purchases.restoreLogHandler() }
+        defer {
+            Purchases.restoreLogHandler()
+            TestLogHandler.restore()
+        }
 
         var messages: [LoggedMessage] = []
 

--- a/Tests/UnitTests/TestHelpers/TestLogHandler.swift
+++ b/Tests/UnitTests/TestHelpers/TestLogHandler.swift
@@ -75,6 +75,12 @@ final class TestLogHandler {
 
     deinit { Self.sharedHandler.remove(observer: self) }
 
+    /// If a test overrides `Purchases.verboseLogHandler` or `Logger.internalLogHandler`
+    /// this needs to be called to re-install the test handler.
+    static func restore() {
+        Self.sharedHandler.install()
+    }
+
     private let loggedMessages: Atomic<[MessageData]> = .init([])
     private let creationContext: Context
 


### PR DESCRIPTION
`Purchases.verboseLogHandler` changed in #2608 with the introduction of a new `internalLogHandler`.
Restoring the log handler doing `Purchases.verboseLogHandler = Purchases.verboseLogHandler` now loses the message category.

We didn't have test coverage for `Purchases.logHandler` either which this adds as well.

This also fixes tests in https://github.com/RevenueCat/purchases-hybrid-common/pull/435
