### PR TITLE
`IntroEligibility`: changed products to `Set<String>`

### DIFF
--- a/Sources/Networking/OfferingsAPI.swift
+++ b/Sources/Networking/OfferingsAPI.swift
@@ -49,7 +49,7 @@ class OfferingsAPI {
 
     func getIntroEligibility(appUserID: String,
                              receiptData: Data,
-                             productIdentifiers: [String],
+                             productIdentifiers: Set<String>,
                              completion: @escaping IntroEligibilityResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
                                                                 appUserID: appUserID)

--- a/Sources/Purchasing/CachingTrialOrIntroPriceEligibilityChecker.swift
+++ b/Sources/Purchasing/CachingTrialOrIntroPriceEligibilityChecker.swift
@@ -49,7 +49,7 @@ class CachingTrialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityCh
 extension CachingTrialOrIntroPriceEligibilityChecker {
 
     func checkEligibility(
-        productIdentifiers: [String],
+        productIdentifiers: Set<String>,
         completion: @escaping ReceiveIntroEligibilityBlock
     ) {
         guard !productIdentifiers.isEmpty else {
@@ -73,7 +73,7 @@ extension CachingTrialOrIntroPriceEligibilityChecker {
         if missingProducts.isEmpty {
             completion(cached)
         } else {
-            self.checker.checkEligibility(productIdentifiers: Array(missingProducts)) { result in
+            self.checker.checkEligibility(productIdentifiers: missingProducts) { result in
                 let productsToCache = result.filter { $0.value.shouldCache }
 
                 Logger.debug(Strings.eligibility.caching_intro_eligibility_for_products(Set(productsToCache.keys)))
@@ -85,6 +85,10 @@ extension CachingTrialOrIntroPriceEligibilityChecker {
     }
 
 }
+
+// @unchecked because:
+// - Class is not `final` (it's mocked). This implicitly makes subclasses `Sendable` even if they're not thread-safe.
+extension CachingTrialOrIntroPriceEligibilityChecker: @unchecked Sendable {}
 
 // MARK: - Private
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -884,8 +884,8 @@ public extension Purchases {
     @objc(checkTrialOrIntroDiscountEligibility:completion:)
     func checkTrialOrIntroDiscountEligibility(productIdentifiers: [String],
                                               completion: @escaping ([String: IntroEligibility]) -> Void) {
-        trialOrIntroPriceEligibilityChecker.checkEligibility(productIdentifiers: productIdentifiers,
-                                                             completion: completion)
+        self.trialOrIntroPriceEligibilityChecker.checkEligibility(productIdentifiers: Set(productIdentifiers),
+                                                                  completion: completion)
     }
 
     @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK1Tests.swift
@@ -94,7 +94,7 @@ class TrialOrIntroPriceEligibilityCheckerSK1Tests: StoreKitConfigTestCase {
                         ("com.revenuecat.annual_39.99.2_week_intro", MockSKProductDiscount()),
                         ("lifetime", MockSKProductDiscount())
         ]
-        let productIdentifiers = productIdentifiersAndDiscounts.map({$0.0})
+        let productIdentifiers = Set(productIdentifiersAndDiscounts.map(\.0))
         let storeProducts = productIdentifiersAndDiscounts.map { (productIdentifier, discount) -> StoreProduct in
             let sk1Product = MockSK1Product(mockProductIdentifier: productIdentifier)
             sk1Product.mockDiscount = discount

--- a/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
+++ b/Tests/StoreKitUnitTests/TrialOrIntroPriceEligibilityCheckerSK2Tests.swift
@@ -61,10 +61,10 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
     func testSK2CheckEligibilityAsync() async throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        let products = ["product_id",
-                        "com.revenuecat.monthly_4.99.1_week_intro",
-                        "com.revenuecat.annual_39.99.2_week_intro",
-                        "lifetime"]
+        let products: Set<String> = ["product_id",
+                                     "com.revenuecat.monthly_4.99.1_week_intro",
+                                     "com.revenuecat.annual_39.99.2_week_intro",
+                                     "lifetime"]
         let expected = ["product_id": IntroEligibilityStatus.unknown,
                         "com.revenuecat.monthly_4.99.1_week_intro": IntroEligibilityStatus.eligible,
                         "com.revenuecat.annual_39.99.2_week_intro": IntroEligibilityStatus.eligible,
@@ -84,10 +84,10 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
     func testCheckEligibilityNoAsync() throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        let products = ["product_id",
-                        "com.revenuecat.monthly_4.99.1_week_intro",
-                        "com.revenuecat.annual_39.99.2_week_intro",
-                        "lifetime"]
+        let products: Set<String> = ["product_id",
+                                     "com.revenuecat.monthly_4.99.1_week_intro",
+                                     "com.revenuecat.annual_39.99.2_week_intro",
+                                     "lifetime"]
         let expected = ["product_id": IntroEligibilityStatus.unknown,
                         "com.revenuecat.monthly_4.99.1_week_intro": IntroEligibilityStatus.eligible,
                         "com.revenuecat.annual_39.99.2_week_intro": IntroEligibilityStatus.eligible,
@@ -113,10 +113,10 @@ class TrialOrIntroPriceEligibilityCheckerSK2Tests: StoreKitConfigTestCase {
     func testCheckEligibilityNoAsyncWithFailure() throws {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
-        let products = ["product_id",
-                        "com.revenuecat.monthly_4.99.1_week_intro",
-                        "com.revenuecat.annual_39.99.2_week_intro",
-                        "lifetime"]
+        let products: Set<String> = ["product_id",
+                                     "com.revenuecat.monthly_4.99.1_week_intro",
+                                     "com.revenuecat.annual_39.99.2_week_intro",
+                                     "lifetime"]
         let expected = ["product_id": IntroEligibilityStatus.unknown,
                         "com.revenuecat.monthly_4.99.1_week_intro": IntroEligibilityStatus.unknown,
                         "com.revenuecat.annual_39.99.2_week_intro": IntroEligibilityStatus.unknown,

--- a/Tests/UnitTests/Mocks/MockOfferingsAPI.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsAPI.swift
@@ -19,16 +19,16 @@ class MockOfferingsAPI: OfferingsAPI {
 
     var invokedGetIntroEligibility = false
     var invokedGetIntroEligibilityCount = 0
-    var invokedGetIntroEligibilityParameters: (appUserID: String?, receiptData: Data?, productIdentifiers: [String]?, completion: OfferingsAPI.IntroEligibilityResponseHandler?)?
+    var invokedGetIntroEligibilityParameters: (appUserID: String?, receiptData: Data?, productIdentifiers: Set<String>?, completion: OfferingsAPI.IntroEligibilityResponseHandler?)?
     var invokedGetIntroEligibilityParametersList = [(appUserID: String?,
                                                      receiptData: Data?,
-                                                     productIdentifiers: [String]?,
+                                                     productIdentifiers: Set<String>?,
                                                      completion: OfferingsAPI.IntroEligibilityResponseHandler?)]()
     var stubbedGetIntroEligibilityCompletionResult: (eligibilities: [String: IntroEligibility], error: BackendError?)?
 
     override func getIntroEligibility(appUserID: String,
                                       receiptData: Data,
-                                      productIdentifiers: [String],
+                                      productIdentifiers: Set<String>,
                                       completion: @escaping IntroEligibilityResponseHandler) {
         self.invokedGetIntroEligibility = true
         self.invokedGetIntroEligibilityCount += 1

--- a/Tests/UnitTests/Mocks/MockTrialOrIntroPriceEligibilityChecker.swift
+++ b/Tests/UnitTests/Mocks/MockTrialOrIntroPriceEligibilityChecker.swift
@@ -34,11 +34,11 @@ class MockTrialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityCheck
 
     var invokedCheckTrialOrIntroPriceEligibilityFromOptimalStore = false
     var invokedCheckTrialOrIntroPriceEligibilityFromOptimalStoreCount = 0
-    var invokedCheckTrialOrIntroPriceEligibilityFromOptimalStoreParameters: [String]?
-    var invokedCheckTrialOrIntroPriceEligibilityFromOptimalStoreParametersList = [Set<String>]()
+    var invokedCheckTrialOrIntroPriceEligibilityFromOptimalStoreParameters: Set<String>?
+    var invokedCheckTrialOrIntroPriceEligibilityFromOptimalStoreParametersList: [Set<String>] = []
     var stubbedCheckTrialOrIntroPriceEligibilityFromOptimalStoreReceiveEligibilityResult: [String: IntroEligibility] = [:]
 
-    override func checkEligibility(productIdentifiers: [String],
+    override func checkEligibility(productIdentifiers: Set<String>,
                                    completion: @escaping ReceiveIntroEligibilityBlock) {
         invokedCheckTrialOrIntroPriceEligibilityFromOptimalStore = true
         invokedCheckTrialOrIntroPriceEligibilityFromOptimalStoreCount += 1
@@ -49,11 +49,11 @@ class MockTrialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityCheck
 
     var invokedSk1checkTrialOrIntroPriceEligibility = false
     var invokedSk1checkTrialOrIntroPriceEligibilityCount = 0
-    var invokedSk1checkTrialOrIntroPriceEligibilityParameters: (productIdentifiers: [String], Void)?
-    var invokedSk1checkTrialOrIntroPriceEligibilityParametersList = [(productIdentifiers: [String], Void)]()
+    var invokedSk1checkTrialOrIntroPriceEligibilityParameters: (productIdentifiers: Set<String>, Void)?
+    var invokedSk1checkTrialOrIntroPriceEligibilityParametersList = [(productIdentifiers: Set<String>, Void)]()
     var stubbedSk1checkTrialOrIntroPriceEligibilityReceiveEligibilityResult: [String: IntroEligibility] = [:]
 
-    override func sk1CheckEligibility(_ productIdentifiers: [String],
+    override func sk1CheckEligibility(_ productIdentifiers: Set<String>,
                                       completion: @escaping ReceiveIntroEligibilityBlock) {
         invokedSk1checkTrialOrIntroPriceEligibility = true
         invokedSk1checkTrialOrIntroPriceEligibilityCount += 1
@@ -64,12 +64,12 @@ class MockTrialOrIntroPriceEligibilityChecker: TrialOrIntroPriceEligibilityCheck
 
     var invokedSk2checkTrialOrIntroPriceEligibility = false
     var invokedSk2checkTrialOrIntroPriceEligibilityCount = 0
-    var invokedSk2checkTrialOrIntroPriceEligibilityParameters: (productIdentifiers: [String], Void)?
-    var invokedSk2checkTrialOrIntroPriceEligibilityParametersList = [(productIdentifiers: [String], Void)]()
+    var invokedSk2checkTrialOrIntroPriceEligibilityParameters: (productIdentifiers: Set<String>, Void)?
+    var invokedSk2checkTrialOrIntroPriceEligibilityParametersList = [(productIdentifiers: Set<String>, Void)]()
     var stubbedSk2checkTrialOrIntroPriceEligibilityReceiveEligibilityResult: [String: IntroEligibility] = [:]
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
-    override func sk2CheckEligibility(_ productIdentifiers: [String]) async -> [String: IntroEligibility] {
+    override func sk2CheckEligibility(_ productIdentifiers: Set<String>) async -> [String: IntroEligibility] {
         invokedSk2checkTrialOrIntroPriceEligibility = true
         invokedSk2checkTrialOrIntroPriceEligibilityCount += 1
         invokedSk2checkTrialOrIntroPriceEligibilityParameters = (productIdentifiers, ())

--- a/Tests/UnitTests/Networking/Backend/BackendGetIntroEligibilityTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetIntroEligibilityTests.swift
@@ -43,9 +43,9 @@ class BackendGetIntroEligibilityTests: BaseBackendTests {
                             response: ["producta": true, "productb": false, "productd": NSNull()])
         )
 
-        let products = ["producta", "productb", "productc", "productd"]
+        let products: Set<String> = ["producta", "productb", "productc", "productd"]
 
-        let eligibility: [String: IntroEligibility]? = waitUntilValue { completed in
+        let result: [String: IntroEligibility]? = waitUntilValue { completed in
             self.offerings.getIntroEligibility(appUserID: Self.userID,
                                                receiptData: Data(1...3),
                                                productIdentifiers: products,
@@ -57,11 +57,12 @@ class BackendGetIntroEligibilityTests: BaseBackendTests {
 
         expect(self.httpClient.calls).to(haveCount(1))
 
-        expect(eligibility?.keys).to(contain(products))
-        expect(eligibility?["producta"]?.status) == .eligible
-        expect(eligibility?["productb"]?.status) == .ineligible
-        expect(eligibility?["productc"]?.status) == .unknown
-        expect(eligibility?["productd"]?.status) == .unknown
+        let eligibility = try XCTUnwrap(result)
+        expect(Set(eligibility.keys)) == products
+        expect(eligibility["producta"]?.status) == .eligible
+        expect(eligibility["productb"]?.status) == .ineligible
+        expect(eligibility["productc"]?.status) == .unknown
+        expect(eligibility["productd"]?.status) == .unknown
     }
 
     func testEligibilityUnknownIfError() {
@@ -71,7 +72,7 @@ class BackendGetIntroEligibilityTests: BaseBackendTests {
         )
 
         let eligibility: [String: IntroEligibility]? = waitUntilValue { completed in
-            let products = ["producta", "productb", "productc"]
+            let products: Set<String> = ["producta", "productb", "productc"]
             self.offerings.getIntroEligibility(appUserID: Self.userID,
                                                receiptData: Data.init(1...2),
                                                productIdentifiers: products,
@@ -93,7 +94,7 @@ class BackendGetIntroEligibilityTests: BaseBackendTests {
         )
 
         var eligibility: [String: IntroEligibility]?
-        let products = ["producta"]
+        let products: Set<String> = ["producta"]
         var eventualError: BackendError?
         self.backend.offerings.getIntroEligibility(appUserID: "",
                                                    receiptData: Data.init(1...2),
@@ -130,7 +131,7 @@ class BackendGetIntroEligibilityTests: BaseBackendTests {
             response: .init(error: error)
         )
 
-        let products = ["producta", "productb", "productc"]
+        let products: Set<String> = ["producta", "productb", "productc"]
 
         let eligibility: [String: IntroEligibility]? = waitUntilValue { completed in
 
@@ -149,7 +150,7 @@ class BackendGetIntroEligibilityTests: BaseBackendTests {
     }
 
     func testEligibilityUnknownIfNoReceipt() {
-        let products = ["producta", "productb", "productc"]
+        let products: Set<String> = ["producta", "productb", "productc"]
         let eligibility: [String: IntroEligibility]? = waitUntilValue { completed in
             self.offerings.getIntroEligibility(appUserID: Self.userID,
                                                receiptData: Data(),

--- a/Tests/UnitTests/Purchasing/CachingTrialOrIntroPriceEligibilityCheckerTests.swift
+++ b/Tests/UnitTests/Purchasing/CachingTrialOrIntroPriceEligibilityCheckerTests.swift
@@ -91,7 +91,7 @@ class CachingTrialOrIntroPriceEligibilityCheckerTests: TestCase {
     }
 
     func testCachesResultForMultipleProducts() async {
-        let productIDs = [
+        let productIDs: Set<String> = [
             Self.productID1,
             Self.productID2
         ]
@@ -109,12 +109,11 @@ class CachingTrialOrIntroPriceEligibilityCheckerTests: TestCase {
         expect(result) == expected
 
         expect(self.mockChecker.invokedCheckTrialOrIntroPriceEligibilityFromOptimalStoreCount) == 1
-        expect(self.mockChecker.invokedCheckTrialOrIntroPriceEligibilityFromOptimalStoreParameters)
-            .to(contain(productIDs))
+        expect(self.mockChecker.invokedCheckTrialOrIntroPriceEligibilityFromOptimalStoreParameters) == productIDs
     }
 
     func testOnlyCachesEligibilitiesThatDidNotFail() async {
-        let productIDs = [
+        let productIDs: Set<String> = [
             Self.productID1,
             Self.productID2
         ]
@@ -140,11 +139,11 @@ class CachingTrialOrIntroPriceEligibilityCheckerTests: TestCase {
     }
 
     func testFetchesOnlyMissingProductsFromCache() async {
-        let cachedProductIDs = [
+        let cachedProductIDs: Set<String> = [
             Self.productID1,
             Self.productID2
         ]
-        let productIDs = [
+        let productIDs: Set<String> = [
             Self.productID1,
             Self.productID2,
             Self.productID3
@@ -226,7 +225,7 @@ private extension CachingTrialOrIntroPriceEligibilityCheckerTests {
 @available(iOS 13.0, tvOS 13.0, watchOS 6.2, macOS 10.15, *)
 private extension TrialOrIntroPriceEligibilityCheckerType {
 
-    func checkEligibility(productIdentifiers: [String]) async -> [String: IntroEligibility] {
+    func checkEligibility(productIdentifiers: Set<String>) async -> [String: IntroEligibility] {
         return await Async.call { completion in
             self.checkEligibility(productIdentifiers: productIdentifiers) { result in
                 completion(result)

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -312,11 +312,11 @@ extension BasePurchasesTests {
 
     final class MockOfferingsAPI: OfferingsAPI {
 
-        var postedProductIdentifiers: [String]?
+        var postedProductIdentifiers: Set<String>?
 
         override func getIntroEligibility(appUserID: String,
                                           receiptData: Data,
-                                          productIdentifiers: [String],
+                                          productIdentifiers: Set<String>,
                                           completion: @escaping OfferingsAPI.IntroEligibilityResponseHandler) {
             self.postedProductIdentifiers = productIdentifiers
 


### PR DESCRIPTION
Order is irrelevant when requesting intro eligibility.

Note that I haven't changed the public API because that wouldn't be backwards compatible.