### PR TITLE
`Integration Tests`: refactored expiration detection

### DIFF
--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -260,6 +260,16 @@ extension BaseStoreKitIntegrationTests {
         try await Task.sleep(nanoseconds: UInt64(timeToSleep * 1_000_000_000))
     }
 
+    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+    @discardableResult
+    func verifySubscriptionExpired() async throws -> CustomerInfo {
+        let info = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
+        self.assertNoActiveSubscription(info)
+
+        return info
+    }
+    #endif
+
     @available(iOS 15.2, tvOS 15.2, macOS 12.1, watchOS 8.3, *)
     static func findTransaction(for productIdentifier: String) async throws -> Transaction {
         let transactions: [Transaction] = await Transaction

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -263,7 +263,7 @@ extension BaseStoreKitIntegrationTests {
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
     @discardableResult
     func verifySubscriptionExpired() async throws -> CustomerInfo {
-        let info = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
+        let info = try await Purchases.shared.syncPurchases()
         self.assertNoActiveSubscription(info)
 
         return info

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -376,7 +376,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
         try await self.expireSubscription(entitlement)
 
-        let info = try await Purchases.shared.syncPurchases()
+        let info = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
         self.assertNoActiveSubscription(info)
 
         let eligibility = await Purchases.shared.checkTrialOrIntroDiscountEligibility(product: productWithIntro)
@@ -394,7 +394,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
         try await self.expireSubscription(entitlement)
 
-        customerInfo = try await Purchases.shared.syncPurchases()
+        customerInfo = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
         self.assertNoActiveSubscription(customerInfo)
     }
 
@@ -495,7 +495,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
         try await self.expireSubscription(entitlement)
 
-        let info = try await Purchases.shared.syncPurchases()
+        let info = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
         self.assertNoActiveSubscription(info)
 
         // 3. Get eligible offer

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -375,9 +375,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         let entitlement = try await self.verifyEntitlementWentThrough(customerInfo)
 
         try await self.expireSubscription(entitlement)
-
-        let info = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
-        self.assertNoActiveSubscription(info)
+        try await self.verifySubscriptionExpired()
 
         let eligibility = await Purchases.shared.checkTrialOrIntroDiscountEligibility(product: productWithIntro)
         expect(eligibility) == .eligible
@@ -389,13 +387,11 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         let (_, created) = try await Purchases.shared.logIn(UUID().uuidString)
         expect(created) == true
 
-        var customerInfo = try await self.purchaseMonthlyOffering().customerInfo
+        let customerInfo = try await self.purchaseMonthlyOffering().customerInfo
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all[Self.entitlementIdentifier])
 
         try await self.expireSubscription(entitlement)
-
-        customerInfo = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
-        self.assertNoActiveSubscription(customerInfo)
+        try await self.verifySubscriptionExpired()
     }
 
     func testResubscribeAfterExpiration() async throws {
@@ -494,9 +490,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         // 2. Expire subscription
 
         try await self.expireSubscription(entitlement)
-
-        let info = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
-        self.assertNoActiveSubscription(info)
+        try await self.verifySubscriptionExpired()
 
         // 3. Get eligible offer
 


### PR DESCRIPTION
This extracts a common `verifySubscriptionExpired`.
If we want to change the approach to detecting this, we can modify a single method.