### PR TITLE
`Xcode 15`: fix non-`visionOS` build by replacing `.custom` platform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,6 +313,15 @@ jobs:
           name: SPM Receipt Parser
           command: swift build -c release --target ReceiptParser
           no_output_timeout: 30m
+  
+  spm-xcode-14-1:
+    <<: *base-job
+    steps:
+      - checkout
+      - run:
+          name: SPM Release Build
+          command: swift build -c release --target RevenueCat
+          no_output_timeout: 30m
 
   run-test-ios-17:
     <<: *base-job
@@ -884,6 +893,8 @@ workflows:
           xcode_version: '14.3.0'
       - spm-release-build:
           xcode_version: '14.3.0'
+      - spm-xcode-14-1:
+          xcode_version: '14.1.0'
       - spm-custom-entitlement-computation-build:
           xcode_version: '14.3.0'
       - spm-receipt-parser:

--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,10 @@ if shouldIncludeDocCPlugin {
     dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
 }
 
+// See https://github.com/RevenueCat/purchases-ios/pull/2989
+// #if os(xrOS) can't really be used in Xcode 13, so we use this instead.
+let visionOSSetting: SwiftSetting = .define("VISION_OS", .when(platforms: [.visionOS]))
+
 let package = Package(
     name: "RevenueCat",
     platforms: [
@@ -41,15 +45,17 @@ let package = Package(
                 resources: [
                     .copy("../Sources/PrivacyInfo.xcprivacy")
                 ],
-                swiftSettings: [.define("VISION_OS", .when(platforms: [.visionOS]))]),
+                swiftSettings: [visionOSSetting]),
         .target(name: "RevenueCat_CustomEntitlementComputation",
                 path: "CustomEntitlementComputation",
                 exclude: ["Info.plist", "LocalReceiptParsing/ReceiptParser-only-files"],
                 resources: [
                     .copy("PrivacyInfo.xcprivacy")
                 ],
-                swiftSettings: [.define("ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION"),
-                                .define("VISION_OS", .when(platforms: [.visionOS]))]),
+                swiftSettings: [
+                    .define("ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION"),
+                    visionOSSetting
+                ]),
         .target(name: "ReceiptParser",
                 path: "LocalReceiptParsing"),
         .testTarget(name: "ReceiptParserTests",

--- a/Package@swift-5.7.swift
+++ b/Package@swift-5.7.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -22,8 +22,7 @@ let package = Package(
         .macOS(.v10_13),
         .watchOS("6.2"),
         .tvOS(.v11),
-        .iOS(.v11),
-        .visionOS(.v1)
+        .iOS(.v11)
     ],
     products: [
         .library(name: "RevenueCat",
@@ -40,16 +39,14 @@ let package = Package(
                 exclude: ["Info.plist", "LocalReceiptParsing/ReceiptParser-only-files"],
                 resources: [
                     .copy("../Sources/PrivacyInfo.xcprivacy")
-                ],
-                swiftSettings: [.define("VISION_OS", .when(platforms: [.visionOS]))]),
+                ]),
         .target(name: "RevenueCat_CustomEntitlementComputation",
                 path: "CustomEntitlementComputation",
                 exclude: ["Info.plist", "LocalReceiptParsing/ReceiptParser-only-files"],
                 resources: [
                     .copy("PrivacyInfo.xcprivacy")
                 ],
-                swiftSettings: [.define("ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION"),
-                                .define("VISION_OS", .when(platforms: [.visionOS]))]),
+                swiftSettings: [.define("ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION")]),
         .target(name: "ReceiptParser",
                 path: "LocalReceiptParsing"),
         .testTarget(name: "ReceiptParserTests",

--- a/Package@swift-5.8.swift
+++ b/Package@swift-5.8.swift
@@ -1,0 +1,56 @@
+// swift-tools-version:5.8
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+import class Foundation.ProcessInfo
+
+// Only add DocC Plugin when building docs, so that clients of this library won't
+// unnecessarily also get the DocC Plugin
+let environmentVariables = ProcessInfo.processInfo.environment
+let shouldIncludeDocCPlugin = environmentVariables["INCLUDE_DOCC_PLUGIN"] == "true"
+
+var dependencies: [Package.Dependency] = [
+    .package(url: "git@github.com:Quick/Nimble.git", from: "10.0.0")
+]
+if shouldIncludeDocCPlugin {
+    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
+}
+
+let package = Package(
+    name: "RevenueCat",
+    platforms: [
+        .macOS(.v10_13),
+        .watchOS("6.2"),
+        .tvOS(.v11),
+        .iOS(.v11)
+    ],
+    products: [
+        .library(name: "RevenueCat",
+                 targets: ["RevenueCat"]),
+        .library(name: "RevenueCat_CustomEntitlementComputation",
+                 targets: ["RevenueCat_CustomEntitlementComputation"]),
+        .library(name: "ReceiptParser",
+                 targets: ["ReceiptParser"])
+    ],
+    dependencies: dependencies,
+    targets: [
+        .target(name: "RevenueCat",
+                path: "Sources",
+                exclude: ["Info.plist", "LocalReceiptParsing/ReceiptParser-only-files"],
+                resources: [
+                    .copy("../Sources/PrivacyInfo.xcprivacy")
+                ]),
+        .target(name: "RevenueCat_CustomEntitlementComputation",
+                path: "CustomEntitlementComputation",
+                exclude: ["Info.plist", "LocalReceiptParsing/ReceiptParser-only-files"],
+                resources: [
+                    .copy("PrivacyInfo.xcprivacy")
+                ],
+                swiftSettings: [.define("ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION")]),
+        .target(name: "ReceiptParser",
+                path: "LocalReceiptParsing"),
+        .testTarget(name: "ReceiptParserTests",
+                    dependencies: ["ReceiptParser", "Nimble"],
+                    exclude: ["ReceiptParserTests-Info.plist"])
+    ]
+)


### PR DESCRIPTION
Fixes #2998. See #2989 for why this is needed in the first place.
This is now fixed in SPM: https://github.com/apple/swift-package-manager/pull/6794, but we need a workaround for now.

Since `.custom` doesn't work properly (it gets evaluated in Xcode even outside of that platform), this splits `Package.swift` based on Xcode version.

Thanks @neonichu for helping with this.