### PR TITLE
`PaywallData`: ignore empty strings in `LocalizedConfiguration`

### DIFF
--- a/Sources/Paywalls/PaywallData.swift
+++ b/Sources/Paywalls/PaywallData.swift
@@ -51,6 +51,8 @@ public protocol PaywallLocalizedConfiguration {
 
 }
 
+// swiftlint:disable identifier_name
+
 extension PaywallData {
 
     /// Defines the necessary localized information for a paywall.
@@ -62,13 +64,21 @@ extension PaywallData {
         public var title: String
         public var subtitle: String
         public var callToAction: String
-        public var callToActionWithIntroOffer: String?
         public var offerDetails: String
-        public var offerDetailsWithIntroOffer: String?
+        @NonEmptyStringDecodable
+        var _callToActionWithIntroOffer: String?
+        @NonEmptyStringDecodable
+        var _offerDetailsWithIntroOffer: String?
 
-        // swiftlint:enable missing_docs
+        public var callToActionWithIntroOffer: String? {
+            get { return self._callToActionWithIntroOffer }
+            set { self._callToActionWithIntroOffer = newValue }
+        }
+        public var offerDetailsWithIntroOffer: String? {
+            get { return self._offerDetailsWithIntroOffer }
+            set { self._offerDetailsWithIntroOffer = newValue }
+        }
 
-        /// swiftlint:disable:next missing_docs
         public init(
             title: String,
             subtitle: String,
@@ -80,11 +90,12 @@ extension PaywallData {
             self.title = title
             self.subtitle = subtitle
             self.callToAction = callToAction
-            self.callToActionWithIntroOffer = callToActionWithIntroOffer
+            self._callToActionWithIntroOffer = callToActionWithIntroOffer
             self.offerDetails = offerDetails
-            self.offerDetailsWithIntroOffer = offerDetailsWithIntroOffer
+            self._offerDetailsWithIntroOffer = offerDetailsWithIntroOffer
         }
 
+        // swiftlint:enable missing_docs
     }
 
     /// - Returns: ``PaywallData/LocalizedConfiguration-swift.struct`` for the given `Locale`, if found.
@@ -196,9 +207,9 @@ extension PaywallData.LocalizedConfiguration: Codable {
         case title
         case subtitle
         case callToAction
-        case callToActionWithIntroOffer
+        case _callToActionWithIntroOffer = "callToActionWithIntroOffer"
         case offerDetails
-        case offerDetailsWithIntroOffer
+        case _offerDetailsWithIntroOffer = "offerDetailsWithIntroOffer"
     }
 
 }

--- a/Tests/UnitTests/Networking/Responses/Fixtures/PaywallData-Sample1.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/PaywallData-Sample1.json
@@ -13,7 +13,8 @@
             "title": "Tienda",
             "subtitle": "Descripción",
             "call_to_action": "Comprar",
-            "offer_details": "{{ price_per_month }} cada mes"
+            "offer_details": "{{ price_per_month }} cada mes",
+            "offer_details_with_intro_offer": " "
         }
     },
     "default_locale": "en_US",


### PR DESCRIPTION
Uses the new wrapper added by #2819.