### PR TITLE
New `TestStoreProduct` for creating mock `StoreProduct`s and `Offering`s

### DIFF
--- a/Examples/MagicWeatherSwiftUI/Shared/Sources/Views/PaywallView.swift
+++ b/Examples/MagicWeatherSwiftUI/Shared/Sources/Views/PaywallView.swift
@@ -17,10 +17,6 @@ struct PaywallView: View {
     /// - This binding is passed from ContentView: `paywallPresented`
     @Binding var isPresented: Bool
     
-    /// - State for displaying an overlay view
-    @State
-    private(set) var isPurchasing: Bool = false
-    
     /// - This can change during the lifetime of the PaywallView (e.g. if poor network conditions mean that loading offerings is slow)
     /// So set this as an observed object to trigger view updates as necessary
     @ObservedObject var userViewModel = UserViewModel.shared
@@ -30,9 +26,20 @@ struct PaywallView: View {
     private var offering: Offering? {
         userViewModel.offerings?.current
     }
-    
-    private let footerText = "Don't forget to add your subscription terms and conditions. Read more about this here: https://www.revenuecat.com/blog/schedule-2-section-3-8-b"
-    
+
+    var body: some View {
+        PaywallContent(offering: self.offering, isPresented: self.$isPresented)
+    }
+
+}
+
+private struct PaywallContent: View {
+
+    var offering: Offering?
+    var isPresented: Binding<Bool>
+
+    /// - State for displaying an overlay view
+    @State private var isPurchasing: Bool = false
     @State private var error: NSError?
     @State private var displayError: Bool = false
 
@@ -41,13 +48,13 @@ struct PaywallView: View {
             ZStack {
                 /// - The paywall view list displaying each package
                 List {
-                    Section(header: Text("\nMagic Weather Premium"), footer: Text(footerText)) {
+                    Section(header: Text("\nMagic Weather Premium"), footer: Text(Self.footerText)) {
                         ForEach(offering?.availablePackages ?? []) { package in
                             PackageCellView(package: package) { (package) in
-                                
+
                                 /// - Set 'isPurchasing' state to `true`
                                 isPurchasing = true
-                                
+
                                 /// - Purchase a package
                                 do {
                                     let result = try await Purchases.shared.purchase(package: package)
@@ -56,7 +63,7 @@ struct PaywallView: View {
                                     self.isPurchasing = false
 
                                     if !result.userCancelled {
-                                        self.isPresented = false
+                                        self.isPresented.wrappedValue = false
                                     }
                                 } catch {
                                     self.isPurchasing = false
@@ -72,7 +79,7 @@ struct PaywallView: View {
                 .navigationBarTitleDisplayMode(.inline)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .edgesIgnoringSafeArea(.bottom)
-                
+
                 /// - Display an overlay during a purchase
                 Rectangle()
                     .foregroundColor(Color.black)
@@ -93,10 +100,13 @@ struct PaywallView: View {
             message: { Text($0.recoverySuggestion ?? "Please try again") }
         )
     }
+
+    private static let footerText = "Don't forget to add your subscription terms and conditions. Read more about this here: https://www.revenuecat.com/blog/schedule-2-section-3-8-b"
+
 }
 
 /* The cell view for each package */
-struct PackageCellView: View {
+private struct PackageCellView: View {
 
     let package: Package
     let onSelection: (Package) async -> Void
@@ -146,6 +156,69 @@ extension NSError: LocalizedError {
 
     public var errorDescription: String? {
         return self.localizedDescription
+    }
+
+}
+
+struct PaywallView_Previews: PreviewProvider {
+
+    private static let product1 = TestStoreProduct(
+        localizedTitle: "PRO monthly",
+        price: 3.99,
+        localizedPriceString: "$3.99",
+        productIdentifier: "com.revenuecat.product",
+        productType: .autoRenewableSubscription,
+        localizedDescription: "Description",
+        subscriptionGroupIdentifier: "group",
+        subscriptionPeriod: .init(value: 1, unit: .month),
+        introductoryDiscount: .init(
+            identifier: "intro",
+            price: 0,
+            localizedPriceString: "$0.00",
+            paymentMode: .freeTrial,
+            subscriptionPeriod: .init(value: 1, unit: .week),
+            numberOfPeriods: 1,
+            type: .introductory
+        ),
+        discounts: []
+    )
+    private static let product2 = TestStoreProduct(
+        localizedTitle: "PRO annual",
+        price: 34.99,
+        localizedPriceString: "$34.99",
+        productIdentifier: "com.revenuecat.product",
+        productType: .autoRenewableSubscription,
+        localizedDescription: "Description",
+        subscriptionGroupIdentifier: "group",
+        subscriptionPeriod: .init(value: 1, unit: .year),
+        introductoryDiscount: nil,
+        discounts: []
+    )
+
+    private static let offering = Offering(
+        identifier: Self.offeringIdentifier,
+        serverDescription: "Main offering",
+        metadata: [:],
+        availablePackages: [
+            .init(
+                identifier: "monthly",
+                packageType: .monthly,
+                storeProduct: product1.toStoreProduct(),
+                offeringIdentifier: Self.offeringIdentifier
+            ),
+            .init(
+                identifier: "annual",
+                packageType: .annual,
+                storeProduct: product2.toStoreProduct(),
+                offeringIdentifier: Self.offeringIdentifier
+            )
+        ]
+    )
+
+    private static let offeringIdentifier = "offering"
+
+    static var previews: some View {
+        PaywallContent(offering: Self.offering, isPresented: .constant(true))
     }
 
 }

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -203,6 +203,7 @@
 		4F0BBA812A1D0524000E75AB /* DefaultDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0BBA802A1D0524000E75AB /* DefaultDecodable.swift */; };
 		4F0BBAAC2A1D253D000E75AB /* OfflineCustomerInfoCreatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0BBAAB2A1D253D000E75AB /* OfflineCustomerInfoCreatorTests.swift */; };
 		4F0CE2BD2A215CE600561895 /* TransactionPosterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0CE2BC2A215CE600561895 /* TransactionPosterTests.swift */; };
+		4F1428A42A4A132C006CD196 /* TestStoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1428A32A4A132C006CD196 /* TestStoreProductDiscount.swift */; };
 		4F2017D52A15587F0061F6EF /* OfflineStoreKitIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2017D42A15587F0061F6EF /* OfflineStoreKitIntegrationTests.swift */; };
 		4F2018732A15797D0061F6EF /* TestLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57057FF728B0048900995F21 /* TestLogHandler.swift */; };
 		4F2F2EFF2A3CDAA800652B24 /* FileHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2F2EFE2A3CDAA800652B24 /* FileHandler.swift */; };
@@ -244,6 +245,7 @@
 		4F8A58182A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */; };
 		4F90AFCB2A3915340047E63F /* TestMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F90AFCA2A3915340047E63F /* TestMessage.swift */; };
 		4F90AFCC2A3915BC0047E63F /* TestMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F90AFCA2A3915340047E63F /* TestMessage.swift */; };
+		4F98E9D32A465A4400DB6EAB /* TestStoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F98E9D22A465A4400DB6EAB /* TestStoreProduct.swift */; };
 		4FA4C8DA2A168956007D2803 /* OfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA4C8D92A168956007D2803 /* OfflineCustomerInfoCreator.swift */; };
 		4FA4C9732A16D3AC007D2803 /* MockBackendConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA4C9722A16D3AC007D2803 /* MockBackendConfiguration.swift */; };
 		4FA4C9742A16D3AC007D2803 /* MockBackendConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA4C9722A16D3AC007D2803 /* MockBackendConfiguration.swift */; };
