### PR TITLE
`Tests`: removed forced-unwrap

### DIFF
--- a/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
@@ -101,7 +101,7 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         }
 
         guard case .failure(.networkError(.decoding)) = result else {
-            fail("Unexpected result: \(result!)")
+            fail("Unexpected result: \(String(describing: result))")
             return
         }
     }


### PR DESCRIPTION
If `result` is `nil` this would have crashed instead of failing.
