### PR TITLE
`Paywalls`: added MIT license to all headers

### DIFF
--- a/RevenueCatUI/Data/Constants.swift
+++ b/RevenueCatUI/Data/Constants.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  Constants.swift
-//  
 //
 //  Created by Nacho Soto on 7/13/23.
-//
 
 import SwiftUI
 

--- a/RevenueCatUI/Data/Errors/PaywallError.swift
+++ b/RevenueCatUI/Data/Errors/PaywallError.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  PaywalError.swift
-//  
 //
 //  Created by Nacho Soto on 7/21/23.
-//
 
 import Foundation
 

--- a/RevenueCatUI/Data/Errors/TemplateError.swift
+++ b/RevenueCatUI/Data/Errors/TemplateError.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  TemplateError.swift
-//  
 //
 //  Created by Nacho Soto on 7/17/23.
-//
 
 import Foundation
 import RevenueCat

--- a/RevenueCatUI/Data/IntroEligibilityViewModel.swift
+++ b/RevenueCatUI/Data/IntroEligibilityViewModel.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  IntroEligibilityViewModel.swift
-//  
 //
 //  Created by Nacho Soto on 7/26/23.
-//
 
 import RevenueCat
 import SwiftUI

--- a/RevenueCatUI/Data/Localization.swift
+++ b/RevenueCatUI/Data/Localization.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  Localization.swift
 //
-//
 //  Created by Nacho Soto on 7/20/23.
-//
 
 import Foundation
 import RevenueCat

--- a/RevenueCatUI/Data/LocalizedAlertError.swift
+++ b/RevenueCatUI/Data/LocalizedAlertError.swift
@@ -1,9 +1,15 @@
 //
-//  File.swift
-//  
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  LocalizedAlertError.swift
 //
 //  Created by Nacho Soto on 7/21/23.
-//
 
 import RevenueCat
 import SwiftUI

--- a/RevenueCatUI/Data/PaywallData+Validation.swift
+++ b/RevenueCatUI/Data/PaywallData+Validation.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  PaywallData+Validation.swift
-//  
 //
 //  Created by Nacho Soto on 8/15/23.
-//
 
 import RevenueCat
 

--- a/RevenueCatUI/Data/PaywallViewMode+Extensions.swift
+++ b/RevenueCatUI/Data/PaywallViewMode+Extensions.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  PaywallViewMode+Extensions.swift
-//  
 //
 //  Created by Nacho Soto on 8/9/23.
-//
 
 import RevenueCat
 

--- a/RevenueCatUI/Data/ProcessedLocalizedConfiguration.swift
+++ b/RevenueCatUI/Data/ProcessedLocalizedConfiguration.swift
@@ -1,3 +1,14 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ProcessedLocalizedConfiguration.swift
+
 import Foundation
 import RevenueCat
 

--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  Strings.swift
-//  
 //
 //  Created by Nacho Soto on 7/31/23.
-//
 
 import Foundation
 import RevenueCat

--- a/RevenueCatUI/Data/TemplateViewConfiguration+Images.swift
+++ b/RevenueCatUI/Data/TemplateViewConfiguration+Images.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  TemplateViewConfiguration+Images.swift
-//  
 //
 //  Created by Nacho Soto on 7/25/23.
-//
 
 import Foundation
 import RevenueCat

--- a/RevenueCatUI/Data/TemplateViewConfiguration.swift
+++ b/RevenueCatUI/Data/TemplateViewConfiguration.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  TemplateViewConfiguration.swift
-//  
 //
 //  Created by Nacho Soto on 7/17/23.
-//
 
 import Foundation
 import RevenueCat

--- a/RevenueCatUI/Data/Variables.swift
+++ b/RevenueCatUI/Data/Variables.swift
@@ -1,3 +1,14 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//   TestData.swift
+
 import Foundation
 import RegexBuilder
 import RevenueCat

--- a/RevenueCatUI/Helpers/ColorInformation+MultiScheme.swift
+++ b/RevenueCatUI/Helpers/ColorInformation+MultiScheme.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  ColorInformation+MultiScheme.swift
-//  
 //
 //  Created by Nacho Soto on 7/14/23.
-//
 
 import Foundation
 import RevenueCat

--- a/RevenueCatUI/Helpers/Logger.swift
+++ b/RevenueCatUI/Helpers/Logger.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  Logger.swift
-//  
 //
 //  Created by Nacho Soto on 7/12/23.
