### PR TITLE
`TransactionPoster`: avoid posting transactions multiple times

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -276,6 +276,8 @@
 		4FC083292A4A35FB00A97089 /* Integer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC083282A4A35FB00A97089 /* Integer+Extensions.swift */; };
 		4FC0832B2A4A361700A97089 /* IntegerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC0832A2A4A361700A97089 /* IntegerExtensionsTests.swift */; };
 		4FC6F8892A73E445002139B2 /* PostedTransactionCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC6F8882A73E445002139B2 /* PostedTransactionCacheTests.swift */; };
+		4FC6F88B2A73FBD9002139B2 /* MockPostedTransactionCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC6F88A2A73FBD9002139B2 /* MockPostedTransactionCache.swift */; };
+		4FC6F88C2A73FBD9002139B2 /* MockPostedTransactionCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC6F88A2A73FBD9002139B2 /* MockPostedTransactionCache.swift */; };
 		4FC8EE522A8D34D70010EDFF /* ClockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC8EE512A8D34D70010EDFF /* ClockTests.swift */; };
 		4FC972172A712DCC008593DE /* CachingProductsManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC972162A712DCC008593DE /* CachingProductsManagerTests.swift */; };
 		4FCBA84F2A15391B004134BD /* SnapshotTesting+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576C8A9127D27DDD0058FA6E /* SnapshotTesting+Extensions.swift */; };
@@ -1002,6 +1004,7 @@
 		4FC083282A4A35FB00A97089 /* Integer+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Integer+Extensions.swift"; sourceTree = "<group>"; };
 		4FC0832A2A4A361700A97089 /* IntegerExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerExtensionsTests.swift; sourceTree = "<group>"; };
 		4FC6F8882A73E445002139B2 /* PostedTransactionCacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostedTransactionCacheTests.swift; sourceTree = "<group>"; };
+		4FC6F88A2A73FBD9002139B2 /* MockPostedTransactionCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPostedTransactionCache.swift; sourceTree = "<group>"; };
 		4FC8EE512A8D34D70010EDFF /* ClockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClockTests.swift; sourceTree = "<group>"; };
 		4FC972162A712DCC008593DE /* CachingProductsManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CachingProductsManagerTests.swift; sourceTree = "<group>"; };
 		4FCBA8522A1539D0004134BD /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
@@ -1851,6 +1854,7 @@
 				5791FBD1299184EF00F1FEDA /* MockAsyncSequence.swift */,
 				57CB2A7B29CCC91800C91439 /* MockProductEntitlementMappingFetcher.swift */,
 				4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */,
+				4FC6F88A2A73FBD9002139B2 /* MockPostedTransactionCache.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -3182,6 +3186,7 @@
 				571E7AD4279F2D0C003B3606 /* StoreKitTestHelpers.swift in Sources */,
 				2DFF6C56270CA28800ECAFAB /* MockRequestFetcher.swift in Sources */,
 				5738F489278CC2500096D623 /* MockTransaction.swift in Sources */,
+				4FC6F88C2A73FBD9002139B2 /* MockPostedTransactionCache.swift in Sources */,
 				576C8ABC27D2997C0058FA6E /* SnapshotTesting+Extensions.swift in Sources */,
 				F5355164286B7125009CA47A /* MockOfferingsFactory.swift in Sources */,
 				57CB2B6029CDF63200C91439 /* PurchasedProductsFetcherTests.swift in Sources */,
@@ -3504,6 +3509,7 @@
 				57554C84282AC273009A7E58 /* PeriodTypeTests.swift in Sources */,
 				57057FF828B0048900995F21 /* TestLogHandler.swift in Sources */,
 				57E415F12846997B00EA5460 /* PurchasesAttributionDataTests.swift in Sources */,
+				4FC6F88B2A73FBD9002139B2 /* MockPostedTransactionCache.swift in Sources */,
 				2DDF41CF24F6F4C3005BC22D /* ReceiptParsing+TestsWithRealReceipts.swift in Sources */,
 				57488C2329CB89CC0000EE7E /* OfflineEntitlementsManagerTests.swift in Sources */,
 				57FDAA962846BDE2009A48F1 /* PurchasesTransactionHandlingTests.swift in Sources */,

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -374,21 +374,6 @@ private extension CustomerInfoManager {
         }
     }
 
