### PR TITLE
`BasePurchasesTests`: consolidate to only initialize one `DeviceCache`

### DIFF
--- a/Tests/UnitTests/Mocks/MockIdentityManager.swift
+++ b/Tests/UnitTests/Mocks/MockIdentityManager.swift
@@ -15,11 +15,10 @@ class MockIdentityManager: IdentityManager {
 
     let mockAttributeSyncing = MockAttributeSyncing()
 
-    init(mockAppUserID: String) {
+    init(mockAppUserID: String, mockDeviceCache: MockDeviceCache) {
         let mockSystemInfo = MockSystemInfo(platformInfo: nil,
                                             finishTransactions: false,
                                             dangerousSettings: nil)
-        let mockDeviceCache = MockDeviceCache(sandboxEnvironmentDetector: mockSystemInfo)
         let mockBackend = MockBackend()
 
         self.mockAppUserID = mockAppUserID

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -25,6 +25,11 @@ class BasePurchasesTests: TestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
 
+        // Some tests rely on the level being at least `.debug`
+        // Because unit tests can run in parallel, if a test needs to modify
+        // this level it should be moved to `StoreKitUnitTests`, which runs serially.
+        Purchases.logLevel = .verbose
+
         self.storeKit1Wrapper = MockStoreKit1Wrapper()
         self.notificationCenter = MockNotificationCenter()
         self.purchasesDelegate = MockPurchasesDelegate()
@@ -40,7 +45,7 @@ class BasePurchasesTests: TestCase {
                                                        requestTimeout: Configuration.storeKitRequestTimeoutDefault)
         self.mockOperationDispatcher = MockOperationDispatcher()
         self.mockReceiptParser = MockReceiptParser()
-        self.identityManager = MockIdentityManager(mockAppUserID: Self.appUserID)
+        self.identityManager = MockIdentityManager(mockAppUserID: Self.appUserID, mockDeviceCache: self.deviceCache)
         self.mockIntroEligibilityCalculator = MockIntroEligibilityCalculator(productsManager: self.mockProductsManager,
                                                                              receiptParser: self.mockReceiptParser)
         let platformInfo = Purchases.PlatformInfo(flavor: "iOS", version: "4.4.0")
@@ -98,11 +103,6 @@ class BasePurchasesTests: TestCase {
                                                                          customerInfoManager: self.customerInfoManager,
                                                                          currentUserProvider: self.identityManager)
         self.mockTransactionsManager = MockTransactionsManager(receiptParser: self.mockReceiptParser)
-
-        // Some tests rely on the level being at least `.debug`
-        // Because unit tests can run in parallel, if a test needs to modify
-        // this level it should be moved to `StoreKitUnitTests`, which runs serially.
-        Purchases.logLevel = .verbose
 
         self.addTeardownBlock {
             weak var purchases = self.purchases
@@ -487,6 +487,7 @@ private extension BasePurchasesTests {
         self.notificationCenter = nil
         self.subscriberAttributesManager = nil
         self.trialOrIntroPriceEligibilityChecker = nil
+        self.cachingTrialOrIntroPriceEligibilityChecker = nil
         self.attributionPoster = nil
         self.attribution = nil
         self.customerInfoManager = nil

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -97,8 +97,8 @@ class PurchasesSubscriberAttributesTests: TestCase {
             attributionFetcher: self.mockAttributionFetcher,
             attributionDataMigrator: AttributionDataMigrator()
         )
-        self.mockIdentityManager = MockIdentityManager(mockAppUserID: "app_user")
-        self.mockAttributionPoster = AttributionPoster(deviceCache: mockDeviceCache,
+        self.mockIdentityManager = MockIdentityManager(mockAppUserID: "app_user", mockDeviceCache: self.mockDeviceCache)
+        self.mockAttributionPoster = AttributionPoster(deviceCache: self.mockDeviceCache,
                                                        currentUserProvider: mockIdentityManager,
                                                        backend: mockBackend,
                                                        attributionFetcher: mockAttributionFetcher,


### PR DESCRIPTION
I moved the `Purchases.logLevel` change to the beginning of the test too, which makes this more obvious: every test was creating 2 instances of `MockDeviceCache`.

This also required setting `MockCachingTrialOrIntroPriceEligibilityChecker` to `nil` because that was making `IdentityManager` leak, and therefore one of the 2 `MockDeviceCache`s leak!
