### PR TITLE
`Integration Tests`: `TestLogHandler` no longer crashes tests

### DIFF
--- a/Tests/UnitTests/TestHelpers/TestLogHandler.swift
+++ b/Tests/UnitTests/TestHelpers/TestLogHandler.swift
@@ -219,9 +219,11 @@ extension TestLogHandler: LogMessageObserver {
         self.loggedMessages.modify {
             $0.append((level, message))
 
-            precondition(
-                $0.count < self.capacity,
-                "\($0.count) messages have been stored. " +
+            let count = $0.count
+
+            expect(count).to(
+                beLessThan(self.capacity),
+                description: "\(count) messages have been stored. " +
                 "This is likely a programming error and \(self) " +
                 "(created in \(self.creationContext.file):\(self.creationContext.line) has leaked."
             )


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/12568/workflows/58ed4f07-e5f8-4ed0-821e-87413ac06e11/jobs/86331/steps

The only source of flaky integration tests now is `testPurchaseWhileServerIsDownPostsReceiptAfterServerComesBack`.
I haven't been able to figure out why the capacity is exceeded there, even after looking through the logs and the implementation.

My only guess is leftover transactions.

However, instead of failing the run altogether, this will now make the test fail so it can be retried.
