### PR TITLE
Refactor: simplified `PurchasesOrchestrator.syncPurchases`

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -963,7 +963,6 @@ private extension PurchasesOrchestrator {
         }
     }
 
-    // swiftlint:disable:next function_body_length
     func syncPurchases(receiptRefreshPolicy: ReceiptRefreshPolicy,
                        isRestore: Bool,
                        initiationSource: ProductRequestData.InitiationSource,
@@ -998,20 +997,14 @@ private extension PurchasesOrchestrator {
             self.operationDispatcher.dispatchOnWorkerThread {
                 let hasTransactions = self.transactionsManager.customerHasTransactions(receiptData: receiptData)
                 let cachedCustomerInfo = self.customerInfoManager.cachedCustomerInfo(appUserID: currentAppUserID)
-                let hasOriginalPurchaseDate = cachedCustomerInfo?.originalPurchaseDate != nil
 
-                if !hasTransactions && hasOriginalPurchaseDate {
+                if !hasTransactions, let customerInfo = cachedCustomerInfo, customerInfo.originalPurchaseDate != nil {
                     if let completion = completion {
                         self.operationDispatcher.dispatchOnMainThread {
-                            completion(
-                                Result(cachedCustomerInfo,
-                                       ErrorUtils.customerInfoError(withMessage: Strings
-                                        .purchase
-                                        .missing_cached_customer_info
-                                        .description))
-                            )
+                            completion(.success(customerInfo))
                         }
                     }
+
                     return
                 }
 

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -1005,7 +1005,10 @@ private extension PurchasesOrchestrator {
                         self.operationDispatcher.dispatchOnMainThread {
                             completion(
                                 Result(cachedCustomerInfo,
-                                       ErrorUtils.customerInfoError(withMessage: "No cached customer info"))
+                                       ErrorUtils.customerInfoError(withMessage: Strings
+                                        .purchase
+                                        .missing_cached_customer_info
+                                        .description))
                             )
                         }
                     }


### PR DESCRIPTION
I found this while looking into SDK-3097.
