### PR TITLE
`VerificationResult: CustomDebugStringConvertible`

### DIFF
--- a/Sources/Security/VerificationResult.swift
+++ b/Sources/Security/VerificationResult.swift
@@ -72,6 +72,21 @@ extension VerificationResult: DefaultValueProvider {
 
 }
 
+extension VerificationResult: CustomDebugStringConvertible {
+
+    var debugDescription: String {
+        let prefix = "\(type(of: self))"
+
+        switch self {
+        case .notRequested: return "\(prefix).notRequested"
+        case .verified: return "\(prefix).verified"
+        case .verifiedOnDevice: return "\(prefix).verifiedOnDevice"
+        case .failed: return "\(prefix).failed"
+        }
+    }
+
+}
+
 extension VerificationResult {
 
     /// - Returns: the most restrictive ``VerificationResult`` based on the cached verification and


### PR DESCRIPTION
I'm debugging some code and it's harder to follow it when we just print `VerificationResult(rawValue: 1)`
