### PR TITLE
`Paywalls`: added `offerName` parameter

### DIFF
--- a/RevenueCatUI/Data/ProcessedLocalizedConfiguration.swift
+++ b/RevenueCatUI/Data/ProcessedLocalizedConfiguration.swift
@@ -11,6 +11,7 @@ struct ProcessedLocalizedConfiguration: PaywallLocalizedConfiguration {
     var callToActionWithIntroOffer: String?
     var offerDetails: String
     var offerDetailsWithIntroOffer: String?
+    var offerName: String?
 
     init(
         _ configuration: PaywallData.LocalizedConfiguration,
@@ -25,7 +26,8 @@ struct ProcessedLocalizedConfiguration: PaywallLocalizedConfiguration {
                                                                                             locale: locale),
             offerDetails: configuration.offerDetails.processed(with: dataProvider, locale: locale),
             offerDetailsWithIntroOffer: configuration.offerDetailsWithIntroOffer?.processed(with: dataProvider,
-                                                                                            locale: locale)
+                                                                                            locale: locale),
+            offerName: configuration.offerName?.processed(with: dataProvider, locale: locale)
         )
     }
 
@@ -35,7 +37,8 @@ struct ProcessedLocalizedConfiguration: PaywallLocalizedConfiguration {
         callToAction: String,
         callToActionWithIntroOffer: String?,
         offerDetails: String,
-        offerDetailsWithIntroOffer: String?
+        offerDetailsWithIntroOffer: String?,
+        offerName: String?
     ) {
         self.title = title
         self.subtitle = subtitle
@@ -43,6 +46,7 @@ struct ProcessedLocalizedConfiguration: PaywallLocalizedConfiguration {
         self.callToActionWithIntroOffer = callToActionWithIntroOffer
         self.offerDetails = offerDetails
         self.offerDetailsWithIntroOffer = offerDetailsWithIntroOffer
+        self.offerName = offerName
     }
 
 }

--- a/RevenueCatUI/Data/TestData.swift
+++ b/RevenueCatUI/Data/TestData.swift
@@ -252,7 +252,8 @@ internal enum TestData {
         subtitle: "Lorem ipsum is simply dummy text of the printing and typesetting industry.",
         callToAction: "Subscribe for {{ price_per_month }}/mo",
         offerDetails: "{{ total_price_and_per_month }}",
-        offerDetailsWithIntroOffer: "{{ total_price_and_per_month }} after {{ intro_duration }} trial"
+        offerDetailsWithIntroOffer: "{{ total_price_and_per_month }} after {{ intro_duration }} trial",
+        offerName: "{{ period }}"
     )
     static let paywallHeaderImageName = "9a17e0a7_1689854430..jpeg"
     static let paywallBackgroundImageName = "9a17e0a7_1689854342..jpg"

--- a/RevenueCatUI/Templates/MultiPackageTemplate.swift
+++ b/RevenueCatUI/Templates/MultiPackageTemplate.swift
@@ -142,7 +142,7 @@ private struct MultiPackageTemplateContent: View {
                         : .gray
                     )
 
-                Text(package.content.productName)
+                Text(self.localization(for: package.content).offerName ?? package.content.productName)
             }
             .foregroundColor(self.configuration.colors.callToActionBackgroundColor)
 

--- a/Sources/Paywalls/PaywallData.swift
+++ b/Sources/Paywalls/PaywallData.swift
@@ -50,6 +50,8 @@ public protocol PaywallLocalizedConfiguration {
     /// Description for the offer to be purchased when an intro offer is available.
     /// If `nil`, no information regarding trial eligibility will be displayed.
     var offerDetailsWithIntroOffer: String? { get }
+    /// The name representing each of the packages, most commonly a variable.
+    var offerName: String? { get }
 
 }
 
