### PR TITLE
`Integration Tests`: added more observer mode tests

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -273,6 +273,14 @@
 		4FCEEA5E2A379B80002C2112 /* DebugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCEEA5D2A379B80002C2112 /* DebugViewController.swift */; };
 		4FD291BE2A1E9A2E0098D1B9 /* StoreKit2TransactionFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD291BD2A1E9A2E0098D1B9 /* StoreKit2TransactionFetcherTests.swift */; };
 		4FDA13842A33D9BD00C45CFE /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 4FDA13662A33D13700C45CFE /* PrivacyInfo.xcprivacy */; };
+		4FDF10E72A725EA6004F3680 /* CustomPuchasesOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF10E62A725EA6004F3680 /* CustomPuchasesOrchestrator.swift */; };
+		4FDF10E82A725EA6004F3680 /* CustomPuchasesOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF10E62A725EA6004F3680 /* CustomPuchasesOrchestrator.swift */; };
+		4FDF10EA2A726269004F3680 /* ObserverModeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF10E92A726269004F3680 /* ObserverModeManager.swift */; };
+		4FDF10EB2A726269004F3680 /* ObserverModeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF10E92A726269004F3680 /* ObserverModeManager.swift */; };
+		4FDF10ED2A726291004F3680 /* SK1ProductFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF10EC2A726291004F3680 /* SK1ProductFetcher.swift */; };
+		4FDF10EE2A726291004F3680 /* SK1ProductFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF10EC2A726291004F3680 /* SK1ProductFetcher.swift */; };
+		4FDF10F02A7262D8004F3680 /* SK2ProductFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF10EF2A7262D8004F3680 /* SK2ProductFetcher.swift */; };
+		4FDF10F12A7262D8004F3680 /* SK2ProductFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF10EF2A7262D8004F3680 /* SK2ProductFetcher.swift */; };
 		4FE0685F2A5F54C500B8F56C /* PackageTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE0685E2A5F54C500B8F56C /* PackageTypeTests.swift */; };
 		4FE6669F2A2F95A1004EEAFC /* PaywallExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE6669E2A2F95A1004EEAFC /* PaywallExtensions.swift */; };
 		4FF8464D2A32554300617F00 /* DiagnosticsStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF8464C2A32554300617F00 /* DiagnosticsStrings.swift */; };
@@ -986,6 +994,10 @@
 		4FCEEA622A37A2E9002C2112 /* ImageSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSnapshot.swift; sourceTree = "<group>"; };
 		4FD291BD2A1E9A2E0098D1B9 /* StoreKit2TransactionFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2TransactionFetcherTests.swift; sourceTree = "<group>"; };
 		4FDA13662A33D13700C45CFE /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		4FDF10E62A725EA6004F3680 /* CustomPuchasesOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPuchasesOrchestrator.swift; sourceTree = "<group>"; };
+		4FDF10E92A726269004F3680 /* ObserverModeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserverModeManager.swift; sourceTree = "<group>"; };
+		4FDF10EC2A726291004F3680 /* SK1ProductFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1ProductFetcher.swift; sourceTree = "<group>"; };
+		4FDF10EF2A7262D8004F3680 /* SK2ProductFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2ProductFetcher.swift; sourceTree = "<group>"; };
 		4FE0685E2A5F54C500B8F56C /* PackageTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackageTypeTests.swift; sourceTree = "<group>"; };
 		4FE6669E2A2F95A1004EEAFC /* PaywallExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallExtensions.swift; sourceTree = "<group>"; };
 		4FF8464C2A32554300617F00 /* DiagnosticsStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsStrings.swift; sourceTree = "<group>"; };
@@ -2208,6 +2220,10 @@
 		4F90AFC92A39152A0047E63F /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				4FDF10E62A725EA6004F3680 /* CustomPuchasesOrchestrator.swift */,
+				4FDF10E92A726269004F3680 /* ObserverModeManager.swift */,
+				4FDF10EC2A726291004F3680 /* SK1ProductFetcher.swift */,
+				4FDF10EF2A7262D8004F3680 /* SK2ProductFetcher.swift */,
 				4F90AFCA2A3915340047E63F /* TestMessage.swift */,
 			);
 			path = Helpers;
