### PR TITLE
`TransactionPoster`: don't finish transactions for non-subscriptions if they're not processed

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -203,6 +203,9 @@
 		4F0BBAAC2A1D253D000E75AB /* OfflineCustomerInfoCreatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0BBAAB2A1D253D000E75AB /* OfflineCustomerInfoCreatorTests.swift */; };
 		4F0CE2BD2A215CE600561895 /* TransactionPosterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0CE2BC2A215CE600561895 /* TransactionPosterTests.swift */; };
 		4F1428A42A4A132C006CD196 /* TestStoreProductDiscount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1428A32A4A132C006CD196 /* TestStoreProductDiscount.swift */; };
+		4F15B4A12A6774C9005BEFE8 /* CustomerInfo+NonSubscriptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F15B4A02A6774C9005BEFE8 /* CustomerInfo+NonSubscriptions.swift */; };
+		4F15B4A22A678A9C005BEFE8 /* MockStoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */; };
+		4F15B4A32A678B81005BEFE8 /* MockStoreTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFD2502922DBED00A9A878 /* MockStoreTransaction.swift */; };
 		4F2017D52A15587F0061F6EF /* OfflineStoreKitIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2017D42A15587F0061F6EF /* OfflineStoreKitIntegrationTests.swift */; };
 		4F2018732A15797D0061F6EF /* TestLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57057FF728B0048900995F21 /* TestLogHandler.swift */; };
 		4F2F2EFF2A3CDAA800652B24 /* FileHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2F2EFE2A3CDAA800652B24 /* FileHandler.swift */; };
@@ -957,6 +960,7 @@
 		4F0BBAAB2A1D253D000E75AB /* OfflineCustomerInfoCreatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineCustomerInfoCreatorTests.swift; sourceTree = "<group>"; };
 		4F0CE2BC2A215CE600561895 /* TransactionPosterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionPosterTests.swift; sourceTree = "<group>"; };
 		4F1428A32A4A132C006CD196 /* TestStoreProductDiscount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestStoreProductDiscount.swift; sourceTree = "<group>"; };
+		4F15B4A02A6774C9005BEFE8 /* CustomerInfo+NonSubscriptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CustomerInfo+NonSubscriptions.swift"; sourceTree = "<group>"; };
 		4F2017D42A15587F0061F6EF /* OfflineStoreKitIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineStoreKitIntegrationTests.swift; sourceTree = "<group>"; };
 		4F2F2EFE2A3CDAA800652B24 /* FileHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileHandler.swift; sourceTree = "<group>"; };
 		4F2F2F132A3CEAB500652B24 /* FileHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileHandlerTests.swift; sourceTree = "<group>"; };
@@ -2618,6 +2622,7 @@
 			children = (
 				A56F9AB026990E9200AFC48F /* CustomerInfo.swift */,
 				57F3C10429B7B22E0004FD7E /* CustomerInfo+ActiveDates.swift */,
+				4F15B4A02A6774C9005BEFE8 /* CustomerInfo+NonSubscriptions.swift */,
 				B3A36AAD26BC76340059EDEA /* CustomerInfoManager.swift */,
 				B3852F9F26C1ED1F005384F8 /* IdentityManager.swift */,
 			);
@@ -3292,6 +3297,7 @@
 				2DD9F4BE274EADC20031AE2C /* Purchases+async.swift in Sources */,
 				B3C4AAD526B8911300E1B3C8 /* Backend.swift in Sources */,
 				B34D2AA626976FC700D88C3A /* ErrorCode.swift in Sources */,
+				4F15B4A12A6774C9005BEFE8 /* CustomerInfo+NonSubscriptions.swift in Sources */,
 				B39E811D268E887500D31189 /* SubscriberAttribute.swift in Sources */,
 				A5F0104E2717B3150090732D /* BeginRefundRequestHelper.swift in Sources */,
 				B378156D285A9772000A7B93 /* OfferingsAPI.swift in Sources */,
@@ -3713,6 +3719,7 @@
 				579234E527F779FE00B39C68 /* SubscriberAttributesManagerIntegrationTests.swift in Sources */,
 				4F2018732A15797D0061F6EF /* TestLogHandler.swift in Sources */,
 				4F90AFCB2A3915340047E63F /* TestMessage.swift in Sources */,
