### PR TITLE
[WIP] New `Purchases.errorHandler` for detecting any `NSError`

### DIFF
--- a/Sources/Caching/DeviceCache.swift
+++ b/Sources/Caching/DeviceCache.swift
@@ -268,7 +268,8 @@ class DeviceCache {
                             Logger.error(
                                 Strings.attribution.latest_attribution_sent_user_defaults_invalid(
                                     networkKey: networkKey
-                                )
+                                ),
+                                error: nil
                             )
                              return nil
                         }

--- a/Sources/CodableExtensions/PurchaseOwnershipType+Extensions.swift
+++ b/Sources/CodableExtensions/PurchaseOwnershipType+Extensions.swift
@@ -33,7 +33,8 @@ extension PurchaseOwnershipType: Decodable {
             self = type
         } else {
             Logger.error(Strings.codable.unexpectedValueError(type: PurchaseOwnershipType.self,
-                                                              value: purchaseOwnershipTypeString))
+                                                              value: purchaseOwnershipTypeString),
+                         error: nil)
             self = .unknown
         }
     }

--- a/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
@@ -20,6 +20,7 @@ Most features require configuring the SDK before using it.
 - ``Purchases/delegate``
 - ``Purchases/logLevel``
 - ``Purchases/logHandler``
+- ``Purchases/errorHandler``
 
 ### Configuring the SDK
 - ``Purchases/configure(withAPIKey:)``

