### PR TITLE
`Paywalls`: new `subscription_duration` variable

### DIFF
--- a/RevenueCatUI/Data/Variables.swift
+++ b/RevenueCatUI/Data/Variables.swift
@@ -23,11 +23,12 @@ protocol VariableDataProvider {
     var productName: String { get }
 
     func periodName(_ locale: Locale) -> String
+    func subscriptionDuration(_ locale: Locale) -> String?
     func introductoryOfferDuration(_ locale: Locale) -> String?
 
 }
 
-/// Processes strings, replacing `{{variable}}` with their associated content.
+/// Processes strings, replacing `{{ variable }}` with their associated content.
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 enum VariableHandler {
 
@@ -101,6 +102,8 @@ private extension VariableDataProvider {
         case "product_name": return self.productName
         case "period":
             return self.periodName(locale)
+        case "subscription_duration":
+            return self.subscriptionDuration(locale) ?? ""
         case "intro_duration":
             return self.introductoryOfferDuration(locale) ?? ""
 

--- a/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
+++ b/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
@@ -29,8 +29,12 @@ extension Package: VariableDataProvider {
                                       locale: locale)
     }
 
+    func subscriptionDuration(_ locale: Locale) -> String? {
+        return self.periodDuration(locale)
+    }
+
     func introductoryOfferDuration(_ locale: Locale) -> String? {
-        self.introDuration(locale)
+        return self.introDuration(locale)
     }
 
 }
@@ -52,6 +56,12 @@ private extension Package {
         // `priceFormatter` can only be `nil` for SK2 products
         // with an unknown code, which should be rare.
         return self.storeProduct.priceFormatter ?? .init()
+    }
+
+    func periodDuration(_ locale: Locale) -> String? {
+        guard let period = self.storeProduct.subscriptionPeriod else { return nil }
+
+        return Localization.localizedDuration(for: period, locale: locale)
     }
 
     func introDuration(_ locale: Locale) -> String? {

--- a/Tests/RevenueCatUITests/Data/VariablesTests.swift
+++ b/Tests/RevenueCatUITests/Data/VariablesTests.swift
@@ -78,6 +78,11 @@ class VariablesTests: TestCase {
         expect(self.process("{{ period }}")) == "Monthly"
     }
 
+    func testSubscriptionDuration() {
+        self.provider.subscriptionDuration = "1 month"
+        expect(self.process("{{ subscription_duration }}")) == "1 month"
+    }
+
     func testIntroDurationName() {
         self.provider.introductoryOfferDuration = "1 week"
         expect(self.process("Start {{ intro_duration }} trial")) == "Start 1 week trial"
@@ -100,7 +105,7 @@ class VariablesTests: TestCase {
             callToAction: "Unlock {{ product_name }} for {{ price_per_month }}",
             callToActionWithIntroOffer: "Start your {{ intro_duration }} free trial\n" +
             "Then {{ price_per_month }} every month",
-            offerDetails: "Purchase for {{ price }}",
+            offerDetails: "Purchase for {{ price }} every {{ subscription_duration }}",
             offerDetailsWithIntroOffer: "Start your {{ intro_duration }} free trial\n" +
             "Then {{ price_per_month }} every month",
             offerName: "{{ period }}",
@@ -119,7 +124,7 @@ class VariablesTests: TestCase {
         expect(processed.subtitle) == "Price: $3.99"
         expect(processed.callToAction) == "Unlock PRO monthly for $3.99"
         expect(processed.callToActionWithIntroOffer) == "Start your 1 week free trial\nThen $3.99 every month"
-        expect(processed.offerDetails) == "Purchase for $3.99"
+        expect(processed.offerDetails) == "Purchase for $3.99 every 1 month"
         expect(processed.offerDetailsWithIntroOffer) == "Start your 1 week free trial\nThen $3.99 every month"
         expect(processed.offerName) == "Monthly"
         expect(processed.features) == [
@@ -153,10 +158,15 @@ private struct MockVariableProvider: VariableDataProvider {
     var localizedPricePerMonth: String = ""
     var productName: String = ""
     var periodName: String = ""
+    var subscriptionDuration: String?
     var introductoryOfferDuration: String?
 
     func periodName(_ locale: Locale) -> String {
         return self.periodName
+    }
+
+    func subscriptionDuration(_ locale: Locale) -> String? {
+        return self.subscriptionDuration
     }
 
     func introductoryOfferDuration(_ locale: Locale) -> String? {


### PR DESCRIPTION
This will be used by template 4, but also useful in others.