### PR TITLE
`CustomEntitlementComputation`: use custom API key

### DIFF
--- a/Tests/BackendIntegrationTests/Constants.swift
+++ b/Tests/BackendIntegrationTests/Constants.swift
@@ -12,6 +12,7 @@ enum Constants {
 
     static let apiKey = "REVENUECAT_API_KEY"
     static let loadShedderApiKey = "REVENUECAT_LOAD_SHEDDER_API_KEY"
+    static let customEntitlementComputationApiKey = "REVENUECAT_CUSTOM_ENTITLEMENT_COMPUTATION_API_KEY"
 
     // Server URL for the tests. If set to empty string, we'll use the default URL.
     static let proxyURL = "REVENUECAT_PROXY_URL"

--- a/Tests/BackendIntegrationTests/CustomEntitlementsComputationIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/CustomEntitlementsComputationIntegrationTests.swift
@@ -21,6 +21,8 @@ import XCTest
 
 final class CustomEntitlementsComputationIntegrationTests: BaseStoreKitIntegrationTests {
 
+    override var apiKey: String { return Constants.customEntitlementComputationApiKey }
+
     override func setUp() async throws {
         try await super.setUp()
 

--- a/Tests/InstallationTests/SPMCustomEntitlementComputationInstallation/InstallationTests.swift
+++ b/Tests/InstallationTests/SPMCustomEntitlementComputationInstallation/InstallationTests.swift
@@ -21,7 +21,7 @@ class InstallationTests: XCTestCase {
             Purchases.proxyURL = URL(string: proxyURL)!
         }
 
-        Purchases.configureInCustomEntitlementsComputationMode(apiKey: "REVENUECAT_API_KEY",
+        Purchases.configureInCustomEntitlementsComputationMode(apiKey: "REVENUECAT_CUSTOM_ENTITLEMENT_COMPUTATION_API_KEY",
                                                                appUserID: "Integration Tests")
     }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -272,6 +272,7 @@ platform :ios do
       previous_text: "REVENUECAT_CUSTOM_ENTITLEMENT_COMPUTATION_API_KEY",
       new_text: ENV["REVENUECAT_CUSTOM_ENTITLEMENT_COMPUTATION_API_KEY"],
       paths_of_files_to_update: [
+        './Tests/BackendIntegrationTests/Constants.swift',
         './Tests/InstallationTests/SPMCustomEntitlementComputationInstallation/InstallationTests.swift'
       ]
     )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -257,8 +257,7 @@ platform :ios do
       new_text: ENV["REVENUECAT_API_KEY"],
       paths_of_files_to_update: [
         './Tests/BackendIntegrationTests/Constants.swift',
-        './Tests/InstallationTests/CommonFiles/RCInstallationRunner.m',
-        './Tests/InstallationTests/SPMCustomEntitlementComputationInstallation/InstallationTests.swift'
+        './Tests/InstallationTests/CommonFiles/RCInstallationRunner.m'
       ]
     )
     replace_text_in_files(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -269,6 +269,13 @@ platform :ios do
         './Tests/v3LoadShedderIntegration/v3LoadShedderIntegrationTests/V3LoadShedderIntegrationTests.swift'
       ]
     )
+    replace_text_in_files(
+      previous_text: "REVENUECAT_CUSTOM_ENTITLEMENT_COMPUTATION_API_KEY",
+      new_text: ENV["REVENUECAT_CUSTOM_ENTITLEMENT_COMPUTATION_API_KEY"],
+      paths_of_files_to_update: [
+        './Tests/InstallationTests/SPMCustomEntitlementComputationInstallation/InstallationTests.swift'
+      ]
+    )
 
     replace_text_in_files(
       previous_text: "REVENUECAT_PROXY_URL",


### PR DESCRIPTION
### Description
We were using the default API key to test the custom entitlement computation package installation and integration tests. This changes that so we use a special API key with some special behavior in the backend to mimic real scenarios. 
