### PR TITLE
`Paywalls`: added default template to `SamplePaywallsList`

### DIFF
--- a/Tests/TestingApps/SimpleApp/SimpleApp/SamplePaywalls.swift
+++ b/Tests/TestingApps/SimpleApp/SimpleApp/SamplePaywalls.swift
@@ -38,6 +38,16 @@ final class SamplePaywallLoader {
         )
     }
 
+    func offeringWithDefaultPaywall() -> Offering {
+        return .init(
+            identifier: Self.offeringIdentifier,
+            serverDescription: Self.offeringIdentifier,
+            metadata: [:],
+            paywall: nil,
+            availablePackages: self.packages
+        )
+    }
+
     private func paywall(for template: PaywallTemplate) -> PaywallData {
         switch template {
         case .onePackageStandard:


### PR DESCRIPTION
This allows debugging the default template.

![Simulator Screenshot - iPhone 14 Pro - 2023-07-31 at 13 05 39](https://github.com/RevenueCat/purchases-ios/assets/685609/bb683d5d-31c1-402d-9213-064fd13071d6)