+				4F15B4A22A678A9C005BEFE8 /* MockStoreTransaction.swift in Sources */,
 				2D3BFAD226DEA46600370B11 /* MockProductsRequest.swift in Sources */,
 				4F83F6B82A5DB78C003F90A5 /* OSVersionEquivalent.swift in Sources */,
 				2D1015DB275A4EAE0086173F /* AvailabilityChecks.swift in Sources */,
@@ -3752,6 +3759,7 @@
 				4FDF10E82A725EA6004F3680 /* ExternalPurchasesManager.swift in Sources */,
 				4F7C37E62A27F14B001E17D3 /* XCTestCase+Extensions.swift in Sources */,
 				4F7C37E52A27EFF7001E17D3 /* BaseStoreKitIntegrationTests.swift in Sources */,
+				4F15B4A32A678B81005BEFE8 /* MockStoreTransaction.swift in Sources */,
 				4F83F6B92A5DB805003F90A5 /* TestCase.swift in Sources */,
 				4F6BEE3C2A27B45900CD9322 /* Constants.swift in Sources */,
 				4F90AFCC2A3915BC0047E63F /* TestMessage.swift in Sources */,

--- a/Sources/Identity/CustomerInfo+NonSubscriptions.swift
+++ b/Sources/Identity/CustomerInfo+NonSubscriptions.swift
@@ -1,0 +1,24 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CustomerInfo+NonSubscriptions.swift
+//
+//  Created by Nacho Soto on 7/18/23.
+
+import Foundation
+
+extension CustomerInfo {
+
+    func containsNonSubscription(_ transation: StoreTransactionType) -> Bool {
+        return self.nonSubscriptions.contains {
+            $0.transactionIdentifier == transation.transactionIdentifier
+        }
+    }
+
+}

