### PR TITLE
`CI`: fixed Fastlane APITester lanes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -225,7 +225,7 @@ platform :ios do
   desc "build Swift API tester"
   lane :build_swift_api_tester do
     xcodebuild(
-      workspace: 'Tests/APITesters/APITesters.xcworkspace',
+      workspace: 'RevenueCat.xcworkspace',
       scheme: 'SwiftAPITester',
       destination: 'generic/platform=iOS Simulator'
     )
@@ -234,7 +234,7 @@ platform :ios do
   desc "build ObjC API tester"
   lane :build_objc_api_tester do
     xcodebuild(
-      workspace: 'Tests/APITesters/APITesters.xcworkspace',
+      workspace: 'RevenueCat.xcworkspace',
       scheme: 'ObjCAPITester',
       destination: 'generic/platform=iOS Simulator'
     )


### PR DESCRIPTION
These aren't used by CI since the targets are compiled along with our unit tests.
But I noticed the definitions were wrong and wouldn't build.
