### PR TITLE
`Paywalls`: moved purchasing state to `PurchaseHandler`

### DIFF
--- a/RevenueCatUI/Data/Constants.swift
+++ b/RevenueCatUI/Data/Constants.swift
@@ -11,5 +11,6 @@ import SwiftUI
 enum Constants {
 
     static let defaultAnimation: Animation = .easeIn(duration: 0.2)
+    static let fastAnimation: Animation = .easeIn(duration: 0.1)
 
 }

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 @available(watchOS, unavailable, message: "RevenueCatUI does not support watchOS yet")
 @available(macOS, unavailable, message: "RevenueCatUI does not support macOS yet")
 @available(macCatalyst, unavailable, message: "RevenueCatUI does not support Catalyst yet")
+@MainActor
 public struct PaywallView: View {
 
     private let mode: PaywallViewMode
@@ -22,6 +23,7 @@ public struct PaywallView: View {
     /// an error will be displayed.
     /// - Warning: `Purchases` must have been configured prior to displaying it.
     /// If you want to handle that, you can use ``init(offering:mode:)`` instead.
+    @MainActor
     public init(mode: PaywallViewMode = .default) {
         self.init(
             offering: nil,
@@ -35,6 +37,7 @@ public struct PaywallView: View {
     /// - Note: if `offering` does not have a current paywall, or it fails to load due to invalid data,
     /// a default paywall will be displayed.
     /// - Warning: `Purchases` must have been configured prior to displaying it.
+    @MainActor
     public init(offering: Offering, mode: PaywallViewMode = .default) {
         self.init(
             offering: offering,
@@ -44,6 +47,7 @@ public struct PaywallView: View {
         )
     }
 
+    @MainActor
     init(
         offering: Offering?,
         mode: PaywallViewMode = .default,
@@ -158,7 +162,7 @@ struct LoadedOfferingPaywallView: View {
         self._introEligibility = .init(
             wrappedValue: .init(introEligibilityChecker: introEligibility)
         )
-        self.purchaseHandler = purchaseHandler
+        self._purchaseHandler = .init(initialValue: purchaseHandler)
     }
 
     var body: some View {
@@ -170,6 +174,7 @@ struct LoadedOfferingPaywallView: View {
             .environmentObject(self.introEligibility)
             .environmentObject(self.purchaseHandler)
             .hidden(if: self.shouldHidePaywall)
+            .disabled(self.purchaseHandler.actionInProgress)
 
         if let aspectRatio = self.mode.aspectRatio {
             view.aspectRatio(aspectRatio, contentMode: .fit)

--- a/RevenueCatUI/Templates/OnePackageStandardTemplate.swift
+++ b/RevenueCatUI/Templates/OnePackageStandardTemplate.swift
@@ -5,33 +5,15 @@ import SwiftUI
 struct OnePackageStandardTemplate: TemplateViewType {
 
     private let configuration: TemplateViewConfiguration
-    @EnvironmentObject
-    private var introEligibility: IntroEligibilityViewModel
-
-    init(_ configuration: TemplateViewConfiguration) {
-        self.configuration = configuration
-    }
-
-    var body: some View {
-        OnePackageTemplateContent(configuration: self.configuration,
-                                  introEligibility: self.introEligibility.singleEligibility)
-    }
-
-}
-
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
-private struct OnePackageTemplateContent: View {
-
-    private var configuration: TemplateViewConfiguration
-    private var introEligibility: IntroEligibilityStatus?
     private var localization: ProcessedLocalizedConfiguration
 
     @EnvironmentObject
+    private var introEligibilityViewModel: IntroEligibilityViewModel
+    @EnvironmentObject
     private var purchaseHandler: PurchaseHandler
 
-    init(configuration: TemplateViewConfiguration, introEligibility: IntroEligibilityStatus?) {
+    init(_ configuration: TemplateViewConfiguration) {
         self.configuration = configuration
-        self.introEligibility = introEligibility
         self.localization = configuration.packages.single.localization
     }
 
@@ -128,12 +110,18 @@ private struct OnePackageTemplateContent: View {
     private var button: some View {
         PurchaseButton(
             package: self.configuration.packages.single.content,
-            purchaseHandler: self.purchaseHandler,
             colors: self.configuration.colors,
             localization: self.localization,
             introEligibility: self.introEligibility,
-            mode: self.configuration.mode
+            mode: self.configuration.mode,
+            purchaseHandler: self.purchaseHandler
         )
+    }
+
+    // MARK: -
+
+    private var introEligibility: IntroEligibilityStatus? {
+        return self.introEligibilityViewModel.singleEligibility
     }
 
     private static let imageAspectRatio = 1.1

--- a/RevenueCatUI/Templates/OnePackageWithFeaturesTemplate.swift
+++ b/RevenueCatUI/Templates/OnePackageWithFeaturesTemplate.swift
@@ -12,35 +12,15 @@ import SwiftUI
 struct OnePackageWithFeaturesTemplate: TemplateViewType {
 
     private let configuration: TemplateViewConfiguration
+    private let localization: ProcessedLocalizedConfiguration
+
     @EnvironmentObject
-    private var introEligibility: IntroEligibilityViewModel
-
-    init(_ configuration: TemplateViewConfiguration) {
-        self.configuration = configuration
-    }
-
-    var body: some View {
-        OnePackageWithFeaturesTemplateContent(
-            configuration: self.configuration,
-            introEligibility: self.introEligibility.singleEligibility
-        )
-    }
-
-}
-
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
-private struct OnePackageWithFeaturesTemplateContent: View {
-
-    private var configuration: TemplateViewConfiguration
-    private var introEligibility: IntroEligibilityStatus?
-    private var localization: ProcessedLocalizedConfiguration
-
+    private var introEligibilityViewModel: IntroEligibilityViewModel
     @EnvironmentObject
     private var purchaseHandler: PurchaseHandler
 
-    init(configuration: TemplateViewConfiguration, introEligibility: IntroEligibilityStatus?) {
+    init(_ configuration: TemplateViewConfiguration) {
         self.configuration = configuration
-        self.introEligibility = introEligibility
         self.localization = configuration.packages.single.localization
     }
 
@@ -84,11 +64,11 @@ private struct OnePackageWithFeaturesTemplateContent: View {
 
             PurchaseButton(
                 package: self.configuration.packages.single.content,
-                purchaseHandler: self.purchaseHandler,
                 colors: self.configuration.colors,
                 localization: self.localization,
                 introEligibility: self.introEligibility,
-                mode: self.configuration.mode
+                mode: self.configuration.mode,
+                purchaseHandler: self.purchaseHandler
             )
             .padding(.bottom)
 
@@ -114,6 +94,10 @@ private struct OnePackageWithFeaturesTemplateContent: View {
             .foregroundStyle(self.configuration.colors.backgroundColor)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .edgesIgnoringSafeArea(.all)
+    }
+
+    private var introEligibility: IntroEligibilityStatus? {
+        return self.introEligibilityViewModel.singleEligibility
     }
 
     @ScaledMetric(relativeTo: .title)

--- a/RevenueCatUI/Views/AsyncButton.swift
+++ b/RevenueCatUI/Views/AsyncButton.swift
@@ -19,10 +19,10 @@ struct AsyncButton<Label>: View where Label: View {
     @State
     private var error: NSError?
 
-    @State
-    private var inProgress: Bool = false
-
-    init(action: @escaping Action, @ViewBuilder label: () -> Label) {
+    init(
+        action: @escaping Action,
+        @ViewBuilder label: () -> Label
+    ) {
         self.action = action
         self.label = label()
     }
@@ -30,9 +30,6 @@ struct AsyncButton<Label>: View where Label: View {
     var body: some View {
         Button {
             Task<Void, Never> {
-                self.inProgress = true
-                defer { self.inProgress = false }
-
                 do {
                     try await self.action()
                 } catch let error as NSError {
@@ -42,7 +39,6 @@ struct AsyncButton<Label>: View where Label: View {
         } label: {
             self.label
         }
-        .disabled(self.inProgress)
         .displayError(self.$error)
     }
 

--- a/RevenueCatUI/Views/FooterView.swift
+++ b/RevenueCatUI/Views/FooterView.swift
@@ -63,12 +63,12 @@ private struct RestorePurchasesButton: View {
     let purchaseHandler: PurchaseHandler
 
     @State
-    private var restored = false
+    private var displayRestoredAlert = false
 
     var body: some View {
         AsyncButton {
             _ = try await self.purchaseHandler.restorePurchases()
-            self.restored = true
+            self.displayRestoredAlert = true
         } label: {
             ViewThatFits {
                 Text("Restore purchases", bundle: .module)
@@ -76,7 +76,7 @@ private struct RestorePurchasesButton: View {
             }
         }
         .buttonStyle(.plain)
-        .alert(isPresented: self.$restored) {
+        .alert(isPresented: self.$displayRestoredAlert) {
             Alert(title: Text("Purchases restored successfully!", bundle: .module))
         }
     }

--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 /// A `PaywallView` suitable to be displayed as a loading placeholder.
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@MainActor
 struct LoadingPaywallView: View {
 
     var body: some View {

--- a/RevenueCatUI/Views/PackageButtonStyle.swift
+++ b/RevenueCatUI/Views/PackageButtonStyle.swift
@@ -1,0 +1,33 @@
+//
+//  PackageButtonStyle.swift
+//  
+//
+//  Created by Nacho Soto on 7/29/23.
+//
+
+import SwiftUI
+
+/// A `ButtonStyle` suitable to be used for a package selection button.
+/// Features:
+/// - Automatic handling of disabled state
+/// - Replaces itself with a loading indicator if it's the selected package.
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+struct PackageButtonStyle: ButtonStyle {
+
+    var isSelected: Bool
+
+    @Environment(\.isEnabled)
+    private var isEnabled
+
+    func makeBody(configuration: ButtonStyleConfiguration) -> some View {
+        configuration
+            .label
+            .hidden(if: !self.isEnabled)
+            .overlay {
+                if self.isSelected, !self.isEnabled {
+                    ProgressView()
+                }
+            }
+    }
+
+}

--- a/RevenueCatUI/Views/PurchaseButton.swift
+++ b/RevenueCatUI/Views/PurchaseButton.swift
@@ -12,11 +12,13 @@ import SwiftUI
 struct PurchaseButton: View {
 
     let package: Package
-    let purchaseHandler: PurchaseHandler
     let colors: PaywallData.Configuration.Colors
     let localization: ProcessedLocalizedConfiguration
     let introEligibility: IntroEligibilityStatus?
     let mode: PaywallViewMode
+
+    @ObservedObject
+    var purchaseHandler: PurchaseHandler
 
     @Environment(\.dismiss)
     private var dismiss
@@ -102,6 +104,7 @@ private extension PaywallViewMode {
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 struct PurchaseButton_Previews: PreviewProvider {
 
+    @MainActor
     private struct Preview: View {
 
         var mode: PaywallViewMode
@@ -112,11 +115,11 @@ struct PurchaseButton_Previews: PreviewProvider {
         var body: some View {
             PurchaseButton(
                 package: Self.package,
-                purchaseHandler: Self.purchaseHandler,
                 colors: TestData.colors,
                 localization: TestData.localization1.processVariables(with: Self.package, locale: .current),
                 introEligibility: self.eligibility,
-                mode: self.mode
+                mode: self.mode,
+                purchaseHandler: Self.purchaseHandler
             )
             .task {
                 self.eligibility = await Self.eligibilityChecker.eligibility(for: Self.package)

--- a/Tests/RevenueCatUITests/BaseSnapshotTest.swift
+++ b/Tests/RevenueCatUITests/BaseSnapshotTest.swift
@@ -11,6 +11,7 @@ import SnapshotTesting
 import XCTest
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+@MainActor
 class BaseSnapshotTest: TestCase {
 
     override class func setUp() {

--- a/Tests/RevenueCatUITests/Templates/MultiPackageBoldPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/Templates/MultiPackageBoldPaywallViewTests.swift
@@ -15,6 +15,19 @@ class MultiPackageBoldPaywallViewTests: BaseSnapshotTest {
         view.snapshot(size: Self.fullScreenSize)
     }
 
+    func testPurchasingState() {
+        let handler = Self.purchaseHandler.with(delay: .seconds(120))
+
+        let view = PaywallView(offering: Self.offering.withLocalImages,
+                               introEligibility: Self.eligibleChecker,
+                               purchaseHandler: handler)
+            .task {
+                _ = try? await handler.purchase(package: TestData.annualPackage)
+            }
+
+        view.snapshot(size: Self.fullScreenSize)
+    }
+
     func testDarkMode() {
         let view = PaywallView(offering: Self.offering.withLocalImages,
                                introEligibility: Self.ineligibleChecker,


### PR DESCRIPTION
This allows `PaywallView` to handle state handling during a purchase: instead of the previous behavior where only `PurchaseButton` would disable itself, now the entire `PaywallView` is disabled.

I extracted `PackageButtonStyle` so any template with multi-package selection can get this same behavior: the package selection also becomes disabled, as well as any other button (like restore purchases).

I've also cleaned up the templates since we no longer needed the "Content" inside view, and they can be simplified with a single type.

By making `PurchaseHandler` `@MainActor` we also ensure that all these state transitions lead to UI changes happening exclusively on the main thread.