### PR TITLE
`Paywalls`: changed `offerDetails` to be optional

### DIFF
--- a/RevenueCatUI/Data/ProcessedLocalizedConfiguration.swift
+++ b/RevenueCatUI/Data/ProcessedLocalizedConfiguration.swift
@@ -11,7 +11,7 @@ struct ProcessedLocalizedConfiguration: PaywallLocalizedConfiguration {
     var subtitle: String?
     var callToAction: String
     var callToActionWithIntroOffer: String?
-    var offerDetails: String
+    var offerDetails: String?
     var offerDetailsWithIntroOffer: String?
     var offerName: String?
     var features: [Feature]
@@ -27,7 +27,7 @@ struct ProcessedLocalizedConfiguration: PaywallLocalizedConfiguration {
             callToAction: configuration.callToAction.processed(with: dataProvider, locale: locale),
             callToActionWithIntroOffer: configuration.callToActionWithIntroOffer?.processed(with: dataProvider,
                                                                                             locale: locale),
-            offerDetails: configuration.offerDetails.processed(with: dataProvider, locale: locale),
+            offerDetails: configuration.offerDetails?.processed(with: dataProvider, locale: locale),
             offerDetailsWithIntroOffer: configuration.offerDetailsWithIntroOffer?.processed(with: dataProvider,
                                                                                             locale: locale),
             offerName: configuration.offerName?.processed(with: dataProvider, locale: locale),
@@ -44,7 +44,7 @@ struct ProcessedLocalizedConfiguration: PaywallLocalizedConfiguration {
         subtitle: String?,
         callToAction: String,
         callToActionWithIntroOffer: String?,
-        offerDetails: String,
+        offerDetails: String?,
         offerDetailsWithIntroOffer: String?,
         offerName: String?,
         features: [Feature]

--- a/RevenueCatUI/Views/IntroEligibilityStateView.swift
+++ b/RevenueCatUI/Views/IntroEligibilityStateView.swift
@@ -12,14 +12,14 @@ import SwiftUI
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 struct IntroEligibilityStateView: View {
 
-    var textWithNoIntroOffer: String
+    var textWithNoIntroOffer: String?
     var textWithIntroOffer: String?
     var introEligibility: IntroEligibilityStatus?
     var foregroundColor: Color?
     var alignment: Alignment
 
     init(
-        textWithNoIntroOffer: String,
+        textWithNoIntroOffer: String?,
         textWithIntroOffer: String?,
         introEligibility: IntroEligibilityStatus?,
         foregroundColor: Color? = nil,
@@ -38,7 +38,7 @@ struct IntroEligibilityStateView: View {
             // only if there is a custom intro text.
             .withPendingData(self.needsToWaitForIntroEligibility, alignment: self.alignment)
             // Hide if there is no intro but we have no text to ensure layout does not change.
-            .hidden(if: self.isNotEligibleForIntro && self.textWithNoIntroOffer.isEmpty)
+            .hidden(if: self.isNotEligibleForIntro && self.textWithNoIntroOffer == nil)
             .foregroundColor(self.foregroundColor)
             .tint(self.foregroundColor)
     }
@@ -49,7 +49,7 @@ struct IntroEligibilityStateView: View {
         } else {
             // Display text with intro offer as a backup to ensure layout does not change
             // when switching states.
-            return self.textWithNoIntroOffer.notEmpty ?? self.textWithIntroOffer ?? ""
+            return self.textWithNoIntroOffer ?? self.textWithIntroOffer ?? ""
         }
     }
 
@@ -89,11 +89,5 @@ private extension View {
             }
             .transition(.opacity.animation(Constants.defaultAnimation))
     }
-
-}
-
-private extension String {
-
-    var notEmpty: String? { return self.isEmpty ? nil : self }
 
 }

--- a/Sources/Paywalls/PaywallData.swift
+++ b/Sources/Paywalls/PaywallData.swift
@@ -46,7 +46,7 @@ public protocol PaywallLocalizedConfiguration {
     /// If `nil`, no information regarding trial eligibility will be displayed.
     var callToActionWithIntroOffer: String? { get }
     /// Description for the offer to be purchased.
-    var offerDetails: String { get }
+    var offerDetails: String? { get }
     /// Description for the offer to be purchased when an intro offer is available.
     /// If `nil`, no information regarding trial eligibility will be displayed.
     var offerDetailsWithIntroOffer: String? { get }
@@ -68,10 +68,11 @@ extension PaywallData {
         public var title: String
         public var subtitle: String?
         public var callToAction: String
-        public var offerDetails: String
         public var offerName: String?
         @NonEmptyStringDecodable
         var _callToActionWithIntroOffer: String?
+        @NonEmptyStringDecodable
+        var _offerDetails: String?
         @NonEmptyStringDecodable
         var _offerDetailsWithIntroOffer: String?
         @DefaultDecodable.EmptyArray
@@ -80,6 +81,10 @@ extension PaywallData {
         public var callToActionWithIntroOffer: String? {
             get { return self._callToActionWithIntroOffer }
             set { self._callToActionWithIntroOffer = newValue }
+        }
+        public var offerDetails: String? {
+            get { return self._offerDetails }
+            set { self._offerDetails = newValue }
         }
         public var offerDetailsWithIntroOffer: String? {
             get { return self._offerDetailsWithIntroOffer }
@@ -95,7 +100,7 @@ extension PaywallData {
             subtitle: String? = nil,
             callToAction: String,
             callToActionWithIntroOffer: String? = nil,
-            offerDetails: String,
+            offerDetails: String?,
             offerDetailsWithIntroOffer: String? = nil,
             offerName: String? = nil,
             features: [Feature] = []
@@ -104,7 +109,7 @@ extension PaywallData {
             self.subtitle = subtitle
             self.callToAction = callToAction
             self._callToActionWithIntroOffer = callToActionWithIntroOffer
-            self.offerDetails = offerDetails
+            self._offerDetails = offerDetails
             self._offerDetailsWithIntroOffer = offerDetailsWithIntroOffer
             self.offerName = offerName
             self.features = features
@@ -395,7 +400,7 @@ extension PaywallData.LocalizedConfiguration: Codable {
         case subtitle
         case callToAction
         case _callToActionWithIntroOffer = "callToActionWithIntroOffer"
-        case offerDetails
+        case _offerDetails = "offerDetails"
         case _offerDetailsWithIntroOffer = "offerDetailsWithIntroOffer"
         case offerName
         case _features = "features"

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PaywallAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PaywallAPI.swift
@@ -55,7 +55,7 @@ func checkPaywallLocalizedConfig(_ config: PaywallData.LocalizedConfiguration) {
     let subtitle: String? = config.subtitle
     let callToAction: String = config.callToAction
     let callToActionWithIntroOffer: String? = config.callToActionWithIntroOffer
-    let offerDetails: String = config.offerDetails
+    let offerDetails: String? = config.offerDetails
     let offerDetailsWithIntroOffer: String? = config.offerDetailsWithIntroOffer
     let offerName: String? = config.offerName
     let features: [PaywallData.LocalizedConfiguration.Feature] = config.features

--- a/Tests/UnitTests/Networking/Responses/Fixtures/PaywallData-Sample1.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/PaywallData-Sample1.json
@@ -25,7 +25,6 @@
         "es_ES": {
             "title": "Tienda",
             "call_to_action": "Comprar",
-            "offer_details": "{{ price_per_month }} cada mes",
             "offer_details_with_intro_offer": " ",
             "offer_name": "{{ period }}",
             "features": [

--- a/Tests/UnitTests/Paywalls/PaywallDataTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallDataTests.swift
@@ -79,7 +79,7 @@ class PaywallDataTests: BaseHTTPResponseTest {
         expect(esConfig.subtitle).to(beNil())
         expect(esConfig.callToAction) == "Comprar"
         expect(esConfig.callToActionWithIntroOffer).to(beNil())
-        expect(esConfig.offerDetails) == "{{ price_per_month }} cada mes"
+        expect(esConfig.offerDetails).to(beNil())
         expect(esConfig.offerDetailsWithIntroOffer).to(beNil())
         expect(esConfig.offerName) == "{{ period }}"
         expect(esConfig.features) == [


### PR DESCRIPTION
In template 4 this is optional, so all templates will support this now.