### PR TITLE
`Paywalls`: temporarily disable non-fullscreen `PaywallView`s

### DIFF
--- a/Tests/TestingApps/SimpleApp/SimpleApp/Views/AppContentView.swift
+++ b/Tests/TestingApps/SimpleApp/SimpleApp/Views/AppContentView.swift
@@ -26,7 +26,7 @@ struct AppContentView: View {
                     Text(verbatim: "You're signed in: \(info.originalAppUserId)")
                         .font(.callout)
 
-                    if !info.hasPro {
+                    if self.shouldDisplayPaywall {
                         PaywallView(mode: .banner)
                     }
 
@@ -35,7 +35,7 @@ struct AppContentView: View {
                     BarChartView(data: (0..<10).map { _ in Double.random(in: 0..<100)})
                         .frame(maxWidth: .infinity)
 
-                    if !info.hasPro {
+                    if self.shouldDisplayPaywall {
                         PaywallView(mode: .card)
                     } else if let date = info.latestExpirationDate {
                         Text(verbatim: "Your subscription expires: \(date.formatted())")
@@ -47,6 +47,14 @@ struct AppContentView: View {
             }
             .navigationTitle("Simple App")
         }
+    }
+
+    private var displayNonFullScreenPaywalls: Bool {
+        return false
+    }
+
+    private var shouldDisplayPaywall: Bool {
+        return self.displayNonFullScreenPaywalls && self.customerInfo?.hasPro == false
     }
 
 }


### PR DESCRIPTION
They're not quite ready yet so we don't want to show them in the sample app.