### PR TITLE
`SystemInfo.init` no longer `throws`

### DIFF
--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -117,7 +117,7 @@ class SystemInfo {
          sandboxEnvironmentDetector: SandboxEnvironmentDetector = BundleSandboxEnvironmentDetector.default,
          storeKit2Setting: StoreKit2Setting = .default,
          responseVerificationMode: Signing.ResponseVerificationMode = .default,
-         dangerousSettings: DangerousSettings? = nil) throws {
+         dangerousSettings: DangerousSettings? = nil) {
         self.platformFlavor = platformInfo?.flavor ?? "native"
         self.platformFlavorVersion = platformInfo?.version
         self._bundle = .init(bundle)

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -273,17 +273,12 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         let receiptRefreshRequestFactory = ReceiptRefreshRequestFactory()
         let fetcher = StoreKitRequestFetcher(requestFactory: receiptRefreshRequestFactory,
                                              operationDispatcher: operationDispatcher)
-        let systemInfo: SystemInfo
-        do {
-            systemInfo = try SystemInfo(platformInfo: platformInfo,
-                                        finishTransactions: !observerMode,
-                                        operationDispatcher: operationDispatcher,
-                                        storeKit2Setting: storeKit2Setting,
-                                        responseVerificationMode: responseVerificationMode,
-                                        dangerousSettings: dangerousSettings)
-        } catch {
-            fatalError(error.localizedDescription)
-        }
+        let systemInfo = SystemInfo(platformInfo: platformInfo,
+                                    finishTransactions: !observerMode,
+                                    operationDispatcher: operationDispatcher,
+                                    storeKit2Setting: storeKit2Setting,
+                                    responseVerificationMode: responseVerificationMode,
+                                    dangerousSettings: dangerousSettings)
 
         let receiptFetcher = ReceiptFetcher(requestFetcher: fetcher, systemInfo: systemInfo)
         let eTagManager = ETagManager()

--- a/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/LocalReceiptParserStoreKitTests.swift
@@ -32,10 +32,10 @@ class LocalReceiptParserStoreKitTests: StoreKitConfigTestCase {
         self.requestFetcher = StoreKitRequestFetcher(requestFactory: receiptRefreshRequestFactory,
                                                      operationDispatcher: operationDispatcher)
 
-        self.systemInfo = try SystemInfo(platformInfo: Purchases.platformInfo,
-                                         finishTransactions: true,
-                                         operationDispatcher: operationDispatcher,
-                                         storeKit2Setting: .disabled)
+        self.systemInfo = SystemInfo(platformInfo: Purchases.platformInfo,
+                                     finishTransactions: true,
+                                     operationDispatcher: operationDispatcher,
+                                     storeKit2Setting: .disabled)
         self.receiptFetcher = ReceiptFetcher(requestFetcher: self.requestFetcher, systemInfo: systemInfo)
         self.parser = .default
     }

--- a/Tests/StoreKitUnitTests/OfferingsManagerStoreKitTests.swift
+++ b/Tests/StoreKitUnitTests/OfferingsManagerStoreKitTests.swift
@@ -21,10 +21,9 @@ class OfferingsManagerStoreKitTests: StoreKitConfigTestCase {
 
     var mockDeviceCache: MockDeviceCache!
     let mockOperationDispatcher = MockOperationDispatcher()
-    // swiftlint:disable:next force_try
-    let mockSystemInfo = try! MockSystemInfo(platformInfo: .init(flavor: "iOS", version: "3.2.1"),
-                                             finishTransactions: true,
-                                             storeKit2Setting: .enabledForCompatibleDevices)
+    let mockSystemInfo = MockSystemInfo(platformInfo: .init(flavor: "iOS", version: "3.2.1"),
+                                        finishTransactions: true,
+                                        storeKit2Setting: .enabledForCompatibleDevices)
     let mockBackend = MockBackend()
     var mockOfferings: MockOfferingsAPI!
     let mockOfferingsFactory = OfferingsFactory()

--- a/Tests/StoreKitUnitTests/ProductsManagerTests.swift
+++ b/Tests/StoreKitUnitTests/ProductsManagerTests.swift
@@ -20,7 +20,7 @@ import XCTest
 class ProductsManagerTests: StoreKitConfigTestCase {
 
     func testFetchProductsWithIdentifiersSK1() throws {
-        let manager = try createManager(storeKit2Setting: .disabled)
+        let manager = self.createManager(storeKit2Setting: .disabled)
 
         let identifier = "com.revenuecat.monthly_4.99.1_week_intro"
         let receivedProducts = waitUntilValue(timeout: Self.requestDispatchTimeout) { completed in
@@ -40,7 +40,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
             throw XCTSkip("Required API is not available for this test.")
         }
 
-        let manager = try createManager(storeKit2Setting: .enabledForCompatibleDevices)
+        let manager = self.createManager(storeKit2Setting: .enabledForCompatibleDevices)
 
         let identifier = "com.revenuecat.monthly_4.99.1_week_intro"
         let receivedProducts = waitUntilValue(timeout: Self.requestDispatchTimeout) { completed in
@@ -56,7 +56,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
     }
 
     func testClearCacheAfterStorefrontChangesSK1() async throws {
-        let manager = try createManager(storeKit2Setting: .disabled)
+        let manager = self.createManager(storeKit2Setting: .disabled)
 
         let identifier = "com.revenuecat.monthly_4.99.1_week_intro"
         var receivedProducts: Set<StoreProduct>?
@@ -86,7 +86,7 @@ class ProductsManagerTests: StoreKitConfigTestCase {
     func testInvalidateAndReFetchCachedProductsAfterStorefrontChangesSK2() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        let manager = try createManager(storeKit2Setting: .enabledForCompatibleDevices)
+        let manager = self.createManager(storeKit2Setting: .enabledForCompatibleDevices)
 
         let identifier = "com.revenuecat.monthly_4.99.1_week_intro"
         var receivedProducts: Set<StoreProduct>?
@@ -112,10 +112,10 @@ class ProductsManagerTests: StoreKitConfigTestCase {
         expect(unwrappedFirstProduct.currencyCode) == "EUR"
     }
 
-    private func createManager(storeKit2Setting: StoreKit2Setting) throws -> ProductsManager {
+    private func createManager(storeKit2Setting: StoreKit2Setting) -> ProductsManager {
         let platformInfo = Purchases.PlatformInfo(flavor: "xyz", version: "123")
         return ProductsManager(
-            systemInfo: try MockSystemInfo(
+            systemInfo: MockSystemInfo(
                 platformInfo: platformInfo,
                 finishTransactions: true,
                 storeKit2Setting: storeKit2Setting

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -47,7 +47,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        try self.setUpSystemInfo()
+        self.setUpSystemInfo()
 
         self.productsManager = MockProductsManager(systemInfo: self.systemInfo,
                                                    requestTimeout: Configuration.storeKitRequestTimeoutDefault)
@@ -111,12 +111,12 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     fileprivate func setUpSystemInfo(
         finishTransactions: Bool = true,
         storeKit2Setting: StoreKit2Setting = .default
-    ) throws {
+    ) {
         let platformInfo = Purchases.PlatformInfo(flavor: "xyz", version: "1.2.3")
 
-        self.systemInfo = try MockSystemInfo(platformInfo: platformInfo,
-                                             finishTransactions: finishTransactions,
-                                             storeKit2Setting: storeKit2Setting)
+        self.systemInfo = MockSystemInfo(platformInfo: platformInfo,
+                                         finishTransactions: finishTransactions,
+                                         storeKit2Setting: storeKit2Setting)
         self.systemInfo.stubbedIsSandbox = true
     }
 
@@ -742,7 +742,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     func testPurchaseSK2PackageRetriesReceiptFetchIfEnabled() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        self.systemInfo = try .init(
+        self.systemInfo = .init(
             platformInfo: nil,
             finishTransactions: false,
             storeKit2Setting: .enabledForCompatibleDevices,
@@ -959,7 +959,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     func testStoreKit2TransactionListenerDelegateWithObserverMode() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        try self.setUpSystemInfo(finishTransactions: false, storeKit2Setting: .enabledForCompatibleDevices)
+        self.setUpSystemInfo(finishTransactions: false, storeKit2Setting: .enabledForCompatibleDevices)
 
         self.setUpOrchestrator()
         self.setUpStoreKit2Listener()
@@ -1030,7 +1030,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         let transactionListener = MockStoreKit2TransactionListener()
 
-        try self.setUpSystemInfo(storeKit2Setting: .disabled)
+        self.setUpSystemInfo(storeKit2Setting: .disabled)
 
         self.setUpOrchestrator(storeKit2TransactionListener: transactionListener,
                                storeKit2StorefrontListener: StoreKit2StorefrontListener(delegate: nil))
@@ -1044,7 +1044,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         let transactionListener = MockStoreKit2TransactionListener()
 
-        try self.setUpSystemInfo(storeKit2Setting: .enabledOnlyForOptimizations)
+        self.setUpSystemInfo(storeKit2Setting: .enabledOnlyForOptimizations)
 
         self.setUpOrchestrator(storeKit2TransactionListener: transactionListener,
                                storeKit2StorefrontListener: StoreKit2StorefrontListener(delegate: nil))
@@ -1058,7 +1058,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         let transactionListener = MockStoreKit2TransactionListener()
 
-        try self.setUpSystemInfo(storeKit2Setting: .enabledForCompatibleDevices)
+        self.setUpSystemInfo(storeKit2Setting: .enabledForCompatibleDevices)
 
         self.setUpOrchestrator(storeKit2TransactionListener: transactionListener,
                                storeKit2StorefrontListener: StoreKit2StorefrontListener(delegate: nil))

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
@@ -32,9 +32,9 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         let platformInfo = Purchases.PlatformInfo(flavor: "xyz", version: "123")
-        mockSystemInfo = try MockSystemInfo(platformInfo: platformInfo,
-                                            finishTransactions: true,
-                                            storeKit2Setting: .disabled)
+        self.mockSystemInfo = MockSystemInfo(platformInfo: platformInfo,
+                                             finishTransactions: true,
+                                             storeKit2Setting: .disabled)
         receiptFetcher = MockReceiptFetcher(requestFetcher: MockRequestFetcher(), systemInfo: mockSystemInfo)
         self.mockProductsManager = MockProductsManager(systemInfo: mockSystemInfo,
                                                        requestTimeout: Configuration.storeKitRequestTimeoutDefault)

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
@@ -30,9 +30,9 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         let platformInfo = Purchases.PlatformInfo(flavor: "xyz", version: "123")
-        mockSystemInfo = try MockSystemInfo(platformInfo: platformInfo,
-                                            finishTransactions: true,
-                                            storeKit2Setting: .enabledForCompatibleDevices)
+        mockSystemInfo = MockSystemInfo(platformInfo: platformInfo,
+                                        finishTransactions: true,
+                                        storeKit2Setting: .enabledForCompatibleDevices)
 
         receiptFetcher = MockReceiptFetcher(requestFetcher: MockRequestFetcher(), systemInfo: mockSystemInfo)
         mockProductsManager = MockProductsManager(

--- a/Tests/UnitTests/Attribution/AttributionPosterTests.swift
+++ b/Tests/UnitTests/Attribution/AttributionPosterTests.swift
@@ -26,10 +26,10 @@ class BaseAttributionPosterTests: TestCase {
     var backend: MockBackend!
     var subscriberAttributesManager: MockSubscriberAttributesManager!
     var attributionFactory: AttributionTypeFactory! = MockAttributionTypeFactory()
-    // swiftlint:disable:next force_try
-    var systemInfo: MockSystemInfo! = try! MockSystemInfo(
+    var systemInfo: MockSystemInfo! =  MockSystemInfo(
         platformInfo: .init(flavor: "iOS", version: "3.2.1"),
-        finishTransactions: true)
+        finishTransactions: true
+    )
 
     let userDefaultsSuiteName = "testUserDefaults"
 

--- a/Tests/UnitTests/Misc/SandboxEnvironmentDetectorTests.swift
+++ b/Tests/UnitTests/Misc/SandboxEnvironmentDetectorTests.swift
@@ -18,30 +18,30 @@ import XCTest
 
 class SandboxEnvironmentDetectorTests: TestCase {
 
-    func testIsSandbox() throws {
-        expect(try SystemInfo.with(receiptResult: .sandboxReceipt, inSimulator: false).isSandbox) == true
+    func testIsSandbox() {
+        expect(SystemInfo.with(receiptResult: .sandboxReceipt, inSimulator: false).isSandbox) == true
     }
 
-    func testIsNotSandbox() throws {
-        expect(try SystemInfo.with(receiptResult: .receiptWithData, inSimulator: false).isSandbox) == false
+    func testIsNotSandbox() {
+        expect(SystemInfo.with(receiptResult: .receiptWithData, inSimulator: false).isSandbox) == false
     }
 
-    func testIsNotSandboxIfNoReceiptURL() throws {
-        expect(try SystemInfo.with(receiptResult: .nilURL, inSimulator: false).isSandbox) == false
+    func testIsNotSandboxIfNoReceiptURL() {
+        expect(SystemInfo.with(receiptResult: .nilURL, inSimulator: false).isSandbox) == false
     }
 
-    func testMacSandboxReceiptIsSandbox() throws {
-        expect(try SystemInfo.with(receiptResult: .macOSSandboxReceipt, inSimulator: false).isSandbox) == true
+    func testMacSandboxReceiptIsSandbox() {
+        expect(SystemInfo.with(receiptResult: .macOSSandboxReceipt, inSimulator: false).isSandbox) == true
     }
 
-    func testMacAppStoreReceiptIsNotSandbox() throws {
-        expect(try SystemInfo.with(receiptResult: .macOSAppStoreReceipt, inSimulator: false).isSandbox) == false
+    func testMacAppStoreReceiptIsNotSandbox() {
+        expect(SystemInfo.with(receiptResult: .macOSAppStoreReceipt, inSimulator: false).isSandbox) == false
     }
 
     func testIsAlwaysSandboxIfRunningInSimulator() {
-        expect(try SystemInfo.with(receiptResult: .sandboxReceipt, inSimulator: true).isSandbox) == true
-        expect(try SystemInfo.with(receiptResult: .receiptWithData, inSimulator: true).isSandbox) == true
-        expect(try SystemInfo.with(receiptResult: .nilURL, inSimulator: true).isSandbox) == true
+        expect(SystemInfo.with(receiptResult: .sandboxReceipt, inSimulator: true).isSandbox) == true
+        expect(SystemInfo.with(receiptResult: .receiptWithData, inSimulator: true).isSandbox) == true
+        expect(SystemInfo.with(receiptResult: .nilURL, inSimulator: true).isSandbox) == true
     }
 
 }
@@ -51,7 +51,7 @@ private extension SandboxEnvironmentDetector {
     static func with(
         receiptResult result: MockBundle.ReceiptURLResult,
         inSimulator: Bool
-    ) throws -> SandboxEnvironmentDetector {
+    ) -> SandboxEnvironmentDetector {
         let bundle = MockBundle()
         bundle.receiptURLResult = result
 

--- a/Tests/UnitTests/Misc/SystemInfoTests.swift
+++ b/Tests/UnitTests/Misc/SystemInfoTests.swift
@@ -30,49 +30,45 @@ class SystemInfoTests: TestCase {
         expect(SystemInfo.systemVersion) == ProcessInfo().operatingSystemVersionString
     }
 
-    func testPlatformFlavor() throws {
+    func testPlatformFlavor() {
         let flavor = "flavor"
         let platformInfo = Purchases.PlatformInfo(flavor: flavor, version: "foo")
-        let systemInfo = try SystemInfo(platformInfo: platformInfo,
-                                        finishTransactions: false)
+        let systemInfo = SystemInfo(platformInfo: platformInfo, finishTransactions: false)
         expect(systemInfo.platformFlavor) == flavor
     }
 
-    func testPlatformFlavorVersion() throws {
+    func testPlatformFlavorVersion() {
         let flavorVersion = "flavorVersion"
         let platformInfo = Purchases.PlatformInfo(flavor: "foo", version: flavorVersion)
-        let systemInfo = try SystemInfo(platformInfo: platformInfo,
-                                        finishTransactions: false)
+        let systemInfo = SystemInfo(platformInfo: platformInfo, finishTransactions: false)
         expect(systemInfo.platformFlavorVersion) == flavorVersion
     }
 
-    func testFinishTransactions() throws {
+    func testFinishTransactions() {
         var finishTransactions = false
-        var systemInfo = try SystemInfo(platformInfo: nil,
-                                        finishTransactions: finishTransactions)
+        var systemInfo = SystemInfo(platformInfo: nil, finishTransactions: finishTransactions)
         expect(systemInfo.finishTransactions) == finishTransactions
         expect(systemInfo.observerMode) == !finishTransactions
 
         finishTransactions = true
 
-        systemInfo = try SystemInfo(platformInfo: nil,
-                                    finishTransactions: finishTransactions)
+        systemInfo = SystemInfo(platformInfo: nil, finishTransactions: finishTransactions)
         expect(systemInfo.finishTransactions) == finishTransactions
         expect(systemInfo.observerMode) == !finishTransactions
     }
 
-    func testIsSandbox() throws {
+    func testIsSandbox() {
         let sandboxDetector = MockSandboxEnvironmentDetector(isSandbox: true)
 
-        expect(try SystemInfo.withReceiptResult(.sandboxReceipt, sandboxDetector).isSandbox) == true
-        expect(try SystemInfo.withReceiptResult(.receiptWithData, sandboxDetector).isSandbox) == true
+        expect(SystemInfo.withReceiptResult(.sandboxReceipt, sandboxDetector).isSandbox) == true
+        expect(SystemInfo.withReceiptResult(.receiptWithData, sandboxDetector).isSandbox) == true
     }
 
-    func testIsNotSandbox() throws {
+    func testIsNotSandbox() {
         let sandboxDetector = MockSandboxEnvironmentDetector(isSandbox: false)
 
-        expect(try SystemInfo.withReceiptResult(.sandboxReceipt, sandboxDetector).isSandbox) == false
-        expect(try SystemInfo.withReceiptResult(.receiptWithData, sandboxDetector).isSandbox) == false
+        expect(SystemInfo.withReceiptResult(.sandboxReceipt, sandboxDetector).isSandbox) == false
+        expect(SystemInfo.withReceiptResult(.receiptWithData, sandboxDetector).isSandbox) == false
     }
 
     func testIsAppleSubscriptionURLWithAnotherURL() {
@@ -144,21 +140,20 @@ private extension SystemInfo {
     static func withReceiptResult(
         _ result: MockBundle.ReceiptURLResult,
         _ sandboxEnvironmentDetector: SandboxEnvironmentDetector? = nil
-    ) throws -> SystemInfo {
+    ) -> SystemInfo {
         let bundle = MockBundle()
         bundle.receiptURLResult = result
 
         let sandboxDetector = sandboxEnvironmentDetector ?? BundleSandboxEnvironmentDetector(bundle: bundle)
 
-        return try SystemInfo(platformInfo: nil,
-                              finishTransactions: false,
-                              bundle: bundle,
-                              sandboxEnvironmentDetector: sandboxDetector)
+        return SystemInfo(platformInfo: nil,
+                          finishTransactions: false,
+                          bundle: bundle,
+                          sandboxEnvironmentDetector: sandboxDetector)
     }
 
     static var `default`: SystemInfo {
-        // swiftlint:disable:next force_try
-        return try! .init(platformInfo: nil, finishTransactions: true)
+        return .init(platformInfo: nil, finishTransactions: true)
     }
 
 }

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -5,7 +5,7 @@
 
 @testable import RevenueCat
 
-// swiftlint:disable large_tuple force_try line_length
+// swiftlint:disable large_tuple line_length
 class MockBackend: Backend {
 
     typealias PostReceiptParameters = (data: Data?,
@@ -22,7 +22,7 @@ class MockBackend: Backend {
     var onPostReceipt: (() -> Void)?
 
     public convenience init() {
-        let systemInfo = try! MockSystemInfo(platformInfo: nil, finishTransactions: false, dangerousSettings: nil)
+        let systemInfo = MockSystemInfo(platformInfo: nil, finishTransactions: false, dangerousSettings: nil)
         let attributionFetcher = AttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
                                                     systemInfo: systemInfo)
 

--- a/Tests/UnitTests/Mocks/MockIdentityManager.swift
+++ b/Tests/UnitTests/Mocks/MockIdentityManager.swift
@@ -16,10 +16,9 @@ class MockIdentityManager: IdentityManager {
     let mockAttributeSyncing = MockAttributeSyncing()
 
     init(mockAppUserID: String) {
-        // swiftlint:disable:next force_try
-        let mockSystemInfo = try! MockSystemInfo(platformInfo: nil,
-                                                 finishTransactions: false,
-                                                 dangerousSettings: nil)
+        let mockSystemInfo = MockSystemInfo(platformInfo: nil,
+                                            finishTransactions: false,
+                                            dangerousSettings: nil)
         let mockDeviceCache = MockDeviceCache(sandboxEnvironmentDetector: mockSystemInfo)
         let mockBackend = MockBackend()
 

--- a/Tests/UnitTests/Mocks/MockSystemInfo.swift
+++ b/Tests/UnitTests/Mocks/MockSystemInfo.swift
@@ -20,11 +20,10 @@ class MockSystemInfo: SystemInfo {
                      storeKit2Setting: StoreKit2Setting = .default,
                      customEntitlementsComputation: Bool = false) {
         let dangerousSettings = DangerousSettings(customEntitlementComputation: customEntitlementsComputation)
-        // swiftlint:disable:next force_try
-        try! self.init(platformInfo: nil,
-                       finishTransactions: finishTransactions,
-                       storeKit2Setting: storeKit2Setting,
-                       dangerousSettings: dangerousSettings)
+        self.init(platformInfo: nil,
+                  finishTransactions: finishTransactions,
+                  storeKit2Setting: storeKit2Setting,
+                  dangerousSettings: dangerousSettings)
     }
 
     override func isApplicationBackgrounded(completion: @escaping (Bool) -> Void) {

--- a/Tests/UnitTests/Mocks/MockTrialOrIntroPriceEligibilityChecker.swift
+++ b/Tests/UnitTests/Mocks/MockTrialOrIntroPriceEligibilityChecker.swift
@@ -13,12 +13,12 @@
 
 @testable import RevenueCat
 
-// swiftlint:disable identifier_name line_length force_try
+// swiftlint:disable identifier_name line_length
 class MockTrialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityChecker {
 
     convenience init() {
         let platformInfo = Purchases.PlatformInfo(flavor: "xyz", version: "123")
-        let systemInfo = try! MockSystemInfo(platformInfo: platformInfo, finishTransactions: true)
+        let systemInfo = MockSystemInfo(platformInfo: platformInfo, finishTransactions: true)
         let productsManager = MockProductsManager(systemInfo: systemInfo,
                                                   requestTimeout: Configuration.storeKitRequestTimeoutDefault)
         self.init(systemInfo: systemInfo,

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -92,7 +92,7 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
         let identifier = try XCTUnwrap(UUID(uuidString: "12345678-1234-1234-1234-C2C35AE34D09")).uuidString
 
         self.createDependencies(
-            try SystemInfo(
+            SystemInfo(
                 platformInfo: nil,
                 finishTransactions: false,
                 dangerousSettings: .init(

--- a/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
+++ b/Tests/UnitTests/Networking/Backend/BaseBackendTest.swift
@@ -39,7 +39,7 @@ class BaseBackendTests: TestCase {
         try super.setUpWithError()
 
         self.createDependencies(
-            try SystemInfo(
+            SystemInfo(
                 platformInfo: nil,
                 finishTransactions: true,
                 responseVerificationMode: self.responseVerificationMode,

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -796,7 +796,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         expect(headerPresent.value) == true
     }
 
-    func testPassesPlatformFlavorHeader() throws {
+    func testPassesPlatformFlavorHeader() {
         let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
         let headerPresent: Atomic<Bool> = false
@@ -806,8 +806,8 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
             return .emptySuccessResponse()
         }
         let platformInfo = Purchases.PlatformInfo(flavor: "react-native", version: "3.2.1")
-        let systemInfo = try SystemInfo(platformInfo: platformInfo,
-                                        finishTransactions: true)
+        let systemInfo = SystemInfo(platformInfo: platformInfo,
+                                    finishTransactions: true)
 
         self.client = self.createClient(systemInfo)
 
@@ -818,7 +818,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         expect(headerPresent.value) == true
     }
 
-    func testPassesPlatformFlavorVersionHeader() throws {
+    func testPassesPlatformFlavorVersionHeader() {
         let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
         let headerPresent: Atomic<Bool> = false
@@ -828,8 +828,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
             return .emptySuccessResponse()
         }
         let platformInfo = Purchases.PlatformInfo(flavor: "react-native", version: "1.2.3")
-        let systemInfo = try SystemInfo(platformInfo: platformInfo,
-                                        finishTransactions: true)
+        let systemInfo = SystemInfo(platformInfo: platformInfo, finishTransactions: true)
         self.client = self.createClient(systemInfo)
 
         waitUntil { completion in
@@ -839,7 +838,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         expect(headerPresent.value) == true
     }
 
-    func testPassesObserverModeHeaderCorrectlyWhenEnabled() throws {
+    func testPassesObserverModeHeaderCorrectlyWhenEnabled() {
         let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
         let headerPresent: Atomic<Bool> = false
@@ -848,7 +847,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
             headerPresent.value = true
             return .emptySuccessResponse()
         }
-        self.client = self.createClient(try SystemInfo(platformInfo: nil, finishTransactions: true))
+        self.client = self.createClient(SystemInfo(platformInfo: nil, finishTransactions: true))
 
         waitUntil { completion in
             self.client.perform(request) { (_: DataResponse) in completion() }
@@ -898,7 +897,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         expect(headerPresent) == false
     }
 
-    func testPassesObserverModeHeaderCorrectlyWhenDisabled() throws {
+    func testPassesObserverModeHeaderCorrectlyWhenDisabled() {
         let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
         let headerPresent: Atomic<Bool> = false
@@ -907,7 +906,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
             headerPresent.value = true
             return .emptySuccessResponse()
         }
-        self.client = self.createClient(try SystemInfo(platformInfo: nil, finishTransactions: false))
+        self.client = self.createClient(SystemInfo(platformInfo: nil, finishTransactions: false))
 
         waitUntil { completion in
             self.client.perform(request) { (_: DataResponse) in completion() }
@@ -1388,7 +1387,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         expect(self.eTagManager.invokedETagHeaderParametersList).to(haveCount(1))
     }
 
-    func testFakeServerErrors() throws {
+    func testFakeServerErrors() {
         let path: HTTPRequest.Path = .mockPath
 
         stub(condition: isPath(path)) { _ in
@@ -1397,7 +1396,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         }
 
         self.client = self.createClient(
-            try .init(
+            .init(
                 platformInfo: nil,
                 finishTransactions: false,
                 dangerousSettings: .init(

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -211,7 +211,7 @@ final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPC
     }
 
     func testPostRequestWithPostParametersHeader() throws {
-        try self.changeClient(.informational)
+        self.changeClient(.informational)
 
         let body = BodyWithSignature(key1: "a", key2: "b")
 

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -235,8 +235,8 @@ final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPC
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPClientTests {
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
 
         self.changeClient(.informational)
     }
@@ -581,8 +581,8 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPClientTests {
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
 
         self.changeClientToEnforced()
     }

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -57,8 +57,8 @@ class BaseSignatureVerificationHTTPClientTests: BaseHTTPClientTests<ETagManager>
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPClientTests {
 
-    func testAutomaticallyAddsNonceIfRequired() throws {
-        try self.changeClient(.informational)
+    func testAutomaticallyAddsNonceIfRequired() {
+        self.changeClient(.informational)
 
         let request = HTTPRequest(method: .get, path: .getCustomerInfo(appUserID: "user"))
 
@@ -93,8 +93,8 @@ final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPC
         expect(headers?[HTTPClient.RequestHeader.nonce.rawValue]) == request.nonce?.base64EncodedString()
     }
 
-    func testFailedVerificationIfResponseContainsNoSignature() throws {
-        try self.changeClient(.informational)
+    func testFailedVerificationIfResponseContainsNoSignature() {
+        self.changeClient(.informational)
         self.mockResponse()
 
         self.signing.stubbedVerificationResult = true
@@ -114,13 +114,13 @@ final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPC
         )
     }
 
-    func testFailedVerificationIfResponseContainsNoSignatureForEndpointWithStaticSignature() throws {
+    func testFailedVerificationIfResponseContainsNoSignatureForEndpointWithStaticSignature() {
         // This test relies on a path with static signatures
         let path: HTTPRequest.Path = .getProductEntitlementMapping
         expect(path.supportsSignatureVerification) == true
         expect(path.needsNonceForSigning) == false
 
-        try self.changeClient(.informational)
+        self.changeClient(.informational)
         self.mockResponse(path: path,
                           signature: nil,
                           requestDate: nil)
@@ -142,8 +142,8 @@ final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPC
         )
     }
 
-    func testHeadersAreCaseInsensitive() throws {
-        try self.changeClient(.informational)
+    func testHeadersAreCaseInsensitive() {
+        self.changeClient(.informational)
 
         stub(condition: isPath(Self.path)) { _ in
             return .init(data: Data(),
@@ -166,8 +166,8 @@ final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPC
         expect(response?.value?.verificationResult) == .verified
     }
 
-    func testSignatureNotRequested() throws {
-        try self.changeClient(.disabled)
+    func testSignatureNotRequested() {
+        self.changeClient(.disabled)
         self.mockResponse()
 
         let response: DataResponse? = waitUntilValue { completion in
@@ -181,7 +181,7 @@ final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPC
     }
 
     func testVerifiedCachedResponseWithNotRequestedVerificationResponse() throws {
-        try self.changeClient(.disabled)
+        self.changeClient(.disabled)
 
         let cachedResponse = BodyWithDate(data: "test", requestDate: Self.date1)
 
@@ -235,10 +235,10 @@ final class SignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPC
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPClientTests {
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    override func setUp() {
+        super.setUp()
 
-        try self.changeClient(.informational)
+        self.changeClient(.informational)
     }
 
     func testValidSignature() throws {
@@ -581,13 +581,13 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificationHTTPClientTests {
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    override func setUp() {
+        super.setUp()
 
-        try self.changeClientToEnforced()
+        self.changeClientToEnforced()
     }
 
-    func testValidSignature() throws {
+    func testValidSignature() {
         self.mockResponse(signature: Self.sampleSignature, requestDate: Self.date1)
 
         self.signing.stubbedVerificationResult = true
@@ -602,7 +602,7 @@ final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificat
         expect(self.signing.requests).to(haveCount(1))
     }
 
-    func testIncorrectSignatureReturnsError() throws {
+    func testIncorrectSignatureReturnsError() {
         self.mockResponse(signature: Self.sampleSignature, requestDate: Self.date1)
 
         self.signing.stubbedVerificationResult = false
@@ -617,7 +617,7 @@ final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificat
             .to(matchError(NetworkError.signatureVerificationFailed(path: Self.path, code: .success)))
     }
 
-    func testPerformRequestOverridesIt() throws {
+    func testPerformRequestOverridesIt() {
         self.mockResponse(signature: Self.sampleSignature, requestDate: Self.date1)
 
         self.signing.stubbedVerificationResult = false
@@ -633,7 +633,7 @@ final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificat
             .to(matchError(NetworkError.signatureVerificationFailed(path: Self.path, code: .success)))
     }
 
-    func testPerformRequestWithDisabledModeOverridesIt() throws {
+    func testPerformRequestWithDisabledModeOverridesIt() {
         self.mockResponse(signature: Self.sampleSignature, requestDate: Self.date1)
 
         self.signing.stubbedVerificationResult = false
@@ -647,11 +647,11 @@ final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificat
         expect(response).to(beSuccess())
     }
 
-    func testFakeSignatureFailuresInEnforcedMode() throws {
+    func testFakeSignatureFailuresInEnforcedMode() {
         self.mockResponse(signature: Self.sampleSignature, requestDate: Self.date1)
         self.signing.stubbedVerificationResult = true
 
-        try self.changeClientToEnforced(forceSignatureFailures: true)
+        self.changeClientToEnforced(forceSignatureFailures: true)
 
         let response: EmptyResponse? = waitUntilValue { completion in
             self.client.perform(.init(method: .get, path: Self.path), completionHandler: completion)
@@ -661,11 +661,11 @@ final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificat
         expect(response?.error) == NetworkError.signatureVerificationFailed(path: Self.path, code: .success)
     }
 
-    func testFakeSignatureFailuresInInformationalMode() throws {
+    func testFakeSignatureFailuresInInformationalMode() {
         self.mockResponse(signature: Self.sampleSignature, requestDate: Self.date1)
         self.signing.stubbedVerificationResult = true
 
-        try self.changeClient(.informational, forceSignatureFailures: true)
+        self.changeClient(.informational, forceSignatureFailures: true)
 
         let response: EmptyResponse? = waitUntilValue { completion in
             self.client.perform(.init(method: .get, path: Self.path), completionHandler: completion)
@@ -675,11 +675,11 @@ final class EnforcedSignatureVerificationHTTPClientTests: BaseSignatureVerificat
         expect(response?.value?.verificationResult) == .failed
     }
 
-    func testFakeSignatureFailuresWithDisabledVerification() throws {
+    func testFakeSignatureFailuresWithDisabledVerification() {
         self.mockResponse(signature: Self.sampleSignature, requestDate: Self.date1)
         self.signing.stubbedVerificationResult = true
 
-        try self.changeClient(.disabled, forceSignatureFailures: true)
+        self.changeClient(.disabled, forceSignatureFailures: true)
 
         let response: EmptyResponse? = waitUntilValue { completion in
             self.client.perform(.init(method: .get, path: Self.path), completionHandler: completion)
@@ -699,21 +699,21 @@ private extension BaseSignatureVerificationHTTPClientTests {
     final func changeClient(
         _ verificationMode: Configuration.EntitlementVerificationMode,
         forceSignatureFailures: Bool = false
-    ) throws {
-        try self.createClient(Signing.verificationMode(with: verificationMode),
-                              forceSignatureFailures: forceSignatureFailures)
+    ) {
+        self.createClient(Signing.verificationMode(with: verificationMode),
+                          forceSignatureFailures: forceSignatureFailures)
     }
 
-    final func changeClientToEnforced(forceSignatureFailures: Bool = false) throws {
-        try self.createClient(Signing.enforcedVerificationMode(),
-                              forceSignatureFailures: forceSignatureFailures)
+    final func changeClientToEnforced(forceSignatureFailures: Bool = false) {
+        self.createClient(Signing.enforcedVerificationMode(),
+                          forceSignatureFailures: forceSignatureFailures)
     }
 
     private final func createClient(
         _ mode: Signing.ResponseVerificationMode,
         forceSignatureFailures: Bool = false
-    ) throws {
-        self.systemInfo = try MockSystemInfo(
+    ) {
+        self.systemInfo = MockSystemInfo(
             platformInfo: nil,
             finishTransactions: false,
             responseVerificationMode: mode,

--- a/Tests/UnitTests/Purchasing/IntroEligibilityCalculatorTests.swift
+++ b/Tests/UnitTests/Purchasing/IntroEligibilityCalculatorTests.swift
@@ -15,7 +15,7 @@ class IntroEligibilityCalculatorTests: TestCase {
         try super.setUpWithError()
 
         let platformInfo = Purchases.PlatformInfo(flavor: "iOS", version: "3.2.1")
-        self.systemInfo = try MockSystemInfo(platformInfo: platformInfo, finishTransactions: true)
+        self.systemInfo = MockSystemInfo(platformInfo: platformInfo, finishTransactions: true)
         self.mockProductsManager = MockProductsManager(systemInfo: systemInfo,
                                                        requestTimeout: Configuration.storeKitRequestTimeoutDefault)
         self.calculator = IntroEligibilityCalculator(productsManager: mockProductsManager,

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -21,9 +21,8 @@ class OfferingsManagerTests: TestCase {
 
     var mockDeviceCache: MockDeviceCache!
     let mockOperationDispatcher = MockOperationDispatcher()
-    // swiftlint:disable:next force_try
-    let mockSystemInfo = try! MockSystemInfo(platformInfo: .init(flavor: "iOS", version: "3.2.1"),
-                                             finishTransactions: true)
+    let mockSystemInfo = MockSystemInfo(platformInfo: .init(flavor: "iOS", version: "3.2.1"),
+                                        finishTransactions: true)
     let mockBackend = MockBackend()
     var mockOfferings: MockOfferingsAPI!
     let mockOfferingsFactory = MockOfferingsFactory()

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -44,8 +44,7 @@ class BasePurchasesTests: TestCase {
         self.mockIntroEligibilityCalculator = MockIntroEligibilityCalculator(productsManager: self.mockProductsManager,
                                                                              receiptParser: self.mockReceiptParser)
         let platformInfo = Purchases.PlatformInfo(flavor: "iOS", version: "4.4.0")
-        let systemInfoAttribution = try MockSystemInfo(platformInfo: platformInfo,
-                                                       finishTransactions: true)
+        let systemInfoAttribution = MockSystemInfo(platformInfo: platformInfo, finishTransactions: true)
         self.receiptFetcher = MockReceiptFetcher(requestFetcher: self.requestFetcher, systemInfo: systemInfoAttribution)
         self.attributionFetcher = MockAttributionFetcher(attributionFactory: MockAttributionTypeFactory(),
                                                          systemInfo: systemInfoAttribution)
@@ -186,10 +185,10 @@ class BasePurchasesTests: TestCase {
         self.initializePurchasesInstance(appUserId: nil)
     }
 
-    func setupPurchasesObserverModeOn() throws {
-        self.systemInfo = try MockSystemInfo(platformInfo: nil,
-                                             finishTransactions: false,
-                                             storeKit2Setting: self.storeKit2Setting)
+    func setUpPurchasesObserverModeOn() {
+        self.systemInfo = MockSystemInfo(platformInfo: nil,
+                                         finishTransactions: false,
+                                         storeKit2Setting: self.storeKit2Setting)
         self.initializePurchasesInstance(appUserId: nil)
     }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
@@ -901,10 +901,10 @@ class PurchasesPurchasingCustomSetupTests: BasePurchasesTests {
     }
 
     func testDoesntPostTransactionsIfAutoSyncPurchasesSettingIsOffInObserverMode() throws {
-        self.systemInfo = try MockSystemInfo(platformInfo: nil,
-                                             finishTransactions: false,
-                                             storeKit2Setting: .enabledOnlyForOptimizations,
-                                             dangerousSettings: DangerousSettings(autoSyncPurchases: false))
+        self.systemInfo = MockSystemInfo(platformInfo: nil,
+                                         finishTransactions: false,
+                                         storeKit2Setting: .enabledOnlyForOptimizations,
+                                         dangerousSettings: DangerousSettings(autoSyncPurchases: false))
         self.initializePurchasesInstance(appUserId: nil)
 
         self.purchases.purchase(product: Self.mockProduct) { (_, _, _, _) in }
@@ -926,10 +926,10 @@ class PurchasesPurchasingCustomSetupTests: BasePurchasesTests {
     }
 
     func testDoesntPostTransactionsIfAutoSyncPurchasesSettingIsOff() throws {
-        self.systemInfo = try MockSystemInfo(platformInfo: nil,
-                                             finishTransactions: true,
-                                             storeKit2Setting: .enabledOnlyForOptimizations,
-                                             dangerousSettings: DangerousSettings(autoSyncPurchases: false))
+        self.systemInfo = MockSystemInfo(platformInfo: nil,
+                                         finishTransactions: true,
+                                         storeKit2Setting: .enabledOnlyForOptimizations,
+                                         dangerousSettings: DangerousSettings(autoSyncPurchases: false))
         self.initializePurchasesInstance(appUserId: nil)
 
         self.purchases.purchase(product: Self.mockProduct) { (_, _, _, _) in }
@@ -951,7 +951,7 @@ class PurchasesPurchasingCustomSetupTests: BasePurchasesTests {
     }
 
     func testDoesntFinishTransactionsIfObserverModeIsSet() throws {
-        try self.setupPurchasesObserverModeOn()
+        self.setUpPurchasesObserverModeOn()
 
         self.purchases.purchase(product: Self.mockProduct) { (_, _, _, _) in }
 
@@ -971,7 +971,7 @@ class PurchasesPurchasingCustomSetupTests: BasePurchasesTests {
     }
 
     func testReceiptsSendsObserverModeWhenObserverMode() throws {
-        try self.setupPurchasesObserverModeOn()
+        self.setUpPurchasesObserverModeOn()
 
         self.purchases.purchase(product: Self.mockProduct) { (_, _, _, _) in }
 
@@ -989,7 +989,7 @@ class PurchasesPurchasingCustomSetupTests: BasePurchasesTests {
     }
 
     func testRestoredPurchasesArePosted() throws {
-        try self.setupPurchasesObserverModeOn()
+        self.setUpPurchasesObserverModeOn()
 
         self.purchases.purchase(product: Self.mockProduct) { (_, _, _, _) in }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncPurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesSyncPurchasesTests.swift
@@ -138,10 +138,10 @@ class PurchasesSyncPurchasesTests: BasePurchasesTests {
         expect(receivedError).to(matchError(error.asPurchasesError))
     }
 
-    func testSyncPurchasesPostsTheReceiptIfAutoSyncPurchasesSettingIsOff() throws {
-        self.systemInfo = try MockSystemInfo(platformInfo: nil,
-                                             finishTransactions: false,
-                                             dangerousSettings: DangerousSettings(autoSyncPurchases: false))
+    func testSyncPurchasesPostsTheReceiptIfAutoSyncPurchasesSettingIsOff() {
+        self.systemInfo = MockSystemInfo(platformInfo: nil,
+                                         finishTransactions: false,
+                                         dangerousSettings: DangerousSettings(autoSyncPurchases: false))
         Purchases.clearSingleton()
         self.initializePurchasesInstance(appUserId: nil)
 

--- a/Tests/UnitTests/Purchasing/ReceiptFetcherTests.swift
+++ b/Tests/UnitTests/Purchasing/ReceiptFetcherTests.swift
@@ -32,9 +32,9 @@ class BaseReceiptFetcherTests: TestCase {
         self.mockBundle = MockBundle()
         self.mockRequestFetcher = MockRequestFetcher()
         self.mockReceiptParser = MockReceiptParser()
-        self.mockSystemInfo = try MockSystemInfo(platformInfo: nil,
-                                                 finishTransactions: false,
-                                                 bundle: self.mockBundle)
+        self.mockSystemInfo = MockSystemInfo(platformInfo: nil,
+                                             finishTransactions: false,
+                                             bundle: self.mockBundle)
         self.clock = TestClock()
 
         self.receiptFetcher = ReceiptFetcher(requestFetcher: self.mockRequestFetcher,

--- a/Tests/UnitTests/Purchasing/StoreKitAbstractions/StoreKitWorkaroundsTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKitAbstractions/StoreKitWorkaroundsTests.swift
@@ -81,9 +81,9 @@ class StoreKitWorkaroundsReceiptURLTests: TestCase {
 
         self.mockBundle = MockBundle()
         self.mockRequestFetcher = MockRequestFetcher()
-        self.mockSystemInfo = try MockSystemInfo(platformInfo: nil,
-                                                 finishTransactions: false,
-                                                 bundle: self.mockBundle)
+        self.mockSystemInfo = MockSystemInfo(platformInfo: nil,
+                                             finishTransactions: false,
+                                             bundle: self.mockBundle)
         self.receiptFetcher = ReceiptFetcher(requestFetcher: self.mockRequestFetcher, systemInfo: self.mockSystemInfo)
     }
 

--- a/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/BackendSubscriberAttributesTests.swift
@@ -46,8 +46,7 @@ class BackendSubscriberAttributesTests: TestCase {
         ] as [String: Any]
     ]
 
-    // swiftlint:disable:next force_try
-    let systemInfo = try! SystemInfo(platformInfo: .init(flavor: "Unity", version: "2.3.3"), finishTransactions: true)
+    let systemInfo = SystemInfo(platformInfo: .init(flavor: "Unity", version: "2.3.3"), finishTransactions: true)
 
     override func setUpWithError() throws {
         mockHTTPClient = self.createClient()

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -86,8 +86,8 @@ class PurchasesSubscriberAttributesTests: TestCase {
         self.mockIntroEligibilityCalculator = MockIntroEligibilityCalculator(productsManager: mockProductsManager,
                                                                              receiptParser: mockReceiptParser)
         let platformInfo = Purchases.PlatformInfo(flavor: "iOS", version: "3.2.1")
-        let systemInfoAttribution = try MockSystemInfo(platformInfo: platformInfo,
-                                                       finishTransactions: true)
+        let systemInfoAttribution = MockSystemInfo(platformInfo: platformInfo,
+                                                   finishTransactions: true)
         self.mockAttributionFetcher = MockAttributionFetcher(attributionFactory: AttributionTypeFactory(),
                                                              systemInfo: systemInfoAttribution)
         self.mockSubscriberAttributesManager = MockSubscriberAttributesManager(

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -30,8 +30,7 @@ class SubscriberAttributesManagerTests: TestCase {
         try super.setUpWithError()
 
         let platformInfo = Purchases.PlatformInfo(flavor: "iOS", version: "3.2.1")
-        let systemInfo = try MockSystemInfo(platformInfo: platformInfo,
-                                            finishTransactions: true)
+        let systemInfo = MockSystemInfo(platformInfo: platformInfo, finishTransactions: true)
 
         self.mockDeviceCache = MockDeviceCache(sandboxEnvironmentDetector: systemInfo)
         self.mockBackend = MockBackend()


### PR DESCRIPTION
Not sure when we stopped throwing errors, but we no longer do, which simplifies code a lot.
