### PR TITLE
`PriceFormatterProvider.priceFormatterForSK2`: enable on all versions

### DIFF
--- a/Sources/Misc/PriceFormatterProvider.swift
+++ b/Sources/Misc/PriceFormatterProvider.swift
@@ -41,7 +41,6 @@ final class PriceFormatterProvider: Sendable {
 
     private let cachedPriceFormatterForSK2: Atomic<NumberFormatter?> = nil
 
-    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func priceFormatterForSK2(withCurrencyCode currencyCode: String) -> NumberFormatter {
         func makePriceFormatterForSK2(with currencyCode: String) -> NumberFormatter {
             let formatter = NumberFormatter()

--- a/Tests/StoreKitUnitTests/PriceFormatterProviderTests.swift
+++ b/Tests/StoreKitUnitTests/PriceFormatterProviderTests.swift
@@ -37,10 +37,7 @@ class PriceFormatterProviderTests: StoreKitConfigTestCase {
         expect(firstPriceFormatter) === secondPriceFormatter
     }
 
-    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func testReturnsCachedPriceFormatterForSK2() throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
-
         let currencyCode = "USD"
         let firstPriceFormatter = self.priceFormatterProvider.priceFormatterForSK2(withCurrencyCode: currencyCode)
 


### PR DESCRIPTION
This is required for #2711
