### PR TITLE
`Paywalls`: avoid warming up cache multiple times

### DIFF
--- a/Sources/Misc/Concurrency/OperationDispatcher.swift
+++ b/Sources/Misc/Concurrency/OperationDispatcher.swift
@@ -59,6 +59,8 @@ class OperationDispatcher {
         }
     }
 
+    /// Prevent DDOS if a notification leads to many users opening an app at the same time,
+    /// by spreading asynchronous operations over time.
     private static func randomDelay() -> TimeInterval {
         Double.random(in: 0..<Self.maxJitterInSeconds)
     }

--- a/Sources/Misc/Concurrency/OperationDispatcher.swift
+++ b/Sources/Misc/Concurrency/OperationDispatcher.swift
@@ -18,7 +18,6 @@ class OperationDispatcher {
 
     private let mainQueue: DispatchQueue = .main
     private let workerQueue: DispatchQueue = .init(label: "OperationDispatcherWorkerQueue")
-    private let maxJitterInSeconds: Double = 5
 
     static let `default`: OperationDispatcher = .init()
 
@@ -43,12 +42,28 @@ class OperationDispatcher {
 
     func dispatchOnWorkerThread(withRandomDelay: Bool = false, block: @escaping @Sendable () -> Void) {
         if withRandomDelay {
-            let delay = Double.random(in: 0..<self.maxJitterInSeconds)
-            self.workerQueue.asyncAfter(deadline: .now() + delay, execute: block)
+            self.workerQueue.asyncAfter(deadline: .now() + Self.randomDelay(), execute: block)
         } else {
             self.workerQueue.async(execute: block)
         }
     }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func dispatchOnWorkerThread(withRandomDelay: Bool = false, block: @escaping @Sendable () async -> Void) {
+        Task.detached(priority: .background) {
+            if withRandomDelay {
+                try? await Task.sleep(nanoseconds: DispatchTimeInterval(Self.randomDelay()).nanoseconds)
+            }
+
+            await block()
+        }
+    }
+
+    private static func randomDelay() -> TimeInterval {
+        Double.random(in: 0..<Self.maxJitterInSeconds)
+    }
+
+    private static let maxJitterInSeconds: Double = 5
 
 }
 

--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -15,7 +15,10 @@ import Foundation
 
 protocol PaywallCacheWarmingType: Sendable {
 
+    @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)
     func warmUpEligibilityCache(offerings: Offerings) async
+
+    @available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *)
     func warmUpPaywallImagesCache(offerings: Offerings) async
 
 }

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1633,7 +1633,7 @@ private extension Purchases {
             appUserID: self.appUserID,
             isAppBackgrounded: isAppBackgrounded
         ) { [cache = self.paywallCache] offerings in
-            if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *),
+            if #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *),
                let cache = cache, let offerings = offerings.value {
                 self.operationDispatcher.dispatchOnWorkerThread {
                     await cache.warmUpEligibilityCache(offerings: offerings)

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -237,7 +237,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     private let attributionPoster: AttributionPoster
     private let backend: Backend
     private let deviceCache: DeviceCache
-    private let paywallCache: PaywallCacheWarmingType
+    private let paywallCache: PaywallCacheWarmingType?
     private let identityManager: IdentityManager
     private let userDefaults: UserDefaults
     private let notificationCenter: NotificationCenter
@@ -428,7 +428,13 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                                                       productsManager: productsManager)
         )
 
-        let paywallCache = PaywallCacheWarming(introEligibiltyChecker: trialOrIntroPriceChecker)
+        let paywallCache: PaywallCacheWarmingType?
+
+        if #available(iOS 15.0, macOS 12.0, watchOS 8.0, tvOS 15.0, *) {
+            paywallCache = PaywallCacheWarming(introEligibiltyChecker: trialOrIntroPriceChecker)
+        } else {
+            paywallCache = nil
+        }
 
         self.init(appUserID: appUserID,
                   requestFetcher: fetcher,
@@ -468,7 +474,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
          systemInfo: SystemInfo,
          offeringsFactory: OfferingsFactory,
          deviceCache: DeviceCache,
-         paywallCache: PaywallCacheWarmingType,
+         paywallCache: PaywallCacheWarmingType?,
          identityManager: IdentityManager,
          subscriberAttributes: Attribution,
          operationDispatcher: OperationDispatcher,
@@ -1627,10 +1633,11 @@ private extension Purchases {
             appUserID: self.appUserID,
             isAppBackgrounded: isAppBackgrounded
         ) { [cache = self.paywallCache] offerings in
-            if let offerings = offerings.value {
+            if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *),
+               let cache = cache, let offerings = offerings.value {
                 self.operationDispatcher.dispatchOnWorkerThread {
-                    cache.warmUpEligibilityCache(offerings: offerings)
-                    cache.warmUpPaywallImagesCache(offerings: offerings)
+                    await cache.warmUpEligibilityCache(offerings: offerings)
+                    await cache.warmUpPaywallImagesCache(offerings: offerings)
                 }
             }
         }

--- a/Tests/TestingApps/SimpleApp/SimpleApp/Products.storekit
+++ b/Tests/TestingApps/SimpleApp/SimpleApp/Products.storekit
@@ -129,6 +129,31 @@
           "referenceName" : "Yearly",
           "subscriptionGroupID" : "CEEF018E",
           "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "0.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "2BD0E5CA",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Weekly",
+              "displayName" : "Weekly",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.revenuecat.simpleapp.weekly",
+          "recurringSubscriptionPeriod" : "P1W",
+          "referenceName" : "Weekly",
+          "subscriptionGroupID" : "CEEF018E",
+          "type" : "RecurringSubscription"
         }
       ]
     }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
@@ -100,6 +100,8 @@ class PurchasesGetOfferingsTests: BasePurchasesTests {
     }
 
     func testWarmsUpPaywallsCache() throws {
+        try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
+
         let bundle = Bundle(for: Self.self)
         let offeringsURL = try XCTUnwrap(bundle.url(forResource: "Offerings",
                                                     withExtension: "json",


### PR DESCRIPTION
This prevents us from warming up the cache twice on app launch (because of the explicit call in `Purchases.init` + `applicationWillEnterForeground`).

I turned `PaywallCacheWarming` into an `actor` to simplify thread-safety of the internal state.
