### PR TITLE
`MainThreadMonitor`: don't crash if there is no test in progress

### DIFF
--- a/Tests/BackendIntegrationTests/MainThreadMonitor.swift
+++ b/Tests/BackendIntegrationTests/MainThreadMonitor.swift
@@ -44,9 +44,13 @@ final class MainThreadMonitor {
                 let deadline = DispatchTime.now() + Self.threshold + Self.checkInterval
                 let result = semaphore.wait(timeout: deadline)
 
+                // `XCTest` sometimes blocks the main thread at the end of a test.
+                // We don't want to detect that as a deadlock.
+                let timedOutDuringTest = CurrentTestCaseTracker.shared.testInProgress && result == .timedOut
+
                 precondition(
-                    result != .timedOut,
-                    "Main thread was blocked for more than \(Self.threshold.seconds) seconds"
+                    !timedOutDuringTest,
+                    "Main thread was blocked for more than \(Self.threshold.seconds) seconds during a test"
                 )
             }
         }

--- a/Tests/UnitTests/TestHelpers/CurrentTestCaseTracker.swift
+++ b/Tests/UnitTests/TestHelpers/CurrentTestCaseTracker.swift
@@ -28,6 +28,10 @@ final class CurrentTestCaseTracker: NSObject, XCTestObservation {
         currentTestCase = nil
     }
 
+    var testInProgress: Bool {
+        return self.currentTestCase != nil
+    }
+
     /// Extracts the name of the current running test.
     ///
     /// Example: extracts `testLoginCachesForSameUserIDs`


### PR DESCRIPTION
I was testing this locally, and I noticed that sometimes this would trigger _after_ a test had already finished:
```
Test Case '-[BackendIntegrationTests.StoreKit2IntegrationTests testCanPurchasePackage]' passed (16.712 seconds).
Test Suite 'StoreKit2IntegrationTests' passed at 2023-07-18 10:27:45.282.
	 Executed 1 test, with 0 failures (0 unexpected) in 16.712 (16.713) seconds
Test Suite 'BackendIntegrationTests.xctest' passed at 2023-07-18 10:27:45.282.
	 Executed 1 test, with 0 failures (0 unexpected) in 16.712 (16.713) seconds
Test Suite 'Selected tests' passed at 2023-07-18 10:27:45.282.
	 Executed 1 test, with 0 failures (0 unexpected) in 16.712 (16.714) seconds
BackendIntegrationTests/MainThreadMonitor.swift:47: Precondition failed: Main thread was blocked for more than 1.0 seconds
2023-07-18 10:27:46.301255-0700 BackendIntegrationTestsHostApp[28299:2377529] BackendIntegrationTests/MainThreadMonitor.swift:47: Precondition failed: Main thread was blocked for more than 1.0 seconds
```

Looking at what the main thread was doing, I noticed `XCTest` was blocked waiting for some internal signal, possibly at the end of a test suite.

![image](https://github.com/RevenueCat/purchases-ios/assets/685609/e81ffe5a-bd80-4650-990e-2f58f13ba3bd)

We obviously don't want to consider that a deadlock, since it's not our fault, so I changed the implementation to ignore this if the test isn't in progress.

I'd bet this is the last time (🤞🏻 ) I have to change this. This follows up several PRs trying to avoid false positives in CI:
- #2820 
- #2662
- #2517