### PR TITLE
`Integration Tests`: begin tests with `UIApplication.willEnterForegroundNotification` to simulate a real app

### DIFF
--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -128,7 +128,7 @@ extension NetworkStrings: LogMessage {
 private extension HTTPRequest {
 
     var description: String {
-        return "\(self.method.httpMethod) \(self.path.relativePath)"
+        return "\(self.method.httpMethod) '\(self.path.relativePath)'"
     }
 
 }

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -170,6 +170,7 @@ private extension BaseBackendIntegrationTests {
     func createPurchases() async {
         self.purchasesDelegate = TestPurchaseDelegate()
         self.configurePurchases()
+        self.simulateForegroundingApp()
 
         Purchases.shared.delegate = self.purchasesDelegate
         Purchases.proxyURL = self.proxyURL.flatMap(URL.init(string:))
@@ -205,6 +206,11 @@ private extension BaseBackendIntegrationTests {
         // However, it still serves the purpose of waiting for the anonymous user.
         // If there is something broken when loading offerings, there is a dedicated test that would fail instead.
         _ = try? await Purchases.shared.offerings()
+    }
+
+    func simulateForegroundingApp() {
+        // This notification is posted automatically on app launch
+        NotificationCenter.default.post(name: SystemInfo.applicationWillEnterForegroundNotification, object: nil)
     }
 
     private var dangerousSettings: DangerousSettings {

--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -236,7 +236,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
         try await self.verifyEntitlementWentThrough(info2)
 
         self.logger.verifyMessageWasLogged(
-            "API request completed: POST /v1/receipts",
+            "API request completed: POST '/v1/receipts'",
             level: .debug,
             expectedCount: 1
         )

--- a/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
@@ -110,6 +110,40 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
         )
     }
 
+    func testCustomerInfoIsOnlyFetchedOnceOnAppLaunch() async throws {
+        // 1. Make sure any existing customer info requests finish
+        _ = try await purchases.customerInfo()
+
+        // 2. Verify only one CustomerInfo request was done
+        try self.logger.verifyMessageWasLogged(
+            Strings.network.api_request_started(
+                .init(
+                    method: .get,
+                    path: .getCustomerInfo(appUserID: self.purchases.appUserID)
+                )
+            ),
+            level: .debug,
+            expectedCount: 1
+        )
+    }
+
+    func testOfferingsAreOnlyFetchedOnceOnAppLaunch() async throws {
+        // 1. Make sure any existing offerings requests finish
+        _ = try await purchases.offerings()
+
+        // 2. Verify only one Offerings request was done
+        try self.logger.verifyMessageWasLogged(
+            Strings.network.api_request_started(
+                .init(
+                    method: .get,
+                    path: .getOfferings(appUserID: self.purchases.appUserID)
+                )
+            ),
+            level: .debug,
+            expectedCount: 1
+        )
+    }
+
     func testGetCustomerInfoReturnsNotModified() async throws {
         // 1. Fetch user once
         _ = try await self.purchases.customerInfo(fetchPolicy: .fetchCurrent)

--- a/Tests/TestingApps/PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit
+++ b/Tests/TestingApps/PurchaseTester/RevenueCat_IntegrationPurchaseTesterConfiguration.storekit
@@ -8,7 +8,7 @@
       "localizations" : [
         {
           "description" : "",
-          "displayName" : "",
+          "displayName" : "Non Renewing Subscription",
           "locale" : "en_US"
         }
       ],
@@ -25,7 +25,7 @@
       "localizations" : [
         {
           "description" : "",
-          "displayName" : "",
+          "displayName" : "Lifetime subscription",
           "locale" : "en_US"
         }
       ],


### PR DESCRIPTION
#2983 was an attempt to work around this. Instead, this PR adds integration tests to cover this behavior and ensure that we don't make duplicate requests.