### PR TITLE
`NetworkError`: 2 new tests to ensure underlying error is included in description

### DIFF
--- a/Tests/UnitTests/Networking/BackendErrorTests.swift
+++ b/Tests/UnitTests/Networking/BackendErrorTests.swift
@@ -17,6 +17,18 @@ import XCTest
 
 class BackendErrorTests: BaseErrorTests {
 
+    func testNetworkError() {
+        let underlyingError = NSError(domain: NSURLErrorDomain, code: NSURLErrorDNSLookupFailed)
+
+        let error: BackendError = .networkError(
+            .networkError(underlyingError)
+        )
+
+        verifyPurchasesError(error,
+                             expectedCode: .networkError,
+                             underlyingError: underlyingError)
+    }
+
     func testMissingAppUserID() {
         let error: BackendError = .missingAppUserID()
 

--- a/Tests/UnitTests/Networking/NetworkErrorTests.swift
+++ b/Tests/UnitTests/Networking/NetworkErrorTests.swift
@@ -30,7 +30,7 @@ class NetworkErrorAsPurchasesErrorTests: BaseErrorTests {
     }
 
     func testNetworkError() {
-        let underlyingError = NSError(domain: "domain", code: 20)
+        let underlyingError = NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotFindHost)
         let error: NetworkError = .networkError(underlyingError)
 
         verifyPurchasesError(error,

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -432,6 +432,21 @@ extension OfferingsManagerTests {
         expect(self.mockDeviceCache.cacheOfferingsInMemoryCount) == 0
     }
 
+    func testNetworkErrorContainsUnderlyingError() {
+        let underlyingError = NSError(domain: NSURLErrorDomain,
+                                      code: NSURLErrorCancelledReasonInsufficientSystemResources)
+
+        let error: OfferingsManager.Error = .backendError(
+            .networkError(
+                .networkError(underlyingError)
+            )
+        )
+        _ = error.asPurchasesError
+
+        self.logger.verifyMessageWasLogged("NSURLErrorDomain error \(underlyingError.code)",
+                                           level: .error)
+    }
+
 }
 
 private extension OfferingsManagerTests {


### PR DESCRIPTION
This has been improved significantly (like #1974). I wrote these tests to see if I could reproduce why the logs in https://github.com/RevenueCat/purchases-flutter/issues/766 don't include the underlying error.

It's likely that's using an old version of the SDK, but these tests are still useful.
