### PR TITLE
`Logging`: avoid logging "updating offerings" when request is cached

### DIFF
--- a/Sources/Networking/OfferingsAPI.swift
+++ b/Sources/Networking/OfferingsAPI.swift
@@ -28,7 +28,7 @@ class OfferingsAPI {
     }
 
     func getOfferings(appUserID: String,
-                      withRandomDelay randomDelay: Bool,
+                      isAppBackgrounded: Bool,
                       completion: @escaping OfferingsResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
                                                                 appUserID: appUserID)
@@ -40,9 +40,15 @@ class OfferingsAPI {
         let offeringsCallback = OfferingsCallback(cacheKey: factory.cacheKey, completion: completion)
         let cacheStatus = self.offeringsCallbacksCache.add(offeringsCallback)
 
+        if cacheStatus == .firstCallbackAddedToList {
+            Logger.debug(isAppBackgrounded
+                         ? Strings.offering.offerings_stale_updating_in_background
+                         : Strings.offering.offerings_stale_updating_in_foreground)
+        }
+
         self.backendConfig.addCacheableOperation(
             with: factory,
-            withRandomDelay: randomDelay,
+            withRandomDelay: isAppBackgrounded,
             cacheStatus: cacheStatus
         )
     }

--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -73,11 +73,7 @@ class OfferingsManager {
         fetchPolicy: FetchPolicy = .default,
         completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
     ) {
-        Logger.debug(isAppBackgrounded
-                     ? Strings.offering.offerings_stale_updating_in_background
-                     : Strings.offering.offerings_stale_updating_in_foreground)
-
-        self.backend.offerings.getOfferings(appUserID: appUserID, withRandomDelay: isAppBackgrounded) { result in
+        self.backend.offerings.getOfferings(appUserID: appUserID, isAppBackgrounded: isAppBackgrounded) { result in
             switch result {
             case let .success(response):
                 self.handleOfferingsBackendResult(with: response,

--- a/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
@@ -18,6 +18,13 @@ import XCTest
 
 class OtherIntegrationTests: BaseBackendIntegrationTests {
 
+    override func setUp() async throws {
+        // Some tests need to introspect logs during initialization.
+        super.initializeLogger()
+
+        try await super.setUp()
+    }
+
     func testGetCustomerInfo() async throws {
         let info = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
         expect(info.entitlements.all).to(beEmpty())
@@ -57,6 +64,15 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
         self.logger.verifyMessageWasLogged(
             Strings.network.api_request_completed(expectedRequest, httpCode: .notModified)
         )
+    }
+
+    func testOfferingsAreOnlyFetchedOnceOnSDKInitialization() async throws {
+        self.logger.verifyMessageWasLogged(Strings.offering.offerings_stale_updating_in_foreground,
+                                           level: .debug,
+                                           expectedCount: 1)
+        self.logger.verifyMessageWasLogged("GetOfferingsOperation: Started",
+                                           level: .debug,
+                                           expectedCount: 1)
     }
 
     func testHealthRequest() async throws {

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -39,10 +39,15 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     }
 
     func testCanGetOfferings() async throws {
+        self.logger.clearMessages()
+
         let receivedOfferings = try await self.purchases.offerings()
 
         expect(receivedOfferings.all).toNot(beEmpty())
         assertSnapshot(matching: receivedOfferings.response, as: .formattedJson)
+
+        self.logger.verifyMessageWasLogged(Strings.offering.vending_offerings_cache_from_memory,
+                                           level: .debug)
     }
 
     func testCanPurchasePackage() async throws {

--- a/Tests/UnitTests/Mocks/MockOfferingsAPI.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsAPI.swift
@@ -39,17 +39,17 @@ class MockOfferingsAPI: OfferingsAPI {
 
     var invokedGetOfferingsForAppUserID = false
     var invokedGetOfferingsForAppUserIDCount = 0
-    var invokedGetOfferingsForAppUserIDParameters: (appUserID: String?, randomDelay: Bool, completion: OfferingsAPI.OfferingsResponseHandler?)?
-    var invokedGetOfferingsForAppUserIDParametersList = [(appUserID: String?, randomDelay: Bool, completion: OfferingsAPI.OfferingsResponseHandler?)]()
+    var invokedGetOfferingsForAppUserIDParameters: (appUserID: String?, isAppBackgrounded: Bool, completion: OfferingsAPI.OfferingsResponseHandler?)?
+    var invokedGetOfferingsForAppUserIDParametersList = [(appUserID: String?, isAppBackgrounded: Bool, completion: OfferingsAPI.OfferingsResponseHandler?)]()
     var stubbedGetOfferingsCompletionResult: Result<OfferingsResponse, BackendError>?
 
     override func getOfferings(appUserID: String,
-                               withRandomDelay randomDelay: Bool,
+                               isAppBackgrounded: Bool,
                                completion: @escaping OfferingsResponseHandler) {
         self.invokedGetOfferingsForAppUserID = true
         self.invokedGetOfferingsForAppUserIDCount += 1
-        self.invokedGetOfferingsForAppUserIDParameters = (appUserID, randomDelay, completion)
-        self.invokedGetOfferingsForAppUserIDParametersList.append((appUserID, randomDelay, completion))
+        self.invokedGetOfferingsForAppUserIDParameters = (appUserID, isAppBackgrounded, completion)
+        self.invokedGetOfferingsForAppUserIDParametersList.append((appUserID, isAppBackgrounded, completion))
 
         completion(self.stubbedGetOfferingsCompletionResult!)
     }

--- a/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
@@ -30,7 +30,7 @@ class BackendGetOfferingsTests: BaseBackendTests {
         )
 
         let result = waitUntilValue { completed in
-            self.offerings.getOfferings(appUserID: Self.userID, withRandomDelay: false, completion: completed)
+            self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false, completion: completed)
         }
 
         expect(result).to(beSuccess())
@@ -45,7 +45,7 @@ class BackendGetOfferingsTests: BaseBackendTests {
         )
 
         let result = waitUntilValue { completed in
-            self.offerings.getOfferings(appUserID: Self.userID, withRandomDelay: true, completion: completed)
+            self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: true, completion: completed)
         }
 
         expect(result).to(beSuccess())
@@ -60,8 +60,8 @@ class BackendGetOfferingsTests: BaseBackendTests {
                             response: Self.noOfferingsResponse as [String: Any],
                             delay: .milliseconds(10))
         )
-        self.offerings.getOfferings(appUserID: Self.userID, withRandomDelay: false) { _ in }
-        self.offerings.getOfferings(appUserID: Self.userID, withRandomDelay: false) { _ in }
+        self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false) { _ in }
+        self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false) { _ in }
 
         expect(self.httpClient.calls).toEventually(haveCount(1))
     }
@@ -73,8 +73,8 @@ class BackendGetOfferingsTests: BaseBackendTests {
                             response: Self.noOfferingsResponse as [String: Any],
                             delay: .milliseconds(10))
         )
-        self.offerings.getOfferings(appUserID: Self.userID, withRandomDelay: false) { _ in }
-        self.offerings.getOfferings(appUserID: Self.userID, withRandomDelay: false) { _ in }
+        self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false) { _ in }
+        self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false) { _ in }
 
         expect(self.httpClient.calls).toEventually(haveCount(1))
 
