### PR TITLE
`Paywalls`: fixed tappable area for a couple of buttons

### DIFF
--- a/RevenueCatUI/Templates/MultiPackageBoldTemplate.swift
+++ b/RevenueCatUI/Templates/MultiPackageBoldTemplate.swift
@@ -105,6 +105,7 @@ private struct MultiPackageTemplateContent: View {
                     self.selectedPackage = package.content
                 } label: {
                     self.packageButton(package, selected: self.selectedPackage === package.content)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(PackageButtonStyle())
             }

--- a/Tests/TestingApps/SimpleApp/SimpleApp/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/SimpleApp/SimpleApp/Views/SamplePaywallsList.swift
@@ -54,6 +54,8 @@ struct SamplePaywallsList: View {
                         self.selectedTemplate = template
                     } label: {
                         Text(template.name)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
                 }


### PR DESCRIPTION
After testing this on a device I realized that both the paywall list in the sample app and the package buttons were only tappable on the labels.