### PR TITLE
`Paywalls`: changed `SamplePaywallsList` to work offline

### DIFF
--- a/Tests/TestingApps/SimpleApp/SimpleApp/SamplePaywalls.swift
+++ b/Tests/TestingApps/SimpleApp/SimpleApp/SamplePaywalls.swift
@@ -12,20 +12,12 @@ final class SamplePaywallLoader {
 
     private let packages: [Package]
 
-    init(packages: [Package]) {
-        self.packages = packages
-    }
-
-    static func create() async throws -> Self {
-        struct PurchasesNotConfigured: Error {}
-
-        guard Purchases.isConfigured else {
-            throw PurchasesNotConfigured()
-        }
-
-        let packages = try await Purchases.shared.offerings().current?.availablePackages
-
-        return .init(packages: packages ?? [])
+    init() {
+        self.packages = [
+            Self.weeklyPackage,
+            Self.monthlyPackage,
+            Self.annualPackage
+        ]
     }
 
     func offering(for template: PaywallTemplate) -> Offering {
@@ -60,6 +52,82 @@ final class SamplePaywallLoader {
     }
 
 }
+
+// MARK: - Packages
+
+private extension SamplePaywallLoader {
+
+    static let weeklyPackage = Package(
+        identifier: "weekly",
+        packageType: .weekly,
+        storeProduct: weeklyProduct.toStoreProduct(),
+        offeringIdentifier: offeringIdentifier
+    )
+    static let monthlyPackage = Package(
+        identifier: "monthly",
+        packageType: .monthly,
+        storeProduct: monthlyProduct.toStoreProduct(),
+        offeringIdentifier: offeringIdentifier
+    )
+    static let annualPackage = Package(
+        identifier: "annual",
+        packageType: .annual,
+        storeProduct: annualProduct.toStoreProduct(),
+        offeringIdentifier: offeringIdentifier
+    )
+
+    static let weeklyProduct = TestStoreProduct(
+        localizedTitle: "Weekly",
+        price: 1.99,
+        localizedPriceString: "$1.99",
+        productIdentifier: "com.revenuecat.product_1",
+        productType: .autoRenewableSubscription,
+        localizedDescription: "PRO weekly",
+        subscriptionGroupIdentifier: "group",
+        subscriptionPeriod: .init(value: 1, unit: .week)
+    )
+    static let monthlyProduct = TestStoreProduct(
+        localizedTitle: "Monthly",
+        price: 12.99,
+        localizedPriceString: "$12.99",
+        productIdentifier: "com.revenuecat.product_2",
+        productType: .autoRenewableSubscription,
+        localizedDescription: "PRO monthly",
+        subscriptionGroupIdentifier: "group",
+        subscriptionPeriod: .init(value: 1, unit: .month),
+        introductoryDiscount: .init(
+            identifier: "intro",
+            price: 0,
+            localizedPriceString: "$0.00",
+            paymentMode: .freeTrial,
+            subscriptionPeriod: .init(value: 1, unit: .week),
+            numberOfPeriods: 1,
+            type: .introductory
+        )
+    )
+    static let annualProduct = TestStoreProduct(
+        localizedTitle: "Annual",
+        price: 69.49,
+        localizedPriceString: "$69.49",
+        productIdentifier: "com.revenuecat.product_3",
+        productType: .autoRenewableSubscription,
+        localizedDescription: "PRO annual",
+        subscriptionGroupIdentifier: "group",
+        subscriptionPeriod: .init(value: 1, unit: .year),
+        introductoryDiscount: .init(
+            identifier: "intro",
+            price: 0,
+            localizedPriceString: "$0.00",
+            paymentMode: .freeTrial,
+            subscriptionPeriod: .init(value: 14, unit: .day),
+            numberOfPeriods: 1,
+            type: .introductory
+        )
+    )
+
+}
+
+// MARK: - Paywalls
 
 private extension SamplePaywallLoader {
     

--- a/Tests/TestingApps/SimpleApp/SimpleApp/SimpleApp.swift
+++ b/Tests/TestingApps/SimpleApp/SimpleApp/SimpleApp.swift
@@ -33,6 +33,7 @@ struct SimpleApp: App {
             .overlay {
                 DebugView()
                     .frame(maxHeight: .infinity, alignment: .bottom)
+                    .offset(y: -50)
             }
             #endif
         }

--- a/Tests/TestingApps/SimpleApp/SimpleApp/Views/AppContentView.swift
+++ b/Tests/TestingApps/SimpleApp/SimpleApp/Views/AppContentView.swift
@@ -34,10 +34,24 @@ struct AppContentView: View {
     private var didPurchase: Bool = false
 
     var body: some View {
-        ZStack {
-            self.background
+        TabView {
+            ZStack {
+                self.background
+                self.content
+            }
+            .tabItem {
+                Label("App", systemImage: "iphone")
+            }
 
-            self.content
+            SamplePaywallsList()
+                .tabItem {
+                    Label("Examples", systemImage: "pawprint")
+                }
+
+            OfferingsList()
+                .tabItem {
+                    Label("All paywalls", systemImage: "network")
+                }
         }
         .presentPaywallIfNecessary {
             !$0.hasPro
@@ -64,22 +78,6 @@ struct AppContentView: View {
                 if self.didPurchase {
                     Text("Thanks for purchasing!")
                 }
-                
-                NavigationLink {
-                    SamplePaywallsList()
-                } label: {
-                    Text("Sample paywalls")
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(.mint)
-
-                NavigationLink {
-                    OfferingsList()
-                } label: {
-                    Text("All offerings")
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(.indigo)
 
                 Spacer()
 

--- a/Tests/TestingApps/SimpleApp/SimpleApp/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/SimpleApp/SimpleApp/Views/SamplePaywallsList.swift
@@ -12,43 +12,19 @@ import SwiftUI
 struct SamplePaywallsList: View {
 
     @State
-    private var loader: Result<SamplePaywallLoader, NSError>?
-
-    @State
     private var display: Display?
 
     var body: some View {
-        self.content
-            .navigationTitle("Paywalls")
-            .task {
-                do {
-                    self.loader = .success(try await .create())
-                } catch let error as NSError {
-                    self.loader = .failure(error)
+        self.list(with: Self.loader)
+            .sheet(item: self.$display) { display in
+                switch display {
+                case let .template(template):
+                    PaywallView(offering: Self.loader.offering(for: template))
+                case .defaultTemplate:
+                    PaywallView(offering: Self.loader.offeringWithDefaultPaywall())
                 }
             }
-    }
-
-    @ViewBuilder
-    private var content: some View {
-        switch self.loader {
-        case let .success(loader):
-            self.list(with: loader)
-                .sheet(item: self.$display) { display in
-                    switch display {
-                    case let .template(template):
-                        PaywallView(offering: loader.offering(for: template))
-                    case .defaultTemplate:
-                        PaywallView(offering: loader.offeringWithDefaultPaywall())
-                    }
-                }
-
-        case let .failure(error):
-            Text(error.description)
-
-        case .none:
-            ProgressView()
-        }
+            .navigationTitle("Paywalls")
     }
 
     private func list(with loader: SamplePaywallLoader) -> some View {
@@ -74,6 +50,8 @@ struct SamplePaywallsList: View {
         .frame(maxWidth: .infinity)
         .buttonStyle(.plain)
     }
+
+    private static let loader: SamplePaywallLoader = .init()
 
 }
 


### PR DESCRIPTION
It no longer loads the real packages and creates demo paywalls.

![simulator_screenshot_7D7C41AC-3D39-43D7-8DE9-80079A43BA07](https://github.com/RevenueCat/purchases-ios/assets/685609/38829e6c-2c35-43a5-8d6c-1e12d3ec7293)
