### PR TITLE
`Paywalls`: more unit tests for purchasing state

### DIFF
--- a/RevenueCatUI/Helpers/TrialOrIntroEligibilityChecker.swift
+++ b/RevenueCatUI/Helpers/TrialOrIntroEligibilityChecker.swift
@@ -27,6 +27,10 @@ final class TrialOrIntroEligibilityChecker: ObservableObject {
         self.checker = checker
     }
 
+    static func `default`() -> Self? {
+        return Purchases.isConfigured ? .init() : nil
+    }
+
 }
 
 @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -26,8 +26,8 @@ public struct PaywallView: View {
         self.init(
             offering: nil,
             mode: mode,
-            introEligibility: Purchases.isConfigured ? .init() : nil,
-            purchaseHandler: Purchases.isConfigured ? .init() : nil
+            introEligibility: .default(),
+            purchaseHandler: .default()
         )
     }
 
@@ -39,8 +39,8 @@ public struct PaywallView: View {
         self.init(
             offering: offering,
             mode: mode,
-            introEligibility: Purchases.isConfigured ? .init() : nil,
-            purchaseHandler: Purchases.isConfigured ? .init() : nil
+            introEligibility: .default(),
+            purchaseHandler: .default()
         )
     }
 
@@ -77,6 +77,10 @@ public struct PaywallView: View {
                         .transition(Self.transition)
                         .task {
                             do {
+                                guard Purchases.isConfigured else {
+                                    throw PaywallError.purchasesNotConfigured
+                                }
+
                                 guard let offering = try await Purchases.shared.offerings().current else {
                                     throw PaywallError.noCurrentOffering
                                 }

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -50,6 +50,10 @@ final class PurchaseHandler: ObservableObject {
         self.restoreBlock = restorePurchases
     }
 
+    static func `default`() -> Self? {
+        return Purchases.isConfigured ? .init() : nil
+    }
+
 }
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -77,6 +77,9 @@ extension View {
     // Visible overload for tests
     func presentPaywallIfNecessary(
         mode: PaywallViewMode = .default,
+        offering: Offering? = nil,
+        introEligibility: TrialOrIntroEligibilityChecker? = nil,
+        purchaseHandler: PurchaseHandler? = nil,
         shouldDisplay: @escaping @Sendable (CustomerInfo) -> Bool,
         purchaseCompleted: PurchaseCompletedHandler? = nil,
         customerInfoFetcher: @escaping CustomerInfoFetcher
@@ -86,7 +89,10 @@ extension View {
                 shouldDisplay: shouldDisplay,
                 purchaseCompleted: purchaseCompleted,
                 mode: mode,
-                customerInfoFetcher: customerInfoFetcher
+                offering: offering,
+                customerInfoFetcher: customerInfoFetcher,
+                introEligibility: introEligibility,
+                purchaseHandler: purchaseHandler
             ))
     }
 
@@ -99,8 +105,11 @@ private struct PresentingPaywallModifier: ViewModifier {
     var shouldDisplay: @Sendable (CustomerInfo) -> Bool
     var purchaseCompleted: PurchaseCompletedHandler?
     var mode: PaywallViewMode
+    var offering: Offering?
 
     var customerInfoFetcher: View.CustomerInfoFetcher
+    var introEligibility: TrialOrIntroEligibilityChecker?
+    var purchaseHandler: PurchaseHandler?
 
     @State
     private var isDisplayed = false
@@ -108,7 +117,12 @@ private struct PresentingPaywallModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .sheet(isPresented: self.$isDisplayed) {
-                PaywallView(mode: self.mode)
+                PaywallView(
+                    offering: self.offering,
+                    mode: self.mode,
+                    introEligibility: self.introEligibility ?? .default(),
+                    purchaseHandler: self.purchaseHandler ?? .default()
+                )
                     .onPurchaseCompleted {
                         self.purchaseCompleted?($0)
                     }

--- a/Tests/RevenueCatUITests/PresentIfNecessaryTests.swift
+++ b/Tests/RevenueCatUITests/PresentIfNecessaryTests.swift
@@ -1,0 +1,48 @@
+//
+//  PresentIfNecessaryTests.swift
+//  
+//
+//  Created by Nacho Soto on 7/31/23.
+//
+
+import Nimble
+import RevenueCat
+@testable import RevenueCatUI
+import SwiftUI
+import XCTest
+
+#if !os(macOS)
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+@MainActor
+class PresentIfNecessaryTests: TestCase {
+
+    func testPresentWithPurchaseHandler() throws {
+        var customerInfo: CustomerInfo?
+
+        Text("")
+            .presentPaywallIfNecessary(offering: Self.offering,
+                                       introEligibility: .producing(eligibility: .eligible),
+                                       purchaseHandler: Self.purchaseHandler) { _ in
+                return true
+            } purchaseCompleted: {
+                customerInfo = $0
+            } customerInfoFetcher: {
+                return TestData.customerInfo
+            }
+            .addToHierarchy()
+
+        Task {
+            _ = try await Self.purchaseHandler.purchase(package: Self.package)
+        }
+
+        expect(customerInfo).toEventually(be(TestData.customerInfo))
+    }
+
+    private static let purchaseHandler: PurchaseHandler = .mock()
+    private static let offering = TestData.offeringWithNoIntroOffer
+    private static let package = TestData.annualPackage
+
+}
+
+#endif

--- a/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
@@ -1,0 +1,57 @@
+//
+//  PurchaseHandlerTests.swift
+//  
+//
+//  Created by Nacho Soto on 7/31/23.
+//
+
+import Nimble
+import RevenueCat
+@testable import RevenueCatUI
+import XCTest
+
+#if !os(macOS)
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
+@MainActor
+class PurchaseHandlerTests: TestCase {
+
+    func testInitialState() async throws {
+        let handler: PurchaseHandler = .mock()
+
+        expect(handler.purchasedCustomerInfo).to(beNil())
+        expect(handler.purchased) == false
+        expect(handler.restored) == false
+        expect(handler.actionInProgress) == false
+    }
+
+    func testPurchaseSetsCustomerInfo() async throws {
+        let handler: PurchaseHandler = .mock()
+
+        _ = try await handler.purchase(package: TestData.packageWithIntroOffer)
+
+        expect(handler.purchasedCustomerInfo) === TestData.customerInfo
+        expect(handler.purchased) == true
+        expect(handler.actionInProgress) == false
+    }
+
+    func testCancellingPurchase() async throws {
+        let handler: PurchaseHandler = .cancelling()
+
+        _ = try await handler.purchase(package: TestData.packageWithIntroOffer)
+        expect(handler.purchasedCustomerInfo).to(beNil())
+        expect(handler.purchased) == false
+        expect(handler.actionInProgress) == false
+    }
+
+    func testRestorePurchases() async throws {
+        let handler: PurchaseHandler = .mock()
+
+        _ = try await handler.restorePurchases()
+        expect(handler.restored) == true
+        expect(handler.actionInProgress) == false
+    }
+
+}
+
+#endif


### PR DESCRIPTION
Follow up to #2930.

Added `PresentIfNecessaryTests` and `PurchaseHandlerTests`.
This also removes the last source of "crashes" whenever `Purchases` isn't configured, leading to errors instead.