### PR TITLE
`MainThreadMonitor`: check deadlocks only ever N seconds

### DIFF
--- a/Tests/BackendIntegrationTests/MainThreadMonitor.swift
+++ b/Tests/BackendIntegrationTests/MainThreadMonitor.swift
@@ -37,11 +37,11 @@ final class MainThreadMonitor {
         self.queue.async { [weak self] in
             while self != nil {
                 let semaphore = DispatchSemaphore(value: 0)
-                DispatchQueue.main.async {
+                DispatchQueue.main.asyncAfter(deadline: .now() + Self.checkInterval) {
                     semaphore.signal()
                 }
 
-                let deadline = DispatchTime.now() + Self.threshold
+                let deadline = DispatchTime.now() + Self.threshold + Self.checkInterval
                 let result = semaphore.wait(timeout: deadline)
 
                 precondition(
@@ -52,7 +52,10 @@ final class MainThreadMonitor {
         }
     }
 
+    /// Elapsed time before the thread is considered deadlocked.
     private static let threshold: DispatchTimeInterval = .seconds(30)
+    /// How often a check is performed
+    private static let checkInterval: DispatchTimeInterval = .seconds(3)
 
 }
 


### PR DESCRIPTION
This was introduced in #2463, as a way to verify the SDK didn't have any deadlocks (#2412, #2375).
However, it has caused more trouble than it's worth, because that loop keeps the main thread busy.

This solution proposed by @aboedo makes it only check every 3 seconds.
If there is a deadlock, it would still detect it. But after it's verified there is no deadlock, it won't check again until that interval has elapsed again.

This makes it so that on a test that takes 6 seconds to run, we only execute this code 2 times instead of... a lot.
