### PR TITLE
`Paywalls`: prevent multiple concurrent purchases

### DIFF
--- a/RevenueCatUI/Views/PurchaseButton.swift
+++ b/RevenueCatUI/Views/PurchaseButton.swift
@@ -67,6 +67,8 @@ struct PurchaseButton: View {
 
     private var button: some View {
         AsyncButton {
+            guard !self.purchaseHandler.actionInProgress else { return }
+
             let cancelled = try await self.purchaseHandler.purchase(package: self.package,
                                                                     with: self.mode).userCancelled
 


### PR DESCRIPTION
Tapping multiple times on the `PurchaseButton` can lead to "purchase already in progress", because of a race condition with SwiftUI not updating the `.disabled` state on time. This works around that.