### PR TITLE
`TestLogHandler`: changed all tests to explicitly deinitialize it

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -24,7 +24,6 @@ custom_rules:
   xctestcase_superclass:
     included: ".*\\.swift"
     excluded:
-      - Tests/BackendIntegrationTests
       - Tests/ReceiptParserTests
       - Tests/v3LoadShedderIntegration
     regex: "\\: XCTestCase \\{"

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -243,6 +243,12 @@
 		4F7DBFBD2A1E986C00A2F511 /* StoreKit2TransactionFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7DBFBC2A1E986C00A2F511 /* StoreKit2TransactionFetcher.swift */; };
 		4F8038332A1EA7C300D21039 /* TransactionPoster.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8038322A1EA7C300D21039 /* TransactionPoster.swift */; };
 		4F82C2682A3CD58200EC98AF /* Matchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F69EB082A14406E00ED6D4B /* Matchers.swift */; };
+		4F83F6B62A5DB773003F90A5 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554CC0282AE1E3009A7E58 /* TestCase.swift */; };
+		4F83F6B72A5DB782003F90A5 /* CurrentTestCaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */; };
+		4F83F6B82A5DB78C003F90A5 /* OSVersionEquivalent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DE80AD28075D77008D6C6F /* OSVersionEquivalent.swift */; };
+		4F83F6B92A5DB805003F90A5 /* TestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57554CC0282AE1E3009A7E58 /* TestCase.swift */; };
+		4F83F6BA2A5DB807003F90A5 /* CurrentTestCaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A17AA2773A59300AA6F22 /* CurrentTestCaseTracker.swift */; };
+		4F83F6BB2A5DB80B003F90A5 /* OSVersionEquivalent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DE80AD28075D77008D6C6F /* OSVersionEquivalent.swift */; };
 		4F8A58172A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */; };
 		4F8A58182A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */; };
 		4F90AFCB2A3915340047E63F /* TestMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F90AFCA2A3915340047E63F /* TestMessage.swift */; };
@@ -3626,11 +3632,13 @@
 				575A8EE22922C56300936709 /* AsyncTestHelpers.swift in Sources */,
 				2DA85A8B26DEA7DD00F1136D /* MockProductsRequestFactory.swift in Sources */,
 				2D3BFAD326DEA47100370B11 /* MockSKProductDiscount.swift in Sources */,
+				4F83F6B72A5DB782003F90A5 /* CurrentTestCaseTracker.swift in Sources */,
 				57DE80BE28077010008D6C6F /* XCTestCase+Extensions.swift in Sources */,
 				2D3BFAD426DEA49200370B11 /* SKProductSubscriptionDurationExtensions.swift in Sources */,
 				579234E327F7788900B39C68 /* BaseBackendIntegrationTests.swift in Sources */,
 				4F2017D52A15587F0061F6EF /* OfflineStoreKitIntegrationTests.swift in Sources */,
 				2DE20B6F264087FB004C597D /* StoreKitIntegrationTests.swift in Sources */,
+				4F83F6B62A5DB773003F90A5 /* TestCase.swift in Sources */,
 				4FCBA84F2A15391B004134BD /* SnapshotTesting+Extensions.swift in Sources */,
 				4FA696BD2A0020A000D228B1 /* MainThreadMonitor.swift in Sources */,
 				2D3BFAD126DEA45C00370B11 /* MockSK1Product.swift in Sources */,
@@ -3641,6 +3649,7 @@
 				4F2018732A15797D0061F6EF /* TestLogHandler.swift in Sources */,
 				4F90AFCB2A3915340047E63F /* TestMessage.swift in Sources */,
 				2D3BFAD226DEA46600370B11 /* MockProductsRequest.swift in Sources */,
+				4F83F6B82A5DB78C003F90A5 /* OSVersionEquivalent.swift in Sources */,
 				2D1015DB275A4EAE0086173F /* AvailabilityChecks.swift in Sources */,
 				5753EE0E294B938900CBAB54 /* StoreKitObserverModeIntegrationTests.swift in Sources */,
 				579189FD28F4966500BF4963 /* OtherIntegrationTests.swift in Sources */,
