### PR TITLE
`Documentation`: add reference to `TestStoreProduct`

### DIFF
--- a/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
@@ -27,6 +27,13 @@ Most features require configuring the SDK before using it.
 - ``PurchasesDiagnostics``
 
 ### Displaying Products
+- ``Offerings``
+- ``Offering``
+- ``Package``
+- ``StoreProduct``
+- ``TestStoreProduct``
+- ``SubscriptionPeriod``
+
 - ``Purchases/offerings()``
 - ``Purchases/getOfferings(completion:)``
 - ``Purchases/products(_:)``

--- a/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/RevenueCat.md
@@ -63,6 +63,7 @@ Or browse our iOS sample apps:
 - ``Offering``
 - ``Package``
 - ``StoreProduct``
+- ``TestStoreProduct``
 - ``SubscriptionPeriod``
 
 - ``Purchases/offerings()``


### PR DESCRIPTION
See #2711.

![Screenshot 2023-06-30 at 09 05 23](https://github.com/RevenueCat/purchases-ios/assets/685609/3d64ab91-bb18-452f-b8d6-c6d162302e22)
