### PR TITLE
`xrOS`: fixed `SubscriptionStoreView` for visionOS beta 2

### DIFF
--- a/Sources/Support/PaywallExtensions.swift
+++ b/Sources/Support/PaywallExtensions.swift
@@ -87,7 +87,7 @@ extension SubscriptionStoreView {
 
 #if os(xrOS)
 @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
-extension SubscriptionStoreView where Content == DefaultSubscriptionStoreMarketingContent {
+extension SubscriptionStoreView where Content == AutomaticSubscriptionStoreMarketingContent {
 
     /// Creates a ``SubscriptionStoreView`` from an ``Offering``
     /// that doesn't take a custom view to use for marketing content.

--- a/Sources/Support/PaywallExtensions.swift
+++ b/Sources/Support/PaywallExtensions.swift
@@ -85,7 +85,6 @@ extension SubscriptionStoreView {
 
 }
 
-#if os(xrOS)
 @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
 extension SubscriptionStoreView where Content == AutomaticSubscriptionStoreMarketingContent {
 
@@ -98,20 +97,6 @@ extension SubscriptionStoreView where Content == AutomaticSubscriptionStoreMarke
     }
 
 }
-#else
-@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
-extension SubscriptionStoreView where Content == AutomaticSubscriptionStoreMarketingContent {
-
-    /// Creates a ``SubscriptionStoreView`` from an ``Offering``
-    /// that doesn't take a custom view to use for marketing content.
-    public static func forOffering(_ offering: Offering) -> some View {
-        return self
-            .init(productIDs: offering.subscriptionProductIdentifiers)
-            .handlePurchases(offering)
-    }
-
-}
-#endif
 
 // MARK: - Private
 


### PR DESCRIPTION
### Motivation

visionOS beta 2 had compile errors in `SubscriptionStoreView`

### Description

Replaced `DefaultSubscriptionStoreMarketingContent` with `AutomaticSubscriptionStoreMarketingContent`