--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -608,13 +608,16 @@ private extension ErrorUtils {
         userInfo[.file] = "\(fileName):\(line)"
         userInfo[.function] = functionName
 
+        let purchasesError = PurchasesError(error: code, userInfo: userInfo)
+
         Self.logErrorIfNeeded(
             code,
+            purchasesError.asPublicError,
             localizedDescription: localizedDescription,
             fileName: fileName, functionName: functionName, line: line
         )
 
-        return .init(error: code, userInfo: userInfo)
+        return purchasesError
     }
 
     static func backendResponseError(
@@ -645,11 +648,11 @@ private extension ErrorUtils {
     }
 
     // Used for logging errors when they're _created_.
-    // Note that these are only sent to the console through `Logger.internalLogHandler`
-    // and not to `Logger.errorHandler`, since we don't want to forward those
-    // until they're specifically logged.
+    // These are sent to the console through `Logger.internalLogHandler`
+    // and to `Logger.errorHandler`.
     // swiftlint:disable:next function_body_length
     private static func logErrorIfNeeded(_ code: ErrorCode,
+                                         _ error: NSError,
                                          localizedDescription: String,
                                          fileName: String = #fileID,
                                          functionName: String = #function,
@@ -682,7 +685,7 @@ private extension ErrorUtils {
                 .signatureVerificationFailed:
                 Logger.error(
                     localizedDescription,
-                    error: nil,
+                    error: error,
                     fileName: fileName,
                     functionName: functionName,
                     line: line
@@ -702,7 +705,7 @@ private extension ErrorUtils {
                 .productRequestTimedOut:
                 Logger.appleError(
                     localizedDescription,
-                    error: nil,
+                    error: error,
                     fileName: fileName,
                     functionName: functionName,
                     line: line
@@ -711,7 +714,7 @@ private extension ErrorUtils {
         @unknown default:
             Logger.error(
                 localizedDescription,
-                error: nil,
+                error: error,
                 fileName: fileName,
                 functionName: functionName,
                 line: line

--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -644,6 +644,10 @@ private extension ErrorUtils {
         ])
     }
 
+    // Used for logging errors when they're _created_.
+    // Note that these are only sent to the console through `Logger.internalLogHandler`
+    // and not to `Logger.errorHandler`, since we don't want to forward those
+    // until they're specifically logged.
     // swiftlint:disable:next function_body_length
     private static func logErrorIfNeeded(_ code: ErrorCode,
                                          localizedDescription: String,
@@ -678,6 +682,7 @@ private extension ErrorUtils {
                 .signatureVerificationFailed:
                 Logger.error(
                     localizedDescription,
+                    error: nil,
                     fileName: fileName,
                     functionName: functionName,
                     line: line
@@ -697,6 +702,7 @@ private extension ErrorUtils {
                 .productRequestTimedOut:
                 Logger.appleError(
                     localizedDescription,
+                    error: nil,
                     fileName: fileName,
                     functionName: functionName,
                     line: line
@@ -705,6 +711,7 @@ private extension ErrorUtils {
         @unknown default:
             Logger.error(
                 localizedDescription,
+                error: nil,
                 fileName: fileName,
                 functionName: functionName,
                 line: line

--- a/Sources/FoundationExtensions/Decoder+Extensions.swift
+++ b/Sources/FoundationExtensions/Decoder+Extensions.swift
@@ -124,37 +124,43 @@ extension JSONEncoder {
 extension ErrorUtils {
 
     static func logDecodingError(_ error: Error, type: Any.Type) {
+        let nsError = error as NSError
+
         guard let decodingError = error as? DecodingError else {
-            Logger.error(Strings.codable.decoding_error(error))
+            Logger.error(Strings.codable.decoding_error(error), error: nsError)
             return
         }
 
         switch decodingError {
         case let .dataCorrupted(context):
-            Logger.error(Strings.codable.corrupted_data_error(context: context))
+            Logger.error(Strings.codable.corrupted_data_error(context: context), error: nsError)
         case let .keyNotFound(key, context):
             // This is expected to happen occasionally, the backend doesn't always populate all key/values.
             Logger.debug(Strings.codable.keyNotFoundError(type: type, key: key, context: context))
         case let .valueNotFound(value, context):
             Logger.debug(Strings.codable.valueNotFoundError(value: value, context: context))
         case let .typeMismatch(type, context):
-            Logger.error(Strings.codable.typeMismatch(type: type, context: context))
+            Logger.error(Strings.codable.typeMismatch(type: type, context: context), error: nsError)
         @unknown default:
-            Logger.error("Unhandled DecodingError: \(decodingError)\n\(Strings.codable.decoding_error(decodingError))")
+            Logger.error("Unhandled DecodingError: \(decodingError)\n\(Strings.codable.decoding_error(decodingError))",
+                         error: nsError)
         }
     }
 
     static func logEncodingError(_ error: Error, type: Any.Type) {
+        let nsError = error as NSError
+
         guard let encodingError = error as? EncodingError else {
-            Logger.error(Strings.codable.encoding_error(error))
+            Logger.error(Strings.codable.encoding_error(error), error: nsError)
             return
         }
 
         switch encodingError {
         case .invalidValue:
-            Logger.error(Strings.codable.encoding_error(encodingError))
+            Logger.error(Strings.codable.encoding_error(encodingError), error: nsError)
         @unknown default:
-            Logger.error("Unhandled EncodingError: \(encodingError)\n\(Strings.codable.encoding_error(encodingError))")
+            Logger.error("Unhandled EncodingError: \(encodingError)\n\(Strings.codable.encoding_error(encodingError))",
+                         error: nsError)
         }
     }
 

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -191,7 +191,8 @@ class CustomerInfoManager {
                 return nil
             }
         } catch {
-            Logger.error("Error loading customer info from cache:\n \(error.localizedDescription)")
+            Logger.error("Error loading customer info from cache:\n \(error.localizedDescription)",
+                         error: error as NSError)
             return nil
         }
     }
@@ -202,7 +203,8 @@ class CustomerInfoManager {
                 let jsonData = try JSONEncoder.default.encode(customerInfo)
                 self.withData { $0.deviceCache.cache(customerInfo: jsonData, appUserID: appUserID) }
             } catch {
-                Logger.error(Strings.customerInfo.error_encoding_customerinfo(error))
+                Logger.error(Strings.customerInfo.error_encoding_customerinfo(error),
+                             error: error as NSError)
             }
         } else {
             Logger.debug(Strings.customerInfo.not_caching_offline_customer_info)

--- a/Sources/Identity/IdentityManager.swift
+++ b/Sources/Identity/IdentityManager.swift
@@ -118,7 +118,7 @@ private extension IdentityManager {
         let oldAppUserID = self.currentAppUserID
         let newAppUserID = appUserID.trimmingWhitespacesAndNewLines
         guard !newAppUserID.isEmpty else {
-            Logger.error(Strings.identity.logging_in_with_empty_appuserid)
+            Logger.error(Strings.identity.logging_in_with_empty_appuserid, error: nil)
             completion(.failure(.missingAppUserID()))
             return
         }

--- a/Sources/LocalReceiptParsing/Helpers/LoggerType.swift
+++ b/Sources/LocalReceiptParsing/Helpers/LoggerType.swift
@@ -34,6 +34,7 @@ protocol LoggerType {
               functionName: String?,
               line: UInt)
     func error(_ message: @autoclosure () -> LogMessage,
+               error: NSError?,
                fileName: String,
                functionName: String,
                line: UInt)
@@ -165,10 +166,11 @@ extension LoggerType {
     }
 
     func error(_ message: @autoclosure () -> LogMessage,
+               error: NSError?,
                _ fileName: String = #fileID,
                _ functionName: String = #function,
                _ line: UInt = #line) {
-        self.error(message(), fileName: fileName, functionName: functionName, line: line)
+        self.error(message(), error: error, fileName: fileName, functionName: functionName, line: line)
     }
 
 }

--- a/Sources/LocalReceiptParsing/Helpers/ReceiptParserLogger.swift
+++ b/Sources/LocalReceiptParsing/Helpers/ReceiptParserLogger.swift
@@ -77,6 +77,7 @@ final class ReceiptParserLogger: LoggerType {
 
     func error(
         _ message: @autoclosure () -> LogMessage,
+        error: NSError?,
         fileName: String,
         functionName: String,
         line: UInt

--- a/Sources/LocalReceiptParsing/PurchasesReceiptParser.swift
+++ b/Sources/LocalReceiptParsing/PurchasesReceiptParser.swift
@@ -48,8 +48,11 @@ public class PurchasesReceiptParser: NSObject {
         let asn1Container = try self.containerBuilder.build(fromPayload: ArraySlice(receiptData))
         guard let receiptASN1Container = try self.findASN1Container(withObjectId: ASN1ObjectIdentifier.data,
                                                                     inContainer: asn1Container) else {
-            self.logger.error(ReceiptStrings.data_object_identifer_not_found_receipt)
-            throw Error.dataObjectIdentifierMissing
+            let error = Error.dataObjectIdentifierMissing
+
+            self.logger.error(ReceiptStrings.data_object_identifer_not_found_receipt,
+                              error: error as NSError)
+            throw error
         }
 
         let receipt = try self.receiptBuilder.build(fromContainer: receiptASN1Container)

--- a/Sources/Logging/Strings/AttributionStrings.swift
+++ b/Sources/Logging/Strings/AttributionStrings.swift
@@ -18,7 +18,7 @@ import Foundation
 enum AttributionStrings {
 
     case appsflyer_id_deprecated
-    case attributes_sync_error(error: NSError?)
+    case attributes_sync_error(error: NSError)
     case attributes_sync_success(appUserID: String)
     case empty_subscriber_attributes
     case marking_attributes_synced(appUserID: String, attributes: SubscriberAttribute.Dictionary)
@@ -58,9 +58,9 @@ extension AttributionStrings: LogMessage {
             return "The parameter key rc_appsflyer_id is deprecated." +
             " Pass networkUserId to addAttribution instead."
 
-        case .attributes_sync_error(let error):
-            return "Error when syncing subscriber attributes. Details: \(error?.localizedDescription ?? "")" +
-            " \nUserInfo: \(error?.userInfo ?? [:])"
+        case let .attributes_sync_error(error):
+            return "Error when syncing subscriber attributes. Details: \(error.localizedDescription)" +
+            " \nUserInfo: \(error.userInfo)"
 
         case .attributes_sync_success(let appUserID):
             return "Subscriber attributes synced successfully for App User ID: \(appUserID)"

--- a/Sources/Misc/Concurrency/Purchases+async.swift
+++ b/Sources/Misc/Concurrency/Purchases+async.swift
@@ -163,7 +163,8 @@ extension Purchases {
                             Strings.eligibility.check_eligibility_failed(
                                 productIdentifier: product.productIdentifier,
                                 error: error
-                            )
+                            ),
+                            error: error as NSError
                         )
                         return nil
                     }

--- a/Sources/Networking/HTTPClient/ErrorResponse.swift
+++ b/Sources/Networking/HTTPClient/ErrorResponse.swift
@@ -142,7 +142,7 @@ extension ErrorResponse {
                 return try JSONDecoder.default.decode(jsonData: data)
             }
         } catch {
-            Logger.error(Strings.codable.decoding_error(error))
+            ErrorUtils.logDecodingError(error, type: Self.self)
 
             return Self.defaultResponse
         }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -390,7 +390,7 @@ private extension HTTPClient {
         guard let urlRequest = urlRequest else {
             let error: NetworkError = .unableToCreateRequest(request.httpRequest.path)
 
-            Logger.error(error.description)
+            Logger.error(error.description, error: error as NSError)
             request.completionHandler?(.failure(error))
             return
         }
@@ -418,8 +418,9 @@ private extension HTTPClient {
 
         do {
             urlRequest.httpBody = try request.httpRequest.requestBody?.jsonEncodedData
-        } catch {
-            Logger.error(Strings.network.creating_json_error(error: error.localizedDescription))
+        } catch let error as NSError {
+            Logger.error(Strings.network.creating_json_error(error: error.localizedDescription),
+                         error: error)
             return nil
         }
 
@@ -506,7 +507,7 @@ private extension NetworkError {
     /// Creates a `NetworkError` from any request `Error`.
     init(_ error: Error, dnsChecker: DNSCheckerType.Type) {
         if let blockedError = dnsChecker.errorWithBlockedHostFromError(error) {
-            Logger.error(blockedError.description)
+            Logger.error(blockedError.description, error: blockedError as NSError)
             self = blockedError
         } else {
             let nsError = error as NSError

--- a/Sources/Networking/HTTPClient/NetworkError.swift
+++ b/Sources/Networking/HTTPClient/NetworkError.swift
@@ -37,10 +37,10 @@ extension NetworkError {
         file: String = #fileID, function: String = #function, line: UInt = #line
     ) -> Self {
         // Explicitly logging errors since it might help debugging issues.
-        Logger.error(Strings.network.parsing_json_error(error: error))
+        Logger.error(Strings.network.parsing_json_error(error: error), error: error as NSError)
         Logger.error(Strings.network.json_data_received(
             dataString: String(data: data, encoding: .utf8) ?? ""
-        ))
+        ), error: nil)
 
         return .decoding(error as NSError, .init(file: file, function: function, line: line))
     }

--- a/Sources/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
+++ b/Sources/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
@@ -56,8 +56,11 @@ class CustomerInfoResponseHandler {
         _ = Task<Void, Never> {
             do {
                 completion(.success(try await offlineCreator.create(for: self.userID)))
-            } catch {
-                Logger.error(Strings.offlineEntitlements.computing_offline_customer_info_failed(error))
+            } catch let error as NSError {
+                Logger.error(
+                    Strings.offlineEntitlements.computing_offline_customer_info_failed(error),
+                    error: error
+                )
                 completion(result)
             }
         }

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -166,15 +166,21 @@ private extension PostReceiptDataOperation {
             self.log(Strings.receipt.posting_receipt(receipt))
 
             for purchase in receipt.inAppPurchases where purchase.purchaseDateEqualsExpiration {
-                Logger.appleError(Strings.receipt.receipt_subscription_purchase_equals_expiration(
-                    productIdentifier: purchase.productId,
-                    purchase: purchase.purchaseDate,
-                    expiration: purchase.expiresDate
-                ))
+                Logger.appleError(
+                    Strings.receipt.receipt_subscription_purchase_equals_expiration(
+                        productIdentifier: purchase.productId,
+                        purchase: purchase.purchaseDate,
+                        expiration: purchase.expiresDate
+                    ),
+                    error: nil
+                )
             }
 
         } catch {
-            Logger.appleError(Strings.receipt.parse_receipt_locally_error(error: error))
+            Logger.appleError(
+                Strings.receipt.parse_receipt_locally_error(error: error),
+                error: nil
+            )
         }
     }
 

--- a/Sources/OfflineEntitlements/OfflineEntitlementsManager.swift
+++ b/Sources/OfflineEntitlements/OfflineEntitlementsManager.swift
@@ -96,7 +96,8 @@ private extension OfflineEntitlementsManager {
     }
 
     func handleProductsEntitlementsUpdateError(_ error: BackendError) {
-        Logger.error(Strings.offlineEntitlements.product_entitlement_mapping_fetching_error(error))
+        Logger.error(Strings.offlineEntitlements.product_entitlement_mapping_fetching_error(error),
+                     error: error as NSError)
     }
 
 }

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -281,7 +281,7 @@ extension Configuration {
         switch self.validate(apiKey: apiKey) {
         case .validApplePlatform: break
         case .legacy: Logger.debug(Strings.configure.legacyAPIKey)
-        case .otherPlatforms: Logger.error(Strings.configure.invalidAPIKey)
+        case .otherPlatforms: Logger.error(Strings.configure.invalidAPIKey, error: nil)
         }
     }
 

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -224,6 +224,8 @@ internal extension Configuration {
 
     /// Defines how strict ``EntitlementInfo`` verification ought to be.
     ///
+    /// Verification failures will be forwarded to ``Purchases/errorHandler``.
+    ///
     /// ### Related Symbols
     /// - ``VerificationResult``
     /// - ``Configuration/Builder/with(entitlementVerificationMode:)``

--- a/Sources/Purchasing/IntroEligibilityCalculator.swift
+++ b/Sources/Purchasing/IntroEligibilityCalculator.swift
@@ -74,7 +74,8 @@ class IntroEligibilityCalculator {
                 completion(result, nil)
             }
         } catch {
-            Logger.error(Strings.customerInfo.checking_intro_eligibility_locally_error(error: error))
+            Logger.error(Strings.customerInfo.checking_intro_eligibility_locally_error(error: error),
+                         error: error as NSError)
             completion([:], error)
             return
         }

--- a/Sources/Purchasing/NonSubscriptionTransaction.swift
+++ b/Sources/Purchasing/NonSubscriptionTransaction.swift
@@ -30,7 +30,8 @@ public final class NonSubscriptionTransaction: NSObject {
         guard let transactionIdentifier = transaction.transactionIdentifier,
               let purchaseDate = transaction.purchaseDate else {
             Logger.error("Couldn't initialize NonSubscriptionTransaction. " +
-                         "Reason: missing data: \(transaction).")
+                         "Reason: missing data: \(transaction).",
+                         error: nil)
             return nil
         }
 

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -243,8 +243,11 @@ private extension OfferingsManager {
         _ error: Error,
         completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
     ) {
-        Logger.appleError(Strings.offering.fetching_offerings_error(error: error,
-                                                                    underlyingError: error.underlyingError))
+        Logger.appleError(
+            Strings.offering.fetching_offerings_error(error: error,
+                                                      underlyingError: error.underlyingError),
+            error: error as NSError
+        )
         self.dispatchCompletionOnMainThreadIfPossible(completion, value: .failure(error))
     }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -161,6 +161,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
      * - Note:``verboseLogHandler`` provides additional information.
      *
      * #### Related Symbols
+     * - ``errorHandler``
      * - ``verboseLogHandler``
      * - ``logLevel``
      */
@@ -188,6 +189,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
      *
      * #### Related Symbols
      * - ``logHandler``
+     * - ``errorHandler``
      * - ``logLevel``
      */
     @objc public static var verboseLogHandler: VerboseLogHandler {
@@ -204,9 +206,26 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         }
     }
 
+    /**
+     * Set a custom handler for redirecting errors to your own logging system.
+     * This does nothing by default, but it can be overriden to detect and handle
+     * any error occuring in the SDK.
+     *
+     * #### Related Symbols
+     * - ``logHandler``
+     * - ``verboseLogHandler``
+     * - ``logLevel``
+     */
+    @objc public static var errorHandler: ErrorHandler {
+        get { return Logger.errorHandler }
+
+        set { Logger.errorHandler = newValue }
+    }
+
     /// Useful for tests that override the log handler.
     internal static func restoreLogHandler() {
         Logger.internalLogHandler = Logger.defaultLogHandler
+        Logger.errorHandler = Logger.defaultErrorHandler
     }
 
     /**

--- a/Sources/Purchasing/ReceiptFetcher.swift
+++ b/Sources/Purchasing/ReceiptFetcher.swift
@@ -203,7 +203,8 @@ private extension ReceiptFetcher {
                         ))
                     }
                 } catch {
-                    Logger.error(Strings.receipt.parse_receipt_locally_error(error: error))
+                    Logger.error(Strings.receipt.parse_receipt_locally_error(error: error),
+                                 error: error as NSError)
                 }
             }
 

--- a/Sources/Purchasing/StoreKit1/ProductsFetcherSK1.swift
+++ b/Sources/Purchasing/StoreKit1/ProductsFetcherSK1.swift
@@ -127,11 +127,11 @@ extension ProductsFetcherSK1: SKProductsRequestDelegate {
         self.queue.async { [self] in
             Logger.rcSuccess(Strings.storeKit.store_product_request_received_response)
             guard let productRequest = self.productsByRequests[request] else {
-                Logger.error("requested products not found for request: \(request)")
+                Logger.error("Requested products not found for request: \(request)", error: nil)
                 return
             }
             guard let completionBlocks = self.completionHandlers[productRequest.identifiers] else {
-                Logger.error("callback not found for failing request: \(request)")
+                Logger.error("Callback not found for failing request: \(request)", error: nil)
                 self.productsByRequests.removeValue(forKey: request)
                 return
             }
@@ -157,16 +157,19 @@ extension ProductsFetcherSK1: SKProductsRequestDelegate {
         }
 
         self.queue.async { [self] in
-            Logger.appleError(Strings.storeKit.store_products_request_failed(error as NSError))
+            Logger.appleError(Strings.storeKit.store_products_request_failed(error as NSError),
+                              error: error as NSError)
 
             guard let productRequest = self.productsByRequests[request] else {
-                Logger.error(Strings.purchase.requested_products_not_found(request: request))
+                Logger.error(Strings.purchase.requested_products_not_found(request: request),
+                             error: nil)
                 return
             }
 
             if productRequest.retriesLeft <= 0 {
                 guard let completionBlocks = self.completionHandlers[productRequest.identifiers] else {
-                    Logger.error(Strings.purchase.callback_not_found_for_request(request: request))
+                    Logger.error(Strings.purchase.callback_not_found_for_request(request: request),
+                                 error: nil)
                     self.productsByRequests.removeValue(forKey: request)
                     return
                 }
@@ -239,11 +242,14 @@ private extension ProductsFetcherSK1 {
 
             request.cancel()
 
-            Logger.appleError(Strings.storeKit.skproductsrequest_timed_out(
-                after: Int(self.requestTimeout.rounded())
-            ))
+            Logger.appleError(
+                Strings.storeKit.skproductsrequest_timed_out(
+                    after: Int(self.requestTimeout.rounded())
+                ),
+                error: nil
+            )
             guard let completionBlocks = self.completionHandlers[productRequest.identifiers] else {
-                Logger.error("callback not found for failing request: \(request)")
+                Logger.error("callback not found for failing request: \(request)", error: nil)
                 return
             }
 

--- a/Sources/Purchasing/StoreKit1/StoreKitRequestFetcher.swift
+++ b/Sources/Purchasing/StoreKit1/StoreKitRequestFetcher.swift
@@ -67,7 +67,7 @@ extension StoreKitRequestFetcher: SKRequestDelegate {
     func request(_ request: SKRequest, didFailWithError error: Error) {
         guard request is SKReceiptRefreshRequest else { return }
 
-        Logger.appleError(Strings.storeKit.skrequest_failed(error as NSError))
+        Logger.appleError(Strings.storeKit.skrequest_failed(error as NSError), error: error as NSError)
         self.finishReceiptRequest(request)
         request.cancel()
     }

--- a/Sources/Purchasing/StoreKit2/SK2BeginRefundRequestHelper.swift
+++ b/Sources/Purchasing/StoreKit2/SK2BeginRefundRequestHelper.swift
@@ -36,8 +36,9 @@ class SK2BeginRefundRequestHelper {
         let result = await StoreKit.Transaction.latest(for: productID)
         guard let nonNilResult = result else {
             let errorMessage = Strings.purchase.product_unpurchased_or_missing.description
-            Logger.error(errorMessage)
-            throw ErrorUtils.beginRefundRequestError(withMessage: errorMessage)
+            let error = ErrorUtils.beginRefundRequestError(withMessage: errorMessage)
+            Logger.error(errorMessage, error: error.asPublicError)
+            throw error
         }
 
         switch nonNilResult {
@@ -45,7 +46,7 @@ class SK2BeginRefundRequestHelper {
             let message = Strings.purchase.transaction_unverified(
                 productID: productID,
                 errorMessage: verificationError.localizedDescription).description
-            Logger.error(message)
+            Logger.error(message, error: verificationError as NSError)
             throw ErrorUtils.beginRefundRequestError(withMessage: message)
         case .verified(let transaction): return transaction.id
         }
@@ -66,7 +67,7 @@ class SK2BeginRefundRequestHelper {
             return .success(sk2Status)
         } catch {
             let message = getErrorMessage(from: error)
-            Logger.error(message)
+            Logger.error(message, error: error as NSError)
             return .failure(ErrorUtils.beginRefundRequestError(withMessage: message, error: error))
         }
     }
@@ -105,13 +106,12 @@ private extension SK2BeginRefundRequestHelper {
         case .success(let sk2Status):
             guard let rcStatus = RefundRequestStatus.from(sk2RefundRequestStatus: sk2Status) else {
                 let message = Strings.purchase.unknown_refund_request_status.description
-                Logger.error(message)
-                throw ErrorUtils.beginRefundRequestError(
-                    withMessage: message)
+                Logger.error(message, error: nil)
+                throw ErrorUtils.beginRefundRequestError(withMessage: message)
             }
             return rcStatus
         case .failure(let error):
-            Logger.error(error.localizedDescription)
+            Logger.error(error.localizedDescription, error: error as NSError)
             throw error
         }
     }

--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
@@ -51,8 +51,8 @@ class StoreKit2TransactionListener {
 
                 do {
                     _ = try await self.handle(transactionResult: result, fromTransactionUpdate: true)
-                } catch {
-                    Logger.error(error.localizedDescription)
+                } catch let error as NSError {
+                    Logger.error(error.localizedDescription, error: error)
                 }
             }
         }

--- a/Sources/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK2StoreProduct.swift
@@ -53,7 +53,8 @@ internal struct SK2StoreProduct: StoreProductType {
 
     var priceFormatter: NumberFormatter? {
         guard let currencyCode = self.currencyCode else {
-            Logger.appleError("Can't initialize priceFormatter for SK2 product! Could not find the currency code")
+            Logger.appleError("Can't initialize priceFormatter for SK2 product! Could not find the currency code",
+                              error: nil)
             return nil
         }
 

--- a/Sources/Purchasing/StoreKitAbstractions/StoreKitWorkarounds.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreKitWorkarounds.swift
@@ -136,7 +136,7 @@ extension SKPaymentQueue {
             Logger.debug(Strings.purchase.presenting_code_redemption_sheet)
             self.presentCodeRedemptionSheet()
         } else {
-            Logger.appleError(Strings.purchase.unable_to_present_redemption_sheet)
+            Logger.appleError(Strings.purchase.unable_to_present_redemption_sheet, error: nil)
         }
     }
 

--- a/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
+++ b/Sources/Purchasing/TrialOrIntroPriceEligibilityChecker.swift
@@ -66,7 +66,8 @@ class TrialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityCheckerTy
                 do {
                     return try await self.sk2CheckEligibility(productIdentifiers)
                 } catch {
-                    Logger.appleError(Strings.eligibility.unable_to_get_intro_eligibility_for_user(error: error))
+                    Logger.appleError(Strings.eligibility.unable_to_get_intro_eligibility_for_user(error: error),
+                                      error: error as NSError)
 
                     return productIdentifiers.reduce(into: [:]) { resultDict, productId in
                         resultDict[productId] = IntroEligibility(eligibilityStatus: IntroEligibilityStatus.unknown)
@@ -151,7 +152,8 @@ private extension TrialOrIntroPriceEligibilityChecker {
             .checkEligibility(with: receiptData,
                               productIdentifiers: Set(productIdentifiers)) { receivedEligibility, error in
                 if let error = error {
-                    Logger.error(Strings.receipt.parse_receipt_locally_error(error: error))
+                    Logger.error(Strings.receipt.parse_receipt_locally_error(error: error),
+                                 error: error as NSError)
                     self.getIntroEligibility(with: receiptData,
                                              productIdentifiers: productIdentifiers,
                                              completion: completion)
@@ -222,7 +224,8 @@ extension TrialOrIntroPriceEligibilityChecker {
                                                    productIdentifiers: productIdentifiers) { backendResult, error in
             let result: [String: IntroEligibility] = {
                 if let error = error {
-                    Logger.error(Strings.eligibility.unable_to_get_intro_eligibility_for_user(error: error))
+                    Logger.error(Strings.eligibility.unable_to_get_intro_eligibility_for_user(error: error),
+                                 error: error as NSError)
                     return Set(productIdentifiers)
                         .dictionaryWithValues { _ in IntroEligibility(eligibilityStatus: .unknown) }
                 } else {

--- a/Sources/Security/Signing.swift
+++ b/Sources/Security/Signing.swift
@@ -306,7 +306,8 @@ private extension Signing {
         do {
             return try Self.createPublicKey(with: intermediatePublicKey)
         } catch {
-            Logger.error(Strings.signing.intermediate_key_failed_creation(error))
+            Logger.error(Strings.signing.intermediate_key_failed_creation(error),
+                         error: error as NSError)
             return nil
         }
     }

--- a/Sources/Security/VerificationResult.swift
+++ b/Sources/Security/VerificationResult.swift
@@ -36,10 +36,13 @@ import Foundation
 /// }
 /// ```
 ///
+/// Verification failures will also be forwarded to ``Purchases/errorHandler``.
+///
 /// ### Related Symbols
 /// - ``Configuration/EntitlementVerificationMode``
 /// - ``Configuration/Builder/with(entitlementVerificationMode:)``
 /// - ``EntitlementInfos/verification``
+/// - ``Purchases/errorHandler``
 // Trusted Entitlements: internal until ready to be made public.
 @objc(RCVerificationResult)
 internal enum VerificationResult: Int {

--- a/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -177,14 +177,14 @@ class SubscriberAttributesManager {
     }
 
     func handleAttributesSynced(syncingAppUserId: String, currentAppUserId: String, error: BackendError?) {
-        if error == nil {
+        if let error = error as NSError? {
+            Logger.error(Strings.attribution.attributes_sync_error(error: error),
+                         error: error)
+        } else {
             Logger.rcSuccess(Strings.attribution.attributes_sync_success(appUserID: syncingAppUserId))
             if syncingAppUserId != currentAppUserId {
                 deviceCache.deleteAttributesIfSynced(appUserID: syncingAppUserId)
             }
-        } else {
-            let receivedNSError = error as NSError?
-            Logger.error(Strings.attribution.attributes_sync_error(error: receivedNSError))
         }
     }
 

--- a/Sources/Support/ManageSubscriptionsHelper.swift
+++ b/Sources/Support/ManageSubscriptionsHelper.swift
@@ -141,7 +141,7 @@ private extension ManageSubscriptionsHelper {
                 Logger.info(Strings.susbscription_management_sheet_dismissed)
             } catch {
                 let message = Strings.error_from_appstore_show_manage_subscription(error: error)
-                Logger.appleError(message)
+                Logger.appleError(message, error: error as NSError)
             }
         }
 

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -67,6 +67,9 @@ BOOL isAnonymous;
                                                                 customEntitlementComputation:NO]];
 
     [RCPurchases setLogHandler:^(RCLogLevel l, NSString *i) {}];
+    [RCPurchases setVerboseLogHandler:^(RCLogLevel l, NSString * _Nonnull m, NSString * _Nullable f1, NSString * _Nullable f2, NSUInteger li) {}];
+    [RCPurchases setErrorHandler:^(NSError * _Nonnull e) {}];
+
     canI = [RCPurchases canMakePayments];
     version = [RCPurchases frameworkVersion];
 

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -78,7 +78,16 @@ func checkPurchasesEnums() {
 
 private func checkStaticMethods() {
     let logHandler: (LogLevel, String) -> Void = { _, _ in }
+    let verboseLogHandler: (_ level: LogLevel,
+                            _ message: String,
+                            _ file: String?,
+                            _ function: String?,
+                            _ line: UInt) -> Void = { _, _, _, _, _ in }
+    let errorHandler: (_ error: NSError) -> Void = { _ in }
+
     Purchases.logHandler = logHandler
+    Purchases.verboseLogHandler = verboseLogHandler
+    Purchases.errorHandler = errorHandler
 
     let canI: Bool = Purchases.canMakePayments()
     let version = Purchases.frameworkVersion

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -296,7 +296,7 @@ extension BaseStoreKitIntegrationTests {
     @MainActor
     func printReceiptContent() async {
         guard Purchases.isConfigured else {
-            Logger.error(TestMessage.unable_parse_receipt_without_sdk)
+            Logger.error(TestMessage.unable_parse_receipt_without_sdk, error: nil)
             return
         }
 
@@ -313,8 +313,8 @@ extension BaseStoreKitIntegrationTests {
 
                 self.add(attachment)
             }
-        } catch {
-            Logger.error(TestMessage.error_parsing_receipt(error))
+        } catch let error as NSError {
+            Logger.error(TestMessage.error_parsing_receipt(error), error: error)
         }
     }
 

--- a/Tests/StoreKitUnitTests/LoggerTests.swift
+++ b/Tests/StoreKitUnitTests/LoggerTests.swift
@@ -102,10 +102,10 @@ class LoggerTests: TestCase {
         self.logger.verifyMessageWasLogged(error.localizedDescription, level: .error, expectedCount: 1)
     }
 
-    func testCreatingErrorsDoesNotForwardError() {
-        _ = ErrorUtils.customerInfoError()
+    func testCreatingErrorsForwardsThem() {
+        let error = ErrorUtils.customerInfoError()
 
-        expect(self.logger.errors).to(beEmpty())
+        self.logger.verifyErrorWasLogged(error.asPublicError)
     }
 
     func testPurchasesLogHandler() {

--- a/Tests/UnitTests/Mocks/MockProductsManager.swift
+++ b/Tests/UnitTests/Mocks/MockProductsManager.swift
@@ -31,7 +31,8 @@ class MockProductsManager: ProductsManager {
                 completion(result)
             }
         } else {
-            Logger.error("\(type(of: self)): no stubbed products, returning fake products for \(identifiers)")
+            Logger.error("\(type(of: self)): no stubbed products, returning fake products for \(identifiers)",
+                         error: nil)
 
             let products: [StoreProduct] = identifiers
                 .map { (identifier) -> MockSK1Product in

--- a/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/CustomerInfoTests.swift
@@ -965,7 +965,8 @@ extension CustomerInfo {
             try self.init(data: testData)
         } catch {
             let errorDescription = (error as? DescribableError)?.description ?? error.localizedDescription
-            Logger.error("Caught error creating testData, this is probably expected, right? \(errorDescription).")
+            Logger.error("Caught error creating testData, this is probably expected, right? \(errorDescription).",
+                         error: error as NSError)
 
             return nil
         }

--- a/Tests/UnitTests/TestHelpers/TestLogHandler.swift
+++ b/Tests/UnitTests/TestHelpers/TestLogHandler.swift
@@ -198,7 +198,9 @@ extension TestLogHandler {
             self.errors
         )
         .to(
-            contain(error),
+            containElementSatisfying {
+                error.domain == $0.domain && error.code == $0.code
+            },
             description: "Error '\(error)' not found. Logged errors: \(self.errors)"
         )
     }


### PR DESCRIPTION
### Description

On Android `LogHandler` has a separate `e` method that receives a `Throwable`. However, it's impossible to receive all logged errors from iOS, since the `LogHandler` definition only has a `message: String`.

This is useful when integrating with other tools like `Sentry`, since you can pipe those errors directly.

### Example usage :

```swift
Purchases.errorHandler = { error in
  SentrySDK.reportError(error)
}
```

### Other benefits
- Makes it easier to detect internal errors when writing tests using `TestLogHandler`
- Makes it easy for users to detect any occurrence of `ErrorCode.signatureVerificationFailed`, even those coming from internal requests.
