### PR TITLE
`PurchasesDiagnostics`: don't test signature verification if it's disabled

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1381,6 +1381,10 @@ extension Purchases: InternalPurchasesType {
         return response.toMapping()
     }
 
+    var responseVerificationMode: Signing.ResponseVerificationMode {
+        return self.systemInfo.responseVerificationMode
+    }
+
 }
 
 /// Necessary because `ErrorUtils` inside of `Purchases` finds the obsoleted type.
@@ -1459,10 +1463,6 @@ internal extension Purchases {
 
     var storeKit2Setting: StoreKit2Setting {
         return self.systemInfo.storeKit2Setting
-    }
-
-    var responseVerificationMode: Signing.ResponseVerificationMode {
-        return self.systemInfo.responseVerificationMode
     }
 
     var publicKey: Signing.PublicKey? {

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -991,4 +991,6 @@ internal protocol InternalPurchasesType: AnyObject {
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func productEntitlementMapping() async throws -> ProductEntitlementMapping
 
+    var responseVerificationMode: Signing.ResponseVerificationMode { get }
+
 }

--- a/Sources/Support/PurchasesDiagnostics.swift
+++ b/Sources/Support/PurchasesDiagnostics.swift
@@ -129,6 +129,8 @@ private extension PurchasesDiagnostics {
     }
 
     func signatureVerification() async throws {
+        guard self.purchases.responseVerificationMode.isEnabled else { return }
+
         do {
             try await self.purchases.healthRequest(signatureVerification: true)
         } catch {

--- a/Tests/BackendIntegrationTests/CustomEntitlementsComputationIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/CustomEntitlementsComputationIntegrationTests.swift
@@ -49,7 +49,7 @@ final class CustomEntitlementsComputationIntegrationTests: BaseStoreKitIntegrati
     // MARK: - Tests
 
     func testPurchasesDiagnostics() async throws {
-        XCTExpectFailure("Signature Verification disabled until backend is updated")
+        try XCTSkipIf(true, "Signature Verification disabled until backend is updated")
 
         let diagnostics = PurchasesDiagnostics(purchases: Purchases.shared)
 

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -33,7 +33,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     }
 
     func testPurchasesDiagnostics() async throws {
-        XCTExpectFailure("Signature Verification disabled until backend is updated")
+        try XCTSkipIf(true, "Signature Verification disabled until backend is updated")
 
         let diagnostics = PurchasesDiagnostics(purchases: Purchases.shared)
 

--- a/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
+++ b/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
@@ -84,7 +84,19 @@ class PurchasesDiagnosticsTests: TestCase {
         }
     }
 
+    func testDoesNotCheckSignatureVerificationIfDisabled() async throws {
+        self.purchases.mockedResponseVerificationMode = .disabled
+
+        self.purchases.mockedHealthRequestWithSignatureVerificationResponse = .failure(
+            ErrorUtils.signatureVerificationFailedError(path: .health, code: .success).asPublicError
+        )
+
+        try await self.diagnostics.testSDKHealth()
+    }
+
     func testFailingSignatureVerification() async throws {
+        self.purchases.mockedResponseVerificationMode = Signing.verificationMode(with: .informational)
+
         let expectedError = ErrorUtils.signatureVerificationFailedError(path: .health, code: .success)
         self.purchases.mockedHealthRequestWithSignatureVerificationResponse = .failure(expectedError.asPublicError)
 

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -45,6 +45,8 @@ final class MockPurchases {
         ErrorUtils.unknownError().asPublicError
     )
 
+    var mockedResponseVerificationMode: Signing.ResponseVerificationMode = .disabled
+
 }
 
 extension MockPurchases: InternalPurchasesType {
@@ -61,6 +63,10 @@ extension MockPurchases: InternalPurchasesType {
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func productEntitlementMapping() async throws -> ProductEntitlementMapping {
         return try self.mockedProductEntitlementMapping.get()
+    }
+
+    var responseVerificationMode: Signing.ResponseVerificationMode {
+        return self.mockedResponseVerificationMode
     }
 
 }


### PR DESCRIPTION
Signature verification is not working due to changing signature (see #2744), but the debug screen shouldn't show an error if verification isn't enabled.
