### PR TITLE
`visionOS`: changed CI job to Release

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -203,6 +203,7 @@ platform :ios do
       workspace: 'RevenueCat.xcworkspace',
       scheme: 'RevenueCat',
       destination: 'generic/platform=visionOS',
+      configuration: 'release',
       xcargs: "CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO"
     )
   end
@@ -237,7 +238,8 @@ platform :ios do
     xcodebuild(
       workspace: 'RevenueCat.xcworkspace',
       scheme: 'SwiftAPITester',
-      destination: 'generic/platform=iOS Simulator'
+      destination: 'generic/platform=iOS Simulator',
+      configuration: 'release',
     )
   end
 
@@ -246,7 +248,8 @@ platform :ios do
     xcodebuild(
       workspace: 'RevenueCat.xcworkspace',
       scheme: 'ObjCAPITester',
-      destination: 'generic/platform=iOS Simulator'
+      destination: 'generic/platform=iOS Simulator',
+      configuration: 'release',
     )
   end
 
@@ -256,7 +259,8 @@ platform :ios do
       project: 'Tests/APITesters/CustomEntitlementComputationSwiftAPITester/CustomEntitlementComputationSwiftAPITester.xcodeproj',
       scheme: 'SwiftAPITester',
       destination: 'generic/platform=iOS',
-      xcargs: "CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO"
+      xcargs: "CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO",
+      configuration: 'release',
     )
   end
 


### PR DESCRIPTION
The `build_tv_watch_mac` job already builds on Release mode (`Carthage`'s default).
This would have also helped detect the issue fixed by #3034.

I've also changed the API tester jobs to compile on release, though those aren't ran by CI.