@@ -67,6 +69,7 @@ extension PaywallData {
         public var subtitle: String
         public var callToAction: String
         public var offerDetails: String
+        public var offerName: String?
         @NonEmptyStringDecodable
         var _callToActionWithIntroOffer: String?
         @NonEmptyStringDecodable
@@ -87,7 +90,8 @@ extension PaywallData {
             callToAction: String,
             callToActionWithIntroOffer: String? = nil,
             offerDetails: String,
-            offerDetailsWithIntroOffer: String? = nil
+            offerDetailsWithIntroOffer: String? = nil,
+            offerName: String? = nil
         ) {
             self.title = title
             self.subtitle = subtitle
@@ -95,6 +99,7 @@ extension PaywallData {
             self._callToActionWithIntroOffer = callToActionWithIntroOffer
             self.offerDetails = offerDetails
             self._offerDetailsWithIntroOffer = offerDetailsWithIntroOffer
+            self.offerName = offerName
         }
 
         // swiftlint:enable missing_docs
@@ -330,6 +335,7 @@ extension PaywallData.LocalizedConfiguration: Codable {
         case _callToActionWithIntroOffer = "callToActionWithIntroOffer"
         case offerDetails
         case _offerDetailsWithIntroOffer = "offerDetailsWithIntroOffer"
+        case offerName
     }
 
 }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PaywallAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PaywallAPI.swift
@@ -56,6 +56,7 @@ func checkPaywallLocalizedConfig(_ config: PaywallData.LocalizedConfiguration) {
     let callToActionWithIntroOffer: String? = config.callToActionWithIntroOffer
     let offerDetails: String = config.offerDetails
     let offerDetailsWithIntroOffer: String? = config.offerDetailsWithIntroOffer
+    let offerName: String? = config.offerName
 
     let _: PaywallData.LocalizedConfiguration = .init(
         title: title,
@@ -63,7 +64,8 @@ func checkPaywallLocalizedConfig(_ config: PaywallData.LocalizedConfiguration) {
         callToAction: callToAction,
         callToActionWithIntroOffer: callToActionWithIntroOffer,
         offerDetails: offerDetails,
-        offerDetailsWithIntroOffer: offerDetailsWithIntroOffer
+        offerDetailsWithIntroOffer: offerDetailsWithIntroOffer,
+        offerName: offerName
     )
 }
 

--- a/Tests/RevenueCatUITests/Data/VariablesTests.swift
+++ b/Tests/RevenueCatUITests/Data/VariablesTests.swift
@@ -96,7 +96,8 @@ class VariablesTests: TestCase {
             "Then {{ price_per_month }} every month",
             offerDetails: "Purchase for {{ price }}",
             offerDetailsWithIntroOffer: "Start your {{ intro_duration }} free trial\n" +
-            "Then {{ price_per_month }} every month"
+            "Then {{ price_per_month }} every month",
+            offerName: "{{ period }}"
         )
         let processed = configuration.processVariables(with: TestData.packageWithIntroOffer)
 
@@ -106,6 +107,7 @@ class VariablesTests: TestCase {
         expect(processed.callToActionWithIntroOffer) == "Start your 1 week free trial\nThen $3.99 every month"
         expect(processed.offerDetails) == "Purchase for $3.99"
         expect(processed.offerDetailsWithIntroOffer) == "Start your 1 week free trial\nThen $3.99 every month"
+        expect(processed.offerName) == "Monthly"
     }
 
 }

--- a/Tests/UnitTests/Networking/Responses/Fixtures/PaywallData-Sample1.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/PaywallData-Sample1.json
@@ -7,14 +7,16 @@
             "call_to_action": "Purchase now",
             "call_to_action_with_intro_offer": "Purchase now",
             "offer_details": "{{ price_per_month }} per month",
-            "offer_details_with_intro_offer": "Start your {{ intro_duration }} trial, then {{ price_per_month }} per month"
+            "offer_details_with_intro_offer": "Start your {{ intro_duration }} trial, then {{ price_per_month }} per month",
+            "offer_name": "{{ period }}"
         },
         "es_ES": {
             "title": "Tienda",
             "subtitle": "Descripción",
             "call_to_action": "Comprar",
             "offer_details": "{{ price_per_month }} cada mes",
-            "offer_details_with_intro_offer": " "
+            "offer_details_with_intro_offer": " ",
+            "offer_name": "{{ period }}"
         }
     },
     "default_locale": "en_US",

--- a/Tests/UnitTests/Networking/Responses/OfferingsDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/OfferingsDecodingTests.swift
@@ -124,6 +124,7 @@ class OfferingsDecodingTests: BaseHTTPResponseTest {
         expect(enConfig.offerDetails) == "{{ price_per_month }} per month"
         expect(enConfig.offerDetailsWithIntroOffer)
         == "Start your {{ intro_duration }} trial, then {{ price_per_month }} per month"
+        expect(enConfig.offerName).to(beNil())
 
         let esConfig = try XCTUnwrap(paywall.config(for: Locale(identifier: "es_ES")))
         expect(esConfig.title) == "Tienda"

--- a/Tests/UnitTests/Paywalls/PaywallDataTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallDataTests.swift
@@ -62,6 +62,7 @@ class PaywallDataTests: BaseHTTPResponseTest {
         expect(enConfig.offerDetails) == "{{ price_per_month }} per month"
         expect(enConfig.offerDetailsWithIntroOffer)
         == "Start your {{ intro_duration }} trial, then {{ price_per_month }} per month"
+        expect(enConfig.offerName) == "{{ period }}"
 
         let esConfig = try XCTUnwrap(paywall.config(for: Locale(identifier: "es_ES")))
         expect(esConfig.title) == "Tienda"
@@ -70,6 +71,7 @@ class PaywallDataTests: BaseHTTPResponseTest {
         expect(esConfig.callToActionWithIntroOffer).to(beNil())
         expect(esConfig.offerDetails) == "{{ price_per_month }} cada mes"
         expect(esConfig.offerDetailsWithIntroOffer).to(beNil())
+        expect(enConfig.offerName) == "{{ period }}"
 
         expect(paywall.localizedConfiguration) == paywall.config(for: Locale.current)
 


### PR DESCRIPTION
This is now used in `MultiPackageTemplate`, defaulting to the `productName` if none is set.