### PR TITLE
`TrustedEntitlements`: measure performance using `TimingUtil`

### DIFF
--- a/Sources/Logging/Strings/SigningStrings.swift
+++ b/Sources/Logging/Strings/SigningStrings.swift
@@ -34,6 +34,8 @@ enum SigningStrings {
 
     case request_date_missing_from_headers(HTTPRequest)
 
+    case verification_too_slow
+
     #if DEBUG
     case verifying_signature(signature: Data,
                              publicKey: Data,
@@ -88,6 +90,9 @@ extension SigningStrings: LogMessage {
         case let .signature_was_requested_but_not_provided(request):
             return "Request to '\(request.path)' required a signature but none was provided. " +
             "This will be reported as a verification failure."
+
+        case .verification_too_slow:
+            return "Signature verification was too slow"
 
         #if DEBUG
         case let .invalid_signature_data(request, data, responseHeaders, statusCode):

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -299,6 +299,7 @@ extension Configuration {
         case productRequest = 3
         case introEligibility = 2
         case purchasedProducts = 1
+        case signatureVerification = 0.5
 
     }
 


### PR DESCRIPTION
Depends on #2715 and #2716.