@@ -3670,10 +3679,13 @@
 			files = (
 				4F7C37B22A27E2E8001E17D3 /* AsyncTestHelpers.swift in Sources */,
 				4F6BEE362A27B0F200CD9322 /* MainThreadMonitor.swift in Sources */,
+				4F83F6BB2A5DB80B003F90A5 /* OSVersionEquivalent.swift in Sources */,
+				4F83F6BA2A5DB807003F90A5 /* CurrentTestCaseTracker.swift in Sources */,
 				4F6BEE3B2A27B45300CD9322 /* StoreKitTestHelpers.swift in Sources */,
 				4F6BEE1F2A27B02400CD9322 /* CustomEntitlementsComputationIntegrationTests.swift in Sources */,
 				4F7C37E62A27F14B001E17D3 /* XCTestCase+Extensions.swift in Sources */,
 				4F7C37E52A27EFF7001E17D3 /* BaseStoreKitIntegrationTests.swift in Sources */,
+				4F83F6B92A5DB805003F90A5 /* TestCase.swift in Sources */,
 				4F6BEE3C2A27B45900CD9322 /* Constants.swift in Sources */,
 				4F90AFCC2A3915BC0047E63F /* TestMessage.swift in Sources */,
 				4F7C37E42A27EFE1001E17D3 /* BaseBackendIntegrationTests.swift in Sources */,

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -36,7 +36,7 @@ final class TestPurchaseDelegate: NSObject, PurchasesDelegate, Sendable {
 }
 
 @MainActor
-class BaseBackendIntegrationTests: XCTestCase {
+class BaseBackendIntegrationTests: TestCase {
 
     private var userDefaults: UserDefaults!
     private var testUUID: UUID!

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -29,6 +29,10 @@ class BaseStoreKitIntegrationTests: BaseBackendIntegrationTests {
     private(set) var testSession: SKTestSession!
 
     override func setUp() async throws {
+        // `super.setUp()` isn't called until the end of this method,
+        // but some tests might need to introspect logs during initialization.
+        super.initializeLogger()
+
         if self.testSession == nil {
             try self.configureTestSession()
         }

--- a/Tests/BackendIntegrationTests/CustomEntitlementsComputationIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/CustomEntitlementsComputationIntegrationTests.swift
@@ -21,23 +21,13 @@ import XCTest
 
 final class CustomEntitlementsComputationIntegrationTests: BaseStoreKitIntegrationTests {
 
-    private var logger: TestLogHandler!
-
     override func setUp() async throws {
-        self.logger = .init()
+        try await super.setUp()
 
         self.addTeardownBlock { [logger = self.logger!] in
             // No `GetCustomerInfoOperation` requests should be made
             logger.verifyMessageWasNotLogged("GetCustomerInfoOperation")
         }
-
-        try await super.setUp()
-    }
-
-    override func tearDown() {
-        self.logger = nil
-
-        super.tearDown()
     }
 
     override func configurePurchases() {
@@ -76,11 +66,9 @@ final class CustomEntitlementsComputationIntegrationTests: BaseStoreKitIntegrati
     func testPurchasingPostsAdAttributionToken() async throws {
         Purchases.shared.attribution.enableAdServicesAttributionTokenCollection()
 
-        let logger = TestLogHandler()
-
         let info = try await self.purchaseMonthlyOffering().customerInfo
 
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             Strings.attribution.adservices_marking_as_synced(appUserID: info.originalAppUserId),
             level: .info
         )

--- a/Tests/BackendIntegrationTests/LoadShedderIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/LoadShedderIntegrationTests.swift
@@ -39,20 +39,6 @@ class LoadShedderStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
     // MARK: -
 
-    private var logger: TestLogHandler!
-
-    override func setUp() async throws {
-        self.logger = TestLogHandler(capacity: 500)
-
-        try await super.setUp()
-    }
-
-    override func tearDown() async throws {
-        self.logger = nil
-
-        try await super.tearDown()
-    }
-
     func testCanGetOfferings() async throws {
         let receivedOfferings = try await Purchases.shared.offerings()
 

--- a/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
@@ -28,8 +28,6 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
         // 1. Fetch user once
         _ = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
 
-        let logger = TestLogHandler()
-
         // 2. Re-fetch user
         _ = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
 
@@ -37,7 +35,7 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
                                           path: .getCustomerInfo(appUserID: Purchases.shared.appUserID))
 
         // 3. Verify response was 304
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             Strings.network.api_request_completed(expectedRequest, httpCode: .notModified)
         )
     }
@@ -49,8 +47,6 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
         // 2. Fetch user once
         _ = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
 
-        let logger = TestLogHandler()
-
         // 3. Re-fetch user
         _ = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
 
@@ -58,7 +54,7 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
                                           path: .getCustomerInfo(appUserID: Purchases.shared.appUserID))
 
         // 4. Verify response was 304
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             Strings.network.api_request_completed(expectedRequest, httpCode: .notModified)
         )
     }
@@ -72,11 +68,9 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
     }
 
     func testHandledByProductionServer() async throws {
-        let logger = TestLogHandler()
-
         try await Purchases.shared.healthRequest(signatureVerification: false)
 
-        logger.verifyMessageWasNotLogged(Strings.network.request_handled_by_load_shedder(.health))
+        self.logger.verifyMessageWasNotLogged(Strings.network.request_handled_by_load_shedder(.health))
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
@@ -91,11 +85,9 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
 
     @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
     func testEnableAdServicesAttributionTokenCollection() async throws {
-        let logger = TestLogHandler()
-
         Purchases.shared.attribution.enableAdServicesAttributionTokenCollection()
 
-        try await logger.verifyMessageIsEventuallyLogged(
+        try await self.logger.verifyMessageIsEventuallyLogged(
             Strings.attribution.adservices_token_post_succeeded.description,
             level: .debug,
             timeout: .seconds(3),

--- a/Tests/BackendIntegrationTests/SignatureVerificationIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/SignatureVerificationIntegrationTests.swift
@@ -194,15 +194,13 @@ class EnforcedSignatureVerificationIntegrationTests: BaseSignatureVerificationIn
     }
 
     func testTransactionIsNotFinishedAfterSignatureFailure() async throws {
-        let logger = TestLogHandler()
-
         self.invalidSignature = true
 
         try await Self.verifyThrowsSignatureVerificationFailed {
             try await self.purchaseMonthlyProduct()
         }
 
-        logger.verifyMessageWasNotLogged("Finishing transaction")
+        self.logger.verifyMessageWasNotLogged("Finishing transaction")
     }
 
     func testTransactionIsFinishedAfterSuccessfulyPostingPurchase() async throws {
@@ -216,14 +214,13 @@ class EnforcedSignatureVerificationIntegrationTests: BaseSignatureVerificationIn
         // 2. Get customer info again, which should post the pending transaction
         self.invalidSignature = false
 
-        let logger = TestLogHandler()
         let info = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
 
         // 3. Verify entitlement is active
         try await self.verifyEntitlementWentThrough(info)
 
         // 4. Verify transaction was finished
-        logger.verifyMessageWasLogged("Finishing transaction", level: .info)
+        self.logger.verifyMessageWasLogged("Finishing transaction", level: .info)
     }
 
 }

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -46,12 +46,10 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     }
 
     func testCanPurchasePackage() async throws {
-        let logger = TestLogHandler()
-
         let package = try await self.monthlyPackage
         try await self.purchaseMonthlyOffering()
 
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             Strings.purchase.transaction_poster_handling_transaction(
                 productID: package.storeProduct.productIdentifier,
                 offeringID: package.offeringIdentifier
@@ -66,8 +64,6 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     func testPurchasingPackageWithPresentedOfferingIdentifier() async throws {
         let package = try await self.monthlyPackage
 
-        let logger = TestLogHandler()
-
         Purchases.shared.cachePresentedOfferingIdentifier(
             package.offeringIdentifier,
             productIdentifier: package.storeProduct.productIdentifier
@@ -75,7 +71,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
         try await self.purchaseMonthlyProduct()
 
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             Strings.purchase.transaction_poster_handling_transaction(
                 productID: package.storeProduct.productIdentifier,
                 offeringID: package.offeringIdentifier

--- a/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
@@ -67,11 +67,9 @@ class StoreKit2ObserverModeIntegrationTests: StoreKit1ObserverModeIntegrationTes
 
         try await self.purchaseProductFromStoreKit(productIdentifier: productID, finishTransaction: true)
 
-        let logger = TestLogHandler()
-
         try self.testSession.forceRenewalOfSubscription(productIdentifier: productID)
 
-        try await logger.verifyMessageIsEventuallyLogged(
+        try await self.logger.verifyMessageIsEventuallyLogged(
             Strings.network.operation_state(PostReceiptDataOperation.self, state: "Finished").description,
             timeout: .seconds(3),
             pollInterval: .milliseconds(100)
@@ -120,11 +118,9 @@ class StoreKit1ObserverModeIntegrationTests: BaseStoreKitObserverModeIntegration
 
         try await self.purchaseProductFromStoreKit(productIdentifier: productID, finishTransaction: true)
 
-        let logger = TestLogHandler()
-
         try? self.testSession.forceRenewalOfSubscription(productIdentifier: productID)
 
-        try await logger.verifyMessageIsEventuallyLogged(
+        try await self.logger.verifyMessageIsEventuallyLogged(
             "Network operation 'PostReceiptDataOperation' found with the same cache key",
             timeout: .seconds(4),
             pollInterval: .milliseconds(100)

--- a/Tests/StoreKitUnitTests/LoggerTests.swift
+++ b/Tests/StoreKitUnitTests/LoggerTests.swift
@@ -20,19 +20,16 @@ import XCTest
 // which means it would interfere with other tests if ran concurrently.
 class LoggerTests: TestCase {
 
-    private var logger: TestLogHandler!
     private var previousLogLevel: LogLevel!
 
     override func setUp() {
         super.setUp()
 
-        self.logger = .init()
         self.previousLogLevel = Logger.logLevel
     }
 
     override func tearDown() {
         Logger.logLevel = self.previousLogLevel
-        self.logger = nil
 
         super.tearDown()
     }

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -1175,15 +1175,13 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     #endif
 
     func testRestorePurchasesDoesNotLogWarningIfAllowSharingAppStoreAccountIsNotDefined() async throws {
-        let logger = TestLogHandler()
-
         self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
 
         _ = try? await self.orchestrator.syncPurchases(receiptRefreshPolicy: .never,
                                                        isRestore: false,
                                                        initiationSource: .restore)
 
-        logger.verifyMessageWasNotLogged(
+        self.logger.verifyMessageWasNotLogged(
             Strings
                 .purchase
                 .restorepurchases_called_with_allow_sharing_appstore_account_false
@@ -1191,8 +1189,6 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     }
 
     func testRestorePurchasesDoesNotLogWarningIfAllowSharingAppStoreAccountIsTrue() async throws {
-        let logger = TestLogHandler()
-
         self.orchestrator.allowSharingAppStoreAccount = true
 
         self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
@@ -1201,7 +1197,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                                                        isRestore: false,
                                                        initiationSource: .restore)
 
-        logger.verifyMessageWasNotLogged(
+        self.logger.verifyMessageWasNotLogged(
             Strings
                 .purchase
                 .restorepurchases_called_with_allow_sharing_appstore_account_false
@@ -1209,8 +1205,6 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     }
 
     func testRestorePurchasesLogsWarningIfAllowSharingAppStoreAccountIsFalse() async throws {
-        let logger = TestLogHandler()
-
         self.orchestrator.allowSharingAppStoreAccount = false
 
         self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
@@ -1219,7 +1213,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
                                                        isRestore: false,
                                                        initiationSource: .restore)
 
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             Strings
                 .purchase
                 .restorepurchases_called_with_allow_sharing_appstore_account_false,

--- a/Tests/StoreKitUnitTests/StoreKit2/StoreKit2TransactionListenerTests.swift
+++ b/Tests/StoreKitUnitTests/StoreKit2/StoreKit2TransactionListenerTests.swift
@@ -205,8 +205,6 @@ class StoreKit2TransactionListenerTransactionUpdatesTests: StoreKit2TransactionL
 
     @available(iOS 16.4, macOS 13.3, tvOS 16.4, watchOS 9.4, *)
     func testNotifiesDelegateForRenewals() async throws {
-        let logger = TestLogHandler()
-
         try await self.simulateAnyPurchase(finishTransaction: true)
 
         self.listener.listenForTransactions()
@@ -220,7 +218,7 @@ class StoreKit2TransactionListenerTransactionUpdatesTests: StoreKit2TransactionL
                 transaction.productIdentifier == Self.productID
             })
 
-        logger.verifyMessageWasLogged(Strings.purchase.sk2_transactions_update_received_transaction(
+        self.logger.verifyMessageWasLogged(Strings.purchase.sk2_transactions_update_received_transaction(
             productID: Self.productID
         ))
     }

--- a/Tests/UnitTests/Identity/CustomerInfoManagerPostReceiptTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerPostReceiptTests.swift
@@ -83,8 +83,6 @@ class CustomerInfoManagerPostReceiptTests: BaseCustomerInfoManagerTests {
     }
 
     func testPostsAllTransactions() async throws {
-        let logger = TestLogHandler()
-
         let transactions = [
             Self.createTransaction(),
             Self.createTransaction(),
@@ -106,7 +104,7 @@ class CustomerInfoManagerPostReceiptTests: BaseCustomerInfoManagerTests {
         )
             == transactions
 
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             Strings.customerInfo.posting_transactions_in_lieu_of_fetching_customerinfo(transactions),
             level: .debug
         )
@@ -123,8 +121,6 @@ class CustomerInfoManagerPostReceiptTests: BaseCustomerInfoManagerTests {
                 "original_application_version": NSNull()
             ]  as [String: Any]
         ])
-
-        let logger = TestLogHandler()
 
         let transactions = [
             Self.createTransaction(),
@@ -151,7 +147,7 @@ class CustomerInfoManagerPostReceiptTests: BaseCustomerInfoManagerTests {
         )
             == transactions
 
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             Strings.customerInfo.posting_transactions_in_lieu_of_fetching_customerinfo(transactions),
             level: .debug
         )

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -433,8 +433,6 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         // Entitlement verification not available prior
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
-        let logger = TestLogHandler()
-
         let appUserID = "myUser"
         let info = self.mockCustomerInfo.copy(with: .verifiedOnDevice)
 
@@ -444,7 +442,7 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         expect(self.mockDeviceCache.cacheCustomerInfoCount) == 0
         expect(self.mockDeviceCache.invokedClearCustomerInfoCache) == true
 
-        logger.verifyMessageWasLogged(Strings.customerInfo.not_caching_offline_customer_info, level: .debug)
+        self.logger.verifyMessageWasLogged(Strings.customerInfo.not_caching_offline_customer_info, level: .debug)
     }
 
     func testCacheCustomerInfoSendsToDelegateIfChanged() {

--- a/Tests/UnitTests/Identity/IdentityManagerTests.swift
+++ b/Tests/UnitTests/Identity/IdentityManagerTests.swift
@@ -111,8 +111,6 @@ class IdentityManagerTests: TestCase {
     func testConfigureInvalidesCacheIfVerificationIsEnabledButCachedUserIsNotVerified() throws {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
-        let logger = TestLogHandler()
-
         self.mockCustomerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo.copy(with: .notRequested)
         self.mockBackend.stubbedSignatureVerificationEnabled = true
         self.create(appUserID: "nacho")
@@ -123,7 +121,7 @@ class IdentityManagerTests: TestCase {
         expect(self.mockDeviceCache.invokedClearCustomerInfoCache) == true
         expect(self.mockDeviceCache.invokedClearCustomerInfoCacheParameters?.appUserID) == "nacho"
 
-        logger.verifyMessageWasLogged(Strings.identity.invalidating_cached_customer_info, level: .info)
+        self.logger.verifyMessageWasLogged(Strings.identity.invalidating_cached_customer_info, level: .info)
     }
 
     func testIdentifyingCorrectlyIdentifies() {

--- a/Tests/UnitTests/Misc/TestCase.swift
+++ b/Tests/UnitTests/Misc/TestCase.swift
@@ -22,6 +22,14 @@ class TestCase: XCTestCase {
 
     private(set) var logger: TestLogHandler!
 
+    /// Called at the beginning of every test, but it can be manually used
+    /// before calling `super.setUp()` in case a test needs to verify logs generated early in the lifetime.
+    final func initializeLogger() {
+        guard self.logger == nil else { return }
+
+        self.logger = TestLogHandler()
+    }
+
     @MainActor
     override class func setUp() {
         XCTestObservationCenter.shared.addTestObserver(CurrentTestCaseTracker.shared)
@@ -38,7 +46,7 @@ class TestCase: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        self.logger = TestLogHandler()
+        self.initializeLogger()
     }
 
     @MainActor

--- a/Tests/UnitTests/Misc/TestCase.swift
+++ b/Tests/UnitTests/Misc/TestCase.swift
@@ -20,33 +20,33 @@ import XCTest
 /// Provides automatic tracking of test cases using `CurrentTestCaseTracker` as well as snapshot testing helpers.
 class TestCase: XCTestCase {
 
+    private(set) var logger: TestLogHandler!
+
+    @MainActor
     override class func setUp() {
         XCTestObservationCenter.shared.addTestObserver(CurrentTestCaseTracker.shared)
 
         SnapshotTests.updateSnapshotsIfNeeded()
     }
 
+    @MainActor
     override class func tearDown() {
         XCTestObservationCenter.shared.removeTestObserver(CurrentTestCaseTracker.shared)
     }
 
-    // MARK: - MainActor overrides
-
-    // Note: these arent't required for Xcode 14+, but solve warnings prior to that.
-
-    #if swift(<5.7)
-
     @MainActor
     override func setUpWithError() throws {
         try super.setUpWithError()
+
+        self.logger = TestLogHandler()
     }
 
     @MainActor
     override func tearDown() {
+        self.logger = nil
+
         super.tearDown()
     }
-
-    #endif
 
     // MARK: -
 

--- a/Tests/UnitTests/Misc/TestCase.swift
+++ b/Tests/UnitTests/Misc/TestCase.swift
@@ -27,7 +27,7 @@ class TestCase: XCTestCase {
     final func initializeLogger() {
         guard self.logger == nil else { return }
 
-        self.logger = TestLogHandler()
+        self.logger = TestLogHandler(capacity: 500)
     }
 
     @MainActor

--- a/Tests/UnitTests/Misc/TimingUtilTests.swift
+++ b/Tests/UnitTests/Misc/TimingUtilTests.swift
@@ -55,8 +55,6 @@ class TimingUtilAsyncTests: TestCase {
     }
 
     func testMeasureAndLogWithResultDoesNotLogIfLowerThanThreshold() async {
-        let logger = TestLogHandler()
-
         let expectedResult = Int.random(in: 0..<1000)
         let threshold: DispatchTimeInterval = .milliseconds(10)
         let sleepDuration = threshold + .milliseconds(-5)
@@ -69,12 +67,10 @@ class TimingUtilAsyncTests: TestCase {
         }
 
         expect(result) == expectedResult
-        expect(logger.messages).to(beEmpty())
+        expect(self.logger.messages).to(beEmpty())
     }
 
     func testMeasureAndLogWithResult() async {
-        let logger = TestLogHandler()
-
         let expectedResult = Int.random(in: 0..<1000)
         let threshold: DispatchTimeInterval = .milliseconds(10)
         let sleepDuration = threshold + .milliseconds(10)
@@ -93,7 +89,7 @@ class TimingUtilAsyncTests: TestCase {
         expect(result) == expectedResult
 
         // Expected: 🍎⚠️ Computation took too long (0.02 seconds)
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             String(format: "%@ %@ (%.2f seconds)",
                    LogIntent.appleWarning.prefix,
                    message,
@@ -103,8 +99,6 @@ class TimingUtilAsyncTests: TestCase {
     }
 
     func testMeasureAndLogThrowsError() async {
-        let logger = TestLogHandler()
-
         let expectedError: ErrorCode = .storeProblemError
 
         do {
@@ -118,12 +112,10 @@ class TimingUtilAsyncTests: TestCase {
             expect(error).to(matchError(expectedError))
         }
 
-        expect(logger.messages).to(beEmpty())
+        expect(self.logger.messages).to(beEmpty())
     }
 
     func testMeasureSyncAndLogDoesNotLogIfLowerThanThreshold() {
-        let logger = TestLogHandler()
-
         let expectedResult = Int.random(in: 0..<1000)
         let threshold: DispatchTimeInterval = .milliseconds(10)
         let sleepDuration = threshold + .milliseconds(-5)
@@ -136,12 +128,10 @@ class TimingUtilAsyncTests: TestCase {
         }
 
         expect(result) == expectedResult
-        expect(logger.messages).to(beEmpty())
+        expect(self.logger.messages).to(beEmpty())
     }
 
     func testMeasureSyncAndLogThrowsError() {
-        let logger = TestLogHandler()
-
         let expectedError: ErrorCode = .storeProblemError
 
         do {
@@ -155,12 +145,10 @@ class TimingUtilAsyncTests: TestCase {
             expect(error).to(matchError(expectedError))
         }
 
-        expect(logger.messages).to(beEmpty())
+        expect(self.logger.messages).to(beEmpty())
     }
 
     func testMeasureSyncAndLogWithResult() {
-        let logger = TestLogHandler()
-
         let expectedResult = Int.random(in: 0..<1000)
         let threshold: DispatchTimeInterval = .milliseconds(10)
         let sleepDuration = threshold + .milliseconds(10)
@@ -179,7 +167,7 @@ class TimingUtilAsyncTests: TestCase {
         expect(result) == expectedResult
 
         // Expected: 🍎⚠️ Computation took too long (0.02 seconds)
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             String(format: "%@ %@ (%.2f seconds)",
                    LogIntent.appleWarning.prefix,
                    message,
@@ -214,8 +202,6 @@ class TimingUtilCompletionBlockTests: TestCase {
     }
 
     func testMeasureAndLogDoesNotLogIfLowerThanThreshold() {
-        let logger = TestLogHandler()
-
         let expectedResult = Int.random(in: 0..<1000)
         let threshold: DispatchTimeInterval = .milliseconds(10)
         let sleepDuration = threshold + .milliseconds(-5)
@@ -233,12 +219,10 @@ class TimingUtilCompletionBlockTests: TestCase {
 
         expect(result).toEventuallyNot(beNil())
         expect(result) == expectedResult
-        expect(logger.messages).to(beEmpty())
+        expect(self.logger.messages).to(beEmpty())
     }
 
     func testMeasureAndLogWithResult() {
-        let logger = TestLogHandler()
-
         let expectedResult = Int.random(in: 0..<1000)
         let threshold: DispatchTimeInterval = .milliseconds(10)
         let sleepDuration = threshold + .milliseconds(10)
@@ -261,7 +245,7 @@ class TimingUtilCompletionBlockTests: TestCase {
         expect(result).toEventuallyNot(beNil())
         expect(result) == expectedResult
 
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             String(format: "%@ %@ (%.2f seconds)",
                    LogIntent.appleWarning.prefix,
                    message,

--- a/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
@@ -67,8 +67,6 @@ class BackendGetOfferingsTests: BaseBackendTests {
     }
 
     func testRepeatedRequestsLogDebugMessage() {
-        let logger = TestLogHandler()
-
         self.httpClient.mock(
             requestPath: .getOfferings(appUserID: Self.userID),
             response: .init(statusCode: .success,
@@ -80,7 +78,7 @@ class BackendGetOfferingsTests: BaseBackendTests {
 
         expect(self.httpClient.calls).toEventually(haveCount(1))
 
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             "Network operation '\(GetOfferingsOperation.self)' found with the same cache key",
             level: .debug
         )

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -401,8 +401,6 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
     }
 
     func testServerSide500sWithUnknownBody() throws {
-        let logger = TestLogHandler()
-
         let request = HTTPRequest(method: .get, path: .mockPath)
         let errorCode = 500 + Int.random(in: 0..<50)
 
@@ -435,7 +433,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
 
         expect(self.signing.requests).to(beEmpty())
 
-        logger.verifyMessageWasNotLogged("Couldn't decode data from json")
+        self.logger.verifyMessageWasNotLogged("Couldn't decode data from json")
     }
 
     func testInvalidJSONAsDataDoesNotFail() {
@@ -1247,8 +1245,6 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         MockDNSChecker.stubbedErrorWithBlockedHostFromErrorResult.value = expectedDNSError
         let expectedMessage = "\(LogIntent.rcError.prefix) \(expectedDNSError.description)"
 
-        let logHandler = TestLogHandler()
-
         stub(condition: isPath(path)) { _ in
             let response = HTTPStubsResponse.emptySuccessResponse()
             response.error = error
@@ -1264,7 +1260,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         expect(MockDNSChecker.invokedErrorWithBlockedHostFromError.value) == true
         expect(MockDNSChecker.invokedIsBlockedAPIError.value) == false
         expect(obtainedError) == expectedDNSError
-        expect(logHandler.messages.map(\.message))
+        expect(self.logger.messages.map(\.message))
             .to(contain(expectedMessage))
     }
 
@@ -1277,8 +1273,6 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
             resolvedHost: "0.0.0.0"
         )
         MockDNSChecker.stubbedIsBlockedAPIErrorResult.value = false
-
-        let logHandler = TestLogHandler()
 
         stub(condition: isPath(path)) { _ in
             let response = HTTPStubsResponse.emptySuccessResponse()
@@ -1294,7 +1288,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
 
         expect(MockDNSChecker.invokedErrorWithBlockedHostFromError.value) == true
         expect(MockDNSChecker.invokedIsBlockedAPIError.value) == false
-        expect(logHandler.messages.map(\.message))
+        expect(self.logger.messages.map(\.message))
             .toNot(contain(unexpectedDNSError.description))
     }
 
@@ -1417,8 +1411,6 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
             )
         }
 
-        let logger = TestLogHandler()
-
         let response: DataResponse? = waitUntilValue { completion in
             self.client.perform(.init(method: .get, path: pathA), completionHandler: completion)
         }
@@ -1426,7 +1418,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         expect(response).to(beSuccess())
         expect(response?.value?.body) == responseData
 
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             "Performing redirect from '\(pathA.url!.absoluteString)' to '\(pathB.url!.absoluteString)'",
             level: .debug
         )
@@ -1443,14 +1435,12 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
             )
         }
 
-        let logger = TestLogHandler()
-
         let response: DataResponse? = waitUntilValue { completion in
             self.client.perform(.init(method: .get, path: path), completionHandler: completion)
         }
         expect(response).to(beSuccess())
 
-        logger.verifyMessageWasNotLogged(Strings.network.request_handled_by_load_shedder(path))
+        self.logger.verifyMessageWasNotLogged(Strings.network.request_handled_by_load_shedder(path))
     }
 
     func testLoadShedderResponsesAreLogged() throws {
@@ -1466,14 +1456,12 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
             )
         }
 
-        let logger = TestLogHandler()
-
         let response: DataResponse? = waitUntilValue { completion in
             self.client.perform(.init(method: .get, path: path), completionHandler: completion)
         }
         expect(response).to(beSuccess())
 
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             Strings.network.request_handled_by_load_shedder(path),
             level: .debug
         )

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -94,8 +94,6 @@ final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPC
     }
 
     func testFailedVerificationIfResponseContainsNoSignature() throws {
-        let logger = TestLogHandler()
-
         try self.changeClient(.informational)
         self.mockResponse()
 
@@ -110,7 +108,7 @@ final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPC
         expect(response?.value?.verificationResult) == .failed
         expect(self.signing.requests).to(beEmpty())
 
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             Strings.signing.signature_was_requested_but_not_provided(request),
             level: .warn
         )
@@ -121,8 +119,6 @@ final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPC
         let path: HTTPRequest.Path = .getProductEntitlementMapping
         expect(path.supportsSignatureVerification) == true
         expect(path.needsNonceForSigning) == false
-
-        let logger = TestLogHandler()
 
         try self.changeClient(.informational)
         self.mockResponse(path: path,
@@ -140,7 +136,7 @@ final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPC
         expect(response?.value?.verificationResult) == .failed
         expect(self.signing.requests).to(beEmpty())
 
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             Strings.signing.signature_was_requested_but_not_provided(request),
             level: .warn
         )
@@ -323,13 +319,11 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         self.mockPath(request.path, statusCode: .success, requestDate: Self.date1)
         self.signing.stubbedVerificationResult = false
 
-        let logger = TestLogHandler()
-
         let _: DataResponse? = waitUntilValue { completion in
             self.client.perform(request, completionHandler: completion)
         }
 
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             Strings.signing.request_failed_verification(request),
             level: .error,
             expectedCount: 1

--- a/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
+++ b/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
@@ -96,8 +96,6 @@ class NormalCustomerInfoResponseHandlerTests: BaseCustomerInfoResponseHandlerTes
             ]
         )
 
-        let logger = TestLogHandler()
-
         let result = await self.handle(
             .success(
                 .init(statusCode: .success,
@@ -112,7 +110,7 @@ class NormalCustomerInfoResponseHandlerTests: BaseCustomerInfoResponseHandlerTes
         expect(result.value) == Self.sampleCustomerInfo.copy(with: .notRequested)
         expect(self.factory.createRequested) == false
 
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             "\(ErrorCode.invalidSubscriberAttributesError.description) \(errorResponse.attributeErrors)",
             level: .error
         )
@@ -155,7 +153,6 @@ class OfflineCustomerInfoResponseHandlerTests: BaseCustomerInfoResponseHandlerTe
         self.factory.stubbedResult = Self.offlineCustomerInfo
 
         let error: NetworkError = .serverDown()
-        let logger = TestLogHandler()
 
         let result = await self.handle(.failure(error), nil)
         expect(result).to(beFailure())
@@ -163,7 +160,7 @@ class OfflineCustomerInfoResponseHandlerTests: BaseCustomerInfoResponseHandlerTe
 
         expect(self.factory.createRequested) == false
 
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             Strings.offlineEntitlements.computing_offline_customer_info_with_no_entitlement_mapping,
             level: .warn
         )
@@ -174,7 +171,6 @@ class OfflineCustomerInfoResponseHandlerTests: BaseCustomerInfoResponseHandlerTe
         self.factory.stubbedResult = Self.offlineCustomerInfo
 
         let error: NetworkError = .serverDown()
-        let logger = TestLogHandler()
 
         let result = await self.handle(.failure(error), nil)
         expect(result).to(beFailure())
@@ -182,7 +178,7 @@ class OfflineCustomerInfoResponseHandlerTests: BaseCustomerInfoResponseHandlerTe
 
         expect(self.factory.createRequested) == false
 
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             Strings.offlineEntitlements.computing_offline_customer_info_with_no_entitlement_mapping,
             level: .warn
         )
@@ -194,7 +190,6 @@ class OfflineCustomerInfoResponseHandlerTests: BaseCustomerInfoResponseHandlerTe
         ])
         self.factory.stubbedResult = Self.offlineCustomerInfo
 
-        let logger = TestLogHandler()
         let error: NetworkError = .serverDown()
 
         let result = await self.handle(.failure(error), Self.mapping)
@@ -207,8 +202,8 @@ class OfflineCustomerInfoResponseHandlerTests: BaseCustomerInfoResponseHandlerTe
         expect(self.factory.createRequestParameters?.mapping) == Self.mapping
         expect(self.factory.createRequestParameters?.userID) == self.userID
 
-        logger.verifyMessageWasLogged(Strings.offlineEntitlements.computing_offline_customer_info, level: .info)
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(Strings.offlineEntitlements.computing_offline_customer_info, level: .info)
+        self.logger.verifyMessageWasLogged(
             Strings.offlineEntitlements.computed_offline_customer_info(Self.offlineCustomerInfo.entitlements),
             level: .info
         )
@@ -228,8 +223,6 @@ class OfflineCustomerInfoResponseHandlerTests: BaseCustomerInfoResponseHandlerTe
     }
 
     func testServerErrorWithFailingPurchasedProductsFetcher() async {
-        let logger = TestLogHandler()
-
         let fetcherError = StoreKitError.systemError(StoreKitError.unknown)
         let error: NetworkError = .serverDown()
 
@@ -241,8 +234,10 @@ class OfflineCustomerInfoResponseHandlerTests: BaseCustomerInfoResponseHandlerTe
 
         expect(self.factory.createRequested) == false
 
-        logger.verifyMessageWasLogged(Strings.offlineEntitlements.computing_offline_customer_info_failed(fetcherError),
-                                      level: .error)
+        self.logger.verifyMessageWasLogged(
+            Strings.offlineEntitlements.computing_offline_customer_info_failed(fetcherError),
+            level: .error
+        )
     }
 
 }

--- a/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
+++ b/Tests/UnitTests/Purchasing/EntitlementInfosTests.swift
@@ -149,8 +149,6 @@ class EntitlementInfosTests: TestCase {
     }
 
     func testSubscriptionActiveIfExpiresDateEqualsRequestDate() throws {
-        let logger = TestLogHandler()
-
         let expirationAndRequestDate = Self.formatter.string(
             from: Date().addingTimeInterval(CustomerInfo.requestDateGracePeriod.seconds / -2)
         )
@@ -179,7 +177,7 @@ class EntitlementInfosTests: TestCase {
         )
 
         try self.verifyEntitlementActive()
-        expect(logger.messages).toNot(containElementSatisfying { $0.level == .warn })
+        expect(self.logger.messages).toNot(containElementSatisfying { $0.level == .warn })
     }
 
     func testRequestDateGracePeriodIsLongerThanOneDay() {
@@ -187,8 +185,6 @@ class EntitlementInfosTests: TestCase {
     }
 
     func testSubscriptionActiveIfExpiresDateAfterRequestDateAndRequestDateWithinGracePeriod() throws {
-        let logger = TestLogHandler()
-
         let requestDate = Date().addingTimeInterval(CustomerInfo.requestDateGracePeriod.seconds / -2)
         let expirationDate = requestDate.addingTimeInterval(100)
 
@@ -217,12 +213,10 @@ class EntitlementInfosTests: TestCase {
         )
 
         try self.verifyEntitlementActive()
-        expect(logger.messages).toNot(containElementSatisfying { $0.level == .warn })
+        expect(self.logger.messages).toNot(containElementSatisfying { $0.level == .warn })
     }
 
     func testSubscriptionNotActiveIfExpiresDateAfterRequestDateButRequestDateIsOlderThanGracePeriod() throws {
-        let logger = TestLogHandler()
-
         let requestDate = Date().addingTimeInterval(CustomerInfo.requestDateGracePeriod.seconds * -1)
         let expirationDate = requestDate.addingTimeInterval(100)
 
@@ -251,7 +245,7 @@ class EntitlementInfosTests: TestCase {
         )
 
         try self.verifyEntitlementActive(false)
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             Strings.purchase.entitlement_expired_outside_grace_period(expiration: expirationDate,
                                                                       reference: requestDate),
             level: .warn

--- a/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
+++ b/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
@@ -20,20 +20,6 @@ import StoreKit
 
 class ErrorUtilsTests: TestCase {
 
-    private var testLogHandler: TestLogHandler!
-
-    override func setUp() {
-        super.setUp()
-
-        self.testLogHandler = TestLogHandler()
-    }
-
-    override func tearDown() {
-        self.testLogHandler = nil
-
-        super.tearDown()
-    }
-
     func testReceiptErrorWithNoURL() {
         let error = ErrorUtils.missingReceiptFileError(nil)
         expect(error).to(matchError(ErrorCode.missingReceiptFileError))
@@ -278,7 +264,7 @@ class ErrorUtilsTests: TestCase {
     // MARK: -
 
     private var loggedMessages: [TestLogHandler.MessageData] {
-        return self.testLogHandler.messages
+        return self.logger.messages
     }
 
     private func expectLoggedError(

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -85,8 +85,6 @@ extension OfferingsManagerTests {
     }
 
     func testOfferingsIgnoresProductsNotFoundAndLogsWarning() throws {
-        let logger = TestLogHandler()
-
         // given
         self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(
             MockData.backendOfferingsResponseWithUnknownProducts
@@ -109,7 +107,7 @@ extension OfferingsManagerTests {
         expect(offerings["base"]!.monthly).toNot(beNil())
         expect(offerings["base"]!.monthly?.storeProduct).toNot(beNil())
 
-        logger.verifyMessageWasLogged(
+        self.logger.verifyMessageWasLogged(
             Strings.offering.cannot_find_product_configuration_error(identifiers: ["yearly_freetrial"]),
             level: .warn
         )
@@ -211,8 +209,6 @@ extension OfferingsManagerTests {
     }
 
     func testOfferingsLogsErrorInformationIfBackendReturnsEmpty() throws {
-        let logger = TestLogHandler()
-
         // given
         self.mockOfferings.stubbedGetOfferingsCompletionResult = .success(
             .init(currentOfferingId: "", offerings: [])

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -159,26 +159,23 @@ class PurchasesConfiguringTests: BasePurchasesTests {
     }
 
     func testStaticUserIdSringLogsMessage() {
-        let logger = TestLogHandler()
-
         _ = Purchases.configure(
             with: .init(withAPIKey: "")
                 .with(appUserID: "Static string")
         )
 
-        logger.verifyMessageWasLogged(Strings.identity.logging_in_with_static_string)
+        self.logger.verifyMessageWasLogged(Strings.identity.logging_in_with_static_string)
     }
 
     func testUserIdSringDoesNotLogMessage() {
         let appUserID = "user ID"
-        let logger = TestLogHandler()
 
         _ = Purchases.configure(
             with: .init(withAPIKey: "")
                 .with(appUserID: appUserID)
         )
 
-        logger.verifyMessageWasNotLogged(Strings.identity.logging_in_with_static_string)
+        self.logger.verifyMessageWasNotLogged(Strings.identity.logging_in_with_static_string)
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
@@ -431,19 +428,15 @@ class PurchasesConfiguringTests: BasePurchasesTests {
     func testConfigureWithCustomEntitlementComputationLogsInformationMessage() throws {
         self.systemInfo = MockSystemInfo(finishTransactions: true,
                                          customEntitlementsComputation: true)
-        let logger = TestLogHandler()
-
         self.setupPurchases()
 
-        logger.verifyMessageWasLogged(Strings.configure.custom_entitlements_computation_enabled, level: .info)
+        self.logger.verifyMessageWasLogged(Strings.configure.custom_entitlements_computation_enabled, level: .info)
     }
 
     func testConfigureWithoutCustomEntitlementComputationDoesntLogInformationMessage() throws {
-        let logger = TestLogHandler()
-
         self.setupPurchases()
 
-        logger.verifyMessageWasNotLogged(Strings.configure.custom_entitlements_computation_enabled)
+        self.logger.verifyMessageWasNotLogged(Strings.configure.custom_entitlements_computation_enabled)
     }
 
     func testConfigureWithCustomEntitlementComputationDisablesLogOut() throws {

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -185,32 +185,28 @@ class PurchasesLogInTests: BasePurchasesTests {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
         let appUserID = "user ID"
-        let logger = TestLogHandler()
 
         self.identityManager.mockLogInResult = .success((Self.mockLoggedInInfo, true))
 
         _ = try await self.purchases.logIn(appUserID)
 
-        logger.verifyMessageWasNotLogged(Strings.identity.logging_in_with_static_string,
-                                         allowNoMessages: true)
+        self.logger.verifyMessageWasNotLogged(Strings.identity.logging_in_with_static_string,
+                                              allowNoMessages: true)
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func testLogInWithStaticStringLogsMessage() async throws {
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
-        let logger = TestLogHandler()
-
         self.identityManager.mockLogInResult = .success((Self.mockLoggedInInfo, true))
 
         _ = try await self.purchases.logIn("Static string")
 
-        logger.verifyMessageWasLogged(Strings.identity.logging_in_with_static_string, level: .warn)
+        self.logger.verifyMessageWasLogged(Strings.identity.logging_in_with_static_string, level: .warn)
     }
 
     func testCompletionBlockLogInWithStringDoesNotLogMessage() {
         let appUserID = "user ID"
-        let logger = TestLogHandler()
 
         self.identityManager.mockLogInResult = .success((Self.mockLoggedInInfo, true))
 
@@ -220,12 +216,10 @@ class PurchasesLogInTests: BasePurchasesTests {
             }
         }
 
-        logger.verifyMessageWasNotLogged(Strings.identity.logging_in_with_static_string)
+        self.logger.verifyMessageWasNotLogged(Strings.identity.logging_in_with_static_string)
     }
 
     func testCompletionBlockLogInWithStaticStringLogsMessage() {
-        let logger = TestLogHandler()
-
         self.identityManager.mockLogInResult = .success((Self.mockLoggedInInfo, true))
 
         waitUntil { completed in
@@ -234,7 +228,7 @@ class PurchasesLogInTests: BasePurchasesTests {
             }
         }
 
-        logger.verifyMessageWasLogged(Strings.identity.logging_in_with_static_string, level: .warn)
+        self.logger.verifyMessageWasLogged(Strings.identity.logging_in_with_static_string, level: .warn)
     }
 
     func testLogInClearsTrialEligibilityCache() {

--- a/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
@@ -95,19 +95,16 @@ class TransactionPosterTests: TestCase {
     }
 
     func testFinishTransactionInObserverMode() throws {
-        let logger = TestLogHandler()
-
         waitUntil { completed in
             self.poster.finishTransactionIfNeeded(self.mockTransaction) {
                 completed()
             }
         }
 
-        logger.verifyMessageWasLogged(Strings.purchase.finishing_transaction(self.mockTransaction))
+        self.logger.verifyMessageWasLogged(Strings.purchase.finishing_transaction(self.mockTransaction))
     }
 
     func testFinishTransactionDoesNotFinishInObserverMode() throws {
-        let logger = TestLogHandler()
         self.setUp(observerMode: true)
 
         waitUntil { completed in
@@ -116,7 +113,7 @@ class TransactionPosterTests: TestCase {
             }
         }
 
-        logger.verifyMessageWasNotLogged("Finished transaction")
+        self.logger.verifyMessageWasNotLogged("Finished transaction")
     }
 
 }

--- a/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
@@ -300,16 +300,12 @@ class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
     }
 
     func testUpdatedTransactionsDoesNotLogWarningForLowNumberOfTransactions() {
-        let logger = TestLogHandler()
-
         self.wrapper.paymentQueue(self.paymentQueue, updatedTransactions: [Self.randomTransaction()])
 
-        logger.verifyMessageWasNotLogged("This high number is unexpected")
+        self.logger.verifyMessageWasNotLogged("This high number is unexpected")
     }
 
     func testUpdatedTransactionsLogsWarningWhenSendingTooManyTransactions() {
-        let logger = TestLogHandler()
-
         let payment = SKPayment(product: .init())
         let transactions = (0..<110).map { _ in
             Self.transaction(with: payment)
@@ -317,7 +313,7 @@ class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
 
         self.wrapper.paymentQueue(self.paymentQueue, updatedTransactions: transactions)
 
-        logger.verifyMessageWasLogged(Strings.storeKit.sk1_payment_queue_too_many_transactions(
+        self.logger.verifyMessageWasLogged(Strings.storeKit.sk1_payment_queue_too_many_transactions(
             count: transactions.count,
             isSandbox: self.sandboxEnvironmentDetector.isSandbox
         ),

--- a/Tests/UnitTests/Security/SigningTests.swift
+++ b/Tests/UnitTests/Security/SigningTests.swift
@@ -43,8 +43,6 @@ class SigningTests: TestCase {
     }
 
     func testVerifySignatureWithInvalidSignatureReturnsFalseAndLogsError() throws {
-        let logger = TestLogHandler()
-
         let message = "Hello World"
         let nonce = "nonce"
         let requestDate: UInt64 = 1677005916012
@@ -62,7 +60,7 @@ class SigningTests: TestCase {
             publicKey: Signing.loadPublicKey()
         )) == false
 
-        logger.verifyMessageWasLogged("Signature is not base64: \(signature)")
+        self.logger.verifyMessageWasLogged("Signature is not base64: \(signature)")
     }
 
     func testVerifySignatureWithExpiredIntermediateSignatureReturnsFalseAndLogsError() throws {
@@ -87,15 +85,13 @@ class SigningTests: TestCase {
             signature: signature
         )
 
-        let logger = TestLogHandler()
-
         expect(self.signing.verify(
             signature: fullSignature.base64EncodedString(),
             with: parameters,
             publicKey: self.publicKey
         )) == false
 
-        logger.verifyMessageWasLogged("Intermediate key expired", level: .warn)
+        self.logger.verifyMessageWasLogged("Intermediate key expired", level: .warn)
     }
 
     func testVerifySignatureWithInvalidIntermediateSignatureExpirationReturnsFalseAndLogsError() throws {
@@ -120,16 +116,16 @@ class SigningTests: TestCase {
             signature: signature
         )
 
-        let logger = TestLogHandler()
-
         expect(self.signing.verify(
             signature: fullSignature.base64EncodedString(),
             with: parameters,
             publicKey: self.publicKey
         )) == false
 
-        logger.verifyMessageWasLogged(Strings.signing.intermediate_key_invalid(Self.invalidIntermediateKeyExpiration),
-                                      level: .warn)
+        self.logger.verifyMessageWasLogged(
+            Strings.signing.intermediate_key_invalid(Self.invalidIntermediateKeyExpiration),
+            level: .warn
+        )
     }
 
     func testVerifySignatureWithInvalidSignature() throws {
@@ -147,8 +143,6 @@ class SigningTests: TestCase {
     }
 
     func testVerifySignatureLogsWarningWhenIntermediateSignatureIsInvalid() throws {
-        let logger = TestLogHandler()
-
         let signature = String(repeating: "x", count: Signing.SignatureComponent.totalSize)
             .asData
 
@@ -164,13 +158,11 @@ class SigningTests: TestCase {
             publicKey: Signing.loadPublicKey()
         )
 
-        logger.verifyMessageWasLogged("Intermediate key failed verification",
-                                      level: .warn)
+        self.logger.verifyMessageWasLogged("Intermediate key failed verification",
+                                           level: .warn)
     }
 
     func testVerifySignatureLogsWarningWhenFail() throws {
-        let logger = TestLogHandler()
-
         let message = "Hello World"
         let nonce = "nonce"
         let requestDate: UInt64 = 1677005916012
@@ -197,13 +189,11 @@ class SigningTests: TestCase {
             )
         ) == false
 
-        logger.verifyMessageWasLogged(Strings.signing.signature_failed_verification,
-                                      level: .warn)
+        self.logger.verifyMessageWasLogged(Strings.signing.signature_failed_verification,
+                                           level: .warn)
     }
 
     func testVerifySignatureLogsWarningWhenSizeIsIncorrect() throws {
-        let logger = TestLogHandler()
-
         let signature = "invalid signature".asData
 
         _ = self.signing.verify(
@@ -218,8 +208,8 @@ class SigningTests: TestCase {
             publicKey: Signing.loadPublicKey()
         )
 
-        logger.verifyMessageWasLogged(Strings.signing.signature_invalid_size(signature),
-                                      level: .warn)
+        self.logger.verifyMessageWasLogged(Strings.signing.signature_invalid_size(signature),
+                                           level: .warn)
     }
 
     func testVerifySignatureWithValidSignature() throws {
@@ -481,15 +471,14 @@ class SigningTests: TestCase {
 
     func testResponseVerificationWithNoSignatureInResponse() throws {
         let request = HTTPRequest.createWithResponseVerification(method: .get, path: .health)
-        let logger = TestLogHandler()
 
         let response = HTTPResponse<Data?>(statusCode: .success, responseHeaders: [:], body: Data())
         let verifiedResponse = response.verify(signing: self.signing, request: request, publicKey: self.publicKey)
 
         expect(verifiedResponse.verificationResult) == .failed
 
-        logger.verifyMessageWasLogged(Strings.signing.signature_was_requested_but_not_provided(request),
-                                      level: .warn)
+        self.logger.verifyMessageWasLogged(Strings.signing.signature_was_requested_but_not_provided(request),
+                                           level: .warn)
     }
 
     func testResponseVerificationWithInvalidSignature() throws {
@@ -609,8 +598,6 @@ class SigningTests: TestCase {
         let message = "Hello World"
         let requestDate = Date().millisecondsSince1970
 
-        let logger = TestLogHandler()
-
         let request = HTTPRequest(method: .get, path: .postOfferForSigning, nonce: nil)
         let response = HTTPResponse<Data?>(
             statusCode: .success,
@@ -623,8 +610,8 @@ class SigningTests: TestCase {
 
         expect(verifiedResponse.verificationResult) == .notRequested
 
-        logger.verifyMessageWasNotLogged(Strings.signing.signature_was_requested_but_not_provided(request),
-                                         allowNoMessages: true)
+        self.logger.verifyMessageWasNotLogged(Strings.signing.signature_was_requested_but_not_provided(request),
+                                              allowNoMessages: true)
     }
 
 }

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -194,8 +194,6 @@ class BackendSubscriberAttributesTests: TestCase {
             subscriberAttribute2.key: subscriberAttribute2
         ]
 
-        let logHandler = TestLogHandler()
-
         let receivedCustomerInfo: Atomic<CustomerInfo?> = nil
         backend.post(receiptData: self.receiptData,
                      productData: nil,
@@ -212,7 +210,7 @@ class BackendSubscriberAttributesTests: TestCase {
 
         expect(self.mockHTTPClient.calls).toEventually(haveCount(1))
 
-        let loggedMessages = logHandler.messages.map(\.message)
+        let loggedMessages = self.logger.messages.map(\.message)
 
         expect(receivedCustomerInfo.value) == CustomerInfo(testData: self.validSubscriberResponse)
         expect(loggedMessages).to(

--- a/Tests/UnitTests/TestHelpers/TestLogHandler.swift
+++ b/Tests/UnitTests/TestHelpers/TestLogHandler.swift
@@ -30,7 +30,8 @@ import Nimble
 ///
 /// ### Examples:
 /// - Initialize `TestLogHandler` for every test. This ensures that the lifetime
-/// matches that of the test, and the observed logged messages are those that happen during the test:
+/// matches that of the test, and the observed logged messages are those that happen during the test.
+/// This is already defined in every subclass of `TestCase`.
 ///
 /// ```swift
 /// private var testLogHandler: TestLogHandler!
@@ -42,18 +43,6 @@ import Nimble
 /// override func tearDown() {
 ///     self.testLogHandler = nil
 ///     super.tearDown()
-/// }
-/// ```
-///
-/// - Alternatively, `TestLogHandler` can be used locally within a single test:
-///
-/// ```swift
-/// func testExample() {
-///     let logHandler = TestLogHandler()
-///
-///     // Run some code
-///
-///     expect(logHandler.loggedMessages.onlyElement?.message) == "Expected log"
 /// }
 /// ```
 final class TestLogHandler {


### PR DESCRIPTION
We get a lot of flaky failures in CI due to `TestLogHandler` exceeding its capacity. I haven't been able reproduce that locally, but it's likely due to the fact that it relies on the autorelease pool releasing the instance, which in turn removes the `LogMessageObserver`.
To fix that, this PR avoids creating custom `TestLogHandler` that rely on the lifetime of the test, and instead explicitly set it to `nil` in `tearDown`.

I implemented that in `TestCase` (now also available for backend tests) so all our test classes can take advantage of that.
