### PR TITLE
`Paywalls`: pre-warm intro eligibility in background thread

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1618,7 +1618,7 @@ private extension Purchases {
         }
     }
 
-    private func warmUpEligibilityCache(offering: RevenueCat.Offering, paywall: PaywallData) {
+    private func warmUpEligibilityCache(offering: RCOffering, paywall: PaywallData) {
         let packageTypes = Set(paywall.config.packages)
         let products: [String] = offering.availablePackages
             .lazy

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1611,17 +1611,22 @@ private extension Purchases {
         self.offeringsManager.updateOfferingsCache(appUserID: self.appUserID,
                                                    isAppBackgrounded: isAppBackgrounded) { offerings in
             if let offering = offerings.value?.current, let paywall = offering.paywall {
-                let packageTypes = Set(paywall.config.packages)
-                let products: [String] = offering.availablePackages
-                    .lazy
-                    .filter { packageTypes.contains($0.packageType) }
-                    .map(\.storeProduct.productIdentifier)
-
-                Logger.debug(Strings.eligibility.warming_up_eligibility_cache(paywall))
-
-                self.trialOrIntroPriceEligibilityChecker.checkEligibility(productIdentifiers: products) { _ in }
+                self.operationDispatcher.dispatchOnWorkerThread {
+                    self.warmUpEligibilityCache(offering: offering, paywall: paywall)
+                }
             }
         }
+    }
+
+    private func warmUpEligibilityCache(offering: RevenueCat.Offering, paywall: PaywallData) {
+        let packageTypes = Set(paywall.config.packages)
+        let products: [String] = offering.availablePackages
+            .lazy
+            .filter { packageTypes.contains($0.packageType) }
+            .map(\.storeProduct.productIdentifier)
+
+        Logger.debug(Strings.eligibility.warming_up_eligibility_cache(paywall))
+        self.trialOrIntroPriceEligibilityChecker.checkEligibility(productIdentifiers: products) { _ in }
     }
 
 }

--- a/Sources/Support/FrameworkDisambiguation.swift
+++ b/Sources/Support/FrameworkDisambiguation.swift
@@ -23,4 +23,5 @@
 
 typealias RCRefundRequestStatus = RefundRequestStatus
 typealias RCErrorCode = ErrorCode
+typealias RCOffering = Offering
 let RCDefaultLogHandler = defaultLogHandler


### PR DESCRIPTION
Follow-up to #2860.
Thanks to integration tests for catching this (#2123).

![image](https://github.com/RevenueCat/purchases-ios/assets/685609/cf1e8e32-5d5e-47ba-b900-394aa780d865)