### PR TITLE
`Integration Tests`: override `SystemInfo.identifierForVendor` on each test

### DIFF
--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -20,15 +20,18 @@ import Foundation
         #if DEBUG
         let forceServerErrors: Bool
         let forceSignatureFailures: Bool
+        let identifierForVendorOverride: UUID?
 
         init(
             enableReceiptFetchRetry: Bool = false,
             forceServerErrors: Bool = false,
-            forceSignatureFailures: Bool = false
+            forceSignatureFailures: Bool = false,
+            identifierForVendorOverride: UUID? = nil
         ) {
             self.enableReceiptFetchRetry = enableReceiptFetchRetry
             self.forceServerErrors = forceServerErrors
             self.forceSignatureFailures = forceSignatureFailures
+            self.identifierForVendorOverride = identifierForVendorOverride
         }
         #else
         init(enableReceiptFetchRetry: Bool = false) {
@@ -116,6 +119,9 @@ internal protocol InternalDangerousSettingsType: Sendable {
 
     /// Whether `HTTPClient` will fake invalid signatures.
     var forceSignatureFailures: Bool { get }
+
+    /// Returning a non-`nil` value allows overriding the current `SystemInfo.identifierForVendor`
+    var identifierForVendorOverride: UUID? { get }
     #endif
 
 }

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -81,12 +81,18 @@ class SystemInfo {
         // https://developer.apple.com/documentation/uikit/uidevice?language=swift
         // https://developer.apple.com/documentation/watchkit/wkinterfacedevice?language=swift
 
+        #if DEBUG
+        if let override = self.dangerousSettings.internalSettings.identifierForVendorOverride {
+            return override.uuidString
+        }
+        #endif
+
         #if os(iOS) || os(tvOS)
             return UIDevice.current.identifierForVendor?.uuidString
         #elseif os(watchOS)
             return WKInterfaceDevice.current().identifierForVendor?.uuidString
         #elseif os(macOS) || targetEnvironment(macCatalyst)
-            return isSandbox ? MacDevice.identifierForVendor?.uuidString : nil
+            return self.isSandbox ? MacDevice.identifierForVendor?.uuidString : nil
         #else
             return nil
         #endif

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -39,6 +39,8 @@ final class TestPurchaseDelegate: NSObject, PurchasesDelegate, Sendable {
 class BaseBackendIntegrationTests: XCTestCase {
 
     private var userDefaults: UserDefaults!
+    private var testUUID: UUID!
+
     // swiftlint:disable:next weak_delegate
     private(set) var purchasesDelegate: TestPurchaseDelegate!
 
@@ -87,6 +89,11 @@ class BaseBackendIntegrationTests: XCTestCase {
         self.mainThreadMonitor.run()
 
         self.createUserDefaults()
+
+        // We use a different IDFV for each test to ensure the backend
+        // doesn't produce conflicts when producing similar receipts across
+        // separate test invocations.
+        self.testUUID = UUID()
 
         self.clearReceiptIfExists()
         await self.createPurchases()
@@ -188,5 +195,6 @@ extension BaseBackendIntegrationTests: InternalDangerousSettingsType {
     var enableReceiptFetchRetry: Bool { return true }
     var forceServerErrors: Bool { return false }
     var forceSignatureFailures: Bool { return false }
+    var identifierForVendorOverride: UUID? { return self.testUUID }
 
 }

--- a/Tests/UnitTests/Misc/SystemInfoTests.swift
+++ b/Tests/UnitTests/Misc/SystemInfoTests.swift
@@ -3,6 +3,10 @@ import XCTest
 
 @testable import RevenueCat
 
+#if os(watchOS)
+import WatchKit
+#endif
+
 class SystemInfoTests: TestCase {
 
     func testProxyURL() {
@@ -85,12 +89,67 @@ class SystemInfoTests: TestCase {
         )) == false
     }
 
-    func testReceiptFetchRetryIsDisabledByDefault() throws {
-        let systemInfo = try SystemInfo(platformInfo: nil, finishTransactions: false)
-        let settings = systemInfo.dangerousSettings.internalSettings
-
-        expect(settings.enableReceiptFetchRetry) == false
+    func testReceiptFetchRetryIsDisabledByDefault() {
+        expect(SystemInfo.default.dangerousSettings.internalSettings.enableReceiptFetchRetry) == false
     }
+
+    // MARK: - identifierForVendor
+
+    func testOverridenIdentifierForVendor() throws {
+        let override = UUID()
+
+        let info = try SystemInfo(
+            platformInfo: nil,
+            finishTransactions: false,
+            dangerousSettings: .init(
+                autoSyncPurchases: true,
+                internalSettings: DangerousSettings.Internal(identifierForVendorOverride: override))
+        )
+
+        expect(info.identifierForVendor) == override.uuidString
+    }
+
+    #if os(iOS) || os(tvOS)
+
+    func testIdentifierForVendor() {
+        expect(SystemInfo.default.identifierForVendor) == UIDevice.current.identifierForVendor?.uuidString
+    }
+
+    #elseif os(watchOS)
+
+    func testIdentifierForVendor() {
+        expect(SystemInfo.default.identifierForVendor) == WKInterfaceDevice.current().identifierForVendor?.uuidString
+    }
+
+    #elseif os(macOS) || targetEnvironment(macCatalyst)
+
+    func testIdentifierForVendorInSandbox() {
+        let info = SystemInfo(
+            platformInfo: nil,
+            finishTransactions: true,
+            sandboxEnvironmentDetector: MockSandboxEnvironmentDetector(true)
+        )
+
+        expect(info.identifierForVendor) == MacDevice.identifierForVendor?.uuidString
+    }
+
+    func testIdentifierForVendorNotSandbox() {
+        let info = SystemInfo(
+            platformInfo: nil,
+            finishTransactions: true,
+            sandboxEnvironmentDetector: MockSandboxEnvironmentDetector(false)
+        )
+
+        expect(info.identifierForVendor).to(beNil())
+    }
+
+    #else
+
+    func testIdentifierForVendorIsNil() {
+        expect(SystemInfo.default.identifierForVendor).to(beNil())
+    }
+
+    #endif
 
 }
 
@@ -109,6 +168,11 @@ private extension SystemInfo {
                               finishTransactions: false,
                               bundle: bundle,
                               sandboxEnvironmentDetector: sandboxDetector)
+    }
+
+    static var `default`: SystemInfo {
+        // swiftlint:disable:next force_try
+        return try! .init(platformInfo: nil, finishTransactions: true)
     }
 
 }

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -702,22 +702,20 @@ final class HTTPClientTests: BaseHTTPClientTests {
         expect(headerPresent.value) == true
     }
 
-    func testAppleDeviceIdentifierNilWhenIsNotSandbox() {
-        systemInfo.stubbedIsSandbox = false
+    func testAppleDeviceIdentifierNilWhenIsNotSandboxInMacOS() {
+        self.systemInfo.stubbedIsSandbox = false
 
-        let obtainedIdentifierForVendor = systemInfo.identifierForVendor
-
-        expect(obtainedIdentifierForVendor).to(beNil())
+        expect(self.systemInfo.identifierForVendor).to(beNil())
     }
 
     #else
 
-    func testAlwaysPassesAppleDeviceIdentifier() {
+    func testAlwaysPassesAppleDeviceIdentifier() throws {
         let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
         let headerPresent: Atomic<Bool> = false
 
-        let idfv = systemInfo.identifierForVendor!
+        let idfv = try XCTUnwrap(self.systemInfo.identifierForVendor)
 
         stub(condition: hasHeaderNamed("X-Apple-Device-Identifier", value: idfv )) { _ in
             headerPresent.value = true


### PR DESCRIPTION
This allows us to ensure that the backend doesn't produce conflicts when processings similar receipts across separate test invocations.
