### PR TITLE
`Integration Tests`: new test to verify that SK1 purchases don't leave SK2 unfinished transactions

### DIFF
--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -61,6 +61,20 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         try await self.purchaseMonthlyProduct()
     }
 
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func testPurchasingSK1ProductDoesNotLeaveUnfinishedSK2Transaction() async throws {
+        try XCTSkipIf(Self.storeKit2Setting.usesStoreKit2IfAvailable, "Test only for SK1")
+
+        func verifyNoUnfinishedTransactions() async {
+            let unfinishedTransactions = await Transaction.unfinished.extractValues()
+            expect(unfinishedTransactions).to(beEmpty())
+        }
+
+        await verifyNoUnfinishedTransactions()
+        try await self.purchaseMonthlyProduct()
+        await verifyNoUnfinishedTransactions()
+    }
+
     func testPurchasingPackageWithPresentedOfferingIdentifier() async throws {
         let package = try await self.monthlyPackage
 


### PR DESCRIPTION
We saw this behavior on a real app. Unfortunately doesn't reproduce in a test, but still useful to cover because it would break many assumptions if we were to see it fail.