### PR TITLE
`XCFramework`: sign archive for `Xcode 15`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -278,7 +278,6 @@ platform :ios do
     version_number = current_version_number
     # making it its own lane until https://github.com/CocoaPods/CocoaPods/issues/11621 is fixed.
     # push_pods 
-    carthage_archive
     export_xcframework
     github_release(version: version_number)
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -415,20 +415,26 @@ platform :ios do
         'macOS',
         'maccatalyst',
         'tvOS',
-        'watchOS'
+        'watchOS',
+        # Fixme: add xrOS
       ]
 
     create_xcframework(
       destinations: platforms,
       scheme: 'RevenueCat',
       xcframework_output_directory: output_directory,
-      # bitcode produces issues with Catalyst when validating builds,
-      # with a message: "object not signed at all".
+      # Bitcode is no longer required since Xcode 14.
       enable_bitcode: false,
       include_debug_symbols: true
     )
+    
     # sh runs from the Fastfile's location, but other commands run from the project root.
     output_directory_for_sh = "../#{output_directory}"
+
+    # Sign XCFramework for Xcode 15
+    sign_xcframework(
+      file: "#{output_directory_for_sh}/RevenueCat.xcframework"
+    )
 
     xcframeworks_zip_path_for_sh = "../RevenueCat.xcframework.zip"
     sh("ditto", "-c", "-k", "--sequesterRsrc", "--keepParent",
@@ -498,6 +504,25 @@ platform :ios do
       previous_text: old_branch_line,
       new_text: new_revision_line,
       paths_of_files_to_update: project_file_locations
+    )
+  end
+
+  private_lane :sign_xcframework do |options|
+    match(
+      readonly: true,
+      git_url: ENV['CERTS_REPO_URL'],
+      type: 'appstore',
+      skip_provisioning_profiles: true,
+      # This isn't important, we just need to fetch the certificate
+      app_identifier: "com.revenuecat.CarthageIntegration"
+    )
+
+    sh(
+      "codesign", 
+      "--timestamp",
+      "-v",
+      "--sign", "Apple Distribution: RevenueCat, Inc. (8SXR2327BM)",
+      options[:file]
     )
   end
 


### PR DESCRIPTION
_I filed https://github.com/fastlane/fastlane/issues/21359, but for now we can do this ourselves._

## Motivation
This is what happens with Xcode 15 if you try to build with an unsigned `XCFramework`:
![image](https://github.com/RevenueCat/purchases-ios/assets/685609/5de8c9d3-3f90-4f27-9c3e-7cf58df2bc84)

That breaks the build until you accept it.

### With the signature
This can be inspected in Xcode:
![image](https://github.com/RevenueCat/purchases-ios/assets/685609/9d074c5f-c54d-4806-8633-916b4e63b830)

When using Xcode 15, this modifies the project to save the known signature:
![image](https://github.com/RevenueCat/purchases-ios/assets/685609/db282066-eeea-475a-afef-cc20cf19ec55)

But the `.xcframework` remains compatible with Xcode 14.
