### PR TITLE
`Integration Tests`: improved `testCanPurchaseMultipleSubscriptions`

### DIFF
--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -182,6 +182,8 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         _ = try await self.purchases.purchase(product: product1)
         let info = try await self.purchases.purchase(product: product2).customerInfo
 
+        try await verifyEntitlementWentThrough(info)
+
         expect(info.allPurchasedProductIdentifiers) == [
             product1.productIdentifier,
             product2.productIdentifier

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -182,7 +182,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         _ = try await self.purchases.purchase(product: product1)
         let info = try await self.purchases.purchase(product: product2).customerInfo
 
-        try await verifyEntitlementWentThrough(info)
+        try await self.verifyEntitlementWentThrough(info)
 
         expect(info.allPurchasedProductIdentifiers) == [
             product1.productIdentifier,


### PR DESCRIPTION
I was looking into #3020, and saw that we already have this test to cover downgrades. I added an extra assertion to verify entitlements.
I also ran this test on iOS 17 and it passes.
