### PR TITLE
`SwiftLint`: disable `unneeded_synthesized_initializer`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -19,6 +19,8 @@ opt_in_rules:
 disabled_rules:
   - orphaned_doc_comment
   - blanket_disable_command
+  # Broken: https://github.com/realm/SwiftLint/issues/5153
+  - unneeded_synthesized_initializer
 
 custom_rules:
   xctestcase_superclass:


### PR DESCRIPTION
See https://realm.github.io/SwiftLint/unneeded_synthesized_initializer.html
This is currently broken (https://github.com/realm/SwiftLint/issues/5153) which leads to `swiftlint --autocorrect` removing actually needed code.
