### PR TITLE
`Paywalls`: removed "couldn't find package" log

### DIFF
--- a/RevenueCatUI/Data/TemplateViewConfiguration.swift
+++ b/RevenueCatUI/Data/TemplateViewConfiguration.swift
@@ -158,7 +158,6 @@ extension TemplateViewConfiguration {
                     return packages.first
                 }
             } else {
-                Logger.warning("Couldn't find '\(type)'")
                 return nil
             }
         }


### PR DESCRIPTION
This is unnecessary noise, especially potentially when displaying `PaywallData.default` because those packages might not exist in a given app.