@@ -2896,6 +2912,9 @@
 					};
 					2DEAC2D926EFE46E006914ED = {
 						CreatedOnToolsVersion = 12.5.1;
+					};
+					4F6BEE042A27B02400CD9322 = {
+						TestTargetID = 2DE20B7E26409EB7004C597D;
 					};
 					57D92C32293E4D0C00D1912A = {
 						CreatedOnToolsVersion = 14.1;
@@ -3651,12 +3670,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4FDF10E72A725EA6004F3680 /* CustomPuchasesOrchestrator.swift in Sources */,
 				4F82C2682A3CD58200EC98AF /* Matchers.swift in Sources */,
 				4FB3FE132A38CB1F004789C6 /* SignatureVerificationIntegrationTests.swift in Sources */,
 				57488AFF29CA58050000EE7E /* LoadShedderIntegrationTests.swift in Sources */,
+				4FDF10F02A7262D8004F3680 /* SK2ProductFetcher.swift in Sources */,
 				575A8EE22922C56300936709 /* AsyncTestHelpers.swift in Sources */,
 				2DA85A8B26DEA7DD00F1136D /* MockProductsRequestFactory.swift in Sources */,
 				2D3BFAD326DEA47100370B11 /* MockSKProductDiscount.swift in Sources */,
+				4FDF10ED2A726291004F3680 /* SK1ProductFetcher.swift in Sources */,
 				4F83F6B72A5DB782003F90A5 /* CurrentTestCaseTracker.swift in Sources */,
 				57DE80BE28077010008D6C6F /* XCTestCase+Extensions.swift in Sources */,
 				2D3BFAD426DEA49200370B11 /* SKProductSubscriptionDurationExtensions.swift in Sources */,
@@ -3676,6 +3698,7 @@
 				2D3BFAD226DEA46600370B11 /* MockProductsRequest.swift in Sources */,
 				4F83F6B82A5DB78C003F90A5 /* OSVersionEquivalent.swift in Sources */,
 				2D1015DB275A4EAE0086173F /* AvailabilityChecks.swift in Sources */,
+				4FDF10EA2A726269004F3680 /* ObserverModeManager.swift in Sources */,
 				5753EE0E294B938900CBAB54 /* StoreKitObserverModeIntegrationTests.swift in Sources */,
 				579189FD28F4966500BF4963 /* OtherIntegrationTests.swift in Sources */,
 			);
@@ -3708,13 +3731,17 @@
 				4F83F6BA2A5DB807003F90A5 /* CurrentTestCaseTracker.swift in Sources */,
 				4F6BEE3B2A27B45300CD9322 /* StoreKitTestHelpers.swift in Sources */,
 				4F6BEE1F2A27B02400CD9322 /* CustomEntitlementsComputationIntegrationTests.swift in Sources */,
+				4FDF10E82A725EA6004F3680 /* CustomPuchasesOrchestrator.swift in Sources */,
 				4F7C37E62A27F14B001E17D3 /* XCTestCase+Extensions.swift in Sources */,
 				4F7C37E52A27EFF7001E17D3 /* BaseStoreKitIntegrationTests.swift in Sources */,
 				4F83F6B92A5DB805003F90A5 /* TestCase.swift in Sources */,
 				4F6BEE3C2A27B45900CD9322 /* Constants.swift in Sources */,
 				4F90AFCC2A3915BC0047E63F /* TestMessage.swift in Sources */,
+				4FDF10F12A7262D8004F3680 /* SK2ProductFetcher.swift in Sources */,
+				4FDF10EB2A726269004F3680 /* ObserverModeManager.swift in Sources */,
 				4FB9069F2A69550500BE2735 /* AvailabilityChecks.swift in Sources */,
 				4F7C37E42A27EFE1001E17D3 /* BaseBackendIntegrationTests.swift in Sources */,
