### PR TITLE
`Paywalls`: fixed `View.scrollableIfNecessary`

### DIFF
--- a/RevenueCatUI/Modifiers/ViewExtensions.swift
+++ b/RevenueCatUI/Modifiers/ViewExtensions.swift
@@ -48,7 +48,7 @@ extension View {
         ViewThatFits(in: axes) {
             self
 
-            ScrollView {
+            ScrollView(axes) {
                 self
             }
         }


### PR DESCRIPTION
This wasn't setting the correct axes on the scroll view. This will be necessary for the upcoming paywall using a horizontal scroll view.