### PR TITLE
`HTTPRequest.Path`: escape `appUserID`

### DIFF
--- a/Sources/FoundationExtensions/String+Extensions.swift
+++ b/Sources/FoundationExtensions/String+Extensions.swift
@@ -16,27 +16,14 @@ import Foundation
 
 extension String {
 
-    enum Error: Swift.Error {
-
-        case escapingEmptyString
-
-    }
-
     func rot13() -> String {
         ROT13.string(self)
     }
 
-    func escapedOrError() throws -> String {
-        let trimmedAndEscaped = self
+    var trimmedAndEscaped: String {
+        return self
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!
-
-        guard trimmedAndEscaped.count > 0 else {
-            Logger.error("Attempting to escape an empty string")
-            throw Error.escapingEmptyString
-        }
-
-        return trimmedAndEscaped
     }
 
     /// Returns `nil` if `self` is an empty string.

--- a/Sources/FoundationExtensions/String+Extensions.swift
+++ b/Sources/FoundationExtensions/String+Extensions.swift
@@ -22,8 +22,8 @@ extension String {
 
     var trimmedAndEscaped: String {
         return self
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!
+            .trimmingWhitespacesAndNewLines
+            .addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? ""
     }
 
     /// Returns `nil` if `self` is an empty string.
@@ -38,6 +38,11 @@ extension String {
         return self.trimmingWhitespacesAndNewLines.isEmpty
         ? nil
         : self
+    }
+
+    /// Returns `true` if it contains anything other than whitespaces.
+    var isNotEmpty: Bool {
+        return self.notEmptyOrWhitespaces != nil
     }
 
     var trimmingWhitespacesAndNewLines: String {

--- a/Sources/Networking/HTTPClient/HTTPRequest.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequest.swift
@@ -176,22 +176,22 @@ extension HTTPRequest.Path: CustomStringConvertible {
     var description: String {
         switch self {
         case let .getCustomerInfo(appUserID):
-            return "subscribers/\(appUserID)"
+            return "subscribers/\(Self.escape(appUserID))"
 
         case let .getOfferings(appUserID):
-            return "subscribers/\(appUserID)/offerings"
+            return "subscribers/\(Self.escape(appUserID))/offerings"
 
         case let .getIntroEligibility(appUserID):
-            return "subscribers/\(appUserID)/intro_eligibility"
+            return "subscribers/\(Self.escape(appUserID))/intro_eligibility"
 
         case .logIn:
             return "subscribers/identify"
 
         case let .postAttributionData(appUserID):
-            return "subscribers/\(appUserID)/attribution"
+            return "subscribers/\(Self.escape(appUserID))/attribution"
 
         case let .postAdServicesToken(appUserID):
-            return "subscribers/\(appUserID)/adservices_attribution"
+            return "subscribers/\(Self.escape(appUserID))/adservices_attribution"
 
         case .postOfferForSigning:
             return "offers"
@@ -200,7 +200,7 @@ extension HTTPRequest.Path: CustomStringConvertible {
             return "receipts"
 
         case let .postSubscriberAttributes(appUserID):
-            return "subscribers/\(appUserID)/attributes"
+            return "subscribers/\(Self.escape(appUserID))/attributes"
 
         case .health:
             return "health"
@@ -208,6 +208,10 @@ extension HTTPRequest.Path: CustomStringConvertible {
         case .getProductEntitlementMapping:
             return "product_entitlement_mapping"
         }
+    }
+
+    private static func escape(_ appUserID: String) -> String {
+        return appUserID.trimmedAndEscaped
     }
 
 }

--- a/Sources/Networking/Operations/GetCustomerInfoOperation.swift
+++ b/Sources/Networking/Operations/GetCustomerInfoOperation.swift
@@ -72,7 +72,7 @@ private extension GetCustomerInfoOperation {
     func getCustomerInfo(completion: @escaping () -> Void) {
         let appUserID = self.configuration.appUserID
 
-        guard !appUserID.trimmedAndEscaped.isEmpty else {
+        guard appUserID.isNotEmpty else {
             self.customerInfoCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 callback.completion(.failure(.missingAppUserID()))
             }

--- a/Sources/Networking/Operations/GetCustomerInfoOperation.swift
+++ b/Sources/Networking/Operations/GetCustomerInfoOperation.swift
@@ -70,7 +70,9 @@ final class GetCustomerInfoOperation: CacheableNetworkOperation {
 private extension GetCustomerInfoOperation {
 
     func getCustomerInfo(completion: @escaping () -> Void) {
-        guard let appUserID = try? configuration.appUserID.escapedOrError() else {
+        let appUserID = self.configuration.appUserID
+
+        guard !appUserID.trimmedAndEscaped.isEmpty else {
             self.customerInfoCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 callback.completion(.failure(.missingAppUserID()))
             }

--- a/Sources/Networking/Operations/GetIntroEligibilityOperation.swift
+++ b/Sources/Networking/Operations/GetIntroEligibilityOperation.swift
@@ -65,7 +65,7 @@ private extension GetIntroEligibilityOperation {
 
         let appUserID = self.configuration.appUserID
 
-        guard !self.configuration.appUserID.trimmedAndEscaped.isEmpty else {
+        guard appUserID.isNotEmpty else {
             self.responseHandler(unknownEligibilities, .missingAppUserID())
             completion()
 

--- a/Sources/Networking/Operations/GetIntroEligibilityOperation.swift
+++ b/Sources/Networking/Operations/GetIntroEligibilityOperation.swift
@@ -63,7 +63,9 @@ private extension GetIntroEligibilityOperation {
             return
         }
 
-        guard let appUserID = try? self.configuration.appUserID.escapedOrError() else {
+        let appUserID = self.configuration.appUserID
+
+        guard !self.configuration.appUserID.trimmedAndEscaped.isEmpty else {
             self.responseHandler(unknownEligibilities, .missingAppUserID())
             completion()
 

--- a/Sources/Networking/Operations/GetOfferingsOperation.swift
+++ b/Sources/Networking/Operations/GetOfferingsOperation.swift
@@ -50,9 +50,9 @@ final class GetOfferingsOperation: CacheableNetworkOperation {
 private extension GetOfferingsOperation {
 
     func getOfferings(completion: @escaping () -> Void) {
-        let userID = self.configuration.appUserID
+        let appUserID = self.configuration.appUserID
 
-        guard !userID.trimmedAndEscaped.isEmpty else {
+        guard appUserID.isNotEmpty else {
             self.offeringsCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 callback.completion(.failure(.missingAppUserID()))
             }
@@ -61,7 +61,7 @@ private extension GetOfferingsOperation {
             return
         }
 
-        let request = HTTPRequest(method: .get, path: .getOfferings(appUserID: userID))
+        let request = HTTPRequest(method: .get, path: .getOfferings(appUserID: appUserID))
 
         httpClient.perform(request) { (response: VerifiedHTTPResponse<OfferingsResponse>.Result) in
             defer {

--- a/Sources/Networking/Operations/GetOfferingsOperation.swift
+++ b/Sources/Networking/Operations/GetOfferingsOperation.swift
@@ -50,7 +50,9 @@ final class GetOfferingsOperation: CacheableNetworkOperation {
 private extension GetOfferingsOperation {
 
     func getOfferings(completion: @escaping () -> Void) {
-        guard let appUserID = try? configuration.appUserID.escapedOrError() else {
+        let userID = self.configuration.appUserID
+
+        guard !userID.trimmedAndEscaped.isEmpty else {
             self.offeringsCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 callback.completion(.failure(.missingAppUserID()))
             }
@@ -59,7 +61,7 @@ private extension GetOfferingsOperation {
             return
         }
 
-        let request = HTTPRequest(method: .get, path: .getOfferings(appUserID: appUserID))
+        let request = HTTPRequest(method: .get, path: .getOfferings(appUserID: userID))
 
         httpClient.perform(request) { (response: VerifiedHTTPResponse<OfferingsResponse>.Result) in
             defer {

--- a/Sources/Networking/Operations/LogInOperation.swift
+++ b/Sources/Networking/Operations/LogInOperation.swift
@@ -56,9 +56,7 @@ final class LogInOperation: CacheableNetworkOperation {
 private extension LogInOperation {
 
     func logIn(completion: @escaping () -> Void) {
-        guard let newAppUserID = self.newAppUserID
-            .trimmingWhitespacesAndNewLines
-            .notEmpty else {
+        guard self.newAppUserID.isNotEmpty else {
             self.loginCallbackCache.performOnAllItemsAndRemoveFromCache(withCacheable: self) { callback in
                 callback.completion(.failure(.missingAppUserID()))
             }
@@ -68,7 +66,7 @@ private extension LogInOperation {
         }
 
         let request = HTTPRequest(method: .post(Body(appUserID: self.configuration.appUserID,
-                                                     newAppUserID: newAppUserID)),
+                                                     newAppUserID: self.newAppUserID)),
                                   path: .logIn)
 
         self.httpClient.perform(request) { (response: VerifiedHTTPResponse<CustomerInfo>.Result) in

--- a/Sources/Networking/Operations/PostAdServicesTokenOperation.swift
+++ b/Sources/Networking/Operations/PostAdServicesTokenOperation.swift
@@ -36,7 +36,7 @@ class PostAdServicesTokenOperation: NetworkOperation {
     private func post(completion: @escaping () -> Void) {
         let appUserID = self.configuration.appUserID
 
-        guard !appUserID.trimmedAndEscaped.isEmpty else {
+        guard appUserID.isNotEmpty else {
             self.responseHandler?(.missingAppUserID())
             completion()
             return

--- a/Sources/Networking/Operations/PostAdServicesTokenOperation.swift
+++ b/Sources/Networking/Operations/PostAdServicesTokenOperation.swift
@@ -34,7 +34,9 @@ class PostAdServicesTokenOperation: NetworkOperation {
     }
 
     private func post(completion: @escaping () -> Void) {
-        guard let appUserID = try? self.configuration.appUserID.escapedOrError() else {
+        let appUserID = self.configuration.appUserID
+
+        guard !appUserID.trimmedAndEscaped.isEmpty else {
             self.responseHandler?(.missingAppUserID())
             completion()
             return

--- a/Sources/Networking/Operations/PostAttributionDataOperation.swift
+++ b/Sources/Networking/Operations/PostAttributionDataOperation.swift
@@ -39,7 +39,7 @@ class PostAttributionDataOperation: NetworkOperation {
     private func post(completion: @escaping () -> Void) {
         let appUserID = self.configuration.appUserID
 
-        guard !appUserID.trimmedAndEscaped.isEmpty else {
+        guard appUserID.isNotEmpty else {
             self.responseHandler?(.missingAppUserID())
             completion()
 

--- a/Sources/Networking/Operations/PostAttributionDataOperation.swift
+++ b/Sources/Networking/Operations/PostAttributionDataOperation.swift
@@ -37,7 +37,9 @@ class PostAttributionDataOperation: NetworkOperation {
     }
 
     private func post(completion: @escaping () -> Void) {
-        guard let appUserID = try? self.configuration.appUserID.escapedOrError() else {
+        let appUserID = self.configuration.appUserID
+
+        guard !appUserID.trimmedAndEscaped.isEmpty else {
             self.responseHandler?(.missingAppUserID())
             completion()
 

--- a/Sources/Networking/Operations/PostSubscriberAttributesOperation.swift
+++ b/Sources/Networking/Operations/PostSubscriberAttributesOperation.swift
@@ -43,7 +43,7 @@ class PostSubscriberAttributesOperation: NetworkOperation {
 
         let appUserID = self.configuration.appUserID
 
-        guard !appUserID.trimmedAndEscaped.isEmpty else {
+        guard appUserID.isNotEmpty else {
             self.responseHandler?(.missingAppUserID())
             completion()
 

--- a/Sources/Networking/Operations/PostSubscriberAttributesOperation.swift
+++ b/Sources/Networking/Operations/PostSubscriberAttributesOperation.swift
@@ -41,7 +41,9 @@ class PostSubscriberAttributesOperation: NetworkOperation {
             return
         }
 
-        guard let appUserID = try? self.configuration.appUserID.escapedOrError() else {
+        let appUserID = self.configuration.appUserID
+
+        guard !appUserID.trimmedAndEscaped.isEmpty else {
             self.responseHandler?(.missingAppUserID())
             completion()
 

--- a/Tests/BackendIntegrationTests/LoadShedderIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/LoadShedderIntegrationTests.swift
@@ -65,7 +65,7 @@ class LoadShedderStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     func testOfferingsComeFromLoadShedder() async throws {
         self.logger.verifyMessageWasLogged(
             Strings.network.request_handled_by_load_shedder(
-                .getOfferings(appUserID: try Purchases.shared.appUserID.escapedOrError())
+                .getOfferings(appUserID: Purchases.shared.appUserID)
             ),
             level: .debug
         )

--- a/Tests/UnitTests/FoundationExtensions/StringExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/StringExtensionsTests.swift
@@ -37,4 +37,19 @@ class StringExtensionsTests: TestCase {
         expect("123\n123\n".countOccurences(of: "\n")) == 2
     }
 
+    func testNotEmpty() {
+        expect("".notEmpty).to(beNil())
+        expect(" ".notEmpty) == " "
+        expect("1".notEmpty) == "1"
+    }
+
+    func testTrimmedAndEscaped() {
+        expect("".trimmedAndEscaped) == ""
+        expect(" ".trimmedAndEscaped) == ""
+        expect("test".trimmedAndEscaped) == "test"
+        expect(" test ".trimmedAndEscaped) == "test"
+        expect(" $RCAnonymousID:8252eb283bbc4453a3f81c978f1a6ee1 ".trimmedAndEscaped)
+        == "$RCAnonymousID%3A8252eb283bbc4453a3f81c978f1a6ee1"
+    }
+
 }

--- a/Tests/UnitTests/FoundationExtensions/StringExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/StringExtensionsTests.swift
@@ -43,6 +43,13 @@ class StringExtensionsTests: TestCase {
         expect("1".notEmpty) == "1"
     }
 
+    func testIsNotEmpty() {
+        expect("".isNotEmpty) == false
+        expect(" ".isNotEmpty) == false
+        expect("1".isNotEmpty) == true
+        expect(" 1 ".isNotEmpty) == true
+    }
+
     func testTrimmedAndEscaped() {
         expect("".trimmedAndEscaped) == ""
         expect(" ".trimmedAndEscaped) == ""

--- a/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
@@ -74,22 +74,6 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         }
     }
 
-    func testEncodesCustomerUserID() {
-        let encodeableUserID = "userid with spaces"
-        let encodedUserID = "userid%20with%20spaces"
-        let response = MockHTTPClient.Response(statusCode: .success, response: Self.validCustomerResponse)
-
-        httpClient.mock(requestPath: .getCustomerInfo(appUserID: encodedUserID), response: response)
-        httpClient.mock(requestPath: .getCustomerInfo(appUserID: encodeableUserID),
-                        response: .init(error: .unexpectedResponse(nil)))
-
-        let customerInfo = waitUntilValue { completed in
-            self.backend.getCustomerInfo(appUserID: encodeableUserID, withRandomDelay: false, completion: completed)
-        }
-
-        expect(customerInfo).to(beSuccess())
-    }
-
     func testHandlesGetCustomerInfoErrors() throws {
         let mockedError = NetworkError.unexpectedResponse(nil)
 

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -22,6 +22,7 @@ class HTTPRequestTests: TestCase {
     // MARK: - Paths
 
     private static let userID = "the_user"
+    private static let anonymousUser = "$RCAnonymousID:8252eb283bbc4453a3f81c978f1a6ee1"
 
     private static let paths: [HTTPRequest.Path] = [
         .getCustomerInfo(appUserID: userID),
@@ -46,6 +47,13 @@ class HTTPRequestTests: TestCase {
         .logIn,
         .postReceiptData,
         .health
+    ]
+    private static let pathsWithUserID: [HTTPRequest.Path] = [
+        .getCustomerInfo(appUserID: anonymousUser),
+        .getOfferings(appUserID: anonymousUser),
+        .getIntroEligibility(appUserID: anonymousUser),
+        .postAttributionData(appUserID: anonymousUser),
+        .postSubscriberAttributes(appUserID: anonymousUser)
     ]
 
     func testPathsDontHaveLeadingSlash() {
@@ -112,6 +120,27 @@ class HTTPRequestTests: TestCase {
                 description: "Path '\(path)' should not have signature validation"
             )
         }
+    }
+
+    func testPathsEscapeUserID() {
+        for path in Self.pathsWithUserID {
+            expect(path.description).toNot(
+                contain(Self.anonymousUser),
+                description: "Path '\(path)' should escape user ID"
+            )
+            expect(path.description).to(
+                contain(Self.anonymousUser.trimmedAndEscaped),
+                description: "Path '\(path)' should escape user ID"
+            )
+        }
+    }
+
+    func testUserIDEscaping() {
+        let encodeableUserID = "userid with spaces"
+        let encodedUserID = "userid%20with%20spaces"
+        let expectedPath = "subscribers/\(encodedUserID)"
+
+        expect(HTTPRequest.Path.getCustomerInfo(appUserID: encodeableUserID).description) == expectedPath
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)


### PR DESCRIPTION
We were escaping users for every (hopefully) request. This refactor moves that responsibility to the path creation in `HTTPRequest.Path` to ensure it's done consistently.

Additionally, this is required so that `SigningTests` produce a consistent path (see #2746).