### PR TITLE
`Paywalls`: SimpleApp reads API key from Xcode Cloud environment

### DIFF
--- a/Tests/TestingApps/SimpleApp/SimpleApp/Configuration.swift
+++ b/Tests/TestingApps/SimpleApp/SimpleApp/Configuration.swift
@@ -18,3 +18,22 @@ enum Configuration {
     static let entitlement = "pro"
 
 }
+
+extension Configuration {
+
+    static var effectiveApiKey: String = {
+        return Self.apiKey.nonEmpty ?? Self.apiKeyFromCI
+    }()
+
+    // This is modified by CI:
+    private static let apiKeyFromCI = ""
+
+}
+
+// MARK: - Extensions
+
+private extension String {
+
+    var nonEmpty: String? { return self.isEmpty ? nil : self }
+
+}

--- a/Tests/TestingApps/SimpleApp/SimpleApp/SimpleApp.swift
+++ b/Tests/TestingApps/SimpleApp/SimpleApp/SimpleApp.swift
@@ -19,7 +19,7 @@ struct SimpleApp: App {
             : URL(string: Configuration.proxyURL)!
 
         Purchases.configure(
-            with: .init(withAPIKey: Configuration.apiKey)
+            with: .init(withAPIKey: Configuration.effectiveApiKey)
                 .with(usesStoreKit2IfAvailable: true)
         )
     }

--- a/Tests/TestingApps/SimpleApp/ci_scripts/ci_pre_xcodebuild.sh
+++ b/Tests/TestingApps/SimpleApp/ci_scripts/ci_pre_xcodebuild.sh
@@ -1,13 +1,14 @@
-#!/bin/sh
+#!/bin/bash -e
 
 SIMPLE_APP_API_KEY=$REVENUECAT_XCODE_CLOUD_SIMPLE_APP_API_KEY
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 if [ -z "$SIMPLE_APP_API_KEY" ]; then
   echo "SimpleApp API key environment variable is not set."
 else
 	echo "Replacing API key on SimpleApp"
 
-	file="Tests/TestingApps/SimpleApp/SimpleApp/Configuration.swift"
+	file="$SCRIPT_DIR/../SimpleApp/Configuration.swift"
 	sed -i.bak 's/private static let apiKeyFromCI = ""/private static let apiKeyFromCI = "'$SIMPLE_APP_API_KEY'"/g' $file
 	rm $file.bak
 fi

--- a/Tests/TestingApps/SimpleApp/ci_scripts/ci_pre_xcodebuild.sh
+++ b/Tests/TestingApps/SimpleApp/ci_scripts/ci_pre_xcodebuild.sh
@@ -4,11 +4,11 @@ SIMPLE_APP_API_KEY=$REVENUECAT_XCODE_CLOUD_SIMPLE_APP_API_KEY
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 if [ -z "$SIMPLE_APP_API_KEY" ]; then
-  echo "SimpleApp API key environment variable is not set."
+    echo "SimpleApp API key environment variable is not set."
 else
-	echo "Replacing API key on SimpleApp"
+    echo "Replacing API key on SimpleApp"
 
-	file="$SCRIPT_DIR/../SimpleApp/Configuration.swift"
-	sed -i.bak 's/private static let apiKeyFromCI = ""/private static let apiKeyFromCI = "'$SIMPLE_APP_API_KEY'"/g' $file
-	rm $file.bak
+    file="$SCRIPT_DIR/../SimpleApp/Configuration.swift"
+    sed -i.bak 's/private static let apiKeyFromCI = ""/private static let apiKeyFromCI = "'$SIMPLE_APP_API_KEY'"/g' $file
+    rm $file.bak
 fi

--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+SIMPLE_APP_API_KEY=$REVENUECAT_XCODE_CLOUD_SIMPLE_APP_API_KEY
+
+if [ -z "$SIMPLE_APP_API_KEY" ]; then
+  echo "SimpleApp API key environment variable is not set."
+else
+	echo "Replacing API key on SimpleApp"
+
+	file="Tests/TestingApps/SimpleApp/SimpleApp/Configuration.swift"
+	sed -i.bak 's/private static let apiKeyFromCI = ""/private static let apiKeyFromCI = "'$SIMPLE_APP_API_KEY'"/g' $file
+	rm $file.bak
+fi


### PR DESCRIPTION
This will allow us to automatically make new releases from the `paywalls` branch.

See [docs](https://developer.apple.com/documentation/xcode/writing-custom-build-scripts).

<img width="553" alt="Screenshot 2023-07-30 at 10 55 47" src="https://github.com/RevenueCat/purchases-ios/assets/685609/d40a00e7-6a57-4340-8160-d903d765b814">
