### PR TITLE
`Trusted Entitlements`: produce verification failures for static endpoints with no signature

### DIFF
--- a/Sources/Logging/Strings/SigningStrings.swift
+++ b/Sources/Logging/Strings/SigningStrings.swift
@@ -23,6 +23,7 @@ enum SigningStrings {
     case signature_invalid_size(Data)
 
     case signature_failed_verification
+    case signature_passed_verification
 
     case intermediate_key_failed_verification(signature: Data)
     case intermediate_key_failed_creation(Error)
@@ -62,6 +63,9 @@ extension SigningStrings: LogMessage {
 
         case .signature_failed_verification:
             return "Signature failed verification"
+
+        case .signature_passed_verification:
+            return "Signature passed verification"
 
         case let .intermediate_key_failed_verification(signature):
             return "Intermediate key failed verification: \(signature.asString)"

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -458,7 +458,7 @@ extension HTTPRequest {
         var result = self
 
         if result.nonce == nil,
-           result.path.supportsSignatureValidation,
+           result.path.needsNonceForSigning,
            verificationMode.isEnabled,
            #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
             result.addRandomNonce()

--- a/Sources/Networking/HTTPClient/HTTPRequest.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequest.swift
@@ -148,8 +148,27 @@ extension HTTPRequest.Path {
         }
     }
 
-    // Whether the endpoint will perform signature validation.
-    var supportsSignatureValidation: Bool {
+    /// Whether the endpoint will perform signature verification.
+    var supportsSignatureVerification: Bool {
+        switch self {
+        case .getCustomerInfo,
+                .logIn,
+                .postReceiptData,
+                .health,
+                .getOfferings,
+                .getProductEntitlementMapping:
+            return true
+        case .getIntroEligibility,
+                .postSubscriberAttributes,
+                .postAttributionData,
+                .postAdServicesToken,
+                .postOfferForSigning:
+            return false
+        }
+    }
+
+    /// Whether endpoint requires a nonce for signature verification.
+    var needsNonceForSigning: Bool {
         switch self {
         case .getCustomerInfo,
                 .logIn,

--- a/Sources/Security/Signing+ResponseVerification.swift
+++ b/Sources/Security/Signing+ResponseVerification.swift
@@ -64,7 +64,7 @@ extension HTTPResponse where Body == Data? {
             forCaseInsensitiveHeaderField: .signature,
             in: headers
         ) else {
-            if request.requiresSignature {
+            if request.path.supportsSignatureVerification {
                 Logger.warn(Strings.signing.signature_was_requested_but_not_provided(request))
                 return .failed
             } else {
@@ -91,19 +91,6 @@ extension HTTPResponse where Body == Data? {
         } else {
             return .failed
         }
-    }
-
-}
-
-private extension HTTPRequest {
-
-    var requiresSignature: Bool {
-        guard self.path.supportsSignatureVerification else {
-            return false
-        }
-
-        let needsNonce = self.path.needsNonceForSigning
-        return !needsNonce || (needsNonce && self.nonce != nil)
     }
 
 }

--- a/Sources/Security/Signing+ResponseVerification.swift
+++ b/Sources/Security/Signing+ResponseVerification.swift
@@ -64,8 +64,7 @@ extension HTTPResponse where Body == Data? {
             forCaseInsensitiveHeaderField: .signature,
             in: headers
         ) else {
-            let requiresSignature = request.path.supportsSignatureVerification
-            if requiresSignature {
+            if request.requiresSignature {
                 Logger.warn(Strings.signing.signature_was_requested_but_not_provided(request))
                 return .failed
             } else {
@@ -92,6 +91,19 @@ extension HTTPResponse where Body == Data? {
         } else {
             return .failed
         }
+    }
+
+}
+
+private extension HTTPRequest {
+
+    var requiresSignature: Bool {
+        guard self.path.supportsSignatureVerification else {
+            return false
+        }
+
+        let needsNonce = self.path.needsNonceForSigning
+        return !needsNonce || (needsNonce && self.nonce != nil)
     }
 
 }

--- a/Sources/Security/Signing+ResponseVerification.swift
+++ b/Sources/Security/Signing+ResponseVerification.swift
@@ -64,8 +64,8 @@ extension HTTPResponse where Body == Data? {
             forCaseInsensitiveHeaderField: .signature,
             in: headers
         ) else {
-            let signatureRequested = request.nonce != nil
-            if signatureRequested {
+            let requiresSignature = request.path.supportsSignatureVerification
+            if requiresSignature {
                 Logger.warn(Strings.signing.signature_was_requested_but_not_provided(request))
                 return .failed
             } else {

--- a/Sources/Security/Signing.swift
+++ b/Sources/Security/Signing.swift
@@ -107,7 +107,9 @@ final class Signing: SigningType {
 
         let isValid = intermediatePublicKey.isValidSignature(payload, for: messageToVerify)
 
-        if !isValid {
+        if isValid {
+            Logger.verbose(Strings.signing.signature_passed_verification)
+        } else {
             Logger.warn(Strings.signing.signature_failed_verification)
         }
 

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -157,6 +157,17 @@ class HTTPRequestTests: TestCase {
         }
     }
 
+    func testStaticEndpoints() {
+        let staticEndpoints = Self.paths
+            .filter { $0.supportsSignatureVerification }
+            .filter { !$0.needsNonceForSigning }
+
+        expect(staticEndpoints) == [
+            .getOfferings(appUserID: Self.userID),
+            .getProductEntitlementMapping
+        ]
+    }
+
     func testPathsEscapeUserID() {
         for path in Self.pathsWithUserID {
             expect(path.description).toNot(

--- a/Tests/UnitTests/Networking/HTTPResponseTests.swift
+++ b/Tests/UnitTests/Networking/HTTPResponseTests.swift
@@ -39,7 +39,7 @@ class HTTPResponseTests: TestCase {
 
         let key = Curve25519.Signing.PrivateKey().publicKey
 
-        let request = HTTPRequest(method: .get, path: .health)
+        let request = HTTPRequest(method: .get, path: .postOfferForSigning)
         let response = HTTPResponse<Data?>(
             statusCode: .success,
             responseHeaders: [:],
@@ -48,6 +48,23 @@ class HTTPResponseTests: TestCase {
         let verifiedResponse = response.verify(signing: Self.signing, request: request, publicKey: key)
 
         expect(verifiedResponse.verificationResult) == .notRequested
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func testResponseVerificationFailedIfMissingSignature() throws {
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
+        let key = Curve25519.Signing.PrivateKey().publicKey
+
+        let request = HTTPRequest(method: .get, path: .getProductEntitlementMapping)
+        let response = HTTPResponse<Data?>(
+            statusCode: .success,
+            responseHeaders: [:],
+            body: Data()
+        )
+        let verifiedResponse = response.verify(signing: Self.signing, request: request, publicKey: key)
+
+        expect(verifiedResponse.verificationResult) == .failed
     }
 
     func testValueForHeaderFieldWithNonExistingField() {

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -116,6 +116,36 @@ final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPC
         )
     }
 
+    func testFailedVerificationIfResponseContainsNoSignatureForEndpointWithStaticSignature() throws {
+        // This test relies on a path with static signatures
+        let path: HTTPRequest.Path = .getProductEntitlementMapping
+        expect(path.supportsSignatureVerification) == true
+        expect(path.needsNonceForSigning) == false
+
+        let logger = TestLogHandler()
+
+        try self.changeClient(.informational)
+        self.mockResponse(path: path,
+                          signature: nil,
+                          requestDate: nil)
+
+        self.signing.stubbedVerificationResult = true
+
+        let request: HTTPRequest = .init(method: .get, path: path)
+        let response: DataResponse? = waitUntilValue { completion in
+            self.client.perform(request, completionHandler: completion)
+        }
+
+        expect(response).to(beSuccess())
+        expect(response?.value?.verificationResult) == .failed
+        expect(self.signing.requests).to(beEmpty())
+
+        logger.verifyMessageWasLogged(
+            Strings.signing.signature_was_requested_but_not_provided(request),
+            level: .warn
+        )
+    }
+
     func testHeadersAreCaseInsensitive() throws {
         try self.changeClient(.informational)
 

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -483,7 +483,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
     }
 
     func testNoCachedResponseAndNotVerifiedResponse() throws {
-        let path: HTTPRequest.Path = .getOfferings(appUserID: "user")
+        let path: HTTPRequest.Path = .getCustomerInfo(appUserID: "user")
 
         self.mockPath(path, statusCode: .success, requestDate: Self.date2, signature: nil)
 
@@ -495,7 +495,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         expect(self.signing.requests).to(beEmpty())
         expect(response).to(beSuccess())
         expect(response?.value?.requestDate).to(beCloseToDate(Self.date2))
-        expect(response?.value?.verificationResult) == .notRequested
+        expect(response?.value?.verificationResult) == .failed
     }
 
     func testNoCachedResponseAndVerifiedResponse() throws {

--- a/Tests/UnitTests/Security/SigningTests.swift
+++ b/Tests/UnitTests/Security/SigningTests.swift
@@ -612,7 +612,7 @@ class SigningTests: TestCase {
 
         let logger = TestLogHandler()
 
-        let request = HTTPRequest(method: .get, path: .health, nonce: nil)
+        let request = HTTPRequest(method: .get, path: .postOfferForSigning, nonce: nil)
         let response = HTTPResponse<Data?>(
             statusCode: .success,
             responseHeaders: [


### PR DESCRIPTION
Equivalent to https://github.com/RevenueCat/purchases-android/pull/1119