-    private func cachedOrRequestCustomerInfoFetcher(
-        appUserID: String,
-        isAppBackgrounded: Bool
-    ) -> TransactionPosterResult.CustomerInfoFetcher {
-        return { completion in
-            if let cachedCustomerInfo = self.cachedCustomerInfo(appUserID: appUserID) {
-                completion(.success(cachedCustomerInfo))
-            } else {
-                self.requestCustomerInfo(appUserID: appUserID,
-                                         isAppBackgrounded: isAppBackgrounded,
-                                         completion: completion)
-            }
-        }
-    }
-
     private func requestCustomerInfo(appUserID: String,
                                      isAppBackgrounded: Bool,
                                      completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {

--- a/Sources/Logging/Strings/CustomerInfoStrings.swift
+++ b/Sources/Logging/Strings/CustomerInfoStrings.swift
@@ -29,7 +29,8 @@ enum CustomerInfoStrings {
     case customerinfo_updated_from_network
     case customerinfo_updated_from_network_error(BackendError)
     case customerinfo_updated_offline
-    case posting_transactions_in_lieu_of_fetching_customerinfo([StoreTransaction])
+    case posting_transactions_in_lieu_of_fetching_customerinfo(allTransactions: [StoreTransaction],
+                                                               unpostedTransactions: [StoreTransaction])
     case updating_request_date(CustomerInfo, Date)
     case sending_latest_customerinfo_to_delegate
     case sending_updated_customerinfo_to_delegate
@@ -73,9 +74,9 @@ extension CustomerInfoStrings: LogMessage {
         case .customerinfo_updated_offline:
             return "There was an error communicating with RevenueCat servers. " +
             "CustomerInfo was temporarily computed offline, and it will be posted again as soon as possible."
-        case let .posting_transactions_in_lieu_of_fetching_customerinfo(transactions):
-            return "Found \(transactions.count) unfinished transactions, will post receipt in lieu " +
-            "of fetching CustomerInfo:\n\(transactions)"
+        case let .posting_transactions_in_lieu_of_fetching_customerinfo(allTransactions, unpostedTransactions):
+            return "Found \(allTransactions.count) unfinished transactions ( \(unpostedTransactions.count) unposted)," +
+            " will post receipt in lieu of fetching CustomerInfo:\n\(allTransactions)"
         case let .updating_request_date(info, newRequestDate):
             return "Updating CustomerInfo '\(info.originalAppUserId)' request date: \(newRequestDate)"
         case .sending_latest_customerinfo_to_delegate:

--- a/Sources/Logging/Strings/CustomerInfoStrings.swift
+++ b/Sources/Logging/Strings/CustomerInfoStrings.swift
@@ -75,7 +75,7 @@ extension CustomerInfoStrings: LogMessage {
             return "There was an error communicating with RevenueCat servers. " +
             "CustomerInfo was temporarily computed offline, and it will be posted again as soon as possible."
         case let .posting_transactions_in_lieu_of_fetching_customerinfo(allTransactions, unpostedTransactions):
-            return "Found \(allTransactions.count) unfinished transactions ( \(unpostedTransactions.count) unposted)," +
+            return "Found \(allTransactions.count) unfinished transactions (\(unpostedTransactions.count) unposted)," +
             " will post receipt in lieu of fetching CustomerInfo:\n\(allTransactions)"
         case let .updating_request_date(info, newRequestDate):
             return "Updating CustomerInfo '\(info.originalAppUserId)' request date: \(newRequestDate)"

--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -83,6 +83,8 @@ enum PurchaseStrings {
     case missing_cached_customer_info
     case sk2_transactions_update_received_transaction(productID: String)
     case transaction_poster_handling_transaction(productID: String, offeringID: String?)
+    case transaction_poster_skipping_duplicate(productID: String, transactionID: String)
+    case transaction_poster_storing_posted_transaction(productID: String, transactionID: String)
     case caching_presented_offering_identifier(offeringID: String, productID: String)
     case payment_queue_wrapper_delegate_call_sk1_enabled
     case restorepurchases_called_with_allow_sharing_appstore_account_false
@@ -315,6 +317,12 @@ extension PurchaseStrings: LogMessage {
             } else {
                 return prefix
             }
+
+        case let .transaction_poster_skipping_duplicate(productID, transactionID):
+            return "TransactionPoster: skipping already posted transaction for product '\(productID)': \(transactionID)"
+
+        case let .transaction_poster_storing_posted_transaction(productID, transactionID):
+            return "TransactionPoster: caching posted transaction for product '\(productID)': \(transactionID)"
 
         case let .caching_presented_offering_identifier(offeringID, productID):
             return "Caching presented offering identifier '\(offeringID)' for product '\(productID)'"

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -322,6 +322,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
             productsManager: productsManager,
             receiptFetcher: receiptFetcher,
             backend: backend,
+            cache: PostedTransactionCache(deviceCache: deviceCache, clock: systemInfo.clock),
             paymentQueueWrapper: paymentQueueWrapper,
             systemInfo: systemInfo,
             operationDispatcher: operationDispatcher

--- a/Sources/Purchasing/Purchases/TransactionPoster.swift
+++ b/Sources/Purchasing/Purchases/TransactionPoster.swift
@@ -312,13 +312,13 @@ private extension TransactionPoster {
 
         switch result {
         case let .success((customerInfo, product)):
-            self.cache.savePostedTransaction(transaction)
-
             if Self.shouldFinish(
                 transaction: transaction,
                 for: product,
                 customerInfo: customerInfo
             ) {
+                self.cache.savePostedTransaction(transaction)
+
                 self.finishTransactionIfNeeded(transaction) {
                     Logger.debug(Strings.purchase.transaction_poster_storing_posted_transaction(
                         productID: transaction.productIdentifier,

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -23,6 +23,8 @@ import XCTest
 @testable import RevenueCat
 #endif
 
+// swiftlint:disable file_length
+
 @MainActor
 class BaseStoreKitIntegrationTests: BaseBackendIntegrationTests {
 
@@ -271,11 +273,30 @@ extension BaseStoreKitIntegrationTests {
                                            line: line)
     }
 
+    func verifyTransactionWasStored(
+        count: Int = 1,
+        file: FileString = #file,
+        line: UInt = #line
+    ) {
+        self.logger.verifyMessageWasLogged(Self.storingTransactionLog,
+                                           level: .debug,
+                                           expectedCount: count,
+                                           file: file,
+                                           line: line)
+    }
+
     func verifyNoTransactionsWereFinished(
         file: FileString = #file,
         line: UInt = #line
     ) {
         self.logger.verifyMessageWasNotLogged(Self.finishingTransactionLog, file: file, line: line)
+    }
+
+    func verifyNoTransactionsWereStored(
+        file: FileString = #file,
+        line: UInt = #line
+    ) {
+        self.logger.verifyMessageWasNotLogged(Self.storingTransactionLog, file: file, line: line)
     }
 
     func verifyTransactionIsEventuallyFinished(
@@ -347,6 +368,7 @@ extension BaseStoreKitIntegrationTests {
     }
 
     static let finishingTransactionLog = "Finishing transaction"
+    static let storingTransactionLog = "Storing transaction"
 
 }
 

--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -16,7 +16,7 @@ import Nimble
 import StoreKit
 import XCTest
 
-// swiftlint:disable type_name
+// swiftlint:disable type_name file_length
 
 class BaseOfflineStoreKitIntegrationTests: BaseStoreKitIntegrationTests {
 
@@ -214,11 +214,27 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
         ]
     }
 
+    func testFetchingCustomerInfoWithPendingTransactionAndNoCachedCustomerInfo() async throws {
+        self.serverDown()
+
+        // 1. Purchase
+        try await self.purchaseMonthlyProduct()
+
+        // 2. Remove cache
+        try self.purchases.invalidateCustomerInfoCache()
+
+        self.serverUp()
+
+        // 3. Fetch customer info
+        let customerInfo = try await self.purchases.customerInfo()
+        try await self.verifyEntitlementWentThrough(customerInfo)
+    }
+
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testSimultanousCallsToGetCustomerInfoWithPendingTransactionPostsReceiptOnlyOnce() async throws {
         self.serverDown()
 
-        _ = try await self.purchaseMonthlyProduct()
+        try await self.purchaseMonthlyProduct()
 
         self.serverUp()
 

--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -277,7 +277,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
         try await self.verifyEntitlementWentThrough(customerInfo)
 
         self.logger.verifyMessageWasLogged(
-            "Found 2 unfinished transactions, will post receipt in lieu of fetching CustomerInfo",
+            "Found 2 unfinished transactions (2 unposted), will post receipt in lieu of fetching CustomerInfo",
             level: .debug,
             expectedCount: 1
         )

--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -104,12 +104,13 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    func testPurchaseWhileServerIsDownSucceedsButDoesNotFinishTransaction() async throws {
+    func testPurchaseWhileServerIsDownSucceedsButDoesNotFinishOrStoreTransaction() async throws {
         self.serverDown()
         try await self.purchaseMonthlyProduct()
 
         self.logger.verifyMessageWasLogged(Strings.offlineEntitlements.computing_offline_customer_info, level: .info)
         self.verifyNoTransactionsWereFinished()
+        self.verifyNoTransactionsWereStored()
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -60,6 +60,8 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
                 offeringID: package.offeringIdentifier
             )
         )
+        self.verifyTransactionWasFinished(count: 1)
+        self.verifyTransactionWasStored(count: 1)
     }
 
     func testCanPurchaseProduct() async throws {

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -32,6 +32,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     private var customerInfoManager: MockCustomerInfoManager!
     private var paymentQueueWrapper: EitherPaymentQueueWrapper!
     private var backend: MockBackend!
+    private var postedTransactionCache: MockPostedTransactionCache!
     private var offerings: MockOfferingsAPI!
     private var currentUserProvider: MockCurrentUserProvider!
     private var transactionsManager: MockTransactionsManager!
@@ -56,6 +57,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         self.receiptParser = MockReceiptParser()
         self.deviceCache = MockDeviceCache(sandboxEnvironmentDetector: self.systemInfo)
         self.backend = MockBackend()
+        self.postedTransactionCache = .init()
         self.offerings = try XCTUnwrap(self.backend.offerings as? MockOfferingsAPI)
 
         self.mockOfferingsManager = MockOfferingsManager(deviceCache: self.deviceCache,
@@ -192,6 +194,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
             productsManager: self.productsManager,
             receiptFetcher: self.receiptFetcher,
             backend: self.backend,
+            cache: self.postedTransactionCache,
             paymentQueueWrapper: self.paymentQueueWrapper,
             systemInfo: self.systemInfo,
             operationDispatcher: self.operationDispatcher
@@ -371,6 +374,47 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         expect(self.receiptFetcher.receiptDataCalled) == true
         expect(self.receiptFetcher.receiptDataReceivedRefreshPolicy) == .onlyIfEmpty
+    }
+
+    func testSK1PurchaseWithAlreadyPostedTransaction() async throws {
+        // Note: this should be impossible because purchases should create new transactions
+        // with unique identifiers, but we still want to make sure that it's handled correctly.
+
+        self.customerInfoManager.stubbedCustomerInfoResult = .success(self.mockCustomerInfo)
+        self.postedTransactionCache.hasPostedAllTransactions = true
+
+        self.systemInfo.stubbedIsSandbox = false
+
+        let product = try await self.fetchSk1Product()
+        let storeProduct = try await self.fetchSk1StoreProduct()
+
+        let package = Package(identifier: "package",
+                              packageType: .monthly,
+                              storeProduct: .from(product: storeProduct),
+                              offeringIdentifier: "offering")
+
+        let payment = self.storeKit1Wrapper.payment(with: product)
+
+        let (transaction, customerInfo, error, cancelled) = await withCheckedContinuation { continuation in
+            self.orchestrator.purchase(
+                sk1Product: product,
+                payment: payment,
+                package: package,
+                wrapper: self.storeKit1Wrapper
+            ) { transaction, customerInfo, error, userCancelled in
+                continuation.resume(returning: (transaction, customerInfo, error, userCancelled))
+            }
+        }
+
+        expect(transaction).toNot(beNil())
+        expect(customerInfo) === self.mockCustomerInfo
+        expect(error).to(beNil())
+        expect(cancelled) == false
+
+        expect(self.receiptFetcher.receiptDataCalled) == false
+        expect(self.backend.invokedPostReceiptData) == false
+        expect(self.customerInfoManager.invokedCustomerInfo) == true
+        expect(self.subscriberAttributesManager.invokedMarkAttributes) == false
     }
 
     func testGetSK1PromotionalOffer() async throws {
@@ -1014,6 +1058,28 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         expect(self.backend.invokedPostReceiptData) == true
         expect(self.backend.invokedPostReceiptDataParameters?.transactionData.source.isRestore) == false
         expect(self.backend.invokedPostReceiptDataParameters?.transactionData.source.initiationSource) == .queue
+    }
+
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testStoreKit2TransactionListenerWithAlreadyPostedTransaction() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        self.setUpStoreKit2Listener()
+
+        let transaction = MockStoreTransaction()
+
+        self.customerInfoManager.stubbedCachedCustomerInfoResult = self.mockCustomerInfo
+        self.postedTransactionCache.savePostedTransaction(transaction)
+        self.backend.stubbedPostReceiptResult = .success(self.mockCustomerInfo)
+
+        try await self.orchestrator.storeKit2TransactionListener(
+            self.mockStoreKit2TransactionListener!,
+            updatedTransaction: transaction
+        )
+
+        expect(transaction.finishInvoked) == true
+        expect(self.backend.invokedPostReceiptData) == false
+        expect(self.customerInfoManager.invokedCacheCustomerInfo) == false
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -5,6 +5,7 @@ import XCTest
 
 @MainActor
 class BaseCustomerInfoManagerTests: TestCase {
+
     static let appUserID = "app_user_id"
 
     var mockOfflineEntitlementsManager: MockOfflineEntitlementsManager!

--- a/Tests/UnitTests/Mocks/MockPostedTransactionCache.swift
+++ b/Tests/UnitTests/Mocks/MockPostedTransactionCache.swift
@@ -1,0 +1,42 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  MockPostedTransactionCache.swift
+//
+//  Created by Nacho Soto on 7/28/23.
+
+@testable import RevenueCat
+
+final class MockPostedTransactionCache: PostedTransactionCacheType {
+
+    private let cache: Atomic<Set<String>> = .init([])
+    private let _hasPostedAllTransactions: Atomic<Bool> = false
+
+    var postedTransactions: Set<String> { self.cache.value }
+
+    /// Makes `hasPostedTransaction` always return `true`.
+    var hasPostedAllTransactions: Bool {
+        get { self._hasPostedAllTransactions.value }
+        set { self._hasPostedAllTransactions.value = newValue }
+    }
+
+    func savePostedTransaction(_ transaction: StoreTransactionType) {
+        self.cache.modify { $0.insert(transaction.transactionIdentifier) }
+    }
+
+    func hasPostedTransaction(_ transaction: StoreTransactionType) -> Bool {
+        return (self.hasPostedAllTransactions ||
+                self.cache.value.contains(transaction.transactionIdentifier))
+    }
+
+    func unpostedTransactions<T: StoreTransactionType>(in transactions: [T]) -> [T] {
+        return Self.unpostedTransactions(in: transactions, with: self.postedTransactions)
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockPurchasesDelegate.swift
+++ b/Tests/UnitTests/Mocks/MockPurchasesDelegate.swift
@@ -10,11 +10,13 @@ import StoreKit
 public class MockPurchasesDelegate: NSObject, PurchasesDelegate {
 
     var customerInfo: CustomerInfo?
+    var customerInfoReceived: [CustomerInfo] = []
     var customerInfoReceivedCount = 0
 
     public func purchases(_ purchases: Purchases, receivedUpdated customerInfo: CustomerInfo) {
-        customerInfoReceivedCount += 1
+        self.customerInfoReceivedCount += 1
         self.customerInfo = customerInfo
+        self.customerInfoReceived.append(customerInfo)
     }
 
     var promoProduct: StoreProduct?

--- a/Tests/UnitTests/Mocks/MockStoreTransaction.swift
+++ b/Tests/UnitTests/Mocks/MockStoreTransaction.swift
@@ -50,6 +50,9 @@ final class MockStoreTransaction: StoreTransactionType {
     private let _finishInvoked: Atomic<Bool> = false
     var finishInvoked: Bool { return self._finishInvoked.value }
 
+    private let _finishInvokedCount: Atomic<Int> = .init(0)
+    var finishInvokedCount: Int { return self._finishInvokedCount.value }
+
     private let _onFinishInvoked: Atomic<(() -> Void)?> = nil
     var onFinishInvoked: (() -> Void)? {
         get { return self._onFinishInvoked.value }
@@ -58,6 +61,7 @@ final class MockStoreTransaction: StoreTransactionType {
 
     func finish(_ wrapper: PaymentQueueWrapperType, completion: @escaping @Sendable () -> Void) {
         self._finishInvoked.value = true
+        self._finishInvokedCount.modify { $0 += 1 }
         self.onFinishInvoked?()
 
         completion()

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -69,6 +69,7 @@ class BasePurchasesTests: TestCase {
                                           offlineCustomerInfoCreator: MockOfflineCustomerInfoCreator(),
                                           dateProvider: MockDateProvider(stubbedNow: MockBackend.referenceDate))
         self.backend = MockBackend(backendConfig: config, attributionFetcher: self.attributionFetcher)
+        self.postedTransactionCache = .init()
         self.subscriberAttributesManager = MockSubscriberAttributesManager(
             backend: self.backend,
             deviceCache: self.deviceCache,
@@ -136,6 +137,7 @@ class BasePurchasesTests: TestCase {
     var requestFetcher: MockRequestFetcher!
     var mockProductsManager: MockProductsManager!
     var backend: MockBackend!
+    var postedTransactionCache: MockPostedTransactionCache!
     var storeKit1Wrapper: MockStoreKit1Wrapper!
     var mockPaymentQueueWrapper: MockPaymentQueueWrapper!
     var notificationCenter: MockNotificationCenter!
@@ -182,6 +184,7 @@ class BasePurchasesTests: TestCase {
             productsManager: self.mockProductsManager,
             receiptFetcher: self.receiptFetcher,
             backend: self.backend,
+            cache: self.postedTransactionCache,
             paymentQueueWrapper: self.paymentQueueWrapper,
             systemInfo: self.systemInfo,
             operationDispatcher: self.mockOperationDispatcher
@@ -483,6 +486,7 @@ private extension BasePurchasesTests {
         self.mockIntroEligibilityCalculator = nil
         self.mockTransactionsManager = nil
         self.backend = nil
+        self.postedTransactionCache = nil
         self.attributionFetcher = nil
         self.purchasesDelegate.makeDeferredPurchase = nil
         self.purchasesDelegate = nil

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -122,6 +122,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
             productsManager: self.mockProductsManager,
             receiptFetcher: self.mockReceiptFetcher,
             backend: self.mockBackend,
+            cache: MockPostedTransactionCache(),
             paymentQueueWrapper: self.paymentQueueWrapper,
             systemInfo: self.systemInfo,
             operationDispatcher: self.mockOperationDispatcher


### PR DESCRIPTION
This is a performance optimization that will help avoid duplicate posts after #2612.

### TODO:
- [x] Tests for finishing (if posted) / not finishing
- [x] Observer mode does not finish if already posted
- [x] Test for get customer info + already posted avoids infinite recursion
- [x] Integration tests