### PR TITLE
`TransactionPoster`: added transaction ID and Date to log

### DIFF
--- a/Sources/Logging/Strings/PurchaseStrings.swift
+++ b/Sources/Logging/Strings/PurchaseStrings.swift
@@ -80,7 +80,10 @@ enum PurchaseStrings {
     case begin_refund_customer_info_error(entitlementID: String?)
     case missing_cached_customer_info
     case sk2_transactions_update_received_transaction(productID: String)
-    case transaction_poster_handling_transaction(productID: String, offeringID: String?)
+    case transaction_poster_handling_transaction(transactionID: String,
+                                                 productID: String,
+                                                 transactionDate: Date,
+                                                 offeringID: String?)
     case caching_presented_offering_identifier(offeringID: String, productID: String)
     case payment_queue_wrapper_delegate_call_sk1_enabled
     case restorepurchases_called_with_allow_sharing_appstore_account_false
@@ -298,8 +301,9 @@ extension PurchaseStrings: LogMessage {
         case let .sk2_transactions_update_received_transaction(productID):
             return "StoreKit.Transaction.updates: received transaction for product '\(productID)'"
 
-        case let .transaction_poster_handling_transaction(productID, offeringID):
-            let prefix = "TransactionPoster: handling transaction for product '\(productID)'"
+        case let .transaction_poster_handling_transaction(transactionID, productID, date, offeringID):
+            let prefix = "TransactionPoster: handling transaction '\(transactionID)' " +
+            "for product '\(productID)' (date: \(date))"
 
             if let offeringIdentifier = offeringID {
                 return prefix + " in Offering '\(offeringIdentifier)'"

--- a/Sources/Purchasing/Purchases/TransactionPoster.swift
+++ b/Sources/Purchasing/Purchases/TransactionPoster.swift
@@ -82,7 +82,9 @@ final class TransactionPoster: TransactionPosterType {
                                     data: PurchasedTransactionData,
                                     completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
         Logger.debug(Strings.purchase.transaction_poster_handling_transaction(
+            transactionID: transaction.transactionIdentifier,
             productID: transaction.productIdentifier,
+            transactionDate: transaction.purchaseDate,
             offeringID: data.presentedOfferingID
         ))
 

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -52,11 +52,13 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
     func testCanPurchasePackage() async throws {
         let package = try await self.monthlyPackage
-        try await self.purchaseMonthlyOffering()
+        let transaction = try await XCTAsyncUnwrap(try await self.purchaseMonthlyOffering().transaction)
 
         self.logger.verifyMessageWasLogged(
             Strings.purchase.transaction_poster_handling_transaction(
+                transactionID: transaction.transactionIdentifier,
                 productID: package.storeProduct.productIdentifier,
+                transactionDate: transaction.purchaseDate,
                 offeringID: package.offeringIdentifier
             )
         )
@@ -88,11 +90,13 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
             productIdentifier: package.storeProduct.productIdentifier
         )
 
-        try await self.purchaseMonthlyProduct()
+        let transaction = try await XCTAsyncUnwrap(try await self.purchaseMonthlyProduct().transaction)
 
         self.logger.verifyMessageWasLogged(
             Strings.purchase.transaction_poster_handling_transaction(
+                transactionID: transaction.transactionIdentifier,
                 productID: package.storeProduct.productIdentifier,
+                transactionDate: transaction.purchaseDate,
                 offeringID: package.offeringIdentifier
             )
         )


### PR DESCRIPTION
Looking into #3020, it would have been helpful to see these.