+				4FDF10EE2A726291004F3680 /* SK1ProductFetcher.swift in Sources */,
 				4F6BEE882A27E16B00CD9322 /* TestLogHandler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4008,7 +4035,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Tests/BackendIntegrationTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -4036,7 +4063,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Tests/BackendIntegrationTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -4302,7 +4329,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Tests/BackendIntegrationTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -4317,7 +4344,7 @@
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BackendIntegrationTestsHostApp.app/BackendIntegrationTestsHostApp";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BackendIntegrationTestsHostApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/BackendIntegrationTestsHostApp";
 				TVOS_DEPLOYMENT_TARGET = 14.1;
 				WATCHOS_DEPLOYMENT_TARGET = 7.1;
 			};
@@ -4330,7 +4357,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Tests/BackendIntegrationTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -4344,7 +4371,7 @@
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BackendIntegrationTestsHostApp.app/BackendIntegrationTestsHostApp";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BackendIntegrationTestsHostApp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/BackendIntegrationTestsHostApp";
 				TVOS_DEPLOYMENT_TARGET = 14.1;
 				WATCHOS_DEPLOYMENT_TARGET = 7.1;
 			};

--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -273,8 +273,8 @@
 		4FCEEA5E2A379B80002C2112 /* DebugViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCEEA5D2A379B80002C2112 /* DebugViewController.swift */; };
 		4FD291BE2A1E9A2E0098D1B9 /* StoreKit2TransactionFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD291BD2A1E9A2E0098D1B9 /* StoreKit2TransactionFetcherTests.swift */; };
 		4FDA13842A33D9BD00C45CFE /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 4FDA13662A33D13700C45CFE /* PrivacyInfo.xcprivacy */; };
-		4FDF10E72A725EA6004F3680 /* CustomPuchasesOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF10E62A725EA6004F3680 /* CustomPuchasesOrchestrator.swift */; };
-		4FDF10E82A725EA6004F3680 /* CustomPuchasesOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF10E62A725EA6004F3680 /* CustomPuchasesOrchestrator.swift */; };
+		4FDF10E72A725EA6004F3680 /* ExternalPurchasesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF10E62A725EA6004F3680 /* ExternalPurchasesManager.swift */; };
+		4FDF10E82A725EA6004F3680 /* ExternalPurchasesManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF10E62A725EA6004F3680 /* ExternalPurchasesManager.swift */; };
 		4FDF10EA2A726269004F3680 /* ObserverModeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF10E92A726269004F3680 /* ObserverModeManager.swift */; };
 		4FDF10EB2A726269004F3680 /* ObserverModeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF10E92A726269004F3680 /* ObserverModeManager.swift */; };
 		4FDF10ED2A726291004F3680 /* SK1ProductFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDF10EC2A726291004F3680 /* SK1ProductFetcher.swift */; };
@@ -994,7 +994,7 @@
 		4FCEEA622A37A2E9002C2112 /* ImageSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSnapshot.swift; sourceTree = "<group>"; };
 		4FD291BD2A1E9A2E0098D1B9 /* StoreKit2TransactionFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2TransactionFetcherTests.swift; sourceTree = "<group>"; };
 		4FDA13662A33D13700C45CFE /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		4FDF10E62A725EA6004F3680 /* CustomPuchasesOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPuchasesOrchestrator.swift; sourceTree = "<group>"; };
+		4FDF10E62A725EA6004F3680 /* ExternalPurchasesManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalPurchasesManager.swift; sourceTree = "<group>"; };
 		4FDF10E92A726269004F3680 /* ObserverModeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserverModeManager.swift; sourceTree = "<group>"; };
 		4FDF10EC2A726291004F3680 /* SK1ProductFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK1ProductFetcher.swift; sourceTree = "<group>"; };
 		4FDF10EF2A7262D8004F3680 /* SK2ProductFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SK2ProductFetcher.swift; sourceTree = "<group>"; };
@@ -2220,7 +2220,7 @@
 		4F90AFC92A39152A0047E63F /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
-				4FDF10E62A725EA6004F3680 /* CustomPuchasesOrchestrator.swift */,
+				4FDF10E62A725EA6004F3680 /* ExternalPurchasesManager.swift */,
 				4FDF10E92A726269004F3680 /* ObserverModeManager.swift */,
 				4FDF10EC2A726291004F3680 /* SK1ProductFetcher.swift */,
 				4FDF10EF2A7262D8004F3680 /* SK2ProductFetcher.swift */,
