### PR TITLE
`StoreKit2TransactionListener`: converted into an `actor`

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -74,9 +74,9 @@ final class PurchasesOrchestrator {
     // swiftlint:enable identifier_name
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    var storeKit2TransactionListener: StoreKit2TransactionListener {
+    var storeKit2TransactionListener: StoreKit2TransactionListenerType {
         // swiftlint:disable:next force_cast
-        return self._storeKit2TransactionListener! as! StoreKit2TransactionListener
+        return self._storeKit2TransactionListener! as! StoreKit2TransactionListenerType
     }
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -102,7 +102,7 @@ final class PurchasesOrchestrator {
                      offeringsManager: OfferingsManager,
                      manageSubscriptionsHelper: ManageSubscriptionsHelper,
                      beginRefundRequestHelper: BeginRefundRequestHelper,
-                     storeKit2TransactionListener: StoreKit2TransactionListener,
+                     storeKit2TransactionListener: StoreKit2TransactionListenerType,
                      storeKit2StorefrontListener: StoreKit2StorefrontListener
     ) {
         self.init(
@@ -127,13 +127,14 @@ final class PurchasesOrchestrator {
         self._storeKit2TransactionListener = storeKit2TransactionListener
         self._storeKit2StorefrontListener = storeKit2StorefrontListener
 
-        storeKit2TransactionListener.delegate = self
         storeKit2StorefrontListener.delegate = self
-
-        storeKit2TransactionListener.listenForTransactions()
-
         if systemInfo.storeKit2Setting == .enabledForCompatibleDevices {
             storeKit2StorefrontListener.listenForStorefrontChanges()
+        }
+
+        Task {
+            await storeKit2TransactionListener.set(delegate: self)
+            await storeKit2TransactionListener.listenForTransactions()
         }
     }
 
@@ -849,7 +850,7 @@ private extension PurchasesOrchestrator {
 extension PurchasesOrchestrator: StoreKit2TransactionListenerDelegate {
 
     func storeKit2TransactionListener(
-        _ listener: StoreKit2TransactionListener,
+        _ listener: StoreKit2TransactionListenerType,
         updatedTransaction transaction: StoreTransactionType
     ) async throws {
         let storefront = await self.storefront(from: transaction)

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -163,7 +163,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
     fileprivate func setUpOrchestrator(
-        storeKit2TransactionListener: StoreKit2TransactionListener,
+        storeKit2TransactionListener: StoreKit2TransactionListenerType,
         storeKit2StorefrontListener: StoreKit2StorefrontListener
     ) {
         self.orchestrator = PurchasesOrchestrator(productsManager: self.productsManager,
@@ -1071,7 +1071,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         self.setUpOrchestrator(storeKit2TransactionListener: transactionListener,
                                storeKit2StorefrontListener: StoreKit2StorefrontListener(delegate: nil))
 
-        expect(transactionListener.invokedListenForTransactions) == true
+        expect(transactionListener.invokedListenForTransactions).toEventually(beTrue())
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
@@ -1085,7 +1085,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         self.setUpOrchestrator(storeKit2TransactionListener: transactionListener,
                                storeKit2StorefrontListener: StoreKit2StorefrontListener(delegate: nil))
 
-        expect(transactionListener.invokedListenForTransactions) == true
+        expect(transactionListener.invokedListenForTransactions).toEventually(beTrue())
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
@@ -1099,7 +1099,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         self.setUpOrchestrator(storeKit2TransactionListener: transactionListener,
                                storeKit2StorefrontListener: StoreKit2StorefrontListener(delegate: nil))
 
-        expect(transactionListener.invokedListenForTransactions) == true
+        expect(transactionListener.invokedListenForTransactions).toEventually(beTrue())
         expect(transactionListener.invokedListenForTransactionsCount) == 1
     }
 

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionListener.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionListener.swift
@@ -16,43 +16,31 @@ import Foundation
 import StoreKit
 
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-class MockStoreKit2TransactionListener: StoreKit2TransactionListener {
+final class MockStoreKit2TransactionListener: StoreKit2TransactionListenerType {
 
-    convenience init() {
-        self.init(delegate: nil)
-    }
+    init() {}
 
     var invokedDelegateSetter = false
     var invokedDelegateSetterCount = 0
     weak var invokedDelegate: StoreKit2TransactionListenerDelegate?
-    var invokedDelegateList = [StoreKit2TransactionListenerDelegate?]()
-    var invokedDelegateGetter = false
-    var invokedDelegateGetterCount = 0
-    weak var stubbedDelegate: StoreKit2TransactionListenerDelegate!
+    var invokedDelegateList: [StoreKit2TransactionListenerDelegate] = []
 
     var mockCancelled = false
     // `StoreKit.Transaction` can't be stored directly as a property.
     // See https://openradar.appspot.com/radar?id=4970535809187840 / https://bugs.swift.org/browse/SR-15825
     var mockTransaction: Box<StoreKit.Transaction?> = .init(nil)
 
-    override var delegate: StoreKit2TransactionListenerDelegate? {
-        get {
-            invokedDelegateGetter = true
-            invokedDelegateGetterCount += 1
-            return stubbedDelegate
-        }
-        set {
-            invokedDelegateSetter = true
-            invokedDelegateSetterCount += 1
-            invokedDelegate = newValue
-            invokedDelegateList.append(newValue)
-        }
+    func set(delegate: StoreKit2TransactionListenerDelegate) {
+        self.invokedDelegateSetter = true
+        self.invokedDelegateSetterCount += 1
+        self.invokedDelegate = delegate
+        self.invokedDelegateList.append(delegate)
     }
 
     var invokedListenForTransactions = false
     var invokedListenForTransactionsCount = 0
 
-    override func listenForTransactions() {
+    func listenForTransactions() {
         self.invokedListenForTransactions = true
         self.invokedListenForTransactionsCount += 1
     }
@@ -64,9 +52,9 @@ class MockStoreKit2TransactionListener: StoreKit2TransactionListener {
     var invokedHandleParameters: (purchaseResult: Box<StoreKit.Product.PurchaseResult>, Void)?
     var invokedHandleParametersList = [(purchaseResult: Box<StoreKit.Product.PurchaseResult>, Void)]()
 
-    override func handle(
+    func handle(
         purchaseResult: StoreKit.Product.PurchaseResult
-    ) async throws -> ResultData {
+    ) async throws -> StoreKit2TransactionListener.ResultData {
         self.invokedHandle = true
         self.invokedHandleCount += 1
         self.invokedHandleParameters = (.init(purchaseResult), ())
@@ -75,3 +63,6 @@ class MockStoreKit2TransactionListener: StoreKit2TransactionListener {
         return (self.mockCancelled, self.mockTransaction.value)
     }
 }
+
+@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+extension MockStoreKit2TransactionListener: @unchecked Sendable {}

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionListenerDelegate.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionListenerDelegate.swift
@@ -23,7 +23,7 @@ final class MockStoreKit2TransactionListenerDelegate: StoreKit2TransactionListen
     private let _updatedTransactions: Atomic<[StoreTransactionType]> = .init([])
 
     func storeKit2TransactionListener(
-        _ listener: StoreKit2TransactionListener,
+        _ listener: StoreKit2TransactionListenerType,
         updatedTransaction transaction: StoreTransactionType
     ) async throws {
         self._invokedTransactionUpdated.value = true
@@ -31,6 +31,3 @@ final class MockStoreKit2TransactionListenerDelegate: StoreKit2TransactionListen
     }
 
 }
-
-@available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
-extension MockStoreKit2TransactionListenerDelegate: Sendable {}


### PR DESCRIPTION
This is a preparatory refactor for an upcoming fix.
This improves the thread-safety of this class, and also refactors its mock to use a `protocol` instead.