### PR TITLE
`Trusted Entitlements`: improved documentation

### DIFF
--- a/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
+++ b/Sources/DocCDocumentation/DocCDocumentation.docc/Purchases.md
@@ -115,13 +115,14 @@ Most features require configuring the SDK before using it.
 - ``Purchases/setOnesignalID(_:)``
 
 ### Advanced Configuration
-- ``Purchases/finishTransactions``
+- ``Configuration/Builder/with(observerMode:)``
 - ``Purchases/invalidateCustomerInfoCache()``
 - ``Purchases/forceUniversalAppStore``
 - ``Purchases/proxyURL``
 - ``Purchases/verboseLogs``
 - ``Purchases/verboseLogHandler``
 - ``Purchases/allowSharingAppStoreAccount``
+- ``Configuration/Builder/with(entitlementVerificationMode:)``
 
 ### Configuring the SDK with parameters (deprecated)
 - ``Purchases/configure(withAPIKey:appUserID:)``

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -172,17 +172,20 @@ import Foundation
         }
 
         /// Set ``Configuration/EntitlementVerificationMode``.
+        ///
         /// Defaults to ``Configuration/EntitlementVerificationMode/disabled``.
         ///
         /// The result of the verification can be obtained from ``EntitlementInfos/verification`` or
         /// ``EntitlementInfo/verification``.
-        ///
-        /// - Note: This requires iOS 13+.
-        /// - Important: This feature is currently in beta.
+        /// 
+        /// - Note: This feature requires iOS 13+.
         /// - Warning:  When changing from ``Configuration/EntitlementVerificationMode/disabled``
         /// to ``Configuration/EntitlementVerificationMode/informational``
         /// the SDK will clear the ``CustomerInfo`` cache.
         /// This means that users will need to connect to the internet to get back their entitlements.
+        ///
+        /// ### Related Articles
+        /// - [Documentation](https://rev.cat/trusted-entitlements)
         ///
         /// ### Related Symbols
         /// - ``Configuration/EntitlementVerificationMode``
@@ -221,6 +224,9 @@ import Foundation
 extension Configuration {
 
     /// Defines how strict ``EntitlementInfo`` verification ought to be.
+    ///
+    /// ### Related Articles
+    /// - [Documentation](https://rev.cat/trusted-entitlements)
     ///
     /// ### Related Symbols
     /// - ``VerificationResult``

--- a/Sources/Purchasing/EntitlementInfo.swift
+++ b/Sources/Purchasing/EntitlementInfo.swift
@@ -167,6 +167,9 @@ extension PeriodType: DefaultValueProvider {
     @objc public var ownershipType: PurchaseOwnershipType { self.contents.ownershipType }
 
     /// Whether this entitlement was verified.
+    /// 
+    /// ### Related Articles
+    /// - [Documentation](https://rev.cat/trusted-entitlements)
     ///
     /// ### Related Symbols
     /// - ``VerificationResult``

--- a/Sources/Purchasing/EntitlementInfos.swift
+++ b/Sources/Purchasing/EntitlementInfos.swift
@@ -32,6 +32,10 @@ import Foundation
     }
 
     /// Whether these entitlements were verified.
+    ///
+    /// ### Related Articles
+    /// - [Documentation](https://rev.cat/trusted-entitlements)
+    ///
     /// ### Related Symbols
     /// - ``VerificationResult``
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)


### PR DESCRIPTION
I've also added a link to our new documentation page: https://rev.cat/trusted-entitlements

![Screenshot 2023-07-11 at 08 47 19](https://github.com/RevenueCat/purchases-ios/assets/685609/1f7cfdd9-7806-4f78-8630-ec860146ac73)