-//
 
 import RevenueCat
 

--- a/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
+++ b/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
@@ -1,3 +1,14 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Package+VariableDataProvider.swift
+
 import Foundation
 import RevenueCat
 

--- a/RevenueCatUI/Helpers/PaywallData+Default.swift
+++ b/RevenueCatUI/Helpers/PaywallData+Default.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  PaywallData+Default.swift
-//  
 //
 //  Created by Nacho Soto on 7/20/23.
-//
 
 import Foundation
 import RevenueCat

--- a/RevenueCatUI/Helpers/PreviewHelpers.swift
+++ b/RevenueCatUI/Helpers/PreviewHelpers.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  PreviewHelpers.swift
-//  
 //
 //  Created by Nacho Soto on 7/29/23.
-//
 
 import RevenueCat
 import SwiftUI

--- a/RevenueCatUI/Helpers/TrialOrIntroEligibilityChecker.swift
+++ b/RevenueCatUI/Helpers/TrialOrIntroEligibilityChecker.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  TrialOrIntroEligibilityChecker.swift
-//  
 //
 //  Created by Nacho Soto on 7/13/23.
-//
 
 import Foundation
 import RevenueCat

--- a/RevenueCatUI/Helpers/VersionDetector.swift
+++ b/RevenueCatUI/Helpers/VersionDetector.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  VersionDetector.swift
-//  
 //
 //  Created by Nacho Soto on 8/17/23.
-//
 
 import Foundation
 

--- a/RevenueCatUI/Modifiers/FitToAspectRatio.swift
+++ b/RevenueCatUI/Modifiers/FitToAspectRatio.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  FitToAspectRatio.swift
-//  
 //
 //  Created by Nacho Soto on 7/13/23.
-//
 
 import Foundation
 import SwiftUI

--- a/RevenueCatUI/Modifiers/FooterHidingModifier.swift
+++ b/RevenueCatUI/Modifiers/FooterHidingModifier.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  FooterHidingModifier.swift
 //
-//
 //  Created by Nacho Soto on 8/9/23.
-//
 
 import RevenueCat
 import SwiftUI

--- a/RevenueCatUI/Modifiers/ViewExtensions.swift
+++ b/RevenueCatUI/Modifiers/ViewExtensions.swift
@@ -1,9 +1,15 @@
+////
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
 //
 //  ViewExtensions.swift
-//  
 //
 //  Created by Nacho Soto on 7/13/23.
-//
 
 import Foundation
 import SwiftUI

--- a/RevenueCatUI/PaywallFontProvider.swift
+++ b/RevenueCatUI/PaywallFontProvider.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  PaywallFontProvider.swift
-//  
 //
 //  Created by Nacho Soto on 8/8/23.
-//
 
 import SwiftUI
 

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -1,3 +1,16 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  PaywallView.swift
+//
+//  Created by Nacho Soto.
+
 import RevenueCat
 import SwiftUI
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  PurchaseHandler.swift
 //  
-//
 //  Created by Nacho Soto on 7/13/23.
-//
 
 import RevenueCat
 import StoreKit

--- a/RevenueCatUI/Templates/Template1View.swift
+++ b/RevenueCatUI/Templates/Template1View.swift
@@ -1,3 +1,16 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Template1View.swift
+//
+//  Created by Nacho Soto.
+
 import RevenueCat
 import SwiftUI
 

--- a/RevenueCatUI/Templates/Template2View.swift
+++ b/RevenueCatUI/Templates/Template2View.swift
@@ -1,3 +1,16 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Template2View.swift
+//
+//  Created by Nacho Soto.
+
 import RevenueCat
 import SwiftUI
 

--- a/RevenueCatUI/Templates/Template3View.swift
+++ b/RevenueCatUI/Templates/Template3View.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  Template3View.swift
-//  
 //
 //  Created by Nacho Soto on 7/26/23.
-//
 
 import RevenueCat
 import SwiftUI

--- a/RevenueCatUI/Templates/Template4View.swift
+++ b/RevenueCatUI/Templates/Template4View.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  Template4View.swift
-//  
 //
 //  Created by Nacho Soto on 8/1/23.
-//
 
 import RevenueCat
 import SwiftUI

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -1,3 +1,16 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  TemplateViewType.swift
+//
+//  Created by Nacho Soto.
+
 import RevenueCat
 import SwiftUI
 

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  PaywallViewController.swift
 //  
