### PR TITLE
`Paywalls`: fuzzy `Locale` lookups

### DIFF
--- a/Sources/Paywalls/PaywallData.swift
+++ b/Sources/Paywalls/PaywallData.swift
@@ -99,8 +99,12 @@ extension PaywallData {
     }
 
     /// - Returns: ``PaywallData/LocalizedConfiguration-swift.struct`` for the given `Locale`, if found.
-    public func config(for locale: Locale) -> LocalizedConfiguration? {
-        return self.localization[locale.identifier]
+    /// - Note: this allows searching by `Locale` with only language code and missing region (like `en`, `es`, etc).
+    public func config(for requiredLocale: Locale) -> LocalizedConfiguration? {
+        self.localization[requiredLocale.identifier] ??
+        self.localization.first { locale, _ in
+            Locale(identifier: locale).sharesLanguageCode(with: requiredLocale)
+        }?.value
     }
 
     /// The default `Locale` used if `Locale.current` is not configured for this paywall.
@@ -363,3 +367,17 @@ extension PaywallData: Sendable {}
 // - `URL` is not `Sendable` until Swift 5.7
 extension PaywallData: @unchecked Sendable {}
 #endif
+
+// MARK: - Extensions
+
+private extension Locale {
+
+    func sharesLanguageCode(with other: Locale) -> Bool {
+        if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+            return self.language.languageCode == other.language.languageCode
+        } else {
+            return false
+        }
+    }
+
+}

--- a/Sources/Paywalls/PaywallData.swift
+++ b/Sources/Paywalls/PaywallData.swift
@@ -373,11 +373,15 @@ extension PaywallData: @unchecked Sendable {}
 private extension Locale {
 
     func sharesLanguageCode(with other: Locale) -> Bool {
+        #if swift(>=5.7)
         if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             return self.language.languageCode == other.language.languageCode
         } else {
             return false
         }
+        #else
+        return false
+        #endif
     }
 
 }

--- a/Tests/UnitTests/Paywalls/PaywallDataTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallDataTests.swift
@@ -75,6 +75,10 @@ class PaywallDataTests: BaseHTTPResponseTest {
     }
 
     func testFindsLocaleWithOnlyLanguage() throws {
+        // `Locale.language.languageCode` is iOS 16 only
+        // and so is RevenueCatUI anyway.
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
+
         let paywall: PaywallData = try self.decodeFixture("PaywallData-Sample1")
 
         let enConfig = try XCTUnwrap(paywall.config(for: Locale(identifier: "en")))

--- a/Tests/UnitTests/Paywalls/PaywallDataTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallDataTests.swift
@@ -74,6 +74,22 @@ class PaywallDataTests: BaseHTTPResponseTest {
         expect(paywall.config(for: Locale(identifier: "gl_ES"))).to(beNil())
     }
 
+    func testFindsLocaleWithOnlyLanguage() throws {
+        let paywall: PaywallData = try self.decodeFixture("PaywallData-Sample1")
+
+        let enConfig = try XCTUnwrap(paywall.config(for: Locale(identifier: "en")))
+        expect(enConfig.title) == "Paywall"
+
+        let esConfig = try XCTUnwrap(paywall.config(for: Locale(identifier: "es")))
+        expect(esConfig.title) == "Tienda"
+    }
+
+    func testDoesNotFindLocaleWithMissingLanguage() throws {
+        let paywall: PaywallData = try self.decodeFixture("PaywallData-Sample1")
+
+        expect(paywall.config(for: Locale(identifier: "fr"))).to(beNil())
+    }
+
     func testMissingCurrentLocaleLoadsDefault() throws {
         let paywall: PaywallData = try self.decodeFixture("PaywallData-missing_current_locale")
 


### PR DESCRIPTION
`Locale.current` might only report a language and not a region. For example when configuring the scheme like this:
<img width="409" alt="Screenshot 2023-07-21 at 10 23 37" src="https://github.com/RevenueCat/purchases-ios/assets/685609/c5813dca-770d-4297-8f0d-10b56cdb6445">

iOS localization supports this, and so should we.