### PR TITLE
`CustomerInfoManager`: allow disabling post-transaction behavior

### DIFF
--- a/Tests/UnitTests/Identity/CustomerInfoManagerPostReceiptTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerPostReceiptTests.swift
@@ -39,6 +39,20 @@ class CustomerInfoManagerPostReceiptTests: BaseCustomerInfoManagerTests {
         expect(self.mockTransactionPoster.invokedHandlePurchasedTransaction.value) == false
     }
 
+    func testDoesNotTryToPostUnfinishedTransactionsIfDisabled() async throws {
+        self.mockTransationFetcher.stubbedUnfinishedTransactions = [Self.createTransaction()]
+        self.mockBackend.stubbedGetCustomerInfoResult = .success(self.mockCustomerInfo)
+
+        let result = try await self.customerInfoManager.fetchAndCacheCustomerInfo(appUserID: Self.userID,
+                                                                                  isAppBackgrounded: false,
+                                                                                  postTransactionsIfNeeded: false)
+        expect(result) === self.mockCustomerInfo
+
+        expect(self.mockBackend.invokedGetSubscriberDataCount) == 1
+        expect(self.mockBackend.invokedGetSubscriberDataParameters?.randomDelay) == false
+        expect(self.mockTransactionPoster.invokedHandlePurchasedTransaction.value) == false
+    }
+
     func testReturnsFailureIfPostingReceiptFails() async throws {
         self.mockTransationFetcher.stubbedUnfinishedTransactions = [Self.createTransaction()]
         self.mockTransactionPoster.stubbedHandlePurchasedTransactionResult.value = .failure(

--- a/Tests/UnitTests/Mocks/MockCustomerInfoManager.swift
+++ b/Tests/UnitTests/Mocks/MockCustomerInfoManager.swift
@@ -16,34 +16,50 @@ class MockCustomerInfoManager: CustomerInfoManager {
 
     var invokedFetchAndCacheCustomerInfo = false
     var invokedFetchAndCacheCustomerInfoCount = 0
-    var invokedFetchAndCacheCustomerInfoParameters: (appUserID: String, isAppBackgrounded: Bool, completion: CustomerInfoCompletion?)?
+    var invokedFetchAndCacheCustomerInfoParameters: (appUserID: String,
+                                                     isAppBackgrounded: Bool,
+                                                     postTransactionsIfNeeded: Bool,
+                                                     completion: CustomerInfoCompletion?)?
     var invokedFetchAndCacheCustomerInfoParametersList = [(appUserID: String,
                                                            isAppBackgrounded: Bool,
+                                                           postTransactionsIfNeeded: Bool,
                                                            completion: CustomerInfoCompletion?)]()
 
     override func fetchAndCacheCustomerInfo(appUserID: String,
                                             isAppBackgrounded: Bool,
+                                            postTransactionsIfNeeded: Bool = true,
                                             completion: CustomerInfoCompletion?) {
-        invokedFetchAndCacheCustomerInfo = true
-        invokedFetchAndCacheCustomerInfoCount += 1
-        invokedFetchAndCacheCustomerInfoParameters = (appUserID, isAppBackgrounded, completion)
-        invokedFetchAndCacheCustomerInfoParametersList.append((appUserID, isAppBackgrounded, completion))
+        self.invokedFetchAndCacheCustomerInfo = true
+        self.invokedFetchAndCacheCustomerInfoCount += 1
+        self.invokedFetchAndCacheCustomerInfoParameters = (appUserID, isAppBackgrounded, postTransactionsIfNeeded, completion)
+        self.invokedFetchAndCacheCustomerInfoParametersList.append((appUserID,
+                                                                    isAppBackgrounded,
+                                                                    postTransactionsIfNeeded,
+                                                                    completion))
     }
 
     var invokedFetchAndCacheCustomerInfoIfStale = false
     var invokedFetchAndCacheCustomerInfoIfStaleCount = 0
-    var invokedFetchAndCacheCustomerInfoIfStaleParameters: (appUserID: String, isAppBackgrounded: Bool, completion: CustomerInfoCompletion?)?
+    var invokedFetchAndCacheCustomerInfoIfStaleParameters: (appUserID: String,
+                                                            isAppBackgrounded: Bool,
+                                                            postTransactionsIfNeeded: Bool,
+                                                            completion: CustomerInfoCompletion?)?
     var invokedFetchAndCacheCustomerInfoIfStaleParametersList = [(appUserID: String,
                                                                   isAppBackgrounded: Bool,
+                                                                  postTransactionsIfNeeded: Bool,
                                                                   completion: CustomerInfoCompletion?)]()
 
     override func fetchAndCacheCustomerInfoIfStale(appUserID: String,
                                                    isAppBackgrounded: Bool,
+                                                   postTransactionsIfNeeded: Bool = true,
                                                    completion: CustomerInfoCompletion?) {
         self.invokedFetchAndCacheCustomerInfoIfStale = true
         self.invokedFetchAndCacheCustomerInfoIfStaleCount += 1
-        self.invokedFetchAndCacheCustomerInfoIfStaleParameters = (appUserID, isAppBackgrounded, completion)
-        self.invokedFetchAndCacheCustomerInfoIfStaleParametersList.append((appUserID, isAppBackgrounded, completion))
+        self.invokedFetchAndCacheCustomerInfoIfStaleParameters = (appUserID,
+                                                                  isAppBackgrounded,
+                                                                  postTransactionsIfNeeded,
+                                                                  completion)
+        self.invokedFetchAndCacheCustomerInfoIfStaleParametersList.append((appUserID, isAppBackgrounded, postTransactionsIfNeeded, completion))
     }
 
     var invokedSendCachedCustomerInfoIfAvailable = false
@@ -62,20 +78,23 @@ class MockCustomerInfoManager: CustomerInfoManager {
     var invokedCustomerInfoCount = 0
     var invokedCustomerInfoParameters: (appUserID: String,
                                         fetchPolicy: CacheFetchPolicy,
+                                        postTransactionsIfNeeded: Bool,
                                         completion: CustomerInfoCompletion?)?
     var invokedCustomerInfoParametersList: [(appUserID: String,
                                              fetchPolicy: CacheFetchPolicy,
+                                             postTransactionsIfNeeded: Bool,
                                              completion: CustomerInfoCompletion?)] = []
 
     var stubbedCustomerInfoResult: Result<CustomerInfo, BackendError> = .failure(.missingAppUserID())
 
     override func customerInfo(appUserID: String,
                                fetchPolicy: CacheFetchPolicy,
+                               postTransactionsIfNeeded: Bool = true,
                                completion: CustomerInfoCompletion?) {
         self.invokedCustomerInfo = true
         self.invokedCustomerInfoCount += 1
-        self.invokedCustomerInfoParameters = (appUserID, fetchPolicy, completion)
-        self.invokedCustomerInfoParametersList.append((appUserID, fetchPolicy, completion))
+        self.invokedCustomerInfoParameters = (appUserID, fetchPolicy, postTransactionsIfNeeded, completion)
+        self.invokedCustomerInfoParametersList.append((appUserID, fetchPolicy, postTransactionsIfNeeded, completion))
 
         OperationDispatcher.dispatchOnMainActor {
             completion?(self.stubbedCustomerInfoResult)


### PR DESCRIPTION
See https://github.com/RevenueCat/purchases-ios/pull/2914#discussion_r1291605284
This will be used by that PR as a fallback whenever we try to post a transaction that had already been posted.
