### PR TITLE
`Purchases`: don't clear intro eligibility / purchased products cache on first launch

### DIFF
--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -19,8 +19,6 @@ class CustomerInfoManager {
 
     typealias CustomerInfoCompletion = @MainActor @Sendable (Result<CustomerInfo, BackendError>) -> Void
 
-    var lastSentCustomerInfo: CustomerInfo? { return self.data.value.lastSentCustomerInfo }
-
     private let offlineEntitlementsManager: OfflineEntitlementsManager
     private let operationDispatcher: OperationDispatcher
     private let backend: Backend
@@ -207,7 +205,6 @@ class CustomerInfoManager {
     func clearCustomerInfoCache(forAppUserID appUserID: String) {
         self.modifyData {
             $0.deviceCache.clearCustomerInfoCache(appUserID: appUserID)
-            $0.lastSentCustomerInfo = nil
         }
     }
 
@@ -250,6 +247,9 @@ class CustomerInfoManager {
             }
         }
     }
+
+    // Visible for tests
+    var lastSentCustomerInfo: CustomerInfo? { return self.data.value.lastSentCustomerInfo }
 
     private func removeObserver(with identifier: Int) {
         self.modifyData {

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -545,9 +545,9 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         (self as DeprecatedSearchAdsAttribution).postAppleSearchAddsAttributionCollectionIfNeeded()
         #endif
 
-        self.customerInfoObservationDisposable = customerInfoManager.monitorChanges { [weak self] customerInfo in
+        self.customerInfoObservationDisposable = customerInfoManager.monitorChanges { [weak self] old, new in
             guard let self = self else { return }
-            self.handleCustomerInfoChanged(customerInfo)
+            self.handleCustomerInfoChanged(from: old, to: new)
         }
     }
 
@@ -1478,10 +1478,13 @@ internal extension Purchases {
 
 private extension Purchases {
 
-    func handleCustomerInfoChanged(_ customerInfo: CustomerInfo) {
-        self.trialOrIntroPriceEligibilityChecker.clearCache()
-        self.purchasedProductsFetcher?.clearCache()
-        self.delegate?.purchases?(self, receivedUpdated: customerInfo)
+    func handleCustomerInfoChanged(from old: CustomerInfo?, to new: CustomerInfo) {
+        if old != nil {
+            self.trialOrIntroPriceEligibilityChecker.clearCache()
+            self.purchasedProductsFetcher?.clearCache()
+        }
+
+        self.delegate?.purchases?(self, receivedUpdated: new)
     }
 
     @objc func applicationWillEnterForeground() {
@@ -1595,6 +1598,7 @@ private extension Purchases {
         }
 
         self.delegate?.purchases?(self, receivedUpdated: info)
+        self.customerInfoManager.setLastSentCustomerInfo(info)
     }
 
     private func updateOfferingsCache(isAppBackgrounded: Bool) {

--- a/Tests/UnitTests/Mocks/MockCustomerInfoManager.swift
+++ b/Tests/UnitTests/Mocks/MockCustomerInfoManager.swift
@@ -46,16 +46,16 @@ class MockCustomerInfoManager: CustomerInfoManager {
         self.invokedFetchAndCacheCustomerInfoIfStaleParametersList.append((appUserID, isAppBackgrounded, completion))
     }
 
-    var invokedSendCachedCustomerInfoIfAvailable = false
-    var invokedSendCachedCustomerInfoIfAvailableCount = 0
-    var invokedSendCachedCustomerInfoIfAvailableParameters: (appUserID: String, Void)?
-    var invokedSendCachedCustomerInfoIfAvailableParametersList = [(appUserID: String, Void)]()
+    var invokedSetLastSentCustomerInfo = false
+    var invokedSetLastSentCustomerInfoCount = 0
+    var invokedSetLastSentCustomerInfoParameters: (info: CustomerInfo, Void)?
+    var invokedSetLastSentCustomerInfoParametersList = [(info: CustomerInfo, Void)]()
 
-    override func sendCachedCustomerInfoIfAvailable(appUserID: String) {
-        self.invokedSendCachedCustomerInfoIfAvailable = true
-        self.invokedSendCachedCustomerInfoIfAvailableCount += 1
-        self.invokedSendCachedCustomerInfoIfAvailableParameters = (appUserID, ())
-        self.invokedSendCachedCustomerInfoIfAvailableParametersList.append((appUserID, ()))
+    override func setLastSentCustomerInfo(_ info: CustomerInfo) {
+        self.invokedSetLastSentCustomerInfo = true
+        self.invokedSetLastSentCustomerInfoCount += 1
+        self.invokedSetLastSentCustomerInfoParameters = (info, ())
+        self.invokedSetLastSentCustomerInfoParametersList.append((info, ()))
     }
 
     var invokedCustomerInfo = false

--- a/Tests/UnitTests/Mocks/MockPurchasesDelegate.swift
+++ b/Tests/UnitTests/Mocks/MockPurchasesDelegate.swift
@@ -13,7 +13,7 @@ public class MockPurchasesDelegate: NSObject, PurchasesDelegate {
     var customerInfoReceivedCount = 0
 
     public func purchases(_ purchases: Purchases, receivedUpdated customerInfo: CustomerInfo) {
-        customerInfoReceivedCount += 1
+        self.customerInfoReceivedCount += 1
         self.customerInfo = customerInfo
     }
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -224,6 +224,20 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expect(self.purchasesDelegate.customerInfoReceivedCount).toEventually(equal(1))
     }
 
+    func testFirstInitializationDoesNotClearIntroEligibilityCache() {
+        self.setupPurchases()
+        expect(self.purchasesDelegate.customerInfoReceivedCount).toEventually(equal(1))
+
+        expect(self.cachingTrialOrIntroPriceEligibilityChecker.invokedClearCache) == false
+    }
+
+    func testFirstInitializationDoesNotClearPurchasedProductsCache() {
+        self.setupPurchases()
+        expect(self.purchasesDelegate.customerInfoReceivedCount).toEventually(equal(1))
+
+        expect(self.mockPurchasedProductsFetcher.invokedClearCache) == false
+    }
+
     func testFirstInitializationFromForegroundDelegateForAnonIfNothingCached() {
         self.systemInfo.stubbedIsApplicationBackgrounded = false
         self.setupPurchases()
@@ -242,7 +256,7 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         let info = try CustomerInfo(data: Self.emptyCustomerInfoData)
         let object = try info.jsonEncodedData
 
-        self.deviceCache.cachedCustomerInfo[identityManager.currentAppUserID] = object
+        self.deviceCache.cachedCustomerInfo[self.identityManager.currentAppUserID] = object
 
         self.setupPurchases()
 

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -17,10 +17,9 @@ import XCTest
 
 @testable import RevenueCat
 
-class PurchasesLogInTests: BasePurchasesTests {
+class BasePurchasesLogInTests: BasePurchasesTests {}
 
-    private typealias LogInResult = Result<(customerInfo: CustomerInfo, created: Bool), PublicError>
-    private typealias LogOutResult = Result<CustomerInfo, PublicError>
+class PurchasesLogInTests: BasePurchasesLogInTests {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -238,6 +237,19 @@ class PurchasesLogInTests: BasePurchasesTests {
         self.logger.verifyMessageWasLogged(Strings.identity.logging_in_with_static_string, level: .warn)
     }
 
+}
+
+class ExistingUserPurchasesLogInTests: BasePurchasesLogInTests {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        self.deviceCache.cachedCustomerInfo[Self.appUserID] = try Self.mockLoggedOutInfo.jsonEncodedData
+        self.initializePurchasesInstance(appUserId: Self.appUserID)
+
+        expect(self.purchasesDelegate.customerInfo).toEventuallyNot(beNil())
+    }
+
     func testLogInClearsTrialEligibilityCache() {
         expect(self.cachingTrialOrIntroPriceEligibilityChecker.invokedClearCache) == false
 
@@ -268,7 +280,10 @@ class PurchasesLogInTests: BasePurchasesTests {
 
 // MARK: -
 
-private extension PurchasesLogInTests {
+private extension BasePurchasesLogInTests {
+
+    typealias LogInResult = Result<(customerInfo: CustomerInfo, created: Bool), PublicError>
+    typealias LogOutResult = Result<CustomerInfo, PublicError>
 
     // swiftlint:disable force_try
     static let mockLoggedInInfo = try! CustomerInfo(data: PurchasesLogInTests.loggedInCustomerInfoData)
@@ -298,7 +313,7 @@ private extension PurchasesLogInTests {
     ]
 
     /// Converts the result of `Purchases.logIn` into `LogInResult`
-    private static func logInResult(_ info: CustomerInfo?, _ created: Bool, _ error: PublicError?) -> LogInResult {
+    static func logInResult(_ info: CustomerInfo?, _ created: Bool, _ error: PublicError?) -> LogInResult {
         return .init(info.map { ($0, created) }, error)
     }
 


### PR DESCRIPTION
These caches are important, especially for `RevenueCatUI`.
Without this fix, launching the app was doing this:
- Pre-warming cache
- Pre-warming cache a second time (to be fixed by a separate PR)
- Clearing cache

Which meant that the cache wasn't really warm when launching paywalls.

To fix that, this only clears the cache after receiving an actual change.

I've also removed `CustomerInfoManager.sendCachedCustomerInfoIfAvailable` because it wasn't used.
