### PR TITLE
`Paywalls`: deploy `debug` sample app

### DIFF
--- a/Tests/TestingApps/SimpleApp/SimpleApp.xcodeproj/xcshareddata/xcschemes/SimpleApp - Live Config.xcscheme
+++ b/Tests/TestingApps/SimpleApp/SimpleApp.xcodeproj/xcshareddata/xcschemes/SimpleApp - Live Config.xcscheme
@@ -71,7 +71,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>


### PR DESCRIPTION
I broke something and noticed that I wasn't seeing the error in TestFlight. Because this is a test app, it's useful to see the debug errors there too.