### PR TITLE
`Trusted Entitlements`: add API key and `HTTPRequest.Path` to signature

### DIFF
--- a/Sources/Logging/Strings/SigningStrings.swift
+++ b/Sources/Logging/Strings/SigningStrings.swift
@@ -93,7 +93,7 @@ extension SigningStrings: LogMessage {
         case let .invalid_signature_data(request, data, responseHeaders, statusCode):
             return """
             INVALID SIGNATURE DETECTED:
-            Request: \(request.method.httpMethod) \(request.path)
+            Request: \(request.method.httpMethod) \(request.path.relativePath)
             Response: \(statusCode.rawValue)
             Headers: \(responseHeaders.map { "\($0.key.base): \($0.value)" })
             Body (length: \(data?.count ?? 0)): \(data?.hashString ?? "<>")
@@ -111,6 +111,7 @@ extension SigningStrings: LogMessage {
             Verifying signature '\(signature.base64EncodedString())'
             Public key: '\(publicKey.asString)'
             Parameters: \(parameters),
+            Path: \(parameters.path.relativePath)
             Salt: \(salt.base64EncodedString()),
             Payload: \(payload.base64EncodedString()),
             Message: \(message?.base64EncodedString() ?? "")

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -36,6 +36,7 @@ class Backend {
         let httpClient = HTTPClient(apiKey: apiKey,
                                     systemInfo: systemInfo,
                                     eTagManager: eTagManager,
+                                    signing: Signing(apiKey: apiKey),
                                     requestTimeout: httpClientTimeout)
         let config = BackendConfiguration(httpClient: httpClient,
                                           operationDispatcher: operationDispatcher,

--- a/Sources/Security/FakeSigning.swift
+++ b/Sources/Security/FakeSigning.swift
@@ -19,13 +19,15 @@ import Foundation
 /// - Seealso: `InternalDangerousSettingsType.forceSignatureFailures`
 final class FakeSigning: SigningType {
 
-    static func verify(
+    func verify(
         signature: String,
         with parameters: Signing.SignatureParameters,
         publicKey: Signing.PublicKey
     ) -> Bool {
         return false
     }
+
+    static let `default`: FakeSigning = .init()
 
 }
 

--- a/Sources/Security/Signing+ResponseVerification.swift
+++ b/Sources/Security/Signing+ResponseVerification.swift
@@ -16,9 +16,9 @@ import Foundation
 extension HTTPResponse where Body == Data? {
 
     func verify(
+        signing: SigningType,
         request: HTTPRequest,
-        publicKey: Signing.PublicKey?,
-        signing: SigningType.Type = Signing.self
+        publicKey: Signing.PublicKey?
     ) -> VerifiedHTTPResponse<Body> {
         let verificationResult = Self.verificationResult(
             body: self.body,
@@ -52,7 +52,7 @@ extension HTTPResponse where Body == Data? {
         requestDate: Date?,
         request: HTTPRequest,
         publicKey: Signing.PublicKey?,
-        signing: SigningType.Type
+        signing: SigningType
     ) -> VerificationResult {
         guard let publicKey = publicKey,
               statusCode.isSuccessfulResponse,
@@ -81,6 +81,7 @@ extension HTTPResponse where Body == Data? {
 
         if signing.verify(signature: signature,
                           with: .init(
+                            path: request.path,
                             message: body,
                             nonce: request.nonce,
                             etag: HTTPResponse.value(forCaseInsensitiveHeaderField: .eTag, in: headers),

--- a/Sources/Security/Signing.swift
+++ b/Sources/Security/Signing.swift
@@ -17,7 +17,7 @@ import Foundation
 /// A type that can verify signatures.
 protocol SigningType {
 
-    static func verify(
+    func verify(
         signature: String,
         with parameters: Signing.SignatureParameters,
         publicKey: Signing.PublicKey
@@ -26,7 +26,7 @@ protocol SigningType {
 }
 
 /// Utilities for handling signature verification.
-enum Signing: SigningType {
+final class Signing: SigningType {
 
     /// An object that represents a cryptographic key.
     typealias PublicKey = SigningPublicKey
@@ -34,11 +34,18 @@ enum Signing: SigningType {
     /// Parameters used for signature creation / verification.
     struct SignatureParameters {
 
+        let path: HTTPRequest.Path
         let message: Data?
         let nonce: Data?
         let etag: String?
         let requestDate: UInt64
 
+    }
+
+    private let apiKey: String
+
+    init(apiKey: String) {
+        self.apiKey = apiKey
     }
 
     /// Parses the binary `key` and returns a `PublicKey`
@@ -61,7 +68,7 @@ enum Signing: SigningType {
         }
     }
 
-    static func verify(
+    func verify(
         signature: String,
         with parameters: SignatureParameters,
         publicKey: Signing.PublicKey
@@ -85,7 +92,7 @@ enum Signing: SigningType {
 
         let salt = signature.component(.salt)
         let payload = signature.component(.payload)
-        let messageToVerify = salt + parameters.asData
+        let messageToVerify = salt + self.apiKey.asData + parameters.asData
 
         #if DEBUG
         Logger.verbose(Strings.signing.verifying_signature(
@@ -230,6 +237,7 @@ extension Signing.SignatureParameters {
     var asData: Data {
         return (
             (self.nonce ?? .init()) +
+            self.path.relativePath.asData +
             String(self.requestDate).asData +
             (self.etag ?? "").asData +
             (self.message ?? .init())

--- a/Sources/Security/Signing.swift
+++ b/Sources/Security/Signing.swift
@@ -237,11 +237,20 @@ extension Signing.SignatureParameters {
     var asData: Data {
         return (
             (self.nonce ?? .init()) +
-            self.path.relativePath.asData +
+            self.path.unescapedPath.asData +
             String(self.requestDate).asData +
             (self.etag ?? "").asData +
             (self.message ?? .init())
         )
+    }
+
+}
+
+private extension HTTPRequest.Path {
+
+    // Signatures remove percent encoding from the paths.
+    var unescapedPath: String {
+        return self.relativePath.removingPercentEncoding ?? ""
     }
 
 }

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -65,6 +65,7 @@ class MockHTTPClient: HTTPClient {
         super.init(apiKey: apiKey,
                    systemInfo: systemInfo,
                    eTagManager: eTagManager,
+                   signing: FakeSigning.default,
                    dnsChecker: dnsChecker,
                    requestTimeout: requestTimeout)
     }

--- a/Tests/UnitTests/Mocks/MockSigning.swift
+++ b/Tests/UnitTests/Mocks/MockSigning.swift
@@ -21,26 +21,21 @@ final class MockSigning: SigningType {
         let publicKey: Signing.PublicKey
     }
 
-    static var requests: [VerificationRequest] = []
-    static var stubbedVerificationResult: Bool?
+    var requests: [VerificationRequest] = []
+    var stubbedVerificationResult: Bool?
 
-    static func verify(
+    func verify(
         signature: String,
         with parameters: Signing.SignatureParameters,
         publicKey: Signing.PublicKey
     ) -> Bool {
-        Self.requests.append(.init(
+        self.requests.append(.init(
             signature: signature,
             parameters: parameters,
             publicKey: publicKey
         ))
 
-        return Self.stubbedVerificationResult!
-    }
-
-    static func resetData() {
-        self.requests.removeAll()
-        self.stubbedVerificationResult = nil
+        return self.stubbedVerificationResult!
     }
 
 }

--- a/Tests/UnitTests/Networking/HTTPResponseTests.swift
+++ b/Tests/UnitTests/Networking/HTTPResponseTests.swift
@@ -19,6 +19,8 @@ import XCTest
 
 class HTTPResponseTests: TestCase {
 
+    private static let signing: Signing = .init(apiKey: "api_key")
+
     func testResponseVerificationNotRequestedWithNoPublicKey() {
         let request = HTTPRequest(method: .get, path: .health)
         let response = HTTPResponse<Data?>(
@@ -26,7 +28,7 @@ class HTTPResponseTests: TestCase {
             responseHeaders: [:],
             body: Data()
         )
-        let verifiedResponse = response.verify(request: request, publicKey: nil)
+        let verifiedResponse = response.verify(signing: Self.signing, request: request, publicKey: nil)
 
         expect(verifiedResponse.verificationResult) == .notRequested
     }
@@ -43,7 +45,7 @@ class HTTPResponseTests: TestCase {
             responseHeaders: [:],
             body: Data()
         )
-        let verifiedResponse = response.verify(request: request, publicKey: key)
+        let verifiedResponse = response.verify(signing: Self.signing, request: request, publicKey: key)
 
         expect(verifiedResponse.verificationResult) == .notRequested
     }

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -99,7 +99,7 @@ final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPC
         try self.changeClient(.informational)
         self.mockResponse()
 
-        MockSigning.stubbedVerificationResult = true
+        self.signing.stubbedVerificationResult = true
 
         let request: HTTPRequest = .createWithResponseVerification(method: .get, path: Self.path)
         let response: DataResponse? = waitUntilValue { completion in
@@ -108,7 +108,7 @@ final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPC
 
         expect(response).to(beSuccess())
         expect(response?.value?.verificationResult) == .failed
-        expect(MockSigning.requests).to(beEmpty())
+        expect(self.signing.requests).to(beEmpty())
 
         logger.verifyMessageWasLogged(
             Strings.signing.signature_was_requested_but_not_provided(request),
@@ -128,7 +128,7 @@ final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPC
                          ])
         }
 
-        MockSigning.stubbedVerificationResult = true
+        self.signing.stubbedVerificationResult = true
 
         let request: HTTPRequest = .createWithResponseVerification(method: .get, path: Self.path)
 
@@ -151,7 +151,7 @@ final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPC
         expect(response).to(beSuccess())
         expect(response?.value?.verificationResult) == .notRequested
 
-        expect(MockSigning.requests).to(beEmpty())
+        expect(self.signing.requests).to(beEmpty())
     }
 
     func testVerifiedCachedResponseWithNotRequestedVerificationResponse() throws {
@@ -176,7 +176,7 @@ final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPC
                                 completionHandler: completion)
         }
 
-        expect(MockSigning.requests).to(beEmpty())
+        expect(self.signing.requests).to(beEmpty())
 
         expect(response).to(beSuccess())
         expect(response?.value?.body.data) == cachedResponse.data
@@ -201,7 +201,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         self.mockResponse(signature: Self.sampleSignature,
                           requestDate: Self.date2,
                           body: body)
-        MockSigning.stubbedVerificationResult = true
+        self.signing.stubbedVerificationResult = true
 
         let request: HTTPRequest = .createWithResponseVerification(method: .get, path: Self.path)
 
@@ -212,8 +212,8 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         expect(response).to(beSuccess())
         expect(response?.value?.verificationResult) == .verified
 
-        expect(MockSigning.requests).to(haveCount(1))
-        let signingRequest = try XCTUnwrap(MockSigning.requests.onlyElement)
+        expect(self.signing.requests).to(haveCount(1))
+        let signingRequest = try XCTUnwrap(self.signing.requests.onlyElement)
 
         expect(signingRequest.parameters.message) == body
         expect(signingRequest.parameters.nonce) == request.nonce
@@ -225,7 +225,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
     func testPerformRequestOverridesVerificationMode() throws {
         self.mockPath(statusCode: .success, requestDate: Self.date1)
 
-        MockSigning.stubbedVerificationResult = false
+        self.signing.stubbedVerificationResult = false
 
         let response: DataResponse? = waitUntilValue { completion in
             self.client.perform(.createWithResponseVerification(method: .get, path: .logIn),
@@ -251,7 +251,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
             )
         )
 
-        MockSigning.stubbedVerificationResult = true
+        self.signing.stubbedVerificationResult = true
 
         let request: HTTPRequest = .createWithResponseVerification(method: .get, path: Self.path)
 
@@ -263,8 +263,8 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         expect(response?.value?.verificationResult) == .verified
         expect(response?.value?.body) == body
 
-        expect(MockSigning.requests).to(haveCount(1))
-        let signingRequest = try XCTUnwrap(MockSigning.requests.onlyElement)
+        expect(self.signing.requests).to(haveCount(1))
+        let signingRequest = try XCTUnwrap(self.signing.requests.onlyElement)
 
         expect(signingRequest.parameters.message).to(beNil())
         expect(signingRequest.parameters.nonce) == request.nonce
@@ -276,7 +276,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
     func testIncorrectSignatureReturnsResponse() throws {
         self.mockPath(statusCode: .success, requestDate: Self.date1)
 
-        MockSigning.stubbedVerificationResult = false
+        self.signing.stubbedVerificationResult = false
 
         let response: DataResponse? = waitUntilValue { completion in
             self.client.perform(.createWithResponseVerification(method: .get, path: Self.path),
@@ -285,11 +285,11 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
 
         expect(response).to(beSuccess())
         expect(response?.value?.verificationResult) == .failed
-        expect(MockSigning.requests).to(haveCount(1))
+        expect(self.signing.requests).to(haveCount(1))
     }
 
     func testIgnoresResponseFromETagManagerIfItHadNotBeenVerified() throws {
-        MockSigning.stubbedVerificationResult = true
+        self.signing.stubbedVerificationResult = true
 
         self.mockPath(
             statusCode: .success,
@@ -328,7 +328,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                 verificationResult: .verified
             )
         )
-        MockSigning.stubbedVerificationResult = false
+        self.signing.stubbedVerificationResult = false
 
         let response: BodyWithDateResponse? = waitUntilValue { completion in
             self.client.perform(.createWithResponseVerification(method: .get, path: Self.path),
@@ -356,7 +356,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
             )
         )
 
-        MockSigning.stubbedVerificationResult = true
+        self.signing.stubbedVerificationResult = true
 
         let response: BodyWithDateResponse? = waitUntilValue { completion in
             self.client.perform(.createWithResponseVerification(method: .get, path: Self.path),
@@ -384,7 +384,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
             )
         )
 
-        MockSigning.stubbedVerificationResult = false
+        self.signing.stubbedVerificationResult = false
 
         let response: BodyWithDateResponse? = waitUntilValue { completion in
             self.client.perform(.createWithResponseVerification(method: .get, path: Self.path),
@@ -400,7 +400,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
     func testCachedResponseUpdatesRequestDateIfNewResponseIsVerified() throws {
         let cachedResponse = BodyWithDate(data: "test", requestDate: Self.date1)
 
-        MockSigning.stubbedVerificationResult = true
+        self.signing.stubbedVerificationResult = true
 
         self.mockPath(
             statusCode: .notModified,
@@ -439,14 +439,14 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
             )
         )
 
-        MockSigning.stubbedVerificationResult = false
+        self.signing.stubbedVerificationResult = false
 
         let response: BodyWithDateResponse? = waitUntilValue { completion in
             self.client.perform(.init(method: .get, path: Self.path),
                                 completionHandler: completion)
         }
 
-        expect(MockSigning.requests).to(haveCount(1))
+        expect(self.signing.requests).to(haveCount(1))
         expect(response).to(beSuccess())
         expect(response?.value?.body.requestDate).to(beCloseToDate(Self.date1))
         expect(response?.value?.verificationResult) == .failed
@@ -462,7 +462,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
                                 completionHandler: completion)
         }
 
-        expect(MockSigning.requests).to(beEmpty())
+        expect(self.signing.requests).to(beEmpty())
         expect(response).to(beSuccess())
         expect(response?.value?.requestDate).to(beCloseToDate(Self.date2))
         expect(response?.value?.verificationResult) == .notRequested
@@ -470,14 +470,14 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
 
     func testNoCachedResponseAndVerifiedResponse() throws {
         self.mockPath(statusCode: .success, requestDate: Self.date2)
-        MockSigning.stubbedVerificationResult = true
+        self.signing.stubbedVerificationResult = true
 
         let response: DataResponse? = waitUntilValue { completion in
             self.client.perform(.init(method: .get, path: Self.path),
                                 completionHandler: completion)
         }
 
-        expect(MockSigning.requests).to(haveCount(1))
+        expect(self.signing.requests).to(haveCount(1))
         expect(response).to(beSuccess())
         expect(response?.value?.requestDate).to(beCloseToDate(Self.date2))
         expect(response?.value?.verificationResult) == .verified
@@ -501,14 +501,14 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
             )
         )
 
-        MockSigning.stubbedVerificationResult = false
+        self.signing.stubbedVerificationResult = false
 
         let response: BodyWithDateResponse? = waitUntilValue { completion in
             self.client.perform(.init(method: .get, path: Self.path),
                                 completionHandler: completion)
         }
 
-        expect(MockSigning.requests).to(haveCount(1))
+        expect(self.signing.requests).to(haveCount(1))
         expect(response).to(beSuccess())
         expect(response?.value?.body.requestDate).to(beCloseToDate(Self.date1))
         expect(response?.value?.verificationResult) == .failed
@@ -528,7 +528,7 @@ final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificat
     func testValidSignature() throws {
         self.mockResponse(signature: Self.sampleSignature, requestDate: Self.date1)
 
-        MockSigning.stubbedVerificationResult = true
+        self.signing.stubbedVerificationResult = true
 
         let response: DataResponse? = waitUntilValue { completion in
             self.client.perform(.createWithResponseVerification(method: .get, path: Self.path),
@@ -537,13 +537,13 @@ final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificat
 
         expect(response).to(beSuccess())
         expect(response?.value?.verificationResult) == .verified
-        expect(MockSigning.requests).to(haveCount(1))
+        expect(self.signing.requests).to(haveCount(1))
     }
 
     func testIncorrectSignatureReturnsError() throws {
         self.mockResponse(signature: Self.sampleSignature, requestDate: Self.date1)
 
-        MockSigning.stubbedVerificationResult = false
+        self.signing.stubbedVerificationResult = false
 
         let response: DataResponse? = waitUntilValue { completion in
             self.client.perform(.createWithResponseVerification(method: .get, path: Self.path),
@@ -558,7 +558,7 @@ final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificat
     func testPerformRequestOverridesIt() throws {
         self.mockResponse(signature: Self.sampleSignature, requestDate: Self.date1)
 
-        MockSigning.stubbedVerificationResult = false
+        self.signing.stubbedVerificationResult = false
 
         let response: DataResponse? = waitUntilValue { completion in
             self.client.perform(.createWithResponseVerification(method: .get, path: .logIn),
@@ -574,7 +574,7 @@ final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificat
     func testPerformRequestWithDisabledModeOverridesIt() throws {
         self.mockResponse(signature: Self.sampleSignature, requestDate: Self.date1)
 
-        MockSigning.stubbedVerificationResult = false
+        self.signing.stubbedVerificationResult = false
 
         let response: DataResponse? = waitUntilValue { completion in
             self.client.perform(.createWithResponseVerification(method: .get, path: Self.path),
@@ -587,7 +587,7 @@ final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificat
 
     func testFakeSignatureFailuresInEnforcedMode() throws {
         self.mockResponse(signature: Self.sampleSignature, requestDate: Self.date1)
-        MockSigning.stubbedVerificationResult = true
+        self.signing.stubbedVerificationResult = true
 
         try self.changeClientToEnforced(forceSignatureFailures: true)
 
@@ -601,7 +601,7 @@ final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificat
 
     func testFakeSignatureFailuresInInformationalMode() throws {
         self.mockResponse(signature: Self.sampleSignature, requestDate: Self.date1)
-        MockSigning.stubbedVerificationResult = true
+        self.signing.stubbedVerificationResult = true
 
         try self.changeClient(.informational, forceSignatureFailures: true)
 
@@ -615,7 +615,7 @@ final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificat
 
     func testFakeSignatureFailuresWithDisabledVerification() throws {
         self.mockResponse(signature: Self.sampleSignature, requestDate: Self.date1)
-        MockSigning.stubbedVerificationResult = true
+        self.signing.stubbedVerificationResult = true
 
         try self.changeClient(.disabled, forceSignatureFailures: true)
 


### PR DESCRIPTION
Depends on #2747.

### Changes:
- Changed `Signing` to a `final class`, so it can be instantiated with the api key.
-  Updated all `SigningTests` to include the correct signatures