### PR TITLE
`Xcode 15`: fixed release build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,7 +283,16 @@ commands:
               bundle exec fastlane update_carthage_commit
 
 jobs:
-  spm-release-build:
+  spm-release-build-xcode-14:
+    <<: *base-job
+    steps:
+      - checkout
+      - run:
+          name: SPM Release Build
+          command: swift build -c release --target RevenueCat
+          no_output_timeout: 30m
+
+  spm-release-build-xcode-15:
     <<: *base-job
     steps:
       - checkout
@@ -891,8 +900,10 @@ workflows:
     jobs:
       - lint:
           xcode_version: '14.3.0'
-      - spm-release-build:
+      - spm-release-build-xcode-14:
           xcode_version: '14.3.0'
+      - spm-release-build-xcode-15:
+          xcode_version: '15.0.0'
       - spm-xcode-14-1:
           xcode_version: '14.1.0'
       - spm-custom-entitlement-computation-build:

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1389,6 +1389,10 @@ internal extension Purchases {
         return self.paymentQueueWrapper.sk1Wrapper != nil
     }
 
+    var storeKit2Setting: StoreKit2Setting {
+        return self.systemInfo.storeKit2Setting
+    }
+
     #if DEBUG
 
     /// - Returns: the parsed `AppleReceipt`
@@ -1452,10 +1456,6 @@ internal extension Purchases {
 
     var offlineCustomerInfoEnabled: Bool {
         return self.backend.offlineCustomerInfoEnabled
-    }
-
-    var storeKit2Setting: StoreKit2Setting {
-        return self.systemInfo.storeKit2Setting
     }
 
     var publicKey: Signing.PublicKey? {


### PR DESCRIPTION
Fixes https://github.com/RevenueCat/purchases-ios/pull/3028#issuecomment-1681533213
This was wrong in #3032 because `Purchases.storeKit2Setting` is only available in `DEBUG` builds, but we didn't catch it because we have no CI for Xcode 15 yet, which this adds as well.
