### PR TITLE
`PurchasesOrchestrator`: disambiguate transactions from the queue

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -257,6 +257,8 @@
 		4F90AFCB2A3915340047E63F /* TestMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F90AFCA2A3915340047E63F /* TestMessage.swift */; };
 		4F90AFCC2A3915BC0047E63F /* TestMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F90AFCA2A3915340047E63F /* TestMessage.swift */; };
 		4F98E9D32A465A4400DB6EAB /* TestStoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F98E9D22A465A4400DB6EAB /* TestStoreProduct.swift */; };
+		4F9BB63F2A7AFB72001C120D /* MockPayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F9BB63E2A7AFB72001C120D /* MockPayment.swift */; };
+		4F9BB6402A7AFB72001C120D /* MockPayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F9BB63E2A7AFB72001C120D /* MockPayment.swift */; };
 		4FA4C8DA2A168956007D2803 /* OfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA4C8D92A168956007D2803 /* OfflineCustomerInfoCreator.swift */; };
 		4FA4C9732A16D3AC007D2803 /* MockBackendConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA4C9722A16D3AC007D2803 /* MockBackendConfiguration.swift */; };
 		4FA4C9742A16D3AC007D2803 /* MockBackendConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA4C9722A16D3AC007D2803 /* MockBackendConfiguration.swift */; };
@@ -971,6 +973,7 @@
 		4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOfflineCustomerInfoCreator.swift; sourceTree = "<group>"; };
 		4F90AFCA2A3915340047E63F /* TestMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestMessage.swift; sourceTree = "<group>"; };
 		4F98E9D22A465A4400DB6EAB /* TestStoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestStoreProduct.swift; sourceTree = "<group>"; };
+		4F9BB63E2A7AFB72001C120D /* MockPayment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPayment.swift; sourceTree = "<group>"; };
 		4FA4C8D92A168956007D2803 /* OfflineCustomerInfoCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineCustomerInfoCreator.swift; sourceTree = "<group>"; };
 		4FA4C9722A16D3AC007D2803 /* MockBackendConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackendConfiguration.swift; sourceTree = "<group>"; };
 		4FA696A329FC43C600D228B1 /* ReceiptParserTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ReceiptParserTests-Info.plist"; sourceTree = "<group>"; };
@@ -1786,6 +1789,7 @@
 				F575858E26C0893600C12B97 /* MockOfferingsManager.swift */,
 				57488BE929CB83540000EE7E /* MockOfflineEntitlementsManager.swift */,
 				351B514A26D44A4A00BD2BD7 /* MockOperationDispatcher.swift */,
+				4F9BB63E2A7AFB72001C120D /* MockPayment.swift */,
 				351B517326D44F4B00BD2BD7 /* MockPaymentDiscount.swift */,
 				5733D00828CFA7A4008638D8 /* MockPaymentQueueWrapper.swift */,
 				37E35C9439E087F63ECC4F59 /* MockProductsManager.swift */,
@@ -3127,6 +3131,7 @@
 				2D90F8C226FD20F7009B9142 /* MockETagManager.swift in Sources */,
 				2D90F8B526FD2093009B9142 /* MockSystemInfo.swift in Sources */,
 				2D90F8C126FD20F2009B9142 /* MockHTTPClient.swift in Sources */,
+				4F9BB6402A7AFB72001C120D /* MockPayment.swift in Sources */,
 				57DDA7B429CBEFB30098B89D /* MockPurchasedProductsFetcher.swift in Sources */,
 				57E6195028D291DC0093170C /* StoreKit2CachingProductsManagerTests.swift in Sources */,
 				F5847431278D00C1001B1CE6 /* MockDNSChecker.swift in Sources */,
@@ -3510,6 +3515,7 @@
 				351B51B526D450E800BD2BD7 /* ProductsFetcherSK1Tests.swift in Sources */,
 				2DDF41CC24F6F4C3005BC22D /* AppleReceiptBuilderTests.swift in Sources */,
 				575A8EE52922C9F300936709 /* MockStoreKit2TransactionListenerDelegate.swift in Sources */,
