### PR TITLE
`Refactor`: extracted `Collection.subscript(safe:)`

### DIFF
--- a/Sources/FoundationExtensions/Array+Extensions.swift
+++ b/Sources/FoundationExtensions/Array+Extensions.swift
@@ -35,6 +35,11 @@ extension Collection {
         return first
     }
 
+    /// Returns the element at the specified index if it exists, otherwise nil.
+    subscript(safe index: Index) -> Element? {
+        return self.indices.contains(index) ? self[index] : nil
+    }
+
 }
 
 extension Sequence where Element: AdditiveArithmetic {

--- a/Tests/UnitTests/FoundationExtensions/ArrayExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/ArrayExtensionsTests.swift
@@ -57,6 +57,24 @@ class ArrayExtensionsTests: TestCase {
         expect([1].onlyElement) == 1
     }
 
+    // MARK: - safeIndex
+
+    func testSafeIndexWithEmptyArray() {
+        expect([Any]()[safe: 0]).to(beNil())
+        expect([Any]()[safe: 1]).to(beNil())
+    }
+
+    func testSafeIndexWithMultipleElements() {
+        expect([1, 2][safe: 0]) == 1
+        expect([1, 2][safe: 1]) == 2
+        expect([1, 2][safe: 3]).to(beNil())
+    }
+
+    func testSafeIndexWithSingleElement() {
+        expect([1][safe: 0]) == 1
+        expect([1][safe: 0]).to(beNil())
+    }
+
     // MARK: - sum
 
     func testSumEmptyArray() {

--- a/Tests/UnitTests/FoundationExtensions/ArrayExtensionsTests.swift
+++ b/Tests/UnitTests/FoundationExtensions/ArrayExtensionsTests.swift
@@ -72,7 +72,7 @@ class ArrayExtensionsTests: TestCase {
 
     func testSafeIndexWithSingleElement() {
         expect([1][safe: 0]) == 1
-        expect([1][safe: 0]).to(beNil())
+        expect([1][safe: 1]).to(beNil())
     }
 
     // MARK: - sum

--- a/Tests/UnitTests/Networking/Responses/OfferingsDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/OfferingsDecodingTests.swift
@@ -104,12 +104,3 @@ class OfferingsDecodingTests: BaseHTTPResponseTest {
     }
 
 }
-
-private extension Collection {
-
-    /// Returns the element at the specified index if it exists, otherwise nil.
-    subscript (safe index: Index) -> Element? {
-        return indices.contains(index) ? self[index] : nil
-    }
-
-}


### PR DESCRIPTION
This is useful to have in extensions and not just in this test.
