### PR TITLE
`AdServices`: Rename `postAdServicesTokenIfNeeded()` to `postAdServicesTokenOncePerInstallIfNeeded()`

### DIFF
--- a/Sources/Attribution/AttributionPoster.swift
+++ b/Sources/Attribution/AttributionPoster.swift
@@ -127,7 +127,7 @@ final class AttributionPoster {
     @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
-    func postAdServicesTokenOnlyOncePerInstallIfNeeded() {
+    func postAdServicesTokenOncePerInstallIfNeeded() {
         guard let attributionToken = self.adServicesTokenToPostIfNeeded else { return }
 
         self.post(adServicesToken: attributionToken)

--- a/Sources/Attribution/AttributionPoster.swift
+++ b/Sources/Attribution/AttributionPoster.swift
@@ -127,7 +127,7 @@ final class AttributionPoster {
     @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
-    func postAdServicesTokenIfNeeded() {
+    func postAdServicesTokenOnlyOncePerInstallIfNeeded() {
         guard let attributionToken = self.adServicesTokenToPostIfNeeded else { return }
 
         self.post(adServicesToken: attributionToken)

--- a/Sources/Purchasing/Purchases/Attribution.swift
+++ b/Sources/Purchasing/Purchases/Attribution.swift
@@ -63,13 +63,13 @@ public extension Attribution {
     @objc func enableAdServicesAttributionTokenCollection() {
         self.automaticAdServicesAttributionTokenCollection = true
 
-        self.postAdServicesTokenIfNeeded()
+        self.postAdServicesTokenOnlyOncePerInstallIfNeeded()
     }
 
-    internal func postAdServicesTokenIfNeeded() {
+    internal func postAdServicesTokenOnlyOncePerInstallIfNeeded() {
         if self.automaticAdServicesAttributionTokenCollection,
            self.automaticAdServicesTokenPostingEnabled {
-            self.attributionPoster.postAdServicesTokenIfNeeded()
+            self.attributionPoster.postAdServicesTokenOnlyOncePerInstallIfNeeded()
         }
     }
 

--- a/Sources/Purchasing/Purchases/Attribution.swift
+++ b/Sources/Purchasing/Purchases/Attribution.swift
@@ -63,13 +63,13 @@ public extension Attribution {
     @objc func enableAdServicesAttributionTokenCollection() {
         self.automaticAdServicesAttributionTokenCollection = true
 
-        self.postAdServicesTokenOnlyOncePerInstallIfNeeded()
+        self.postAdServicesTokenOncePerInstallIfNeeded()
     }
 
-    internal func postAdServicesTokenOnlyOncePerInstallIfNeeded() {
+    internal func postAdServicesTokenOncePerInstallIfNeeded() {
         if self.automaticAdServicesAttributionTokenCollection,
            self.automaticAdServicesTokenPostingEnabled {
-            self.attributionPoster.postAdServicesTokenOnlyOncePerInstallIfNeeded()
+            self.attributionPoster.postAdServicesTokenOncePerInstallIfNeeded()
         }
     }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1498,7 +1498,7 @@ private extension Purchases {
 
         #if os(iOS) || os(macOS)
         if #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) {
-            self.attribution.postAdServicesTokenOnlyOncePerInstallIfNeeded()
+            self.attribution.postAdServicesTokenOncePerInstallIfNeeded()
         }
         #endif
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1498,7 +1498,7 @@ private extension Purchases {
 
         #if os(iOS) || os(macOS)
         if #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) {
-            self.attribution.postAdServicesTokenIfNeeded()
+            self.attribution.postAdServicesTokenOnlyOncePerInstallIfNeeded()
         }
         #endif
 

--- a/Tests/UnitTests/Attribution/AttributionPosterTests.swift
+++ b/Tests/UnitTests/Attribution/AttributionPosterTests.swift
@@ -311,35 +311,35 @@ class AdServicesAttributionPosterTests: BaseAttributionPosterTests {
 
         expect(self.attributionPoster.adServicesTokenToPostIfNeeded).toNot(beNil())
 
-        self.attributionPoster.postAdServicesTokenOnlyOncePerInstallIfNeeded()
+        self.attributionPoster.postAdServicesTokenOncePerInstallIfNeeded()
 
         expect(self.attributionPoster.adServicesTokenToPostIfNeeded).to(beNil())
     }
 
-    func testPostAdServicesTokenOnlyOncePerInstallIfNeededSkipsIfAlreadySent() {
+    func testPostAdServicesTokenOncePerInstallIfNeededSkipsIfAlreadySent() {
         backend.stubbedPostAdServicesTokenCompletionResult = .success(())
 
-        attributionPoster.postAdServicesTokenOnlyOncePerInstallIfNeeded()
+        attributionPoster.postAdServicesTokenOncePerInstallIfNeeded()
         expect(self.backend.invokedPostAdServicesTokenCount) == 1
         expect(self.subscriberAttributesManager.invokedConvertAttributionDataAndSetCount) == 0
         expect(self.deviceCache.invokedSetLatestNetworkAndAdvertisingIdsSentCount) == 1
 
-        attributionPoster.postAdServicesTokenOnlyOncePerInstallIfNeeded()
+        attributionPoster.postAdServicesTokenOncePerInstallIfNeeded()
         expect(self.backend.invokedPostAdServicesTokenCount) == 1
         expect(self.deviceCache.invokedSetLatestNetworkAndAdvertisingIdsSentCount) == 1
         expect(self.subscriberAttributesManager.invokedConvertAttributionDataAndSetCount) == 0
     }
 
-    func testPostAdServicesTokenOnlyOncePerInstallIfNeededSkipsIfNilToken() throws {
+    func testPostAdServicesTokenOncePerInstallIfNeededSkipsIfNilToken() throws {
         backend.stubbedPostAdServicesTokenCompletionResult = .success(())
 
         attributionFetcher.adServicesTokenToReturn = nil
-        attributionPoster.postAdServicesTokenOnlyOncePerInstallIfNeeded()
+        attributionPoster.postAdServicesTokenOncePerInstallIfNeeded()
         expect(self.backend.invokedPostAdServicesTokenCount) == 0
         expect(self.subscriberAttributesManager.invokedConvertAttributionDataAndSetCount) == 0
     }
 
-    func testPostAdServicesTokenOnlyOncePerInstallIfNeededDoesNotCacheOnAPIError() throws {
+    func testPostAdServicesTokenOncePerInstallIfNeededDoesNotCacheOnAPIError() throws {
         let stubbedError: BackendError = .networkError(
             .errorResponse(.init(code: .invalidAPIKey,
                                  originalCode: BackendErrorCode.invalidAPIKey.rawValue,
@@ -350,7 +350,7 @@ class AdServicesAttributionPosterTests: BaseAttributionPosterTests {
         backend.stubbedPostAdServicesTokenCompletionResult = .failure(stubbedError)
 
         attributionFetcher.adServicesTokenToReturn = nil
-        attributionPoster.postAdServicesTokenOnlyOncePerInstallIfNeeded()
+        attributionPoster.postAdServicesTokenOncePerInstallIfNeeded()
         expect(self.deviceCache.invokedSetLatestNetworkAndAdvertisingIdsSentCount) == 0
     }
 
@@ -359,7 +359,7 @@ class AdServicesAttributionPosterTests: BaseAttributionPosterTests {
 
         let adServicesToken = "asdf"
         attributionFetcher.adServicesTokenToReturn = adServicesToken
-        attributionPoster.postAdServicesTokenOnlyOncePerInstallIfNeeded()
+        attributionPoster.postAdServicesTokenOncePerInstallIfNeeded()
         expect(self.deviceCache.invokedSetLatestNetworkAndAdvertisingIdsSentCount) == 1
         expect(self.deviceCache.invokedSetLatestNetworkAndAdvertisingIdsSentParameters) ==
             ([.adServices: adServicesToken], currentUserProvider.currentAppUserID)

--- a/Tests/UnitTests/Attribution/AttributionPosterTests.swift
+++ b/Tests/UnitTests/Attribution/AttributionPosterTests.swift
@@ -311,35 +311,35 @@ class AdServicesAttributionPosterTests: BaseAttributionPosterTests {
 
         expect(self.attributionPoster.adServicesTokenToPostIfNeeded).toNot(beNil())
 
-        self.attributionPoster.postAdServicesTokenIfNeeded()
+        self.attributionPoster.postAdServicesTokenOnlyOncePerInstallIfNeeded()
 
         expect(self.attributionPoster.adServicesTokenToPostIfNeeded).to(beNil())
     }
 
-    func testPostAdServicesTokenIfNeededSkipsIfAlreadySent() {
+    func testPostAdServicesTokenOnlyOncePerInstallIfNeededSkipsIfAlreadySent() {
         backend.stubbedPostAdServicesTokenCompletionResult = .success(())
 
-        attributionPoster.postAdServicesTokenIfNeeded()
+        attributionPoster.postAdServicesTokenOnlyOncePerInstallIfNeeded()
         expect(self.backend.invokedPostAdServicesTokenCount) == 1
         expect(self.subscriberAttributesManager.invokedConvertAttributionDataAndSetCount) == 0
         expect(self.deviceCache.invokedSetLatestNetworkAndAdvertisingIdsSentCount) == 1
 
-        attributionPoster.postAdServicesTokenIfNeeded()
+        attributionPoster.postAdServicesTokenOnlyOncePerInstallIfNeeded()
         expect(self.backend.invokedPostAdServicesTokenCount) == 1
         expect(self.deviceCache.invokedSetLatestNetworkAndAdvertisingIdsSentCount) == 1
         expect(self.subscriberAttributesManager.invokedConvertAttributionDataAndSetCount) == 0
     }
 
-    func testPostAdServicesTokenIfNeededSkipsIfNilToken() throws {
+    func testPostAdServicesTokenOnlyOncePerInstallIfNeededSkipsIfNilToken() throws {
         backend.stubbedPostAdServicesTokenCompletionResult = .success(())
 
         attributionFetcher.adServicesTokenToReturn = nil
-        attributionPoster.postAdServicesTokenIfNeeded()
+        attributionPoster.postAdServicesTokenOnlyOncePerInstallIfNeeded()
         expect(self.backend.invokedPostAdServicesTokenCount) == 0
         expect(self.subscriberAttributesManager.invokedConvertAttributionDataAndSetCount) == 0
     }
 
-    func testPostAdServicesTokenIfNeededDoesNotCacheOnAPIError() throws {
+    func testPostAdServicesTokenOnlyOncePerInstallIfNeededDoesNotCacheOnAPIError() throws {
         let stubbedError: BackendError = .networkError(
             .errorResponse(.init(code: .invalidAPIKey,
                                  originalCode: BackendErrorCode.invalidAPIKey.rawValue,
@@ -350,7 +350,7 @@ class AdServicesAttributionPosterTests: BaseAttributionPosterTests {
         backend.stubbedPostAdServicesTokenCompletionResult = .failure(stubbedError)
 
         attributionFetcher.adServicesTokenToReturn = nil
-        attributionPoster.postAdServicesTokenIfNeeded()
+        attributionPoster.postAdServicesTokenOnlyOncePerInstallIfNeeded()
         expect(self.deviceCache.invokedSetLatestNetworkAndAdvertisingIdsSentCount) == 0
     }
 
@@ -359,7 +359,7 @@ class AdServicesAttributionPosterTests: BaseAttributionPosterTests {
 
         let adServicesToken = "asdf"
         attributionFetcher.adServicesTokenToReturn = adServicesToken
-        attributionPoster.postAdServicesTokenIfNeeded()
+        attributionPoster.postAdServicesTokenOnlyOncePerInstallIfNeeded()
         expect(self.deviceCache.invokedSetLatestNetworkAndAdvertisingIdsSentCount) == 1
         expect(self.deviceCache.invokedSetLatestNetworkAndAdvertisingIdsSentParameters) ==
             ([.adServices: adServicesToken], currentUserProvider.currentAppUserID)


### PR DESCRIPTION
### Motivation

It was not clear what `postAdServicesTokenIfNeeded()` was doing for anybody unfamiliar with our codebase or AdServices. This method is in `applicationWillEnterForeground` and without digging into any of the implementation, it looks like it could send the attribution token every time the app enters the foreground. 

The behavior was actually only sending it once per install (as it should) so the method rename reflects that.

### Description
Renames `postAdServicesTokenIfNeeded()` to `postAdServicesTokenOncePerInstallIfNeeded()`
