### PR TITLE
`Paywalls`: added ability to calculate and localize subscription discounts

### DIFF
--- a/RevenueCatUI/Data/Localization.swift
+++ b/RevenueCatUI/Data/Localization.swift
@@ -89,6 +89,20 @@ enum Localization {
         return path.flatMap(Bundle.init(path:)) ?? containerBundle
     }
 
+    /// - Returns: localized string for a discount. Example: "37% off"
+    static func localized(
+        discount: Double,
+        locale: Locale
+    ) -> String {
+        assert(discount >= 0, "Invalid discount: \(discount)")
+
+        let number = Int((discount * 100).rounded(.toNearestOrAwayFromZero))
+        let format = self.localizedBundle(locale)
+            .localizedString(forKey: "%d%% off", value: nil, table: nil)
+
+        return String(format: format, number)
+    }
+
 }
 
 // MARK: - Private

--- a/RevenueCatUI/Resources/en.lproj/Localizable.strings
+++ b/RevenueCatUI/Resources/en.lproj/Localizable.strings
@@ -13,3 +13,5 @@
 "PackageType.twoMonth" = "2 month";
 "PackageType.monthly" = "Monthly";
 "PackageType.weekly" = "Weekly";
+
+"%d%% off" = "%d%% off";

--- a/RevenueCatUI/Resources/es.lproj/Localizable.strings
+++ b/RevenueCatUI/Resources/es.lproj/Localizable.strings
@@ -13,3 +13,5 @@
 "PackageType.twoMonth" = "2 meses";
 "PackageType.monthly" = "Mensual";
 "PackageType.weekly" = "Semanal";
+
+"%d%% off" = "Ahorra %d%%";

--- a/Tests/RevenueCatUITests/Data/TemplateViewConfigurationTests.swift
+++ b/Tests/RevenueCatUITests/Data/TemplateViewConfigurationTests.swift
@@ -54,6 +54,7 @@ class TemplateViewConfigurationCreationTests: BaseTemplateViewConfigurationTests
         switch result {
         case let .single(package):
             expect(package.content) === TestData.monthlyPackage
+            expect(package.discountRelativeToMostExpensivePerMonth).to(beNil())
             Self.verifyLocalizationWasProcessed(package.localization, for: TestData.monthlyPackage)
         case .multiple:
             fail("Invalid result: \(result)")
@@ -80,10 +81,13 @@ class TemplateViewConfigurationCreationTests: BaseTemplateViewConfigurationTests
 
             let annual = packages[0]
             expect(annual.content) === TestData.annualPackage
+            expect(annual.discountRelativeToMostExpensivePerMonth)
+                .to(beCloseTo(0.55, within: 0.01))
             Self.verifyLocalizationWasProcessed(annual.localization, for: TestData.annualPackage)
 
             let monthly = packages[1]
             expect(monthly.content) === TestData.monthlyPackage
+            expect(monthly.discountRelativeToMostExpensivePerMonth).to(beNil())
             Self.verifyLocalizationWasProcessed(monthly.localization, for: TestData.monthlyPackage)
         }
     }

--- a/Tests/RevenueCatUITests/LocalizationTests.swift
+++ b/Tests/RevenueCatUITests/LocalizationTests.swift
@@ -180,6 +180,51 @@ class PackageTypeOtherLanguageLocalizationTests: BaseLocalizationTests {
     }
 }
 
+// MARK: - Discount
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+class DiscountEnglishLocalizationTests: BaseLocalizationTests {
+
+    override var locale: Locale { return .init(identifier: "en_US") }
+
+    func testLocalization() {
+        verify(0, "0% off")
+        verify(0.1, "10% off")
+        verify(0.331, "33% off")
+        verify(0.5, "50% off")
+        verify(1, "100% off")
+        verify(1.1, "110% off")
+    }
+
+}
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+class DiscountSpanishLocalizationTests: BaseLocalizationTests {
+
+    override var locale: Locale { return .init(identifier: "es_ES") }
+
+    func testLocalization() {
+        verify(0, "Ahorra 0%")
+        verify(0.1, "Ahorra 10%")
+        verify(0.331, "Ahorra 33%")
+        verify(0.5, "Ahorra 50%")
+        verify(1, "Ahorra 100%")
+        verify(1.1, "Ahorra 110%")
+    }
+
+}
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+class DiscountOtherLanguageLocalizationTests: BaseLocalizationTests {
+
+    override var locale: Locale { return .init(identifier: "fr") }
+
+    func testLocalizationDefaultsToEnglish() {
+        verify(1, "100% off")
+    }
+
+}
+
 // MARK: - Private
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
@@ -215,6 +260,17 @@ private extension BaseLocalizationTests {
         line: UInt = #line
     ) {
         let result = Localization.localized(packageType: packageType,
+                                            locale: self.locale)
+        expect(file: file, line: line, result) == expected
+    }
+
+    func verify(
+        _ discount: Double,
+        _ expected: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let result = Localization.localized(discount: discount,
                                             locale: self.locale)
         expect(file: file, line: line, result) == expected
     }


### PR DESCRIPTION
![Screenshot 2023-08-02 at 08 17 45](https://github.com/RevenueCat/purchases-ios/assets/685609/0c3ee7b8-1b37-4e6d-81d0-4b2d18086d82)

Useful for template 4, but also for others.