### PR TITLE
`Paywalls`: changed `subtitle` to be optional

### DIFF
--- a/RevenueCatUI/Data/ProcessedLocalizedConfiguration.swift
+++ b/RevenueCatUI/Data/ProcessedLocalizedConfiguration.swift
@@ -8,7 +8,7 @@ struct ProcessedLocalizedConfiguration: PaywallLocalizedConfiguration {
     typealias Feature = PaywallData.LocalizedConfiguration.Feature
 
     var title: String
-    var subtitle: String
+    var subtitle: String?
     var callToAction: String
     var callToActionWithIntroOffer: String?
     var offerDetails: String
@@ -23,7 +23,7 @@ struct ProcessedLocalizedConfiguration: PaywallLocalizedConfiguration {
     ) {
         self.init(
             title: configuration.title.processed(with: dataProvider, locale: locale),
-            subtitle: configuration.subtitle.processed(with: dataProvider, locale: locale),
+            subtitle: configuration.subtitle?.processed(with: dataProvider, locale: locale),
             callToAction: configuration.callToAction.processed(with: dataProvider, locale: locale),
             callToActionWithIntroOffer: configuration.callToActionWithIntroOffer?.processed(with: dataProvider,
                                                                                             locale: locale),
@@ -41,7 +41,7 @@ struct ProcessedLocalizedConfiguration: PaywallLocalizedConfiguration {
 
     private init(
         title: String,
-        subtitle: String,
+        subtitle: String?,
         callToAction: String,
         callToActionWithIntroOffer: String?,
         offerDetails: String,

--- a/RevenueCatUI/Templates/MultiPackageBoldTemplate.swift
+++ b/RevenueCatUI/Templates/MultiPackageBoldTemplate.swift
@@ -102,7 +102,7 @@ private struct MultiPackageTemplateContent: View {
 
             Spacer()
 
-            Text(self.selectedLocalization.subtitle)
+            Text(self.selectedLocalization.subtitle ?? "")
                 .font(.title2)
 
             Spacer()

--- a/RevenueCatUI/Templates/SinglePackageStandardTemplate.swift
+++ b/RevenueCatUI/Templates/SinglePackageStandardTemplate.swift
@@ -63,8 +63,8 @@ private struct SinglePackageTemplateContent: View {
                                 : []
                         )
 
-                    if self.configuration.mode.displaySubtitle {
-                        Text(verbatim: self.localization.subtitle)
+                    if self.configuration.mode.displaySubtitle, let subtitle = self.localization.subtitle {
+                        Text(verbatim: subtitle)
                             .font(self.configuration.mode.subtitleFont)
                     }
                 }

--- a/Sources/Paywalls/PaywallData.swift
+++ b/Sources/Paywalls/PaywallData.swift
@@ -39,7 +39,7 @@ public protocol PaywallLocalizedConfiguration {
     /// The title of the paywall screen.
     var title: String { get }
     /// The subtitle of the paywall screen.
-    var subtitle: String { get }
+    var subtitle: String? { get }
     /// The content of the main action button for purchasing a subscription.
     var callToAction: String { get }
     /// The content of the main action button for purchasing a subscription when an intro offer is available.
@@ -66,7 +66,7 @@ extension PaywallData {
         // swiftlint:disable missing_docs
 
         public var title: String
-        public var subtitle: String
+        public var subtitle: String?
         public var callToAction: String
         public var offerDetails: String
         public var offerName: String?
@@ -92,7 +92,7 @@ extension PaywallData {
 
         public init(
             title: String,
-            subtitle: String,
+            subtitle: String? = nil,
             callToAction: String,
             callToActionWithIntroOffer: String? = nil,
             offerDetails: String,

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PaywallAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PaywallAPI.swift
@@ -52,7 +52,7 @@ func checkPaywallConfiguration(_ config: PaywallData.Configuration,
 
 func checkPaywallLocalizedConfig(_ config: PaywallData.LocalizedConfiguration) {
     let title: String = config.title
-    let subtitle: String = config.subtitle
+    let subtitle: String? = config.subtitle
     let callToAction: String = config.callToAction
     let callToActionWithIntroOffer: String? = config.callToActionWithIntroOffer
     let offerDetails: String = config.offerDetails

--- a/Tests/UnitTests/Networking/Responses/Fixtures/Offerings.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/Offerings.json
@@ -58,7 +58,6 @@
                     },
                     "es_ES": {
                         "title": "Tienda",
-                        "subtitle": "Descripción",
                         "call_to_action": "Comprar",
                         "call_to_action_with_intro_offer": "Comprar",
                         "offer_details": "{{ price_per_month }} cada mes",

--- a/Tests/UnitTests/Networking/Responses/Fixtures/PaywallData-Sample1.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/PaywallData-Sample1.json
@@ -24,7 +24,6 @@
         },
         "es_ES": {
             "title": "Tienda",
-            "subtitle": "Descripción",
             "call_to_action": "Comprar",
             "offer_details": "{{ price_per_month }} cada mes",
             "offer_details_with_intro_offer": " ",

--- a/Tests/UnitTests/Networking/Responses/OfferingsDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/OfferingsDecodingTests.swift
@@ -133,7 +133,7 @@ class OfferingsDecodingTests: BaseHTTPResponseTest {
 
         let esConfig = try XCTUnwrap(paywall.config(for: Locale(identifier: "es_ES")))
         expect(esConfig.title) == "Tienda"
-        expect(esConfig.subtitle) == "Descripción"
+        expect(esConfig.subtitle).to(beNil())
         expect(esConfig.callToAction) == "Comprar"
         expect(esConfig.callToActionWithIntroOffer) == "Comprar"
         expect(esConfig.offerDetails) == "{{ price_per_month }} cada mes"

--- a/Tests/UnitTests/Paywalls/PaywallDataTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallDataTests.swift
@@ -74,7 +74,7 @@ class PaywallDataTests: BaseHTTPResponseTest {
 
         let esConfig = try XCTUnwrap(paywall.config(for: Locale(identifier: "es_ES")))
         expect(esConfig.title) == "Tienda"
-        expect(esConfig.subtitle) == "Descripción"
+        expect(esConfig.subtitle).to(beNil())
         expect(esConfig.callToAction) == "Comprar"
         expect(esConfig.callToActionWithIntroOffer).to(beNil())
         expect(esConfig.offerDetails) == "{{ price_per_month }} cada mes"


### PR DESCRIPTION
Not all templates require it, so it's optional from here on.