+				4F9BB63F2A7AFB72001C120D /* MockPayment.swift in Sources */,
 				57BF87592967880C00424254 /* MockCachingTrialOrIntroPriceEligibilityChecker.swift in Sources */,
 				2DDF41CD24F6F4C3005BC22D /* ASN1ContainerBuilderTests.swift in Sources */,
 				573A10D52800A7C800F976E5 /* SKErrorTests.swift in Sources */,

--- a/Sources/LocalReceiptParsing/Helpers/ReceiptStrings.swift
+++ b/Sources/LocalReceiptParsing/Helpers/ReceiptStrings.swift
@@ -28,7 +28,7 @@ enum ReceiptStrings {
     case parsing_receipt
     case refreshing_empty_receipt
     case unable_to_load_receipt(Error)
-    case posting_receipt(AppleReceipt)
+    case posting_receipt(AppleReceipt, initiationSource: String)
     case receipt_subscription_purchase_equals_expiration(
         productIdentifier: String,
         purchase: Date,
@@ -87,8 +87,8 @@ extension ReceiptStrings: LogMessage {
             return "Unable to load receipt, ensure you are logged in to a valid Apple account.\n" +
             "Error: \(error)"
 
-        case let .posting_receipt(receipt):
-            return "Posting receipt (note: the contents might not be up-to-date, " +
+        case let .posting_receipt(receipt, initiationSource):
+            return "Posting receipt (source: '\(initiationSource)') (note: the contents might not be up-to-date, " +
             "but it will be refreshed with Apple's servers):\n\(receipt.debugDescription)"
 
         case let .receipt_subscription_purchase_equals_expiration(

--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -40,6 +40,9 @@ enum PurchaseStrings {
                                                              SKPaymentTransaction)
     case paymentqueue_updated_transaction(SKPaymentTransactionObserver,
                                           SKPaymentTransaction)
+    case paymentqueue_ignoring_callback_for_older_transaction(PurchasesOrchestrator,
+                                                              StoreTransactionType,
+                                                              Date)
     case presenting_code_redemption_sheet
     case unable_to_present_redemption_sheet
     case purchases_synced
@@ -167,6 +170,11 @@ extension PurchaseStrings: LogMessage {
             ]
                 .compactMap { $0 }
                 .joined(separator: " ")
+
+        case let .paymentqueue_ignoring_callback_for_older_transaction(observer, transaction, date):
+            return "\(Strings.objectDescription(observer)): will not notify callback for transaction " +
+            "'\(transaction.transactionIdentifier)'. " +
+            "Transaction date '\(transaction.purchaseDate)' - callback date '\(date)'"
 
         case .presenting_code_redemption_sheet:
             return "Presenting code redemption sheet."

--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -51,7 +51,7 @@ enum PurchaseStrings {
     case product_purchase_failed(productIdentifier: String, error: Error)
     case skpayment_missing_from_skpaymenttransaction
     case skpayment_missing_product_identifier
-    case sktransaction_missing_transaction_date
+    case sktransaction_missing_transaction_date(SKPaymentTransactionState)
     case sktransaction_missing_transaction_identifier
     case could_not_purchase_product_id_not_found
     case payment_identifier_nil
@@ -208,11 +208,12 @@ extension PurchaseStrings: LogMessage {
             return "There is a problem with the SKPayment missing " +
             "a product identifier - this is an issue with the App Store."
 
-        case .sktransaction_missing_transaction_date:
+        case let .sktransaction_missing_transaction_date(transactionState):
             return """
             The SKPaymentTransaction has a nil value for transaction date - this is a bug in StoreKit.
             Unix Epoch will be used instead for the transaction within the app.
             Transactions in the backend and in webhooks are unaffected and will have the correct timestamps.
+            Transaction state: \(transactionState)
             """
 
         case .sktransaction_missing_transaction_identifier:

--- a/Sources/Misc/Deprecations.swift
+++ b/Sources/Misc/Deprecations.swift
@@ -378,6 +378,8 @@ extension CustomerInfo {
         let quantity: Int
         var storefront: Storefront? { return nil }
 
+        var hasKnownPurchaseDate: Bool { true }
+
         init(with transaction: NonSubscriptionTransaction) {
             self.productIdentifier = transaction.productIdentifier
             self.purchaseDate = transaction.purchaseDate

--- a/Sources/Networking/Operations/PostReceiptDataOperation.swift
+++ b/Sources/Networking/Operations/PostReceiptDataOperation.swift
@@ -163,7 +163,10 @@ private extension PostReceiptDataOperation {
     func printReceiptData() {
         do {
             let receipt = try PurchasesReceiptParser.default.parse(from: self.postData.receiptData)
-            self.log(Strings.receipt.posting_receipt(receipt))
+            self.log(Strings.receipt.posting_receipt(
+                receipt,
+                initiationSource: self.postData.initiationSource.rawValue
+            ))
 
             for purchase in receipt.inAppPurchases where purchase.purchaseDateEqualsExpiration {
                 Logger.appleError(Strings.receipt.receipt_subscription_purchase_equals_expiration(

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -970,7 +970,7 @@ private extension PurchasesOrchestrator {
         return self.purchaseCompleteCallbacksByProductID.modify { callbacks -> PurchaseCompletedBlock? in
             guard let value = callbacks[transaction.productIdentifier] else { return nil }
 
-            if value.creationDate <= transaction.purchaseDate {
+            if !transaction.hasKnownPurchaseDate || value.creationDate <= transaction.purchaseDate {
                 callbacks.removeValue(forKey: transaction.productIdentifier)
                 return value.completion
             } else {

--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -974,6 +974,8 @@ private extension PurchasesOrchestrator {
                 callbacks.removeValue(forKey: transaction.productIdentifier)
                 return value.completion
             } else {
+                // This callback was added to handle a purchase _after_ the transaction was created,
+                // therefore it should not be notified.
                 Logger.verbose(Strings.purchase.paymentqueue_ignoring_callback_for_older_transaction(
                     self,
                     transaction,

--- a/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
@@ -36,6 +36,10 @@ internal struct SK1StoreTransaction: StoreTransactionType {
         return nil
     }
 
+    var hasKnownPurchaseDate: Bool {
+        return self.underlyingSK1Transaction.transactionDate != nil
+    }
+
     func finish(_ wrapper: PaymentQueueWrapperType, completion: @escaping @Sendable () -> Void) {
         wrapper.finishTransaction(self.underlyingSK1Transaction, completion: completion)
     }

--- a/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK1StoreTransaction.swift
@@ -58,7 +58,7 @@ extension SKPaymentTransaction {
 
     fileprivate var purchaseDate: Date {
         guard let date = self.transactionDate else {
-            Logger.verbose(Strings.purchase.sktransaction_missing_transaction_date)
+            Logger.verbose(Strings.purchase.sktransaction_missing_transaction_date(self.transactionState))
 
             return Date(timeIntervalSince1970: 0)
         }

--- a/Sources/Purchasing/StoreKitAbstractions/SK2StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK2StoreTransaction.swift
@@ -43,6 +43,8 @@ internal struct SK2StoreTransaction: StoreTransactionType {
     let quantity: Int
     let storefront: Storefront?
 
+    var hasKnownPurchaseDate: Bool { return true }
+
     func finish(_ wrapper: PaymentQueueWrapperType, completion: @escaping @Sendable () -> Void) {
         Async.call(with: completion) {
             await self.underlyingSK2Transaction.finish()

--- a/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/StoreTransaction.swift
@@ -43,6 +43,10 @@ public typealias SK2Transaction = StoreKit.Transaction
     @objc public var quantity: Int { self.transaction.quantity }
     @objc public var storefront: Storefront? { self.transaction.storefront }
 
+    var hasKnownPurchaseDate: Bool {
+        return self.transaction.hasKnownPurchaseDate
+    }
+
     func finish(_ wrapper: PaymentQueueWrapperType, completion: @escaping @Sendable () -> Void) {
         self.transaction.finish(wrapper, completion: completion)
     }
@@ -89,6 +93,10 @@ internal protocol StoreTransactionType: Sendable {
     /// The date that App Store charged the user’s account for a purchased or restored product,
     /// or for a subscription purchase or renewal after a lapse.
     var purchaseDate: Date { get }
+
+    /// Whether the underlying transaction has a non-nil purchase date.
+    /// See `SK1StoreTransaction/purchaseDate``
+    var hasKnownPurchaseDate: Bool { get }
 
     /// The unique identifier for the transaction.
     var transactionIdentifier: String { get }

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -204,7 +204,7 @@ extension BaseStoreKitIntegrationTests {
         }
 
         if !entitlement.isActive {
-            try await failTest("Entitlement is not active")
+            try await failTest("Entitlement is not active: \(entitlement)")
         }
 
         return entitlement

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -435,6 +435,35 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         try await subscribe()
     }
 
+    func testSubscribeAfterExpirationWhileAppIsClosed() async throws {
+        // 1. Subscribe
+        let customerInfo = try await self.purchaseMonthlyOffering().customerInfo
+        let entitlement = try XCTUnwrap(customerInfo.entitlements[Self.entitlementIdentifier])
+
+        // 2. Simulate closing app
+        Purchases.clearSingleton()
+
+        // 3. Force several renewals while app is closed.
+        for _ in 0..<3 {
+            try self.testSession.forceRenewalOfSubscription(productIdentifier: entitlement.productIdentifier)
+        }
+
+        // 4. Expire subscription
+        try await self.expireSubscription(entitlement)
+
+        // 5. Re-open app
+        await self.resetSingleton()
+        self.logger.clearMessages()
+
+        // 6. Purchase again
+        _ = try await self.purchases.purchase(package: self.monthlyPackage)
+
+        self.logger.clearMessages()
+
+        // 7. Verify no transaction is posted as a purchase.
+        self.logger.verifyMessageWasNotLogged("Posting receipt (source: 'purchase')")
+    }
+
     func testGetPromotionalOfferWithNoPurchasesReturnsIneligible() async throws {
         let product = try await self.monthlyPackage.storeProduct
         let discount = try XCTUnwrap(product.discounts.onlyElement)

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -458,11 +458,8 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         // 6. Purchase again
         try await self.purchaseMonthlyProduct()
 
-        self.logger.clearMessages()
-
-        // 7. Verify no transaction is posted as a purchase.
-        self.logger.verifyMessageWasNotLogged("Posting receipt (source: 'purchase')",
-                                              allowNoMessages: true)
+        // 7. Verify transaction is posted as a purchase.
+        self.logger.verifyMessageWasLogged("Posting receipt (source: 'purchase')")
     }
 
     func testGetPromotionalOfferWithNoPurchasesReturnsIneligible() async throws {

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -461,7 +461,8 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         self.logger.clearMessages()
 
         // 7. Verify no transaction is posted as a purchase.
-        self.logger.verifyMessageWasNotLogged("Posting receipt (source: 'purchase')")
+        self.logger.verifyMessageWasNotLogged("Posting receipt (source: 'purchase')",
+                                              allowNoMessages: true)
     }
 
     func testGetPromotionalOfferWithNoPurchasesReturnsIneligible() async throws {

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -456,7 +456,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         self.logger.clearMessages()
 
         // 6. Purchase again
-        _ = try await self.purchases.purchase(package: self.monthlyPackage)
+        try await self.purchaseMonthlyProduct()
 
         self.logger.clearMessages()
 

--- a/Tests/StoreKitUnitTests/StoreTransactionTests.swift
+++ b/Tests/StoreKitUnitTests/StoreTransactionTests.swift
@@ -78,6 +78,7 @@ class StoreTransactionTests: StoreKitConfigTestCase {
         expect(transaction.purchaseDate.timeIntervalSinceNow) <= 5
         expect(transaction.transactionIdentifier) == String(sk2Transaction.id)
         expect(transaction.quantity) == sk2Transaction.purchasedQuantity
+        expect(transaction.hasKnownPurchaseDate) == true
 
         if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
             let expected = await Storefront.currentStorefront

--- a/Tests/StoreKitUnitTests/StoreTransactionTests.swift
+++ b/Tests/StoreKitUnitTests/StoreTransactionTests.swift
@@ -27,6 +27,7 @@ class StoreTransactionTests: StoreKitConfigTestCase {
         sk1Transaction.mockPayment = payment
         sk1Transaction.mockTransactionDate = Date()
         sk1Transaction.mockTransactionIdentifier = UUID().uuidString
+        sk1Transaction.mockState = .purchased
 
         let transaction = StoreTransaction(sk1Transaction: sk1Transaction)
 
@@ -37,6 +38,29 @@ class StoreTransactionTests: StoreKitConfigTestCase {
         expect(transaction.transactionIdentifier) == sk1Transaction.mockTransactionIdentifier
         expect(transaction.quantity) == payment.quantity
         expect(transaction.storefront).to(beNil())
+        expect(transaction.hasKnownPurchaseDate) == true
+    }
+
+    func testSK1TransactionWithMissingDate() async throws {
+        let product = MockSK1Product(mockProductIdentifier: Self.productID)
+        let payment = SKPayment(product: product)
+
+        let sk1Transaction = MockTransaction()
+        sk1Transaction.mockPayment = payment
+        sk1Transaction.mockTransactionDate = Date()
+        sk1Transaction.mockTransactionIdentifier = UUID().uuidString
+        sk1Transaction.mockState = .failed
+
+        let transaction = StoreTransaction(sk1Transaction: sk1Transaction)
+
+        expect(transaction.sk1Transaction) === sk1Transaction
+
+        expect(transaction.productIdentifier) == Self.productID
+        expect(transaction.purchaseDate) == Date(millisecondsSince1970: 0)
+        expect(transaction.transactionIdentifier) == sk1Transaction.mockTransactionIdentifier
+        expect(transaction.quantity) == payment.quantity
+        expect(transaction.storefront).to(beNil())
+        expect(transaction.hasKnownPurchaseDate) == false
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)

--- a/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
+++ b/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
@@ -37,14 +37,14 @@ class MockOperationDispatcher: OperationDispatcher {
     }
 
     override func dispatchOnMainActor(_ block: @escaping @Sendable @MainActor () -> Void) {
-        let invoke: @Sendable @MainActor () -> Void = {
+        let invoke: @Sendable @MainActor () -> Void = { [atomic = self.pendingMainActorDispatches] in
             block()
-            self.pendingMainActorDispatches.value -= 1
+            atomic.modify { $0 -= 1 }
         }
 
         self.invokedDispatchOnMainThread = true
         self.invokedDispatchOnMainThreadCount += 1
-        self.pendingMainActorDispatches.value += 1
+        self.pendingMainActorDispatches.modify { $0 += 1 }
 
         if self.forwardToOriginalDispatchOnMainThread {
             super.dispatchOnMainActor(invoke)

--- a/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
+++ b/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
@@ -27,6 +27,7 @@ class MockOperationDispatcher: OperationDispatcher {
 
     var invokedDispatchAsyncOnMainThread = false
     var invokedDispatchAsyncOnMainThreadCount = 0
+    var pendingMainActorDispatches: Atomic<Int> = .init(0)
 
     override func dispatchAsyncOnMainThread(_ block: @escaping @Sendable () -> Void) {
         self.invokedDispatchAsyncOnMainThread = true
@@ -36,15 +37,19 @@ class MockOperationDispatcher: OperationDispatcher {
     }
 
     override func dispatchOnMainActor(_ block: @escaping @Sendable @MainActor () -> Void) {
+        let invoke: @Sendable @MainActor () -> Void = {
+            block()
+            self.pendingMainActorDispatches.value -= 1
+        }
+
         self.invokedDispatchOnMainThread = true
         self.invokedDispatchOnMainThreadCount += 1
+        self.pendingMainActorDispatches.value += 1
 
         if self.forwardToOriginalDispatchOnMainThread {
-            super.dispatchOnMainActor(block)
+            super.dispatchOnMainActor(invoke)
         } else {
-            OperationDispatcher.dispatchOnMainActor {
-                block()
-            }
+            OperationDispatcher.dispatchOnMainActor(invoke)
         }
     }
 

--- a/Tests/UnitTests/Mocks/MockPayment.swift
+++ b/Tests/UnitTests/Mocks/MockPayment.swift
@@ -1,0 +1,24 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockPayment.swift
+//
+//  Created by Nacho Soto on 8/2/23.
+
+import StoreKit
+
+final class MockPayment: SKPayment {
+
+    var mockProductIdentifier: String?
+
+    override var productIdentifier: String {
+        return self.mockProductIdentifier ?? ""
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockStoreTransaction.swift
+++ b/Tests/UnitTests/Mocks/MockStoreTransaction.swift
@@ -30,6 +30,12 @@ final class MockStoreTransaction: StoreTransactionType {
         self.storefront = nil
     }
 
+    private let _hasKnownPurchaseDate: Atomic<Bool> = true
+    var hasKnownPurchaseDate: Bool {
+        get { return self._hasKnownPurchaseDate.value }
+        set { self._hasKnownPurchaseDate.value = newValue }
+    }
+
     private let _finishInvoked: Atomic<Bool> = false
     var finishInvoked: Bool { return self._finishInvoked.value }
 

--- a/Tests/UnitTests/Mocks/MockTransaction.swift
+++ b/Tests/UnitTests/Mocks/MockTransaction.swift
@@ -24,7 +24,12 @@ class MockTransaction: SKPaymentTransaction {
 
     var mockTransactionDate: Date? = Date()
     override var transactionDate: Date? {
-        mockTransactionDate
+        // This matches the behavior of `SKPaymentTransaction`.
+        guard self.transactionState == .purchased || self.transactionState == .restored else {
+            return nil
+        }
+
+        return self.mockTransactionDate
     }
 
     var mockTransactionIdentifier: String? = UUID().uuidString

--- a/Tests/UnitTests/TestHelpers/TestLogHandler.swift
+++ b/Tests/UnitTests/TestHelpers/TestLogHandler.swift
@@ -86,6 +86,11 @@ extension TestLogHandler: Sendable {}
 
 extension TestLogHandler {
 
+    /// Useful if you want to ignore messages logged so far.
+    func clearMessages() {
+        self.loggedMessages.value.removeAll(keepingCapacity: false)
+    }
+
     func verifyMessageWasLogged(
         _ message: CustomStringConvertible,
         level: LogLevel? = nil,


### PR DESCRIPTION
This adds tests and a fix for a scenario discovered by @aboedo and @mcastany.

### Timeline:
- Make a purchase of product_1
- Close app
- Renewals happen in the background
- Subscription expires
- Open app, renewals are in the queue but not processed yet
- Start a purchase of `product_1` (`SKPaymentQueue.add`)
- StoreKit queue shows renewal from step 3 as finished, it's expired
- SDK sees finished transaction in the queue for `product_1`
- SDK sees completion block for `product_1`, considers it a successful `.purchase`
- SDK posts receipt, `initiation_source: .purchase` 💥
- Backend replies with 422 because StoreKit hasn't processed the transaction from 6

### Fix:
The fix looks at the date when the completion block was added (the time `.purchase()` is called).
If the transaction was created _before_ this, we know it didn't come from the actual purchase, and therefore it should be identified as `.queue`.
