### PR TITLE
`Paywalls`: added tests for `PackageType` filtering

### DIFF
--- a/RevenueCatUI/Templates/Example1Template.swift
+++ b/RevenueCatUI/Templates/Example1Template.swift
@@ -22,7 +22,7 @@ struct Example1Template: TemplateViewType {
             self.data = .failure(.noPackages)
         } else {
             let allPackages = paywall.config.packages
-            let packages = Self.filter(packages: packages, with: allPackages)
+            let packages = PaywallData.filter(packages: packages, with: allPackages)
 
             if let package = packages.first {
                 self.data = .success(.init(

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -26,10 +26,6 @@ extension PaywallData {
             )
         }
     }
-}
-
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
-extension TemplateViewType {
 
     static func filter(packages: [Package], with list: [PackageType]) -> [Package] {
         // Only subscriptions are supported at the moment

--- a/Tests/RevenueCatUITests/PackageFilteringTests.swift
+++ b/Tests/RevenueCatUITests/PackageFilteringTests.swift
@@ -1,0 +1,72 @@
+//
+//  PackageFilteringTests.swift
+//  
+//
+//  Created by Nacho Soto on 7/13/23.
+//
+
+import Nimble
+import RevenueCat
+@testable import RevenueCatUI
+import XCTest
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+class PackageFilteringTests: TestCase {
+
+    func testFilterNoPackages() {
+        expect(PaywallData.filter(packages: [], with: [.monthly])) == []
+    }
+
+    func testFilterPackagesWithEmptyList() {
+        expect(PaywallData.filter(packages: [Self.monthly], with: [])) == []
+    }
+
+    func testFilterOutSinglePackge() {
+        expect(PaywallData.filter(packages: [Self.monthly], with: [.annual])) == []
+    }
+
+    func testFilterOutNonSubscriptions() {
+        expect(PaywallData.filter(packages: [Self.consumable], with: [.custom])) == []
+    }
+
+    func testFilterByPackageType() {
+        expect(PaywallData.filter(packages: [Self.monthly, Self.annual], with: [.monthly])) == [Self.monthly]
+    }
+
+}
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+private extension PackageFilteringTests {
+
+    static let monthly = Package(
+        identifier: "monthly",
+        packageType: .monthly,
+        storeProduct: TestData.productWithIntroOffer.toStoreProduct(),
+        offeringIdentifier: offeringIdentifier
+    )
+    static let annual = Package(
+        identifier: "annual",
+        packageType: .annual,
+        storeProduct: TestData.productWithNoIntroOffer.toStoreProduct(),
+        offeringIdentifier: offeringIdentifier
+    )
+
+    static let consumable = Package(
+        identifier: "consumable",
+        packageType: .custom,
+        storeProduct: consumableProduct.toStoreProduct(),
+        offeringIdentifier: offeringIdentifier
+    )
+
+    private static let consumableProduct = TestStoreProduct(
+        localizedTitle: "Coins",
+        price: 199.99,
+        localizedPriceString: "$199.99",
+        productIdentifier: "com.revenuecat.coins",
+        productType: .consumable,
+        localizedDescription: "Coins"
+    )
+
+    private static let offeringIdentifier = "offering"
+
+}

--- a/Tests/RevenueCatUITests/PackageFilteringTests.swift
+++ b/Tests/RevenueCatUITests/PackageFilteringTests.swift
@@ -33,11 +33,31 @@ class PackageFilteringTests: TestCase {
         expect(PaywallData.filter(packages: [Self.monthly, Self.annual], with: [.monthly])) == [Self.monthly]
     }
 
+    func testFilterWithDuplicatedPackageTypes() {
+        expect(PaywallData.filter(packages: [Self.monthly, Self.annual], with: [.monthly, .monthly])) == [
+            Self.monthly,
+            Self.monthly
+        ]
+    }
+
+    func testFilterReturningMultiplePackages() {
+        expect(PaywallData.filter(packages: [Self.weekly, Self.monthly, Self.annual], with: [.weekly, .monthly])) == [
+            Self.weekly,
+            Self.monthly
+        ]
+    }
+
 }
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 private extension PackageFilteringTests {
 
+    static let weekly = Package(
+        identifier: "weekly",
+        packageType: .weekly,
+        storeProduct: TestData.productWithIntroOffer.toStoreProduct(),
+        offeringIdentifier: offeringIdentifier
+    )
     static let monthly = Package(
         identifier: "monthly",
         packageType: .monthly,


### PR DESCRIPTION
Some missing tests for the logic added in #2798.
I've also moved this function to be fined in `PaywallData` instead of the `TemplateViewType` protocol, which makes more sense.