### PR TITLE
`Paywalls`: added new `blurredBackgroundImage` configuration

### DIFF
--- a/RevenueCatUI/Data/TestData.swift
+++ b/RevenueCatUI/Data/TestData.swift
@@ -177,6 +177,7 @@ internal enum TestData {
                         callToActionForeground: "#000000"
                     )
                 ),
+                blurredBackgroundImage: true,
                 termsOfServiceURL: URL(string: "https://revenuecat.com/tos")!,
                 privacyURL: URL(string: "https://revenuecat.com/tos")!
             ),

--- a/RevenueCatUI/Templates/MultiPackageTemplate.swift
+++ b/RevenueCatUI/Templates/MultiPackageTemplate.swift
@@ -183,9 +183,13 @@ private struct MultiPackageTemplateContent: View {
     @ViewBuilder
     private var backgroundImage: some View {
         if let url = self.configuration.backgroundURL {
-            RemoteImage(url: url)
-                .blur(radius: 40)
-                .opacity(0.7)
+            if self.configuration.configuration.blurredBackgroundImage {
+                RemoteImage(url: url)
+                    .blur(radius: 40)
+                    .opacity(0.7)
+            } else {
+                RemoteImage(url: url)
+            }
         } else {
             DebugErrorView("Template configuration is missing background URL",
                            releaseBehavior: .emptyView)

--- a/Sources/Paywalls/PaywallData.swift
+++ b/Sources/Paywalls/PaywallData.swift
@@ -147,6 +147,12 @@ extension PaywallData {
             set { self._imageNames = newValue }
         }
 
+        /// Whether the background image will be blurred (in templates with one).
+        public var blurredBackgroundImage: Bool {
+            get { self._blurredBackgroundImage }
+            set { self._blurredBackgroundImage = newValue }
+        }
+
         /// Whether a restore purchases button should be displayed.
         public var displayRestorePurchases: Bool {
             get { self._displayRestorePurchases }
@@ -173,6 +179,7 @@ extension PaywallData {
             packages: [PackageType],
             imageNames: [String],
             colors: ColorInformation,
+            blurredBackgroundImage: Bool = false,
             displayRestorePurchases: Bool = true,
             termsOfServiceURL: URL? = nil,
             privacyURL: URL? = nil
@@ -182,6 +189,7 @@ extension PaywallData {
             self.packages = packages
             self._imageNames = imageNames
             self.colors = colors
+            self._blurredBackgroundImage = blurredBackgroundImage
             self._displayRestorePurchases = displayRestorePurchases
             self._termsOfServiceURL = termsOfServiceURL
             self._privacyURL = privacyURL
@@ -189,6 +197,9 @@ extension PaywallData {
 
         @EnsureNonEmptyArrayDecodable
         var _imageNames: [String]
+
+        @DefaultDecodable.False
+        var _blurredBackgroundImage: Bool
 
         @DefaultDecodable.True
         var _displayRestorePurchases: Bool
@@ -324,6 +335,7 @@ extension PaywallData.Configuration: Codable {
     private enum CodingKeys: String, CodingKey {
         case packages
         case _imageNames = "images"
+        case _blurredBackgroundImage = "blurredBackgroundImage"
         case _displayRestorePurchases = "displayRestorePurchases"
         case _termsOfServiceURL = "tosUrl"
         case _privacyURL = "privacyUrl"

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PaywallAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PaywallAPI.swift
@@ -34,12 +34,14 @@ func checkPaywallConfiguration(_ config: PaywallData.Configuration,
     let _: PaywallData.Configuration = .init(packages: [.monthly, .annual],
                                              imageNames: [""],
                                              colors: colors,
+                                             blurredBackgroundImage: true,
                                              displayRestorePurchases: true,
                                              termsOfServiceURL: URL(string: ""),
                                              privacyURL: URL(string: ""))
     let _: [PackageType] = config.packages
     let _: [String] = config.imageNames
     let _: PaywallData.Configuration.ColorInformation = config.colors
+    let _: Bool = config.blurredBackgroundImage
     let _: Bool = config.displayRestorePurchases
     let _: URL? = config.termsOfServiceURL
     let _: URL? = config.privacyURL

--- a/Tests/UnitTests/Networking/Responses/Fixtures/PaywallData-Sample1.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/PaywallData-Sample1.json
@@ -21,6 +21,7 @@
     "config": {
         "packages": ["$rc_monthly", "$rc_annual"],
         "images": ["asset_name.png"],
+        "blurredBackgroundImage": true,
         "display_restore_purchases": false,
         "tos_url": "https://revenuecat.com/tos",
         "privacy_url": "https://revenuecat.com/privacy",

--- a/Tests/UnitTests/Paywalls/PaywallDataTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallDataTests.swift
@@ -34,6 +34,7 @@ class PaywallDataTests: BaseHTTPResponseTest {
         expect(paywall.assetBaseURL) == URL(string: "https://rc-paywalls.s3.amazonaws.com")!
         expect(paywall.config.packages) == [.monthly, .annual]
         expect(paywall.config.imageNames) == ["asset_name.png"]
+        expect(paywall.config.blurredBackgroundImage) == true
         expect(paywall.config.displayRestorePurchases) == false
         expect(paywall.config.termsOfServiceURL) == URL(string: "https://revenuecat.com/tos")!
         expect(paywall.config.privacyURL) == URL(string: "https://revenuecat.com/privacy")!


### PR DESCRIPTION
<img width="387" alt="Screenshot 2023-07-20 at 18 21 42" src="https://github.com/RevenueCat/purchases-ios/assets/685609/b8cb4109-fdc7-4c6a-8014-b2f778b03bcd">
