### PR TITLE
`Xcode 15 beta 5`: fixed test compilation

### DIFF
--- a/Tests/UnitTests/Misc/XCTestCase+Extensions.swift
+++ b/Tests/UnitTests/Misc/XCTestCase+Extensions.swift
@@ -24,7 +24,7 @@ import XCTest
 /// Similar to `XCTUnrap` but it allows an `async` closure.
 @MainActor
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-func XCTAsyncUnwrap<T>(
+func XCTAsyncUnwrap<T: Sendable>(
     _ expression: @autoclosure () async throws -> T?,
     _ message: @autoclosure () -> String = "",
     file: StaticString = #filePath,


### PR DESCRIPTION
This started failing with beta 5.

<img width="844" alt="Screenshot 2023-07-26 at 09 49 27" src="https://github.com/RevenueCat/purchases-ios/assets/685609/2637d52a-a3cc-47de-ab71-98305a8adc0c">
