### PR TITLE
`xrOS`: add support for `debugRevenueCatOverlay`

### DIFF
--- a/Sources/Support/DebugUI/DebugContentViews.swift
+++ b/Sources/Support/DebugUI/DebugContentViews.swift
@@ -12,7 +12,6 @@
 //  Created by Nacho Soto on 5/30/23.
 
 #if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS))
-#if !(swift(>=5.9) && os(xrOS))
 
 import StoreKit
 import SwiftUI
@@ -294,11 +293,13 @@ private struct DebugOfferingView: View {
                 .foregroundStyle(.secondary)
                 .font(.subheadline)
             }
+            #if !(swift(>=5.9) && os(xrOS))
             .containerBackground(for: .subscriptionStoreFullHeight) {
                 Rectangle()
                     .edgesIgnoringSafeArea(.all)
                     .foregroundStyle(Color.blue.gradient.quaternary)
             }
+            #endif
         }
         .backgroundStyle(.clear)
         .subscriptionStoreButtonLabel(.multiline)
@@ -413,5 +414,4 @@ private struct ProductStyle: ProductViewStyle {
 }
 #endif
 
-#endif
 #endif

--- a/Sources/Support/DebugUI/DebugView.swift
+++ b/Sources/Support/DebugUI/DebugView.swift
@@ -12,7 +12,6 @@
 //  Created by Nacho Soto on 5/30/23.
 
 #if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS))
-#if !(swift(>=5.9) && os(xrOS))
 
 import SwiftUI
 
@@ -54,11 +53,7 @@ public extension View {
     /// ```
     func debugRevenueCatOverlay(isPresented: Binding<Bool>) -> some View {
         self.bottomSheet(
-            presentationDetents: [
-                .fraction(0.2),
-                .fraction(0.6),
-                .large
-            ],
+            presentationDetents: self.detents,
             isPresented: isPresented,
             largestUndimmedIdentifier: .fraction(0.6),
             cornerRadius: DebugSwiftUIRootView.cornerRadius,
@@ -66,12 +61,25 @@ public extension View {
                 DebugSwiftUIRootView()
                 #if os(macOS)
                     .frame(width: 500, height: 600)
+                #elseif swift(>=5.9) && os(xrOS)
+                    .frame(width: 600, height: 700)
                 #endif
             }
         )
     }
 
+    private var detents: Set<PresentationDetent> {
+        #if swift(>=5.9) && os(xrOS)
+            return [.large]
+        #else
+            return [
+                .fraction(0.2),
+                .fraction(0.6),
+                .large
+            ]
+        #endif
+    }
+
 }
 
-#endif
 #endif

--- a/Sources/Support/DebugUI/DebugViewModel.swift
+++ b/Sources/Support/DebugUI/DebugViewModel.swift
@@ -14,7 +14,6 @@
 import Foundation
 
 #if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS))
-#if !(swift(>=5.9) && os(xrOS))
 
 import SwiftUI
 
@@ -146,5 +145,4 @@ private extension Signing.ResponseVerificationMode {
 
 }
 
-#endif
 #endif

--- a/Sources/Support/DebugUI/DebugViewSheetPresentation.swift
+++ b/Sources/Support/DebugUI/DebugViewSheetPresentation.swift
@@ -12,7 +12,6 @@
 //  Created by Nacho Soto on 5/30/23.
 
 #if DEBUG && swift(>=5.8) && (os(iOS) || os(macOS))
-#if !(swift(>=5.9) && os(xrOS))
 
 import SwiftUI
 
@@ -46,5 +45,4 @@ extension View {
     }
 }
 
-#endif
 #endif


### PR DESCRIPTION
![image](https://github.com/RevenueCat/purchases-ios/assets/685609/5013bdb3-3ffd-4a99-92d0-9f0a13ce961a)
![image](https://github.com/RevenueCat/purchases-ios/assets/685609/89b46cff-b5aa-499c-adfd-dd67a52c4cd8)