@@ -92,8 +92,8 @@ class BackendGetOfferingsTests: BaseBackendTests {
         self.httpClient.mock(requestPath: .getOfferings(appUserID: Self.userID), response: response)
         self.httpClient.mock(requestPath: .getOfferings(appUserID: userID2), response: response)
 
-        self.offerings.getOfferings(appUserID: Self.userID, withRandomDelay: false, completion: { _ in })
-        self.offerings.getOfferings(appUserID: userID2, withRandomDelay: false, completion: { _ in })
+        self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false, completion: { _ in })
+        self.offerings.getOfferings(appUserID: userID2, isAppBackgrounded: false, completion: { _ in })
 
         expect(self.httpClient.calls).toEventually(haveCount(2))
     }
@@ -105,7 +105,7 @@ class BackendGetOfferingsTests: BaseBackendTests {
         )
 
         let result: Atomic<Result<OfferingsResponse, BackendError>?> = nil
-        self.offerings.getOfferings(appUserID: Self.userID, withRandomDelay: false) {
+        self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false) {
             result.value = $0
         }
 
@@ -135,7 +135,7 @@ class BackendGetOfferingsTests: BaseBackendTests {
         )
 
         let result = waitUntilValue { completed in
-            self.offerings.getOfferings(appUserID: Self.userID, withRandomDelay: false, completion: completed)
+            self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false, completion: completed)
         }
 
         expect(result).to(beFailure())
