### PR TITLE
`Integration Tests`: updated load-shedder offerings snapshot

### DIFF
--- a/Tests/BackendIntegrationTests/__Snapshots__/LoadShedderIntegrationTests/testCanGetOfferings.1.json
+++ b/Tests/BackendIntegrationTests/__Snapshots__/LoadShedderIntegrationTests/testCanGetOfferings.1.json
@@ -14,6 +14,19 @@
           "platform_product_identifier" : "com.revenuecat.loadShedder.monthly"
         }
       ]
+    },
+    {
+      "description" : "an alternative offering",
+      "identifier" : "alternative offering",
+      "metadata" : {
+
+      },
+      "packages" : [
+        {
+          "identifier" : "$rc_monthly",
+          "platform_product_identifier" : "com.revenuecat.loadShedder.monthly"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Yesterday this was added, making this test fail.
![Screenshot 2023-07-05 at 10 12 33](https://github.com/RevenueCat/purchases-ios/assets/685609/d38271d3-6825-4891-a927-9617aacf47c9)
