### PR TITLE
`Trusted Entitlements`: add support for signing `POST` body

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -241,6 +241,7 @@
 		4F7C37E42A27EFE1001E17D3 /* BaseBackendIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579234E127F777EE00B39C68 /* BaseBackendIntegrationTests.swift */; };
 		4F7C37E52A27EFF7001E17D3 /* BaseStoreKitIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5753EE0F294B93CC00CBAB54 /* BaseStoreKitIntegrationTests.swift */; };
 		4F7C37E62A27F14B001E17D3 /* XCTestCase+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D22BF6626F3CBFB001AE2F9 /* XCTestCase+Extensions.swift */; };
+		4F7D8E562A56290100F17FFC /* HTTPRequestBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7D8E552A56290100F17FFC /* HTTPRequestBody.swift */; };
 		4F7DBFBD2A1E986C00A2F511 /* StoreKit2TransactionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7DBFBC2A1E986C00A2F511 /* StoreKit2TransactionFetcher.swift */; };
 		4F8038332A1EA7C300D21039 /* TransactionPoster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8038322A1EA7C300D21039 /* TransactionPoster.swift */; };
 		4F82C2682A3CD58200EC98AF /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F69EB082A14406E00ED6D4B /* Matchers.swift */; };
@@ -250,6 +251,7 @@
 		4F83F6B92A5DB805003F90A5 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554CC0282AE1E3009A7E58 /* TestCase.swift */; };
 		4F83F6BA2A5DB807003F90A5 /* CurrentTestCaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */; };
 		4F83F6BB2A5DB80B003F90A5 /* OSVersionEquivalent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DE80AD28075D77008D6C6F /* OSVersionEquivalent.swift */; };
+		4F8452682A5756CC00084550 /* HTTPRequestBody+Signing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8452672A5756CC00084550 /* HTTPRequestBody+Signing.swift */; };
 		4F8A58172A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */; };
 		4F8A58182A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */; };
 		4F90AFCB2A3915340047E63F /* TestMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F90AFCA2A3915340047E63F /* TestMessage.swift */; };
@@ -958,8 +960,10 @@
 		4F6BEE022A27ADF900CD9322 /* CustomEntitlementsComputationIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomEntitlementsComputationIntegrationTests.swift; sourceTree = "<group>"; };
 		4F6BEE312A27B02400CD9322 /* BackendCustomEntitlementsIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BackendCustomEntitlementsIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F6EEBD82A38ED76007FD783 /* FakeSigning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeSigning.swift; sourceTree = "<group>"; };
+		4F7D8E552A56290100F17FFC /* HTTPRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestBody.swift; sourceTree = "<group>"; };
 		4F7DBFBC2A1E986C00A2F511 /* StoreKit2TransactionFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2TransactionFetcher.swift; sourceTree = "<group>"; };
 		4F8038322A1EA7C300D21039 /* TransactionPoster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionPoster.swift; sourceTree = "<group>"; };
+		4F8452672A5756CC00084550 /* HTTPRequestBody+Signing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HTTPRequestBody+Signing.swift"; sourceTree = "<group>"; };
 		4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOfflineCustomerInfoCreator.swift; sourceTree = "<group>"; };
 		4F90AFCA2A3915340047E63F /* TestMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestMessage.swift; sourceTree = "<group>"; };
 		4F98E9D22A465A4400DB6EAB /* TestStoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestStoreProduct.swift; sourceTree = "<group>"; };
@@ -2417,6 +2421,7 @@
 				5791FE492994453500F1FEDA /* Signing+ResponseVerification.swift */,
 				5740FCD22996CE5E00E049F9 /* VerificationResult.swift */,
 				4F6EEBD82A38ED76007FD783 /* FakeSigning.swift */,
+				4F8452672A5756CC00084550 /* HTTPRequestBody+Signing.swift */,
 			);
 			path = Security;
 			sourceTree = "<group>";
@@ -2547,6 +2552,7 @@
 				35D832CC262A5B7500E60AC5 /* ETagManager.swift */,
 				35F82BB326A9A74D0051DF03 /* HTTPClient.swift */,
 				57DC9F4527CC2E4900DA6AF9 /* HTTPRequest.swift */,
+				4F7D8E552A56290100F17FFC /* HTTPRequestBody.swift */,
 				35D832F3262E606500E60AC5 /* HTTPResponse.swift */,
 				575137CE27F50D2F0064AB2C /* HTTPResponseBody.swift */,
 				35D832D1262E56DB00E60AC5 /* HTTPStatusCode.swift */,
@@ -3258,6 +3264,7 @@
 				35F82BB426A9A74D0051DF03 /* HTTPClient.swift in Sources */,
 				57488BD429CB7E2D0000EE7E /* OfflineEntitlementsManager.swift in Sources */,
 				B3A55B7D26C452A7007EFC56 /* AttributionPoster.swift in Sources */,
+				4F8452682A5756CC00084550 /* HTTPRequestBody+Signing.swift in Sources */,
 				5791FE4A2994453500F1FEDA /* Signing+ResponseVerification.swift in Sources */,
 				2DC19195255F36D10039389A /* Logger.swift in Sources */,
 				2DDF419F24F6F331005BC22D /* ReceiptParsingError.swift in Sources */,
@@ -3372,6 +3379,7 @@
 				A56DFDEC2866438B00EF2E32 /* AfficheClientProxy.swift in Sources */,
 				35D0E5D026A5886C0099EAD8 /* ErrorUtils.swift in Sources */,
 				B372EC54268FEDC60099171E /* StoreProductDiscount.swift in Sources */,
+				4F7D8E562A56290100F17FFC /* HTTPRequestBody.swift in Sources */,
 				B34605BE279A6E380031CA74 /* OfferingsCallback.swift in Sources */,
 				B34605BF279A6E380031CA74 /* LogInCallback.swift in Sources */,
 				9A65DFDE258AD60A00DE00B0 /* LogIntent.swift in Sources */,

