### PR TITLE
[WIP] `ErrorUtils`: don't log errors automatically on creation

### DIFF
--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -608,12 +608,6 @@ private extension ErrorUtils {
         userInfo[.file] = "\(fileName):\(line)"
         userInfo[.function] = functionName
 
-        Self.logErrorIfNeeded(
-            code,
-            localizedDescription: localizedDescription,
-            fileName: fileName, functionName: functionName, line: line
-        )
-
         return .init(error: code, userInfo: userInfo)
     }
 
@@ -642,74 +636,6 @@ private extension ErrorUtils {
             NSLocalizedDescriptionKey as NSError.UserInfoKey: backendMessage ?? "",
             .backendErrorCode: originalBackendErrorCode
         ])
-    }
-
-    // swiftlint:disable:next function_body_length
-    private static func logErrorIfNeeded(_ code: ErrorCode,
-                                         localizedDescription: String,
-                                         fileName: String = #fileID,
-                                         functionName: String = #function,
-                                         line: UInt = #line) {
-        switch code {
-        case .networkError,
-                .unknownError,
-                .receiptAlreadyInUseError,
-                .unexpectedBackendResponseError,
-                .invalidReceiptError,
-                .invalidAppUserIdError,
-                .invalidCredentialsError,
-                .operationAlreadyInProgressForProductError,
-                .unknownBackendError,
-                .invalidSubscriberAttributesError,
-                .logOutAnonymousUserError,
-                .receiptInUseByOtherSubscriberError,
-                .configurationError,
-                .unsupportedError,
-                .emptySubscriberAttributes,
-                .productDiscountMissingIdentifierError,
-                .productDiscountMissingSubscriptionGroupIdentifierError,
-                .customerInfoError,
-                .systemInfoError,
-                .beginRefundRequestError,
-                .apiEndpointBlockedError,
-                .invalidPromotionalOfferError,
-                .offlineConnectionError,
-                .featureNotAvailableInCustomEntitlementsComputationMode,
-                .signatureVerificationFailed:
-                Logger.error(
-                    localizedDescription,
-                    fileName: fileName,
-                    functionName: functionName,
-                    line: line
-                )
-
-        case .purchaseCancelledError,
-                .storeProblemError,
-                .purchaseNotAllowedError,
-                .purchaseInvalidError,
-                .productNotAvailableForPurchaseError,
-                .productAlreadyPurchasedError,
-                .missingReceiptFileError,
-                .invalidAppleSubscriptionKeyError,
-                .ineligibleError,
-                .insufficientPermissionsError,
-                .paymentPendingError,
-                .productRequestTimedOut:
-                Logger.appleError(
-                    localizedDescription,
-                    fileName: fileName,
-                    functionName: functionName,
-                    line: line
-                )
-
-        @unknown default:
-            Logger.error(
-                localizedDescription,
-                fileName: fileName,
-                functionName: functionName,
-                line: line
-            )
-        }
     }
 }
 

