### PR TITLE
`Paywalls`: fixed `LoadingPaywallView` displaying a progress view

### DIFF
--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -104,3 +104,21 @@ private extension LoadingPaywallView {
         subscriptionPeriod: .init(value: 1, unit: .year)
     )
 }
+
+// MARK: -
+
+#if DEBUG
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(watchOS, unavailable)
+@available(macOS, unavailable)
+@available(macCatalyst, unavailable)
+struct LoadingPaywallView_Previews: PreviewProvider {
+
+    static var previews: some View {
+        LoadingPaywallView()
+    }
+
+}
+
+#endif

--- a/RevenueCatUI/Views/PackageButtonStyle.swift
+++ b/RevenueCatUI/Views/PackageButtonStyle.swift
@@ -16,15 +16,15 @@ struct PackageButtonStyle: ButtonStyle {
 
     var isSelected: Bool
 
-    @Environment(\.isEnabled)
-    private var isEnabled
+    @EnvironmentObject
+    private var purchaseHandler: PurchaseHandler
 
     func makeBody(configuration: ButtonStyleConfiguration) -> some View {
         configuration
             .label
-            .hidden(if: !self.isEnabled)
+            .hidden(if: self.purchaseHandler.actionInProgress)
             .overlay {
-                if self.isSelected, !self.isEnabled {
+                if self.isSelected, self.purchaseHandler.actionInProgress {
                     ProgressView()
                 }
             }


### PR DESCRIPTION
This was broken in #2923. Unfortunately it couldn't be caught by snapshot tests because those don't display progress views.

I simplified `PackageButtonStyle` to get the shared `PurchaseHandler.actionInProgress` state instead of relying on whether the button is enabled.