### PR TITLE
`Integration Tests`: workaround Swift runtime crash

### DIFF
--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -160,18 +160,18 @@ private extension BaseBackendIntegrationTests {
     }
 
     func verifyPurchasesDoesNotLeak() {
+        weak var purchases = Purchases.shared
+
         // See `addTeardownBlock` docs:
         // - These run *before* `tearDown`.
         // - They run in LIFO order.
-        self.addTeardownBlock { [weak purchases = Purchases.shared] in
-            // Note: this captures the boolean to avoid race conditions when Nimble tries
-            // to print `purchases` while it's being deallocated.
-            expect { purchases == nil }.toEventually(beTrue(), description: "Purchases has leaked")
-        }
-
         self.addTeardownBlock {
             Purchases.shared.delegate = nil
             Purchases.clearSingleton()
+
+            // Note: this captures the boolean to avoid race conditions when Nimble tries
+            // to print `purchases` while it's being deallocated.
+            expect { purchases == nil }.toEventually(beTrue(), description: "Purchases has leaked")
         }
     }
 


### PR DESCRIPTION
Looks like #2806 didn't work.
I still see this race-condition crash:
```
Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   libswiftCore.dylib            	       0x10bc64589 swift::runtime::AccessSet::insert(swift::runtime::Access*, void*, void*, swift::ExclusivityFlags) + 73
1   libswiftCore.dylib            	       0x10bc647e2 swift_beginAccess + 66
2   BackendIntegrationTests       	       0x13ab37c76 default argument 1 of Expectation.toEventually(_:timeout:pollInterval:description:) + 54
3   BackendIntegrationTests       	       0x13ab37b44 closure #1 in BaseBackendIntegrationTests.verifyPurchasesDoesNotLeak() + 276 (BaseBackendIntegrationTests.swift:167)
```

This slight refactor matches the implementation in `BasePurchasesTests`, and I haven't the crash there. So hopefully this will work.
