### PR TITLE
`Paywalls`: added test to ensure package selection maintains order

### DIFF
--- a/Tests/RevenueCatUITests/Data/TemplateViewConfigurationTests.swift
+++ b/Tests/RevenueCatUITests/Data/TemplateViewConfigurationTests.swift
@@ -138,6 +138,19 @@ class TemplateViewConfigurationFilteringTests: BaseTemplateViewConfigurationTest
         ]
     }
 
+    func testFilterMaintainsOrder() {
+        expect(
+            TemplateViewConfiguration.filter(
+                packages: [TestData.weeklyPackage,
+                           TestData.monthlyPackage,
+                           TestData.annualPackage],
+                with: [.monthly, .weekly])
+        ) == [
+            TestData.monthlyPackage,
+            TestData.weeklyPackage
+        ]
+    }
+
 }
 
 // MARK: - Private


### PR DESCRIPTION
I thought I saw a bug because this wasn't true, and realized that it's important to cover in a test. The order of package should depend on the setting, not the offering order. This test ensures that.