### PR TITLE
`CI`: make all `Codecov` jobs `informational`

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,3 +7,7 @@ coverage:
       default:
         target: auto
         informational: true
+    patch:
+      default:
+        informational: true
+


### PR DESCRIPTION
Follow up to #2670. Reading through [the docs](https://docs.codecov.com/docs#tips-and-tricks) I realized we were missing this too.
