### PR TITLE
`Paywalls`: validate `PaywallData` to ensure displayed data is always correct

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -262,7 +262,6 @@
 		4F83F6BB2A5DB80B003F90A5 /* OSVersionEquivalent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DE80AD28075D77008D6C6F /* OSVersionEquivalent.swift */; };
 		4F8452682A5756CC00084550 /* HTTPRequestBody+Signing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8452672A5756CC00084550 /* HTTPRequestBody+Signing.swift */; };
 		4F87610F2A5C9E490006FA14 /* PaywallData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F87610E2A5C9E490006FA14 /* PaywallData.swift */; };
-		4F87612C2A5CAB980006FA14 /* PaywallTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F87612B2A5CAB980006FA14 /* PaywallTemplate.swift */; };
 		4F8929192A65EF3000A91EA2 /* EnsureNonEmptyCollectionDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8929182A65EF3000A91EA2 /* EnsureNonEmptyCollectionDecodable.swift */; };
 		4F89A55D2A6ABADF008A411E /* PaywallViewMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F89A55C2A6ABADF008A411E /* PaywallViewMode.swift */; };
 		4F8A58172A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */; };
@@ -1002,7 +1001,6 @@
 		4F8038322A1EA7C300D21039 /* TransactionPoster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionPoster.swift; sourceTree = "<group>"; };
 		4F8452672A5756CC00084550 /* HTTPRequestBody+Signing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HTTPRequestBody+Signing.swift"; sourceTree = "<group>"; };
 		4F87610E2A5C9E490006FA14 /* PaywallData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallData.swift; sourceTree = "<group>"; };
-		4F87612B2A5CAB980006FA14 /* PaywallTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallTemplate.swift; sourceTree = "<group>"; };
 		4F8929182A65EF3000A91EA2 /* EnsureNonEmptyCollectionDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnsureNonEmptyCollectionDecodable.swift; sourceTree = "<group>"; };
 		4F89A55C2A6ABADF008A411E /* PaywallViewMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallViewMode.swift; sourceTree = "<group>"; };
 		4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOfflineCustomerInfoCreator.swift; sourceTree = "<group>"; };
@@ -2262,7 +2260,6 @@
 				4FBBD4E52A620573001CBA21 /* PaywallColor.swift */,
 				4F87610E2A5C9E490006FA14 /* PaywallData.swift */,
 				4F062D312A85A11600A8A613 /* PaywallData+Localization.swift */,
-				4F87612B2A5CAB980006FA14 /* PaywallTemplate.swift */,
 				4F6ABC772A81595900250E63 /* PaywallCacheWarming.swift */,
 				4F89A55C2A6ABADF008A411E /* PaywallViewMode.swift */,
 			);
@@ -3424,7 +3421,6 @@
 				2DDF41AD24F6F37C005BC22D /* ASN1ObjectIdentifier.swift in Sources */,
 				35549323269E298B005F9AE9 /* OfferingsFactory.swift in Sources */,
 				57536A28278522B400E2AE7F /* SK2StoreTransaction.swift in Sources */,
-				4F87612C2A5CAB980006FA14 /* PaywallTemplate.swift in Sources */,
 				2D9C7BB326D838FC006838BE /* UIApplication+RCExtensions.swift in Sources */,
 				F56E2E7727622B5E009FED5B /* TransactionsManager.swift in Sources */,
 				B34605CC279A6E380031CA74 /* LogInOperation.swift in Sources */,

--- a/RevenueCatUI/Data/PaywallData+Validation.swift
+++ b/RevenueCatUI/Data/PaywallData+Validation.swift
@@ -1,0 +1,131 @@
+//
+//  PaywallData+Validation.swift
+//  
+//
+//  Created by Nacho Soto on 8/15/23.
+//
+
+import RevenueCat
+
+// MARK: - Errors
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension Offering {
+
+    typealias ValidationResult = (displayablePaywall: PaywallData, error: Offering.PaywallValidationError?)
+
+    enum PaywallValidationError: Equatable {
+
+        case missingPaywall
+        case invalidVariables(Set<String>)
+
+    }
+
+}
+
+// MARK: - Offering validation
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension Offering {
+
+    /// - Returns: a validated paywall suitable to be displayed, and any associated error.
+    func validatedPaywall() -> ValidationResult {
+        if let paywall = self.paywall {
+            if let error = paywall.validate() {
+                // If there are any errors, create a default paywall
+                // with only the configured packages.
+                return (.createDefault(with: paywall.config.packages), error)
+            } else {
+                // Use the original paywall.
+                return (paywall, nil)
+            }
+        } else {
+            // If `Offering` has no paywall, create a default one with all available packages.
+            return (displayablePaywall: .createDefault(with: self.availablePackages),
+                    error: .missingPaywall)
+        }
+    }
+
+}
+
+// MARK: - PaywallData validation
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension PaywallData {
+
+    typealias Error = Offering.PaywallValidationError
+
+    /// - Returns: `nil` if there are no validation errors.
+    func validate() -> Error? {
+        if let error = Self.validateLocalization(self.localizedConfiguration) {
+            return error
+        }
+
+        return nil
+    }
+
+    /// Validates that all strings inside of `LocalizedConfiguration` contain no unrecognized variables.
+    private static func validateLocalization(_ localization: LocalizedConfiguration) -> Error? {
+        let unrecognizedVariables = Set(
+            localization
+                .allValues
+                .lazy
+                .compactMap { $0.unrecognizedVariables() }
+                .joined()
+        )
+
+        return unrecognizedVariables.isEmpty
+        ? nil
+        : .invalidVariables(unrecognizedVariables)
+    }
+
+}
+
+// MARK: - Errors
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+extension Offering.PaywallValidationError: CustomStringConvertible {
+
+    var description: String {
+        switch self {
+        case .missingPaywall:
+            return "Offering has no configured paywall"
+
+        case let .invalidVariables(names):
+            return "Found unrecognized variables: \(names.joined(separator: ", "))"
+        }
+    }
+
+}
+
+// MARK: - PaywallLocalizedConfiguration
+
+private extension PaywallLocalizedConfiguration {
+
+    /// The set of properties inside a `PaywallLocalizedConfiguration`.
+    static var allProperties: Set<KeyPath<Self, String?>> {
+        return [
+            \.optionalTitle,
+             \.subtitle,
+             \.optionalCallToAction,
+             \.callToActionWithIntroOffer,
+             \.offerDetails,
+             \.offerDetailsWithIntroOffer,
+             \.offerName
+        ]
+    }
+
+    var allValues: [String] {
+        return Self
+            .allProperties
+            .compactMap { self[keyPath: $0] }
+    }
+
+}
+
+private extension PaywallLocalizedConfiguration {
+
+    var optionalTitle: String? { return self.title }
+    var optionalCallToAction: String? { self.callToAction }
+
+}

