### PR TITLE
`Trusted Entitlements`: log signature errors on requests with `.informational` mode

### DIFF
--- a/Sources/Logging/Strings/SigningStrings.swift
+++ b/Sources/Logging/Strings/SigningStrings.swift
@@ -25,6 +25,8 @@ enum SigningStrings {
     case signature_failed_verification
     case signature_passed_verification
 
+    case request_failed_verification(HTTPRequest)
+
     case intermediate_key_failed_verification(signature: Data)
     case intermediate_key_failed_creation(Error)
     case intermediate_key_expired(Date, Data)
@@ -66,6 +68,10 @@ extension SigningStrings: LogMessage {
 
         case .signature_passed_verification:
             return "Signature passed verification"
+
+        case let .request_failed_verification(request):
+            return "Request to \(request.path) failed verification. This is likely due to " +
+            "a malicious user intercepting and modifying requests."
 
         case let .intermediate_key_failed_verification(signature):
             return "Intermediate key failed verification: \(signature.asString)"

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -318,6 +318,24 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         expect(self.signing.requests).to(haveCount(1))
     }
 
+    func testIncorrectSignatureLogsError() throws {
+        let request: HTTPRequest = .createWithResponseVerification(method: .get, path: Self.path)
+        self.mockPath(request.path, statusCode: .success, requestDate: Self.date1)
+        self.signing.stubbedVerificationResult = false
+
+        let logger = TestLogHandler()
+
+        let _: DataResponse? = waitUntilValue { completion in
+            self.client.perform(request, completionHandler: completion)
+        }
+
+        logger.verifyMessageWasLogged(
+            Strings.signing.request_failed_verification(request),
+            level: .error,
+            expectedCount: 1
+        )
+    }
+
     func testIgnoresResponseFromETagManagerIfItHadNotBeenVerified() throws {
         self.signing.stubbedVerificationResult = true
 


### PR DESCRIPTION
Example (the first `warn` log is `debug` and when running RC tests only):
```
[signing] WARN: ⚠️ INVALID SIGNATURE DETECTED:
Request: GET /v1/subscribers/identify
Response: 200
Headers: ["X-Signature: signature", "X-RevenueCat-Request-Time: 1658749988564", "Content-Length: 0", "X-RevenueCat-ETag: etag"]
Body (length: 0): e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
[signing] ERROR: 😿‼️ Request to subscribers/identify failed verification. This is likely due to a malicious user intercepting and modifying requests.
```