### PR TITLE
`Tests`: fixed flaky failure with asynchronous check

### DIFF
--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -377,7 +377,7 @@ extension BasePurchasesTests {
         var userID: String?
         var originalApplicationVersion: String?
         var originalPurchaseDate: Date?
-        var getSubscriberCallCount = 0
+        var getCustomerInfoCallCount = 0
         var overrideCustomerInfoResult: Result<CustomerInfo, BackendError> = .success(
             // swiftlint:disable:next force_try
             try! CustomerInfo(data: BasePurchasesTests.emptyCustomerInfoData)
@@ -387,7 +387,7 @@ extension BasePurchasesTests {
                                       withRandomDelay randomDelay: Bool,
                                       allowComputingOffline: Bool,
                                       completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
-            self.getSubscriberCallCount += 1
+            self.getCustomerInfoCallCount += 1
             self.userID = appUserID
 
             let result = self.overrideCustomerInfoResult

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -287,13 +287,13 @@ class PurchasesConfiguringTests: BasePurchasesTests {
     func testFirstInitializationFromBackgroundDoesntUpdateCustomerInfoCache() {
         self.systemInfo.stubbedIsApplicationBackgrounded = true
         self.setupPurchases()
-        expect(self.backend.getSubscriberCallCount).toEventually(equal(0))
+        expect(self.backend.getCustomerInfoCallCount).toEventually(equal(0))
     }
 
     func testFirstInitializationFromForegroundUpdatesCustomerInfoCacheIfNotInUserDefaults() {
         self.systemInfo.stubbedIsApplicationBackgrounded = false
         self.setupPurchases()
-        expect(self.backend.getSubscriberCallCount).toEventually(equal(1))
+        expect(self.backend.getCustomerInfoCallCount).toEventually(equal(1))
     }
 
     func testFirstInitializationFromForegroundUpdatesCustomerInfoCacheIfUserDefaultsCacheStale() {
@@ -304,7 +304,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
 
         self.setupPurchases()
 
-        expect(self.backend.getSubscriberCallCount).toEventually(equal(1))
+        expect(self.backend.getCustomerInfoCallCount).toEventually(equal(1))
     }
 
     func testFirstInitializationFromForegroundUpdatesCustomerInfoEvenIfCacheValid() {
@@ -316,7 +316,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
 
         self.setupPurchases()
 
-        expect(self.backend.getSubscriberCallCount).toEventually(equal(1))
+        expect(self.backend.getCustomerInfoCallCount).toEventually(equal(1))
     }
 
     func testProxyURL() {
@@ -474,7 +474,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
 
         self.setupPurchases()
 
-        expect(self.backend.getSubscriberCallCount).toEventually(equal(0))
+        expect(self.backend.getCustomerInfoCallCount).toEventually(equal(0))
     }
 
     // MARK: - UserDefaults

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesDelegateTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesDelegateTests.swift
@@ -61,21 +61,21 @@ class PurchasesDelegateTests: BasePurchasesTests {
     }
 
     func testAutomaticallyFetchesCustomerInfoOnDidBecomeActiveIfCacheStale() {
-        expect(self.backend.getSubscriberCallCount).toEventually(equal(1))
+        expect(self.backend.getCustomerInfoCallCount).toEventually(equal(1))
 
         self.deviceCache.stubbedIsCustomerInfoCacheStale = true
         self.notificationCenter.fireNotifications()
 
-        expect(self.backend.getSubscriberCallCount).toEventually(equal(2))
+        expect(self.backend.getCustomerInfoCallCount).toEventually(equal(2))
     }
 
     func testDoesntAutomaticallyFetchCustomerInfoOnDidBecomeActiveIfCacheValid() {
-        expect(self.backend.getSubscriberCallCount).toEventually(equal(1))
+        expect(self.backend.getCustomerInfoCallCount).toEventually(equal(1))
         self.deviceCache.stubbedIsCustomerInfoCacheStale = false
 
         self.notificationCenter.fireNotifications()
 
-        expect(self.backend.getSubscriberCallCount).toEventually(equal(1))
+        expect(self.backend.getCustomerInfoCallCount).toEventually(equal(1))
     }
 
     func testAutomaticallyCallsDelegateOnDidBecomeActiveAndUpdate() {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetCustomerInfoTests.swift
@@ -137,7 +137,7 @@ class PurchasesGetCustomerInfoTests: BasePurchasesTests {
     func testDoesntSendCacheIfNoCacheAndCallsBackendAgain() {
         self.setupPurchases()
 
-        expect(self.backend.getSubscriberCallCount).toEventually(equal(1))
+        expect(self.backend.getCustomerInfoCallCount).toEventually(equal(1))
 
         self.deviceCache.cachedCustomerInfo = [:]
 
@@ -145,7 +145,7 @@ class PurchasesGetCustomerInfoTests: BasePurchasesTests {
             self.purchases.getCustomerInfo { (_, _) in completion() }
         }
 
-        expect(self.backend.getSubscriberCallCount) == 2
+        expect(self.backend.getCustomerInfoCallCount) == 2
     }
 
     func testFetchCustomerInfoWhenCacheStale() {
@@ -157,7 +157,7 @@ class PurchasesGetCustomerInfoTests: BasePurchasesTests {
             self.purchases.getCustomerInfo { (_, _) in completed() }
         }
 
-        expect(self.backend.getSubscriberCallCount) == 2
+        expect(self.backend.getCustomerInfoCallCount) == 2
     }
 
     func testGetCustomerInfoAfterInvalidatingDoesntReturnCachedVersion() throws {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -65,7 +65,7 @@ class PurchasesLogInTests: BasePurchasesTests {
         self.identityManager.mockLogOutError = nil
         self.backend.overrideCustomerInfoResult = .success(Self.mockLoggedOutInfo)
 
-        expect(self.backend.getSubscriberCallCount) == 1
+        expect(self.backend.getCustomerInfoCallCount).toEventually(equal(1))
 
         let result = waitUntilValue { completed in
             self.purchases.logOut { customerInfo, error in
@@ -76,7 +76,7 @@ class PurchasesLogInTests: BasePurchasesTests {
         expect(result).to(beSuccess())
         expect(result?.value) == Self.mockLoggedOutInfo
 
-        expect(self.backend.getSubscriberCallCount) == 2
+        expect(self.backend.getCustomerInfoCallCount) == 2
         expect(self.identityManager.invokedLogOutCount) == 1
     }
 
@@ -94,7 +94,7 @@ class PurchasesLogInTests: BasePurchasesTests {
         expect(result).to(beFailure())
         expect(result?.error).to(matchError(error))
 
-        expect(self.backend.getSubscriberCallCount) == 1
+        expect(self.backend.getCustomerInfoCallCount) == 1
         expect(self.identityManager.invokedLogOutCount) == 1
     }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
@@ -1032,7 +1032,7 @@ class PurchasesPurchasingCustomSetupTests: BasePurchasesTests {
         expect(underlyingError.domain) == SKErrorDomain
         expect(underlyingError.code) == SKError.Code.paymentCancelled.rawValue
 
-        expect(self.backend.getSubscriberCallCount) == 0
+        expect(self.backend.getCustomerInfoCallCount) == 0
     }
 
     @MainActor
@@ -1066,7 +1066,7 @@ class PurchasesPurchasingCustomSetupTests: BasePurchasesTests {
         expect(receivedError).to(matchError(ErrorCode.purchaseCancelledError))
         expect(result).to(beNil())
 
-        expect(self.backend.getSubscriberCallCount) == 0
+        expect(self.backend.getCustomerInfoCallCount) == 0
     }
 
     // MARK: -


### PR DESCRIPTION
The `getCustomerInfo` call is asynchronous, so this expectation should be too.

I also renamed the old property name to "customer".