@@ -929,6 +931,7 @@
 		4F0BBA802A1D0524000E75AB /* DefaultDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultDecodable.swift; sourceTree = "<group>"; };
 		4F0BBAAB2A1D253D000E75AB /* OfflineCustomerInfoCreatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineCustomerInfoCreatorTests.swift; sourceTree = "<group>"; };
 		4F0CE2BC2A215CE600561895 /* TransactionPosterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionPosterTests.swift; sourceTree = "<group>"; };
+		4F1428A32A4A132C006CD196 /* TestStoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestStoreProductDiscount.swift; sourceTree = "<group>"; };
 		4F2017D42A15587F0061F6EF /* OfflineStoreKitIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineStoreKitIntegrationTests.swift; sourceTree = "<group>"; };
 		4F2F2EFE2A3CDAA800652B24 /* FileHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileHandler.swift; sourceTree = "<group>"; };
 		4F2F2F132A3CEAB500652B24 /* FileHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileHandlerTests.swift; sourceTree = "<group>"; };
@@ -951,6 +954,7 @@
 		4F8038322A1EA7C300D21039 /* TransactionPoster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionPoster.swift; sourceTree = "<group>"; };
 		4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOfflineCustomerInfoCreator.swift; sourceTree = "<group>"; };
 		4F90AFCA2A3915340047E63F /* TestMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestMessage.swift; sourceTree = "<group>"; };
+		4F98E9D22A465A4400DB6EAB /* TestStoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestStoreProduct.swift; sourceTree = "<group>"; };
 		4FA4C8D92A168956007D2803 /* OfflineCustomerInfoCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineCustomerInfoCreator.swift; sourceTree = "<group>"; };
 		4FA4C9722A16D3AC007D2803 /* MockBackendConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackendConfiguration.swift; sourceTree = "<group>"; };
 		4FA696A329FC43C600D228B1 /* ReceiptParserTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ReceiptParserTests-Info.plist"; sourceTree = "<group>"; };
@@ -1428,6 +1432,7 @@
 		2D1015DC275A57DB0086173F /* StoreKitAbstractions */ = {
 			isa = PBXGroup;
 			children = (
+				4F1428A52A4A1330006CD196 /* Test Data */,
 				57EFDC6A27BC1F370057EC39 /* ProductType.swift */,
 				2C0B98CC2797070B00C5874F /* PromotionalOffer.swift */,
 				57DE807028074C23008D6C6F /* SK1Storefront.swift */,
@@ -2142,6 +2147,15 @@
 				2DDF41AA24F6F37C005BC22D /* InAppPurchase.swift */,
 			);
 			path = BasicTypes;
+			sourceTree = "<group>";
+		};
+		4F1428A52A4A1330006CD196 /* Test Data */ = {
+			isa = PBXGroup;
+			children = (
+				4F98E9D22A465A4400DB6EAB /* TestStoreProduct.swift */,
+				4F1428A32A4A132C006CD196 /* TestStoreProductDiscount.swift */,
+			);
+			path = "Test Data";
 			sourceTree = "<group>";
 		};
 		4F2F2EFD2A3CDA9B00652B24 /* Diagnostics */ = {
@@ -3263,6 +3277,7 @@
 				4FCEEA5E2A379B80002C2112 /* DebugViewController.swift in Sources */,
 				579415D529368AB200218FBC /* ReceiptStrings.swift in Sources */,
 				57A0FBF02749C0C2009E2FC3 /* Atomic.swift in Sources */,
+				4F98E9D32A465A4400DB6EAB /* TestStoreProduct.swift in Sources */,
 				2DC5623224EC63730031F69B /* TransactionsFactory.swift in Sources */,
 				579415D2293689DD00218FBC /* Codable+Extensions.swift in Sources */,
 				2DDF41B424F6F387005BC22D /* ASN1ContainerBuilder.swift in Sources */,
@@ -3334,6 +3349,7 @@
 				57D5414227F656D9004CC35C /* NetworkError.swift in Sources */,
 				B3781568285A79FC000A7B93 /* IdentityAPI.swift in Sources */,
 				B325543C2825C81800DA62EA /* Configuration.swift in Sources */,
+				4F1428A42A4A132C006CD196 /* TestStoreProductDiscount.swift in Sources */,
 				F5BE447B269E4A7500254A30 /* TrackingManagerProxy.swift in Sources */,
 				5746508C27586B2E0053AB09 /* Result+Extensions.swift in Sources */,
 				B34D2AA0269606E400D88C3A /* IntroEligibility.swift in Sources */,

--- a/Sources/Purchasing/Offering.swift
+++ b/Sources/Purchasing/Offering.swift
@@ -116,8 +116,15 @@ import Foundation
         return package(identifier: key)
     }
 
