### PR TITLE
`PostReceiptDataOperation`: add new `testReceiptIdentifier` parameter

### DIFF
--- a/Sources/Misc/DangerousSettings.swift
+++ b/Sources/Misc/DangerousSettings.swift
@@ -20,15 +20,18 @@ import Foundation
         #if DEBUG
         let forceServerErrors: Bool
         let forceSignatureFailures: Bool
+        let testReceiptIdentifier: String?
 
         init(
             enableReceiptFetchRetry: Bool = false,
             forceServerErrors: Bool = false,
-            forceSignatureFailures: Bool = false
+            forceSignatureFailures: Bool = false,
+            testReceiptIdentifier: String? = nil
         ) {
             self.enableReceiptFetchRetry = enableReceiptFetchRetry
             self.forceServerErrors = forceServerErrors
             self.forceSignatureFailures = forceSignatureFailures
+            self.testReceiptIdentifier = testReceiptIdentifier
         }
         #else
         init(enableReceiptFetchRetry: Bool = false) {
@@ -116,6 +119,10 @@ internal protocol InternalDangerousSettingsType: Sendable {
 
     /// Whether `HTTPClient` will fake invalid signatures.
     var forceSignatureFailures: Bool { get }
+
+    /// Allows defining the receipt identifier for `PostReceiptDataOperation`.
+    /// This allows the backend to disambiguate between receipts created across separate test invocations.
+    var testReceiptIdentifier: String? { get }
     #endif
 
 }

--- a/Sources/Networking/CustomerAPI.swift
+++ b/Sources/Networking/CustomerAPI.swift
@@ -110,7 +110,8 @@ final class CustomerAPI {
             transactionData: transactionData.withAttributesToPost(subscriberAttributesToPost),
             productData: productData,
             receiptData: receiptData,
-            observerMode: observerMode
+            observerMode: observerMode,
+            testReceiptIdentifier: self.backendConfig.systemInfo.testReceiptIdentifier
         )
         let factory = PostReceiptDataOperation.createFactory(
             configuration: config,
@@ -137,6 +138,22 @@ private extension PurchasedTransactionData {
         copy.unsyncedAttributes = newAttributes
 
         return copy
+    }
+
+}
+
+// MARK: -
+
+private extension SystemInfo {
+
+    /// This allows the backend to disambiguate between receipts created across
+    /// separate test invocations when in the sandbox.
+    var testReceiptIdentifier: String? {
+        #if DEBUG
+        return self.dangerousSettings.internalSettings.testReceiptIdentifier
+        #else
+        return nil
+        #endif
     }
 
 }

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -26,6 +26,8 @@ final class PostReceiptDataOperation: CacheableNetworkOperation {
         let initiationSource: ProductRequestData.InitiationSource
         let subscriberAttributesByKey: SubscriberAttribute.Dictionary?
         let aadAttributionToken: String?
+        /// - Note: this is only used for the backend to disambiguate receipts created in `SKTestSession`s.
+        let testReceiptIdentifier: String?
 
     }
 
@@ -135,7 +137,8 @@ extension PostReceiptDataOperation.PostData {
         transactionData data: PurchasedTransactionData,
         productData: ProductRequestData?,
         receiptData: Data,
-        observerMode: Bool
+        observerMode: Bool,
+        testReceiptIdentifier: String?
     ) {
         self.init(
             appUserID: data.appUserID,
@@ -146,7 +149,8 @@ extension PostReceiptDataOperation.PostData {
             observerMode: observerMode,
             initiationSource: data.source.initiationSource,
             subscriberAttributesByKey: data.unsyncedAttributes,
-            aadAttributionToken: data.aadAttributionToken
+            aadAttributionToken: data.aadAttributionToken,
+            testReceiptIdentifier: testReceiptIdentifier
         )
     }
 
@@ -190,6 +194,7 @@ extension PostReceiptDataOperation.PostData: Encodable {
         case attributes
         case aadAttributionToken
         case presentedOfferingIdentifier
+        case testReceiptIdentifier = "receipt_id"
 
     }
 
@@ -217,6 +222,7 @@ extension PostReceiptDataOperation.PostData: Encodable {
         )
 
         try container.encodeIfPresent(self.aadAttributionToken, forKey: .aadAttributionToken)
+        try container.encodeIfPresent(self.testReceiptIdentifier, forKey: .testReceiptIdentifier)
     }
 
 }

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -194,7 +194,7 @@ extension PostReceiptDataOperation.PostData: Encodable {
         case attributes
         case aadAttributionToken
         case presentedOfferingIdentifier
-        case testReceiptIdentifier = "receipt_id"
+        case testReceiptIdentifier = "test_receipt_identifier"
 
     }
 

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -39,6 +39,8 @@ final class TestPurchaseDelegate: NSObject, PurchasesDelegate, Sendable {
 class BaseBackendIntegrationTests: XCTestCase {
 
     private var userDefaults: UserDefaults!
+    private var testUUID: UUID!
+
     // swiftlint:disable:next weak_delegate
     private(set) var purchasesDelegate: TestPurchaseDelegate!
 
@@ -89,6 +91,11 @@ class BaseBackendIntegrationTests: XCTestCase {
         self.mainThreadMonitor.run()
 
         self.createUserDefaults()
+
+        // We use a different identifier for each test to ensure the backend
+        // doesn't produce conflicts when producing similar receipts across
+        // separate test invocations.
+        self.testUUID = UUID()
 
         self.clearReceiptIfExists()
         await self.createPurchases()
@@ -193,5 +200,6 @@ extension BaseBackendIntegrationTests: InternalDangerousSettingsType {
     var enableReceiptFetchRetry: Bool { return true }
     var forceServerErrors: Bool { return false }
     var forceSignatureFailures: Bool { return false }
+    var testReceiptIdentifier: String? { return self.testUUID.uuidString }
 
 }

--- a/Tests/BackendIntegrationTests/__Snapshots__/LoadShedderIntegrationTests/testCanGetOfferings.1.json
+++ b/Tests/BackendIntegrationTests/__Snapshots__/LoadShedderIntegrationTests/testCanGetOfferings.1.json
@@ -14,6 +14,19 @@
           "platform_product_identifier" : "com.revenuecat.loadShedder.monthly"
         }
       ]
+    },
+    {
+      "description" : "an alternative offering",
+      "identifier" : "alternative offering",
+      "metadata" : {
+
+      },
+      "packages" : [
+        {
+          "identifier" : "$rc_monthly",
+          "platform_product_identifier" : "com.revenuecat.loadShedder.monthly"
+        }
+      ]
     }
   ]
 }

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -38,12 +38,18 @@ class BaseBackendTests: TestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        self.systemInfo = try SystemInfo(
-            platformInfo: nil,
-            finishTransactions: true,
-            responseVerificationMode: self.responseVerificationMode,
-            dangerousSettings: self.dangerousSettings
+        self.createDependencies(
+            try SystemInfo(
+                platformInfo: nil,
+                finishTransactions: true,
+                responseVerificationMode: self.responseVerificationMode,
+                dangerousSettings: self.dangerousSettings
+            )
         )
+    }
+
+    final func createDependencies(_ systemInfo: SystemInfo) {
+        self.systemInfo = systemInfo
         self.httpClient = self.createClient()
         self.operationDispatcher = MockOperationDispatcher()
         self.mockProductEntitlementMappingFetcher = MockProductEntitlementMappingFetcher()

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -18,8 +18,8 @@
       "observer_mode" : true,
       "price" : "15.99",
       "product_id" : "product_id",
-      "receipt_id" : "12345678-1234-1234-1234-C2C35AE34D09",
-      "store_country" : "ESP"
+      "store_country" : "ESP",
+      "test_receipt_identifier" : "12345678-1234-1234-1234-C2C35AE34D09"
     },
     "method" : "POST",
     "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -1,0 +1,27 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "notDetermined"