--- a/Sources/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
+++ b/Sources/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
@@ -31,8 +31,11 @@ class CustomerInfoResponseHandler {
                 // If the response was successful we always want to return the `CustomerInfo`.
                 if !response.body.errorResponse.attributeErrors.isEmpty {
                     // If there are any, log attribute errors.
-                    // Creating the error implicitly logs it.
-                    _ = response.body.errorResponse.asBackendError(with: response.statusCode)
+                    Logger.error(
+                        response.body.errorResponse
+                            .asBackendError(with: response.statusCode)
+                            .localizedDescription
+                    )
                 }
 
                 return response.body.customerInfo.copy(with: response.verificationResult)

--- a/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
+++ b/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
@@ -150,22 +150,11 @@ class ErrorUtilsTests: TestCase {
             .to(matchError(error))
     }
 
-    func testPurchaseErrorsAreLoggedAsApppleErrors() {
-        let underlyingError = NSError(domain: SKErrorDomain, code: SKError.Code.paymentInvalid.rawValue)
-        let error = ErrorUtils.purchaseNotAllowedError(error: underlyingError)
-
-        self.expectLoggedError(error, .appleError)
-    }
-
-    func testNetworkErrorsAreLogged() {
-        let error = ErrorUtils.networkError(message: Strings.network.json_data_received(dataString: "test").description)
-
-        self.expectLoggedError(error, .rcError)
-    }
-
     func testNetworkErrorsLogUnderlyingError() throws {
         let underlyingError = NSError(domain: NSURLErrorDomain, code: NSURLErrorDNSLookupFailed)
         let networkError = ErrorUtils.networkError(withUnderlyingError: underlyingError)
+
+        Logger.error(networkError.localizedDescription)
 
         let loggedMessage = try XCTUnwrap(self.loggedMessages.onlyElement)
 
@@ -180,6 +169,7 @@ class ErrorUtilsTests: TestCase {
 
     func testLoggedErrorsWithNoMessage() throws {
         let error = ErrorUtils.customerInfoError()
+        Logger.error(error.localizedDescription)
 
         let loggedMessage = try XCTUnwrap(self.loggedMessages.onlyElement)
 
@@ -196,6 +186,8 @@ class ErrorUtilsTests: TestCase {
                                      attributeErrors: [:])
         let purchasesError = response.asBackendError(with: .notFoundError)
 
+        Logger.error(purchasesError.localizedDescription)
+
         let loggedMessage = try XCTUnwrap(self.loggedMessages.onlyElement)
 
         expect(loggedMessage.level) == .error
@@ -209,7 +201,7 @@ class ErrorUtilsTests: TestCase {
 
     func testLoggedErrorsWithMessageIncludeErrorDescriptionAndMessage() throws {
         let message = Strings.customerInfo.no_cached_customerinfo.description
-        _ = ErrorUtils.customerInfoError(withMessage: message)
+        Logger.error(ErrorUtils.customerInfoError(withMessage: message).localizedDescription)
 
         let loggedMessage = try XCTUnwrap(self.loggedMessages.onlyElement)
 
@@ -222,7 +214,9 @@ class ErrorUtilsTests: TestCase {
     }
 
     func testLoggedErrorsDontDuplicateMessageIfEqualToErrorDescription() throws {
-        _ = ErrorUtils.customerInfoError(withMessage: ErrorCode.customerInfoError.description)
+        Logger.error(
+            ErrorUtils.customerInfoError(withMessage: ErrorCode.customerInfoError.description).localizedDescription
+        )
 
         let loggedMessage = try XCTUnwrap(self.loggedMessages.onlyElement)
 
@@ -242,7 +236,7 @@ class ErrorUtilsTests: TestCase {
                                           ])
 
         let error: NetworkError = .errorResponse(errorResponse, .invalidRequest)
-        _ = error.asPurchasesError
+        Logger.error(error.asPurchasesError.localizedDescription)
 
         let loggedMessage = try XCTUnwrap(self.loggedMessages.onlyElement)
 
@@ -262,7 +256,7 @@ class ErrorUtilsTests: TestCase {
                                           attributeErrors: [:])
 
         let error: NetworkError = .errorResponse(errorResponse, .invalidRequest)
-        _ = error.asPurchasesError
+        Logger.error(error.asPurchasesError.localizedDescription)
 
         let loggedMessage = try XCTUnwrap(self.loggedMessages.onlyElement)
 

--- a/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
@@ -116,7 +116,7 @@ class TransactionPosterTests: TestCase {
             }
         }
 
-        logger.verifyMessageWasNotLogged("Finished transaction")
+        logger.verifyMessageWasNotLogged("Finished transaction", allowNoMessages: true)
     }
 
 }

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -211,10 +211,9 @@ class BackendSubscriberAttributesTests: TestCase {
         }
 
         expect(self.mockHTTPClient.calls).toEventually(haveCount(1))
+        expect(receivedCustomerInfo.value) == CustomerInfo(testData: self.validSubscriberResponse)
 
         let loggedMessages = logHandler.messages.map(\.message)
-
-        expect(receivedCustomerInfo.value) == CustomerInfo(testData: self.validSubscriberResponse)
         expect(loggedMessages).to(
             containElementSatisfying {
                 $0.localizedCaseInsensitiveContains(ErrorCode.invalidSubscriberAttributesError.description)


### PR DESCRIPTION
This is a pre-requisite for #2750, to ensure that we don't forward duplicate errors.