### PR TITLE
Remove unused `Signing.loadPublicKey(with:)`

### DIFF
--- a/Sources/Logging/Strings/ConfigureStrings.swift
+++ b/Sources/Logging/Strings/ConfigureStrings.swift
@@ -65,10 +65,6 @@ enum ConfigureStrings {
 
     case public_key_could_not_be_found(fileName: String)
 
-    case public_key_is_empty
-
-    case public_key_could_not_load_key
-
     case custom_entitlements_computation_enabled
 
     case custom_entitlements_computation_enabled_but_no_app_user_id
@@ -163,12 +159,6 @@ extension ConfigureStrings: LogMessage {
 
         case let .public_key_could_not_be_found(fileName):
             return "Could not find public key '\(fileName)'"
-
-        case .public_key_is_empty:
-            return "Attempted to load an empty public key."
-
-        case .public_key_could_not_load_key:
-            return "Failed to load public key. Ensure that it's a valid ed25519 key."
 
         case .custom_entitlements_computation_enabled:
             return "Entering customEntitlementComputation mode. CustomerInfo cache will not be " +

--- a/Sources/Security/Signing.swift
+++ b/Sources/Security/Signing.swift
@@ -159,28 +159,6 @@ extension CryptoKit.Curve25519.Signing.PublicKey: SigningPublicKey {}
 
 // MARK: - Internal implementation (visible for tests)
 
-extension Signing {
-
-    /// Parses the binary `key` and returns a `PublicKey`
-    /// - Throws: ``ErrorCode/configurationError`` if the certificate couldn't be loaded.
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    static func loadPublicKey(with data: Data) throws -> PublicKey {
-        guard !data.isEmpty else {
-            throw ErrorUtils.configurationError(message: Strings.configure.public_key_is_empty.description)
-        }
-
-        do {
-            return try CryptoKit.Curve25519.Signing.PublicKey(rawRepresentation: data)
-        } catch {
-            throw ErrorUtils.configurationError(
-                message: Strings.configure.public_key_could_not_load_key.description,
-                underlyingError: error
-            )
-        }
-    }
-
-}
-
 extension Signing.SignatureParameters {
 
     var asData: Data {

--- a/Tests/UnitTests/Security/SigningTests.swift
+++ b/Tests/UnitTests/Security/SigningTests.swift
@@ -37,17 +37,6 @@ class SigningTests: TestCase {
         expect(key.rawRepresentation).toNot(beEmpty())
     }
 
-    func testThrowsErrorIfPublicKeyFileCannotBeParsed() throws {
-        expect {
-            try Signing.loadPublicKey(with: .init([1, 2, 3]))
-        }.to(throwError { error in
-            expect(error).to(matchError(ErrorCode.configurationError))
-            expect(error.localizedDescription) == "There is an issue with your configuration. " +
-            "Check the underlying error for more details. Failed to load public key. " +
-            "Ensure that it's a valid ed25519 key."
-        })
-    }
-
     func testVerifySignatureWithInvalidSignatureReturnsFalseAndLogsError() throws {
         let logger = TestLogHandler()
 


### PR DESCRIPTION
Same as #2638. This was never needed.