--- a/RevenueCatUI/Data/PaywallData+Validation.swift
+++ b/RevenueCatUI/Data/PaywallData+Validation.swift
@@ -133,6 +133,9 @@ private extension PaywallLocalizedConfiguration {
         return Self
             .allProperties
             .compactMap { self[keyPath: $0] }
+        + self.features.flatMap {
+            [$0.title, $0.content].compactMap { $0 }
+        }
     }
 
 }

--- a/RevenueCatUI/Data/PaywallTemplate.swift
+++ b/RevenueCatUI/Data/PaywallTemplate.swift
@@ -14,19 +14,14 @@
 import Foundation
 
 /// The type of template used to display a paywall.
-public enum PaywallTemplate: String {
+internal enum PaywallTemplate: String {
 
-    // swiftlint:disable missing_docs
     case template1 = "1"
     case template2 = "2"
     case template3 = "3"
     case template4 = "4"
 
-    // swiftlint:enable missing_docs
-
 }
 
-extension PaywallTemplate: Codable {}
-extension PaywallTemplate: Sendable {}
 extension PaywallTemplate: Equatable {}
 extension PaywallTemplate: CaseIterable {}

--- a/RevenueCatUI/Data/TestData.swift
+++ b/RevenueCatUI/Data/TestData.swift
@@ -150,7 +150,7 @@ internal enum TestData {
     ]
 
     static let paywallWithIntroOffer = PaywallData(
-        template: .template1,
+        templateName: PaywallTemplate.template1.rawValue,
         config: .init(
             packages: [PackageType.monthly.identifier],
             images: Self.images,
@@ -162,7 +162,7 @@ internal enum TestData {
         assetBaseURL: Self.paywallAssetBaseURL
     )
     static let paywallWithNoIntroOffer = PaywallData(
-        template: .template1,
+        templateName: PaywallTemplate.template1.rawValue,
         config: .init(
             packages: [PackageType.annual.identifier],
             images: Self.images,
@@ -193,7 +193,7 @@ internal enum TestData {
         serverDescription: "Offering",
         metadata: [:],
         paywall: .init(
-            template: .template2,
+            templateName: PaywallTemplate.template2.rawValue,
             config: .init(
                 packages: [PackageType.annual.identifier, PackageType.monthly.identifier],
                 images: Self.images,
@@ -231,7 +231,7 @@ internal enum TestData {
         serverDescription: "Offering",
         metadata: [:],
         paywall: .init(
-            template: .template3,
+            templateName: PaywallTemplate.template3.rawValue,
             config: .init(
                 packages: [PackageType.annual.identifier],
                 images: Self.images,
@@ -288,7 +288,7 @@ internal enum TestData {
         serverDescription: "Offering",
         metadata: [:],
         paywall: .init(
-            template: .template4,
+            templateName: PaywallTemplate.template4.rawValue,
             config: .init(
                 packages: [PackageType.monthly.identifier,
                            PackageType.sixMonth.identifier,

--- a/RevenueCatUI/Data/TestData.swift
+++ b/RevenueCatUI/Data/TestData.swift
@@ -323,6 +323,14 @@ internal enum TestData {
                             TestData.annualPackage]
     )
 
+    static let offeringWithNoPaywall = Offering(
+        identifier: Self.offeringIdentifier,
+        serverDescription: "Offering",
+        metadata: [:],
+        paywall: nil,
+        availablePackages: Self.packages
+    )
+
     static let lightColors: PaywallData.Configuration.Colors = .init(
         background: "#FFFFFF",
         text1: "#000000",

--- a/RevenueCatUI/Helpers/PaywallData+Default.swift
+++ b/RevenueCatUI/Helpers/PaywallData+Default.swift
@@ -22,7 +22,7 @@ extension PaywallData {
 
     static func createDefault(with packageIdentifiers: [String]) -> Self {
         return .init(
-            template: .template2,
+            templateName: Self.defaultTemplate.rawValue,
             config: .init(
                 packages: packageIdentifiers,
                 images: .init(
@@ -37,6 +37,8 @@ extension PaywallData {
             assetBaseURL: Self.defaultTemplateBaseURL
         )
     }
+
+    static let defaultTemplate: PaywallTemplate = .template2
 
     static let appIconPlaceholder = "revenuecatui_default_paywall_app_icon"
 

--- a/RevenueCatUI/Helpers/PreviewHelpers.swift
+++ b/RevenueCatUI/Helpers/PreviewHelpers.swift
@@ -57,8 +57,11 @@ struct PreviewableTemplate<T: TemplateViewType>: View {
         presentInSheet: Bool = false,
         creator: @escaping Creator
     ) {
-        self.configuration = offering.paywall!.configuration(
+        let paywall = offering.paywall!
+
+        self.configuration = paywall.configuration(
             for: offering,
+            template: PaywallTemplate(rawValue: paywall.templateName)!,
             mode: mode,
             fonts: DefaultPaywallFontProvider(),
             locale: .current

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -121,11 +121,12 @@ public struct PaywallView: View {
         checker: TrialOrIntroEligibilityChecker,
         purchaseHandler: PurchaseHandler
     ) -> some View {
-        let (paywall, error) = offering.validatedPaywall()
+        let (paywall, template, error) = offering.validatedPaywall()
 
         let paywallView = LoadedOfferingPaywallView(
             offering: offering,
             paywall: paywall,
+            template: template,
             mode: self.mode,
             fonts: fonts,
             introEligibility: checker,
@@ -155,6 +156,7 @@ struct LoadedOfferingPaywallView: View {
 
     private let offering: Offering
     private let paywall: PaywallData
+    private let template: PaywallTemplate
     private let mode: PaywallViewMode
     private let fonts: PaywallFontProvider
 
@@ -169,6 +171,7 @@ struct LoadedOfferingPaywallView: View {
     init(
         offering: Offering,
         paywall: PaywallData,
+        template: PaywallTemplate,
         mode: PaywallViewMode,
         fonts: PaywallFontProvider,
         introEligibility: TrialOrIntroEligibilityChecker,
@@ -176,6 +179,7 @@ struct LoadedOfferingPaywallView: View {
     ) {
         self.offering = offering
         self.paywall = paywall
+        self.template = template
         self.mode = mode
         self.fonts = fonts
         self._introEligibility = .init(
@@ -187,6 +191,7 @@ struct LoadedOfferingPaywallView: View {
     var body: some View {
         let view = self.paywall
             .createView(for: self.offering,
+                        template: self.template,
                         mode: self.mode,
                         fonts: self.fonts,
                         introEligibility: self.introEligibility,
@@ -231,7 +236,7 @@ struct PaywallView_Previews: PreviewProvider {
                     purchaseHandler: PreviewHelpers.purchaseHandler
                 )
                 .previewLayout(mode.layout)
-                .previewDisplayName("\(offering.paywall?.template.name ?? "")-\(mode)")
+                .previewDisplayName("\(offering.paywall?.templateName ?? "")-\(mode)")
             }
         }
     }

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -121,34 +121,27 @@ public struct PaywallView: View {
         checker: TrialOrIntroEligibilityChecker,
         purchaseHandler: PurchaseHandler
     ) -> some View {
-        if let paywall = offering.paywall {
-            LoadedOfferingPaywallView(
-                offering: offering,
-                paywall: paywall,
-                mode: self.mode,
-                fonts: fonts,
-                introEligibility: checker,
-                purchaseHandler: purchaseHandler
-            )
-        } else {
+        let (paywall, error) = offering.validatedPaywall()
+
+        let paywallView = LoadedOfferingPaywallView(
+            offering: offering,
+            paywall: paywall,
+            mode: self.mode,
+            fonts: fonts,
+            introEligibility: checker,
+            purchaseHandler: purchaseHandler
+        )
+
+        if let error {
             DebugErrorView(
-                "Offering '\(offering.identifier)' has no configured paywall, or it has invalid data.\n" +
+                "\(error.description)\n" +
                 "You can fix this by editing the paywall in the RevenueCat dashboard.\n" +
                 "The displayed paywall contains default configuration.\n" +
                 "This error will be hidden in production.",
-                releaseBehavior: .replacement(
-                    AnyView(
-                        LoadedOfferingPaywallView(
-                            offering: offering,
-                            paywall: .createDefault(with: offering.availablePackages),
-                            mode: self.mode,
-                            fonts: fonts,
-                            introEligibility: checker,
-                            purchaseHandler: purchaseHandler
-                        )
-                    )
-                )
+                releaseBehavior: .replacement(AnyView(paywallView))
             )
+        } else {
+            paywallView
         }
     }
 

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -40,14 +40,20 @@ private extension PaywallTemplate {
 extension PaywallData {
 
     @ViewBuilder
+    // swiftlint:disable:next function_parameter_count
     func createView(for offering: Offering,
+                    template: PaywallTemplate,
                     mode: PaywallViewMode,
                     fonts: PaywallFontProvider,
                     introEligibility: IntroEligibilityViewModel,
                     locale: Locale) -> some View {
-        switch self.configuration(for: offering, mode: mode, fonts: fonts, locale: locale) {
+        switch self.configuration(for: offering,
+                                  template: template,
+                                  mode: mode,
+                                  fonts: fonts,
+                                  locale: locale) {
         case let .success(configuration):
-            Self.createView(template: self.template, configuration: configuration)
+            Self.createView(template: template, configuration: configuration)
                 .task(id: offering) {
                     await introEligibility.computeEligibility(for: configuration.packages)
                 }
@@ -60,6 +66,7 @@ extension PaywallData {
 
     func configuration(
         for offering: Offering,
+        template: PaywallTemplate,
         mode: PaywallViewMode,
         fonts: PaywallFontProvider,
         locale: Locale
@@ -71,7 +78,7 @@ extension PaywallData {
                                       filter: self.config.packages,
                                       default: self.config.defaultPackage,
                                       localization: self.localizedConfiguration,
-                                      setting: self.template.packageSetting,
+                                      setting: template.packageSetting,
                                       locale: locale),
                 configuration: self.config,
                 colors: self.config.colors.multiScheme,

--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -27,6 +27,7 @@ struct LoadingPaywallView: View {
                 availablePackages: Self.packages
             ),
             paywall: Self.defaultPaywall,
+            template: Self.template,
             mode: self.mode,
             fonts: DefaultPaywallFontProvider(),
             introEligibility: Self.introEligibility,
@@ -36,6 +37,7 @@ struct LoadingPaywallView: View {
         .redacted(reason: .placeholder)
     }
 
+    private static let template: PaywallTemplate = PaywallData.defaultTemplate
     private static let defaultPaywall: PaywallData = .createDefault(with: Self.packages)
 
     private static let packages: [Package] = [

--- a/Sources/Paywalls/PaywallData.swift
+++ b/Sources/Paywalls/PaywallData.swift
@@ -32,7 +32,7 @@ public struct PaywallData {
     public var assetBaseURL: URL
 
     @EnsureNonEmptyCollectionDecodable
-    internal var localization: [String: LocalizedConfiguration]
+    internal private(set) var localization: [String: LocalizedConfiguration]
 
 }
 

--- a/Sources/Paywalls/PaywallData.swift
+++ b/Sources/Paywalls/PaywallData.swift
@@ -55,6 +55,8 @@ public protocol PaywallLocalizedConfiguration {
     var offerDetailsWithIntroOffer: String? { get }
     /// The name representing each of the packages, most commonly a variable.
     var offerName: String? { get }
+    /// An optional list of features that describe this paywall.
+    var features: [PaywallData.LocalizedConfiguration.Feature] { get }
 
 }
 

--- a/Sources/Paywalls/PaywallData.swift
+++ b/Sources/Paywalls/PaywallData.swift
@@ -23,7 +23,7 @@ import Foundation
 public struct PaywallData {
 
     /// The type of template used to display this paywall.
-    public var template: PaywallTemplate
+    public var templateName: String
 
     /// Generic configuration for any paywall.
     public var config: Configuration
@@ -327,12 +327,12 @@ extension PaywallData.Configuration {
 extension PaywallData {
 
     init(
-        template: PaywallTemplate,
+        templateName: String,
         config: Configuration,
         localization: [String: LocalizedConfiguration],
         assetBaseURL: URL
     ) {
-        self.template = template
+        self.templateName = templateName
         self.config = config
         self.localization = localization
         self.assetBaseURL = assetBaseURL
@@ -340,7 +340,7 @@ extension PaywallData {
 
     /// Creates a test ``PaywallData`` with one localization
     public init(
-        template: PaywallTemplate,
+        templateName: String,
         config: Configuration,
         localization: LocalizedConfiguration,
         assetBaseURL: URL
@@ -348,7 +348,7 @@ extension PaywallData {
         let locale = Locale.current.identifier
 
         self.init(
-            template: template,
+            templateName: templateName,
             config: config,
             localization: [locale: localization],
             assetBaseURL: assetBaseURL
@@ -407,7 +407,7 @@ extension PaywallData: Codable {
 
     // Note: these are camel case but converted by the decoder
     private enum CodingKeys: String, CodingKey {
-        case template = "templateName"
+        case templateName
         case config
         case localization = "localizedStrings"
         case assetBaseURL = "assetBaseUrl"

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PaywallAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PaywallAPI.swift
@@ -13,13 +13,13 @@ import SwiftUI
 #endif
 
 func checkPaywallData(_ data: PaywallData) {
-    let template: PaywallTemplate = data.template
+    let templateName: String = data.templateName
     let config: PaywallData.Configuration = data.config
     let _: PaywallData.LocalizedConfiguration? = data.config(for: Locale.current)
     let localization: PaywallData.LocalizedConfiguration = data.localizedConfiguration
     let assetBaseURL: URL = data.assetBaseURL
 
-    let _: PaywallData = .init(template: template,
+    let _: PaywallData = .init(templateName: templateName,
                                config: config,
                                localization: localization,
                                assetBaseURL: assetBaseURL)
@@ -141,21 +141,6 @@ func checkPaywallColor(_ color: PaywallColor) throws {
         let _: Color = color.underlyingColor
     }
     #endif
-}
-
-func checkPaywallTemplate(_ template: PaywallTemplate) {
-    switch template {
-    case .template1:
-        break
-    case .template2:
-        break
-    case .template3:
-        break
-    case .template4:
-        break
-    @unknown default:
-        break
-    }
 }
 
 func checkPaywallViewMode(_ mode: PaywallViewMode) {

--- a/Tests/RevenueCatUITests/Data/PaywallDataValidationTests.swift
+++ b/Tests/RevenueCatUITests/Data/PaywallDataValidationTests.swift
@@ -32,17 +32,30 @@ class PaywallDataValidationTests: TestCase {
         expect(result.error).to(beNil())
     }
 
+    func testUnrecognizedTemplateNameGeneratesDefaultPaywall() {
+        let templateName = "unrecognized_template"
+
+        let originalOffering = TestData.offeringWithMultiPackagePaywall
+        let offering = originalOffering.with(templateName: templateName)
+        let result = offering.validatedPaywall()
+
+        Self.verifyPackages(in: result.displayablePaywall, match: originalOffering.paywall)
+        Self.snapshot(result.displayablePaywall)
+
+        expect(result.error) == .invalidTemplate(templateName)
+    }
+
     func testUnrecognizedVariableGeneratesDefaultPaywall() {
-        let offering = TestData.offeringWithMultiPackagePaywall
-        let paywall = offering
+        let originalOffering = TestData.offeringWithMultiPackagePaywall
+        let offering = originalOffering
             .with(localization: .init(
                 title: "Title with {{ unrecognized_variable }}",
                 callToAction: "{{ future_variable }}",
                 offerDetails: nil
             ))
-        let result = paywall.validatedPaywall()
+        let result = offering.validatedPaywall()
 
-        Self.verifyPackages(in: result.displayablePaywall, match: offering.paywall)
+        Self.verifyPackages(in: result.displayablePaywall, match: originalOffering.paywall)
         Self.snapshot(result.displayablePaywall)
 
         expect(result.error) == .invalidVariables(["unrecognized_variable", "future_variable"])

--- a/Tests/RevenueCatUITests/Data/PaywallDataValidationTests.swift
+++ b/Tests/RevenueCatUITests/Data/PaywallDataValidationTests.swift
@@ -61,6 +61,22 @@ class PaywallDataValidationTests: TestCase {
         expect(result.error) == .invalidVariables(["unrecognized_variable", "future_variable"])
     }
 
+    func testUnrecognizedVariableInFeaturesGeneratesDefaultPaywall() throws {
+        let originalOffering = TestData.offeringWithMultiPackagePaywall
+        var localization = try XCTUnwrap(originalOffering.paywall?.localizedConfiguration)
+        localization.features = [
+            .init(title: "{{ future_variable }}", content: "{{ new_variable }}"),
+            .init(title: "{{ another_one }}"),
+        ]
+
+        let offering = originalOffering.with(localization: localization)
+        let result = offering.validatedPaywall()
+
+        Self.verifyPackages(in: result.displayablePaywall, match: originalOffering.paywall)
+        Self.snapshot(result.displayablePaywall)
+
+        expect(result.error) == .invalidVariables(["future_variable", "new_variable", "another_one"])
+    }
 }
 
 // MARK: -

--- a/Tests/RevenueCatUITests/Data/PaywallDataValidationTests.swift
+++ b/Tests/RevenueCatUITests/Data/PaywallDataValidationTests.swift
@@ -1,0 +1,106 @@
+//
+//  PaywallDataValidationTests.swift
+//  
+//
+//  Created by Nacho Soto on 8/15/23.
+//
+
+import Nimble
+import RevenueCat
+@testable import RevenueCatUI
+import SnapshotTesting
+import XCTest
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+class PaywallDataValidationTests: TestCase {
+
+    func testValidateMissingPaywall() {
+        let offering = TestData.offeringWithNoPaywall
+        let result = TestData.offeringWithNoPaywall.validatedPaywall()
+
+        Self.verifyPackages(in: result.displayablePaywall, match: offering.availablePackages)
+        Self.snapshot(result.displayablePaywall)
+
+        expect(result.error) == .missingPaywall
+    }
+
+    func testValidateValidPaywall() {
+        let offering = TestData.offeringWithSinglePackageFeaturesPaywall
+        let result = offering.validatedPaywall()
+
+        expect(result.displayablePaywall) == offering.paywall
+        expect(result.error).to(beNil())
+    }
+
+    func testUnrecognizedVariableGeneratesDefaultPaywall() {
+        let offering = TestData.offeringWithMultiPackagePaywall
+        let paywall = offering
+            .with(localization: .init(
+                title: "Title with {{ unrecognized_variable }}",
+                callToAction: "{{ future_variable }}",
+                offerDetails: nil
+            ))
+        let result = paywall.validatedPaywall()
+
+        Self.verifyPackages(in: result.displayablePaywall, match: offering.paywall)
+        Self.snapshot(result.displayablePaywall)
+
+        expect(result.error) == .invalidVariables(["unrecognized_variable", "future_variable"])
+    }
+
+}
+
+// MARK: -
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension PaywallDataValidationTests {
+
+    static func verifyPackages(
+        in paywall: PaywallData,
+        match other: PaywallData?,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        expect(
+            file: file, line: line,
+            paywall.config.packages
+        ) == other?.config.packages
+    }
+
+    static func verifyPackages(
+        in paywall: PaywallData,
+        match packages: [Package],
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        expect(
+            file: file, line: line,
+            paywall.config.packages
+        ) == packages.map(\.identifier)
+    }
+
+    static func snapshot(
+        _ paywall: PaywallData,
+        file: StaticString = #file,
+        testName: String = #function,
+        line: UInt = #line
+    ) {
+        assertSnapshot(
+            matching: paywall.withTestAssetBaseURL,
+            as: .formattedJson,
+            file: file,
+            testName: testName,
+            line: line
+        )
+    }
+
+    static func offering(with paywall: PaywallData?) -> Offering {
+        return .init(
+            identifier: "offering",
+            serverDescription: "Offering",
+            paywall: paywall,
+            availablePackages: TestData.packages
+        )
+    }
+
+}

--- a/Tests/RevenueCatUITests/Data/PaywallDataValidationTests.swift
+++ b/Tests/RevenueCatUITests/Data/PaywallDataValidationTests.swift
@@ -66,7 +66,7 @@ class PaywallDataValidationTests: TestCase {
         var localization = try XCTUnwrap(originalOffering.paywall?.localizedConfiguration)
         localization.features = [
             .init(title: "{{ future_variable }}", content: "{{ new_variable }}"),
-            .init(title: "{{ another_one }}"),
+            .init(title: "{{ another_one }}")
         ]
 
         let offering = originalOffering.with(localization: localization)
@@ -77,6 +77,24 @@ class PaywallDataValidationTests: TestCase {
 
         expect(result.error) == .invalidVariables(["future_variable", "new_variable", "another_one"])
     }
+
+    func testUnrecognizedIconsGeneratesDefaultPaywall() throws {
+        let originalOffering = TestData.offeringWithMultiPackagePaywall
+        var localization = try XCTUnwrap(originalOffering.paywall?.localizedConfiguration)
+        localization.features = [
+            .init(title: "Title 1", content: "Content 1", iconID: "unrecognized_icon_1"),
+            .init(title: "Title 2", content: "Content 2", iconID: "unrecognized_icon_2")
+        ]
+
+        let offering = originalOffering.with(localization: localization)
+        let result = offering.validatedPaywall()
+
+        Self.verifyPackages(in: result.displayablePaywall, match: originalOffering.paywall)
+        Self.snapshot(result.displayablePaywall)
+
+        expect(result.error) == .invalidIcons(["unrecognized_icon_1", "unrecognized_icon_2"])
+    }
+
 }
 
 // MARK: -

--- a/Tests/RevenueCatUITests/Data/VariablesTests.swift
+++ b/Tests/RevenueCatUITests/Data/VariablesTests.swift
@@ -169,6 +169,25 @@ class VariablesTests: TestCase {
         expect(result) == "$53.99 ($4.49/mo)"
     }
 
+    // MARK: - validation
+
+    func testNoUnrecognizedVariables() {
+        let allVariables = "{{ app_name }} {{ price }} {{ price_per_period }} " +
+        "{{ total_price_and_per_month }} {{ product_name }} {{ sub_period }} " +
+        "{{ sub_price_per_month }} {{ sub_duration }} {{ sub_offer_duration }} " +
+        "{{ sub_offer_price }}"
+
+        expect("".unrecognizedVariables()).to(beEmpty())
+        expect(allVariables.unrecognizedVariables()).to(beEmpty())
+    }
+
+    func testUnrecognizedVariable() {
+        expect("This contains {{ multiple }} unrecognized {{ variables }}".unrecognizedVariables()) == [
+            "multiple",
+            "variables"
+        ]
+    }
+
 }
 
 // MARK: - Private

--- a/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedIconsGeneratesDefaultPaywall.1.json
+++ b/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedIconsGeneratesDefaultPaywall.1.json
@@ -1,0 +1,40 @@
+{
+  "asset_base_url" : "https://assets.pawwalls.com",
+  "config" : {
+    "blurred_background_image" : true,
+    "colors" : {
+      "light" : {
+        "accent1" : "#FFFFFF",
+        "accent2" : "#FFFFFF",
+        "background" : "#FFFFFF",
+        "call_to_action_background" : "#FFFFFF",
+        "call_to_action_foreground" : "#FFFFFF",
+        "text1" : "#FFFFFF"
+      }
+    },
+    "display_restore_purchases" : true,
+    "images" : {
+      "background" : "background.jpg",
+      "icon" : "revenuecatui_default_paywall_app_icon"
+    },
+    "packages" : [
+      "$rc_annual",
+      "$rc_monthly"
+    ],
+    "privacy_url" : null,
+    "tos_url" : null
+  },
+  "localized_strings" : {
+    "en_US" : {
+      "call_to_action" : "Continue",
+      "call_to_action_with_intro_offer" : null,
+      "features" : [
+
+      ],
+      "offer_details" : "{{ total_price_and_per_month }}",
+      "offer_details_with_intro_offer" : "Start your {{ sub_offer_duration }} trial, then {{ total_price_and_per_month }}.",
+      "title" : "{{ app_name }}"
+    }
+  },
+  "template_name" : "2"
+}

--- a/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedTemplateNameGeneratesDefaultPaywall.1.json
+++ b/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedTemplateNameGeneratesDefaultPaywall.1.json
@@ -1,0 +1,40 @@
+{
+  "asset_base_url" : "https://assets.pawwalls.com",
+  "config" : {
+    "blurred_background_image" : true,
+    "colors" : {
+      "light" : {
+        "accent1" : "#FFFFFF",
+        "accent2" : "#FFFFFF",
+        "background" : "#FFFFFF",
+        "call_to_action_background" : "#FFFFFF",
+        "call_to_action_foreground" : "#FFFFFF",
+        "text1" : "#FFFFFF"
+      }
+    },
+    "display_restore_purchases" : true,
+    "images" : {
+      "background" : "background.jpg",
+      "icon" : "revenuecatui_default_paywall_app_icon"
+    },
+    "packages" : [
+      "$rc_annual",
+      "$rc_monthly"
+    ],
+    "privacy_url" : null,
+    "tos_url" : null
+  },
+  "localized_strings" : {
+    "en_US" : {
+      "call_to_action" : "Continue",
+      "call_to_action_with_intro_offer" : null,
+      "features" : [
+
+      ],
+      "offer_details" : "{{ total_price_and_per_month }}",
+      "offer_details_with_intro_offer" : "Start your {{ sub_offer_duration }} trial, then {{ total_price_and_per_month }}.",
+      "title" : "{{ app_name }}"
+    }
+  },
+  "template_name" : "2"
+}

--- a/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedVariableGeneratesDefaultPaywall.1.json
+++ b/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedVariableGeneratesDefaultPaywall.1.json
@@ -1,0 +1,40 @@
+{
+  "asset_base_url" : "https://assets.pawwalls.com",
+  "config" : {
+    "blurred_background_image" : true,
+    "colors" : {
+      "light" : {
+        "accent1" : "#FFFFFF",
+        "accent2" : "#FFFFFF",
+        "background" : "#FFFFFF",
+        "call_to_action_background" : "#FFFFFF",
+        "call_to_action_foreground" : "#FFFFFF",
+        "text1" : "#FFFFFF"
+      }
+    },
+    "display_restore_purchases" : true,
+    "images" : {
+      "background" : "background.jpg",
+      "icon" : "revenuecatui_default_paywall_app_icon"
+    },
+    "packages" : [
+      "$rc_annual",
+      "$rc_monthly"
+    ],
+    "privacy_url" : null,
+    "tos_url" : null
+  },
+  "localized_strings" : {
+    "en_US" : {
+      "call_to_action" : "Continue",
+      "call_to_action_with_intro_offer" : null,
+      "features" : [
+
+      ],
+      "offer_details" : "{{ total_price_and_per_month }}",
+      "offer_details_with_intro_offer" : "Start your {{ sub_offer_duration }} trial, then {{ total_price_and_per_month }}.",
+      "title" : "{{ app_name }}"
+    }
+  },
+  "template_name" : "2"
+}

--- a/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedVariableInFeaturesGeneratesDefaultPaywall.1.json
+++ b/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedVariableInFeaturesGeneratesDefaultPaywall.1.json
@@ -1,0 +1,40 @@
+{
+  "asset_base_url" : "https://assets.pawwalls.com",
+  "config" : {
+    "blurred_background_image" : true,
+    "colors" : {
+      "light" : {
+        "accent1" : "#FFFFFF",
+        "accent2" : "#FFFFFF",
+        "background" : "#FFFFFF",
+        "call_to_action_background" : "#FFFFFF",
+        "call_to_action_foreground" : "#FFFFFF",
+        "text1" : "#FFFFFF"
+      }
+    },
+    "display_restore_purchases" : true,
+    "images" : {
+      "background" : "background.jpg",
+      "icon" : "revenuecatui_default_paywall_app_icon"
+    },
+    "packages" : [
+      "$rc_annual",
+      "$rc_monthly"
+    ],
+    "privacy_url" : null,
+    "tos_url" : null
+  },
+  "localized_strings" : {
+    "en_US" : {
+      "call_to_action" : "Continue",
+      "call_to_action_with_intro_offer" : null,
+      "features" : [
+
+      ],
+      "offer_details" : "{{ total_price_and_per_month }}",
+      "offer_details_with_intro_offer" : "Start your {{ sub_offer_duration }} trial, then {{ total_price_and_per_month }}.",
+      "title" : "{{ app_name }}"
+    }
+  },
+  "template_name" : "2"
+}

--- a/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testValidateMissingPaywall.1.json
+++ b/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testValidateMissingPaywall.1.json
@@ -1,0 +1,40 @@
+{
+  "asset_base_url" : "https://assets.pawwalls.com",
+  "config" : {
+    "blurred_background_image" : true,
+    "colors" : {
+      "light" : {
+        "accent1" : "#FFFFFF",
+        "accent2" : "#FFFFFF",
+        "background" : "#FFFFFF",
+        "call_to_action_background" : "#FFFFFF",
+        "call_to_action_foreground" : "#FFFFFF",
+        "text1" : "#FFFFFF"
+      }
+    },
+    "display_restore_purchases" : true,
+    "images" : {
+      "background" : "background.jpg",
+      "icon" : "revenuecatui_default_paywall_app_icon"
+    },
+    "packages" : [
+      "$rc_monthly",
+      "$rc_annual"
+    ],
+    "privacy_url" : null,
+    "tos_url" : null
+  },
+  "localized_strings" : {
+    "en_US" : {
+      "call_to_action" : "Continue",
+      "call_to_action_with_intro_offer" : null,
+      "features" : [
+
+      ],
+      "offer_details" : "{{ total_price_and_per_month }}",
+      "offer_details_with_intro_offer" : "Start your {{ sub_offer_duration }} trial, then {{ total_price_and_per_month }}.",
+      "title" : "{{ app_name }}"
+    }
+  },
+  "template_name" : "2"
+}

--- a/Tests/RevenueCatUITests/Helpers/DataExtensions.swift
+++ b/Tests/RevenueCatUITests/Helpers/DataExtensions.swift
@@ -22,6 +22,11 @@ extension Offering {
         return self.map { $0?.with(localization: localization) }
     }
 
+    /// Creates a copy of the offering's paywall with a new template name
+    func with(templateName: String) -> Self {
+        return self.map { $0?.with(templateName: templateName) }
+    }
+
     private func map(_ modifier: (PaywallData?) -> PaywallData?) -> Self {
         return .init(
             identifier: self.identifier,
@@ -57,9 +62,17 @@ extension PaywallData {
 
     /// Creates a copy of the paywall with a single localization
     func with(localization: LocalizedConfiguration) -> Self {
-        return .init(template: self.template,
+        return .init(templateName: self.templateName,
                      config: self.config,
                      localization: localization,
+                     assetBaseURL: self.assetBaseURL)
+    }
+
+    /// Creates a copy of the paywall with a new template name
+    func with(templateName: String) -> Self {
+        return .init(templateName: templateName,
+                     config: self.config,
+                     localization: self.localizedConfiguration,
                      assetBaseURL: self.assetBaseURL)
     }
 

--- a/Tests/RevenueCatUITests/Helpers/DataExtensions.swift
+++ b/Tests/RevenueCatUITests/Helpers/DataExtensions.swift
@@ -7,18 +7,27 @@
 
 import Foundation
 import RevenueCat
-import RevenueCatUI
+@testable import RevenueCatUI
 
 // MARK: - Extensions
 
 extension Offering {
 
     var withLocalImages: Offering {
+        return self.map { $0?.withLocalImages }
+    }
+
+    /// Creates a copy of the offering's paywall with a single localization
+    func with(localization: PaywallData.LocalizedConfiguration) -> Self {
+        return self.map { $0?.with(localization: localization) }
+    }
+
+    private func map(_ modifier: (PaywallData?) -> PaywallData?) -> Self {
         return .init(
             identifier: self.identifier,
             serverDescription: self.serverDescription,
             metadata: self.metadata,
-            paywall: self.paywall?.withLocalImages,
+            paywall: modifier(self.paywall),
             availablePackages: self.availablePackages
         )
     }
@@ -35,6 +44,23 @@ extension PaywallData {
                                    icon: "header.jpg")
 
         return copy
+    }
+
+    /// For snapshot tests to be able to produce a consistent `assetBaseURL`
+    @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+    var withTestAssetBaseURL: Self {
+        var copy = self
+        copy.assetBaseURL = TestData.paywallAssetBaseURL
+
+        return copy
+    }
+
+    /// Creates a copy of the paywall with a single localization
+    func with(localization: LocalizedConfiguration) -> Self {
+        return .init(template: self.template,
+                     config: self.config,
+                     localization: localization,
+                     assetBaseURL: self.assetBaseURL)
     }
 
 }

--- a/Tests/RevenueCatUITests/Templates/OtherPaywallViewTests.swift
+++ b/Tests/RevenueCatUITests/Templates/OtherPaywallViewTests.swift
@@ -16,7 +16,7 @@ import SnapshotTesting
 class OtherPaywallViewTests: BaseSnapshotTest {
 
     func testDefaultPaywall() {
-        let view = PaywallView(offering: Self.offeringWithNoPaywall,
+        let view = PaywallView(offering: TestData.offeringWithNoPaywall,
                                introEligibility: Self.eligibleChecker,
                                purchaseHandler: Self.purchaseHandler)
 
@@ -24,7 +24,7 @@ class OtherPaywallViewTests: BaseSnapshotTest {
     }
 
     func testDefaultDarkModePaywall() {
-        let view = PaywallView(offering: Self.offeringWithNoPaywall,
+        let view = PaywallView(offering: TestData.offeringWithNoPaywall,
                                introEligibility: Self.eligibleChecker,
                                purchaseHandler: Self.purchaseHandler)
             .environment(\.colorScheme, .dark)
@@ -46,14 +46,6 @@ class OtherPaywallViewTests: BaseSnapshotTest {
         LoadingPaywallView(mode: .condensedCard)
             .snapshot(size: Self.cardSize)
     }
-
-    private static let offeringWithNoPaywall = Offering(
-        identifier: "offering",
-        serverDescription: "Main offering",
-        metadata: [:],
-        paywall: nil,
-        availablePackages: TestData.packages
-    )
 
 }
 

--- a/Tests/RevenueCatUITests/Templates/PaywallViewLocalizationTests.swift
+++ b/Tests/RevenueCatUITests/Templates/PaywallViewLocalizationTests.swift
@@ -53,7 +53,7 @@ private extension PaywallViewLocalizationTests {
         serverDescription: "Offering",
         metadata: [:],
         paywall: .init(
-            template: .template2,
+            templateName: PaywallTemplate.template2.rawValue,
             config: .init(
                 packages: [PackageType.weekly.identifier,
                            PackageType.annual.identifier,

--- a/Tests/TestingApps/SimpleApp/SimpleApp/SamplePaywalls.swift
+++ b/Tests/TestingApps/SimpleApp/SimpleApp/SamplePaywalls.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import RevenueCat
+@testable import RevenueCatUI
 
 final class SamplePaywallLoader {
 
@@ -38,6 +39,16 @@ final class SamplePaywallLoader {
             serverDescription: Self.offeringIdentifier,
             metadata: [:],
             paywall: nil,
+            availablePackages: self.packages
+        )
+    }
+
+    func offeringWithUnrecognizedPaywall() -> Offering {
+        return .init(
+            identifier: Self.offeringIdentifier,
+            serverDescription: Self.offeringIdentifier,
+            metadata: [:],
+            paywall: Self.unrecognizedTemplate(),
             availablePackages: self.packages
         )
     }
@@ -178,7 +189,7 @@ private extension SamplePaywallLoader {
     
     static func template1() -> PaywallData {
         return .init(
-            template: .template1,
+            templateName: PaywallTemplate.template1.rawValue,
             config: .init(
                 packages: [Package.string(from: PackageType.monthly)!],
                 images: Self.images,
@@ -214,7 +225,7 @@ private extension SamplePaywallLoader {
 
     static func template2() -> PaywallData {
         return .init(
-            template: .template2,
+            templateName: PaywallTemplate.template2.rawValue,
             config: .init(
                 packages: Array<PackageType>([.weekly, .monthly, .annual, .lifetime])
                     .map { Package.string(from: $0)! },
@@ -254,7 +265,7 @@ private extension SamplePaywallLoader {
 
     static func template3() -> PaywallData {
         return .init(
-            template: .template3,
+            templateName: PaywallTemplate.template3.rawValue,
             config: .init(
                 packages: [Package.string(from: .annual)!],
                 images: Self.images,
@@ -303,7 +314,7 @@ private extension SamplePaywallLoader {
 
     static func template4() -> PaywallData {
         return .init(
-            template: .template4,
+            templateName: PaywallTemplate.template4.rawValue,
             config: .init(
                 packages: Array<PackageType>([.monthly, .sixMonth, .annual])
                     .map { Package.string(from: $0)! },
@@ -327,6 +338,35 @@ private extension SamplePaywallLoader {
                 offerDetails: nil,
                 offerDetailsWithIntroOffer: "Includes {{ sub_offer_duration }} **free** trial",
                 offerName: "{{ sub_duration }}"
+            ),
+            assetBaseURL: Self.paywallAssetBaseURL
+        )
+    }
+
+    static func unrecognizedTemplate() -> PaywallData {
+        return .init(
+            templateName: "unrecognized_template_name",
+            config: .init(
+                packages: [Package.string(from: PackageType.monthly)!],
+                images: Self.images,
+                colors:  .init(
+                    light: .init(
+                        background: "#FFFFFF",
+                        text1: "#000000",
+                        callToActionBackground: "#5CD27A",
+                        callToActionForeground: "#FFFFFF",
+                        accent1: "#BC66FF"
+                    )
+                ),
+                termsOfServiceURL: Self.tosURL
+            ),
+            localization: .init(
+                title: "Ignite your child's curiosity",
+                subtitle: "Get access to all our educational content trusted by thousands of parents.",
+                callToAction: "Purchase for {{ price }}",
+                callToActionWithIntroOffer: "Purchase for {{ sub_price_per_month }} per month",
+                offerDetails: "{{ sub_price_per_month }} per month",
+                offerDetailsWithIntroOffer: "Start your {{ sub_offer_duration }} trial, then {{ sub_price_per_month }} per month"
             ),
             assetBaseURL: Self.paywallAssetBaseURL
         )

--- a/Tests/TestingApps/SimpleApp/SimpleApp/Views/OfferingsList.swift
+++ b/Tests/TestingApps/SimpleApp/SimpleApp/Views/OfferingsList.swift
@@ -65,7 +65,7 @@ struct OfferingsList: View {
                     } label: {
                         VStack(alignment: .leading) {
                             Text(offering.serverDescription)
-                            Text(verbatim: "Template: \(paywall.template.name)")
+                            Text(verbatim: "Template: \(paywall.templateName)")
                         }
                     }
                     .buttonStyle(.plain)

--- a/Tests/TestingApps/SimpleApp/SimpleApp/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/SimpleApp/SimpleApp/Views/SamplePaywallsList.swift
@@ -46,8 +46,13 @@ struct SamplePaywallsList: View {
                 case let .customPaywall(mode):
                     CustomPaywall(mode: mode)
 
-                case .defaultTemplate:
+                case .missingPaywall:
                     PaywallView(offering: Self.loader.offeringWithDefaultPaywall(),
+                                introEligibility: Self.introEligibility,
+                                purchaseHandler: .default())
+
+                case .unrecognizedPaywall:
+                    PaywallView(offering: Self.loader.offeringWithUnrecognizedPaywall(),
                                 introEligibility: Self.introEligibility,
                                 purchaseHandler: .default())
                 }
@@ -92,9 +97,15 @@ struct SamplePaywallsList: View {
                 }
 
                 Button {
-                    self.display = .defaultTemplate
+                    self.display = .missingPaywall
                 } label: {
-                    TemplateLabel(name: "Default template", icon: "exclamationmark.triangle")
+                    TemplateLabel(name: "Offering with no paywall", icon: "exclamationmark.triangle")
+                }
+
+                Button {
+                    self.display = .unrecognizedPaywall
+                } label: {
+                    TemplateLabel(name: "Unrecognized paywall", icon: "exclamationmark.triangle")
                 }
             }
         }
@@ -141,7 +152,8 @@ private extension SamplePaywallsList {
         case template(PaywallTemplate, PaywallViewMode)
         case customFont(PaywallTemplate)
         case customPaywall(PaywallViewMode)
-        case defaultTemplate
+        case missingPaywall
+        case unrecognizedPaywall
 
     }
 
@@ -160,8 +172,11 @@ extension SamplePaywallsList.Display: Identifiable {
         case .customPaywall:
             return "custom-paywall"
 
-        case .defaultTemplate:
-            return "default"
+        case .missingPaywall:
+            return "missing"
+
+        case .unrecognizedPaywall:
+            return "unrecognized"
         }
     }
 

--- a/Tests/UnitTests/Networking/Responses/OfferingsDecodingTests.swift
+++ b/Tests/UnitTests/Networking/Responses/OfferingsDecodingTests.swift
@@ -110,7 +110,7 @@ class OfferingsDecodingTests: BaseHTTPResponseTest {
         expect(offering.packages).to(haveCount(2))
 
         let paywall = try XCTUnwrap(offering.paywall)
-        expect(paywall.template) == .template1
+        expect(paywall.templateName) == "1"
         try expect(paywall.assetBaseURL) == XCTUnwrap(URL(string: "https://rc-paywalls.s3.amazonaws.com"))
 
         expect(paywall.config.packages) == ["$rc_monthly", "$rc_annual", "custom_package"]

--- a/Tests/UnitTests/Paywalls/PaywallDataTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallDataTests.swift
@@ -20,7 +20,7 @@ class PaywallDataTests: BaseHTTPResponseTest {
     func testSample1() throws {
         let paywall: PaywallData = try self.decodeFixture("PaywallData-Sample1")
 
-        expect(paywall.template) == .template1
+        expect(paywall.templateName) == "1"
         expect(paywall.assetBaseURL) == URL(string: "https://rc-paywalls.s3.amazonaws.com")!
         expect(paywall.config.packages) == ["$rc_monthly", "$rc_annual", "custom_package"]
         expect(paywall.config.defaultPackage) == "$rc_annual"


### PR DESCRIPTION
See https://docs.google.com/document/d/1oLZR77apAjZf04hDzlrJpPaFV0xhuQ1-hApsNBohhfA/edit

This simplifies `PaywallView`: the validated `PaywallData` is what's always displayed, and a `DebugErrorView` containing an error description will potentially explain why a default paywall is being displayed.

### Validations:

- [x] `Offering` contains a `PaywallData`
- [x] `PaywallLocalizedConfiguration` contains no unrecognized variables
- [x] `PaywallIcon`s are all recognized
- [x] `PaywallTemplate` is recognized