### PR TITLE
`CustomerInfo`: add `VerificationResult` to `description`

### DIFF
--- a/Sources/Identity/CustomerInfo.swift
+++ b/Sources/Identity/CustomerInfo.swift
@@ -141,6 +141,14 @@ import Foundation
 
         let allEntitlementsDescription = self.entitlements.all.mapValues { $0.description }
 
+        let verificationResult: String
+
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) {
+            verificationResult = self.entitlements.verification.debugDescription
+        } else {
+            verificationResult = "unknown"
+        }
+
         return """
             <\(String(describing: CustomerInfo.self)):
             originalApplicationVersion=\(self.originalApplicationVersion ?? ""),
@@ -152,6 +160,7 @@ import Foundation
             firstSeen=\(String(describing: self.firstSeen)),
             originalAppUserId=\(self.originalAppUserId),
             entitlements=\(allEntitlementsDescription)
+            verification=\(verificationResult)
             >
             """
     }


### PR DESCRIPTION
I needed this to debug a test failure, so it can be useful.
