### PR TITLE
`Integration Tests`: fixed race condition in flaky test

### DIFF
--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -250,9 +250,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
             productIdentifier: await self.monthlyPackage.storeProduct.productIdentifier
         )
 
-        try await asyncWait(description: "Expected 2 unfinished transactions") {
-            await Transaction.unfinished.extractValues().count == 2
-        }
+        try await self.waitUntilUnfinishedTransactions(2)
 
         self.serverUp()
 

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -513,12 +513,15 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
         // 5. Re-open app
         await self.resetSingleton()
-        self.logger.clearMessages()
 
-        // 6. Purchase again
+        // 6. Wait for pending transactions to be posted
+        try await self.waitUntilUntilNoUnfinishedTransactions()
+
+        // 7. Purchase again
+        self.logger.clearMessages()
         try await self.purchaseMonthlyProduct()
 
-        // 7. Verify transaction is posted as a purchase.
+        // 8. Verify transaction is posted as a purchase.
         self.logger.verifyMessageWasLogged("Posting receipt (source: 'purchase')")
     }
 

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -515,7 +515,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         await self.resetSingleton()
 
         // 6. Wait for pending transactions to be posted
-        try await self.waitUntilUntilNoUnfinishedTransactions()
+        try await self.waitUntilNoUnfinishedTransactions()
 
         // 7. Purchase again
         self.logger.clearMessages()

--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
@@ -60,7 +60,7 @@ extension XCTestCase {
         }
     }
 
-    func waitUntilUntilNoUnfinishedTransactions(file: FileString = #fileID, line: UInt = #line) async throws {
+    func waitUntilNoUnfinishedTransactions(file: FileString = #fileID, line: UInt = #line) async throws {
         try await self.waitUntilUnfinishedTransactions(0)
     }
 

--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
@@ -44,7 +44,24 @@ extension XCTestCase {
         }
 
         expect(file: file, line: line, verified.id) == identifier
+    }
 
+    func waitUntilUnfinishedTransactions(
+        _ expectedCount: Int,
+        file: FileString = #fileID,
+        line: UInt = #line
+    ) async throws {
+        try await asyncWait(
+            description: "Expected \(expectedCount) unfinished transactions",
+            file: file,
+            line: line
+        ) {
+            await Transaction.unfinished.extractValues().count == expectedCount
+        }
+    }
+
+    func waitUntilUntilNoUnfinishedTransactions(file: FileString = #fileID, line: UInt = #line) async throws {
+        try await self.waitUntilUnfinishedTransactions(0)
     }
 
     func deleteAllTransactions(session: SKTestSession) async {


### PR DESCRIPTION
This test had a race condition because it was assuming that the prior transactions had already been posted.
Otherwise the only post receipt that happens is detected as `.queue`.
