### PR TITLE
`CustomEntitlementsComputation`: fixed API testers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,8 +303,7 @@ jobs:
       - update-spm-installation-commit
       - run:
           name: Custom Entitlement Computation API Tests
-          working_directory: Tests/APITesters/CustomEntitlementComputationSwiftAPITester
-          command: bundle exec fastlane build_ios_app --skip_archive --destination "generic/platform=ios" --skip_codesigning
+          command: bundle exec fastlane build_custom_entitlement_computation_api_tester
 
   spm-receipt-parser:
     <<: *base-job

--- a/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/CustomEntitlementComputationSwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -31,8 +31,6 @@ func checkPurchasesAPI() {
     checkPurchasesPurchasingAPI(purchases: purch)
     checkPurchasesSupportAPI(purchases: purch)
 
-    let _: Attribution = purch.attribution
-
     if #available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *) {
         _ = Task<Void, Never> {
             await checkAsyncMethods(purchases: purch)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -240,6 +240,16 @@ platform :ios do
     )
   end
 
+  desc "build CustomEntitlementComputation API tester"
+  lane :build_custom_entitlement_computation_api_tester do
+    xcodebuild(
+      project: 'Tests/APITesters/CustomEntitlementComputationSwiftAPITester/CustomEntitlementComputationSwiftAPITester.xcodeproj',
+      scheme: 'SwiftAPITester',
+      destination: 'generic/platform=iOS',
+      xcargs: "CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO"
+    )
+  end
+
   desc "replace API KEY for installation and integration tests"
   lane :replace_api_key_integration_tests do
     replace_text_in_files(

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -154,6 +154,14 @@ build Swift API tester
 
 build ObjC API tester
 
+### ios build_custom_entitlement_computation_api_tester
+
+```sh
+[bundle exec] fastlane ios build_custom_entitlement_computation_api_tester
+```
+
+build CustomEntitlementComputation API tester
+
 ### ios replace_api_key_integration_tests
 
 ```sh


### PR DESCRIPTION
For some reason the existing command was failing, but CI was ignoring that failure.
This moves the job to our `Fastfile`, and fixes compilation.

That API was removed in #2442.
