### PR TITLE
`Signing`: inject `ClockType` to ensure hardcoded signatures don't fail when intermediate key expires

### DIFF
--- a/Sources/Security/Signing.swift
+++ b/Sources/Security/Signing.swift
@@ -43,9 +43,11 @@ final class Signing: SigningType {
     }
 
     private let apiKey: String
+    private let clock: ClockType
 
-    init(apiKey: String) {
+    init(apiKey: String, clock: ClockType = Clock.default) {
         self.apiKey = apiKey
+        self.clock = clock
     }
 
     /// Parses the binary `key` and returns a `PublicKey`
@@ -85,7 +87,8 @@ final class Signing: SigningType {
 
         guard let intermediatePublicKey = Self.extractAndVerifyIntermediateKey(
             from: signature,
-            publicKey: publicKey
+            publicKey: publicKey,
+            clock: self.clock
         ) else {
             return false
         }
@@ -282,7 +285,8 @@ private extension Signing {
 
     static func extractAndVerifyIntermediateKey(
         from signature: Data,
-        publicKey: Signing.PublicKey
+        publicKey: Signing.PublicKey,
+        clock: ClockType
     ) -> Signing.PublicKey? {
         guard #available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *) else { return nil }
 
@@ -296,7 +300,8 @@ private extension Signing {
             return nil
         }
 
-        guard let expirationDate = Self.extractAndVerifyIntermediateKeyExpiration(intermediateKeyExpiration) else {
+        guard let expirationDate = Self.extractAndVerifyIntermediateKeyExpiration(intermediateKeyExpiration,
+                                                                                  clock) else {
             return nil
         }
 
@@ -312,7 +317,10 @@ private extension Signing {
     }
 
     /// - Returns: `nil` if the key is expired or has an invalid expiration date.
-    private static func extractAndVerifyIntermediateKeyExpiration(_ expirationData: Data) -> Date? {
+    private static func extractAndVerifyIntermediateKeyExpiration(
+        _ expirationData: Data,
+        _ clock: ClockType
+    ) -> Date? {
         let daysSince1970 = UInt32(littleEndian32Bits: expirationData)
 
         guard daysSince1970 > 0 else {

--- a/Tests/UnitTests/Mocks/TestClock.swift
+++ b/Tests/UnitTests/Mocks/TestClock.swift
@@ -21,7 +21,7 @@ final class TestClock: ClockType {
 
     var now: Date
 
-    init() { self.now = Date() }
+    init(now: Date = .init()) { self.now = now }
 
 }
 

--- a/Tests/UnitTests/Security/SigningTests.swift
+++ b/Tests/UnitTests/Security/SigningTests.swift
@@ -33,7 +33,7 @@ class SigningTests: TestCase {
 
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
-        self.signing = .init(apiKey: Self.apiKey)
+        self.signing = .init(apiKey: Self.apiKey, clock: TestClock(now: Self.mockDate))
     }
 
     func testLoadDefaultPublicKey() throws {
@@ -667,8 +667,8 @@ private extension SigningTests {
         return intermediateKey + expiration + signature
     }
 
-    static let intermediateKeyFutureExpiration = Date().addingTimeInterval(DispatchTimeInterval.days(5).seconds)
-    static let intermediateKeyPastExpiration = Date().addingTimeInterval(DispatchTimeInterval.days(5).seconds * -1)
+    static let intermediateKeyFutureExpiration = mockDate.addingTimeInterval(DispatchTimeInterval.days(5).seconds)
+    static let intermediateKeyPastExpiration = mockDate.addingTimeInterval(DispatchTimeInterval.days(5).seconds * -1)
     static let invalidIntermediateKeyExpiration = Data(
         repeating: 0,
         count: Signing.SignatureComponent.intermediateKeyExpiration.size
@@ -676,6 +676,10 @@ private extension SigningTests {
 
     static let apiKey = "appl_fFVBVAoYujMZJnepIziGKVjnZBz"
     static let mockPath: HTTPRequest.Path = .getCustomerInfo(appUserID: "user")
+
+    // 2023-07-07: The hardcoded signatures have an intermediate signature that expires
+    // 2 weeks after that date.
+    static let mockDate: Date = Date(timeIntervalSince1970: 1688769125)
 
 }
 


### PR DESCRIPTION
Thanks to @aboedo for catching this and providing this simple idea.