### PR TITLE
`Paywalls`: changed default `PaywallData` to display available packages

### DIFF
--- a/RevenueCatUI/Helpers/PaywallData+Default.swift
+++ b/RevenueCatUI/Helpers/PaywallData+Default.swift
@@ -15,22 +15,24 @@ extension PaywallData {
 
     /// Default `PaywallData` to display when attempting to present a ``PaywallView`` with an offering
     /// that has no paywall configuration, or when that configuration is invalid.
-    public static let `default`: Self = .init(
-        template: .multiPackageBold,
-        config: .init(
-            packages: [
-                Package.string(from: .weekly)!,
-                Package.string(from: .monthly)!,
-                Package.string(from: .annual)!
-            ],
-            images: .init(background: Self.backgroundImage),
-            colors: Self.colors,
-            blurredBackgroundImage: true,
-            displayRestorePurchases: true
-        ),
-        localization: Self.localization,
-        assetBaseURL: Self.defaultTemplateBaseURL
-    )
+    static func createDefault(with packages: [Package]) -> Self {
+        return self.createDefault(with: packages.map(\.identifier))
+    }
+
+    static func createDefault(with packageIdentifiers: [String]) -> Self {
+        return .init(
+            template: .multiPackageBold,
+            config: .init(
+                packages: packageIdentifiers,
+                images: .init(background: Self.backgroundImage),
+                colors: Self.colors,
+                blurredBackgroundImage: true,
+                displayRestorePurchases: true
+            ),
+            localization: Self.localization,
+            assetBaseURL: Self.defaultTemplateBaseURL
+        )
+    }
 
 }
 
@@ -91,7 +93,11 @@ struct DefaultPaywall_Previews: PreviewProvider {
         identifier: "offering",
         serverDescription: "Main offering",
         metadata: [:],
-        paywall: .default,
+        paywall: .createDefault(with: [
+            TestData.weeklyPackage,
+            TestData.monthlyPackage,
+            TestData.annualPackage
+        ]),
         availablePackages: TestData.packages
     )
 

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -108,7 +108,7 @@ public struct PaywallView: View {
             LoadedOfferingPaywallView(
                 offering: offering,
                 paywall: paywall,
-                mode: mode,
+                mode: self.mode,
                 introEligibility: checker,
                 purchaseHandler: purchaseHandler
             )
@@ -121,8 +121,8 @@ public struct PaywallView: View {
                     AnyView(
                         LoadedOfferingPaywallView(
                             offering: offering,
-                            paywall: .default,
-                            mode: mode,
+                            paywall: .createDefault(with: offering.availablePackages),
+                            mode: self.mode,
                             introEligibility: checker,
                             purchaseHandler: purchaseHandler
                         )

--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -21,14 +21,10 @@ struct LoadingPaywallView: View {
                 identifier: Self.offeringIdentifier,
                 serverDescription: "",
                 metadata: [:],
-                paywall: .default,
-                availablePackages: [
-                    Self.monthlyPackage,
-                    Self.weeklyPackage,
-                    Self.annualPackage
-                ]
+                paywall: Self.defaultPaywall,
+                availablePackages: Self.packages
             ),
-            paywall: .default,
+            paywall: Self.defaultPaywall,
             mode: .fullScreen,
             introEligibility: Self.introEligibility,
             purchaseHandler: Self.purchaseHandler
@@ -36,6 +32,14 @@ struct LoadingPaywallView: View {
         .disabled(true)
         .redacted(reason: .placeholder)
     }
+
+    private static let defaultPaywall: PaywallData = .createDefault(with: Self.packages)
+
+    private static let packages: [Package] = [
+        Self.monthlyPackage,
+        Self.weeklyPackage,
+        Self.annualPackage
+    ]
 
 }
 


### PR DESCRIPTION
Currently it was doing a best effort and showing `weekly`/`monthly`/`annual` if those existed in the offering. This makes it so it doesn't have to guess, and it creates a `Paywall` using the `availablePackages`.