-    // swiftlint:disable:next cyclomatic_complexity
-    init(identifier: String, serverDescription: String, metadata: [String: Any], availablePackages: [Package]) {
+    // swiftlint:disable cyclomatic_complexity
+
+    /// Initialize an ``Offering`` given a list of ``Package``s.
+    public init(
+        identifier: String,
+        serverDescription: String,
+        metadata: [String: Any],
+        availablePackages: [Package]
+    ) {
         self.identifier = identifier
         self.serverDescription = serverDescription
         self.availablePackages = availablePackages
@@ -170,6 +177,8 @@ import Foundation
 
         super.init()
     }
+
+    // swiftlint:enable cyclomatic_complexity
 
 }
 

--- a/Sources/Purchasing/Package.swift
+++ b/Sources/Purchasing/Package.swift
@@ -45,11 +45,19 @@ import Foundation
         return self.storeProduct.localizedIntroductoryPriceString
     }
 
-    init(identifier: String, packageType: PackageType, storeProduct: StoreProductType, offeringIdentifier: String) {
+    /// Initialize a ``Package``.
+    public init(
+        identifier: String,
+        packageType: PackageType,
+        storeProduct: StoreProduct,
+        offeringIdentifier: String
+    ) {
         self.identifier = identifier
         self.packageType = packageType
-        self.storeProduct = StoreProduct.from(product: storeProduct)
+        self.storeProduct = storeProduct
         self.offeringIdentifier = offeringIdentifier
+
+        super.init()
     }
 
     public override func isEqual(_ object: Any?) -> Bool {

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -289,6 +289,8 @@ final class PurchasesOrchestrator {
                           package: package,
                           promotionalOffer: nil,
                           completion: completion)
+        } else if product.isTestProduct {
+            self.handleTestProduct(completion)
         } else {
             fatalError("Unrecognized product: \(product)")
         }
@@ -315,6 +317,8 @@ final class PurchasesOrchestrator {
                           package: package,
                           promotionalOffer: promotionalOffer,
                           completion: completion)
+        } else if product.isTestProduct {
+            self.handleTestProduct(completion)
         } else {
             fatalError("Unrecognized product: \(product)")
         }
@@ -1146,6 +1150,17 @@ private extension PurchasesOrchestrator {
             }
 
             completion(result)
+        }
+    }
+
+    func handleTestProduct(_ completion: @escaping PurchaseCompletedBlock) {
+        self.operationDispatcher.dispatchOnMainActor {
+            completion(
+                nil,
+                nil,
+                ErrorUtils.productNotAvailableForPurchaseError().asPublicError,
+                false
+            )
         }
     }
 

--- a/Sources/Purchasing/StoreKitAbstractions/ProductType.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/ProductType.swift
@@ -88,3 +88,6 @@ extension StoreProduct.ProductType {
     }
 
 }
+
+extension StoreProduct.ProductCategory: Sendable {}
+extension StoreProduct.ProductType: Sendable {}

--- a/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -277,6 +277,14 @@ extension StoreProduct {
         return (self.product as? SK2StoreProduct)?.underlyingSK2Product
     }
 
+    var isTestProduct: Bool {
+        #if DEBUG
+        return self.product is TestStoreProduct
+        #else
+        return false
+        #endif
+    }
+
 }
 
 // MARK: - Renames

