### PR TITLE
`Paywalls`: set up CI tests and API Tester

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,6 +314,25 @@ jobs:
           command: swift build -c release --target ReceiptParser
           no_output_timeout: 30m
 
+  spm-revenuecat-ui-ios-16:
+    <<: *base-job
+    steps:
+      - checkout
+      - update-spm-installation-commit
+      - run:
+          name: SPM RevenueCatUI Release Build
+          command: swift build -c release --target RevenueCatUI
+          no_output_timeout: 5m
+      - run:
+          name: SPM RevenueCatUI Tests
+          command: bundle exec fastlane test_revenuecatui
+          no_output_timeout: 5m
+          environment:
+            SCAN_DEVICE: iPhone 14 (16.4)
+      - run:
+          name: RevenueCatUI API Tests
+          command: bundle exec fastlane build_revenuecatui_api_tester
+
   run-test-ios-17:
     <<: *base-job
     steps:
@@ -877,6 +896,8 @@ workflows:
       - spm-custom-entitlement-computation-build:
           xcode_version: '14.3.0'
       - spm-receipt-parser:
+          xcode_version: '14.3.0'
+      - spm-revenuecat-ui-ios-16:
           xcode_version: '14.3.0'
       # Disabled until we drop support for iOS 11
       # - run-test-ios-17:

--- a/Package.swift
+++ b/Package.swift
@@ -66,6 +66,7 @@ let package = Package(
                         "Nimble",
                         .product(name: "SnapshotTesting", package: "swift-snapshot-testing")
                     ],
+                    exclude: ["__Snapshots__"],
                     resources: [.copy("Resources/image.png")])
     ]
 )

--- a/RevenueCatUI/Templates/Example1Template.swift
+++ b/RevenueCatUI/Templates/Example1Template.swift
@@ -192,7 +192,9 @@ private struct Example1TemplateContent: View {
         .fontWeight(.semibold)
         .tint(Color.green.gradient.opacity(0.8))
         .buttonStyle(.borderedProminent)
+        #if !os(macOS)
         .buttonBorderShape(.capsule)
+        #endif
         .controlSize(.large)
     }
 

--- a/RevenueCatUI/Views/DebugErrorView.swift
+++ b/RevenueCatUI/Views/DebugErrorView.swift
@@ -49,7 +49,7 @@ struct DebugErrorView: View {
                     Logger.warning("Couldn't load paywall: \(self.description)")
                 }
 
-        case let .fatalError:
+        case .fatalError:
             fatalError(self.description)
         }
         #endif