--- a/Sources/FoundationExtensions/Data+Extensions.swift
+++ b/Sources/FoundationExtensions/Data+Extensions.swift
@@ -46,7 +46,7 @@ extension Data {
         return self.base64EncodedString()
     }
 
-    /// - Returns: a hash representation of the underlying bytes.
+    /// - Returns: a hash representation of the underlying bytes, using SHA256.
     var hashString: String {
         if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
             var sha256 = SHA256()
@@ -66,7 +66,7 @@ extension Data {
         }
     }
 
-    private static func hexString(_ iterator: Array<UInt8>.Iterator) -> String {
+    fileprivate static func hexString(_ iterator: Array<UInt8>.Iterator) -> String {
         return iterator
             .lazy
             .map { String(format: "%02x", $0) }
@@ -88,6 +88,15 @@ extension Data {
 
 // MARK: - Hashing
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+extension HashFunction {
+
+    func toString() -> String {
+        return Data.hexString(self.finalize().makeIterator())
+    }
+
+}
+
 private extension Data {
 
     typealias HashingFunction = (
@@ -99,8 +108,7 @@ private extension Data {
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func hashString<T: HashFunction>(with digest: inout T) -> String {
         digest.update(data: self)
-
-        return Self.hexString(digest.finalize().makeIterator())
+        return digest.toString()
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -97,7 +97,7 @@ extension HTTPClient {
         return [RequestHeader.nonce.rawValue: data.base64EncodedString()]
     }
 
-    static func postParametersHeader(for body: HTTPRequestBody) -> RequestHeaders {
+    static func postParametersHeaderForSigning(with body: HTTPRequestBody) -> RequestHeaders {
         if let header = body.postParameterHeader {
             return [RequestHeader.postParameters.rawValue: header]
         } else {
@@ -499,7 +499,7 @@ extension HTTPRequest {
            verificationMode.isEnabled,
            self.path.supportsSignatureVerification,
            let body = self.requestBody {
-            result += HTTPClient.postParametersHeader(for: body)
+            result += HTTPClient.postParametersHeaderForSigning(with: body)
         }
 
         return result

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -97,12 +97,21 @@ extension HTTPClient {
         return [RequestHeader.nonce.rawValue: data.base64EncodedString()]
     }
 
+    static func postParametersHeader(for body: HTTPRequestBody) -> RequestHeaders {
+        if let header = body.postParameterHeader {
+            return [RequestHeader.postParameters.rawValue: header]
+        } else {
+            return [:]
+        }
+    }
+
     enum RequestHeader: String {
 
         case authorization = "Authorization"
         case nonce = "X-Nonce"
         case eTag = "X-RevenueCat-ETag"
         case eTagValidationTime = "X-RC-Last-Refresh-Time"
+        case postParameters = "X-Post-Params-Hash"
 
     }
 
@@ -147,7 +156,8 @@ private extension HTTPClient {
                                       verificationMode: Signing.ResponseVerificationMode,
                                       completionHandler: HTTPClient.Completion<Value>?) {
             self.httpRequest = httpRequest.requestAddingNonceIfRequired(with: verificationMode)
-            self.headers = self.httpRequest.headers(with: authHeaders)
+            self.headers = self.httpRequest.headers(with: authHeaders,
+                                                    verificationMode: verificationMode)
             self.verificationMode = verificationMode
 
             if let completionHandler = completionHandler {
@@ -471,7 +481,10 @@ extension HTTPRequest {
         return result
     }
 
-    func headers(with authHeaders: HTTPClient.RequestHeaders) -> HTTPClient.RequestHeaders {
+    func headers(
+        with authHeaders: HTTPClient.RequestHeaders,
+        verificationMode: Signing.ResponseVerificationMode
+    ) -> HTTPClient.RequestHeaders {
         var result: HTTPClient.RequestHeaders = [:]
 
         if self.path.authenticated {
@@ -480,6 +493,13 @@ extension HTTPRequest {
 
         if let nonce = self.nonce {
             result += HTTPClient.nonceHeader(with: nonce)
+        }
+
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *),
+           verificationMode.isEnabled,
+           self.path.supportsSignatureVerification,
+           let body = self.requestBody {
+            result += HTTPClient.postParametersHeader(for: body)
         }
 
         return result

--- a/Sources/Networking/HTTPClient/HTTPRequest.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequest.swift
@@ -57,7 +57,7 @@ extension HTTPRequest {
     enum Method {
 
         case get
-        case post(Encodable)
+        case post(HTTPRequestBody)
 
     }
 
@@ -65,7 +65,7 @@ extension HTTPRequest {
 
 extension HTTPRequest {
 
-    var requestBody: Encodable? {
+    var requestBody: HTTPRequestBody? {
         switch self.method {
         case let .post(body): return body
         case .get: return nil

--- a/Sources/Networking/HTTPClient/HTTPRequestBody.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestBody.swift
@@ -1,0 +1,32 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  HTTPRequestBody.swift
+//
+//  Created by Nacho Soto on 7/5/23.
+
+import Foundation
+
+/// The content of an `HTTPRequest` for `HTTPRequest.Method.post`
+protocol HTTPRequestBody: Encodable {
+
+    /// The keys and values that will be included in the signature.
+    /// - Note: this is not `[String: String]` because we need to preserve ordering.
+    var contentForSignature: [(key: String, value: String)] { get }
+
+}
+
+extension HTTPRequestBody {
+
+    // Default implementation for endpoints which don't support signing.
+    var contentForSignature: [(key: String, value: String)] {
+        return []
+    }
+
+}

--- a/Sources/Networking/HTTPClient/HTTPResponseBody.swift
+++ b/Sources/Networking/HTTPClient/HTTPResponseBody.swift
@@ -14,7 +14,6 @@
 import Foundation
 
 /// The content of an `HTTPResponse`
-/// - Note: this can be removed in favor of `Decodable` when all responses implement `Decodable`.
 protocol HTTPResponseBody {
 
     static func create(with data: Data) throws -> Self

--- a/Sources/Networking/Operations/GetIntroEligibilityOperation.swift
+++ b/Sources/Networking/Operations/GetIntroEligibilityOperation.swift
@@ -104,7 +104,7 @@ private extension GetIntroEligibilityOperation {
 
 private extension GetIntroEligibilityOperation {
 
-    struct Body: Encodable {
+    struct Body: HTTPRequestBody {
 
         let productIdentifiers: [String]
         let fetchToken: String

--- a/Sources/Networking/Operations/LogInOperation.swift
+++ b/Sources/Networking/Operations/LogInOperation.swift
@@ -82,7 +82,10 @@ private extension LogInOperation {
                      completion: IdentityAPI.LogInResponseHandler) {
         let result: Result<(info: CustomerInfo, created: Bool), BackendError> = result
             .map { response in
-                (response.body, created: response.statusCode == .createdSuccess)
+                (
+                    response.body.copy(with: response.verificationResult),
+                    created: response.statusCode == .createdSuccess
+                )
             }
             .mapError(BackendError.networkError)
 
@@ -94,11 +97,12 @@ private extension LogInOperation {
     }
 }
 
-private extension LogInOperation {
+extension LogInOperation {
 
     struct Body: Encodable {
 
         // These need to be explicit for `contentForSignature`
+        // swiftlint:disable:next nesting
         fileprivate enum CodingKeys: String, CodingKey {
             case appUserID = "app_user_id"
             case newAppUserID = "new_app_user_id"
@@ -113,7 +117,6 @@ private extension LogInOperation {
 
 extension LogInOperation.Body: HTTPRequestBody {
 
-    // TODO: verify these in snapshot tests
     var contentForSignature: [(key: String, value: String)] {
         return [
             (Self.CodingKeys.appUserID.stringValue, self.appUserID),

--- a/Sources/Networking/Operations/LogInOperation.swift
+++ b/Sources/Networking/Operations/LogInOperation.swift
@@ -98,9 +98,27 @@ private extension LogInOperation {
 
     struct Body: Encodable {
 
+        // These need to be explicit for `contentForSignature`
+        fileprivate enum CodingKeys: String, CodingKey {
+            case appUserID = "app_user_id"
+            case newAppUserID = "new_app_user_id"
+        }
+
         let appUserID: String
         let newAppUserID: String
 
+    }
+
+}
+
+extension LogInOperation.Body: HTTPRequestBody {
+
+    // TODO: verify these in snapshot tests
+    var contentForSignature: [(key: String, value: String)] {
+        return [
+            (Self.CodingKeys.appUserID.stringValue, self.appUserID),
+            (Self.CodingKeys.newAppUserID.stringValue, self.newAppUserID)
+        ]
     }
 
 }

--- a/Sources/Networking/Operations/PostAdServicesTokenOperation.swift
+++ b/Sources/Networking/Operations/PostAdServicesTokenOperation.swift
@@ -58,7 +58,7 @@ class PostAdServicesTokenOperation: NetworkOperation {
 
 private extension PostAdServicesTokenOperation {
 
-    struct Body: Encodable {
+    struct Body: HTTPRequestBody {
 
         let aadAttributionToken: String
 

--- a/Sources/Networking/Operations/PostAttributionDataOperation.swift
+++ b/Sources/Networking/Operations/PostAttributionDataOperation.swift
@@ -62,7 +62,7 @@ class PostAttributionDataOperation: NetworkOperation {
 
 private extension PostAttributionDataOperation {
 
-    struct Body: Encodable {
+    struct Body: HTTPRequestBody {
 
         let network: AttributionNetwork
         let data: AnyEncodable

--- a/Sources/Networking/Operations/PostOfferForSigningOperation.swift
+++ b/Sources/Networking/Operations/PostOfferForSigningOperation.swift
@@ -110,7 +110,7 @@ private extension PostOfferResponse.Offer {
 
 private extension PostOfferForSigningOperation {
 
-    struct Body: Encodable {
+    struct Body: HTTPRequestBody {
 
         // swiftlint:disable:next nesting
         struct Offer: Encodable {

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -186,8 +186,8 @@ extension PostReceiptDataOperation.PostData: Encodable {
 
     private enum CodingKeys: String, CodingKey {
 
-        case fetchToken
-        case appUserID
+        case fetchToken = "fetch_token"
+        case appUserID = "app_user_id"
         case isRestore
         case observerMode
         case initiationSource
@@ -201,7 +201,7 @@ extension PostReceiptDataOperation.PostData: Encodable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
-        try container.encode(self.receiptData.asFetchToken, forKey: .fetchToken)
+        try container.encode(self.fetchToken, forKey: .fetchToken)
         try container.encode(self.appUserID, forKey: .appUserID)
         try container.encode(self.isRestore, forKey: .isRestore)
         try container.encode(self.observerMode, forKey: .observerMode)
@@ -223,6 +223,19 @@ extension PostReceiptDataOperation.PostData: Encodable {
 
         try container.encodeIfPresent(self.aadAttributionToken, forKey: .aadAttributionToken)
         try container.encodeIfPresent(self.testReceiptIdentifier, forKey: .testReceiptIdentifier)
+    }
+
+    var fetchToken: String { return self.receiptData.asFetchToken }
+
+}
+
+extension PostReceiptDataOperation.PostData: HTTPRequestBody {
+
+    var contentForSignature: [(key: String, value: String)] {
+        return [
+            (Self.CodingKeys.appUserID.stringValue, self.appUserID),
+            (Self.CodingKeys.fetchToken.stringValue, self.fetchToken)
+        ]
     }
 
 }

--- a/Sources/Networking/Operations/PostSubscriberAttributesOperation.swift
+++ b/Sources/Networking/Operations/PostSubscriberAttributesOperation.swift
@@ -64,9 +64,9 @@ class PostSubscriberAttributesOperation: NetworkOperation {
 
 }
 
-extension PostSubscriberAttributesOperation {
+private extension PostSubscriberAttributesOperation {
 
-    private struct Body: Encodable {
+    struct Body: HTTPRequestBody {
 
         let attributes: AnyEncodable
 

--- a/Sources/Security/HTTPRequestBody+Signing.swift
+++ b/Sources/Security/HTTPRequestBody+Signing.swift
@@ -44,7 +44,7 @@ extension HTTPRequestBody {
 
         for (index, value) in values.enumerated() {
             if index > 0 {
-                sha256.update(data: Self.separator)
+                sha256.update(data: fieldSeparator)
             }
 
             sha256.update(data: value.asData)
@@ -62,8 +62,7 @@ private extension HTTPRequestBody {
         return self.contentForSignature.map(\.key)
     }
 
-    private static var separator: Data { .init(bytes: [0x00], count: 2) }
-
 }
 
 private let postParameterHashingAlgorithmName = "sha256"
+private let fieldSeparator = Data(bytes: [0x00], count: 1)

--- a/Sources/Security/HTTPRequestBody+Signing.swift
+++ b/Sources/Security/HTTPRequestBody+Signing.swift
@@ -1,0 +1,69 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  HTTPRequestBody+Signing.swift
+//
+//  Created by Nacho Soto on 7/6/23.
+
+import CryptoKit
+import Foundation
+
+extension HTTPRequestBody {
+
+    var postParameterHeader: String? {
+        guard #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) else {
+            // Signature verification is not available.
+            return nil
+        }
+
+        let keys = self.keysToSign
+        guard !keys.isEmpty else {
+            return nil
+        }
+
+        let pieces = [
+            keys.joined(separator: ","),
+            postParameterHashingAlgorithmName,
+            self.postParameterHash
+        ]
+
+        return pieces.joined(separator: ":")
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    var postParameterHash: String {
+        var sha256 = SHA256()
+
+        let values = self.contentForSignature.map(\.value)
+
+        for (index, value) in values.enumerated() {
+            if index > 0 {
+                sha256.update(data: Self.separator)
+            }
+
+            sha256.update(data: value.asData)
+        }
+
+        return sha256.toString()
+    }
+
+}
+
+private extension HTTPRequestBody {
+
+    /// - Returns: an ordered list of keys that will be included in the signature.
+    var keysToSign: [String] {
+        return self.contentForSignature.map(\.key)
+    }
+
+    private static var separator: Data { .init(bytes: [0x00], count: 2) }
+
+}
+
+private let postParameterHashingAlgorithmName = "sha256"

--- a/Sources/Security/Signing+ResponseVerification.swift
+++ b/Sources/Security/Signing+ResponseVerification.swift
@@ -82,6 +82,7 @@ extension HTTPResponse where Body == Data? {
                           with: .init(
                             path: request.path,
                             message: body,
+                            requestBody: request.requestBody,
                             nonce: request.nonce,
                             etag: HTTPResponse.value(forCaseInsensitiveHeaderField: .eTag, in: headers),
                             requestDate: requestDate.millisecondsSince1970

--- a/Tests/BackendIntegrationTests/SignatureVerificationIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/SignatureVerificationIntegrationTests.swift
@@ -90,6 +90,18 @@ class InformationalSignatureVerificationIntegrationTests: BaseSignatureVerificat
         expect(info.entitlements.verification) == .failed
     }
 
+    func testLogInWithValidSignature() async throws {
+        let info = try await Purchases.shared.logIn(UUID().uuidString).customerInfo
+        expect(info.entitlements.verification) == .verified
+    }
+
+    func testLogInWithInvalidSignature() async throws {
+        self.invalidSignature = true
+
+        let info = try await Purchases.shared.logIn(UUID().uuidString).customerInfo
+        expect(info.entitlements.verification) == .failed
+    }
+
     func testNotModifiedCustomerInfoWithInvalidSignature() async throws {
         // 1. Log-in to force a new user
         _ = try await Purchases.shared.logIn(UUID().uuidString)
@@ -153,6 +165,19 @@ class EnforcedSignatureVerificationIntegrationTests: BaseSignatureVerificationIn
 
         try await Self.verifyThrowsSignatureVerificationFailed {
             _ = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
+        }
+    }
+
+    func testLogInWithValidSignature() async throws {
+        let info = try await Purchases.shared.logIn(UUID().uuidString).customerInfo
+        expect(info.entitlements.verification) == .verified
+    }
+
+    func testLogInWithInvalidSignature() async throws {
+        self.invalidSignature = true
+
+        try await Self.verifyThrowsSignatureVerificationFailed {
+            _ = try await Purchases.shared.logIn(UUID().uuidString).customerInfo
         }
     }
 

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -77,12 +77,15 @@ class MockHTTPClient: HTTPClient {
         with verificationMode: Signing.ResponseVerificationMode? = nil,
         completionHandler: Completion<Value>?
     ) {
+        let verificationMode = verificationMode ?? self.systemInfo.responseVerificationMode
+
         let request = request
-            .requestAddingNonceIfRequired(with: verificationMode ?? self.systemInfo.responseVerificationMode)
+            .requestAddingNonceIfRequired(with: verificationMode)
             .withHardcodedNonce
 
         let call = Call(request: request,
-                        headers: request.headers(with: self.authHeaders))
+                        headers: request.headers(with: self.authHeaders,
+                                                 verificationMode: verificationMode))
 
         DispatchQueue.main.async {
             self.calls.append(call)

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -715,68 +715,6 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
         expect(completionCalled.value).toEventually(equal(2))
     }
 
-    func testGetsEntitlementsWithVerifiedResponse() {
-        self.httpClient.mock(
-            requestPath: .postReceiptData,
-            response: .init(statusCode: .success,
-                            response: Self.validCustomerResponse,
-                            verificationResult: .verified)
-        )
-
-        let result = waitUntilValue { completed in
-            self.backend.post(receiptData: Self.receiptData,
-                              productData: nil,
-                              transactionData: .init(
-                                 appUserID: Self.userID,
-                                 presentedOfferingID: nil,
-                                 unsyncedAttributes: nil,
-                                 storefront: nil,
-                                 source: .init(isRestore: false, initiationSource: .purchase)
-                              ),
-                              observerMode: false,
-                              completion: { result in
-                completed(result)
-            })
-        }
-
-        expect(result).to(beSuccess())
-
-        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
-            expect(result?.value?.entitlements.verification) == .verified
-        }
-    }
-
-    func testGetsEntitlementsWithFailedVerification() {
-        self.httpClient.mock(
-            requestPath: .postReceiptData,
-            response: .init(statusCode: .success,
-                            response: Self.validCustomerResponse,
-                            verificationResult: .failed)
-        )
-
-        let result = waitUntilValue { completed in
-            self.backend.post(receiptData: Self.receiptData,
-                              productData: nil,
-                              transactionData: .init(
-                                 appUserID: Self.userID,
-                                 presentedOfferingID: nil,
-                                 unsyncedAttributes: nil,
-                                 storefront: nil,
-                                 source: .init(isRestore: false, initiationSource: .purchase)
-                              ),
-                              observerMode: false,
-                              completion: { result in
-                completed(result)
-            })
-        }
-
-        expect(result).to(beSuccess())
-
-        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
-            expect(result?.value?.entitlements.verification) == .failed
-        }
-    }
-
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testPostingReceiptWithNoProductDataAndServerErrorComputesOfflineUser() throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
@@ -845,6 +783,75 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
 
         expect(self.mockOfflineCustomerInfoCreator.createRequested) == true
         expect(self.mockOfflineCustomerInfoCreator.createRequestCount) == 1
+    }
+
+}
+
+// swiftlint:disable:next type_name
+class BackendPostReceiptWithSignatureVerificationTests: BaseBackendPostReceiptDataTests {
+
+    override var verificationMode: Configuration.EntitlementVerificationMode { .informational }
+
+    func testGetsEntitlementsWithVerifiedResponse() {
+        self.httpClient.mock(
+            requestPath: .postReceiptData,
+            response: .init(statusCode: .success,
+                            response: Self.validCustomerResponse,
+                            verificationResult: .verified)
+        )
+
+        let result = waitUntilValue { completed in
+            self.backend.post(receiptData: Self.receiptData,
+                              productData: nil,
+                              transactionData: .init(
+                                 appUserID: Self.userID,
+                                 presentedOfferingID: nil,
+                                 unsyncedAttributes: nil,
+                                 storefront: nil,
+                                 source: .init(isRestore: false, initiationSource: .purchase)
+                              ),
+                              observerMode: false,
+                              completion: { result in
+                completed(result)
+            })
+        }
+
+        expect(result).to(beSuccess())
+
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
+            expect(result?.value?.entitlements.verification) == .verified
+        }
+    }
+
+    func testGetsEntitlementsWithFailedVerification() {
+        self.httpClient.mock(
+            requestPath: .postReceiptData,
+            response: .init(statusCode: .success,
+                            response: Self.validCustomerResponse,
+                            verificationResult: .failed)
+        )
+
+        let result = waitUntilValue { completed in
+            self.backend.post(receiptData: Self.receiptData2,
+                              productData: nil,
+                              transactionData: .init(
+                                 appUserID: Self.userID,
+                                 presentedOfferingID: nil,
+                                 unsyncedAttributes: nil,
+                                 storefront: nil,
+                                 source: .init(isRestore: false, initiationSource: .purchase)
+                              ),
+                              observerMode: false,
+                              completion: { result in
+                completed(result)
+            })
+        }
+
+        expect(result).to(beSuccess())
+
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
+            expect(result?.value?.entitlements.verification) == .failed
+        }
     }
 
 }

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginWithFailedVerification.1.json
@@ -1,0 +1,13 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "$RCAnonymousID:6b2787de2fb848a8b403a45f695ee74f",
+      "new_app_user_id" : "F72BF276-CD70-4C27-BCD2-FC1EFD988FA3"
+    },
+    "method" : "POST",
+    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS12-testLoginWithVerifiedResponse.1.json
@@ -1,0 +1,13 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "old id",
+      "new_app_user_id" : "new id"
+    },
+    "method" : "POST",
+    "url" : "https:\/\/api.revenuecat.com\/v1\/subscribers\/identify"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithFailedVerification.1.json
@@ -1,0 +1,15 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "$RCAnonymousID:6b2787de2fb848a8b403a45f695ee74f",
+      "new_app_user_id" : "F72BF276-CD70-4C27-BCD2-FC1EFD988FA3"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithVerifiedResponse.1.json
@@ -1,0 +1,15 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "old id",
+      "new_app_user_id" : "new id"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithFailedVerification.1.json
@@ -1,0 +1,15 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "$RCAnonymousID:6b2787de2fb848a8b403a45f695ee74f",
+      "new_app_user_id" : "F72BF276-CD70-4C27-BCD2-FC1EFD988FA3"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithVerifiedResponse.1.json
@@ -1,0 +1,15 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "old id",
+      "new_app_user_id" : "new id"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithFailedVerification.1.json
@@ -1,0 +1,15 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "$RCAnonymousID:6b2787de2fb848a8b403a45f695ee74f",
+      "new_app_user_id" : "F72BF276-CD70-4C27-BCD2-FC1EFD988FA3"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithVerifiedResponse.1.json
@@ -1,0 +1,15 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "old id",
+      "new_app_user_id" : "new id"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithFailedVerification.1.json
@@ -1,0 +1,15 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "$RCAnonymousID:6b2787de2fb848a8b403a45f695ee74f",
+      "new_app_user_id" : "F72BF276-CD70-4C27-BCD2-FC1EFD988FA3"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithVerifiedResponse.1.json
@@ -1,0 +1,15 @@
+{
+  "headers" : {
+    "Authorization" : "Bearer asharedsecret",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Post-Params-Hash" : "app_user_id,new_app_user_id:sha256:ce001f7b6730af645a00622c062081d2105742d40101bb415176b88a18cfee97"
+  },
+  "request" : {
+    "body" : {
+      "app_user_id" : "old id",
+      "new_app_user_id" : "new id"
+    },
+    "method" : "POST",
+    "url" : "https://api.revenuecat.com/v1/subscribers/identify"
+  }
+}

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS12-testGetsEntitlementsWithFailedVerification.1.json
@@ -11,7 +11,7 @@
           "value" : "notDetermined"
         }
       },
-      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "fetch_token" : "YW4gYXdlc29tZWVyIHJlY2VpcHQ=",
       "initiation_source" : "purchase",
       "is_restore" : false,
       "observer_mode" : false

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithFailedVerification.1.json
@@ -1,6 +1,8 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729"
   },
   "request" : {
     "body" : {
@@ -11,7 +13,7 @@
           "value" : "notDetermined"
         }
       },
-      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "fetch_token" : "YW4gYXdlc29tZWVyIHJlY2VpcHQ=",
       "initiation_source" : "purchase",
       "is_restore" : false,
       "observer_mode" : false

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -1,6 +1,8 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithFailedVerification.1.json
@@ -1,6 +1,8 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729"
   },
   "request" : {
     "body" : {
@@ -11,7 +13,7 @@
           "value" : "authorized"
         }
       },
-      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "fetch_token" : "YW4gYXdlc29tZWVyIHJlY2VpcHQ=",
       "initiation_source" : "purchase",
       "is_restore" : false,
       "observer_mode" : false

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -1,6 +1,8 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithFailedVerification.1.json
@@ -1,6 +1,8 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729"
   },
   "request" : {
     "body" : {
@@ -11,7 +13,7 @@
           "value" : "authorized"
         }
       },
-      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "fetch_token" : "YW4gYXdlc29tZWVyIHJlY2VpcHQ=",
       "initiation_source" : "purchase",
       "is_restore" : false,
       "observer_mode" : false

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -1,6 +1,8 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithFailedVerification.1.json
@@ -2,7 +2,7 @@
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:a11ca6539990f076ad393859a4a940cd759de0db732b9c63bfbad52ca1cb3f9f"
+    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:be95d3a1d4c00357de2696c1a4546be1d0312dbee67feee8a971f01f8ac4b729"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithFailedVerification.1.json
@@ -1,6 +1,8 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:a11ca6539990f076ad393859a4a940cd759de0db732b9c63bfbad52ca1cb3f9f"
   },
   "request" : {
     "body" : {
@@ -11,7 +13,7 @@
           "value" : "authorized"
         }
       },
-      "fetch_token" : "YW4gYXdlc29tZSByZWNlaXB0",
+      "fetch_token" : "YW4gYXdlc29tZWVyIHJlY2VpcHQ=",
       "initiation_source" : "purchase",
       "is_restore" : false,
       "observer_mode" : false

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -1,6 +1,8 @@
 {
   "headers" : {
-    "Authorization" : "Bearer asharedsecret"
+    "Authorization" : "Bearer asharedsecret",
+    "X-Nonce" : "MTIzNDU2Nzg5MGFi",
+    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:bbe03fe8adb95ede9f2a2a9911c25d1df008e4aa567cf76090632120e3fec863"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -2,7 +2,7 @@
   "headers" : {
     "Authorization" : "Bearer asharedsecret",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
-    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:bbe03fe8adb95ede9f2a2a9911c25d1df008e4aa567cf76090632120e3fec863"
+    "X-Post-Params-Hash" : "app_user_id,fetch_token:sha256:2cc3741ddb808ae6fd179f1398d9115b58772590765edf799ec778f929faa46d"
   },
   "request" : {
     "body" : {

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -126,6 +126,40 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         expect(headers?.keys).toNot(contain(HTTPClient.RequestHeader.nonce.rawValue))
     }
 
+    func testGetRequestDoesNotContainPostParametersHeader() {
+        let request = HTTPRequest(method: .get, path: .mockPath)
+
+        let headers: [String: String]? = waitUntilValue { completion in
+            stub(condition: isPath(request.path)) { request in
+                completion(request.allHTTPHeaderFields)
+                return .emptySuccessResponse()
+            }
+
+            self.client.perform(request) { (_: EmptyResponse) in }
+        }
+
+        expect(headers).toNot(beEmpty())
+        expect(headers?.keys).toNot(contain(HTTPClient.RequestHeader.postParameters.rawValue))
+    }
+
+    func testPostRequestWithDisabledSignatureVerificationDoesNotContainPostParametersHeader() {
+        let body = BodyWithSignature(key1: "a", key2: "b")
+
+        let request = HTTPRequest(method: .post(body), path: .postReceiptData)
+
+        let headers: [String: String]? = waitUntilValue { completion in
+            stub(condition: isPath(request.path)) { request in
+                completion(request.allHTTPHeaderFields)
+                return .emptySuccessResponse()
+            }
+
+            self.client.perform(request) { (_: EmptyResponse) in }
+        }
+
+        expect(headers).toNot(beEmpty())
+        expect(headers?.keys).toNot(contain(HTTPClient.RequestHeader.postParameters.rawValue))
+    }
+
     func testRequestIncludesNonceInBase64() {
         let request = HTTPRequest(method: .get, path: .mockPath, nonce: "1234567890ab".asData)
 
@@ -1522,6 +1556,18 @@ extension BaseHTTPClientTests {
         }
     }
 
+    struct BodyWithSignature: HTTPRequestBody {
+        var key1: String
+        var key2: String
+
+        var contentForSignature: [(key: String, value: String)] {
+            return [
+                ("key1", self.key1),
+                ("key2", self.key2)
+            ]
+        }
+    }
+
 }
 
 extension HTTPRequest.Path {
@@ -1548,7 +1594,19 @@ extension HTTPRequest.Method {
     /// Creates a `HTTPRequest.Method.post` request with `[String: Any]`.
     /// - Note: this is for testing only, real requests must use `Encodable`.
     internal static func post(_ body: [String: Any]) -> Self {
-        return .post(AnyEncodable(body))
+        return .post(AnyEncodableRequestBody(body))
     }
+
+}
+
+private struct AnyEncodableRequestBody: HTTPRequestBody {
+
+    var body: AnyEncodable
+
+    init(_ body: [String: Any]) {
+        self.body = .init(body)
+    }
+
+    var contentForSignature: [(key: String, value: String)] { [] }
 
 }

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -227,7 +227,7 @@ final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPC
         }
 
         let header = try XCTUnwrap(headers?[HTTPClient.RequestHeader.postParameters.rawValue] as? String)
-        expect(header) == "key1,key2:sha256:0ffc67878b872d1e948951a21bda17237afa6f72d28665534c37e4c7f5191b4f"
+        expect(header) == "key1,key2:sha256:59b271ae1bbcb1d31d41929817f4b16fb439eb4f31520b5ad1d5ce98920a7138"
     }
 
 }

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -210,6 +210,26 @@ final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPC
         expect(response?.value?.verificationResult) == .notRequested
     }
 
+    func testPostRequestWithPostParametersHeader() throws {
+        try self.changeClient(.informational)
+
+        let body = BodyWithSignature(key1: "a", key2: "b")
+
+        let request = HTTPRequest(method: .post(body), path: .mockPath)
+
+        let headers: [String: String]? = waitUntilValue { completion in
+            stub(condition: isPath(request.path)) { request in
+                completion(request.allHTTPHeaderFields)
+                return .emptySuccessResponse()
+            }
+
+            self.client.perform(request) { (_: EmptyResponse) in }
+        }
+
+        let header = try XCTUnwrap(headers?[HTTPClient.RequestHeader.postParameters.rawValue] as? String)
+        expect(header) == "key1,key2:sha256:0ffc67878b872d1e948951a21bda17237afa6f72d28665534c37e4c7f5191b4f"
+    }
+
 }
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)

--- a/Tests/UnitTests/Security/SigningTests.swift
+++ b/Tests/UnitTests/Security/SigningTests.swift
@@ -461,6 +461,44 @@ class SigningTests: TestCase {
         ) == true
     }
 
+    func testVerifyKnownSignatureForPostRequest() throws {
+        /*
+         Signature retrieved with:
+        curl -v 'https://api.revenuecat.com/v1/subscribers/identify' \
+        -X POST \
+        -H 'X-Nonce: MTIzNDU2Nzg5MGFi' \
+        -H 'X-Post-Params-Hash: current_user_id,new_user_id:sha256:633e3581dc391a2ef66e4b2b39c9d63e4ab82e801d8f17436774e65ae2a513e9' \
+        -H 'Authorization: Bearer appl_fFVBVAoYujMZJnepIziGKVjnZBz' \
+        -H 'Content-Type: application/json' \
+         --data-raw '{"new_app_user_id":"F72BF276-CD70-4C27-BCD2-FC1EFD988FA3","app_user_id":"$RCAnonymousID:6b2787de2fb848a8b403a45f695ee74f"}'
+         */
+
+        // swiftlint:disable line_length
+        let response = """
+        {"request_date":"2023-07-06T19:25:15Z","request_date_ms":1688671515638,"subscriber":{"entitlements":{},"first_seen":"2023-06-30T23:06:23Z","last_seen":"2023-06-30T23:06:23Z","management_url":null,"non_subscriptions":{},"original_app_user_id":"$RCAnonymousID:1af512a3b9c848899fe427f39dd69f2b","original_application_version":null,"original_purchase_date":null,"other_purchases":{},"subscriptions":{}}}\n
+        """
+        let expectedSignature = "XX8Mh8DTcqPC5A48nncRU3hDkL/v3baxxqLIWnWJzg1tTAAA7ok0iXupT2bjju/BSHVmgxc0XiwTZXBmsGuWEXa9lsyoFi9HMF4aAIOs4Y+lYE2i4USJCP7ev07QZk7D2b6ZBSrxh7Tsw8z/B0jfCUIVOlzAJqMSoDWL3zy1etinl/pU/xzwZ9HdZWwyAgn38I9rv/JM0FSCcYMC2C8KE06wFyQTz+7c9btj/v2ueXRgAJYB"
+        // swiftlint:enable line_length
+
+        let nonce = try XCTUnwrap(Data(base64Encoded: "MTIzNDU2Nzg5MGFi"))
+        let requestDate: UInt64 = 1688671515638
+        let etag = "a896a69e4b31304d"
+
+        expect(
+            self.signing.verify(
+                signature: expectedSignature,
+                with: .init(
+                    path: .getCustomerInfo(appUserID: "$RCAnonymousID:1af512a3b9c848899fe427f39dd69f2b"),
+                    message: response.asData,
+                    nonce: nonce,
+                    etag: etag,
+                    requestDate: requestDate
+                ),
+                publicKey: Signing.loadPublicKey()
+            )
+        ) == true
+    }
+
     func testResponseVerificationWithNoProvidedKey() throws {
         let request = HTTPRequest.createWithResponseVerification(method: .get, path: .health)
         let response = HTTPResponse<Data?>(statusCode: .success, responseHeaders: [:], body: Data())

--- a/Tests/UnitTests/Security/SigningTests.swift
+++ b/Tests/UnitTests/Security/SigningTests.swift
@@ -462,36 +462,39 @@ class SigningTests: TestCase {
     }
 
     func testVerifyKnownSignatureForPostRequest() throws {
+        // swiftlint:disable line_length
         /*
          Signature retrieved with:
         curl -v 'https://api.revenuecat.com/v1/subscribers/identify' \
         -X POST \
         -H 'X-Nonce: MTIzNDU2Nzg5MGFi' \
-        -H 'X-Post-Params-Hash: current_user_id,new_user_id:sha256:633e3581dc391a2ef66e4b2b39c9d63e4ab82e801d8f17436774e65ae2a513e9' \
+         -H 'X-Post-Params-Hash: app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a' \
         -H 'Authorization: Bearer appl_fFVBVAoYujMZJnepIziGKVjnZBz' \
         -H 'Content-Type: application/json' \
          --data-raw '{"new_app_user_id":"F72BF276-CD70-4C27-BCD2-FC1EFD988FA3","app_user_id":"$RCAnonymousID:6b2787de2fb848a8b403a45f695ee74f"}'
          */
 
-        // swiftlint:disable line_length
         let response = """
-        {"request_date":"2023-07-06T19:25:15Z","request_date_ms":1688671515638,"subscriber":{"entitlements":{},"first_seen":"2023-06-30T23:06:23Z","last_seen":"2023-06-30T23:06:23Z","management_url":null,"non_subscriptions":{},"original_app_user_id":"$RCAnonymousID:1af512a3b9c848899fe427f39dd69f2b","original_application_version":null,"original_purchase_date":null,"other_purchases":{},"subscriptions":{}}}\n
+        {"request_date":"2023-07-07T19:47:59Z","request_date_ms":1688759279804,"subscriber":{"entitlements":{},"first_seen":"2023-07-06T19:51:18Z","last_seen":"2023-07-06T19:51:18Z","management_url":null,"non_subscriptions":{},"original_app_user_id":"F72BF276-CD70-4C27-BCD2-FC1EFD988FA3","original_application_version":null,"original_purchase_date":null,"other_purchases":{},"subscriptions":{}}}\n
         """
-        let expectedSignature = "XX8Mh8DTcqPC5A48nncRU3hDkL/v3baxxqLIWnWJzg1tTAAA7ok0iXupT2bjju/BSHVmgxc0XiwTZXBmsGuWEXa9lsyoFi9HMF4aAIOs4Y+lYE2i4USJCP7ev07QZk7D2b6ZBSrxh7Tsw8z/B0jfCUIVOlzAJqMSoDWL3zy1etinl/pU/xzwZ9HdZWwyAgn38I9rv/JM0FSCcYMC2C8KE06wFyQTz+7c9btj/v2ueXRgAJYB"
+        let expectedSignature = "XX8Mh8DTcqPC5A48nncRU3hDkL/v3baxxqLIWnWJzg1tTAAA7ok0iXupT2bjju/BSHVmgxc0XiwTZXBmsGuWEXa9lsyoFi9HMF4aAIOs4Y+lYE2i4USJCP7ev07QZk7D2b6ZBYArl3A6DzmFY4Yh9CLUnG6RHMuVDFHmhOd4I6L10UiJUyO/vH9prON6j9E0bOyPdq5Cv+5/cQg2f2dA4NKPCFcZ9Ursc6O9c/HQ+qoVfX8H"
         // swiftlint:enable line_length
 
         let nonce = try XCTUnwrap(Data(base64Encoded: "MTIzNDU2Nzg5MGFi"))
-        let requestDate: UInt64 = 1688671515638
-        let etag = "a896a69e4b31304d"
+        let requestDate: UInt64 = 1688759279805
 
         expect(
             self.signing.verify(
                 signature: expectedSignature,
                 with: .init(
-                    path: .getCustomerInfo(appUserID: "$RCAnonymousID:1af512a3b9c848899fe427f39dd69f2b"),
+                    path: .logIn,
                     message: response.asData,
+                    requestBody: LogInOperation.Body(
+                        appUserID: "$RCAnonymousID:6b2787de2fb848a8b403a45f695ee74f",
+                        newAppUserID: "F72BF276-CD70-4C27-BCD2-FC1EFD988FA3"
+                    ),
                     nonce: nonce,
-                    etag: etag,
+                    etag: nil,
                     requestDate: requestDate
                 ),
                 publicKey: Signing.loadPublicKey()

--- a/Tests/UnitTests/Security/SigningTests.swift
+++ b/Tests/UnitTests/Security/SigningTests.swift
@@ -468,7 +468,7 @@ class SigningTests: TestCase {
         curl -v 'https://api.revenuecat.com/v1/subscribers/identify' \
         -X POST \
         -H 'X-Nonce: MTIzNDU2Nzg5MGFi' \
-         -H 'X-Post-Params-Hash: app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a' \
+        -H 'X-Post-Params-Hash: app_user_id,new_app_user_id:sha256:6fa58b9e3bdb1ca187ac082d128c19f04da8711fe6b17873a48bc7ca37bbf95a' \
         -H 'Authorization: Bearer appl_fFVBVAoYujMZJnepIziGKVjnZBz' \
         -H 'Content-Type: application/json' \
          --data-raw '{"new_app_user_id":"F72BF276-CD70-4C27-BCD2-FC1EFD988FA3","app_user_id":"$RCAnonymousID:6b2787de2fb848a8b403a45f695ee74f"}'


### PR DESCRIPTION
### Changes:
- `HTTPClient` has a new `X-Post-Params-Hash` request header
- Replaced `HTTPRequest.Method.post`'s `Encodable` value with a more specific `HTTPRequestBody` (like `HTTPResponseBody`)
- `HTTPRequestBody` allows overriding `contentForSignature` (it defaults to `[]`) which then `Signing` uses for the hash
- Fixed `LogInOperation` not passing the `VerificationResult` to the result `CustomerInfo`. This is captured in unit and integration tests now.
- Add support for signing `POST` requests in `Path.logIn` and `Path.postReceiptData`

Depends on https://github.com/RevenueCat/khepri/pull/6246