--- a/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -131,11 +131,11 @@ internal protocol StoreProductType: Sendable {
     /// For a string representation of the price to display to customers, use ``localizedPriceString``.
     ///
     /// #### Related Symbols
-    /// - ``pricePerMonth``
-    /// - ``pricePerYear``
+    /// - ``StoreProduct/pricePerMonth``
+    /// - ``StoreProduct/pricePerYear``
     var price: Decimal { get }
 
-    /// The price of this product using ``priceFormatter``.
+    /// The price of this product using ``StoreProduct/priceFormatter``.
     var localizedPriceString: String { get }
 
     /// The string that identifies the product to the Apple App Store.

--- a/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
@@ -58,6 +58,7 @@ public struct TestStoreProduct {
     public var localizedDescription: String
     public var subscriptionGroupIdentifier: String?
     public var subscriptionPeriod: SubscriptionPeriod?
+    public var isFamilyShareable: Bool
     public var introductoryDiscount: StoreProductDiscount?
     public var discounts: [StoreProductDiscount]
 
@@ -70,6 +71,7 @@ public struct TestStoreProduct {
         localizedDescription: String,
         subscriptionGroupIdentifier: String? = nil,
         subscriptionPeriod: SubscriptionPeriod? = nil,
+        isFamilyShareable: Bool = false,
         introductoryDiscount: TestStoreProductDiscount? = nil,
         discounts: [TestStoreProductDiscount] = []
     ) {
@@ -81,6 +83,7 @@ public struct TestStoreProduct {
         self.localizedDescription = localizedDescription
         self.subscriptionGroupIdentifier = subscriptionGroupIdentifier
         self.subscriptionPeriod = subscriptionPeriod
+        self.isFamilyShareable = isFamilyShareable
         self.introductoryDiscount = introductoryDiscount?.toStoreProductDiscount()
         self.discounts = discounts.map { $0.toStoreProductDiscount() }
     }
@@ -100,8 +103,6 @@ extension TestStoreProduct: StoreProductType {
         // Test currency defaults to current locale
         return Locale.current.rc_currencyCode
     }
-
-    internal var isFamilyShareable: Bool { return false }
 
     internal var priceFormatter: NumberFormatter? {
         return self.currencyCode.map {

--- a/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
@@ -88,7 +88,7 @@ public struct TestStoreProduct {
     // swiftlint:enable missing_docs
 
     private let priceFormatterProvider: PriceFormatterProvider = .init()
-    
+
 }
 
 // Ensure consistency with the internal type

--- a/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
@@ -1,0 +1,122 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  TestStoreProduct.swift
+//
+//  Created by Nacho Soto on 6/23/23.
+
+import Foundation
+
+#if DEBUG
+
+/// A type that contains the necessary data to create a ``StoreProduct``.
+public struct TestStoreProduct {
+
+    // Note: this class inherits its docs from `StoreProductType`
+    // swiftlint:disable missing_docs
+
+    public var localizedTitle: String
+    public var price: Decimal
+    public var localizedPriceString: String
+    public var productIdentifier: String
+    public var productType: StoreProduct.ProductType
+    public var localizedDescription: String
+    public var subscriptionGroupIdentifier: String?
+    public var subscriptionPeriod: SubscriptionPeriod?
+    public var introductoryDiscount: StoreProductDiscount?
+    public var discounts: [StoreProductDiscount]
+
+    public init(
+        localizedTitle: String,
+        price: Decimal,
+        localizedPriceString: String,
+        productIdentifier: String,
+        productType: StoreProduct.ProductType,
+        localizedDescription: String,
+        subscriptionGroupIdentifier: String? = nil,
+        subscriptionPeriod: SubscriptionPeriod? = nil,
+        introductoryDiscount: TestStoreProductDiscount? = nil,
+        discounts: [TestStoreProductDiscount] = []
+    ) {
+        self.localizedTitle = localizedTitle
+        self.price = price
+        self.localizedPriceString = localizedPriceString
+        self.productIdentifier = productIdentifier
+        self.productType = productType
+        self.localizedDescription = localizedDescription
+        self.subscriptionGroupIdentifier = subscriptionGroupIdentifier
+        self.subscriptionPeriod = subscriptionPeriod
+        self.introductoryDiscount = introductoryDiscount?.toStoreProductDiscount()
+        self.discounts = discounts.map { $0.toStoreProductDiscount() }
+    }
+
+    // swiftlint:enable missing_docs
+
+    private let priceFormatterProvider: PriceFormatterProvider = .init()
+    
+}
+
+// Ensure consistency with the internal type
+extension TestStoreProduct: StoreProductType {
+
+    internal var productCategory: StoreProduct.ProductCategory { return self.productType.productCategory }
+
+    internal var currencyCode: String? {
+        // Test currency defaults to current locale
+        return Locale.current.rc_currencyCode
+    }
+
+    internal var isFamilyShareable: Bool { return false }
+
+    internal var priceFormatter: NumberFormatter? {
+        return self.currencyCode.map {
+            self.priceFormatterProvider.priceFormatterForSK2(withCurrencyCode: $0)
+        }
+    }
+
+}
+
+extension TestStoreProduct {
+
+    /// Convert it into a ``StoreProduct``.
+    public func toStoreProduct() -> StoreProduct {
+        return .from(product: self)
+    }
+
+}
+
+#else
+
+// swiftlint:disable missing_docs
+
+@available(
+    iOS,
+    obsoleted: 1,
+    message: "This API is only available for debug builds. Use #if DEBUG to conditionally compile it."
+)
+public struct TestStoreProduct {
+
+    public init(
+        localizedTitle: String,
+        price: Decimal,
+        localizedPriceString: String,
+        productIdentifier: String,
+        productType: StoreProduct.ProductType,
+        localizedDescription: String,
+        subscriptionGroupIdentifier: String? = nil,
+        subscriptionPeriod: SubscriptionPeriod? = nil,
+        introductoryDiscount: TestStoreProductDiscount? = nil,
+        discounts: [TestStoreProductDiscount] = []
+    ) {}
+
+}
+
+// swiftlint:enable missing_docs
+
+#endif

--- a/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
@@ -16,6 +16,35 @@ import Foundation
 #if DEBUG
 
 /// A type that contains the necessary data to create a ``StoreProduct``.
+/// This can be used to create mock data for tests or SwiftUI previews.
+///
+/// Example:
+/// ```swift
+/// let product = TestStoreProduct(
+///     localizedTitle: "PRO monthly",
+///     price: 3.99,
+///     localizedPriceString: "$3.99",
+///     productIdentifier: "com.revenuecat.product",
+///     productType: .autoRenewableSubscription,
+///     localizedDescription: "Description",
+///     subscriptionGroupIdentifier: "group",
+///     subscriptionPeriod: .init(value: 1, unit: .month)
+/// )
+///
+/// let offering = Offering(
+///     identifier: "offering",
+///     serverDescription: "Main offering",
+///     metadata: [:],
+///     availablePackages: [
+///         .init(
+///             identifier: "monthly",
+///             packageType: .monthly,
+///             storeProduct: product.toStoreProduct(),
+///             offeringIdentifier: offering
+///         ),
+///     ]
+/// )
+/// ```
 public struct TestStoreProduct {
 
     // Note: this class inherits its docs from `StoreProductType`
@@ -116,7 +145,5 @@ public struct TestStoreProduct {
     ) {}
 
 }
-
-// swiftlint:enable missing_docs
 
 #endif

--- a/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
@@ -139,9 +139,7 @@ public struct TestStoreProduct {
         productType: StoreProduct.ProductType,
         localizedDescription: String,
         subscriptionGroupIdentifier: String? = nil,
-        subscriptionPeriod: SubscriptionPeriod? = nil,
-        introductoryDiscount: TestStoreProductDiscount? = nil,
-        discounts: [TestStoreProductDiscount] = []
+        subscriptionPeriod: SubscriptionPeriod? = nil
     ) {}
 
 }

--- a/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProductDiscount.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProductDiscount.swift
@@ -1,0 +1,98 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  TestStoreProductDiscount.swift
+//
+//  Created by Nacho Soto on 6/26/23.
+
+import Foundation
+
+#if DEBUG
+
+/// A type that contains the necessary data to create a ``StoreProduct``.
+public struct TestStoreProductDiscount {
+
+    // Note: this class inherits its docs from `StoreProductDiscountType`
+    // swiftlint:disable missing_docs
+
+    public var identifier: String
+    public var price: Decimal
+    public var localizedPriceString: String
+    public var paymentMode: StoreProductDiscount.PaymentMode
+    public var subscriptionPeriod: SubscriptionPeriod
+    public var numberOfPeriods: Int
+    public var type: StoreProductDiscount.DiscountType
+
+    public init(
+        identifier: String,
+        price: Decimal,
+        localizedPriceString: String,
+        paymentMode: StoreProductDiscount.PaymentMode,
+        subscriptionPeriod: SubscriptionPeriod,
+        numberOfPeriods: Int,
+        type: StoreProductDiscount.DiscountType
+    ) {
+        self.identifier = identifier
+        self.price = price
+        self.localizedPriceString = localizedPriceString
+        self.paymentMode = paymentMode
+        self.subscriptionPeriod = subscriptionPeriod
+        self.numberOfPeriods = numberOfPeriods
+        self.type = type
+    }
+
+}
+
+extension TestStoreProductDiscount: StoreProductDiscountType {
+
+    var offerIdentifier: String? {
+        return self.identifier
+    }
+
+    var currencyCode: String? {
+        // Test currency defaults to current locale
+        return Locale.current.rc_currencyCode
+    }
+
+}
+
+extension TestStoreProductDiscount {
+
+    /// Convert it into a ``StoreProductDiscount``.
+    public func toStoreProductDiscount() -> StoreProductDiscount {
+        return .from(discount: self)
+    }
+
+}
+
+#else
+
+@available(
+    iOS,
+    obsoleted: 1,
+    message: "This API is only available for debug builds. Use #if DEBUG to conditionally compile it."
+)
+// swiftlint:disable missing_docs
+public struct TestStoreProductDiscount {
+
+    public init(
+        identifier: String,
+        price: Decimal,
+        localizedPriceString: String,
+        paymentMode: StoreProductDiscount.PaymentMode,
+        subscriptionPeriod: SubscriptionPeriod,
+        numberOfPeriods: Int,
+        type: StoreProductDiscount.DiscountType
+    ) {}
+
+}
+
+// swiftlint:enable missing_docs
+
+#endif

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj/project.pbxproj
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		2DD778ED270E23460079CBD4 /* OfferingAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C726EBE7EA007DDB75 /* OfferingAPI.swift */; };
 		2DD778EE270E23460079CBD4 /* EntitlementInfosAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C526EBE7EA007DDB75 /* EntitlementInfosAPI.swift */; };
 		2DD778EF270E23460079CBD4 /* EntitlementInfoAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C826EBE7EA007DDB75 /* EntitlementInfoAPI.swift */; };
+		4F1428A22A4A11D7006CD196 /* TestStoreProductAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1428A12A4A11D7006CD196 /* TestStoreProductAPI.swift */; };
+		4F1428A72A4A16C0006CD196 /* TestStoreProductDiscountAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1428A62A4A16C0006CD196 /* TestStoreProductDiscountAPI.swift */; };
 		4F6BEE752A27C77C00CD9322 /* OtherAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6BEE742A27C77C00CD9322 /* OtherAPI.swift */; };
 		570FAF562864EE1D00D3C769 /* NonSubscriptionTransactionAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570FAF552864EE1D00D3C769 /* NonSubscriptionTransactionAPI.swift */; };
 		5738F40C27866DD00096D623 /* StoreProductDiscountAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5738F40B27866DD00096D623 /* StoreProductDiscountAPI.swift */; };
