### PR TITLE
`Integration Tests`: workaround to not lose debug logs

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		37E35C8515C5E2D01B0AF5C1 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37E3507939634ED5A9280544 /* Strings.swift */; };
 		42F1DF385E3C1F9903A07FBF /* ProductsFetcherSK1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFB3CBAA73855779FE828CE2 /* ProductsFetcherSK1.swift */; };
 		4F0201C42A13C85500091612 /* Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0201C32A13C85500091612 /* Assertions.swift */; };
+		4F0404622A9CF64600009408 /* ProcessInfo+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578D798D2936ACF70042E434 /* ProcessInfo+Extensions.swift */; };
 		4F0BBA812A1D0524000E75AB /* DefaultDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0BBA802A1D0524000E75AB /* DefaultDecodable.swift */; };
 		4F0BBAAC2A1D253D000E75AB /* OfflineCustomerInfoCreatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0BBAAB2A1D253D000E75AB /* OfflineCustomerInfoCreatorTests.swift */; };
 		4F0CE2BD2A215CE600561895 /* TransactionPosterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F0CE2BC2A215CE600561895 /* TransactionPosterTests.swift */; };
@@ -3796,6 +3797,7 @@
 				5759B32E296DF4E3002472D5 /* PurchasesReceiptParser+Fetching.swift in Sources */,
 				57D92C47293E4DE500D1912A /* ReceiptParsingError.swift in Sources */,
 				5753EDDE294A7A9D00CBAB54 /* PurchasesReceiptParser+Extensions.swift in Sources */,
+				4F0404622A9CF64600009408 /* ProcessInfo+Extensions.swift in Sources */,
 				57D92C50293E506100D1912A /* ReceiptParserLogger.swift in Sources */,
 				57D92C4C293E4DE500D1912A /* AppleReceipt.swift in Sources */,
 				57D92C44293E4DE500D1912A /* ASN1ContainerBuilder.swift in Sources */,

--- a/Sources/FoundationExtensions/ProcessInfo+Extensions.swift
+++ b/Sources/FoundationExtensions/ProcessInfo+Extensions.swift
@@ -49,7 +49,9 @@ extension ProcessInfo {
     }
 
     static var mockAdServicesToken: String? {
-        return self[.RCMockAdServicesToken]?.notEmptyOrWhitespaces
+        guard let token = self[.RCMockAdServicesToken], !token.isEmpty else { return nil }
+
+        return token
     }
 
 }

--- a/Sources/LocalReceiptParsing/Helpers/LoggerType.swift
+++ b/Sources/LocalReceiptParsing/Helpers/LoggerType.swift
@@ -177,8 +177,17 @@ private extension LogLevel {
 
     var logType: OSLogType {
         switch self {
-        case .verbose: return .debug
-        case .debug: return .debug
+        case .verbose, .debug:
+            #if DEBUG
+            if ProcessInfo.isRunningIntegrationTests {
+                return .info
+            } else {
+                return .debug
+            }
+            #else
+            return .debug
+            #endif
+
         case .info: return .info
         case .warn: return .error
         case .error: return .error

--- a/Sources/LocalReceiptParsing/Helpers/LoggerType.swift
+++ b/Sources/LocalReceiptParsing/Helpers/LoggerType.swift
@@ -184,6 +184,8 @@ private extension LogLevel {
         case .verbose, .debug:
             #if DEBUG
             if ProcessInfo.isRunningIntegrationTests {
+                // See https://github.com/RevenueCat/purchases-ios/pull/3108
+                // With `.debug` we'd lose these logs when running integration tests on CI.
                 return .info
             } else {
                 return .debug

--- a/Sources/LocalReceiptParsing/Helpers/LoggerType.swift
+++ b/Sources/LocalReceiptParsing/Helpers/LoggerType.swift
@@ -200,6 +200,9 @@ private extension LogLevel {
         }
     }
 
-    private static let logTypes: [Self: OSLogType] = Set(Self.allCases).dictionaryWithValues { $0.calculateLogType() }
+    private static let logTypes: [Self: OSLogType] =
+        .init(uniqueKeysWithValues: Self.allCases.lazy.map {
+            ($0, $0.calculateLogType())
+        })
 
 }

--- a/Sources/LocalReceiptParsing/Helpers/LoggerType.swift
+++ b/Sources/LocalReceiptParsing/Helpers/LoggerType.swift
@@ -176,6 +176,10 @@ extension LoggerType {
 private extension LogLevel {
 
     var logType: OSLogType {
+        return Self.logTypes[self]!
+    }
+
+    private func calculateLogType() -> OSLogType {
         switch self {
         case .verbose, .debug:
             #if DEBUG
@@ -193,5 +197,7 @@ private extension LogLevel {
         case .error: return .error
         }
     }
+
+    private static let logTypes: [Self: OSLogType] = Set(Self.allCases).dictionaryWithValues { $0.calculateLogType() }
 
 }


### PR DESCRIPTION
`OSLogType.debug` logs are purged and not saved:
> The system only captures debug-level messages in memory when you enable debug logging through a configuration change, and purges them in accordance with the configuration’s persistence setting.

I haven't been able to find a way to override this behavior. This means than when reading the logs on CI or when downloading the `xcresult` archive, we can't see these, making it really hard to debug failures.

See also #3048.