--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -31,6 +31,8 @@ enum PurchaseStrings {
     case entitlements_revoked_syncing_purchases(productIdentifiers: [String])
     case entitlement_expired_outside_grace_period(expiration: Date, reference: Date)
     case finishing_transaction(StoreTransactionType)
+    case finish_transaction_skipped_because_its_missing_in_non_subscriptions(StoreTransactionType,
+                                                                             [NonSubscriptionTransaction])
     case purchasing_with_observer_mode_and_finish_transactions_false_warning
     case paymentqueue_revoked_entitlements_for_product_identifiers(productIdentifiers: [String])
     case paymentqueue_adding_payment(SKPaymentQueue, SKPayment)
@@ -129,6 +131,10 @@ extension PurchaseStrings: LogMessage {
         case let .finishing_transaction(transaction):
             return "Finishing transaction '\(transaction.transactionIdentifier)' " +
             "for product '\(transaction.productIdentifier)'"
+
+        case let .finish_transaction_skipped_because_its_missing_in_non_subscriptions(transaction, nonSubscriptions):
+            return "Transaction '\(transaction.transactionIdentifier)' will not be finished: " +
+            "it's a non-subscription and it's missing in CustomerInfo list: \(nonSubscriptions)"
 
         case .purchasing_with_observer_mode_and_finish_transactions_false_warning:
             return "Observer mode is active (finishTransactions is set to false) and " +

--- a/Sources/Misc/Deprecations.swift
+++ b/Sources/Misc/Deprecations.swift
@@ -379,6 +379,7 @@ extension CustomerInfo {
         var storefront: Storefront? { return nil }
 
         var hasKnownPurchaseDate: Bool { true }
+        var hasKnownTransactionIdentifier: Bool { return true }
 
         init(with transaction: NonSubscriptionTransaction) {
             self.productIdentifier = transaction.productIdentifier

--- a/Sources/Purchasing/Purchases/TransactionPoster.swift
+++ b/Sources/Purchasing/Purchases/TransactionPoster.swift
@@ -137,6 +137,8 @@ final class TransactionPoster: TransactionPosterType {
 
         switch product.productCategory {
         case .subscription:
+            // Note: this includes non-renewing subscriptions. Those are included in `.nonSubscriptions`,
+            // but we can't tell them apart using `product.productType` because that's unknown for SK1 products.
             return true
 
         case .nonSubscription:

--- a/Sources/Purchasing/Purchases/TransactionPoster.swift
+++ b/Sources/Purchasing/Purchases/TransactionPoster.swift
@@ -124,6 +124,40 @@ final class TransactionPoster: TransactionPosterType {
         transaction.finish(self.paymentQueueWrapper.paymentQueueWrapperType, completion: complete)
     }
 
+    static func shouldFinish(
+        transaction: StoreTransactionType,
+        for product: StoreProductType?,
+        customerInfo: CustomerInfo
+    ) -> Bool {
+        // Don't finish transactions if CustomerInfo was computed offline
+        guard !customerInfo.isComputedOffline else { return false }
+
+        // If we couldn't find the product, we can't determine if it's a consumable
+        guard let product = product else { return true }
+
+        switch product.productCategory {
+        case .subscription:
+            return true
+
+        case .nonSubscription:
+            // Only finish consumables if the server actually processed it.
+            let shouldFinish = (
+                !transaction.hasKnownTransactionIdentifier ||
+                customerInfo.nonSubscriptions.contains {
+                    $0.storeTransactionIdentifier == transaction.transactionIdentifier
+                }
+            )
+            if !shouldFinish {
+                Logger.warn(Strings.purchase.finish_transaction_skipped_because_its_missing_in_non_subscriptions(
+                    transaction,
+                    customerInfo.nonSubscriptions
+                ))
+            }
+
+            return shouldFinish
+        }
+    }
+
 }
 
 /// Async extension
@@ -153,11 +187,11 @@ private extension TransactionPoster {
         completion: @escaping CustomerAPI.CustomerInfoResponseHandler
     ) {
         if let productIdentifier = transaction.productIdentifier.notEmpty {
-            self.product(with: productIdentifier) { products in
+            self.product(with: productIdentifier) { product in
                 self.postReceipt(transaction: transaction,
                                  purchasedTransactionData: data,
                                  receiptData: receiptData,
-                                 product: products,
+                                 product: product,
                                  completion: completion)
             }
         } else {
@@ -169,27 +203,34 @@ private extension TransactionPoster {
     }
 
     func handleReceiptPost(withTransaction transaction: StoreTransactionType,
-                           result: Result<CustomerInfo, BackendError>,
+                           result: Result<(info: CustomerInfo, product: StoreProduct?), BackendError>,
                            subscriberAttributes: SubscriberAttribute.Dictionary?,
                            completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
+        let customerInfoResult = result.map(\.info)
+
         self.operationDispatcher.dispatchOnMainActor {
             switch result {
-            case let .success(customerInfo):
-                if customerInfo.isComputedOffline {
-                    completion(result)
-                } else {
+            case let .success((customerInfo, product)):
+                if Self.shouldFinish(
+                    transaction: transaction,
+                    for: product,
+                    customerInfo: customerInfo
+                ) {
                     self.finishTransactionIfNeeded(transaction) {
-                        completion(result)
+                        completion(customerInfoResult)
                     }
+                } else {
+                    completion(customerInfoResult)
+
                 }
 
             case let .failure(error):
                 if error.finishable {
                     self.finishTransactionIfNeeded(transaction) {
-                        completion(result)
+                        completion(customerInfoResult)
                     }
                 } else {
-                    completion(result)
+                    completion(customerInfoResult)
                 }
             }
         }
@@ -207,7 +248,7 @@ private extension TransactionPoster {
                           transactionData: purchasedTransactionData,
                           observerMode: self.observerMode) { result in
             self.handleReceiptPost(withTransaction: transaction,
-                                   result: result,
+                                   result: result.map { ($0, product) },
                                    subscriberAttributes: purchasedTransactionData.unsyncedAttributes,
                                    completion: completion)
         }

--- a/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
@@ -44,6 +44,10 @@ internal struct SK1StoreTransaction: StoreTransactionType {
         wrapper.finishTransaction(self.underlyingSK1Transaction, completion: completion)
     }
 
+    var hasKnownTransactionIdentifier: Bool {
+        return self.underlyingSK1Transaction.transactionIdentifier != nil
+    }
+
 }
 
 extension SKPaymentTransaction {

--- a/Sources/Purchasing/StoreKitAbstractions/SK2StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK2StoreTransaction.swift
@@ -44,6 +44,7 @@ internal struct SK2StoreTransaction: StoreTransactionType {
     let storefront: Storefront?
 
     var hasKnownPurchaseDate: Bool { return true }
+    var hasKnownTransactionIdentifier: Bool { return true }
 
     func finish(_ wrapper: PaymentQueueWrapperType, completion: @escaping @Sendable () -> Void) {
         Async.call(with: completion) {

--- a/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
@@ -43,9 +43,8 @@ public typealias SK2Transaction = StoreKit.Transaction
     @objc public var quantity: Int { self.transaction.quantity }
     @objc public var storefront: Storefront? { self.transaction.storefront }
 
-    var hasKnownPurchaseDate: Bool {
-        return self.transaction.hasKnownPurchaseDate
-    }
+    var hasKnownPurchaseDate: Bool { return self.transaction.hasKnownPurchaseDate }
+    var hasKnownTransactionIdentifier: Bool { self.transaction.hasKnownTransactionIdentifier }
 
     func finish(_ wrapper: PaymentQueueWrapperType, completion: @escaping @Sendable () -> Void) {
         self.transaction.finish(wrapper, completion: completion)
@@ -100,6 +99,10 @@ internal protocol StoreTransactionType: Sendable {
 
     /// The unique identifier for the transaction.
     var transactionIdentifier: String { get }
+
+    /// Whether the underlying transaction has a known transaction identifier.
+    /// See `SKPaymentTransaction.transactionID`.
+    var hasKnownTransactionIdentifier: Bool { get }
 
     /// The number of consumable products purchased.
     /// - Note: multi-quantity purchases aren't currently supported.

--- a/Sources/Support/FrameworkDisambiguation.swift
+++ b/Sources/Support/FrameworkDisambiguation.swift
@@ -23,4 +23,6 @@
 
 typealias RCRefundRequestStatus = RefundRequestStatus
 typealias RCErrorCode = ErrorCode
+typealias RCStorefront = Storefront
+
 let RCDefaultLogHandler = defaultLogHandler

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -259,6 +259,41 @@ extension BaseStoreKitIntegrationTests {
         )
     }
 
+    func verifyTransactionWasFinished(
+        count: Int = 1,
+        file: FileString = #file,
+        line: UInt = #line
+    ) {
+        self.logger.verifyMessageWasLogged(Self.finishingTransactionLog,
+                                           level: .info,
+                                           expectedCount: count,
+                                           file: file,
+                                           line: line)
+    }
+
+    func verifyNoTransactionsWereFinished(
+        file: FileString = #file,
+        line: UInt = #line
+    ) {
+        self.logger.verifyMessageWasNotLogged(Self.finishingTransactionLog, file: file, line: line)
+    }
+
+    func verifyTransactionIsEventuallyFinished(
+        count: Int? = nil,
+        file: FileString = #file,
+        line: UInt = #line
+    ) async throws {
+        try await self.logger.verifyMessageIsEventuallyLogged(
+            Self.finishingTransactionLog,
+            level: .info,
+            expectedCount: count,
+            timeout: .seconds(5),
+            pollInterval: .milliseconds(100),
+            file: file,
+            line: line
+        )
+    }
+
     func expireSubscription(_ entitlement: EntitlementInfo) async throws {
         guard let expirationDate = entitlement.expirationDate else { return }
 
@@ -310,6 +345,8 @@ extension BaseStoreKitIntegrationTests {
         expect(transactions).to(haveCount(1))
         return try XCTUnwrap(transactions.first)
     }
+
+    static let finishingTransactionLog = "Finishing transaction"
 
 }
 

--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -109,7 +109,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
         try await self.purchaseMonthlyProduct()
 
         self.logger.verifyMessageWasLogged(Strings.offlineEntitlements.computing_offline_customer_info, level: .info)
-        self.logger.verifyMessageWasNotLogged("Finishing transaction")
+        self.verifyNoTransactionsWereFinished()
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
@@ -118,7 +118,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
         self.serverDown()
         try await self.purchaseMonthlyProduct()
 
-        self.logger.verifyMessageWasNotLogged("Finishing transaction")
+        self.verifyNoTransactionsWereFinished()
 
         // 2. "Re-open" the app after the server is back
         self.serverUp()
@@ -135,12 +135,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
         }
 
         // 4. Ensure transaction is eventually finished
-        try await self.logger.verifyMessageIsEventuallyLogged(
-            "Finishing transaction",
-            level: .info,
-            timeout: .seconds(5),
-            pollInterval: .milliseconds(100)
-        )
+        try await self.verifyTransactionIsEventuallyFinished()
 
         // 5. Restart app again
         try self.purchases.invalidateCustomerInfoCache()
@@ -303,7 +298,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
         self.serverDown()
         try await self.purchaseMonthlyProduct()
 
-        self.logger.verifyMessageWasNotLogged("Finishing transaction")
+        self.verifyNoTransactionsWereFinished()
 
         // 2. Server is back
         self.serverUp()
@@ -313,7 +308,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
         try await self.verifyEntitlementWentThrough(info1)
 
         // 4. Ensure transaction is finished
-        self.logger.verifyMessageWasLogged("Finishing transaction", level: .info)
+        self.verifyTransactionWasFinished()
 
         // 5. Restart app
         try self.purchases.invalidateCustomerInfoCache()
@@ -335,7 +330,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
             fail("Consumable purchases should fail while offline")
         } catch {}
 
-        self.logger.verifyMessageWasNotLogged("Finishing transaction")
+        self.verifyNoTransactionsWereFinished()
 
         // 2. Server is back
         self.serverUp()
@@ -351,9 +346,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
         expect(info.nonSubscriptions.onlyElement?.productIdentifier) == Self.consumable10Coins
 
         // 6. Ensure transactions are finished
-        try await self.logger.verifyMessageIsEventuallyLogged("Finishing transaction",
-                                                              level: .info,
-                                                              expectedCount: 2)
+        try await self.verifyTransactionIsEventuallyFinished(count: 2)
     }
 
 }

--- a/Tests/BackendIntegrationTests/SignatureVerificationIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/SignatureVerificationIntegrationTests.swift
@@ -240,7 +240,7 @@ class EnforcedSignatureVerificationIntegrationTests: BaseSignatureVerificationIn
             try await self.purchaseMonthlyProduct()
         }
 
-        self.logger.verifyMessageWasNotLogged("Finishing transaction")
+        self.verifyNoTransactionsWereFinished()
     }
 
     func testTransactionIsFinishedAfterSuccessfulyPostingPurchase() async throws {
@@ -260,7 +260,7 @@ class EnforcedSignatureVerificationIntegrationTests: BaseSignatureVerificationIn
         try await self.verifyEntitlementWentThrough(info)
 
         // 4. Verify transaction was finished
-        self.logger.verifyMessageWasLogged("Finishing transaction", level: .info)
+        self.verifyTransactionWasFinished()
     }
 
 }

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -107,6 +107,8 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         expect(nonSubscription.productIdentifier) == Self.consumable10Coins
         expect(nonSubscription.storeTransactionIdentifier) == transaction.transactionIdentifier
         expect(info.allPurchasedProductIdentifiers).to(contain(Self.consumable10Coins))
+
+        self.verifyTransactionWasFinished()
     }
 
     func testCanPurchaseConsumableMultipleTimes() async throws {
@@ -120,6 +122,8 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         expect(info.nonSubscriptions).to(haveCount(count))
         expect(info.nonSubscriptions.map(\.productIdentifier)) == Array(repeating: Self.consumable10Coins,
                                                                         count: count)
+
+        self.verifyTransactionWasFinished(count: count)
     }
 
     func testCanPurchaseConsumableWithMultipleUsers() async throws {
@@ -137,6 +141,8 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
         let info2 = try await self.purchaseConsumablePackage().customerInfo
         verifyPurchase(info2)
+
+        self.verifyTransactionWasFinished(count: 2)
     }
 
     func testCanPurchaseNonConsumable() async throws {
@@ -147,8 +153,11 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
         expect(info.allPurchasedProductIdentifiers).to(contain(Self.nonConsumableLifetime))
         expect(nonSubscription.productIdentifier) == transaction.productIdentifier
+        expect(nonSubscription.storeTransactionIdentifier) == transaction.transactionIdentifier
 
         try await self.verifyEntitlementWentThrough(info)
+
+        self.verifyTransactionWasFinished()
     }
 
     func testCanPurchaseNonRenewingSubscription() async throws {
@@ -159,8 +168,11 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
         expect(info.allPurchasedProductIdentifiers).to(contain(transaction.productIdentifier))
         expect(nonSubscription.productIdentifier) == transaction.productIdentifier
+        expect(nonSubscription.storeTransactionIdentifier) == transaction.transactionIdentifier
 
         try await self.verifyEntitlementWentThrough(info)
+
+        self.verifyTransactionWasFinished()
     }
 
     func testCanPurchaseMultipleSubscriptions() async throws {

--- a/Tests/StoreKitUnitTests/StoreTransactionTests.swift
+++ b/Tests/StoreKitUnitTests/StoreTransactionTests.swift
@@ -39,6 +39,7 @@ class StoreTransactionTests: StoreKitConfigTestCase {
         expect(transaction.quantity) == payment.quantity
         expect(transaction.storefront).to(beNil())
         expect(transaction.hasKnownPurchaseDate) == true
+        expect(transaction.hasKnownTransactionIdentifier) == true
     }
 
     func testSK1TransactionWithMissingDate() async throws {
@@ -61,6 +62,7 @@ class StoreTransactionTests: StoreKitConfigTestCase {
         expect(transaction.quantity) == payment.quantity
         expect(transaction.storefront).to(beNil())
         expect(transaction.hasKnownPurchaseDate) == false
+        expect(transaction.hasKnownTransactionIdentifier) == true
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
@@ -79,6 +81,7 @@ class StoreTransactionTests: StoreKitConfigTestCase {
         expect(transaction.transactionIdentifier) == String(sk2Transaction.id)
         expect(transaction.quantity) == sk2Transaction.purchasedQuantity
         expect(transaction.hasKnownPurchaseDate) == true
+        expect(transaction.hasKnownTransactionIdentifier) == true
 
         if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
             let expected = await Storefront.currentStorefront
@@ -107,6 +110,7 @@ class StoreTransactionTests: StoreKitConfigTestCase {
 
         let transaction = StoreTransaction(sk1Transaction: sk1Transaction)
         expect(transaction.transactionIdentifier).toNot(beEmpty())
+        expect(transaction.hasKnownTransactionIdentifier) == false
     }
 
     func testSk1TransactionQuantityBecomes1IfNoPayment() {

--- a/Tests/UnitTests/Mocks/MockStoreTransaction.swift
+++ b/Tests/UnitTests/Mocks/MockStoreTransaction.swift
@@ -11,7 +11,12 @@
 //
 //  Created by Nacho Soto on 11/14/22.
 
+#if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+@testable import RevenueCat_CustomEntitlementComputation
+#else
 @testable import RevenueCat
+#endif
+
 import StoreKit
 
 final class MockStoreTransaction: StoreTransactionType {
@@ -20,7 +25,7 @@ final class MockStoreTransaction: StoreTransactionType {
     let purchaseDate: Date
     let transactionIdentifier: String
     let quantity: Int
-    let storefront: RevenueCat.Storefront?
+    let storefront: RCStorefront?
 
     init() {
         self.productIdentifier = UUID().uuidString
@@ -34,6 +39,12 @@ final class MockStoreTransaction: StoreTransactionType {
     var hasKnownPurchaseDate: Bool {
         get { return self._hasKnownPurchaseDate.value }
         set { self._hasKnownPurchaseDate.value = newValue }
+    }
+
+    private let _hasKnownTransactionIdentifier: Atomic<Bool> = true
+    var hasKnownTransactionIdentifier: Bool {
+        get { return self._hasKnownTransactionIdentifier.value }
+        set { self._hasKnownTransactionIdentifier.value = newValue }
     }
 
     private let _finishInvoked: Atomic<Bool> = false

--- a/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
@@ -28,6 +28,7 @@ class TransactionPosterTests: TestCase {
     private var poster: TransactionPoster!
 
     private var mockTransaction: MockStoreTransaction!
+
     private static let mockCustomerInfo: CustomerInfo = .emptyInfo
 
     override func setUpWithError() throws {
@@ -65,6 +66,59 @@ class TransactionPosterTests: TestCase {
         let result = try self.handleTransaction(transactionData)
         expect(result).to(beSuccess())
         expect(result.value) === Self.mockCustomerInfo
+
+        expect(self.backend.invokedPostReceiptData) == true
+        expect(self.backend.invokedPostReceiptDataParameters?.transactionData).to(match(transactionData))
+        expect(self.backend.invokedPostReceiptDataParameters?.observerMode) == self.systemInfo.observerMode
+        expect(self.mockTransaction.finishInvoked) == true
+    }
+
+    func testHandlePurchasedTransactionDoesNotFinishNonProcessedConsumables() throws {
+        let product = Self.createTestProduct(.consumable)
+        let transactionData = PurchasedTransactionData(
+            appUserID: "user",
+            source: .init(isRestore: false, initiationSource: .queue)
+        )
+        let customerInfo = self.createCustomerInfo(nonSubscriptionProductID: nil)
+
+        self.receiptFetcher.shouldReturnReceipt = true
+        self.productsManager.stubbedProductsCompletionResult = .success([product.toStoreProduct()])
+        self.backend.stubbedPostReceiptResult = .success(customerInfo)
+
+        let result = try self.handleTransaction(transactionData)
+        expect(result).to(beSuccess())
+        expect(result.value) === customerInfo
+
+        expect(self.backend.invokedPostReceiptData) == true
+        expect(self.backend.invokedPostReceiptDataParameters?.transactionData).to(match(transactionData))
+        expect(self.backend.invokedPostReceiptDataParameters?.observerMode) == self.systemInfo.observerMode
+        expect(self.mockTransaction.finishInvoked) == false
+
+        self.logger.verifyMessageWasLogged(
+            Strings.purchase.finish_transaction_skipped_because_its_missing_in_non_subscriptions(
+                self.mockTransaction,
+                customerInfo.nonSubscriptions
+            ),
+            level: .warn,
+            expectedCount: 1
+        )
+    }
+
+    func testHandlePurchasedTransactionFinishesProcessedConsumable() throws {
+        let product = Self.createTestProduct(.consumable)
+        let transactionData = PurchasedTransactionData(
+            appUserID: "user",
+            source: .init(isRestore: false, initiationSource: .queue)
+        )
+        let customerInfo = self.createCustomerInfo(nonSubscriptionProductID: product.productIdentifier)
+
+        self.receiptFetcher.shouldReturnReceipt = true
+        self.productsManager.stubbedProductsCompletionResult = .success([product.toStoreProduct()])
+        self.backend.stubbedPostReceiptResult = .success(customerInfo)
+
+        let result = try self.handleTransaction(transactionData)
+        expect(result).to(beSuccess())
+        expect(result.value) === customerInfo
 
         expect(self.backend.invokedPostReceiptData) == true
         expect(self.backend.invokedPostReceiptDataParameters?.transactionData).to(match(transactionData))
@@ -116,6 +170,86 @@ class TransactionPosterTests: TestCase {
         self.logger.verifyMessageWasNotLogged("Finished transaction")
     }
 
+    // MARK: - shouldFinishTransaction
+
+    func testShouldNotFinishWithOfflineCustomerInfo() {
+        let info = Self.mockCustomerInfo.copy(with: .verifiedOnDevice)
+
+        expect(
+            TransactionPoster.shouldFinish(
+                transaction: self.mockTransaction,
+                for: nil,
+                customerInfo: info)
+        ) == false
+    }
+
+    func testShouldFinishTransactionWithMissingProduct() {
+        expect(
+            TransactionPoster.shouldFinish(
+                transaction: self.mockTransaction,
+                for: nil,
+                customerInfo: Self.mockCustomerInfo)
+        ) == true
+    }
+
+    func testShouldFinishAutoRenewableSubscription() {
+        let mockProduct = Self.createTestProduct(.autoRenewableSubscription)
+        expect(
+            TransactionPoster.shouldFinish(
+                transaction: self.mockTransaction,
+                for: mockProduct,
+                customerInfo: Self.mockCustomerInfo)
+        ) == true
+    }
+
+    func testShouldFinishNonRenewableSubscription() {
+        let mockProduct = Self.createTestProduct(.nonRenewableSubscription)
+        expect(
+            TransactionPoster.shouldFinish(
+                transaction: self.mockTransaction,
+                for: mockProduct,
+                customerInfo: Self.mockCustomerInfo)
+        ) == true
+    }
+
+    func testShouldFinishConsumableIncludedInNonSubscriptions() throws {
+        let product = Self.createTestProduct(.consumable)
+        let customerInfo = self.createCustomerInfo(nonSubscriptionProductID: product.productIdentifier)
+
+        expect(
+            TransactionPoster.shouldFinish(
+                transaction: self.mockTransaction,
+                for: product.toStoreProduct(),
+                customerInfo: customerInfo)
+        ) == true
+    }
+
+    func testShouldNotFinishConsumableNotIncludedInNonSubscriptions() throws {
+        let product = Self.createTestProduct(.consumable)
+        let customerInfo = self.createCustomerInfo(nonSubscriptionProductID: nil)
+
+        expect(
+            TransactionPoster.shouldFinish(
+                transaction: self.mockTransaction,
+                for: product.toStoreProduct(),
+                customerInfo: customerInfo)
+        ) == false
+    }
+
+    func testShouldFinishTransactionWithUnknownIdentifier() throws {
+        let product = Self.createTestProduct(.consumable)
+        let customerInfo = self.createCustomerInfo(nonSubscriptionProductID: nil)
+
+        self.mockTransaction.hasKnownTransactionIdentifier = false
+
+        expect(
+            TransactionPoster.shouldFinish(
+                transaction: self.mockTransaction,
+                for: product.toStoreProduct(),
+                customerInfo: customerInfo)
+        ) == true
+    }
+
 }
 
 // MARK: -
@@ -149,6 +283,51 @@ private extension TransactionPosterTests {
         }
 
         return try XCTUnwrap(result)
+    }
+
+    static func createTestProduct(_ productType: StoreProduct.ProductType) -> TestStoreProduct {
+        return .init(localizedTitle: "Title",
+                     price: 1.99,
+                     localizedPriceString: "$1.99",
+                     productIdentifier: "product",
+                     productType: productType,
+                     localizedDescription: "Description")
+    }
+
+    func createCustomerInfo(nonSubscriptionProductID: String?) -> CustomerInfo {
+        let nonSubscriptions: [String: [CustomerInfoResponse.Transaction]]
+
+        if let productID = nonSubscriptionProductID {
+            nonSubscriptions = [
+                productID: [
+                    CustomerInfoResponse.Transaction(
+                        purchaseDate: Date(),
+                        originalPurchaseDate: Date(),
+                        transactionIdentifier: UUID().uuidString,
+                        storeTransactionIdentifier: self.mockTransaction.transactionIdentifier,
+                        store: .appStore,
+                        isSandbox: true
+                    )
+                ]
+            ]
+        } else {
+            nonSubscriptions = [:]
+        }
+
+        let response = CustomerInfoResponse(
+            subscriber: .init(
+                originalAppUserId: "user",
+                firstSeen: Date(),
+                subscriptions: [:],
+                nonSubscriptions: nonSubscriptions,
+                entitlements: [:]
+            ),
+            requestDate: Date(),
+            rawData: [:]
+        )
+        return CustomerInfo(response: response,
+                            entitlementVerification: .notRequested,
+                            sandboxEnvironmentDetector: self.systemInfo)
     }
 
 }


### PR DESCRIPTION
This ensures that if the server returns a 200, but didn't actually process the transaction, we don't lose it forever.

When this happens, a warning will be logged:
```
[purchases] DEBUG: ℹ️ TransactionPoster: handling transaction for product 'BA92DCD8-74C2-45FF-AEE4-2FFD036AF827'
[purchases] WARN: ⚠️ Transaction '19B3BD23-181B-442A-A5B8-05D686ED98E2' will not be finished: it's a non-subscription and it's missing in CustomerInfo list: []
```

#### Dependencies:
- #3008
- #3009 