### PR TITLE
`CI`: removed `carthage_archive` from `release` lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -278,7 +278,6 @@ platform :ios do
     version_number = current_version_number
     # making it its own lane until https://github.com/CocoaPods/CocoaPods/issues/11621 is fixed.
     # push_pods 
-    carthage_archive
     export_xcframework
     github_release(version: version_number)
   end


### PR DESCRIPTION
It's useful to have it in `release_checks` lane, to make sure that our framework can be built with `Carthage`.
However, what we actually release is using `export_xcframework`, which also builds the frameworks.

This will make `release` MUCH faster since we no longer build everything twice as many times (and for each platform / architecture combination).