+        }
+      },
+      "currency" : "UYU",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "initiation_source" : "purchase",
+      "is_restore" : false,
+      "observer_mode" : true,
+      "price" : "15.99",
+      "product_id" : "product_id",
+      "receipt_id" : "12345678-1234-1234-1234-C2C35AE34D09",
+      "store_country" : "ESP"
+    },
+    "method" : "POST",
+    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -1,0 +1,27 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "notDetermined"
+        }
+      },
+      "currency" : "UYU",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "initiation_source" : "purchase",
+      "is_restore" : false,
+      "observer_mode" : true,
+      "price" : "15.99",
+      "product_id" : "product_id",
+      "receipt_id" : "12345678-1234-1234-1234-C2C35AE34D09",
+      "store_country" : "ESP"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -18,8 +18,8 @@
       "observer_mode" : true,
       "price" : "15.99",
       "product_id" : "product_id",
-      "receipt_id" : "12345678-1234-1234-1234-C2C35AE34D09",
-      "store_country" : "ESP"
+      "store_country" : "ESP",
+      "test_receipt_identifier" : "12345678-1234-1234-1234-C2C35AE34D09"
     },
     "method" : "POST",
     "url" : "https://api.revenuecat.com/v1/receipts"

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -1,0 +1,27 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "currency" : "UYU",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "initiation_source" : "purchase",
+      "is_restore" : false,
+      "observer_mode" : true,
+      "price" : "15.99",
+      "product_id" : "product_id",
+      "receipt_id" : "12345678-1234-1234-1234-C2C35AE34D09",
+      "store_country" : "ESP"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -18,8 +18,8 @@
       "observer_mode" : true,
       "price" : "15.99",
       "product_id" : "product_id",
