### PR TITLE
`TestStoreProduct`: made available on release builds

### DIFF
--- a/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreProduct.swift
@@ -278,11 +278,7 @@ extension StoreProduct {
     }
 
     var isTestProduct: Bool {
-        #if DEBUG
         return self.product is TestStoreProduct
-        #else
-        return false
-        #endif
     }
 
 }

--- a/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
@@ -13,8 +13,6 @@
 
 import Foundation
 
-#if DEBUG
-
 /// A type that contains the necessary data to create a ``StoreProduct``.
 /// This can be used to create mock data for tests or SwiftUI previews.
 ///
@@ -120,29 +118,3 @@ extension TestStoreProduct {
     }
 
 }
-
-#else
-
-// swiftlint:disable missing_docs
-
-@available(
-    iOS,
-    obsoleted: 1,
-    message: "This API is only available for debug builds. Use #if DEBUG to conditionally compile it."
-)
-public struct TestStoreProduct {
-
-    public init(
-        localizedTitle: String,
-        price: Decimal,
-        localizedPriceString: String,
-        productIdentifier: String,
-        productType: StoreProduct.ProductType,
-        localizedDescription: String,
-        subscriptionGroupIdentifier: String? = nil,
-        subscriptionPeriod: SubscriptionPeriod? = nil
-    ) {}
-
-}
-
-#endif

--- a/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProductDiscount.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProductDiscount.swift
@@ -13,8 +13,6 @@
 
 import Foundation
 
-#if DEBUG
-
 /// A type that contains the necessary data to create a ``StoreProduct``.
 public struct TestStoreProductDiscount {
 
@@ -70,29 +68,3 @@ extension TestStoreProductDiscount {
     }
 
 }
-
-#else
-
-@available(
-    iOS,
-    obsoleted: 1,
-    message: "This API is only available for debug builds. Use #if DEBUG to conditionally compile it."
-)
-// swiftlint:disable missing_docs
-public struct TestStoreProductDiscount {
-
-    public init(
-        identifier: String,
-        price: Decimal,
-        localizedPriceString: String,
-        paymentMode: StoreProductDiscount.PaymentMode,
-        subscriptionPeriod: SubscriptionPeriod,
-        numberOfPeriods: Int,
-        type: StoreProductDiscount.DiscountType
-    ) {}
-
-}
-
-// swiftlint:enable missing_docs
-
-#endif

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductAPI.swift
@@ -7,8 +7,6 @@
 
 import RevenueCat
 
-#if DEBUG
-
 // swiftlint:disable syntactic_sugar
 
 private var testProduct: TestStoreProduct!
@@ -67,5 +65,3 @@ private func checkStoreProductCreation(discount: TestStoreProductDiscount) {
         discounts: [discount]
     )
 }
-
-#endif

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductDiscountAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductDiscountAPI.swift
@@ -7,8 +7,6 @@
 
 import RevenueCat
 
-#if DEBUG
-
 var testProductDiscount: TestStoreProductDiscount!
 
 func checkTestStoreProductDiscountAPI() {
@@ -52,5 +50,3 @@ private func checkCreateStoreProduct() {
         type: .promotional
     )
 }
-
-#endif

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/main.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/main.swift
@@ -55,10 +55,8 @@ func main() -> Int {
     checkStoreProductAPI()
     checkStoreProductDiscountAPI()
 
-    #if DEBUG
     checkTestStoreProductAPI()
     checkTestStoreProductDiscountAPI()
-    #endif
 
     checkPaymentModeEnum()
 

--- a/Tests/StoreKitUnitTests/StoreProductTests.swift
+++ b/Tests/StoreKitUnitTests/StoreProductTests.swift
@@ -345,8 +345,6 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(nonSubscription.productCategory) == .nonSubscription
     }
 
-    #if DEBUG
-
     func testTestProduct() {
         let title = "Product"
         let price: Decimal = 3.99
@@ -387,8 +385,6 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(storeProduct.priceFormatter).toNot(beNil())
         expect(storeProduct.isFamilyShareable) == isFamilyShareable
     }
-
-    #endif
 
 }
 


### PR DESCRIPTION
See #2711. This is needed for #2855. In order to be able to create test products for the paywall loading screen, we need to be able to do this in release builds as well.

Another benefit of exposing `TestStoreProduct` in release builds is that it's also usable for pre-built versions of the SDK (like Carthage).
