### PR TITLE
`Tests`: fixed another flaky failure with asynchronous check

### DIFF
--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -249,7 +249,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
 
         self.setupPurchases()
 
-        expect(self.mockBackend.invokedGetSubscriberDataCount) == 1
+        expect(self.mockBackend.invokedGetSubscriberDataCount).toEventually(equal(1))
         expect(self.mockDeviceCache.cacheCustomerInfoCount).toEventually(equal(1))
         expect(self.mockDeviceCache.cachedCustomerInfo.count) == 1
         expect(self.mockSubscriberAttributesManager.invokedSyncAttributesForAllUsersCount) == 0


### PR DESCRIPTION
This is the same as #2777.
