### PR TITLE
`Tests`: fixed another flaky test

### DIFF
--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -82,8 +82,12 @@ class PurchasesLogInTests: BasePurchasesTests {
 
     func testLogOutWithFailure() {
         let error = BackendError.networkError(.offlineConnection()).asPurchasesError
-
         self.identityManager.mockLogOutError = error
+
+        expect(self.backend.getCustomerInfoCallCount).toEventually(
+            equal(1),
+            description: "Initial cache update should take place"
+        )
 
         let result = waitUntilValue { completed in
             self.purchases.logOut { customerInfo, error in
@@ -94,7 +98,10 @@ class PurchasesLogInTests: BasePurchasesTests {
         expect(result).to(beFailure())
         expect(result?.error).to(matchError(error))
 
-        expect(self.backend.getCustomerInfoCallCount) == 1
+        expect(self.backend.getCustomerInfoCallCount).to(
+            equal(1),
+            description: "Customer info should not have been updated"
+        )
         expect(self.identityManager.invokedLogOutCount) == 1
     }
 


### PR DESCRIPTION
Similar to #2786 and #2777.
This test was verifying `getCustomerInfoCallCount`, but that gets updated asynchronously since #2533.

The correct version waits for it to be updated, then ensures that it doesn't get updated again after logging out.

Fixes https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/12762/workflows/a7e8c4ac-cecb-4c25-90ff-4390ed226bc4/jobs/88794
