### PR TITLE
`TimingUtil`: improved tests by using `Clock`

### DIFF
--- a/Sources/Misc/DateAndTime/Clock.swift
+++ b/Sources/Misc/DateAndTime/Clock.swift
@@ -14,9 +14,10 @@
 import Foundation
 
 /// A type that can provide the current `Date`
-protocol ClockType {
+protocol ClockType: Sendable {
 
     var now: Date { get }
+    var currentTime: DispatchTime { get }
 
 }
 
@@ -24,6 +25,7 @@ protocol ClockType {
 final class Clock: ClockType {
 
     var now: Date { return Date() }
+    var currentTime: DispatchTime { return .now() }
 
     static let `default`: Clock = .init()
 

--- a/Tests/UnitTests/Misc/TimingUtilTests.swift
+++ b/Tests/UnitTests/Misc/TimingUtilTests.swift
@@ -212,7 +212,7 @@ class TimingUtilCompletionBlockTests: TestCase {
         TimingUtil.measure(self.clock) { [clock = self.clock!] completion in
             clock.advance(by: sleepDuration)
             Self.asynchronousWork(expectedResult, completion)
-        } result: { value, time in
+        } result: { (value: Int, time: TimingUtil.Duration) in
             result = value
             duration = time
         }


### PR DESCRIPTION
These tests will be a lot less flaky now since they won't depend on sleeping the current thread, so they won't be susceptible to slow running CI.
Additionally, we can use `seconds` instead of `milliseconds` which will remove imprecision errors when determining if the time was over the threshold.