--- a/Tests/APITesters/ReceiptParserAPITester/ReceiptParserAPITester.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Tests/APITesters/ReceiptParserAPITester/ReceiptParserAPITester.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Tests/APITesters/RevenueCatUIAPITester/RevenueCatUISwiftAPITester.xcodeproj/project.pbxproj
+++ b/Tests/APITesters/RevenueCatUIAPITester/RevenueCatUISwiftAPITester.xcodeproj/project.pbxproj
@@ -1,0 +1,397 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		2C396F5C281C64AF00669657 /* AdServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2C396F5B281C64AF00669657 /* AdServices.framework */; platformFilters = (ios, maccatalyst, macos, ); };
+		4F592A502A1FDC6F00851F36 /* PaywallViewAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F592A4F2A1FDC6F00851F36 /* PaywallViewAPI.swift */; };
+		4FD737882A61AD71002AFE75 /* RevenueCatUI in Frameworks */ = {isa = PBXBuildFile; productRef = 4FD737872A61AD71002AFE75 /* RevenueCatUI */; };
+		4FD7378A2A61ADF8002AFE75 /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = 4FD737892A61ADF8002AFE75 /* RevenueCat */; };
+		5738F42127866F8F0096D623 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D614C626EBE7EA007DDB75 /* main.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		5758859E2748272A00CA2169 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		2C396F5B281C64AF00669657 /* AdServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdServices.framework; path = System/Library/Frameworks/AdServices.framework; sourceTree = SDKROOT; };
+		2DD778D0270E233F0079CBD4 /* SwiftAPITester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftAPITester.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		4F592A4F2A1FDC6F00851F36 /* PaywallViewAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewAPI.swift; sourceTree = "<group>"; };
+		A5D614C626EBE7EA007DDB75 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		2DD778CD270E233F0079CBD4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4FD737882A61AD71002AFE75 /* RevenueCatUI in Frameworks */,
+				2C396F5C281C64AF00669657 /* AdServices.framework in Frameworks */,
+				4FD7378A2A61ADF8002AFE75 /* RevenueCat in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		2D6F3871270E58DB002C9987 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				2C396F5B281C64AF00669657 /* AdServices.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		A55F62AC26EAFFD200A1B466 = {
+			isa = PBXGroup;
+			children = (
+				A55F62B726EAFFD200A1B466 /* SwiftAPITester */,
+				A55F62B626EAFFD200A1B466 /* Products */,
+				2D6F3871270E58DB002C9987 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		A55F62B626EAFFD200A1B466 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				2DD778D0270E233F0079CBD4 /* SwiftAPITester.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		A55F62B726EAFFD200A1B466 /* SwiftAPITester */ = {
+			isa = PBXGroup;
+			children = (
+				4F592A4F2A1FDC6F00851F36 /* PaywallViewAPI.swift */,
+				A5D614C626EBE7EA007DDB75 /* main.swift */,
+			);
+			path = SwiftAPITester;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		2DD778CF270E233F0079CBD4 /* SwiftAPITester */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2DD778E3270E23400079CBD4 /* Build configuration list for PBXNativeTarget "SwiftAPITester" */;
+			buildPhases = (
+				2DD778CC270E233F0079CBD4 /* Sources */,
+				2DD778CD270E233F0079CBD4 /* Frameworks */,
+				2DD778CE270E233F0079CBD4 /* Resources */,
+				5758859E2748272A00CA2169 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftAPITester;
+			packageProductDependencies = (
+				4FD737872A61AD71002AFE75 /* RevenueCatUI */,
+				4FD737892A61ADF8002AFE75 /* RevenueCat */,
+			);
+			productName = SwiftAPITesterIOS;
+			productReference = 2DD778D0270E233F0079CBD4 /* SwiftAPITester.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A55F62AD26EAFFD200A1B466 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1300;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+					2DD778CF270E233F0079CBD4 = {
+						CreatedOnToolsVersion = 13.0;
+					};
+				};
+			};
+			buildConfigurationList = A55F62B026EAFFD200A1B466 /* Build configuration list for PBXProject "RevenueCatUISwiftAPITester" */;
+			compatibilityVersion = "Xcode 12.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A55F62AC26EAFFD200A1B466;
+			packageReferences = (
+				4FD737862A61AD71002AFE75 /* XCRemoteSwiftPackageReference "purchases-ios" */,
+			);
+			productRefGroup = A55F62B626EAFFD200A1B466 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				2DD778CF270E233F0079CBD4 /* SwiftAPITester */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		2DD778CE270E233F0079CBD4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		2DD778CC270E233F0079CBD4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5738F42127866F8F0096D623 /* main.swift in Sources */,
+				4F592A502A1FDC6F00851F36 /* PaywallViewAPI.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		2DD778E1270E23400079CBD4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8SXR2327BM;
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.SwiftAPITesterIOS;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development com.revenuecat.SwiftAPITesterIOS";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
+			};
+			name = Debug;
+		};
+		2DD778E2270E23400079CBD4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8SXR2327BM;
+				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.revenuecat.SwiftAPITesterIOS;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development com.revenuecat.SwiftAPITesterIOS";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2,3,4,6";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		A55F62BA26EAFFD200A1B466 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.3;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
+			};
+			name = Debug;
+		};
+		A55F62BB26EAFFD200A1B466 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		2DD778E3270E23400079CBD4 /* Build configuration list for PBXNativeTarget "SwiftAPITester" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2DD778E1270E23400079CBD4 /* Debug */,
+				2DD778E2270E23400079CBD4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A55F62B026EAFFD200A1B466 /* Build configuration list for PBXProject "RevenueCatUISwiftAPITester" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A55F62BA26EAFFD200A1B466 /* Debug */,
+				A55F62BB26EAFFD200A1B466 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		4FD737862A61AD71002AFE75 /* XCRemoteSwiftPackageReference "purchases-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/RevenueCat/purchases-ios";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		4FD737872A61AD71002AFE75 /* RevenueCatUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4FD737862A61AD71002AFE75 /* XCRemoteSwiftPackageReference "purchases-ios" */;
+			productName = RevenueCatUI;
+		};
+		4FD737892A61ADF8002AFE75 /* RevenueCat */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4FD737862A61AD71002AFE75 /* XCRemoteSwiftPackageReference "purchases-ios" */;
+			productName = RevenueCat;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = A55F62AD26EAFFD200A1B466 /* Project object */;
+}

