### PR TITLE
`MockDeviceCache`: avoid using real `UserDefaults`

### DIFF
--- a/Tests/UnitTests/Mocks/MockDeviceCache.swift
+++ b/Tests/UnitTests/Mocks/MockDeviceCache.swift
@@ -9,7 +9,7 @@ class MockDeviceCache: DeviceCache {
 
     convenience init(sandboxEnvironmentDetector: SandboxEnvironmentDetector = MockSandboxEnvironmentDetector()) {
         self.init(sandboxEnvironmentDetector: sandboxEnvironmentDetector,
-                  userDefaults: .computeDefault())
+                  userDefaults: MockUserDefaults())
     }
 
     // MARK: appUserID


### PR DESCRIPTION
I noticed that in some tests that shouldn't be using real `UserDefaults` this was being logged, even multiple times per test:
> Configuring SDK using RevenueCat's UserDefaults suite.
