### PR TITLE
`Integration Tests`: avoid crashes when stopping tests early

### DIFF
--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -47,11 +47,13 @@ class BaseStoreKitIntegrationTests: BaseBackendIntegrationTests {
     }
 
     override func tearDown() async throws {
-        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
-            await self.deleteAllTransactions(session: self.testSession)
-        }
+        if let testSession = self.testSession {
+            if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+                await self.deleteAllTransactions(session: testSession)
+            }
 
-        self.testSession.clearTransactions()
+            testSession.clearTransactions()
+        }
 
         try await super.tearDown()
     }


### PR DESCRIPTION
If tests are skipped or failed early, before the `SKTestSession` is initialized, this will crash instead of failing or being skipped.
