### PR TITLE
`Paywalls`: fixed `tvOS` compilation by making it explicitly unavailable

### DIFF
--- a/RevenueCatUI/Helpers/PaywallData+Default.swift
+++ b/RevenueCatUI/Helpers/PaywallData+Default.swift
@@ -73,6 +73,7 @@ private extension PaywallData {
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 @available(watchOS, unavailable)
 @available(macOS, unavailable)
+@available(tvOS, unavailable)
 @available(macCatalyst, unavailable)
 struct DefaultPaywall_Previews: PreviewProvider {
 

--- a/RevenueCatUI/Helpers/PreviewHelpers.swift
+++ b/RevenueCatUI/Helpers/PreviewHelpers.swift
@@ -37,6 +37,7 @@ enum PreviewHelpers {
 /// ```
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 @available(macOS, unavailable)
+@available(tvOS, unavailable)
 struct PreviewableTemplate<T: TemplateViewType>: View {
 
     typealias Creator = @Sendable @MainActor (TemplateViewConfiguration) -> T

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 @available(watchOS, unavailable, message: "RevenueCatUI does not support watchOS yet")
 @available(macOS, unavailable, message: "RevenueCatUI does not support macOS yet")
+@available(tvOS, unavailable, message: "RevenueCatUI does not support tvOS yet")
 @available(macCatalyst, unavailable, message: "RevenueCatUI does not support Catalyst yet")
 public struct PaywallView: View {
 
@@ -136,6 +137,7 @@ public struct PaywallView: View {
 }
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(tvOS, unavailable)
 struct LoadedOfferingPaywallView: View {
 
     private let offering: Offering
@@ -220,6 +222,7 @@ private extension PaywallViewMode {
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 @available(watchOS, unavailable)
 @available(macOS, unavailable)
+@available(tvOS, unavailable)
 @available(macCatalyst, unavailable)
 struct PaywallView_Previews: PreviewProvider {
 

--- a/RevenueCatUI/Templates/MultiPackageBoldTemplate.swift
+++ b/RevenueCatUI/Templates/MultiPackageBoldTemplate.swift
@@ -2,6 +2,7 @@ import RevenueCat
 import SwiftUI
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(tvOS, unavailable)
 struct MultiPackageBoldTemplate: TemplateViewType {
 
     private let configuration: TemplateViewConfiguration
@@ -206,6 +207,7 @@ struct MultiPackageBoldTemplate: TemplateViewType {
 // MARK: - Extensions
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(tvOS, unavailable)
 private extension MultiPackageBoldTemplate {
 
     func localization(for package: Package) -> ProcessedLocalizedConfiguration {
@@ -226,6 +228,7 @@ private extension MultiPackageBoldTemplate {
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 @available(watchOS, unavailable)
 @available(macOS, unavailable)
+@available(tvOS, unavailable)
 @available(macCatalyst, unavailable)
 struct MultiPackageBoldTemplate_Previews: PreviewProvider {
 

--- a/RevenueCatUI/Templates/OnePackageStandardTemplate.swift
+++ b/RevenueCatUI/Templates/OnePackageStandardTemplate.swift
@@ -2,6 +2,7 @@ import RevenueCat
 import SwiftUI
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(tvOS, unavailable)
 struct OnePackageStandardTemplate: TemplateViewType {
 
     private let configuration: TemplateViewConfiguration
@@ -210,6 +211,7 @@ private struct CircleMaskModifier: ViewModifier {
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 @available(watchOS, unavailable)
 @available(macOS, unavailable)
+@available(tvOS, unavailable)
 @available(macCatalyst, unavailable)
 struct OnePackageStandardTemplate_Previews: PreviewProvider {
 

--- a/RevenueCatUI/Templates/OnePackageWithFeaturesTemplate.swift
+++ b/RevenueCatUI/Templates/OnePackageWithFeaturesTemplate.swift
@@ -9,6 +9,7 @@ import RevenueCat
 import SwiftUI
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(tvOS, unavailable)
 struct OnePackageWithFeaturesTemplate: TemplateViewType {
 
     private let configuration: TemplateViewConfiguration
@@ -183,6 +184,7 @@ private struct FeatureView: View {
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 @available(watchOS, unavailable)
 @available(macOS, unavailable)
+@available(tvOS, unavailable)
 @available(macCatalyst, unavailable)
 struct OnePackageWithFeaturesTemplate_Previews: PreviewProvider {
 

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 /// A `SwiftUI` view that can display a paywall with `TemplateViewConfiguration`.
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(tvOS, unavailable)
 protocol TemplateViewType: SwiftUI.View {
 
     init(_ configuration: TemplateViewConfiguration)
@@ -23,6 +24,7 @@ private extension PaywallTemplate {
 }
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(tvOS, unavailable)
 extension PaywallData {
 
     @ViewBuilder

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 @available(macOS, unavailable, message: "RevenueCatUI does not support macOS yet")
+@available(tvOS, unavailable, message: "RevenueCatUI does not support tvOS yet")
 extension View {
 
     typealias CustomerInfoFetcher = @Sendable () async throws -> CustomerInfo
@@ -93,7 +94,8 @@ extension View {
 }
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
-@available(macOS, unavailable, message: "RevenueCatUI does not support macOS yet")
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
 private struct PresentingPaywallModifier: ViewModifier {
 
     var shouldDisplay: @Sendable (CustomerInfo) -> Bool

--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 
 /// A `PaywallView` suitable to be displayed as a loading placeholder.
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
 @MainActor
 struct LoadingPaywallView: View {
 
@@ -38,6 +40,8 @@ struct LoadingPaywallView: View {
 }
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
 private extension LoadingPaywallView {
 
     static let introEligibility: TrialOrIntroEligibilityChecker = .init(checker: { packages in
@@ -112,6 +116,7 @@ private extension LoadingPaywallView {
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 @available(watchOS, unavailable)
 @available(macOS, unavailable)
+@available(tvOS, unavailable)
 @available(macCatalyst, unavailable)
 struct LoadingPaywallView_Previews: PreviewProvider {
 

--- a/RevenueCatUI/Views/PurchaseButton.swift
+++ b/RevenueCatUI/Views/PurchaseButton.swift
@@ -9,6 +9,7 @@ import RevenueCat
 import SwiftUI
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(tvOS, unavailable)
 struct PurchaseButton: View {
 
     let package: Package
@@ -75,6 +76,7 @@ private extension PaywallViewMode {
         }
     }
 
+    @available(tvOS, unavailable)
     var buttonSize: ControlSize {
         switch self {
         case .fullScreen: return .large
@@ -86,7 +88,7 @@ private extension PaywallViewMode {
     var buttonBorderShape: ButtonBorderShape {
         switch self {
         case .fullScreen:
-            #if os(macOS)
+            #if os(macOS) || os(tvOS)
             return .roundedRectangle
             #else
             return .capsule
@@ -103,6 +105,7 @@ private extension PaywallViewMode {
 #if DEBUG && canImport(SwiftUI) && canImport(UIKit)
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(tvOS, unavailable, message: "RevenueCatUI does not support tvOS yet")
 struct PurchaseButton_Previews: PreviewProvider {
 
     @MainActor


### PR DESCRIPTION
Follow up to #2821.