### PR TITLE
`Unit Tests`: removed leak detection

### DIFF
--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -104,25 +104,12 @@ class BasePurchasesTests: TestCase {
         // Because unit tests can run in parallel, if a test needs to modify
         // this level it should be moved to `StoreKitUnitTests`, which runs serially.
         Purchases.logLevel = .verbose
-
-        self.addTeardownBlock {
-            weak var purchases = self.purchases
-            weak var orchestrator = self.purchasesOrchestrator
-            weak var deviceCache = self.deviceCache
-
-            Purchases.clearSingleton()
-            self.clearReferences()
-
-            expect(purchases)
-                .toEventually(beNil(), description: "Purchases has leaked")
-            expect(orchestrator)
-                .toEventually(beNil(), description: "PurchasesOrchestrator has leaked")
-            expect(deviceCache)
-                .toEventually(beNil(), description: "DeviceCache has leaked: \(self)")
-        }
     }
 
     override func tearDown() {
+        Purchases.clearSingleton()
+        self.clearReferences()
+
         self.userDefaults.removePersistentDomain(forName: Self.userDefaultsSuiteName)
 
         super.tearDown()


### PR DESCRIPTION
While useful, this has proven to be extremely flaky in CI. This relies on `XCTest`'s finishing and the autorelease pool being cleared. When CI is slow, this can take more than 1 second.

We could increase the timeout, but it doesn't make sense to make tests wait for over a second, that can really add up with ~1800 tests, instead of continuing with the next test.

Note that `BaseBackendIntegrationTests` still checks that `Purchases` doesn't leak, so at least we get some level of functional test for this.