-      "receipt_id" : "12345678-1234-1234-1234-C2C35AE34D09",
-      "store_country" : "ESP"
+      "store_country" : "ESP",
+      "test_receipt_identifier" : "12345678-1234-1234-1234-C2C35AE34D09"
     },
     "method" : "POST",
     "url" : "https://api.revenuecat.com/v1/receipts"

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -1,0 +1,27 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "currency" : "UYU",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "initiation_source" : "purchase",
+      "is_restore" : false,
+      "observer_mode" : true,
+      "price" : "15.99",
+      "product_id" : "product_id",
+      "receipt_id" : "12345678-1234-1234-1234-C2C35AE34D09",
+      "store_country" : "ESP"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -18,8 +18,8 @@
       "observer_mode" : true,
       "price" : "15.99",
       "product_id" : "product_id",
-      "receipt_id" : "12345678-1234-1234-1234-C2C35AE34D09",
-      "store_country" : "ESP"
+      "store_country" : "ESP",
+      "test_receipt_identifier" : "12345678-1234-1234-1234-C2C35AE34D09"
     },
     "method" : "POST",
     "url" : "https://api.revenuecat.com/v1/receipts"

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -1,0 +1,27 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "user",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "currency" : "UYU",
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "initiation_source" : "purchase",
+      "is_restore" : false,
+      "observer_mode" : true,
+      "price" : "15.99",
+      "product_id" : "product_id",
+      "receipt_id" : "12345678-1234-1234-1234-C2C35AE34D09",
+      "store_country" : "ESP"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithTestReceiptIdentifier.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testPostsReceiptDataWithTestReceiptIdentifier.1.json
@@ -18,8 +18,8 @@
       "observer_mode" : true,
       "price" : "15.99",
       "product_id" : "product_id",
-      "receipt_id" : "12345678-1234-1234-1234-C2C35AE34D09",
-      "store_country" : "ESP"
+      "store_country" : "ESP",
+      "test_receipt_identifier" : "12345678-1234-1234-1234-C2C35AE34D09"
     },
     "method" : "POST",
     "url" : "https://api.revenuecat.com/v1/receipts"

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS12-testPostReceiptWithAdServicesToken.1.json
@@ -1,0 +1,23 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer the api key"
+  },
+  "request" : {
+    "body" : {
+      "aad_attribution_token" : "token",
+      "app_user_id" : "abc123",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "notDetermined"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "initiation_source" : "restore",
+      "is_restore" : false,
+      "observer_mode" : false
+    },
+    "method" : "POST",
+    "url" : "https:\/\/api.revenuecat.com\/v1\/receipts"
+  }
+}

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS13-testPostReceiptWithAdServicesToken.1.json
@@ -1,0 +1,23 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer the api key"
+  },
+  "request" : {
+    "body" : {
+      "aad_attribution_token" : "token",
+      "app_user_id" : "abc123",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "notDetermined"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "initiation_source" : "restore",
+      "is_restore" : false,
+      "observer_mode" : false
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS14-testPostReceiptWithAdServicesToken.1.json
@@ -1,0 +1,23 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer the api key"
+  },
+  "request" : {
+    "body" : {
+      "aad_attribution_token" : "token",
+      "app_user_id" : "abc123",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "initiation_source" : "restore",
+      "is_restore" : false,
+      "observer_mode" : false
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}

--- a/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithAdServicesToken.1.json
+++ b/Tests/UnitTests/SubscriberAttributes/__Snapshots__/BackendSubscriberAttributesTests/iOS15-testPostReceiptWithAdServicesToken.1.json
@@ -1,0 +1,23 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer the api key"
+  },
+  "request" : {
+    "body" : {
+      "aad_attribution_token" : "token",
+      "app_user_id" : "abc123",
+      "attributes" : {
+        "$attConsentStatus" : {
+          "updated_at_ms" : 1678307200000,
+          "value" : "authorized"
+        }
+      },
+      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "initiation_source" : "restore",
+      "is_restore" : false,
+      "observer_mode" : false
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/receipts"
+  }
+}


### PR DESCRIPTION
This allows the backend to disambiguate receipts that are coming from different test invocations.

With `SKTestSession` receipts, [the backend has limited information](https://github.com/RevenueCat/khepri/blob/d8887de84863fd846bee559d2bed03245bfb8467/khepri/stores/apple/local/store_kit_test_receipt_formatter.py#L281) to disambiguate receipts coming from different tests. By adding a new UUID that we can re-generate in each test, we help the backend not mix receipts from separate tests.

Note that the value sent in `X-Apple-Device-Identifier` is unchanged (and verified with tests) because it's important that this is the real `IDFV`, since it's used to validate `AppleReceipt.sha1Hash`.

Depends on https://github.com/RevenueCat/khepri/pull/6183