-//
 //  Created by Nacho Soto on 8/1/23.
-//
 
 #if canImport(UIKit)
 

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  View+PresentPaywall.swift
-//  
 //
 //  Created by Nacho Soto on 7/24/23.
-//
 
 import RevenueCat
 import SwiftUI

--- a/RevenueCatUI/View+PresentPaywallFooter.swift
+++ b/RevenueCatUI/View+PresentPaywallFooter.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  View+PresentPaywallFooter.swift
-//  
 //
 //  Created by Josh Holtz on 8/18/23.
-//
 
 import RevenueCat
 import SwiftUI

--- a/RevenueCatUI/View+PurchaseCompleted.swift
+++ b/RevenueCatUI/View+PurchaseCompleted.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  View+PurchaseCompleted.swift
 //  
-//
 //  Created by Nacho Soto on 7/31/23.
-//
 
 import RevenueCat
 import SwiftUI

--- a/RevenueCatUI/Views/AsyncButton.swift
+++ b/RevenueCatUI/Views/AsyncButton.swift
@@ -1,9 +1,16 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+
 //  AsyncButton.swift
-//  
 //
 //  Created by Nacho Soto on 7/13/23.
-//
 
 import RevenueCat
 import SwiftUI

--- a/RevenueCatUI/Views/DebugErrorView.swift
+++ b/RevenueCatUI/Views/DebugErrorView.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  DebugErrorView.swift
 //  
-//
 //  Created by Nacho Soto on 7/13/23.
-//
 
 import Foundation
 import SwiftUI

--- a/RevenueCatUI/Views/ErrorDisplay.swift
+++ b/RevenueCatUI/Views/ErrorDisplay.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  ErrorDisplay.swift
-//  
 //
 //  Created by Nacho Soto on 7/21/23.
-//
 
 import SwiftUI
 

--- a/RevenueCatUI/Views/FooterView.swift
+++ b/RevenueCatUI/Views/FooterView.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  FooterView.swift
 //  
-//
 //  Created by Nacho Soto on 7/20/23.
-//
 
 import RevenueCat
 import SwiftUI

--- a/RevenueCatUI/Views/IconView.swift
+++ b/RevenueCatUI/Views/IconView.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  IconView.swift
-//  
 //
 //  Created by Nacho Soto on 7/25/23.
-//
 
 import SwiftUI
 

--- a/RevenueCatUI/Views/IntroEligibilityStateView.swift
+++ b/RevenueCatUI/Views/IntroEligibilityStateView.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  IntroEligibilityStateView.swift
 //  
-//
 //  Created by Nacho Soto on 7/18/23.
-//
 
 import RevenueCat
 import SwiftUI

--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  LoadingPaywallView.swift
-//  
 //
 //  Created by Nacho Soto on 7/21/23.
-//
 
 import RevenueCat
 import SwiftUI

--- a/RevenueCatUI/Views/PackageButtonStyle.swift
+++ b/RevenueCatUI/Views/PackageButtonStyle.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  PackageButtonStyle.swift
-//  
 //
 //  Created by Nacho Soto on 7/29/23.
-//
 
 import SwiftUI
 

--- a/RevenueCatUI/Views/PurchaseButton.swift
+++ b/RevenueCatUI/Views/PurchaseButton.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  PurchaseButton.swift
 //  
-//
 //  Created by Nacho Soto on 7/18/23.
-//
 
 import RevenueCat
 import SwiftUI

--- a/RevenueCatUI/Views/RemoteImage.swift
+++ b/RevenueCatUI/Views/RemoteImage.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  RemoteImage.swift
 //  
-//
 //  Created by Nacho Soto on 7/19/23.
-//
 
 import SwiftUI
 

--- a/RevenueCatUI/Views/TemplateBackgroundImageView.swift
+++ b/RevenueCatUI/Views/TemplateBackgroundImageView.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  TemplateBackgroundImageView.swift
 //  
-//
 //  Created by Nacho Soto on 8/1/23.
-//
 
 import RevenueCat
 import SwiftUI

--- a/Tests/RevenueCatUITests/BaseSnapshotTest.swift
+++ b/Tests/RevenueCatUITests/BaseSnapshotTest.swift
@@ -1,9 +1,16 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  BaseSnapshotTest.swift
-//  
 //
 //  Created by Nacho Soto on 7/17/23.
-//
+
 import Nimble
 import RevenueCat
 @testable import RevenueCatUI

