### PR TITLE
Fix google play purchases missing purchase date

### DIFF
--- a/Sources/Networking/Responses/CustomerInfoResponse.swift
+++ b/Sources/Networking/Responses/CustomerInfoResponse.swift
@@ -233,6 +233,7 @@ extension CustomerInfoResponse.Subscriber {
         return self.allPurchasesByProductId.mapValues { $0.asTransaction }
     }
 
+    // This returns objects of type `Subscription` but also includes non-subscriptions
     var allPurchasesByProductId: [String: CustomerInfoResponse.Subscription] {
         let subscriptions = self.subscriptions
         let latestNonSubscriptionTransactionsByProductId = self.nonSubscriptions

--- a/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
@@ -58,7 +58,8 @@ class BasicCustomerInfoTests: TestCase {
                     "expires_date": "2100-07-30T02:40:36Z",
                     "period_type": "normal",
                     "is_sandbox": false,
-                    "product_plan_identifier": "monthly"
+                    "product_plan_identifier": "monthly",
+                    "purchase_date": "2018-05-20T06:24:50Z"
                 ],
                 "onemonth": [
                     "expires_date": BasicCustomerInfoTests.expiredSubscriptionDate,
@@ -444,6 +445,11 @@ class BasicCustomerInfoTests: TestCase {
 
     func testPurchaseDateForProductIdentifier() throws {
         let purchaseDate = try XCTUnwrap(self.customerInfo.purchaseDate(forProductIdentifier: "threemonth_freetrial"))
+        expect(purchaseDate) == Date(timeIntervalSince1970: 1526797490)
+    }
+
+    func testPurchaseDateForGooglePlayProductIdentifier() throws {
+        let purchaseDate = try XCTUnwrap(self.customerInfo.purchaseDate(forProductIdentifier: "gold:monthly"))
         expect(purchaseDate) == Date(timeIntervalSince1970: 1526797490)
     }
 


### PR DESCRIPTION
### Description 
Reported in https://github.com/RevenueCat/purchases-flutter/issues/738. 

After https://github.com/RevenueCat/purchases-ios/pull/2654, we were using the new Google Play identifiers that include the plan id in expiration dates, but we didn't change the system that parses purchase dates. Later on, when we map purchases, we iterate over the expiration dates map, and since that id wasn't found in the purchase dates, it was null, causing the issue in flutter.

This makes the purchase date calculation use the same algorithm that we use for expiration dates to get the new google play product identifiers.
