### PR TITLE
`TransactionPoster`: fix iOS 12 test

### DIFF
--- a/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/TransactionPosterTests.swift
@@ -172,7 +172,10 @@ class TransactionPosterTests: TestCase {
 
     // MARK: - shouldFinishTransaction
 
-    func testShouldNotFinishWithOfflineCustomerInfo() {
+    func testShouldNotFinishWithOfflineCustomerInfo() throws {
+        // Offline CustomerInfo isn't available on iOS 12
+        try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
+
         let info = Self.mockCustomerInfo.copy(with: .verifiedOnDevice)
 
         expect(


### PR DESCRIPTION
This test was added in #2841, but iOS 12 can't detect offline `CustomerInfo`s because those aren't available, so this test isn't relevant there.

Fixes https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/14193/workflows/a3836667-878c-4bdd-939a-e809e9f0ac5a/jobs/107291/tests
