### PR TITLE
`SK1StoreProduct`: changed `productType` warning to debug

### DIFF
--- a/Sources/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK1StoreProduct.swift
@@ -33,7 +33,7 @@ internal struct SK1StoreProduct: StoreProductType {
     }
 
     var productType: StoreProduct.ProductType {
-        Logger.warn(Strings.storeKit.sk1_no_known_product_type)
+        Logger.debug(Strings.storeKit.sk1_no_known_product_type)
 
         return .defaultType
     }

--- a/Tests/StoreKitUnitTests/StoreProductTests.swift
+++ b/Tests/StoreKitUnitTests/StoreProductTests.swift
@@ -392,7 +392,7 @@ class StoreProductTests: StoreKitConfigTestCase {
 
         // Verify warning is only logged when calling method.
         expect(product.productType) == .defaultType
-        self.logger.verifyMessageWasLogged(Strings.storeKit.sk1_no_known_product_type, level: .warn)
+        self.logger.verifyMessageWasLogged(Strings.storeKit.sk1_no_known_product_type, level: .debug)
     }
 
 }


### PR DESCRIPTION
See https://community.revenuecat.com/sdks-51/purchases-purchasepackage-doesn-t-return-1956?postid=10251#post10251
Because hybrids proactively call this method to construct the internal representation, it gets logged automatically whether they call it or not,.

It's still useful, but making it a warning makes it seem more of a bug.
