### PR TITLE
`Codable`: debug log entire JSON when decoding fails

### DIFF
--- a/Sources/FoundationExtensions/Decoder+Extensions.swift
+++ b/Sources/FoundationExtensions/Decoder+Extensions.swift
@@ -63,7 +63,7 @@ extension JSONDecoder {
             return try self.decode(type, from: jsonData)
         } catch {
             if logErrors {
-                ErrorUtils.logDecodingError(error, type: type)
+                ErrorUtils.logDecodingError(error, type: type, data: jsonData)
             }
             throw error
         }
@@ -123,7 +123,11 @@ extension JSONEncoder {
 
 extension ErrorUtils {
 
-    static func logDecodingError(_ error: Error, type: Any.Type) {
+    static func logDecodingError(_ error: Error, type: Any.Type, data: Data? = nil) {
+        if let data = data {
+            Logger.debug(Strings.codable.invalid_data_when_decoding(data))
+        }
+
         guard let decodingError = error as? DecodingError else {
             Logger.error(Strings.codable.decoding_error(error, type))
             return

--- a/Sources/Logging/Strings/CodableStrings.swift
+++ b/Sources/Logging/Strings/CodableStrings.swift
@@ -16,6 +16,7 @@ import Foundation
 // swiftlint:disable identifier_name
 enum CodableStrings {
 
+    case invalid_data_when_decoding(Data)
     case unexpectedValueError(type: Any.Type, value: Any)
     case valueNotFoundError(value: Any.Type, context: DecodingError.Context)
     case keyNotFoundError(type: Any.Type, key: CodingKey, context: DecodingError.Context)
@@ -31,6 +32,9 @@ extension CodableStrings: LogMessage {
 
     var description: String {
         switch self {
+        case let .invalid_data_when_decoding(data):
+            let content = String(data: data, encoding: .utf8) ?? ""
+            return "Encountered error when decoding JSON: \(content)"
         case let .unexpectedValueError(type, value):
             return "Found unexpected value '\(value)' for type '\(type)'"
         case let .valueNotFoundError(value, context):

--- a/Sources/Networking/HTTPClient/ErrorResponse.swift
+++ b/Sources/Networking/HTTPClient/ErrorResponse.swift
@@ -142,7 +142,7 @@ extension ErrorResponse {
                 return try JSONDecoder.default.decode(jsonData: data)
             }
         } catch {
-            ErrorUtils.logDecodingError(error, type: Self.self)
+            ErrorUtils.logDecodingError(error, type: Self.self, data: data)
             return Self.defaultResponse
         }
     }


### PR DESCRIPTION
This is a simple example, but on a larger JSON it becomes easier for us to debug decoding the entire JSON rather than seeing only the part that failed:
```
[codable] DEBUG: ℹ️ Encountered error when decoding JSON: {"e": "e3"}
[codable] ERROR: 😿‼️ Couldn't decode data from json, it was corrupted: Context(codingPath: [CodingKeys(stringValue: "e", intValue: nil)], debugDescription: "Cannot initialize E from invalid String value e3", underlyingError: nil)
```
