### PR TITLE
`Paywalls`: fix crash when computing localization with duplicate packages

### DIFF
--- a/RevenueCatUI/Data/TemplateViewConfiguration.swift
+++ b/RevenueCatUI/Data/TemplateViewConfiguration.swift
@@ -90,6 +90,24 @@ extension TemplateViewConfiguration.PackageConfiguration {
 
 }
 
+// MARK: - Helpers
+
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+extension TemplateViewConfiguration.PackageConfiguration {
+
+    /// - Returns: a dictionary for all localizations keyed by each package.
+    func localizationPerPackage() -> [Package: ProcessedLocalizedConfiguration] {
+        return .init(
+            self.all
+                .lazy
+                .map { ($0.content, $0.localization) },
+            // Ignore duplicates
+            uniquingKeysWith: { first, _ in first }
+        )
+    }
+
+}
+
 // MARK: - Creation
 
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)

--- a/RevenueCatUI/Templates/MultiPackageBoldTemplate.swift
+++ b/RevenueCatUI/Templates/MultiPackageBoldTemplate.swift
@@ -19,11 +19,7 @@ struct MultiPackageBoldTemplate: TemplateViewType {
         self._selectedPackage = .init(initialValue: configuration.packages.default.content)
 
         self.configuration = configuration
-        self.localization = Dictionary(
-            uniqueKeysWithValues: configuration.packages.all
-                .lazy
-                .map { ($0.content, $0.localization) }
-            )
+        self.localization = configuration.packages.localizationPerPackage()
     }
 
     var body: some View {


### PR DESCRIPTION
Thanks to @joshdholtz for catching this.