@@ -3670,7 +3670,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4FDF10E72A725EA6004F3680 /* CustomPuchasesOrchestrator.swift in Sources */,
+				4FDF10E72A725EA6004F3680 /* ExternalPurchasesManager.swift in Sources */,
 				4F82C2682A3CD58200EC98AF /* Matchers.swift in Sources */,
 				4FB3FE132A38CB1F004789C6 /* SignatureVerificationIntegrationTests.swift in Sources */,
 				57488AFF29CA58050000EE7E /* LoadShedderIntegrationTests.swift in Sources */,
@@ -3731,7 +3731,7 @@
 				4F83F6BA2A5DB807003F90A5 /* CurrentTestCaseTracker.swift in Sources */,
 				4F6BEE3B2A27B45300CD9322 /* StoreKitTestHelpers.swift in Sources */,
 				4F6BEE1F2A27B02400CD9322 /* CustomEntitlementsComputationIntegrationTests.swift in Sources */,
-				4FDF10E82A725EA6004F3680 /* CustomPuchasesOrchestrator.swift in Sources */,
+				4FDF10E82A725EA6004F3680 /* ExternalPurchasesManager.swift in Sources */,
 				4F7C37E62A27F14B001E17D3 /* XCTestCase+Extensions.swift in Sources */,
 				4F7C37E52A27EFF7001E17D3 /* BaseStoreKitIntegrationTests.swift in Sources */,
 				4F83F6B92A5DB805003F90A5 /* TestCase.swift in Sources */,

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -34,14 +34,7 @@ class BaseStoreKitIntegrationTests: BaseBackendIntegrationTests {
         super.initializeLogger()
 
         if self.testSession == nil {
-            try self.configureTestSession()
-        }
-
-        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
-            // Despite calling `SKTestSession.clearTransactions` tests sometimes
-            // begin with leftover transactions. This ensures that we remove them
-            // to always start with a clean state.
-            await self.deleteAllTransactions(session: self.testSession)
+            try await self.configureTestSession()
         }
 
         // Initialize `Purchases` *after* the fresh new session has been created
@@ -62,7 +55,7 @@ class BaseStoreKitIntegrationTests: BaseBackendIntegrationTests {
         try await super.tearDown()
     }
 
-    func configureTestSession() throws {
+    func configureTestSession() async throws {
         assert(self.testSession == nil, "Attempted to configure session multiple times")
 
         self.testSession = try SKTestSession(configurationFileNamed: Constants.storeKitConfigFileName)
@@ -73,6 +66,13 @@ class BaseStoreKitIntegrationTests: BaseBackendIntegrationTests {
             self.testSession.timeRate = .monthlyRenewalEveryThirtySeconds
         } else {
             self.testSession.timeRate = .oneSecondIsOneDay
+        }
+
+        if #available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *) {
+            // Despite calling `SKTestSession.clearTransactions` tests sometimes
+            // begin with leftover transactions. This ensures that we remove them
+            // to always start with a clean state.
+            await self.deleteAllTransactions(session: self.testSession)
         }
     }
 

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -322,23 +322,4 @@ extension BaseStoreKitIntegrationTests {
         }
     }
 
-    /// Purchases a product directly with StoreKit.
-    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    @discardableResult
-    func purchaseProductFromStoreKit(
-        productIdentifier: String = BaseStoreKitIntegrationTests.monthlyNoIntroProductID,
-        finishTransaction: Bool = false
-    ) async throws -> Product.PurchaseResult {
-        let products = try await StoreKit.Product.products(for: [productIdentifier])
-        let product = try XCTUnwrap(products.onlyElement)
-
-        let result = try await product.purchase()
-
-        if finishTransaction {
-            await result.verificationResult?.underlyingTransaction.finish()
-        }
-
-        return result
-    }
-
 }

