### PR TITLE
`Perf`: update `CustomerInfo` cache before anything else

### DIFF
--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
@@ -26,6 +26,14 @@ class PurchasesGetOfferingsTests: BasePurchasesTests {
         expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount).toEventually(equal(1))
     }
 
+    func testFirstInitializationGetsOfferingsIfAppActiveInCustomEntitlementComputation() {
+        self.systemInfo = .init(finishTransactions: true, customEntitlementsComputation: true)
+        self.systemInfo.stubbedIsApplicationBackgrounded = false
+        self.setupPurchases()
+
+        expect(self.mockOfferingsManager.invokedUpdateOfferingsCacheCount).toEventually(equal(1))
+    }
+
     func testFirstInitializationGetsOfflineEntitlementsIfAppActive() {
         self.systemInfo.stubbedIsApplicationBackgrounded = false
         self.setupPurchases()


### PR DESCRIPTION
I noticed the order of cache updates on SDK initialization was:
- `Offerings`
- `ProductEntitlementMapping`
- `CustomerInfo`

This is inefficient because fetching `CustomerInfo` first is the most important. Also, #2860 will pre-warm intro eligibility, so we want to do that _after_ we might have potentially cleared the intro eligibility cache after a `CustomerInfo` update.
Example log from before:
```
[eligibility] DEBUG: ℹ️ Warming up intro eligibility cache for packages in paywall: [PackageType.$rc_monthly, PackageType.$rc_annual]
[customer] DEBUG: ℹ️ Sending latest CustomerInfo to delegate.
[customer] DEBUG: 😻 CustomerInfo updated from network.
[eligibility] DEBUG: ℹ️ Detected active subscriptions changed. Clearing trial or intro eligibility cache.
```


The new order is:
- `CustomerInfo`
- `ProductEntitlementMapping`
- `Offerings`

_Note: I recommend reviewing the diff ignoring whitespace._
