### PR TITLE
`Integration Tests`: fix clearing `UserDefaults` before each test

### DIFF
--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -127,6 +127,9 @@ private extension BaseBackendIntegrationTests {
     func createUserDefaults() {
         self.userDefaults = UserDefaults(suiteName: Constants.userDefaultsSuiteName)
         self.userDefaults.removePersistentDomain(forName: Constants.userDefaultsSuiteName)
+        // See also `SynchronizedUserDefaults`.
+        // While Apple states `this method is unnecessary and shouldn't be used`, it's still
+        // necessary to call `synchronize` in order for the `removePersistentDomain` changes to take effect.
         self.userDefaults.synchronize()
 
         // Verify that user defaults is indeed empty.


### PR DESCRIPTION
For some reason `synchronize()` is needed so that subsequent reads and writes actually see that we cleared the domain.
I added a new expectation to make sure if this breaks we catch it early instead of a weird failure later in the test.