@@ -55,6 +57,8 @@
 /* Begin PBXFileReference section */
 		2C396F5B281C64AF00669657 /* AdServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdServices.framework; path = System/Library/Frameworks/AdServices.framework; sourceTree = SDKROOT; };
 		2DD778D0270E233F0079CBD4 /* SwiftAPITester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftAPITester.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		4F1428A12A4A11D7006CD196 /* TestStoreProductAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestStoreProductAPI.swift; sourceTree = "<group>"; };
+		4F1428A62A4A16C0006CD196 /* TestStoreProductDiscountAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestStoreProductDiscountAPI.swift; sourceTree = "<group>"; };
 		4F6BEE742A27C77C00CD9322 /* OtherAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherAPI.swift; sourceTree = "<group>"; };
 		570FAF552864EE1D00D3C769 /* NonSubscriptionTransactionAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonSubscriptionTransactionAPI.swift; sourceTree = "<group>"; };
 		5738F40B27866DD00096D623 /* StoreProductDiscountAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProductDiscountAPI.swift; sourceTree = "<group>"; };
@@ -152,6 +156,8 @@
 				5738F40B27866DD00096D623 /* StoreProductDiscountAPI.swift */,
 				5758EE572786542200B3B703 /* StoreTransactionAPI.swift */,
 				5738F429278673A80096D623 /* SubscriptionPeriodAPI.swift */,
