### PR TITLE
`Paywalls`: temporarily disable `PaywallTemplate.template4`

### DIFF
--- a/RevenueCatUI/Data/PaywallTemplate.swift
+++ b/RevenueCatUI/Data/PaywallTemplate.swift
@@ -19,7 +19,9 @@ internal enum PaywallTemplate: String {
     case template1 = "1"
     case template2 = "2"
     case template3 = "3"
-    case template4 = "4"
+
+    // Temporarily disabled until it's supported in the dashboard
+    case template4 = "4_disabled"
 
 }
 


### PR DESCRIPTION
It's not available in the dashboard so we don't want the first SDK releases to support it yet.

I was going to remove the `enum` `case` but that required commenting out a lot of extra code.
This is a much simpler one-line change.