### PR TITLE
`HTTPClient`: extracted `HTTPRequestPath` protocol

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -236,6 +236,7 @@
 		4F6BEE3B2A27B45300CD9322 /* StoreKitTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571E7AD3279F2D0C003B3606 /* StoreKitTestHelpers.swift */; };
 		4F6BEE3C2A27B45900CD9322 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE61A83264190830021CEA0 /* Constants.swift */; };
 		4F6BEE882A27E16B00CD9322 /* TestLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57057FF728B0048900995F21 /* TestLogHandler.swift */; };
+		4F6E81E62A82AAE1006EF181 /* HTTPRequestPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6E81E52A82AAE1006EF181 /* HTTPRequestPath.swift */; };
 		4F6EEBD92A38ED76007FD783 /* FakeSigning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F6EEBD82A38ED76007FD783 /* FakeSigning.swift */; };
 		4F7C37B22A27E2E8001E17D3 /* AsyncTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575A8EE02922C56300936709 /* AsyncTestHelpers.swift */; };
 		4F7C37E42A27EFE1001E17D3 /* BaseBackendIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579234E127F777EE00B39C68 /* BaseBackendIntegrationTests.swift */; };
@@ -975,6 +976,7 @@
 		4F6BEDE12A26B69500CD9322 /* DebugContentViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugContentViews.swift; sourceTree = "<group>"; };
 		4F6BEE022A27ADF900CD9322 /* CustomEntitlementsComputationIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomEntitlementsComputationIntegrationTests.swift; sourceTree = "<group>"; };
 		4F6BEE312A27B02400CD9322 /* BackendCustomEntitlementsIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BackendCustomEntitlementsIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4F6E81E52A82AAE1006EF181 /* HTTPRequestPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestPath.swift; sourceTree = "<group>"; };
 		4F6EEBD82A38ED76007FD783 /* FakeSigning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeSigning.swift; sourceTree = "<group>"; };
 		4F7D8E552A56290100F17FFC /* HTTPRequestBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequestBody.swift; sourceTree = "<group>"; };
 		4F7DBFBC2A1E986C00A2F511 /* StoreKit2TransactionFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit2TransactionFetcher.swift; sourceTree = "<group>"; };
@@ -2593,6 +2595,7 @@
 				35D832D1262E56DB00E60AC5 /* HTTPStatusCode.swift */,
 				57D5414127F656D9004CC35C /* NetworkError.swift */,
 				57CB2AD329CCF21900C91439 /* RedirectLoggerTaskDelegate.swift */,
+				4F6E81E52A82AAE1006EF181 /* HTTPRequestPath.swift */,
 			);
 			path = HTTPClient;
 			sourceTree = "<group>";
@@ -3403,6 +3406,7 @@
 				57F2C60C29784C11009EE527 /* SwiftVersionCheck.swift in Sources */,
 				57EAE527274324C60060EB74 /* Lock.swift in Sources */,
 				4F8038332A1EA7C300D21039 /* TransactionPoster.swift in Sources */,
+				4F6E81E62A82AAE1006EF181 /* HTTPRequestPath.swift in Sources */,
 				B32B74FF26868AEB005647BF /* Package.swift in Sources */,
 				578DAA482948EEAD001700FD /* Clock.swift in Sources */,
 				2DDF41B324F6F387005BC22D /* InAppPurchaseBuilder.swift in Sources */,

