### PR TITLE
`Integration Tests`: add tests to verify `CustomerInfo`+`Offerings` request de-dupping

### DIFF
--- a/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
@@ -31,6 +31,74 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
         expect(info.isComputedOffline) == false
     }
 
+    func testGetCustomerInfoMultipleTimesInParallel() async throws {
+        let requestCount = 3
+
+        let purchases = try self.purchases
+
+        // 1. Make sure any existing customer info requests finish
+        _ = try await purchases.customerInfo()
+        // 2. Invalidate cache
+        purchases.invalidateCustomerInfoCache()
+        self.logger.clearMessages()
+
+        // 3. Request customer info multiple times in parallel
+        await withThrowingTaskGroup(of: Void.self) {
+            for _ in 0..<requestCount {
+                $0.addTask { _ = try await purchases.customerInfo() }
+            }
+        }
+
+        // 4. Verify N-1 requests were de-duped
+        self.logger.verifyMessageWasLogged(
+            "Network operation 'GetCustomerInfoOperation' found with the same cache key",
+            level: .debug,
+            expectedCount: requestCount - 1
+        )
+        self.logger.verifyMessageWasLogged(
+            Strings.network.api_request_completed(
+                .init(method: .get,
+                      path: .getCustomerInfo(appUserID: try self.purchases.appUserID)),
+                httpCode: .notModified
+            ),
+            level: .debug,
+            expectedCount: 1
+        )
+    }
+
+    func testGetOfferingsMultipleTimesInParallel() async throws {
+        let requestCount = 3
+
+        let purchases = try self.purchases
+
+        // 1. Invalidate cache
+        purchases.invalidateOfferingsCache()
+        self.logger.clearMessages()
+
+        // 2. Request offerings multiple times in parallel
+        await withThrowingTaskGroup(of: Void.self) {
+            for _ in 0..<requestCount {
+                $0.addTask { _ = try await purchases.offerings() }
+            }
+        }
+
+        // 3. Verify N-1 requests were de-duped
+        self.logger.verifyMessageWasLogged(
+            "Network operation 'GetOfferingsOperation' found with the same cache key",
+            level: .debug,
+            expectedCount: requestCount - 1
+        )
+        self.logger.verifyMessageWasLogged(
+            Strings.network.api_request_completed(
+                .init(method: .get,
+                      path: .getOfferings(appUserID: try self.purchases.appUserID)),
+                httpCode: .notModified
+            ),
+            level: .debug,
+            expectedCount: 1
+        )
+    }
+
     func testGetCustomerInfoReturnsNotModified() async throws {
         // 1. Fetch user once
         _ = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)

--- a/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
@@ -66,6 +66,17 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
         )
     }
 
+    func testGetCustomerInfoCaching() async throws {
+        _ = try await self.purchases.customerInfo()
+
+        self.logger.clearMessages()
+
+        _ = try await self.purchases.customerInfo()
+
+        self.logger.verifyMessageWasLogged(Strings.customerInfo.vending_cache, level: .debug)
+        self.logger.verifyMessageWasNotLogged("API request started")
+    }
+
     func testGetOfferingsMultipleTimesInParallel() async throws {
         let requestCount = 3
 


### PR DESCRIPTION
This adds more coverage for why we don't actually need #2983.
