### PR TITLE
[DO NOT MERGE] Post SK2 transaction JWS instead of SK1 receipt to the receipts endpoint

### DIFF
--- a/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
+++ b/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
@@ -14,7 +14,7 @@
 import Foundation
 import StoreKit
 
-protocol PurchasedProductsFetcherType {
+protocol PurchasedProductsFetcherType: Sendable {
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func fetchPurchasedProducts() async throws -> [PurchasedSK2Product]

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -321,6 +321,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         let transactionPoster = TransactionPoster(
             productsManager: productsManager,
             receiptFetcher: receiptFetcher,
+            purchasedProductsFetcher: purchasedProductsFetcher,
             backend: backend,
             paymentQueueWrapper: paymentQueueWrapper,
             systemInfo: systemInfo,

--- a/Sources/Purchasing/Purchases/TransactionPoster.swift
+++ b/Sources/Purchasing/Purchases/TransactionPoster.swift
@@ -90,8 +90,7 @@ final class TransactionPoster: TransactionPosterType {
         ))
 
         self.purchasedProductsFetcher?.fetchPurchasedProductForTransaction(
-          transaction.transactionIdentifier
-        ) { jwsRepresentation in
+          transaction.transactionIdentifier) { jwsRepresentation in
           guard let jwsRepresentation = jwsRepresentation else {
             fatalError("Could not fetch jswRepesentation")
           }

--- a/Sources/Purchasing/Purchases/TransactionPoster.swift
+++ b/Sources/Purchasing/Purchases/TransactionPoster.swift
@@ -57,6 +57,7 @@ final class TransactionPoster: TransactionPosterType {
 
     private let productsManager: ProductsManagerType
     private let receiptFetcher: ReceiptFetcher
+    private let purchasedProductsFetcher: PurchasedProductsFetcherType?
     private let backend: Backend
     private let paymentQueueWrapper: EitherPaymentQueueWrapper
     private let systemInfo: SystemInfo
@@ -65,6 +66,7 @@ final class TransactionPoster: TransactionPosterType {
     init(
         productsManager: ProductsManagerType,
         receiptFetcher: ReceiptFetcher,
+        purchasedProductsFetcher: PurchasedProductsFetcherType?,
         backend: Backend,
         paymentQueueWrapper: EitherPaymentQueueWrapper,
         systemInfo: SystemInfo,
@@ -72,6 +74,7 @@ final class TransactionPoster: TransactionPosterType {
     ) {
         self.productsManager = productsManager
         self.receiptFetcher = receiptFetcher
+        self.purchasedProductsFetcher = purchasedProductsFetcher
         self.backend = backend
         self.paymentQueueWrapper = paymentQueueWrapper
         self.systemInfo = systemInfo
@@ -86,22 +89,18 @@ final class TransactionPoster: TransactionPosterType {
             offeringID: data.presentedOfferingID
         ))
 
-        self.receiptFetcher.receiptData(
-            refreshPolicy: self.refreshRequestPolicy(forProductIdentifier: transaction.productIdentifier)
-        ) { receiptData, receiptURL in
-            if let receiptData = receiptData, !receiptData.isEmpty {
-                self.fetchProductsAndPostReceipt(
-                    transaction: transaction,
-                    data: data,
-                    receiptData: receiptData,
-                    completion: completion
-                )
-            } else {
-                self.handleReceiptPost(withTransaction: transaction,
-                                       result: .failure(.missingReceiptFile(receiptURL)),
-                                       subscriberAttributes: nil,
-                                       completion: completion)
-            }
+        self.purchasedProductsFetcher?.fetchPurchasedProductForTransaction(
+          transaction.transactionIdentifier
+        ) { jwsRepresentation in
+          guard let jwsRepresentation = jwsRepresentation else {
+            fatalError("Could not fetch jswRepesentation")
+          }
+          self.fetchProductsAndPostReceipt(
+              transaction: transaction,
+              data: data,
+              receiptData: jwsRepresentation.asData,
+              completion: completion
+          )
         }
     }
 

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -21,6 +21,7 @@ import XCTest
 class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
     private var productsManager: MockProductsManager!
+    private var purchasedProductsFetcher: MockPurchasedProductsFetcher!
     private var storeKit1Wrapper: MockStoreKit1Wrapper!
     private var systemInfo: MockSystemInfo!
     private var subscriberAttributesManager: MockSubscriberAttributesManager!
@@ -51,6 +52,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         self.productsManager = MockProductsManager(systemInfo: self.systemInfo,
                                                    requestTimeout: Configuration.storeKitRequestTimeoutDefault)
+        self.purchasedProductsFetcher = .init()
         self.operationDispatcher = MockOperationDispatcher()
         self.receiptFetcher = MockReceiptFetcher(requestFetcher: MockRequestFetcher(), systemInfo: self.systemInfo)
         self.receiptParser = MockReceiptParser()
@@ -191,6 +193,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         return .init(
             productsManager: self.productsManager,
             receiptFetcher: self.receiptFetcher,
+            purchasedProductsFetcher: self.purchasedProductsFetcher,
             backend: self.backend,
             paymentQueueWrapper: self.paymentQueueWrapper,
             systemInfo: self.systemInfo,

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/PurchaseTester.xcodeproj/project.pbxproj
@@ -982,7 +982,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/RevenueCat/purchases-ios";
 			requirement = {
-				branch = main;
+				branch = "poc-sk2-jwt";
 				kind = branch;
 			};
 		};

--- a/Tests/UnitTests/Mocks/MockPurchasedProductsFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockPurchasedProductsFetcher.swift
@@ -15,7 +15,7 @@ import Foundation
 @testable import RevenueCat
 import StoreKit
 
-final class MockPurchasedProductsFetcher: PurchasedProductsFetcherType {
+class MockPurchasedProductsFetcher: PurchasedProductsFetcherType, @unchecked Sendable {
 
     var invokedFetch = false
     var invokedFetchCount = 0
@@ -27,6 +27,10 @@ final class MockPurchasedProductsFetcher: PurchasedProductsFetcherType {
         self.invokedFetchCount += 1
 
         return try self.stubbedResult.get()
+    }
+
+    func fetchPurchasedProductForTransaction(_ transactionId: String, completion: @escaping (String?) -> Void) {
+
     }
 
     var invokedClearCache = false

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -41,6 +41,7 @@ class BasePurchasesTests: TestCase {
         self.deviceCache = MockDeviceCache(sandboxEnvironmentDetector: self.systemInfo,
                                            userDefaults: self.userDefaults)
         self.requestFetcher = MockRequestFetcher()
+        self.purchasedProductsFetcher = .init()
         self.mockProductsManager = MockProductsManager(systemInfo: self.systemInfo,
                                                        requestTimeout: Configuration.storeKitRequestTimeoutDefault)
         self.mockOperationDispatcher = MockOperationDispatcher()
@@ -132,6 +133,7 @@ class BasePurchasesTests: TestCase {
     var receiptFetcher: MockReceiptFetcher!
     var requestFetcher: MockRequestFetcher!
     var mockProductsManager: MockProductsManager!
+    var purchasedProductsFetcher: MockPurchasedProductsFetcher!
     var backend: MockBackend!
     var storeKit1Wrapper: MockStoreKit1Wrapper!
     var mockPaymentQueueWrapper: MockPaymentQueueWrapper!
@@ -177,6 +179,7 @@ class BasePurchasesTests: TestCase {
         return .init(
             productsManager: self.mockProductsManager,
             receiptFetcher: self.receiptFetcher,
+            purchasedProductsFetcher: self.purchasedProductsFetcher,
             backend: self.backend,
             paymentQueueWrapper: self.paymentQueueWrapper,
             systemInfo: self.systemInfo,

--- a/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
@@ -19,6 +19,7 @@ import XCTest
 class TransactionPosterTests: TestCase {
 
     private var productsManager: MockProductsManager!
+    private var purchasedProductsFetcher: MockPurchasedProductsFetcher!
     private var receiptFetcher: MockReceiptFetcher!
     private var backend: MockBackend!
     private var paymentQueueWrapper: MockPaymentQueueWrapper!
@@ -126,6 +127,7 @@ private extension TransactionPosterTests {
         self.operationDispatcher = .init()
         self.systemInfo = .init(finishTransactions: !observerMode)
         self.productsManager = .init(systemInfo: self.systemInfo, requestTimeout: 0)
+        self.purchasedProductsFetcher = .init()
         self.receiptFetcher = .init(requestFetcher: .init(operationDispatcher: self.operationDispatcher),
                                     systemInfo: self.systemInfo)
         self.backend = .init()
@@ -134,6 +136,7 @@ private extension TransactionPosterTests {
         self.poster = .init(
             productsManager: self.productsManager,
             receiptFetcher: self.receiptFetcher,
+            purchasedProductsFetcher: self.purchasedProductsFetcher,
             backend: self.backend,
             paymentQueueWrapper: .right(self.paymentQueueWrapper),
             systemInfo: self.systemInfo,

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -117,6 +117,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
         self.transactionPoster = TransactionPoster(
             productsManager: self.mockProductsManager,
             receiptFetcher: self.mockReceiptFetcher,
+            purchasedProductsFetcher: self.mockPurchasedProductsFetcher,
             backend: self.mockBackend,
             paymentQueueWrapper: self.paymentQueueWrapper,
             systemInfo: self.systemInfo,


### PR DESCRIPTION
This is just a Proof of Concept to post SK2 transaction JWS instead of SK1 receipt to the /receipts endpoint