### PR TITLE
`Paywalls`: fixed `{{ total_price_and_per_month }}`

### DIFF
--- a/RevenueCatUI/Data/Variables.swift
+++ b/RevenueCatUI/Data/Variables.swift
@@ -14,6 +14,8 @@ extension PaywallData.LocalizedConfiguration {
 /// A type that can provide necessary information for `VariableHandler` to replace variable content in strings.
 protocol VariableDataProvider {
 
+    var isMonthly: Bool { get }
+
     var localizedPrice: String { get }
     var localizedPricePerMonth: String { get }
     var productName: String { get }
@@ -86,14 +88,11 @@ private extension VariableDataProvider {
         case "price": return self.localizedPrice
         case "price_per_month": return self.localizedPricePerMonth
         case "total_price_and_per_month":
-            let price = self.localizedPrice
-            let perMonth = self.localizedPricePerMonth
-
-            if price == perMonth {
-                return price
+            if self.isMonthly {
+                return self.localizedPrice
             } else {
                 let unit = Localization.abbreviatedUnitLocalizedString(for: .month, locale: locale)
-                return "\(price) (\(perMonth)/\(unit))"
+                return "\(self.localizedPrice) (\(self.localizedPricePerMonth)/\(unit))"
             }
 
         case "product_name": return self.productName

--- a/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
+++ b/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
@@ -4,6 +4,10 @@ import RevenueCat
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 extension Package: VariableDataProvider {
 
+    var isMonthly: Bool {
+        return self.packageType == .monthly
+    }
+
     var localizedPrice: String {
         return self.storeProduct.localizedPriceString
     }

--- a/Tests/RevenueCatUITests/Data/VariablesTests.swift
+++ b/Tests/RevenueCatUITests/Data/VariablesTests.swift
@@ -50,6 +50,7 @@ class VariablesTests: TestCase {
     }
 
     func testTotalPriceAndPerMonthWithDifferentPricesFrench() {
+        self.provider.isMonthly = false
         self.provider.localizedPrice = "49,99€"
         self.provider.localizedPricePerMonth = "4,16€"
         expect(self.process("{{ total_price_and_per_month }}",
@@ -57,8 +58,8 @@ class VariablesTests: TestCase {
     }
 
     func testTotalPriceAndPerMonthWithSamePrice() {
+        self.provider.isMonthly = true
         self.provider.localizedPrice = "$4.99"
-        self.provider.localizedPricePerMonth = "$4.99"
         expect(self.process("{{ total_price_and_per_month }}")) == "$4.99"
     }
 
@@ -125,6 +126,7 @@ private extension VariablesTests {
 
 private struct MockVariableProvider: VariableDataProvider {
 
+    var isMonthly: Bool = false
     var localizedPrice: String = ""
     var localizedPricePerMonth: String = ""
     var productName: String = ""


### PR DESCRIPTION
We were relying on both the price and price per month to be formatted the same way. When debugging in the simulator, the actual region doesn't change, so StoreKit's internal price formatter doesn't pick it up.
To make this more resilient, this now checks whether it's a monthly subscription instead of comparing strings.

This is an example where `Locale.current` is only overriden partially and the logic breaks:
![image](https://github.com/RevenueCat/purchases-ios/assets/685609/76eabfdb-ea16-4d67-b7b3-411a3c4393a5)
