### PR TITLE
`StoreProduct`: added test covering warning log

### DIFF
--- a/Tests/StoreKitUnitTests/StoreProductTests.swift
+++ b/Tests/StoreKitUnitTests/StoreProductTests.swift
@@ -386,6 +386,15 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(storeProduct.isFamilyShareable) == isFamilyShareable
     }
 
+    func testSK1ProductCannotDetermineProductType() {
+        let product = StoreProduct(sk1Product: .init())
+        self.logger.verifyMessageWasNotLogged(Strings.storeKit.sk1_no_known_product_type)
+
+        // Verify warning is only logged when calling method.
+        expect(product.productType) == .defaultType
+        self.logger.verifyMessageWasLogged(Strings.storeKit.sk1_no_known_product_type, level: .warn)
+    }
+
 }
 
 @available(iOS 14.0, tvOS 14.0, macOS 11.0, watchOS 7.0, *)

--- a/Tests/StoreKitUnitTests/StoreProductTests.swift
+++ b/Tests/StoreKitUnitTests/StoreProductTests.swift
@@ -386,7 +386,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(storeProduct.isFamilyShareable) == isFamilyShareable
     }
 
-    func testSK1ProductCannotDetermineProductType() {
+    func testWarningLogWhenGettingSK1ProductType() {
         let product = StoreProduct(sk1Product: .init())
         self.logger.verifyMessageWasNotLogged(Strings.storeKit.sk1_no_known_product_type)
 


### PR DESCRIPTION
I saw this log duplicated in our logs. I thought this test would cover the cause for it, but afterwards realized this only happens in hybrids because we call this eagerly.
Either way I thought covering this in a test was helpful.
