### PR TITLE
`Paywalls`: using `PaywallData` and setting up basic template loading

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -6,46 +6,16 @@ import SwiftUI
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 public struct PaywallView: View {
 
-    public let offering: Offering
+    private let offering: Offering
+    private let paywall: PaywallData
 
-    public init(offering: Offering) {
+    public init(offering: Offering, paywall: PaywallData) {
         self.offering = offering
+        self.paywall = paywall
     }
 
     public var body: some View {
-        VStack {
-            Text(verbatim: "Offering: \(self.offering.identifier)")
-                .font(.title)
-
-            List {
-                ForEach(self.offering.availablePackages, id: \.identifier) { package in
-                    self.label(for: package)
-                        .listRowBackground(
-                            Rectangle()
-                                .foregroundStyle(.thinMaterial)
-                        )
-                }
-            }
-            .scrollContentBackground(.hidden)
-        }
-        .background(.blue.gradient)
-    }
-
-    private func label(for package: Package) -> some View {
-        HStack {
-            Button {
-
-            } label: {
-                Text(package.storeProduct.localizedTitle)
-                    .padding(.vertical)
-            }
-            .buttonStyle(.plain)
-
-            Spacer()
-
-            Image(systemName: "chevron.right")
-                .font(.body)
-        }
+        self.paywall.createView(for: self.offering)
     }
 
 }
@@ -56,7 +26,7 @@ public struct PaywallView: View {
 struct PaywallView_Previews: PreviewProvider {
 
     static var previews: some View {
-        PaywallView(offering: TestData.offering)
+        PaywallView(offering: TestData.offering, paywall: TestData.paywall)
     }
 
 }

--- a/RevenueCatUI/Templates/Example1Template.swift
+++ b/RevenueCatUI/Templates/Example1Template.swift
@@ -1,0 +1,73 @@
+import RevenueCat
+import SwiftUI
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+struct Example1Template: TemplateViewType {
+
+    private let packages: [Package]
+    private let localization: PaywallData.LocalizedConfiguration
+    private let configuration: PaywallData.Configuration
+
+    init(
+        packages: [Package],
+        localization: PaywallData.LocalizedConfiguration,
+        configuration: PaywallData.Configuration
+    ) {
+        self.packages = packages
+        self.localization = localization
+        self.configuration = configuration
+    }
+
+    var body: some View {
+        VStack {
+            Text(verbatim: self.localization.title)
+                .font(.title)
+
+            List {
+                ForEach(self.packages, id: \.identifier) { package in
+                    self.label(for: package)
+                        .listRowBackground(
+                            Rectangle()
+                                .foregroundStyle(.thinMaterial)
+                        )
+                }
+            }
+            .scrollContentBackground(.hidden)
+
+            Button {
+
+            } label: {
+                Text(self.localization.callToAction)
+            }
+            .buttonStyle(.borderedProminent)
+            .font(.title2)
+            .tint(Color.indigo.gradient)
+            .buttonBorderShape(.roundedRectangle)
+            .controlSize(.large)
+        }
+        .background(.blue.gradient)
+    }
+
+}
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+private extension Example1Template {
+
+    private func label(for package: Package) -> some View {
+        HStack {
+            Button {
+
+            } label: {
+                Text(package.storeProduct.localizedTitle)
+                    .padding(.vertical)
+            }
+            .buttonStyle(.plain)
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.body)
+        }
+    }
+
+}

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -1,0 +1,29 @@
+import RevenueCat
+import SwiftUI
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+protocol TemplateViewType: SwiftUI.View {
+
+    init(
+        packages: [Package],
+        localization: PaywallData.LocalizedConfiguration,
+        configuration: PaywallData.Configuration
+    )
+
+}
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+extension PaywallData {
+
+    @ViewBuilder
+    func createView(for offering: Offering) -> some View {
+        switch self.template {
+        case .example1:
+            Example1Template(
+                packages: offering.availablePackages,
+                localization: self.localizedConfiguration,
+                configuration: self.config
+            )
+        }
+    }
+}

--- a/RevenueCatUI/TestData.swift
+++ b/RevenueCatUI/TestData.swift
@@ -45,10 +45,17 @@ internal enum TestData {
         discounts: []
     )
 
+    static let paywall = PaywallData(
+        template: .example1,
+        config: .init(),
+        localization: .init(callToAction: "Purchase Now", title: "Example paywall")
+    )
+
     static let offering = Offering(
         identifier: Self.offeringIdentifier,
         serverDescription: "Main offering",
         metadata: [:],
+        paywall: Self.paywall,
         availablePackages: [
             .init(
                 identifier: "monthly",

--- a/Tests/RevenueCatUITests/PaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallViewTests.swift
@@ -7,7 +7,7 @@ import XCTest
 class PaywallViewTests: TestCase {
 
     func testOne() {
-        let view = PaywallView(offering: TestData.offering)
+        let view = PaywallView(offering: TestData.offering, paywall: TestData.paywall)
             .frame(width: 300, height: 400)
 
         expect(view).to(haveValidSnapshot(as: .image))


### PR DESCRIPTION
This adds a new `TemplateViewType` that different templates can conform to.
`PaywallView` now takes `PaywallData` and renders the paywall depending on its template.
