### PR TITLE
`IntegrationTests`: replaced `Purchases.shared` with a `throw`ing property

### DIFF
--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -114,6 +114,22 @@ class BaseBackendIntegrationTests: TestCase {
         await self.createPurchases()
     }
 
+    /// - Returns: `Purchases.shared` if it's currently configured
+    /// - Throws: `ErrorCode` if it's not
+    /// - Note: This is the recomended way of accessing `Purchases.shared`, as it won't make the test crash.
+    /// If an expectation fails in an `async` fails, sometimes `XCTest` seems to continue execution of the test despite
+    /// having started tearing down the test (and therefore clearing `Purchases.shared`, which will lead to a crash
+    /// and will prevent the test from being retried.
+    final var purchases: Purchases {
+        get throws {
+            if Purchases.isConfigured {
+                return Purchases.shared
+            } else {
+                throw ErrorCode.configurationError
+            }
+        }
+    }
+
 }
 
 private extension BaseBackendIntegrationTests {

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -91,7 +91,7 @@ extension BaseStoreKitIntegrationTests {
 
     private var currentOffering: Offering {
         get async throws {
-            return try await XCTAsyncUnwrap(try await Purchases.shared.offerings().current)
+            return try await XCTAsyncUnwrap(try await self.purchases.offerings().current)
         }
     }
 
@@ -114,7 +114,7 @@ extension BaseStoreKitIntegrationTests {
     }
 
     func product(_ identifier: String) async throws -> StoreProduct {
-        let products = await Purchases.shared.products([identifier])
+        let products = try await self.purchases.products([identifier])
         return try XCTUnwrap(products.onlyElement)
     }
 
@@ -123,7 +123,7 @@ extension BaseStoreKitIntegrationTests {
         file: FileString = #file,
         line: UInt = #line
     ) async throws -> PurchaseResultData {
-        let data = try await Purchases.shared.purchase(package: self.monthlyPackage)
+        let data = try await self.purchases.purchase(package: self.monthlyPackage)
 
         try await self.verifyEntitlementWentThrough(data.customerInfo,
                                                     file: file,
@@ -137,7 +137,7 @@ extension BaseStoreKitIntegrationTests {
         file: FileString = #file,
         line: UInt = #line
     ) async throws -> PurchaseResultData {
-        let data = try await Purchases.shared.purchase(product: self.monthlyPackage.storeProduct)
+        let data = try await self.purchases.purchase(product: self.monthlyPackage.storeProduct)
 
         try await self.verifyEntitlementWentThrough(data.customerInfo,
                                                     file: file,
@@ -152,7 +152,7 @@ extension BaseStoreKitIntegrationTests {
         line: UInt = #line
     ) async throws -> PurchaseResultData {
         let offering = try await XCTAsyncUnwrap(
-            try await Purchases.shared.offerings().offering(identifier: "coins"),
+            try await self.purchases.offerings().offering(identifier: "coins"),
             file: file, line: line
         )
         let package = try XCTUnwrap(
@@ -160,7 +160,7 @@ extension BaseStoreKitIntegrationTests {
             file: file, line: line
         )
 
-        return try await Purchases.shared.purchase(package: package)
+        return try await self.purchases.purchase(package: package)
     }
 
     @discardableResult
@@ -267,7 +267,7 @@ extension BaseStoreKitIntegrationTests {
     #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
     @discardableResult
     func verifySubscriptionExpired() async throws -> CustomerInfo {
-        let info = try await Purchases.shared.syncPurchases()
+        let info = try await self.purchases.syncPurchases()
         self.assertNoActiveSubscription(info)
 
         return info
@@ -305,7 +305,7 @@ extension BaseStoreKitIntegrationTests {
         }
 
         do {
-            let receipt = try await Purchases.shared.fetchReceipt(.always)
+            let receipt = try await self.purchases.fetchReceipt(.always)
             let description = receipt.map { $0.debugDescription } ?? "<null>"
 
             Logger.appleWarning(TestMessage.receipt_content(description))

--- a/Tests/BackendIntegrationTests/CustomEntitlementsComputationIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/CustomEntitlementsComputationIntegrationTests.swift
@@ -39,20 +39,20 @@ final class CustomEntitlementsComputationIntegrationTests: BaseStoreKitIntegrati
     // MARK: - Tests
 
     func testPurchasesDiagnostics() async throws {
-        let diagnostics = PurchasesDiagnostics(purchases: Purchases.shared)
+        let diagnostics = PurchasesDiagnostics(purchases: try self.purchases)
 
         try await diagnostics.testSDKHealth()
     }
 
     func testCanGetOfferings() async throws {
-        let receivedOfferings = try await Purchases.shared.offerings()
+        let receivedOfferings = try await self.purchases.offerings()
         expect(receivedOfferings.all).toNot(beEmpty())
     }
 
     func testCanSwitchUser() async throws {
         let newUser = UUID().uuidString
 
-        Purchases.shared.switchUser(to: newUser)
+        try self.purchases.switchUser(to: newUser)
 
         let info = try await self.purchaseMonthlyOffering().customerInfo
         expect(info.originalAppUserId) == newUser
@@ -64,7 +64,7 @@ final class CustomEntitlementsComputationIntegrationTests: BaseStoreKitIntegrati
 
     @available(iOS 14.3, *)
     func testPurchasingPostsAdAttributionToken() async throws {
-        Purchases.shared.attribution.enableAdServicesAttributionTokenCollection()
+        try self.purchases.attribution.enableAdServicesAttributionTokenCollection()
 
         let info = try await self.purchaseMonthlyOffering().customerInfo
 
@@ -82,7 +82,7 @@ final class CustomEntitlementsComputationIntegrationTests: BaseStoreKitIntegrati
         try await self.testSession.setSimulatedError(.generic(.userCancelled), forAPI: .purchase)
 
         do {
-            _ = try await Purchases.shared.purchase(package: self.monthlyPackage)
+            _ = try await self.purchases.purchase(package: self.monthlyPackage)
             fail("Expected error")
         } catch ErrorCode.purchaseCancelledError {
             // Expected error

--- a/Tests/BackendIntegrationTests/LoadShedderIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/LoadShedderIntegrationTests.swift
@@ -40,7 +40,7 @@ class LoadShedderStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     // MARK: -
 
     func testCanGetOfferings() async throws {
-        let receivedOfferings = try await Purchases.shared.offerings()
+        let receivedOfferings = try await self.purchases.offerings()
 
         expect(receivedOfferings.all).toNot(beEmpty())
         assertSnapshot(matching: receivedOfferings.response, as: .formattedJson)
@@ -49,7 +49,7 @@ class LoadShedderStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     func testOfferingsComeFromLoadShedder() async throws {
         self.logger.verifyMessageWasLogged(
             Strings.network.request_handled_by_load_shedder(
-                .getOfferings(appUserID: Purchases.shared.appUserID)
+                .getOfferings(appUserID: try self.purchases.appUserID)
             ),
             level: .debug
         )
@@ -68,7 +68,7 @@ class LoadShedderStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     func testProductEntitlementMapping() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        let result = try await Purchases.shared.productEntitlementMapping()
+        let result = try await self.purchases.productEntitlementMapping()
         expect(result.entitlementsByProduct).to(haveCount(1))
         expect(result.entitlementsByProduct["com.revenuecat.loadShedder.monthly"]) == ["premium"]
     }

--- a/Tests/BackendIntegrationTests/SignatureVerificationIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/SignatureVerificationIntegrationTests.swift
@@ -42,7 +42,7 @@ class DisabledSignatureVerificationIntegrationTests: BaseSignatureVerificationIn
     func testFetchingCustomerInfoWithFailedSignature() async throws {
         self.invalidSignature = true
 
-        let info = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
+        let info = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
         expect(info.entitlements.verification) == .notRequested
     }
 
@@ -55,29 +55,29 @@ class InformationalSignatureVerificationIntegrationTests: BaseSignatureVerificat
     }
 
     func testCustomerInfoWithValidSignature() async throws {
-        let info = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
+        let info = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
         expect(info.entitlements.verification) == .verified
     }
 
     func testCustomerInfo304ResponseWithValidSignature() async throws {
         // 1. Fetch user once
-        _ = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
+        _ = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
 
         // 1. Re-fetch user
-        let user = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
+        let user = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
         expect(user.entitlements.verification) == .verified
     }
 
     func testLoggedInCustomerInfo304ResponseWithValidSignature() async throws {
         // 1. Log-in to force a new user
-        _ = try await Purchases.shared.logIn(UUID().uuidString)
+        _ = try await self.purchases.logIn(UUID().uuidString)
 
         // 2. Fetch user once
-        let user1 = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
+        let user1 = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
         expect(user1.entitlements.verification) == .verified
 
         // 3. Re-fetch user
-        let user2 = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
+        let user2 = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
         expect(user2.entitlements.verification) == .verified
 
         expect(user2.requestDate) != user1.requestDate
@@ -86,34 +86,34 @@ class InformationalSignatureVerificationIntegrationTests: BaseSignatureVerificat
     func testCustomerInfoWithInvalidSignature() async throws {
         self.invalidSignature = true
 
-        let info = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
+        let info = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
         expect(info.entitlements.verification) == .failed
     }
 
     func testLogInWithValidSignature() async throws {
-        let info = try await Purchases.shared.logIn(UUID().uuidString).customerInfo
+        let info = try await self.purchases.logIn(UUID().uuidString).customerInfo
         expect(info.entitlements.verification) == .verified
     }
 
     func testLogInWithInvalidSignature() async throws {
         self.invalidSignature = true
 
-        let info = try await Purchases.shared.logIn(UUID().uuidString).customerInfo
+        let info = try await self.purchases.logIn(UUID().uuidString).customerInfo
         expect(info.entitlements.verification) == .failed
     }
 
     func testNotModifiedCustomerInfoWithInvalidSignature() async throws {
         // 1. Log-in to force a new user
-        _ = try await Purchases.shared.logIn(UUID().uuidString)
+        _ = try await self.purchases.logIn(UUID().uuidString)
 
         // 2. Fetch user once
-        let user1 = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
+        let user1 = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
         expect(user1.entitlements.verification) == .verified
 
         // 3. Re-fetch user
         self.invalidSignature = true
 
-        let user2 = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
+        let user2 = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
 
         // 4. Verify failed verification returns original `requestDate`
         expect(user2.entitlements.verification) == .failed
@@ -132,11 +132,11 @@ class InformationalSignatureVerificationIntegrationTests: BaseSignatureVerificat
 
         self.invalidSignature = true
 
-        Purchases.shared.invalidateOfferingsCache()
+        try self.purchases.invalidateOfferingsCache()
 
         // Currently there's no API to detect signature failures
         // See also `EnforcedSignatureVerificationIntegrationTests.testOfferingsWithInvalidSignature`
-        _ = try await Purchases.shared.offerings()
+        _ = try await self.purchases.offerings()
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
@@ -144,7 +144,7 @@ class InformationalSignatureVerificationIntegrationTests: BaseSignatureVerificat
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         self.invalidSignature = true
-        _ = try await Purchases.shared.productEntitlementMapping()
+        _ = try await self.purchases.productEntitlementMapping()
     }
 
 }
@@ -156,7 +156,7 @@ class EnforcedSignatureVerificationIntegrationTests: BaseSignatureVerificationIn
     }
 
     func testCustomerInfoWithValidSignature() async throws {
-        let info = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
+        let info = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
         expect(info.entitlements.verification) == .verified
     }
 
@@ -164,12 +164,12 @@ class EnforcedSignatureVerificationIntegrationTests: BaseSignatureVerificationIn
         self.invalidSignature = true
 
         try await Self.verifyThrowsSignatureVerificationFailed {
-            _ = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
+            _ = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
         }
     }
 
     func testLogInWithValidSignature() async throws {
-        let info = try await Purchases.shared.logIn(UUID().uuidString).customerInfo
+        let info = try await self.purchases.logIn(UUID().uuidString).customerInfo
         expect(info.entitlements.verification) == .verified
     }
 
@@ -177,7 +177,7 @@ class EnforcedSignatureVerificationIntegrationTests: BaseSignatureVerificationIn
         self.invalidSignature = true
 
         try await Self.verifyThrowsSignatureVerificationFailed {
-            _ = try await Purchases.shared.logIn(UUID().uuidString).customerInfo
+            _ = try await self.purchases.logIn(UUID().uuidString).customerInfo
         }
     }
 
@@ -186,18 +186,18 @@ class EnforcedSignatureVerificationIntegrationTests: BaseSignatureVerificationIn
 
         self.invalidSignature = true
 
-        Purchases.shared.invalidateOfferingsCache()
+        try self.purchases.invalidateOfferingsCache()
 
         try await Self.verifyThrowsSignatureVerificationFailed {
-            _ = try await Purchases.shared.offerings()
+            _ = try await self.purchases.offerings()
         }
     }
 
     func testOfferingsWithValidSignature() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        Purchases.shared.invalidateOfferingsCache()
-        _ = try await Purchases.shared.offerings()
+        try self.purchases.invalidateOfferingsCache()
+        _ = try await self.purchases.offerings()
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
@@ -207,7 +207,7 @@ class EnforcedSignatureVerificationIntegrationTests: BaseSignatureVerificationIn
         self.invalidSignature = true
 
         try await Self.verifyThrowsSignatureVerificationFailed {
-            _ = try await Purchases.shared.productEntitlementMapping()
+            _ = try await self.purchases.productEntitlementMapping()
         }
     }
 
@@ -215,7 +215,7 @@ class EnforcedSignatureVerificationIntegrationTests: BaseSignatureVerificationIn
     func testEntitlementMappingWithValidSignature() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        _ = try await Purchases.shared.productEntitlementMapping()
+        _ = try await self.purchases.productEntitlementMapping()
     }
 
     func testTransactionIsNotFinishedAfterSignatureFailure() async throws {
@@ -239,7 +239,7 @@ class EnforcedSignatureVerificationIntegrationTests: BaseSignatureVerificationIn
         // 2. Get customer info again, which should post the pending transaction
         self.invalidSignature = false
 
-        let info = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
+        let info = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
 
         // 3. Verify entitlement is active
         try await self.verifyEntitlementWentThrough(info)
@@ -269,18 +269,18 @@ class DynamicModeSignatureVerificationIntegrationTests: BaseSignatureVerificatio
         await self.changeMode(to: Signing.enforcedVerificationMode())
 
         // 2. Fetch CustomerInfo
-        _ = try await Purchases.shared.customerInfo()
+        _ = try await self.purchases.customerInfo()
 
         // 3. Disable verification again
         await self.changeMode(to: .disabled)
 
         // 4. Verify CustomerInfo is still cached
-        _ = try await Purchases.shared.customerInfo(fetchPolicy: .fromCacheOnly)
+        _ = try await self.purchases.customerInfo(fetchPolicy: .fromCacheOnly)
     }
 
     func testChangingToInformationalModeResetsCustomerInfoCache() async throws {
         // 1. Fetch CustomerInfo
-        _ = try await Purchases.shared.customerInfo()
+        _ = try await self.purchases.customerInfo()
 
         // 2. Enable signature verification
         await self.changeMode(to: Signing.verificationMode(with: .informational))
@@ -291,7 +291,7 @@ class DynamicModeSignatureVerificationIntegrationTests: BaseSignatureVerificatio
 
     func testChangingToEnforcedModeResetsCustomerInfoCache() async throws {
         // 1. Fetch CustomerInfo
-        _ = try await Purchases.shared.customerInfo()
+        _ = try await self.purchases.customerInfo()
 
         // 2. Enable signature verification
         await self.changeMode(to: Signing.enforcedVerificationMode())
@@ -307,7 +307,7 @@ class DynamicModeSignatureVerificationIntegrationTests: BaseSignatureVerificatio
 
     private func verifyNoCachedCustomerInfo() async {
         do {
-            _ = try await Purchases.shared.customerInfo(fetchPolicy: .fromCacheOnly)
+            _ = try await self.purchases.customerInfo(fetchPolicy: .fromCacheOnly)
         } catch {
             expect(error).to(matchError(ErrorCode.customerInfoError))
             expect(error.localizedDescription)
@@ -336,7 +336,7 @@ private extension BaseSignatureVerificationIntegrationTests {
     }
 
     func waitForPendingCustomerInfoRequests() async {
-        _ = try? await Purchases.shared.customerInfo()
+        _ = try? await self.purchases.customerInfo()
     }
 
 }

--- a/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
@@ -85,7 +85,7 @@ class StoreKit1ObserverModeIntegrationTests: BaseStoreKitObserverModeIntegration
     func testPurchaseOutsideTheAppPostsReceipt() async throws {
         try self.testSession.buyProduct(productIdentifier: Self.monthlyNoIntroProductID)
 
-        let info = try await Purchases.shared.restorePurchases()
+        let info = try await self.purchases.restorePurchases()
         try await self.verifyEntitlementWentThrough(info)
     }
 
@@ -178,7 +178,7 @@ class StoreKit1ObserverModeWithExistingPurchasesTests: BaseStoreKitObserverModeI
     func testDoesNotSyncExistingPurchase() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        let info = try await Purchases.shared.customerInfo(fetchPolicy: .fetchCurrent)
+        let info = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
         self.assertNoPurchases(info)
     }
 

--- a/Tests/UnitTests/TestHelpers/AsyncTestHelpers.swift
+++ b/Tests/UnitTests/TestHelpers/AsyncTestHelpers.swift
@@ -15,7 +15,11 @@ import Foundation
 
 import Nimble
 
+#if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+@testable import RevenueCat_CustomEntitlementComputation
+#else
 @testable import RevenueCat
+#endif
 
 /// Overload for `Nimble.waitUntil` with our default timeout
 func waitUntil(


### PR DESCRIPTION
This is a similar change to #2532.

I noticed yet another source of crashes in our integration tests.
This is what [the result](https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/13247/workflows/52fd2014-7a19-442f-a572-64116393abec/jobs/94728) was:
```
failed - Message 'Finishing transaction' should not have been logged
expected to not find object in collection that satisfies predicate
```

That came from this code:
```swift
self.logger.verifyMessageWasNotLogged("Finishing transaction")

let info1 = try await Purchases.shared.customerInfo()
```

After that assertion failure, `XCTest` continued execution, while it had already tear down `Purchases`, which lead to this crash:
```
Thread 0 Crashed:
0   libswiftCore.dylib            	       0x103b84e81 _assertionFailure(_:_:file:line:flags:) + 353
1   RevenueCat                    	       0x1332516d0 static Purchases.shared.getter + 352 (Purchases.swift:65)
2   BackendIntegrationTests       	       0x130f7048a OfflineStoreKit1IntegrationTests.testPurchaseWhileServerIsDownPostsReceiptWhenForegroundingApp() + 362 (OfflineStoreKitIntegrationTests.swift:289)
3   BackendIntegrationTests       	       0x130f75ee1 @objc closure #1 in OfflineStoreKit1IntegrationTests.testPurchaseWhileServerIsDownPostsReceiptWhenForegroundingApp() + 1
4   BackendIntegrationTests       	       0x130f77d91 partial apply for @objc closure #1 in OfflineStoreKit1IntegrationTests.testPurchaseWhileServerIsDownPostsReceiptWhenForegroundingApp() + 1
```

To prevent this, instead of using `Purchases.shared` this replaces that with a throwing `self.purchases`.
Just like we don't use force-unwraps in tests and instead use `XCTUwnrap`, this now will fail the test instead of crashing it.
