### PR TITLE
`Integration Tests`: test for `SignatureVerificationMode.informational` and receipt posting when fetching `CustomerInfo`

### DIFF
--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -46,6 +46,8 @@ class BaseBackendIntegrationTests: TestCase {
 
     private var mainThreadMonitor: MainThreadMonitor!
 
+    fileprivate var serverIsDown: Bool = false
+
     // MARK: - Overridable configuration
 
     class var storeKit2Setting: StoreKit2Setting { return .default }
@@ -214,8 +216,11 @@ private extension BaseBackendIntegrationTests {
 extension BaseBackendIntegrationTests: InternalDangerousSettingsType {
 
     var enableReceiptFetchRetry: Bool { return true }
-    var forceServerErrors: Bool { return false }
+    var forceServerErrors: Bool { return self.serverIsDown }
     var forceSignatureFailures: Bool { return false }
     var testReceiptIdentifier: String? { return self.testUUID.uuidString }
+
+    final func serverDown() { self.serverIsDown = true }
+    final func serverUp() { self.serverIsDown = false }
 
 }

--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -20,11 +20,8 @@ import XCTest
 
 class BaseOfflineStoreKitIntegrationTests: BaseStoreKitIntegrationTests {
 
-    fileprivate var serverIsDown: Bool = false
-    override var forceServerErrors: Bool { return self.serverIsDown }
-
     override func setUp() async throws {
-        self.serverIsDown = false
+        self.serverUp()
         try await super.setUp()
 
         await self.waitForPendingCustomerInfoRequests()
@@ -353,9 +350,6 @@ class OfflineWithNoMappingStoreKitIntegrationTests: BaseOfflineStoreKitIntegrati
 // MARK: -
 
 private extension BaseOfflineStoreKitIntegrationTests {
-
-    final func serverDown() { self.serverIsDown = true }
-    final func serverUp() { self.serverIsDown = false }
 
     func waitForPendingCustomerInfoRequests() async {
         _ = try? await self.purchases.customerInfo()

--- a/Tests/BackendIntegrationTests/SignatureVerificationIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/SignatureVerificationIntegrationTests.swift
@@ -147,6 +147,21 @@ class InformationalSignatureVerificationIntegrationTests: BaseSignatureVerificat
         _ = try await self.purchases.productEntitlementMapping()
     }
 
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    func testPostingReceiptInLieuOfCustomerInfoReturnsVerificationResult() async throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
+        self.serverDown()
+        try await self.purchaseMonthlyOffering()
+
+        self.serverUp()
+        self.invalidSignature = true
+
+        let customerInfo = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)
+        expect(customerInfo.entitlements.verification) == .failed
+        try await self.verifyEntitlementWentThrough(customerInfo)
+    }
+
 }
 
 class EnforcedSignatureVerificationIntegrationTests: BaseSignatureVerificationIntegrationTests {


### PR DESCRIPTION
This is useful to verify how these 2 features are working together.
