### PR TITLE
`StoreKit2TransactionListener`: handle transactions asynchronously

### DIFF
--- a/Sources/FoundationExtensions/AsyncExtensions.swift
+++ b/Sources/FoundationExtensions/AsyncExtensions.swift
@@ -125,3 +125,15 @@ internal extension AsyncSequence {
     }
 
 }
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+internal extension AsyncSequence {
+
+    func toAsyncStream() -> AsyncStream<Element> {
+        var asyncIterator = self.makeAsyncIterator()
+        return AsyncStream<Element> {
+            try? await asyncIterator.next()
+        }
+    }
+
+}

--- a/Sources/Purchasing/StoreKit2/StoreKit2StorefrontListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2StorefrontListener.swift
@@ -68,15 +68,3 @@ class StoreKit2StorefrontListener {
     }
 
 }
-
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-private extension AsyncSequence {
-
-    func toAsyncStream() -> AsyncStream<Element> {
-        var asyncIterator = self.makeAsyncIterator()
-        return AsyncStream<Element> {
-            try? await asyncIterator.next()
-        }
-    }
-
-}

--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
@@ -54,11 +54,18 @@ actor StoreKit2TransactionListener: StoreKit2TransactionListenerType {
     private weak var delegate: StoreKit2TransactionListenerDelegate?
     private let updates: AsyncStream<TransactionResult>
 
-    init(
-        delegate: StoreKit2TransactionListenerDelegate? = nil
-    ) {
+    #if swift(<5.7)
+    // Note that these 2 constructors are duplicated because
+    // not having convinience here is an error in Xcode 13
+    // But having it is an error in Xcode 14.
+    convenience init(delegate: StoreKit2TransactionListenerDelegate? = nil) {
         self.init(delegate: delegate, updates: StoreKit.Transaction.updates)
     }
+    #else
+    init(delegate: StoreKit2TransactionListenerDelegate? = nil) {
+        self.init(delegate: delegate, updates: StoreKit.Transaction.updates)
+    }
+    #endif
 
     /// Creates a listener with an `AsyncSequence` of `VerificationResult<Transaction>`s
     /// By default `StoreKit.Transaction.updates` is used, but a custom one can be passed for testing.

--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
@@ -82,6 +82,9 @@ actor StoreKit2TransactionListener: StoreKit2TransactionListenerType {
             for await result in updates {
                 guard let self = self else { break }
 
+                // Important that handling transactions doesn't block this
+                // to allow all potential `PostReceiptOperations` to begin
+                // and get de-duped if they share the same cache key.
                 Task.detached {
                     do {
                         _ = try await self.handle(transactionResult: result, fromTransactionUpdate: true)

--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
@@ -47,13 +47,27 @@ actor StoreKit2TransactionListener: StoreKit2TransactionListenerType {
 
     /// Similar to ``PurchaseResultData`` but with an optional `CustomerInfo`
     typealias ResultData = (userCancelled: Bool, transaction: SK2Transaction?)
+    typealias TransactionResult = StoreKit.VerificationResult<StoreKit.Transaction>
 
     private(set) var taskHandle: Task<Void, Never>?
 
     private weak var delegate: StoreKit2TransactionListenerDelegate?
+    private let updates: AsyncStream<TransactionResult>
 
-    init(delegate: StoreKit2TransactionListenerDelegate?) {
+    init(
+        delegate: StoreKit2TransactionListenerDelegate? = nil
+    ) {
+        self.init(delegate: delegate, updates: StoreKit.Transaction.updates)
+    }
+
+    /// Creates a listener with an `AsyncSequence` of `VerificationResult<Transaction>`s
+    /// By default `StoreKit.Transaction.updates` is used, but a custom one can be passed for testing.
+    init<S: AsyncSequence>(
+        delegate: StoreKit2TransactionListenerDelegate? = nil,
+        updates: S
+    ) where S.Element == TransactionResult {
         self.delegate = delegate
+        self.updates = updates.toAsyncStream()
     }
 
     func set(delegate: StoreKit2TransactionListenerDelegate) {
@@ -64,14 +78,16 @@ actor StoreKit2TransactionListener: StoreKit2TransactionListenerType {
         Logger.debug(Strings.storeKit.sk2_observing_transaction_updates)
 
         self.taskHandle?.cancel()
-        self.taskHandle = Task(priority: .utility) { [weak self] in
-            for await result in StoreKit.Transaction.updates {
+        self.taskHandle = Task(priority: .utility) { [weak self, updates = self.updates] in
+            for await result in updates {
                 guard let self = self else { break }
 
-                do {
-                    _ = try await self.handle(transactionResult: result, fromTransactionUpdate: true)
-                } catch {
-                    Logger.error(error.localizedDescription)
+                Task.detached {
+                    do {
+                        _ = try await self.handle(transactionResult: result, fromTransactionUpdate: true)
+                    } catch {
+                        Logger.error(error.localizedDescription)
+                    }
                 }
             }
         }
@@ -113,7 +129,7 @@ private extension StoreKit2TransactionListener {
     /// - Throws: ``ErrorCode`` if the transaction fails to verify.
     /// - Parameter fromTransactionUpdate: `true` only for transactions detected outside of a manual purchase flow.
     func handle(
-        transactionResult: StoreKit.VerificationResult<StoreKit.Transaction>,
+        transactionResult: TransactionResult,
         fromTransactionUpdate: Bool
     ) async throws -> SK2Transaction {
         switch transactionResult {

--- a/Tests/UnitTests/Mocks/MockStoreKit2TransactionListenerDelegate.swift
+++ b/Tests/UnitTests/Mocks/MockStoreKit2TransactionListenerDelegate.swift
@@ -18,16 +18,37 @@ final class MockStoreKit2TransactionListenerDelegate: StoreKit2TransactionListen
 
     var invokedTransactionUpdated: Bool { return self._invokedTransactionUpdated.value }
     var updatedTransactions: [StoreTransactionType] { return self._updatedTransactions.value }
+    var fakeHandlingDelay: DispatchTimeInterval {
+        get { return self._fakeHandlingDelay.value }
+        set { self._fakeHandlingDelay.value = newValue }
+    }
+    var receivedConcurrentRequest: Bool {
+        return self._receivedConcurrentRequest.value
+    }
 
     private let _invokedTransactionUpdated: Atomic<Bool> = false
     private let _updatedTransactions: Atomic<[StoreTransactionType]> = .init([])
+
+    // Useful for detecting if this listener receives concurrent requests
+    private let _fakeHandlingDelay: Atomic<DispatchTimeInterval> = .init(.never)
+    private let _wasHandlingRequest: Atomic<Bool> = false
+    private let _receivedConcurrentRequest: Atomic<Bool> = false
 
     func storeKit2TransactionListener(
         _ listener: StoreKit2TransactionListenerType,
         updatedTransaction transaction: StoreTransactionType
     ) async throws {
+        if self._wasHandlingRequest.value {
+            self._receivedConcurrentRequest.value = true
+        }
+
+        self._wasHandlingRequest.value = true
+        defer { self._wasHandlingRequest.value = false }
+
         self._invokedTransactionUpdated.value = true
         self._updatedTransactions.value.append(transaction)
+
+        try await Task.sleep(nanoseconds: self.fakeHandlingDelay.nanoseconds)
     }
 
 }


### PR DESCRIPTION
Currently when launching an app in SK1 mode, if there are multiple transactions in the queue, we handle them all and begin operations in parallel. If the cache keys are the same, those end up being a combined POST receipt request.

However with `StoreKit 2`, because we were waiting to handle each one of the `StoreKit.Transaction.updates` using `await`, we ended up posting them all sequentially, instead of relying on `CallbackCache`.

This also adds a lot more coverage for `StoreKit2TransactionListener` to verify this behavior.