### PR TITLE
`Tests`: unified default timeouts

### DIFF
--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -253,7 +253,7 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
             completionCalled.value += 1
         })
 
-        expect(self.httpClient.calls).toEventually(haveCount(2))
+        expect(self.httpClient.calls).toEventually(haveCount(2), timeout: defaultTimeout)
         expect(completionCalled.value).toEventually(equal(2))
     }
 
@@ -623,7 +623,7 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
             completionCalled.value += 1
         })
 
-        expect(self.httpClient.calls).toEventually(haveCount(2))
+        expect(self.httpClient.calls).toEventually(haveCount(2), timeout: defaultTimeout)
         expect(completionCalled.value).toEventually(equal(2))
     }
 

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -908,7 +908,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
             }
         }
 
-        self.waitForExpectations(timeout: defaultTimeout.seconds * TimeInterval(serialRequests))
+        self.waitForExpectations(timeout: defaultTimeout.seconds)
         expect(completionCallCount.value) == serialRequests
     }
 

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -62,7 +62,7 @@ class BaseHTTPClientTests<ETag: ETagManager>: TestCase {
                           eTagManager: self.eTagManager,
                           signing: self.signing,
                           dnsChecker: MockDNSChecker.self,
-                          requestTimeout: 3)
+                          requestTimeout: defaultTimeout.seconds)
     }
 
 }
@@ -908,7 +908,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
             }
         }
 
-        self.waitForExpectations(timeout: 1)
+        self.waitForExpectations(timeout: defaultTimeout.seconds * TimeInterval(serialRequests))
         expect(completionCallCount.value) == serialRequests
     }
 
@@ -947,7 +947,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
             expectations[1].fulfill()
         }
 
-        self.waitForExpectations(timeout: 1)
+        self.waitForExpectations(timeout: defaultTimeout.seconds)
 
         expect(firstRequestFinished.value) == true
         expect(secondRequestFinished.value) == true
@@ -1004,7 +1004,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
             expectations[2].fulfill()
         }
 
-        self.waitForExpectations(timeout: 3)
+        self.waitForExpectations(timeout: defaultTimeout.seconds)
 
         expect(firstRequestFinished.value) == true
         expect(secondRequestFinished.value) == true

--- a/Tests/UnitTests/TestHelpers/AsyncTestHelpers.swift
+++ b/Tests/UnitTests/TestHelpers/AsyncTestHelpers.swift
@@ -17,6 +17,16 @@ import Nimble
 
 @testable import RevenueCat
 
+/// Overload for `Nimble.waitUntil` with our default timeout
+func waitUntil(
+    timeout: DispatchTimeInterval = defaultTimeout,
+    file: FileString = #file,
+    line: UInt = #line,
+    action: @escaping (@escaping () -> Void) -> Void
+) {
+    Nimble.waitUntil(timeout: timeout, file: file, line: line, action: action)
+}
+
 /// Waits for `action` to be invoked, and returns the provided value, or `nil` on timeout.
 /// Usage:
 /// ```swift
@@ -27,7 +37,7 @@ import Nimble
 /// }
 /// ```
 func waitUntilValue<Value>(
-    timeout: DispatchTimeInterval = AsyncDefaults.timeout,
+    timeout: DispatchTimeInterval = defaultTimeout,
     file: FileString = #file,
     line: UInt = #line,
     action: @escaping (@escaping @Sendable (Value?) -> Void) -> Void
@@ -53,8 +63,8 @@ func waitUntilValue<Value>(
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 func asyncWait(
     until condition: @Sendable () async -> Bool,
-    timeout: DispatchTimeInterval = AsyncDefaults.timeout,
-    pollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval,
+    timeout: DispatchTimeInterval = defaultTimeout,
+    pollInterval: DispatchTimeInterval = defaultPollInterval,
     description: String? = nil,
     file: FileString = #fileID,
     line: UInt = #line
@@ -88,3 +98,7 @@ func asyncWait(
         throw ConditionFailedError()
     }
 }
+
+// Higher value required to avoid slow CI failing tests.
+let defaultTimeout: DispatchTimeInterval = .seconds(2)
+let defaultPollInterval: DispatchTimeInterval = AsyncDefaults.pollInterval


### PR DESCRIPTION
I did this as part of looking into issues running tests on CI.
Ultimately I found the root cause, but this is a useful refactor to make sure all tests have a shared timeout.