--- a/Tests/BackendIntegrationTests/Helpers/CustomPuchasesOrchestrator.swift
+++ b/Tests/BackendIntegrationTests/Helpers/CustomPuchasesOrchestrator.swift
@@ -1,0 +1,162 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  CustomPuchasesOrchestrator.swift
+//
+//  Created by Nacho Soto on 7/27/23.
+
+@testable import RevenueCat
+import StoreKit
+
+/// A simplified `PurchasesOrchestrator` used for simulating purchases
+/// made from outside the SDK.
+final class CustomPurchasesOrchestrator: NSObject {
+
+    typealias SK1PurchaseCompletedResult = SK1Transaction
+
+    private let finishTransactions: Bool
+    private let paymentQueue: SKPaymentQueue
+
+    private var sk1PurchaseCompleteCallbacksByProductID: [String: (SK1PurchaseCompletedResult) -> Void] = [:]
+
+    init(finishTransactions: Bool) {
+        self.finishTransactions = finishTransactions
+        self.paymentQueue = .init()
+
+        super.init()
+
+        self.paymentQueue.add(self)
+    }
+
+    deinit {
+        self.paymentQueue.remove(self)
+    }
+
+    func purchase(
+        sk1Product product: SK1Product,
+        completion: @escaping (SK1PurchaseCompletedResult) -> Void
+    ) {
+        let productIdentifier = product.productIdentifier
+        assert(!productIdentifier.isEmpty)
+        assert(self.sk1PurchaseCompleteCallbacksByProductID[productIdentifier] == nil)
+
+        self.sk1PurchaseCompleteCallbacksByProductID[productIdentifier] = completion
+        self.paymentQueue.add(.init(product: product))
+    }
+
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+    @discardableResult
+    func purchase(sk2Product product: SK2Product) async throws -> Product.PurchaseResult {
+        let result = try await product.purchase()
+
+        switch result {
+        case let .success(.verified(transaction)):
+            if self.finishTransactions {
+                await transaction.finish()
+            }
+
+            Logger.rcPurchaseSuccess(Message.purchasedSK2Product)
+
+        case let .success(.unverified(transaction, error)):
+            if self.finishTransactions {
+                await transaction.finish()
+            }
+
+            throw error
+
+        case .userCancelled: break
+        case .pending: break
+        @unknown default:
+            fatalError()
+        }
+
+        return result
+    }
+
+}
+
+extension CustomPurchasesOrchestrator {
+
+    func purchase(sk1Product product: SK1Product) async throws -> SK1PurchaseCompletedResult {
+        return try await withCheckedThrowingContinuation { continuation in
+            self.purchase(sk1Product: product) { transaction in
+                if let error = transaction.error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: transaction)
+                }
+            }
+        }
+    }
+
+}
+
+extension CustomPurchasesOrchestrator: SKPaymentTransactionObserver {
+
+    func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
+        for transaction in transactions {
+            let productIdentifier = transaction.payment.productIdentifier
+            guard let completion = self.sk1PurchaseCompleteCallbacksByProductID[productIdentifier] else {
+                continue
+            }
+
+            func finishAndReportCompletion() {
+                if self.finishTransactions {
+                    self.paymentQueue.finishTransaction(transaction)
+                }
+
+                self.sk1PurchaseCompleteCallbacksByProductID.removeValue(forKey: productIdentifier)
+
+                completion(transaction)
+            }
+
+            switch transaction.transactionState {
+            case .purchasing: break
+
+            case .restored, .purchased:
+                Logger.rcPurchaseSuccess(Message.purchasedSK1Product)
+                finishAndReportCompletion()
+
+            case .failed:
+                Logger.rcPurchaseError(Message.errorPurchasingSK1Product)
+                finishAndReportCompletion()
+
+            case .deferred:
+                fatalError("Not supported right now")
+
+            @unknown default:
+                break
+            }
+        }
+    }
+
+}
+
+private enum Message: LogMessage {
+
+    case purchasedSK1Product
+    case errorPurchasingSK1Product
+    case purchasedSK2Product
+
+    var description: String {
+        switch self {
+        case .purchasedSK1Product:
+            return "Successfully purchased SK1 product"
+        case .errorPurchasingSK1Product:
+            return "Error purchasing SK1 product"
+        case .purchasedSK2Product:
+            return "Successfully purchased SK2 product"
+        }
+    }
+
+    var category: String {
+        return "custom_purchases"
+    }
+
+}

--- a/Tests/BackendIntegrationTests/Helpers/ExternalPurchasesManager.swift
+++ b/Tests/BackendIntegrationTests/Helpers/ExternalPurchasesManager.swift
@@ -7,16 +7,15 @@
 //
 //      https://opensource.org/licenses/MIT
 //