+				4F1428A12A4A11D7006CD196 /* TestStoreProductAPI.swift */,
+				4F1428A62A4A16C0006CD196 /* TestStoreProductDiscountAPI.swift */,
 				A5D614CB26EBE7EA007DDB75 /* TransactionAPI.swift */,
 				5740FCD42996D7B800E049F9 /* VerificationResultAPI.swift */,
 			);
@@ -237,10 +243,12 @@
 				2DD778E8270E23460079CBD4 /* PackageAPI.swift in Sources */,
 				57918A1328F4C49500BF4963 /* PurchasesDiagnosticsAPI.swift in Sources */,
 				4F6BEE752A27C77C00CD9322 /* OtherAPI.swift in Sources */,
+				4F1428A22A4A11D7006CD196 /* TestStoreProductAPI.swift in Sources */,
 				570FAF562864EE1D00D3C769 /* NonSubscriptionTransactionAPI.swift in Sources */,
 				57DE807528074D9C008D6C6F /* StorefrontAPI.swift in Sources */,
 				2DD778E6270E23460079CBD4 /* PurchasesAPI.swift in Sources */,
 				2DD778EF270E23460079CBD4 /* EntitlementInfoAPI.swift in Sources */,
+				4F1428A72A4A16C0006CD196 /* TestStoreProductDiscountAPI.swift in Sources */,
 				2DD778E9270E23460079CBD4 /* CustomerInfoAPI.swift in Sources */,
 				5758EE4F2786493400B3B703 /* StoreProductAPI.swift in Sources */,
 				5753ED9D294A6F3F00CBAB54 /* PurchasesReceiptParserAPI.swift in Sources */,

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/OfferingAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/OfferingAPI.swift
@@ -37,3 +37,11 @@ func checkOfferingAPI() {
     print(off!, ident, sDesc, aPacks, lPack!, annPack!, smPack!, thmPack!, twmPack!,
           mPack!, wPack!, pPack!, package!, metadata, metadataString, metadataInt, metadataOptionalInt!)
 }
+
+private func checkCreateOfferingAPI(package: Package) {
+    _ = Offering(identifier: "",
+                 serverDescription: "",
+                 metadata: [String: Any](),
+                 availablePackages: [package]
+    )
+}

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PackageAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PackageAPI.swift
@@ -26,6 +26,14 @@ func checkPackageAPI() {
     print(pack!, ident, pType, prod, lps, lips!)
 }
 
