### PR TITLE
`CachingProductsManager`: avoid crash when caching different products with same identifier

### DIFF
--- a/Sources/Purchasing/CachingProductsManager.swift
+++ b/Sources/Purchasing/CachingProductsManager.swift
@@ -160,7 +160,7 @@ private extension CachingProductsManager {
     }
 
     static func cache<T: StoreProductType>(_ products: Set<T>, container: Atomic<[String: T]>) {
-        container.value += products.dictionaryWithKeys { $0.productIdentifier }
+        container.value += products.dictionaryAllowingDuplicateKeys { $0.productIdentifier }
     }
 
     /// - Returns: true if there is already a request in progress for these products.


### PR DESCRIPTION
@joshdholtz found this because he had a typo in his product setup. It shouldn't happen, but technically `SK2StoreProduct.hashValue` is not _just_ the product identifier.