--- a/Tests/APITesters/RevenueCatUIAPITester/RevenueCatUISwiftAPITester.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Tests/APITesters/RevenueCatUIAPITester/RevenueCatUISwiftAPITester.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Tests/APITesters/RevenueCatUIAPITester/RevenueCatUISwiftAPITester.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Tests/APITesters/RevenueCatUIAPITester/RevenueCatUISwiftAPITester.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Tests/APITesters/RevenueCatUIAPITester/RevenueCatUISwiftAPITester.xcodeproj/xcshareddata/xcschemes/SwiftAPITester.xcscheme
+++ b/Tests/APITesters/RevenueCatUIAPITester/RevenueCatUISwiftAPITester.xcodeproj/xcshareddata/xcschemes/SwiftAPITester.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2DD778CF270E233F0079CBD4"
+               BuildableName = "SwiftAPITester.app"
+               BlueprintName = "SwiftAPITester"
+               ReferencedContainer = "container:RevenueCatUISwiftAPITester.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2DD778CF270E233F0079CBD4"
+            BuildableName = "SwiftAPITester.app"
+            BlueprintName = "SwiftAPITester"
+            ReferencedContainer = "container:RevenueCatUISwiftAPITester.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
@@ -1,0 +1,22 @@
+//
+//  PaywallViewAPI.swift
+//  SwiftAPITester
+//
+//  Created by Nacho Soto on 7/14/23.
+//
+
+import RevenueCat
+import RevenueCatUI
+import SwiftUI
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+struct App: View {
+
+    private var offering: Offering
+    private var paywall: PaywallData
+
+    var body: some View {
+        PaywallView(offering: self.offering, paywall: self.paywall)
+    }
+
+}

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/main.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/main.swift
@@ -1,0 +1,18 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  main.swift
+//
+//  Created by Nacho Soto on 7/14/23.
+
+import Foundation
+
+func main() -> Int {
+    return 0
+}

