### PR TITLE
`Logging`: log entire cache key with verbose logs

### DIFF
--- a/Sources/FoundationExtensions/OperationQueue+Extensions.swift
+++ b/Sources/FoundationExtensions/OperationQueue+Extensions.swift
@@ -23,7 +23,14 @@ extension OperationQueue {
         case .firstCallbackAddedToList:
             self.addOperation(factory.create())
         case .addedToExistingInFlightList:
-            Logger.debug(Strings.network.reusing_existing_request_for_operation(T.self, factory.cacheKey))
+            Logger.debug(
+                Strings.network.reusing_existing_request_for_operation(
+                    T.self,
+                    Logger.logLevel == .verbose
+                    ? factory.cacheKey
+                    : factory.cacheKey.prefix(15) + "…"
+                )
+            )
             return
         }
     }

--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -62,7 +62,7 @@ extension NetworkStrings: LogMessage {
 
         case let .reusing_existing_request_for_operation(operationType, cacheKey):
             return "Network operation '\(operationType)' found with the same cache key " +
-            "'\(cacheKey.prefix(15))...'. Skipping request."
+            "'\(cacheKey)'. Skipping request."
 
         case let .creating_json_error(error):
             return "Error creating request with body: \(error)"


### PR DESCRIPTION
This can be useful when figuring out why requests are being shared.
No need to crop it if we have verbose logs.