+private func checkCreatePackageAPI(product: StoreProduct) {
+    _ = Package(
+        identifier: "", packageType: PackageType.annual,
+        storeProduct: product,
+        offeringIdentifier: ""
+    )
+}
+
 var packageType: PackageType!
 func checkPackageEnums() {
     switch packageType! {

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductAPI.swift
@@ -23,6 +23,7 @@ func checkTestStoreProductAPI() {
     let localizedDescription: String = testProduct.localizedDescription
     let subscriptionGroupIdentifier: String? = testProduct.subscriptionGroupIdentifier
     let subscriptionPeriod: SubscriptionPeriod? = testProduct.subscriptionPeriod
+    let isFamilyShareable: Bool = testProduct.isFamilyShareable
     let introductoryDiscount: StoreProductDiscount? = testProduct.introductoryDiscount
     let discounts: [StoreProductDiscount] = testProduct.discounts
 
@@ -35,6 +36,7 @@ func checkTestStoreProductAPI() {
     testProduct.localizedDescription = localizedDescription
     testProduct.subscriptionGroupIdentifier = subscriptionGroupIdentifier
     testProduct.subscriptionPeriod = subscriptionPeriod
+    testProduct.isFamilyShareable = isFamilyShareable
     testProduct.introductoryDiscount = introductoryDiscount
     testProduct.discounts = discounts
 
@@ -60,6 +62,7 @@ private func checkStoreProductCreation(discount: TestStoreProductDiscount) {
         localizedDescription: "",
         subscriptionGroupIdentifier: Optional<String>.some(""),
         subscriptionPeriod: Optional<SubscriptionPeriod>.some(.init(value: 1, unit: .day)),
+        isFamilyShareable: true,
         introductoryDiscount: Optional<TestStoreProductDiscount>.some(discount),
         discounts: [discount]
     )

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductAPI.swift
@@ -7,6 +7,8 @@
 
 import RevenueCat
 
+#if DEBUG
+
 // swiftlint:disable syntactic_sugar
 
 private var testProduct: TestStoreProduct!
@@ -62,3 +64,5 @@ private func checkStoreProductCreation(discount: TestStoreProductDiscount) {
         discounts: [discount]
     )
 }
+
+#endif

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductAPI.swift
@@ -1,0 +1,64 @@
+//
+//  TestStoreProductAPI.swift
+//  SwiftAPITester
+//
+//  Created by Nacho Soto on 6/26/23.
+//
+
+import RevenueCat
+
+// swiftlint:disable syntactic_sugar
+
+private var testProduct: TestStoreProduct!
+
+func checkTestStoreProductAPI() {
+    // Getters
+    let localizedTitle: String = testProduct.localizedTitle
+    let price: Decimal = testProduct.price
+    let localizedPriceString: String = testProduct.localizedPriceString
+    let productIdentifier: String = testProduct.productIdentifier
+    let productType: StoreProduct.ProductType = testProduct.productType
+    let localizedDescription: String = testProduct.localizedDescription
+    let subscriptionGroupIdentifier: String? = testProduct.subscriptionGroupIdentifier
+    let subscriptionPeriod: SubscriptionPeriod? = testProduct.subscriptionPeriod
+    let introductoryDiscount: StoreProductDiscount? = testProduct.introductoryDiscount
+    let discounts: [StoreProductDiscount] = testProduct.discounts
+
+    // Setters
+    testProduct.localizedTitle = localizedTitle
+    testProduct.price = price
+    testProduct.localizedPriceString = localizedPriceString
+    testProduct.productIdentifier = productIdentifier
+    testProduct.productType = productType
+    testProduct.localizedDescription = localizedDescription
+    testProduct.subscriptionGroupIdentifier = subscriptionGroupIdentifier
+    testProduct.subscriptionPeriod = subscriptionPeriod
+    testProduct.introductoryDiscount = introductoryDiscount
+    testProduct.discounts = discounts
+
+    let _: StoreProduct = testProduct.toStoreProduct()
+}
+
+private func checkStoreProductCreation(discount: TestStoreProductDiscount) {
+    _ = TestStoreProduct(
+        localizedTitle: "",
+        price: 3.99,
+        localizedPriceString: "",
+        productIdentifier: "",
+        productType: .autoRenewableSubscription,
+        localizedDescription: ""
+    )
+
+    _ = TestStoreProduct(
+        localizedTitle: "",
+        price: 1.99,
+        localizedPriceString: "",
+        productIdentifier: "",
+        productType: .autoRenewableSubscription,
+        localizedDescription: "",
+        subscriptionGroupIdentifier: Optional<String>.some(""),
+        subscriptionPeriod: Optional<SubscriptionPeriod>.some(.init(value: 1, unit: .day)),
+        introductoryDiscount: Optional<TestStoreProductDiscount>.some(discount),
+        discounts: [discount]
+    )
+}

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductDiscountAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductDiscountAPI.swift
@@ -1,0 +1,52 @@
+//
+//  TestStoreProductDiscountAPI.swift
+//  SwiftAPITester
+//
+//  Created by Nacho Soto on 6/26/23.
+//
+
+import RevenueCat
+
+var testProductDiscount: TestStoreProductDiscount!
+
+func checkTestStoreProductDiscountAPI() {
+    // Getters
+    let identifier: String = testProductDiscount.identifier
+    let price: Decimal = testProductDiscount.price
+    let localizedPriceString: String = testProductDiscount.localizedPriceString
+    let paymentMode: StoreProductDiscount.PaymentMode = testProductDiscount.paymentMode
+    let subscriptionPeriod: SubscriptionPeriod = testProductDiscount.subscriptionPeriod
+    let numberOfPeriods: Int = testProductDiscount.numberOfPeriods
+    let type: StoreProductDiscount.DiscountType = testProductDiscount.type
+
+    // Setters
+    testProductDiscount.identifier = identifier
+    testProductDiscount.price = price
+    testProductDiscount.localizedPriceString = localizedPriceString
+    testProductDiscount.paymentMode = paymentMode
+    testProductDiscount.subscriptionPeriod = subscriptionPeriod
+    testProductDiscount.numberOfPeriods = numberOfPeriods
+    testProductDiscount.type = type
+}
+
+private func checkCreateStoreProduct() {
+    _ = TestStoreProductDiscount(
+        identifier: "",
+        price: 3.99,
+        localizedPriceString: "",
+        paymentMode: .payAsYouGo,
+        subscriptionPeriod: .init(value: 1, unit: .month),
+        numberOfPeriods: 2,
+        type: .introductory
+    )
+
+    _ = TestStoreProductDiscount(
+        identifier: "",
+        price: 1.99,
+        localizedPriceString: "",
+        paymentMode: .freeTrial,
+        subscriptionPeriod: .init(value: 0, unit: .day),
+        numberOfPeriods: 1,
+        type: .promotional
+    )
+}

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductDiscountAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductDiscountAPI.swift
@@ -7,6 +7,8 @@
 
 import RevenueCat
 
+#if DEBUG
+
 var testProductDiscount: TestStoreProductDiscount!
 
 func checkTestStoreProductDiscountAPI() {
@@ -50,3 +52,5 @@ private func checkCreateStoreProduct() {
         type: .promotional
     )
 }
+
+#endif

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/main.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/main.swift
@@ -52,9 +52,12 @@ func main() -> Int {
     checkNonSubscriptionTransactionAPI()
     checkTransactionAPI()
 
+    checkTestStoreProductAPI()
     checkStoreProductAPI()
 
+    checkTestStoreProductDiscountAPI()
     checkStoreProductDiscountAPI()
+
     checkPaymentModeEnum()
 
     checkSubscriptionPeriodAPI()

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/main.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/main.swift
@@ -52,11 +52,13 @@ func main() -> Int {
     checkNonSubscriptionTransactionAPI()
     checkTransactionAPI()
 
-    checkTestStoreProductAPI()
     checkStoreProductAPI()
-
-    checkTestStoreProductDiscountAPI()
     checkStoreProductDiscountAPI()
+
+    #if DEBUG
+    checkTestStoreProductAPI()
+    checkTestStoreProductDiscountAPI()
+    #endif
 
     checkPaymentModeEnum()
 

--- a/Tests/StoreKitUnitTests/StoreProductTests.swift
+++ b/Tests/StoreKitUnitTests/StoreProductTests.swift
@@ -345,6 +345,8 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(nonSubscription.productCategory) == .nonSubscription
     }
 
+    #if DEBUG
+
     func testTestProduct() {
         let title = "Product"
         let price: Decimal = 3.99
@@ -383,6 +385,8 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(storeProduct.priceFormatter).toNot(beNil())
         expect(storeProduct.isFamilyShareable) == false
     }
+
+    #endif
 
 }
 

--- a/Tests/StoreKitUnitTests/StoreProductTests.swift
+++ b/Tests/StoreKitUnitTests/StoreProductTests.swift
@@ -356,6 +356,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         let description = "Description"
         let subscriptionGroup = "group"
         let period: SubscriptionPeriod = .init(value: 1, unit: .month)
+        let isFamilyShareable = Bool.random()
 
         let product = TestStoreProduct(
             localizedTitle: title,
@@ -366,6 +367,7 @@ class StoreProductTests: StoreKitConfigTestCase {
             localizedDescription: description,
             subscriptionGroupIdentifier: subscriptionGroup,
             subscriptionPeriod: period,
+            isFamilyShareable: isFamilyShareable,
             introductoryDiscount: nil,
             discounts: []
         )
@@ -383,7 +385,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(storeProduct.subscriptionPeriod) == period
         expect(storeProduct.currencyCode) == Locale.current.rc_currencyCode
         expect(storeProduct.priceFormatter).toNot(beNil())
-        expect(storeProduct.isFamilyShareable) == false
+        expect(storeProduct.isFamilyShareable) == isFamilyShareable
     }
 
     #endif

--- a/Tests/StoreKitUnitTests/StoreProductTests.swift
+++ b/Tests/StoreKitUnitTests/StoreProductTests.swift
@@ -100,6 +100,8 @@ class StoreProductTests: StoreKitConfigTestCase {
 
         expect(storeProduct.sk1Product) === sk1Product.underlyingSK1Product
 
+        expect(storeProduct.isTestProduct) == false
+
         expect(storeProduct.productIdentifier) == Self.productID
         expect(storeProduct.productCategory) == .subscription
         expect(storeProduct.localizedDescription) == "Monthly subscription with a 1-week free trial"
@@ -151,6 +153,8 @@ class StoreProductTests: StoreKitConfigTestCase {
 
         // Can't use `===` because `SK2Product` is a `struct`
         expect(storeProduct.sk2Product) == storeProduct.sk2Product
+
+        expect(storeProduct.isTestProduct) == false
 
         expect(storeProduct.productIdentifier) == Self.productID
         expect(storeProduct.productCategory) == .subscription
@@ -339,6 +343,45 @@ class StoreProductTests: StoreKitConfigTestCase {
 
         expect(subscription.productCategory) == .subscription
         expect(nonSubscription.productCategory) == .nonSubscription
+    }
+
+    func testTestProduct() {
+        let title = "Product"
+        let price: Decimal = 3.99
+        let localizedPrice = "$3.99"
+        let identifier = "com.revenuecat.product"
+        let type: StoreProduct.ProductType = .autoRenewableSubscription
+        let description = "Description"
+        let subscriptionGroup = "group"
+        let period: SubscriptionPeriod = .init(value: 1, unit: .month)
+
+        let product = TestStoreProduct(
+            localizedTitle: title,
+            price: price,
+            localizedPriceString: localizedPrice,
+            productIdentifier: identifier,
+            productType: type,
+            localizedDescription: description,
+            subscriptionGroupIdentifier: subscriptionGroup,
+            subscriptionPeriod: period,
+            introductoryDiscount: nil,
+            discounts: []
+        )
+        let storeProduct = product.toStoreProduct()
+
+        expect(storeProduct.isTestProduct) == true
+        expect(storeProduct.localizedTitle) == title
+        expect(storeProduct.price) == price
+        expect(storeProduct.localizedPriceString) == localizedPrice
+        expect(storeProduct.productIdentifier) == identifier
+        expect(storeProduct.productType) == type
+        expect(storeProduct.productCategory) == .subscription
+        expect(storeProduct.localizedDescription) == description
+        expect(storeProduct.subscriptionGroupIdentifier) == subscriptionGroup
+        expect(storeProduct.subscriptionPeriod) == period
+        expect(storeProduct.currencyCode) == Locale.current.rc_currencyCode
+        expect(storeProduct.priceFormatter).toNot(beNil())
+        expect(storeProduct.isFamilyShareable) == false
     }
 
 }

--- a/Tests/UnitTests/Mocks/MockOfferingsFactory.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsFactory.swift
@@ -25,6 +25,7 @@ class MockOfferingsFactory: OfferingsFactory {
 
         let product = MockSK1Product(mockProductIdentifier: "monthly_freetrial")
         let storeProduct = SK1StoreProduct(sk1Product: product)
+
         return Offerings(
             offerings: [
                 "base": Offering(
@@ -33,8 +34,8 @@ class MockOfferingsFactory: OfferingsFactory {
                     metadata: [:],
                     availablePackages: [
                         Package(identifier: "$rc_monthly",
-                                packageType: PackageType.monthly,
-                                storeProduct: storeProduct,
+                                packageType: .monthly,
+                                storeProduct: .from(product: storeProduct),
                                 offeringIdentifier: "base")
                     ]
                 )],


### PR DESCRIPTION
Fixes #1563 and #2193.

This introduces **`DEBUG` and `Swift` only** types that allow creating a whole `Offering` for tests and SwiftUI previews.

Example:
![Screenshot 2023-06-26 at 12 36 40](https://github.com/RevenueCat/purchases-ios/assets/685609/03d83e65-b95b-40ba-80ad-f8be435c6d3e)

By making it available in only `DEBUG` builds we ensure that apps can't accidentally try to purchase these products, which would be impossible. If this is attempted in `DEBUG` builds, we return `ErrorCode`.

When trying to compile this API in release builds, you get an error with a suggestion:
![image](https://github.com/RevenueCat/purchases-ios/assets/685609/f83b8848-dab6-4ae6-a92d-5c07a30be217)

