### PR TITLE
`Tests`: added missing `super.setUp()`

### DIFF
--- a/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
@@ -147,6 +147,8 @@ class StoreKit1ObserverModeWithExistingPurchasesTests: BaseStoreKitObserverModeI
     private static var transactionsObservation: Task<Void, Never>?
 
     override class func setUp() {
+        super.setUp()
+
         Self.transactionsObservation?.cancel()
         Self.transactionsObservation = Task {
             // Silence warning in tests:
@@ -158,6 +160,8 @@ class StoreKit1ObserverModeWithExistingPurchasesTests: BaseStoreKitObserverModeI
     override class func tearDown() {
         Self.transactionsObservation?.cancel()
         Self.transactionsObservation = nil
+
+        super.tearDown()
     }
 
     override func setUp() async throws {

--- a/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
+++ b/Tests/StoreKitUnitTests/StoreKitConfigTestCase.swift
@@ -79,6 +79,8 @@ class StoreKitConfigTestCase: TestCase {
     private static var transactionsObservation: Task<Void, Never>?
 
     override class func setUp() {
+        super.setUp()
+
         if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
             Self.transactionsObservation?.cancel()
             Self.transactionsObservation = Task {
@@ -92,6 +94,8 @@ class StoreKitConfigTestCase: TestCase {
     override class func tearDown() {
         Self.transactionsObservation?.cancel()
         Self.transactionsObservation = nil
+
+        super.tearDown()
     }
 
 }


### PR DESCRIPTION
`class func setUp` also needs to call the `super` implementation. `TestCase`'s implementation sets up `CurrentTestCaseTracker`.
