### PR TITLE
`Documentation`: removed references to deprecated methods on index

### DIFF
--- a/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
@@ -115,9 +115,3 @@ Most features require configuring the SDK before using it.
 - ``Purchases/verboseLogs``
 - ``Purchases/verboseLogHandler``
 - ``Purchases/allowSharingAppStoreAccount``
-
-### Configuring the SDK with parameters (deprecated)
-- ``Purchases/configure(withAPIKey:appUserID:)``
-- ``Purchases/configure(withAPIKey:appUserID:observerMode:)``
-- ``Purchases/configure(withAPIKey:appUserID:observerMode:userDefaults:)``
-- ``Purchases/configure(withAPIKey:appUserID:observerMode:userDefaults:useStoreKit2IfAvailable:)``

--- a/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md
@@ -151,9 +151,3 @@ Or browse our iOS sample apps:
 - ``Purchases/setMixpanelDistinctID(_:)``
 - ``Purchases/setMparticleID(_:)``
 - ``Purchases/setOnesignalID(_:)``
-
-### Configuring the SDK with parameters (deprecated)
-- ``Purchases/configure(withAPIKey:appUserID:)``
-- ``Purchases/configure(withAPIKey:appUserID:observerMode:)``
-- ``Purchases/configure(withAPIKey:appUserID:observerMode:userDefaults:)``
-- ``Purchases/configure(withAPIKey:appUserID:observerMode:userDefaults:useStoreKit2IfAvailable:)``


### PR DESCRIPTION
The documentation is still there, but I don't think we need to reference them in the index anymore.
