### PR TITLE
`Integration Tests`: fixed another flaky test

### DIFF
--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -496,6 +496,12 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     }
 
     func testSubscribeAfterExpirationWhileAppIsClosed() async throws {
+        func waitForNewPurchaseDate() async {
+            // The backend uses the transaction purchase date as a way to disambiguate transactions.
+            // Therefor we need to sleep to force these to have unique dates.
+            try? await Task.sleep(nanoseconds: DispatchTimeInterval.seconds(2).nanoseconds)
+        }
+
         // 1. Subscribe
         let customerInfo = try await self.purchaseMonthlyOffering().customerInfo
         let entitlement = try XCTUnwrap(customerInfo.entitlements[Self.entitlementIdentifier])
@@ -505,8 +511,11 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
         // 3. Force several renewals while app is closed.
         for _ in 0..<3 {
+            await waitForNewPurchaseDate()
             try self.testSession.forceRenewalOfSubscription(productIdentifier: entitlement.productIdentifier)
         }
+
+        await waitForNewPurchaseDate()
 
         // 4. Expire subscription
         try await self.expireSubscription(entitlement)


### PR DESCRIPTION
This test was failing very often in CI. This is an example receipt from the failing second purchase:
```json
{
    "opaque_value": "9JfV+g8AAAA=",
    "sha1_hash": "Bw7/MSbUKKs9ZaUI2FugNBo/DtM=",
    "bundle_id": "com.revenuecat.StoreKitTestApp",
    "in_app_purchases": [
        {
            "product_id": "com.revenuecat.monthly_4.99.1_week_intro",
            "quantity": 1,
            "transaction_id": "146",
            "is_in_intro_offer_period": false,
            "expires_date": "2023-08-28T15:52:19Z",
            "original_purchase_date": "2023-08-28T15:52:18Z",
            "original_transaction_id": "143",
            "product_type": -1,
            "purchase_date": "2023-08-28T15:52:19Z"
        },
        {
            "product_id": "com.revenuecat.monthly_4.99.1_week_intro",
            "quantity": 1,
            "transaction_id": "143",
            "is_in_intro_offer_period": true,
            "expires_date": "2023-08-28T15:52:19Z",
            "purchase_date": "2023-08-28T15:52:18Z",
            "product_type": -1
        },
        {
            "product_id": "com.revenuecat.monthly_4.99.1_week_intro",
            "quantity": 1,
            "transaction_id": "145",
            "is_in_intro_offer_period": false,
            "expires_date": "2023-08-28T15:52:19Z",
            "original_purchase_date": "2023-08-28T15:52:18Z",
            "original_transaction_id": "143",
            "product_type": -1,
            "purchase_date": "2023-08-28T15:52:19Z"
        },
        {
            "product_id": "com.revenuecat.monthly_4.99.1_week_intro",
            "quantity": 1,
            "transaction_id": "147",
            "is_in_intro_offer_period": false,
            "expires_date": "2023-08-28T15:52:49Z",
            "original_purchase_date": "2023-08-28T15:52:18Z",
            "original_transaction_id": "143",
            "product_type": -1,
            "purchase_date": "2023-08-28T15:52:19Z"
        },
        {
            "product_id": "com.revenuecat.monthly_4.99.1_week_intro",
            "quantity": 1,
            "transaction_id": "144",
            "is_in_intro_offer_period": false,
            "expires_date": "2023-08-28T15:52:19Z",
            "original_purchase_date": "2023-08-28T15:52:18Z",
            "original_transaction_id": "143",
            "product_type": -1,
            "purchase_date": "2023-08-28T15:52:19Z"
        }
    ],
    "application_version": "1",
    "creation_date": "2023-08-28T15:52:30Z",
    "expiration_date": "4001-01-01T00:00:00Z"
}
```

Note that the latest transaction has the same purchase date. That was making the backend filter that out believing it was a duplicate transaction. Thanks @MarkVillacampa for the help debugging this and suggesting a workaround.

This new implementation forces each transaction to have a unique `purchase_date` to work around that.