--- a/Tests/RevenueCatUITests/PaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/PaywallViewTests.swift
@@ -4,7 +4,9 @@ import RevenueCat
 import SnapshotTesting
 import XCTest
 
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+#if !os(macOS)
+
+@available(iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 class PaywallViewTests: TestCase {
 
     override class func setUp() {
@@ -89,3 +91,5 @@ private extension PaywallData {
     }
 
 }
+
+#endif

--- a/Tests/UnitTests/TestHelpers/OSVersionEquivalent.swift
+++ b/Tests/UnitTests/TestHelpers/OSVersionEquivalent.swift
@@ -12,7 +12,14 @@
 //  Created by Nacho Soto on 4/13/22.
 
 import Foundation
+
+#if canImport(UIKit)
 import UIKit
+#endif
+
+#if canImport(WatchKit)
+import WatchKit
+#endif
 
 /// The equivalent version for the current device running tests.
 /// Examples:
@@ -57,25 +64,24 @@ extension OSVersionEquivalent {
 
 }
 
-#if os(watchOS)
-import WatchKit
-#endif
-
 private extension OSVersionEquivalent {
 
     private enum Error: Swift.Error {
 
         case unknownOS(systemName: String, version: String)
+        case unknownPlatform
 
         static func unknownOS() -> Self {
             #if os(watchOS)
             let device = WKInterfaceDevice.current()
 
             return .unknownOS(systemName: device.systemName, version: device.systemVersion)
-            #else
+            #elseif os(iOS) || os(tvOS)
             let device = UIDevice.current
 
             return .unknownOS(systemName: device.systemName, version: device.systemVersion)
+            #else
+            return .unknownPlatform
             #endif
         }
 

--- a/Tests/UnitTests/TestHelpers/SnapshotTesting+Extensions.swift
+++ b/Tests/UnitTests/TestHelpers/SnapshotTesting+Extensions.swift
@@ -45,7 +45,7 @@ extension Snapshotting where Value == Encodable, Format == String {
 
 // MARK: - Image Snapshoting
 
-#if !os(watchOS) && swift(>=5.8)
+#if !os(watchOS) && !os(macOS) && swift(>=5.8)
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension SwiftUI.View {
 
@@ -133,7 +133,7 @@ private let outputFormatting: JSONEncoder.OutputFormatting = {
 
 // MARK: - SwiftUIContainerView
 
-#if !os(watchOS)
+#if !os(watchOS) && !os(macOS)
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 @available(watchOS, unavailable)
 private final class SwiftUIContainerView<V: SwiftUI.View>: UIView {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -175,6 +175,17 @@ platform :ios do
     )
   end
 
+  desc "Runs all RevenueCatUI tests"
+  lane :test_revenuecatui do |options|
+    # See https://forums.swift.org/t/i-made-a-little-spm-package-that-uses-uikit-how-can-i-run-tests-from-command-line/50399/2
+    xcodebuild(
+      workspace: '.',
+      scheme: 'RevenueCatUI',
+      destination: "platform=iOS Simulator,name=" + (ENV['SCAN_DEVICE'] || "iPhone 14 (16.4)"),
+      test: true
+    )
+  end
+
   desc "Release checks"
   lane :release_checks do |options|
     version_number = current_version_number
@@ -244,6 +255,16 @@ platform :ios do
   lane :build_custom_entitlement_computation_api_tester do
     xcodebuild(
       project: 'Tests/APITesters/CustomEntitlementComputationSwiftAPITester/CustomEntitlementComputationSwiftAPITester.xcodeproj',
+      scheme: 'SwiftAPITester',
+      destination: 'generic/platform=iOS',
+      xcargs: "CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO"
+    )
+  end
+
+  desc "build RevenueCatUI API tester"
+  lane :build_revenuecatui_api_tester do
+    xcodebuild(
+      project: 'Tests/APITesters/RevenueCatUIAPITester/RevenueCatUISwiftAPITester.xcodeproj',
       scheme: 'SwiftAPITester',
       destination: 'generic/platform=iOS',
       xcargs: "CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO"
@@ -492,6 +513,8 @@ platform :ios do
       './Tests/InstallationTests/SPMCustomEntitlementComputationInstallation/SPMInstallation.xcodeproj/project.pbxproj',
       './Tests/InstallationTests/ReceiptParserInstallation/ReceiptParserInstallation.xcodeproj/project.pbxproj',
       './Tests/APITesters/CustomEntitlementComputationSwiftAPITester/CustomEntitlementComputationSwiftAPITester.xcodeproj/project.pbxproj',
+      # Fixme: this project is currently pointing to `paywalls` branch, it needs to be changed to `main` once that's merged.
+      './Tests/APITesters/RevenueCatUIAPITester/RevenueCatUISwiftAPITester.xcodeproj/project.pbxproj',
       './Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj',
       './Examples/MagicWeather/MagicWeather.xcodeproj/project.pbxproj',
       './RevenueCat.xcodeproj/project.pbxproj'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -513,7 +513,6 @@ platform :ios do
       './Tests/InstallationTests/SPMCustomEntitlementComputationInstallation/SPMInstallation.xcodeproj/project.pbxproj',
       './Tests/InstallationTests/ReceiptParserInstallation/ReceiptParserInstallation.xcodeproj/project.pbxproj',
       './Tests/APITesters/CustomEntitlementComputationSwiftAPITester/CustomEntitlementComputationSwiftAPITester.xcodeproj/project.pbxproj',
-      # Fixme: this project is currently pointing to `paywalls` branch, it needs to be changed to `main` once that's merged.
       './Tests/APITesters/RevenueCatUIAPITester/RevenueCatUISwiftAPITester.xcodeproj/project.pbxproj',
       './Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj',
       './Examples/MagicWeather/MagicWeather.xcodeproj/project.pbxproj',

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -90,6 +90,14 @@ Runs all the tvOS tests
 
 Runs all the watchOS tests
 
+### ios test_revenuecatui
+
+```sh
+[bundle exec] fastlane ios test_revenuecatui
+```
+
+Runs all RevenueCatUI tests
+
 ### ios release_checks
 
 ```sh
@@ -161,6 +169,14 @@ build ObjC API tester
 ```
 
 build CustomEntitlementComputation API tester
+
+### ios build_revenuecatui_api_tester
+
+```sh
+[bundle exec] fastlane ios build_revenuecatui_api_tester
+```
+
+build RevenueCatUI API tester
 
 ### ios replace_api_key_integration_tests
 


### PR DESCRIPTION
### Description:
The new `spm-revenuecat-ui-ios-16` CircleCI job does the following:
- Build using `SPM` on release configuration, on `macOS` (because SPM on command line can only build for the target architecture)
- Run tests on iOS 16 simulator
- Compile new API tests

### Other changes:
- Fixed a couple of warnings building `RevenueCatUI`
- Fixed `macOS` `RevenueCatUI` build (even though it will be disabled in #2821).