-//  CustomPuchasesOrchestrator.swift
+//  ExternalPurchasesManager.swift
 //
 //  Created by Nacho Soto on 7/27/23.
 
 @testable import RevenueCat
 import StoreKit
 
-/// A simplified `PurchasesOrchestrator` used for simulating purchases
-/// made from outside the SDK.
-final class CustomPurchasesOrchestrator: NSObject {
+/// Used for simulating purchases made from outside the SDK.
+final class ExternalPurchasesManager: NSObject {
 
     typealias SK1PurchaseCompletedResult = SK1Transaction
 
@@ -81,7 +80,7 @@ final class CustomPurchasesOrchestrator: NSObject {
 
 }
 
-extension CustomPurchasesOrchestrator {
+extension ExternalPurchasesManager {
 
     func purchase(sk1Product product: SK1Product) async throws -> SK1PurchaseCompletedResult {
         return try await withCheckedThrowingContinuation { continuation in
@@ -97,7 +96,7 @@ extension CustomPurchasesOrchestrator {
 
 }
 
-extension CustomPurchasesOrchestrator: SKPaymentTransactionObserver {
+extension ExternalPurchasesManager: SKPaymentTransactionObserver {
 
     func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
         for transaction in transactions {

--- a/Tests/BackendIntegrationTests/Helpers/ObserverModeManager.swift
+++ b/Tests/BackendIntegrationTests/Helpers/ObserverModeManager.swift
@@ -21,12 +21,12 @@ final class ObserverModeManager: ObservableObject {
 
     private let productFetcherSK1: SK1ProductFetcher
     private let productFetcherSK2: SK2ProductFetcher
-    private let purchasesOrchestrator: CustomPurchasesOrchestrator
+    private let purchasesManager: ExternalPurchasesManager
 
     init() {
         self.productFetcherSK1 = .init()
         self.productFetcherSK2 = .init()
-        self.purchasesOrchestrator = .init(finishTransactions: true)
+        self.purchasesManager = .init(finishTransactions: true)
     }
 
     @discardableResult
@@ -36,7 +36,7 @@ final class ObserverModeManager: ObservableObject {
         let products = try await self.productFetcherSK1.products(with: [productIdentifier])
         let product = try XCTUnwrap(products.onlyElement)
 
-        return try await self.purchasesOrchestrator.purchase(sk1Product: product)
+        return try await self.purchasesManager.purchase(sk1Product: product)
     }
 
     /// Purchases a product directly with StoreKit.
@@ -48,6 +48,6 @@ final class ObserverModeManager: ObservableObject {
         let products = try await StoreKit.Product.products(for: [productIdentifier])
         let product = try XCTUnwrap(products.onlyElement)
 
-        return try await self.purchasesOrchestrator.purchase(sk2Product: product)
+        return try await self.purchasesManager.purchase(sk2Product: product)
     }
 }

--- a/Tests/BackendIntegrationTests/Helpers/ObserverModeManager.swift
+++ b/Tests/BackendIntegrationTests/Helpers/ObserverModeManager.swift
@@ -1,0 +1,53 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ObserverModeManager.swift
+//
+//  Created by Nacho Soto on 7/27/23.
+
+import Foundation
+@testable import RevenueCat
+import StoreKit
+import XCTest
+
+/// A helper for observer mode tests.
+final class ObserverModeManager: ObservableObject {
+
+    private let productFetcherSK1: SK1ProductFetcher
+    private let productFetcherSK2: SK2ProductFetcher
+    private let purchasesOrchestrator: CustomPurchasesOrchestrator
+
+    init() {
+        self.productFetcherSK1 = .init()
+        self.productFetcherSK2 = .init()
+        self.purchasesOrchestrator = .init(finishTransactions: true)
+    }
+
+    @discardableResult
+    func purchaseProductFromStoreKit1(
+        productIdentifier: String = BaseStoreKitIntegrationTests.monthlyNoIntroProductID
+    ) async throws -> SK1Transaction {
+        let products = try await self.productFetcherSK1.products(with: [productIdentifier])
+        let product = try XCTUnwrap(products.onlyElement)
+
+        return try await self.purchasesOrchestrator.purchase(sk1Product: product)
+    }
+
+    /// Purchases a product directly with StoreKit.
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    @discardableResult
+    func purchaseProductFromStoreKit2(
+        productIdentifier: String = BaseStoreKitIntegrationTests.monthlyNoIntroProductID
+    ) async throws -> Product.PurchaseResult {
+        let products = try await StoreKit.Product.products(for: [productIdentifier])
+        let product = try XCTUnwrap(products.onlyElement)
+
+        return try await self.purchasesOrchestrator.purchase(sk2Product: product)
+    }
+}

--- a/Tests/BackendIntegrationTests/Helpers/SK1ProductFetcher.swift
+++ b/Tests/BackendIntegrationTests/Helpers/SK1ProductFetcher.swift
@@ -1,0 +1,69 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SK1ProductFetcher.swift
+//
+//  Created by Nacho Soto on 7/27/23.
+
+import RevenueCat
+import StoreKit
+
+/// Simplified version of the fetcher in RevenueCat.
+/// Used to fetch products directly and test observer mode.
+final class SK1ProductFetcher: NSObject {
+
+    typealias Callback = (Result<Set<SK1Product>, Error>) -> Void
+
+    private var completionHandlers: [Set<String>: Callback] = [:]
+    private var productsByRequests: [SKRequest: Set<String>] = [:]
+
+    func products(with identifiers: Set<String>, completion: @escaping Callback) {
+        assert(self.completionHandlers[identifiers] == nil)
+
+        self.completionHandlers[identifiers] = completion
+        self.startRequest(for: identifiers)
+    }
+
+    func products(with identifiers: Set<String>) async throws -> Set<SK1Product> {
+        return try await withCheckedThrowingContinuation { continuation in
+            self.products(with: identifiers) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+
+    private func startRequest(for identifiers: Set<String>) {
+        let request = SKProductsRequest(productIdentifiers: identifiers)
+        request.delegate = self
+        self.productsByRequests[request] = identifiers
+        request.start()
+    }
+
+}
+
+extension SK1ProductFetcher: SKProductsRequestDelegate {
+
+    func productsRequest(_ request: SKProductsRequest, didReceive response: SKProductsResponse) {
+        self.report(result: .success(Set(response.products)), from: request)
+    }
+
+    func request(_ request: SKRequest, didFailWithError error: Error) {
+        self.report(result: .failure(error), from: request)
+    }
+
+    private func report(result: Result<Set<SK1Product>, Error>, from request: SKRequest) {
+        guard let identifiers = self.productsByRequests.removeValue(forKey: request),
+              let completion = self.completionHandlers.removeValue(forKey: identifiers) else {
+            fatalError("Couldn't find matching callback")
+        }
+
+        completion(result)
+    }
+
+}

--- a/Tests/BackendIntegrationTests/Helpers/SK2ProductFetcher.swift
+++ b/Tests/BackendIntegrationTests/Helpers/SK2ProductFetcher.swift
@@ -1,0 +1,26 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  SK2ProductFetcher.swift
+//
+//  Created by Nacho Soto on 7/27/23.
+
+import RevenueCat
+import StoreKit
+
+/// Simplified version of the fetcher in RevenueCat.
+/// Used to fetch products directly and test observer mode.
+@available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+final actor SK2ProductFetcher {
+
+    func products(with identifiers: Set<String>) async throws -> Set<SK2Product> {
+        return try await Set(StoreKit.Product.products(for: identifiers))
+    }
+
+}

--- a/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
@@ -26,8 +26,8 @@ class BaseStoreKitObserverModeIntegrationTests: BaseStoreKitIntegrationTests {
 
     var manager: ObserverModeManager!
 
-    final override func configureTestSession() throws {
-        try super.configureTestSession()
+    final override func configureTestSession() async throws {
+        try await super.configureTestSession()
 
         self.manager = .init()
     }
@@ -179,7 +179,7 @@ class StoreKit1ObserverModeWithExistingPurchasesTests: BaseStoreKitObserverModeI
 
     func testDoesNotSyncExistingSK1Purchases() async throws {
         // 1. Create `SKTestSession`
-        try self.configureTestSession()
+        try await self.configureTestSession()
 
         // 2. Purchase product directly from StoreKit
         try await self.manager.purchaseProductFromStoreKit1()
@@ -194,7 +194,7 @@ class StoreKit1ObserverModeWithExistingPurchasesTests: BaseStoreKitObserverModeI
 
     func testDoesNotSyncExistingSK2Purchases() async throws {
         // 1. Create `SKTestSession`
-        try self.configureTestSession()
+        try await self.configureTestSession()
 
         // 2. Purchase product directly from StoreKit
         try await self.manager.purchaseProductFromStoreKit2()

--- a/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitObserverModeIntegrationTests.swift
@@ -24,6 +24,14 @@ class BaseStoreKitObserverModeIntegrationTests: BaseStoreKitIntegrationTests {
 
     override class var observerMode: Bool { return true }
 
+    var manager: ObserverModeManager!
+
+    final override func configureTestSession() throws {
+        try super.configureTestSession()
+
+        self.manager = .init()
+    }
+
 }
 
 class StoreKit2ObserverModeIntegrationTests: StoreKit1ObserverModeIntegrationTests {
@@ -38,7 +46,7 @@ class StoreKit2ObserverModeIntegrationTests: StoreKit1ObserverModeIntegrationTes
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testPurchaseInDevicePostsReceipt() async throws {
-        let result = try await self.purchaseProductFromStoreKit()
+        let result = try await self.manager.purchaseProductFromStoreKit2()
         let transaction = try XCTUnwrap(result.verificationResult?.underlyingTransaction)
 
         try self.testSession.disableAutoRenewForTransaction(identifier: UInt(transaction.id))
@@ -65,7 +73,7 @@ class StoreKit2ObserverModeIntegrationTests: StoreKit1ObserverModeIntegrationTes
 
         let productID = Self.monthlyNoIntroProductID
 
-        try await self.purchaseProductFromStoreKit(productIdentifier: productID, finishTransaction: true)
+        try await self.manager.purchaseProductFromStoreKit2(productIdentifier: productID)
 
         try self.testSession.forceRenewalOfSubscription(productIdentifier: productID)
 
@@ -116,7 +124,7 @@ class StoreKit1ObserverModeIntegrationTests: BaseStoreKitObserverModeIntegration
 
         let productID = Self.monthlyNoIntroProductID
 
-        try await self.purchaseProductFromStoreKit(productIdentifier: productID, finishTransaction: true)
+        try await self.manager.purchaseProductFromStoreKit2(productIdentifier: productID)
 
         try? self.testSession.forceRenewalOfSubscription(productIdentifier: productID)
 
@@ -165,19 +173,36 @@ class StoreKit1ObserverModeWithExistingPurchasesTests: BaseStoreKitObserverModeI
     }
 
     override func setUp() async throws {
+        // Not calling `super.setUp` so each test can
+        // do something else before initializing SDK.
+    }
+
+    func testDoesNotSyncExistingSK1Purchases() async throws {
         // 1. Create `SKTestSession`
         try self.configureTestSession()
 
         // 2. Purchase product directly from StoreKit
-        try await self.purchaseProductFromStoreKit()
+        try await self.manager.purchaseProductFromStoreKit1()
 
         // 3. Configure SDK
         try await super.setUp()
+
+        // 4. Sync customer info
+        let info = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
+        self.assertNoPurchases(info)
     }
 
-    func testDoesNotSyncExistingPurchase() async throws {
-        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+    func testDoesNotSyncExistingSK2Purchases() async throws {
+        // 1. Create `SKTestSession`
+        try self.configureTestSession()
 
+        // 2. Purchase product directly from StoreKit
+        try await self.manager.purchaseProductFromStoreKit2()
+
+        // 3. Configure SDK
+        try await super.setUp()
+
+        // 4. Sync customer info
         let info = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
         self.assertNoPurchases(info)
     }


### PR DESCRIPTION
This extracts the purchasing code into a new `ExternalPurchasesManager` and `ObserverModeManager`, which can be used to perform purchases without using the SDK.

I've also bumped the deployment target of integration tests to 15.0 to simplify the code.
