### PR TITLE
`Tests`: increased default logger capacity

### DIFF
--- a/Tests/UnitTests/Misc/TestCase.swift
+++ b/Tests/UnitTests/Misc/TestCase.swift
@@ -27,7 +27,7 @@ class TestCase: XCTestCase {
     final func initializeLogger() {
         guard self.logger == nil else { return }
 
-        self.logger = TestLogHandler(capacity: 500)
+        self.logger = TestLogHandler(capacity: 1000)
     }
 
     @MainActor


### PR DESCRIPTION
We get failures due to this sometimes in `Integration Tests` (https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/13272/workflows/112808d6-7292-4a58-8530-7e499fe9d91f/jobs/95055/tests).
I noticed that it's mostly because of `ReceiptRefreshPolicy.retryUntilProductIsFound`, where we log the receipt multiple times as we wait for the product to be found.