--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -63,15 +63,15 @@ enum ErrorUtils {
      * Constructs an NSError with the ``ErrorCode/signatureVerificationFailed`` code.
      */
     static func signatureVerificationFailedError(
-        path: HTTPRequest.Path,
+        path: String,
         code: HTTPStatusCode,
         fileName: String = #fileID, functionName: String = #function, line: UInt = #line
     ) -> PurchasesError {
         return error(
             with: .signatureVerificationFailed,
-            message: "Request to \(path.relativePath) failed verification",
+            message: "Request to '\(path)' failed verification",
             extraUserInfo: [
-                "request_path": path.relativePath,
+                "request_path": path,
                 "status_code": code.rawValue
             ],
             fileName: fileName, functionName: functionName, line: line

--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -34,7 +34,7 @@ enum NetworkStrings {
     case blocked_network(url: URL, newHost: String?)
     case api_request_redirect(from: URL, to: URL)
     case operation_state(NetworkOperation.Type, state: String)
-    case request_handled_by_load_shedder(HTTPRequest.Path)
+    case request_handled_by_load_shedder(HTTPRequestPath)
 
     #if DEBUG
     case api_request_forcing_server_error(HTTPRequest)
@@ -105,7 +105,7 @@ extension NetworkStrings: LogMessage {
             return "\(operation): \(state)"
 
         case let .request_handled_by_load_shedder(path):
-            return "Request was handled by load shedder: \(path.description)"
+            return "Request was handled by load shedder: \(path.relativePath)"
 
         #if DEBUG
         case let .api_request_forcing_server_error(request):
@@ -124,7 +124,7 @@ extension NetworkStrings: LogMessage {
 private extension HTTPRequest {
 
     var description: String {
-        return "\(self.method.httpMethod) \(self.path.url?.path ?? "")"
+        return "\(self.method.httpMethod) \(self.path.relativePath)"
     }
 
 }

--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -92,22 +92,12 @@ class SystemInfo {
         #endif
     }
 
-    static var serverHostURL: URL {
-        return Self.proxyURL ?? Self.defaultServerHostURL
-    }
-
     static var proxyURL: URL? {
         didSet {
             if let privateProxyURLString = proxyURL?.absoluteString {
                 Logger.info(Strings.configure.configuring_purchases_proxy_url_set(url: privateProxyURLString))
             }
         }
-    }
-
-    private static let defaultServerHostName = "https://api.revenuecat.com"
-
-    private static var defaultServerHostURL: URL {
-        return URL(string: defaultServerHostName)!
     }
 
     init(platformInfo: Purchases.PlatformInfo?,

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -418,7 +418,10 @@ private extension HTTPClient {
     }
 
     func convert(request: Request) -> URLRequest? {
-        var urlRequest = URLRequest(url: request.httpRequest.path.url(proxyURL: SystemInfo.proxyURL))
+        guard let requestURL = request.httpRequest.path.url(proxyURL: SystemInfo.proxyURL) else {
+            return nil
+        }
+        var urlRequest = URLRequest(url: requestURL)
         urlRequest.httpMethod = request.method.httpMethod
         urlRequest.allHTTPHeaderFields = self.headers(for: request, urlRequest: urlRequest)
 

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -170,7 +170,7 @@ private extension HTTPClient {
         }
 
         var method: HTTPRequest.Method { self.httpRequest.method }
-        var path: String { self.httpRequest.path.description }
+        var path: String { self.httpRequest.path.relativePath }
 
         func adding(defaultHeaders: HTTPClient.RequestHeaders) -> Self {
             var copy = self
@@ -418,11 +418,7 @@ private extension HTTPClient {
     }
 
     func convert(request: Request) -> URLRequest? {
-        guard let requestURL = request.httpRequest.path.url else {
-            return nil
-        }
-
-        var urlRequest = URLRequest(url: requestURL)
+        var urlRequest = URLRequest(url: request.httpRequest.path.url(proxyURL: SystemInfo.proxyURL))
         urlRequest.httpMethod = request.method.httpMethod
         urlRequest.allHTTPHeaderFields = self.headers(for: request, urlRequest: urlRequest)
 
@@ -505,19 +501,11 @@ extension HTTPRequest {
         return result
     }
 
-}
-
-extension HTTPRequest.Path {
-
-    var url: URL? {
-        return URL(string: self.relativePath, relativeTo: SystemInfo.serverHostURL)
+    /// Add a nonce to the request
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    private mutating func addRandomNonce() {
+        self.nonce = Data.randomNonce()
     }
-
-    var relativePath: String {
-        return "\(Self.pathPrefix)/\(self.description)"
-    }
-
-    private static let pathPrefix: String = "/v1"
 
 }
 

--- a/Sources/Networking/HTTPClient/HTTPRequest.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequest.swift
@@ -19,33 +19,21 @@ struct HTTPRequest {
     typealias Headers = [String: String]
 
     var method: Method
-    var path: Path
+    var path: HTTPRequestPath
     /// If present, this will be used by the server to compute a checksum of the response signed with a private key.
     var nonce: Data?
 
-    init(method: Method, path: Path, nonce: Data? = nil) {
+    init(method: Method, path: HTTPRequest.Path, nonce: Data? = nil) {
+        self.init(method: method, requestPath: path, nonce: nonce)
+    }
+
+    private init(method: Method, requestPath: HTTPRequestPath, nonce: Data? = nil) {
         assert(nonce == nil || nonce?.count == Data.nonceLength,
                "Invalid nonce: \(nonce?.description ?? "")")
 
         self.method = method
-        self.path = path
+        self.path = requestPath
         self.nonce = nonce
-    }
-
-}
-
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-extension HTTPRequest {
-
-    /// Creates an `HTTPRequest` with a `nonce`.
-    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    static func createWithResponseVerification(method: Method, path: Path) -> Self {
-        return .init(method: method, path: path, nonce: Data.randomNonce())
-    }
-
-    /// Add a nonce to the request
-    mutating func addRandomNonce() {
-        self.nonce = Data.randomNonce()
     }
 
 }
@@ -81,156 +69,6 @@ extension HTTPRequest.Method {
         case .get: return "GET"
         case .post: return "POST"
         }
-    }
-
-}
-
-// MARK: - Path
-
-extension HTTPRequest {
-
-    enum Path: Equatable {
-
-        case getCustomerInfo(appUserID: String)
-        case getOfferings(appUserID: String)
-        case getIntroEligibility(appUserID: String)
-        case logIn
-        case postAttributionData(appUserID: String)
-        case postOfferForSigning
-        case postReceiptData
-        case postSubscriberAttributes(appUserID: String)
-        case postAdServicesToken(appUserID: String)
-        case health
-        case getProductEntitlementMapping
-
-    }
-
-}
-
-extension HTTPRequest.Path {
-
-    /// Whether requests to this path are authenticated.
-    var authenticated: Bool {
-        switch self {
-        case .getCustomerInfo,
-                .getOfferings,
-                .getIntroEligibility,
-                .logIn,
-                .postAttributionData,
-                .postOfferForSigning,
-                .postReceiptData,
-                .postSubscriberAttributes,
-                .postAdServicesToken,
-                .getProductEntitlementMapping:
-            return true
-
-        case .health:
-            return false
-        }
-    }
-
-    /// Whether requests to this path can be cached using `ETagManager`.
-    var shouldSendEtag: Bool {
-        switch self {
-        case .getCustomerInfo,
-                .getOfferings,
-                .getIntroEligibility,
-                .logIn,
-                .postAttributionData,
-                .postOfferForSigning,
-                .postReceiptData,
-                .postSubscriberAttributes,
-                .postAdServicesToken,
-                .getProductEntitlementMapping:
-            return true
-        case .health:
-            return false
-        }
-    }
-
-    /// Whether the endpoint will perform signature verification.
-    var supportsSignatureVerification: Bool {
-        switch self {
-        case .getCustomerInfo,
-                .logIn,
-                .postReceiptData,
-                .health,
-                .getOfferings,
-                .getProductEntitlementMapping:
-            return true
-        case .getIntroEligibility,
-                .postSubscriberAttributes,
-                .postAttributionData,
-                .postAdServicesToken,
-                .postOfferForSigning:
-            return false
-        }
-    }
-
-    /// Whether endpoint requires a nonce for signature verification.
-    var needsNonceForSigning: Bool {
-        switch self {
-        case .getCustomerInfo,
-                .logIn,
-                .postReceiptData,
-                .health:
-            return true
-        case .getOfferings,
-                .getIntroEligibility,
-                .postSubscriberAttributes,
-                .postAttributionData,
-                .postAdServicesToken,
-                .postOfferForSigning,
-                .getProductEntitlementMapping:
-            return false
-        }
-    }
-
-}
-
-extension HTTPRequest.Path: Hashable {}
-
-extension HTTPRequest.Path: CustomStringConvertible {
-
-    var description: String {
-        switch self {
-        case let .getCustomerInfo(appUserID):
-            return "subscribers/\(Self.escape(appUserID))"
-
-        case let .getOfferings(appUserID):
-            return "subscribers/\(Self.escape(appUserID))/offerings"
-
-        case let .getIntroEligibility(appUserID):
-            return "subscribers/\(Self.escape(appUserID))/intro_eligibility"
-
-        case .logIn:
-            return "subscribers/identify"
-
-        case let .postAttributionData(appUserID):
-            return "subscribers/\(Self.escape(appUserID))/attribution"
-
-        case let .postAdServicesToken(appUserID):
-            return "subscribers/\(Self.escape(appUserID))/adservices_attribution"
-
-        case .postOfferForSigning:
-            return "offers"
-
-        case .postReceiptData:
-            return "receipts"
-
-        case let .postSubscriberAttributes(appUserID):
-            return "subscribers/\(Self.escape(appUserID))/attributes"
-
-        case .health:
-            return "health"
-
-        case .getProductEntitlementMapping:
-            return "product_entitlement_mapping"
-        }
-    }
-
-    private static func escape(_ appUserID: String) -> String {
-        return appUserID.trimmedAndEscaped
     }
 
 }

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -42,11 +42,10 @@ extension HTTPRequestPath {
         return "/v1/\(self.pathComponent)"
     }
 
-    var url: URL { return self.url(proxyURL: nil) }
+    var url: URL? { return self.url(proxyURL: nil) }
 
-    func url(proxyURL: URL? = nil) -> URL {
-        return (proxyURL ?? Self.serverHostURL)
-            .appendingPathComponent(self.relativePath)
+    func url(proxyURL: URL? = nil) -> URL? {
+        return URL(string: self.relativePath, relativeTo: proxyURL ?? Self.serverHostURL)
     }
 
 }

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -30,16 +30,23 @@ protocol HTTPRequestPath {
     /// Whether endpoint requires a nonce for signature verification.
     var needsNonceForSigning: Bool { get }
 
-    /// The relative path component for this endpoint.
-    var relativePath: String { get }
+    /// The path component for this endpoint.
+    var pathComponent: String { get }
 
 }
 
 extension HTTPRequestPath {
 
-    func url(proxyURL: URL?) -> URL {
-        let baseURL = proxyURL ?? Self.serverHostURL
-        return baseURL.appendingPathComponent(self.relativePath)
+    /// The full relative path for this endpoint.
+    var relativePath: String {
+        return "/v1/\(self.pathComponent)"
+    }
+
+    var url: URL { return self.url(proxyURL: nil) }
+
+    func url(proxyURL: URL? = nil) -> URL {
+        return (proxyURL ?? Self.serverHostURL)
+            .appendingPathComponent(self.relativePath)
     }
 
 }
@@ -68,7 +75,7 @@ extension HTTPRequest {
 
 extension HTTPRequest.Path: HTTPRequestPath {
 
-    static let serverHostURL = URL(string: "https://api.revenuecat.com/v1")!
+    static let serverHostURL = URL(string: "https://api.revenuecat.com")!
 
     var authenticated: Bool {
         switch self {
@@ -143,7 +150,7 @@ extension HTTPRequest.Path: HTTPRequestPath {
         }
     }
 
-    var relativePath: String {
+    var pathComponent: String {
         switch self {
         case let .getCustomerInfo(appUserID):
             return "subscribers/\(Self.escape(appUserID))"

--- a/Sources/Networking/HTTPClient/HTTPRequestPath.swift
+++ b/Sources/Networking/HTTPClient/HTTPRequestPath.swift
@@ -1,0 +1,186 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  HTTPRequestPath.swift
+//
+//  Created by Nacho Soto on 8/8/23.
+
+import Foundation
+
+protocol HTTPRequestPath {
+
+    /// The base URL for requests to this path.
+    static var serverHostURL: URL { get }
+
+    /// Whether requests to this path are authenticated.
+    var authenticated: Bool { get }
+
+    /// Whether requests to this path can be cached using `ETagManager`.
+    var shouldSendEtag: Bool { get }
+
+    /// Whether the endpoint will perform signature verification.
+    var supportsSignatureVerification: Bool { get }
+
+    /// Whether endpoint requires a nonce for signature verification.
+    var needsNonceForSigning: Bool { get }
+
+    /// The relative path component for this endpoint.
+    var relativePath: String { get }
+
+}
+
+extension HTTPRequestPath {
+
+    func url(proxyURL: URL?) -> URL {
+        let baseURL = proxyURL ?? Self.serverHostURL
+        return baseURL.appendingPathComponent(self.relativePath)
+    }
+
+}
+
+// MARK: - Main paths
+
+extension HTTPRequest {
+
+    enum Path: Hashable {
+
+        case getCustomerInfo(appUserID: String)
+        case getOfferings(appUserID: String)
+        case getIntroEligibility(appUserID: String)
+        case logIn
+        case postAttributionData(appUserID: String)
+        case postOfferForSigning
+        case postReceiptData
+        case postSubscriberAttributes(appUserID: String)
+        case postAdServicesToken(appUserID: String)
+        case health
+        case getProductEntitlementMapping
+
+    }
+
+}
+
+extension HTTPRequest.Path: HTTPRequestPath {
+
+    static let serverHostURL = URL(string: "https://api.revenuecat.com/v1")!
+
+    var authenticated: Bool {
+        switch self {
+        case .getCustomerInfo,
+                .getOfferings,
+                .getIntroEligibility,
+                .logIn,
+                .postAttributionData,
+                .postOfferForSigning,
+                .postReceiptData,
+                .postSubscriberAttributes,
+                .postAdServicesToken,
+                .getProductEntitlementMapping:
+            return true
+
+        case .health:
+            return false
+        }
+    }
+
+    var shouldSendEtag: Bool {
+        switch self {
+        case .getCustomerInfo,
+                .getOfferings,
+                .getIntroEligibility,
+                .logIn,
+                .postAttributionData,
+                .postOfferForSigning,
+                .postReceiptData,
+                .postSubscriberAttributes,
+                .postAdServicesToken,
+                .getProductEntitlementMapping:
+            return true
+        case .health:
+            return false
+        }
+    }
+
+    var supportsSignatureVerification: Bool {
+        switch self {
+        case .getCustomerInfo,
+                .logIn,
+                .postReceiptData,
+                .health,
+                .getOfferings,
+                .getProductEntitlementMapping:
+            return true
+        case .getIntroEligibility,
+                .postSubscriberAttributes,
+                .postAttributionData,
+                .postAdServicesToken,
+                .postOfferForSigning:
+            return false
+        }
+    }
+
+    var needsNonceForSigning: Bool {
+        switch self {
+        case .getCustomerInfo,
+                .logIn,
+                .postReceiptData,
+                .health:
+            return true
+        case .getOfferings,
+                .getIntroEligibility,
+                .postSubscriberAttributes,
+                .postAttributionData,
+                .postAdServicesToken,
+                .postOfferForSigning,
+                .getProductEntitlementMapping:
+            return false
+        }
+    }
+
+    var relativePath: String {
+        switch self {
+        case let .getCustomerInfo(appUserID):
+            return "subscribers/\(Self.escape(appUserID))"
+
+        case let .getOfferings(appUserID):
+            return "subscribers/\(Self.escape(appUserID))/offerings"
+
+        case let .getIntroEligibility(appUserID):
+            return "subscribers/\(Self.escape(appUserID))/intro_eligibility"
+
+        case .logIn:
+            return "subscribers/identify"
+
+        case let .postAttributionData(appUserID):
+            return "subscribers/\(Self.escape(appUserID))/attribution"
+
+        case let .postAdServicesToken(appUserID):
+            return "subscribers/\(Self.escape(appUserID))/adservices_attribution"
+
+        case .postOfferForSigning:
+            return "offers"
+
+        case .postReceiptData:
+            return "receipts"
+
+        case let .postSubscriberAttributes(appUserID):
+            return "subscribers/\(Self.escape(appUserID))/attributes"
+
+        case .health:
+            return "health"
+
+        case .getProductEntitlementMapping:
+            return "product_entitlement_mapping"
+        }
+    }
+
+    private static func escape(_ appUserID: String) -> String {
+        return appUserID.trimmedAndEscaped
+    }
+}

--- a/Sources/Networking/HTTPClient/NetworkError.swift
+++ b/Sources/Networking/HTTPClient/NetworkError.swift
@@ -22,10 +22,10 @@ enum NetworkError: Swift.Error, Equatable {
     case offlineConnection(Source)
     case networkError(NSError, Source)
     case dnsError(failedURL: URL, resolvedHost: String?, Source)
-    case unableToCreateRequest(HTTPRequest.Path, Source)
+    case unableToCreateRequest(path: String, Source)
     case unexpectedResponse(URLResponse?, Source)
     case errorResponse(ErrorResponse, HTTPStatusCode, Source)
-    case signatureVerificationFailed(HTTPRequest.Path, HTTPStatusCode, Source)
+    case signatureVerificationFailed(path: String, HTTPStatusCode, Source)
 
 }
 
@@ -67,10 +67,10 @@ extension NetworkError {
     }
 
     static func unableToCreateRequest(
-        _ path: HTTPRequest.Path,
+        _ path: HTTPRequestPath,
         file: String = #fileID, function: String = #function, line: UInt = #line
     ) -> Self {
-        return .unableToCreateRequest(path, .init(file: file, function: function, line: line))
+        return .unableToCreateRequest(path: path.relativePath, .init(file: file, function: function, line: line))
     }
 
     static func unexpectedResponse(
@@ -88,12 +88,12 @@ extension NetworkError {
     }
 
     static func signatureVerificationFailed(
-        path: HTTPRequest.Path,
+        path: HTTPRequestPath,
         code: HTTPStatusCode,
         file: String = #fileID, function: String = #function, line: UInt = #line
     ) -> Self {
         return .signatureVerificationFailed(
-            path,
+            path: path.relativePath,
             code,
             .init(file: file, function: function, line: line)
         )
@@ -140,7 +140,7 @@ extension NetworkError: PurchasesErrorConvertible {
         case let .unableToCreateRequest(path, source):
             return ErrorUtils.networkError(
                 extraUserInfo: [
-                    "request_url": path.description
+                    "request_path": path
                 ],
                 fileName: source.file,
                 functionName: source.function,

--- a/Sources/Security/Signing.swift
+++ b/Sources/Security/Signing.swift
@@ -35,7 +35,7 @@ final class Signing: SigningType {
     /// Parameters used for signature creation / verification.
     struct SignatureParameters {
 
-        var path: HTTPRequest.Path
+        var path: HTTPRequestPath
         var message: Data?
         var requestBody: HTTPRequestBody?
         var nonce: Data?
@@ -242,6 +242,22 @@ extension Signing {
 
 @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
 extension Signing.SignatureParameters {
+
+    init(
+        path: HTTPRequest.Path,
+        message: Data? = nil,
+        requestBody: HTTPRequestBody? = nil,
+        nonce: Data? = nil,
+        etag: String? = nil,
+        requestDate: UInt64
+    ) {
+        self.path = path
+        self.message = message
+        self.requestBody = requestBody
+        self.nonce = nonce
+        self.etag = etag
+        self.requestDate = requestDate
+    }
 
     func signature(salt: Data, apiKey: String) -> Data {
         let apiKey = self.path.authenticated ? apiKey : ""

--- a/Tests/BackendIntegrationTests/LoadShedderIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/LoadShedderIntegrationTests.swift
@@ -49,7 +49,7 @@ class LoadShedderStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     func testOfferingsComeFromLoadShedder() async throws {
         self.logger.verifyMessageWasLogged(
             Strings.network.request_handled_by_load_shedder(
-                .getOfferings(appUserID: try self.purchases.appUserID)
+                HTTPRequest.Path.getOfferings(appUserID: try self.purchases.appUserID)
             ),
             level: .debug
         )
@@ -59,7 +59,7 @@ class LoadShedderStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         try await self.purchaseMonthlyOffering()
 
         self.logger.verifyMessageWasLogged(
-            Strings.network.request_handled_by_load_shedder(.postReceiptData),
+            Strings.network.request_handled_by_load_shedder(HTTPRequest.Path.postReceiptData),
             level: .debug
         )
     }
@@ -78,7 +78,7 @@ class LoadShedderStoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         try await self.logger.verifyMessageIsEventuallyLogged(
-            Strings.network.request_handled_by_load_shedder(.getProductEntitlementMapping).description,
+            Strings.network.request_handled_by_load_shedder(HTTPRequest.Path.getProductEntitlementMapping).description,
             level: .debug,
             timeout: .seconds(5),
             pollInterval: .milliseconds(100)

--- a/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
@@ -86,7 +86,7 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
     func testHandledByProductionServer() async throws {
         try await self.purchases.healthRequest(signatureVerification: false)
 
-        self.logger.verifyMessageWasNotLogged(Strings.network.request_handled_by_load_shedder(.health))
+        self.logger.verifyMessageWasNotLogged(Strings.network.request_handled_by_load_shedder(HTTPRequest.Path.health))
     }
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)

--- a/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
+++ b/Tests/UnitTests/Misc/PurchasesDiagnosticsTests.swift
@@ -88,7 +88,8 @@ class PurchasesDiagnosticsTests: TestCase {
         self.purchases.mockedResponseVerificationMode = .disabled
 
         self.purchases.mockedHealthRequestWithSignatureVerificationResponse = .failure(
-            ErrorUtils.signatureVerificationFailedError(path: .health, code: .success).asPublicError
+            ErrorUtils.signatureVerificationFailedError(path: HTTPRequest.Path.health.relativePath,
+                                                        code: .success).asPublicError
         )
 
         try await self.diagnostics.testSDKHealth()
@@ -97,7 +98,8 @@ class PurchasesDiagnosticsTests: TestCase {
     func testFailingSignatureVerification() async throws {
         self.purchases.mockedResponseVerificationMode = Signing.verificationMode(with: .informational)
 
-        let expectedError = ErrorUtils.signatureVerificationFailedError(path: .health, code: .success)
+        let expectedError = ErrorUtils.signatureVerificationFailedError(path: HTTPRequest.Path.health.relativePath,
+                                                                        code: .success)
         self.purchases.mockedHealthRequestWithSignatureVerificationResponse = .failure(expectedError.asPublicError)
 
         do {

--- a/Tests/UnitTests/Misc/SystemInfoTests.swift
+++ b/Tests/UnitTests/Misc/SystemInfoTests.swift
@@ -9,23 +9,6 @@ import WatchKit
 
 class SystemInfoTests: TestCase {
 
-    func testProxyURL() {
-        let defaultURL = URL(string: "https://api.revenuecat.com")
-        expect(SystemInfo.serverHostURL) == defaultURL
-        expect(SystemInfo.proxyURL).to(beNil())
-
-        let url = URL(string: "https://my_url")
-        SystemInfo.proxyURL = url
-
-        expect(SystemInfo.serverHostURL) == url
-        expect(SystemInfo.proxyURL) == url
-
-        SystemInfo.proxyURL = nil
-        expect(SystemInfo.proxyURL).to(beNil())
-
-        expect(SystemInfo.serverHostURL) == defaultURL
-    }
-
     func testSystemVersion() {
         expect(SystemInfo.systemVersion) == ProcessInfo().operatingSystemVersionString
     }

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -95,7 +95,7 @@ class MockHTTPClient: HTTPClient {
                            file: self.sourceTestFile,
                            testName: CurrentTestCaseTracker.osVersionAndTestName)
 
-            let mock = self.mocks[request.path.url] ?? .init(statusCode: .success)
+            let mock = self.mocks[request.path.url!] ?? .init(statusCode: .success)
 
             if let completionHandler = completionHandler {
                 let response: VerifiedHTTPResponse<Value>.Result = mock.response.parseResponse()
@@ -116,7 +116,7 @@ class MockHTTPClient: HTTPClient {
     }
 
     private func mock(path: HTTPRequestPath, response: Response) {
-        self.mocks[path.url] = response
+        self.mocks[path.url!] = response
     }
 
 }

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -51,7 +51,7 @@ class MockHTTPClient: HTTPClient {
 
     }
 
-    var mocks: [HTTPRequest.Path: Response] = [:]
+    var mocks: [URL: Response] = [:]
     var calls: [Call] = []
 
     init(apiKey: String,
@@ -95,7 +95,7 @@ class MockHTTPClient: HTTPClient {
                            file: self.sourceTestFile,
                            testName: CurrentTestCaseTracker.osVersionAndTestName)
 
-            let mock = self.mocks[request.path] ?? .init(statusCode: .success)
+            let mock = self.mocks[request.path.url] ?? .init(statusCode: .success)
 
             if let completionHandler = completionHandler {
                 let response: VerifiedHTTPResponse<Value>.Result = mock.response.parseResponse()
@@ -112,8 +112,18 @@ class MockHTTPClient: HTTPClient {
     }
 
     func mock(requestPath: HTTPRequest.Path, response: Response) {
-        self.mocks[requestPath] = response
+        self.mock(path: requestPath, response: response)
     }
+
+    private func mock(path: HTTPRequestPath, response: Response) {
+        self.mocks[path.url] = response
+    }
+
+}
+
+private extension HTTPRequestPath {
+
+    var url: URL { return self.url(proxyURL: nil) }
 
 }
 

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -121,12 +121,6 @@ class MockHTTPClient: HTTPClient {
 
 }
 
-private extension HTTPRequestPath {
-
-    var url: URL { return self.url(proxyURL: nil) }
-
-}
-
 // MARK: - MockHTTPClient.Call Encodable
 
 extension HTTPRequest: Encodable {

--- a/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
@@ -134,7 +134,7 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         expect(firstResult.value).to(beSuccess())
         expect(secondResult.value?.value) == firstResult.value?.value
 
-        expect(self.httpClient.calls.map { $0.request.path }) == [path]
+        expect(self.httpClient.calls.map { $0.request.path as? HTTPRequest.Path }) == [path]
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -487,7 +487,7 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
             originalSubscriberInfo.value = result.value
             callOrder.value.initialGet = true
 
-            self.httpClient.mocks.removeValue(forKey: getCustomerInfoPath.url)
+            self.httpClient.mocks.removeValue(forKey: getCustomerInfoPath.url!)
         }
 
         backend.post(receiptData: Self.receiptData,

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -487,7 +487,7 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
             originalSubscriberInfo.value = result.value
             callOrder.value.initialGet = true
 
-            self.httpClient.mocks.removeValue(forKey: getCustomerInfoPath.url(proxyURL: nil))
+            self.httpClient.mocks.removeValue(forKey: getCustomerInfoPath.url)
         }
 
         backend.post(receiptData: Self.receiptData,

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -483,11 +483,11 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
         let callOrder: Atomic<(initialGet: Bool,
                                postResponse: Bool,
                                updatedGet: Bool)> = .init((false, false, false))
-        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) { result in
+        self.backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) { result in
             originalSubscriberInfo.value = result.value
             callOrder.value.initialGet = true
 
-            self.httpClient.mocks.removeValue(forKey: getCustomerInfoPath)
+            self.httpClient.mocks.removeValue(forKey: getCustomerInfoPath.url(proxyURL: nil))
         }
 
         backend.post(receiptData: Self.receiptData,
@@ -517,7 +517,7 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
         expect(updatedSubscriberInfo.value) == postSubscriberInfo.value
         expect(updatedSubscriberInfo.value) != originalSubscriberInfo.value
 
-        expect(self.httpClient.calls.map { $0.request.path }) == [
+        expect(self.httpClient.calls.map { $0.request.path as? HTTPRequest.Path }) == [
             getCustomerInfoPath,
             .postReceiptData
         ]

--- a/Tests/UnitTests/Networking/Backend/BackendSignatureVerificationTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendSignatureVerificationTests.swift
@@ -41,7 +41,7 @@ class BackendSignatureVerificationTests: BaseBackendTests {
     }
 
     func testRequestFailsIfSignatureVerificationFails() throws {
-        let expectedError: NetworkError = .signatureVerificationFailed(path: .health, code: .success)
+        let expectedError: NetworkError = .signatureVerificationFailed(path: HTTPRequest.Path.health, code: .success)
 
         self.httpClient.mock(
             requestPath: .health,

--- a/Tests/UnitTests/Networking/ETagManagerTests.swift
+++ b/Tests/UnitTests/Networking/ETagManagerTests.swift
@@ -811,8 +811,8 @@ private extension ETagManagerTests {
                      verificationResult: verificationResult)
     }
 
-    private static let testURL = HTTPRequest.Path.getCustomerInfo(appUserID: "appUserID").url
-    private static let testURL2 = HTTPRequest.Path.getCustomerInfo(appUserID: "appUserID_2").url
+    private static let testURL = HTTPRequest.Path.getCustomerInfo(appUserID: "appUserID").url!
+    private static let testURL2 = HTTPRequest.Path.getCustomerInfo(appUserID: "appUserID_2").url!
 
     static let testETag = "etag_1"
 

--- a/Tests/UnitTests/Networking/ETagManagerTests.swift
+++ b/Tests/UnitTests/Networking/ETagManagerTests.swift
@@ -811,8 +811,8 @@ private extension ETagManagerTests {
                      verificationResult: verificationResult)
     }
 
-    private static let testURL = HTTPRequest.Path.getCustomerInfo(appUserID: "appUserID").url(proxyURL: nil)
-    private static let testURL2 = HTTPRequest.Path.getCustomerInfo(appUserID: "appUserID_2").url(proxyURL: nil)
+    private static let testURL = HTTPRequest.Path.getCustomerInfo(appUserID: "appUserID").url
+    private static let testURL2 = HTTPRequest.Path.getCustomerInfo(appUserID: "appUserID_2").url
 
     static let testETag = "etag_1"
 

--- a/Tests/UnitTests/Networking/ETagManagerTests.swift
+++ b/Tests/UnitTests/Networking/ETagManagerTests.swift
@@ -811,8 +811,8 @@ private extension ETagManagerTests {
                      verificationResult: verificationResult)
     }
 
-    private static let testURL = HTTPRequest.Path.getCustomerInfo(appUserID: "appUserID").url!
-    private static let testURL2 = HTTPRequest.Path.getCustomerInfo(appUserID: "appUserID_2").url!
+    private static let testURL = HTTPRequest.Path.getCustomerInfo(appUserID: "appUserID").url(proxyURL: nil)
+    private static let testURL2 = HTTPRequest.Path.getCustomerInfo(appUserID: "appUserID_2").url(proxyURL: nil)
 
     static let testETag = "etag_1"
 

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -78,7 +78,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
     func testUsesTheCorrectHost() throws {
         let hostCorrect: Atomic<Bool> = false
 
-        let host = try XCTUnwrap(SystemInfo.serverHostURL.host)
+        let host = try XCTUnwrap(HTTPRequest.Path.serverHostURL.host)
         stub(condition: isHost(host)) { _ in
             hostCorrect.value = true
             return .emptySuccessResponse()
@@ -1052,7 +1052,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         }
 
         let error = try XCTUnwrap(response?.error)
-        expect(error) == .unableToCreateRequest(.mockPath)
+        expect(error) == .unableToCreateRequest(HTTPRequest.Path.mockPath)
     }
 
     func testPerformRequestDoesntPerformRequestIfBodyCouldntBeParsedIntoJSON() {
@@ -1432,7 +1432,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
                 data: .init(),
                 statusCode: .temporaryRedirect,
                 headers: [
-                    HTTPClient.ResponseHeader.location.rawValue: pathB.url!.absoluteString
+                    HTTPClient.ResponseHeader.location.rawValue: pathB.url(proxyURL: nil).absoluteString
                 ]
             )
         }
@@ -1452,7 +1452,8 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         expect(response?.value?.body) == responseData
 
         self.logger.verifyMessageWasLogged(
-            "Performing redirect from '\(pathA.url!.absoluteString)' to '\(pathB.url!.absoluteString)'",
+            "Performing redirect from '\(pathA.url(proxyURL: nil).absoluteString)' " +
+            "to '\(pathB.url(proxyURL: nil).absoluteString)'",
             level: .debug
         )
     }
@@ -1502,7 +1503,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
 
 }
 
-func isPath(_ path: HTTPRequest.Path) -> HTTPStubsTestBlock {
+func isPath(_ path: HTTPRequestPath) -> HTTPStubsTestBlock {
     return isPath(path.relativePath)
 }
 

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1432,7 +1432,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
                 data: .init(),
                 statusCode: .temporaryRedirect,
                 headers: [
-                    HTTPClient.ResponseHeader.location.rawValue: pathB.url.absoluteString
+                    HTTPClient.ResponseHeader.location.rawValue: pathB.url!.absoluteString
                 ]
             )
         }
@@ -1452,7 +1452,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         expect(response?.value?.body) == responseData
 
         self.logger.verifyMessageWasLogged(
-            "Performing redirect from '\(pathA.url.absoluteString)' to '\(pathB.url.absoluteString)'",
+            "Performing redirect from '\(pathA.url!.absoluteString)' to '\(pathB.url!.absoluteString)'",
             level: .debug
         )
     }

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1432,7 +1432,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
                 data: .init(),
                 statusCode: .temporaryRedirect,
                 headers: [
-                    HTTPClient.ResponseHeader.location.rawValue: pathB.url(proxyURL: nil).absoluteString
+                    HTTPClient.ResponseHeader.location.rawValue: pathB.url.absoluteString
                 ]
             )
         }
@@ -1452,8 +1452,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         expect(response?.value?.body) == responseData
 
         self.logger.verifyMessageWasLogged(
-            "Performing redirect from '\(pathA.url(proxyURL: nil).absoluteString)' " +
-            "to '\(pathB.url(proxyURL: nil).absoluteString)'",
+            "Performing redirect from '\(pathA.url.absoluteString)' to '\(pathB.url.absoluteString)'",
             level: .debug
         )
     }

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -66,7 +66,7 @@ class HTTPRequestTests: TestCase {
 
     func testPathsDontHaveLeadingSlash() {
         for path in Self.paths {
-            expect(path.relativePath).toNot(beginWith("/"))
+            expect(path.pathComponent).toNot(beginWith("/"))
         }
     }
 
@@ -186,7 +186,7 @@ class HTTPRequestTests: TestCase {
         let encodedUserID = "userid%20with%20spaces"
         let expectedPath = "subscribers/\(encodedUserID)"
 
-        expect(HTTPRequest.Path.getCustomerInfo(appUserID: encodeableUserID).relativePath) == expectedPath
+        expect(HTTPRequest.Path.getCustomerInfo(appUserID: encodeableUserID).pathComponent) == expectedPath
     }
 
     func testURLWithNoProxy() {

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -191,6 +191,7 @@ class HTTPRequestTests: TestCase {
 
     func testURLWithNoProxy() {
         let path: HTTPRequest.Path = .health
+        expect(path.url) == URL(string: "https://api.revenuecat.com/v1/health")
         expect(path.url(proxyURL: nil)) == URL(string: "https://api.revenuecat.com/v1/health")
     }
 

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -189,15 +189,24 @@ class HTTPRequestTests: TestCase {
         expect(HTTPRequest.Path.getCustomerInfo(appUserID: encodeableUserID).pathComponent) == expectedPath
     }
 
+    func testUserIDEscapingOnURL() {
+        let encodeableUserID = "userid with spaces"
+        let encodedUserID = "userid%20with%20spaces"
+        let expectedURL = "https://api.revenuecat.com/v1/subscribers/\(encodedUserID)"
+        let result = HTTPRequest.Path.getCustomerInfo(appUserID: encodeableUserID).url
+
+        expect(result?.absoluteString) == expectedURL
+    }
+
     func testURLWithNoProxy() {
         let path: HTTPRequest.Path = .health
-        expect(path.url) == URL(string: "https://api.revenuecat.com/v1/health")
-        expect(path.url(proxyURL: nil)) == URL(string: "https://api.revenuecat.com/v1/health")
+        expect(path.url?.absoluteString) == "https://api.revenuecat.com/v1/health"
+        expect(path.url(proxyURL: nil)?.absoluteString) == "https://api.revenuecat.com/v1/health"
     }
 
     func testURLWithProxy() {
         let path: HTTPRequest.Path = .health
-        expect(path.url(proxyURL: URL(string: "https://test_url"))) == URL(string: "https://test_url/v1/health")
+        expect(path.url(proxyURL: URL(string: "https://test_url"))?.absoluteString) == "https://test_url/v1/health"
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)

--- a/Tests/UnitTests/Networking/HTTPRequestTests.swift
+++ b/Tests/UnitTests/Networking/HTTPRequestTests.swift
@@ -66,7 +66,7 @@ class HTTPRequestTests: TestCase {
 
     func testPathsDontHaveLeadingSlash() {
         for path in Self.paths {
-            expect(path.description).toNot(beginWith("/"))
+            expect(path.relativePath).toNot(beginWith("/"))
         }
     }
 
@@ -170,11 +170,11 @@ class HTTPRequestTests: TestCase {
 
     func testPathsEscapeUserID() {
         for path in Self.pathsWithUserID {
-            expect(path.description).toNot(
+            expect(path.relativePath).toNot(
                 contain(Self.anonymousUser),
                 description: "Path '\(path)' should escape user ID"
             )
-            expect(path.description).to(
+            expect(path.relativePath).to(
                 contain(Self.anonymousUser.trimmedAndEscaped),
                 description: "Path '\(path)' should escape user ID"
             )
@@ -186,7 +186,17 @@ class HTTPRequestTests: TestCase {
         let encodedUserID = "userid%20with%20spaces"
         let expectedPath = "subscribers/\(encodedUserID)"
 
-        expect(HTTPRequest.Path.getCustomerInfo(appUserID: encodeableUserID).description) == expectedPath
+        expect(HTTPRequest.Path.getCustomerInfo(appUserID: encodeableUserID).relativePath) == expectedPath
+    }
+
+    func testURLWithNoProxy() {
+        let path: HTTPRequest.Path = .health
+        expect(path.url(proxyURL: nil)) == URL(string: "https://api.revenuecat.com/v1/health")
+    }
+
+    func testURLWithProxy() {
+        let path: HTTPRequest.Path = .health
+        expect(path.url(proxyURL: URL(string: "https://test_url"))) == URL(string: "https://test_url/v1/health")
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)

--- a/Tests/UnitTests/Networking/NetworkErrorTests.swift
+++ b/Tests/UnitTests/Networking/NetworkErrorTests.swift
@@ -60,8 +60,8 @@ class NetworkErrorAsPurchasesErrorTests: BaseErrorTests {
 
         verifyPurchasesError(error,
                              expectedCode: .networkError,
-                             userInfoKeys: ["request_url"],
-                             localizedDescription: "Could not create request to \(path)")
+                             userInfoKeys: ["request_path"],
+                             localizedDescription: "Could not create request to \(path.relativePath)")
     }
 
     func testUnexpectedResponse() {

--- a/Tests/UnitTests/Networking/NetworkErrorTests.swift
+++ b/Tests/UnitTests/Networking/NetworkErrorTests.swift
@@ -347,13 +347,15 @@ class NetworkErrorTests: TestCase {
     private static let dnsError: NetworkError = .dnsError(failedURL: URL(string: "https://google.com")!,
                                                           resolvedHost: "https://google.com")
     private static let unableToCreateRequestError: NetworkError = .unableToCreateRequest(
-        .getCustomerInfo(appUserID: "user ID")
+        HTTPRequest.Path.getCustomerInfo(appUserID: "user ID")
     )
 
     private static let unexpectedResponseError: NetworkError = .unexpectedResponse(nil)
 
-    private static let signatureVerificationFailed: NetworkError = .signatureVerificationFailed(path: .health,
-                                                                                                code: .success)
+    private static let signatureVerificationFailed: NetworkError = .signatureVerificationFailed(
+        path: HTTPRequest.Path.health,
+        code: .success
+    )
 
     private static func responseError(_ statusCode: HTTPStatusCode) -> NetworkError {
         return .errorResponse(

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -730,7 +730,7 @@ private extension BaseSignatureVerificationHTTPClientTests {
     }
 
     final func mockResponse(
-        path: HTTPRequest.Path = BaseSignatureVerificationHTTPClientTests.path,
+        path: HTTPRequestPath = BaseSignatureVerificationHTTPClientTests.path,
         signature: String?,
         requestDate: Date?,
         eTag: String? = nil,
@@ -757,7 +757,7 @@ private extension BaseSignatureVerificationHTTPClientTests {
     }
 
     final func mockPath(
-        _ path: HTTPRequest.Path = BaseSignatureVerificationHTTPClientTests.path,
+        _ path: HTTPRequestPath = BaseSignatureVerificationHTTPClientTests.path,
         statusCode: HTTPStatusCode,
         requestDate: Date,
         signature: String? = BaseSignatureVerificationHTTPClientTests.sampleSignature,

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -321,21 +321,6 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expect(self.backend.getCustomerInfoCallCount).toEventually(equal(1))
     }
 
-    func testProxyURL() {
-        expect(SystemInfo.proxyURL).to(beNil())
-        let defaultHostURL = URL(string: "https://api.revenuecat.com")
-        expect(SystemInfo.serverHostURL) == defaultHostURL
-
-        let testURL = URL(string: "https://test_url")
-        Purchases.proxyURL = testURL
-
-        expect(SystemInfo.serverHostURL) == testURL
-
-        Purchases.proxyURL = nil
-
-        expect(SystemInfo.serverHostURL) == defaultHostURL
-    }
-
     func testIsAnonymous() {
         setupAnonPurchases()
         expect(self.purchases.isAnonymous).to(beTrue())

--- a/Tests/UnitTests/Security/SigningTests.swift
+++ b/Tests/UnitTests/Security/SigningTests.swift
@@ -720,3 +720,13 @@ private extension Date {
     }
 
 }
+
+extension HTTPRequest {
+
+    /// Creates an `HTTPRequest` with a `nonce`.
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    static func createWithResponseVerification(method: Method, path: Path) -> Self {
+        return .init(method: method, path: path, nonce: Data.randomNonce())
+    }
+
+}


### PR DESCRIPTION
This paves the way to add a second set of paths with a separate server URL to be able to shed requests to offerings and product entitlement mapping to a separate server.

### Changes:
- New `HTTPRequestPath` with the same properties as `HTTPRequest.Path` + a new `serverHostURL`
- Moved proxy logic from `SystemInfo`/`HTTPClient` to `HTTPRequestPath`
- Simplified `HTTPRequest` implementation