@@ -150,7 +150,7 @@ class BackendGetOfferingsTests: BaseBackendTests {
         )
 
         let result = waitUntilValue { completed in
-            self.offerings.getOfferings(appUserID: Self.userID, withRandomDelay: false, completion: completed)
+            self.offerings.getOfferings(appUserID: Self.userID, isAppBackgrounded: false, completion: completed)
         }
 
         expect(result).to(beFailure())
@@ -159,7 +159,7 @@ class BackendGetOfferingsTests: BaseBackendTests {
 
     func testGetOfferingsSkipsBackendCallIfAppUserIDIsEmpty() {
         waitUntil { completed in
-            self.offerings.getOfferings(appUserID: "", withRandomDelay: false) { _ in
+            self.offerings.getOfferings(appUserID: "", isAppBackgrounded: false) { _ in
                 completed()
             }
         }
@@ -169,7 +169,7 @@ class BackendGetOfferingsTests: BaseBackendTests {
 
     func testGetOfferingsCallsCompletionWithErrorIfAppUserIDIsEmpty() {
         let receivedError = waitUntilValue { completed in
-            self.offerings.getOfferings(appUserID: "", withRandomDelay: false) { result in
+            self.offerings.getOfferings(appUserID: "", isAppBackgrounded: false) { result in
                 completed(result.error)
             }
         }

--- a/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
+++ b/Tests/UnitTests/Purchasing/OfferingsManagerTests.swift
@@ -348,7 +348,7 @@ extension OfferingsManagerTests {
         // then
         expect(self.mockOfferings.invokedGetOfferingsForAppUserIDCount) == expectedCallCount
         expect(self.mockDeviceCache.cacheOfferingsCount) == expectedCallCount
-        expect(self.mockOfferings.invokedGetOfferingsForAppUserIDParameters?.randomDelay) == true
+        expect(self.mockOfferings.invokedGetOfferingsForAppUserIDParameters?.isAppBackgrounded) == true
         expect(result).to(beSuccess())
 
         let offerings = try XCTUnwrap(result?.value)

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -333,7 +333,7 @@ extension BasePurchasesTests {
         var gotOfferings = 0
 
         override func getOfferings(appUserID: String,
-                                   withRandomDelay randomDelay: Bool,
+                                   isAppBackgrounded: Bool,
                                    completion: @escaping OfferingsAPI.OfferingsResponseHandler) {
             self.gotOfferings += 1
             if self.failOfferings {


### PR DESCRIPTION
I noticed this in our logs:
```
[offering] DEBUG: ℹ️ No cached Offerings, fetching from network
[purchases] VERBOSE: Updating all caches
[offering] DEBUG: ℹ️ Offerings cache is stale, updating from network in foreground
[offering] DEBUG: ℹ️ Offerings cache is stale, updating from network in foreground
[network] DEBUG: ℹ️ Network operation 'GetOfferingsOperation' found with the same cache key 'GetOfferingsOpe...'. Skipping request.
[network] DEBUG: ℹ️ GetOfferingsOperation: Started
```

The double "updating from network" can be confusing, so this fixes it so it's only logged if the request will actually be started. Also added/updated our tests to verify the correct logs as well as caching behavior.