### PR TITLE
`Paywalls`: only dismiss `PaywallView` when explicitly presenting it with `.presentPaywallIfNeeded`

### DIFF
--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -129,6 +129,8 @@ private struct PresentingPaywallModifier: ViewModifier {
                     )
                     .onPurchaseCompleted {
                         self.purchaseCompleted?($0)
+
+                        self.state.displayed = false
                     }
                     .toolbar {
                         ToolbarItem(placement: .destructiveAction) {

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -130,7 +130,7 @@ private struct PresentingPaywallModifier: ViewModifier {
                     .onPurchaseCompleted {
                         self.purchaseCompleted?($0)
 
-                        self.state.displayed = false
+                        self.isDisplayed = false
                     }
                     .toolbar {
                         ToolbarItem(placement: .destructiveAction) {

--- a/RevenueCatUI/Views/PurchaseButton.swift
+++ b/RevenueCatUI/Views/PurchaseButton.swift
@@ -53,9 +53,6 @@ struct PurchaseButton: View {
         self.purchaseHandler = purchaseHandler
     }
 
-    @Environment(\.dismiss)
-    private var dismiss
-
     var body: some View {
         self.button
     }
@@ -64,12 +61,8 @@ struct PurchaseButton: View {
         AsyncButton {
             guard !self.purchaseHandler.actionInProgress else { return }
 
-            let cancelled = try await self.purchaseHandler.purchase(package: self.package.content,
-                                                                    with: self.mode).userCancelled
-
-            if !cancelled, case .fullScreen = self.mode {
-                self.dismiss()
-            }
+            _ = try await self.purchaseHandler.purchase(package: self.package.content,
+                                                        with: self.mode)
         } label: {
             IntroEligibilityStateView(
                 textWithNoIntroOffer: self.package.localization.callToAction,

--- a/Tests/TestingApps/SimpleApp/SimpleApp/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/SimpleApp/SimpleApp/Views/SamplePaywallsList.swift
@@ -57,6 +57,9 @@ struct SamplePaywallsList: View {
                                 purchaseHandler: .default())
                 }
             }
+            .onPurchaseCompleted { _ in
+                self.display = nil
+            }
             .navigationTitle("Paywalls")
     }
 


### PR DESCRIPTION
This makes more sense than assuming we can call the `\.dismiss` environment variable.
