### PR TITLE
`Paywalls`: removed `mode` parameter from `presentPaywallIfNecessary`

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -1,7 +1,7 @@
 import RevenueCat
 import SwiftUI
 
-/// A full-screen SwiftUI view for displaying a `PaywallData` for an `Offering`.
+/// A SwiftUI view for displaying a `PaywallData` for an `Offering`.
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 @available(watchOS, unavailable, message: "RevenueCatUI does not support watchOS yet")
 @available(macOS, unavailable, message: "RevenueCatUI does not support macOS yet")

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -25,12 +25,10 @@ extension View {
     /// - Note: If loading the `CustomerInfo` fails (for example, if Internet is offline),
     /// the paywall won't be displayed.
     public func presentPaywallIfNecessary(
-        mode: PaywallViewMode = .default,
         requiredEntitlementIdentifier: String,
         purchaseCompleted: PurchaseCompletedHandler? = nil
     ) -> some View {
         return self.presentPaywallIfNecessary(
-            mode: mode,
             shouldDisplay: { info in
                 !info.entitlements
                     .activeInCurrentEnvironment
@@ -56,12 +54,10 @@ extension View {
     /// - Note: If loading the `CustomerInfo` fails (for example, if Internet is offline),
     /// the paywall won't be displayed.
     public func presentPaywallIfNecessary(
-        mode: PaywallViewMode = .default,
         shouldDisplay: @escaping @Sendable (CustomerInfo) -> Bool,
         purchaseCompleted: PurchaseCompletedHandler? = nil
     ) -> some View {
         return self.presentPaywallIfNecessary(
-            mode: mode,
             shouldDisplay: shouldDisplay,
             purchaseCompleted: purchaseCompleted,
             customerInfoFetcher: {
@@ -76,7 +72,6 @@ extension View {
 
     // Visible overload for tests
     func presentPaywallIfNecessary(
-        mode: PaywallViewMode = .default,
         offering: Offering? = nil,
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
         purchaseHandler: PurchaseHandler? = nil,
@@ -88,7 +83,6 @@ extension View {
             .modifier(PresentingPaywallModifier(
                 shouldDisplay: shouldDisplay,
                 purchaseCompleted: purchaseCompleted,
-                mode: mode,
                 offering: offering,
                 customerInfoFetcher: customerInfoFetcher,
                 introEligibility: introEligibility,
@@ -104,7 +98,6 @@ private struct PresentingPaywallModifier: ViewModifier {
 
     var shouldDisplay: @Sendable (CustomerInfo) -> Bool
     var purchaseCompleted: PurchaseCompletedHandler?
-    var mode: PaywallViewMode
     var offering: Offering?
 
     var customerInfoFetcher: View.CustomerInfoFetcher
@@ -120,7 +113,6 @@ private struct PresentingPaywallModifier: ViewModifier {
                 NavigationView {
                     PaywallView(
                         offering: self.offering,
-                        mode: self.mode,
                         introEligibility: self.introEligibility ?? .default(),
                         purchaseHandler: self.purchaseHandler ?? .default()
                     )

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
@@ -34,16 +34,8 @@ struct App: View {
         Text("")
             .presentPaywallIfNecessary(requiredEntitlementIdentifier: "")
             .presentPaywallIfNecessary(requiredEntitlementIdentifier: "", purchaseCompleted: completed)
-            .presentPaywallIfNecessary(mode: .fullScreen,
-                                       requiredEntitlementIdentifier: "",
-                                       purchaseCompleted: completed)
             .presentPaywallIfNecessary { (_: CustomerInfo) in false }
             .presentPaywallIfNecessary { (_: CustomerInfo) in false } purchaseCompleted: { completed($0) }
-            .presentPaywallIfNecessary(mode: .fullScreen) { (_: CustomerInfo) in
-                return false
-            } purchaseCompleted: {
-                completed($0)
-            }
     }
 
     @ViewBuilder


### PR DESCRIPTION
This displays a paywall fullscreen, which implies that `PaywallViewMode`. Also corrected the docstring in `PaywallView` since it doesn't necessary imply fullscreen.