--- a/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
+++ b/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  PackageVariablesTests.swift
-//  
 //
 //  Created by Nacho Soto on 8/4/23.
-//
 
 import Nimble
 import RevenueCat

--- a/Tests/RevenueCatUITests/Data/PaywallDataValidationTests.swift
+++ b/Tests/RevenueCatUITests/Data/PaywallDataValidationTests.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  PaywallDataValidationTests.swift
-//  
 //
 //  Created by Nacho Soto on 8/15/23.
-//
 
 import Nimble
 import RevenueCat

--- a/Tests/RevenueCatUITests/Data/TemplateViewConfigurationTests.swift
+++ b/Tests/RevenueCatUITests/Data/TemplateViewConfigurationTests.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  TemplateViewConfigurationTests.swift
-//  
 //
 //  Created by Nacho Soto on 7/13/23.
-//
 
 import Nimble
 import RevenueCat

--- a/Tests/RevenueCatUITests/Data/VariablesTests.swift
+++ b/Tests/RevenueCatUITests/Data/VariablesTests.swift
@@ -1,3 +1,14 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  VariablesTests.swift
+
 import Nimble
 import RevenueCat
 @testable import RevenueCatUI

--- a/Tests/RevenueCatUITests/Helpers/TestCase.swift
+++ b/Tests/RevenueCatUITests/Helpers/TestCase.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  TestCase.swift
-//  
 //
 //  Created by Nacho Soto on 7/12/23.
-//
 
 import SnapshotTesting
 import XCTest

--- a/Tests/RevenueCatUITests/LocalizationTests.swift
+++ b/Tests/RevenueCatUITests/LocalizationTests.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  LocalizationTests.swift
-//  
 //
 //  Created by Nacho Soto on 7/12/23.
-//
 
 import Nimble
 import RevenueCat

--- a/Tests/RevenueCatUITests/PaywallFooterTests.swift
+++ b/Tests/RevenueCatUITests/PaywallFooterTests.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  PaywallFooterTests.swift
-//  
 //
 //  Created by Josh Holtz on 8/22/23.
-//
 
 import Nimble
 import RevenueCat

--- a/Tests/RevenueCatUITests/PresentIfNeededTests.swift
+++ b/Tests/RevenueCatUITests/PresentIfNeededTests.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  PresentIfNeededTests.swift
-//  
 //
 //  Created by Nacho Soto on 7/31/23.
-//
 
 import Nimble
 import RevenueCat

--- a/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  PurchaseCompletedHandlerTests.swift
-//  
 //
 //  Created by Nacho Soto on 7/31/23.
-//
 
 import Nimble
 import RevenueCat

--- a/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
@@ -1,9 +1,15 @@
 //
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
 //  PurchaseHandlerTests.swift
-//  
 //
 //  Created by Nacho Soto on 7/31/23.
-//
 
 import Nimble
 import RevenueCat

--- a/Tests/RevenueCatUITests/Templates/Template1ViewTests.swift
+++ b/Tests/RevenueCatUITests/Templates/Template1ViewTests.swift
@@ -1,3 +1,14 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Template1ViewTests.swift
+
 import Nimble
 import RevenueCat
 @testable import RevenueCatUI

--- a/Tests/RevenueCatUITests/Templates/Template2ViewTests.swift
+++ b/Tests/RevenueCatUITests/Templates/Template2ViewTests.swift
@@ -1,3 +1,14 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Template2ViewTests.swift
+
 import Nimble
 import RevenueCat
 @testable import RevenueCatUI

--- a/Tests/RevenueCatUITests/Templates/Template3ViewTests.swift
+++ b/Tests/RevenueCatUITests/Templates/Template3ViewTests.swift
@@ -1,3 +1,14 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Template3ViewTests.swift
+
 import Nimble
 import RevenueCat
 @testable import RevenueCatUI

--- a/Tests/RevenueCatUITests/Templates/Template4ViewTests.swift
+++ b/Tests/RevenueCatUITests/Templates/Template4ViewTests.swift
@@ -1,3 +1,14 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  Template4ViewTests.swift
+
 import Nimble
 import RevenueCat
 @testable import RevenueCatUI


### PR DESCRIPTION
`Xcode` doesn't allow customizing the header (looks like maybe it worked at some point but not anymore: https://stackoverflow.com/questions/67614785/changing-the-default-header-comment-license-in-swift-package).

At least this adds the license to all the initial files in the package.