### PR TITLE
`Paywalls`: move snapshots to `LFS`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,8 @@ aliases:
     environment:
       CIRCLECI_TESTS_GENERATE_SNAPSHOTS: << pipeline.parameters.generate_snapshots >>
       CIRCLECI_TESTS_GENERATE_REVENUECAT_UI_SNAPSHOTS: << pipeline.parameters.generate_revenuecatui_snapshots >>
+      # See https://www.develer.com/en/blog/avoiding-git-lfs-bandwidth-waste-with-github-and-circleci/
+      GIT_LFS_SKIP_SMUDGE: 1
     working_directory: ~/purchases-ios
     shell: /bin/bash --login -o pipefail
   release-branches: &release-branches
@@ -162,6 +164,21 @@ commands:
           key: v1-rubydocker-gem-cache-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
+
+  # See https://www.develer.com/en/blog/avoiding-git-lfs-bandwidth-waste-with-github-and-circleci/
+  fetch-lfs:
+    steps:
+      - run:
+          command: |
+            git lfs ls-files -l | cut -d' ' -f1 | sort > .assets-id
+      - restore_cache:
+          key: v1-lfs-cache-{{ checksum ".assets-id" }}
+      - run:
+          command: git lfs pull
+      - save_cache:
+          key: v1-lfs-cache-{{ checksum ".assets-id" }}
+          paths:
+            - .git/lfs
 
   compress_result_bundle:
     parameters:
@@ -341,6 +358,7 @@ jobs:
     <<: *base-job
     steps:
       - checkout
+      - fetch-lfs
       - update-spm-installation-commit
       - run:
           name: SPM RevenueCatUI Tests
@@ -367,6 +385,7 @@ jobs:
     <<: *base-job
     steps:
       - checkout
+      - fetch-lfs
       - update-spm-installation-commit
       - run:
           name: SPM RevenueCatUI Release Build
@@ -400,6 +419,7 @@ jobs:
     <<: *base-job
     steps:
       - checkout
+      - fetch-lfs
       - update-spm-installation-commit
       - run:
           name: SPM RevenueCatUI Tests

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/.gitattributes
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/.gitattributes
@@ -1,0 +1,1 @@
+*.png filter=lfs diff=lfs merge=lfs -text

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS15-testDefaultDarkModePaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS15-testDefaultDarkModePaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6bbbc5e19497f0e7711db3c3ba5b2f98695bd092d99afac4ae6371ee07e7d4e5
+size 751094

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS15-testDefaultPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS15-testDefaultPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46ed4cc2682c68bc6d876d6d5fcc8ae1df1335d0bb94988b4fa3091514e09c58
+size 752190

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS15-testLoadingCondensedFooterPaywallView.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS15-testLoadingCondensedFooterPaywallView.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6edfcc488586f81626140a357c3ac9cdc9219ffa3a3c9e88119dd63f615858d
+size 6678

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS15-testLoadingFooterPaywallView.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS15-testLoadingFooterPaywallView.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e99f94752a5e1d04a574fba3a7c5f59b75bfe6b7d03d3767a4c9333240d9752c
+size 10827

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS15-testLoadingPaywallView.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS15-testLoadingPaywallView.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35cdf1341af54e7bec05faaab3f3baa50c9887127e237ba8a63a376fc3310fad
+size 923679

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS16-testDefaultDarkModePaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS16-testDefaultDarkModePaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac1fc1311af9def32459646c5a55d65743adab17417fa91d6d0412484fe9074a
+size 749121

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS16-testDefaultPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS16-testDefaultPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:788dc4b34454fcf57774805642db7630b43d4a7fc99119f17f862c2728d72330
+size 750266

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS16-testLoadingCondensedFooterPaywallView.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS16-testLoadingCondensedFooterPaywallView.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19a4613cd3885523d1f4c93ce87a4e9fd6d427273111abe2a84128a182f8bfe5
+size 6772

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS16-testLoadingFooterPaywallView.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS16-testLoadingFooterPaywallView.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfc04ed7f4d243b78e205445c87b1a18d4afcc9b13d5434c5aa3c82ee8d6b6a2
+size 11019

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS16-testLoadingPaywallView.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS16-testLoadingPaywallView.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06d839ce768ceec7cb54c3cc51363415d471ea934ad5ed5d6a34da1a63dd4fa2
+size 920369

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS17-testDefaultDarkModePaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS17-testDefaultDarkModePaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27bcffca31475f73656079998480e86a04128f34ebb4ad6fda0920fd9b2a38a4
+size 749438

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS17-testDefaultPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS17-testDefaultPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:862f73cbc980feb32c2f2cae7a152001ca8b73336afd6192aa287a0b94b48915
+size 750579

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS17-testLoadingCondensedFooterPaywallView.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS17-testLoadingCondensedFooterPaywallView.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1fdeeadc4e83da29491115ecec98061a795f0c0a1a012fdfe53adabdecee000
+size 6857

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS17-testLoadingFooterPaywallView.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS17-testLoadingFooterPaywallView.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc95cb553211c7b2b2649adf250bcbf032c1392fba3ba88c6da398d4ecc0a25e
+size 11104

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS17-testLoadingPaywallView.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/OtherPaywallViewTests/iOS17-testLoadingPaywallView.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c56d949c472fe489018dd1111c6aea2b3fecd484b9ddf4ed52c0c8975668fb9
+size 920454

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS15-testAccessibility1.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS15-testAccessibility1.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fc210e2cc96f891f27e93dbc096031cb7152b501caf49de2359adb48d4c07dfd
+size 477840

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS15-testAccessibility3.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS15-testAccessibility3.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87e97116d017f9821fecded2bb02443da582612544f8ed8bb5492901c28d1cf1
+size 227479

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS15-testAccessibility5.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS15-testAccessibility5.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e2db6071593538445d0f5634cdc1466941d62311275f5f7664d1a97b269c3c6
+size 184072

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS15-testLarge.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS15-testLarge.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a81ff966fd78ee075d0cc72a8652d7a1c46bb8c3ac95818f445a01e45223f3e1
+size 459251

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS15-testMedium.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS15-testMedium.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d7240f6e464dffef1e23fe7cebcd7801a66d64cc8944f0db9c9d78af20d6d0a
+size 453922

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS15-testSmall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS15-testSmall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd5129964b7606425179f9c8b8e0069468f3dccc222d38b9e0342edb35cd6292
+size 452099

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS15-testXLarge.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS15-testXLarge.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a81ff966fd78ee075d0cc72a8652d7a1c46bb8c3ac95818f445a01e45223f3e1
+size 459251

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS15-testXSmall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS15-testXSmall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8951bd884ed79e18ee33b06138e076ff510d08b7053c8f28370dfd3064069de
+size 449884

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS15-testXXLarge.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS15-testXXLarge.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d4b8f2e2c3fadbde13c412493d4c46b2f98847e480c943d91d8b71a60b8d910
+size 462907

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS15-testXXXLarge.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS15-testXXXLarge.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5176a6411b56f317b78b87d9a8adbe1566eac3414d1ce41c70c73fd012e2939
+size 466934

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS16-testAccessibility1.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS16-testAccessibility1.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6c0a448199f5b70da9ba78ce3772b87b744e7bb6cc52c3e0f5240289260099f
+size 473464

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS16-testAccessibility3.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS16-testAccessibility3.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11220bd79d76df2b8b6d08071cf3f90d80be16e5cd4c8f60b87b5b336c57e449
+size 483529

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS16-testAccessibility5.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS16-testAccessibility5.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70509a781425b4e81a8906c866c7b5993cf8a8808860b26eaaf46cb032b46744
+size 474295

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS16-testLarge.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS16-testLarge.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e224f288148beb4dcc30f0bdc7511763cdd4015e2f09cab95689c69ade86dfc1
+size 459438

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS16-testMedium.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS16-testMedium.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:041469f8387086617cd6240cc0449d692158d933dce1de8194ab51e281419c92
+size 454040

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS16-testSmall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS16-testSmall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ff66aef8f0b67568d22deb64127f369f0b7ce047af30983ba12afa368803cc2
+size 452225

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS16-testXLarge.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS16-testXLarge.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e224f288148beb4dcc30f0bdc7511763cdd4015e2f09cab95689c69ade86dfc1
+size 459438

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS16-testXSmall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS16-testXSmall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fb03aba6cb0c63c3a57235f6ea9876be8ea91a840fdd212c9522159462f7638
+size 449978

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS16-testXXLarge.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS16-testXXLarge.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a3e1d611ed166851c93c423c4349181ccaf3f212dee1d4e256a787b17f40a10
+size 461737

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS16-testXXXLarge.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS16-testXXXLarge.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8fbbdc27673482e073d691bd407e2639bebdc3ce9b7c8662fb8bbd721100e0f
+size 465265

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS17-testAccessibility1.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS17-testAccessibility1.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35193496bfe3d725485dd7b0a238183ffb04bb9237b5bd7ea337505530550c95
+size 473567

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS17-testAccessibility3.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS17-testAccessibility3.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e2f36061818aafc25343c4464fd34b86894521c989f887152b2b7d7ca0521de
+size 483639

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS17-testAccessibility5.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS17-testAccessibility5.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6db7c7c8bfab3da4a96ab2f889d46714fa18be951b3dc31aad4ada6a3cc6f7f
+size 474308

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS17-testLarge.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS17-testLarge.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7dbca8eb733a16f5ed2b043b832fd809259ade99a270df26c156d5e2159b1c5e
+size 459517

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS17-testMedium.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS17-testMedium.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69b4f1a49fb1482949ae63d3563fa98e99e1e6722b9658f5edd798d7b91658c5
+size 454216

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS17-testSmall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS17-testSmall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43adb808d6d42be339d95df0c344bcd33fec62e38fb94f8f08deb0c0a21c390a
+size 452319

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS17-testXLarge.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS17-testXLarge.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7dbca8eb733a16f5ed2b043b832fd809259ade99a270df26c156d5e2159b1c5e
+size 459517

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS17-testXSmall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS17-testXSmall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c8a31ada3ef043b1621f2b8b030a19b0b3587ac1dfee8ab3d33c42d547abd43
+size 450078

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS17-testXXLarge.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS17-testXXLarge.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fdfc795e5feecf528543e766a40c77d7ec5c560f0801e3719381f2c3e55e6991
+size 461920

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS17-testXXXLarge.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewDynamicTypeTests/iOS17-testXXXLarge.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e99d252b6e9d082a36b33c01eccd8cd8d61069efc42993ed89516375b53e2239
+size 465312

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewLocalizationTests/iOS15-testSpanish.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewLocalizationTests/iOS15-testSpanish.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7db1e30a3c4456edbc16dde940d5c3b3ae1b1b44b9daf6ed4a4c8c0ec841354
+size 971844

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewLocalizationTests/iOS16-testSpanish.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewLocalizationTests/iOS16-testSpanish.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:393e65b7ae6c29010b1df71be406d8e12c1accb8290445511695b0129da79525
+size 973302

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewLocalizationTests/iOS17-testSpanish.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/PaywallViewLocalizationTests/iOS17-testSpanish.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7066387bde20345ce47ddcdb00cc556f4156e171c2273990c039a986fa4afcf6
+size 973988

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS15-testCondensedFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS15-testCondensedFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4862355724ba835b95d094ccd883b6b883bd3fa27cecae85544277aca5228a4f
+size 15235

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS15-testCustomFont.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS15-testCustomFont.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5909e609b2cfdd1a864a061792ebe81febd3ea0249f234e4516529af093b9a1
+size 447781

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS15-testDarkMode.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS15-testDarkMode.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b173c9f5beb809fbdbcfdef3633acc0dcbe83dad5e238d9043513b6b870c920
+size 454885

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS15-testFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS15-testFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4862355724ba835b95d094ccd883b6b883bd3fa27cecae85544277aca5228a4f
+size 15235

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS15-testSamplePaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS15-testSamplePaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78758d374f13fd7833a2db08b0f2c83d5f7f7ba44362433b11e6ccd72db8bb8d
+size 449428

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS15-testSamplePaywallWithIneligibleIntroOffer.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS15-testSamplePaywallWithIneligibleIntroOffer.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15190da1c5b14646989c65f6100f649d6a76a3e7bcf87ffd15c7b96dd78e0341
+size 455707

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS15-testSamplePaywallWithIntroOffer.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS15-testSamplePaywallWithIntroOffer.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15190da1c5b14646989c65f6100f649d6a76a3e7bcf87ffd15c7b96dd78e0341
+size 455707

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS15-testSamplePaywallWithLoadingEligibility.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS15-testSamplePaywallWithLoadingEligibility.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15190da1c5b14646989c65f6100f649d6a76a3e7bcf87ffd15c7b96dd78e0341
+size 455707

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS15-testTabletPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS15-testTabletPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f6a572edacb473d31abff87d5044a7373ada770b54231aa4c6f27f59d8a087e
+size 1014904

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS16-testCondensedFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS16-testCondensedFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7459b595fa243015af5f5ca8ebe8eda13c6cd3e78d2e1148c7b544d8142f7c7a
+size 15531

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS16-testCustomFont.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS16-testCustomFont.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:546735e9500d8fef496bba21f32475649c3ac9d327505621fa661653a8ab8b20
+size 448049

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS16-testDarkMode.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS16-testDarkMode.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1eac84e3b1f20f5c1264c3061307e9473a822f67c258d061adb1a6efa8e2fad1
+size 454993

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS16-testFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS16-testFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7459b595fa243015af5f5ca8ebe8eda13c6cd3e78d2e1148c7b544d8142f7c7a
+size 15531

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS16-testSamplePaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS16-testSamplePaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:deded8b56d490cd9f281717dae8a0db02566909ccd95ced3844be199e4999fb6
+size 449593

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS16-testSamplePaywallWithIneligibleIntroOffer.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS16-testSamplePaywallWithIneligibleIntroOffer.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f0a8e29c0628ff9382ed088642f2c9160240e397d86895587f01e1d256670e0
+size 455802

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS16-testSamplePaywallWithIntroOffer.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS16-testSamplePaywallWithIntroOffer.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f0a8e29c0628ff9382ed088642f2c9160240e397d86895587f01e1d256670e0
+size 455802

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS16-testSamplePaywallWithLoadingEligibility.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS16-testSamplePaywallWithLoadingEligibility.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f0a8e29c0628ff9382ed088642f2c9160240e397d86895587f01e1d256670e0
+size 455802

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS16-testTabletPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS16-testTabletPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca81230bb7235cbf0ff429108a03cb4ba88300413002ed3e9878e508562b80da
+size 1014360

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS17-testCondensedFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS17-testCondensedFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea5db0327a23ab03ec987d0cbf55a4b59a0cbee5e7f302695c5bbdbc93b91fb6
+size 15616

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS17-testCustomFont.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS17-testCustomFont.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d5b266dccb9d92de39e4d51cf431e79a38e5130ce31d8ecf9b46af28e480099
+size 448134

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS17-testDarkMode.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS17-testDarkMode.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73de9f00861f6a72cfb8e943daf556038384ebdf7ad5fd02e1ee3a575c954f78
+size 455168

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS17-testFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS17-testFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea5db0327a23ab03ec987d0cbf55a4b59a0cbee5e7f302695c5bbdbc93b91fb6
+size 15616

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS17-testSamplePaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS17-testSamplePaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0082920ca337591d3ac423b8d9c3ce5c972a851ef5be484c934cf54e4e76b3b0
+size 449735

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS17-testSamplePaywallWithIneligibleIntroOffer.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS17-testSamplePaywallWithIneligibleIntroOffer.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bebb1cbf446b50308f8e3ee65b2445799cefb304cfd98a02bcdb483631da5972
+size 455930

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS17-testSamplePaywallWithIntroOffer.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS17-testSamplePaywallWithIntroOffer.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bebb1cbf446b50308f8e3ee65b2445799cefb304cfd98a02bcdb483631da5972
+size 455930

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS17-testSamplePaywallWithLoadingEligibility.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS17-testSamplePaywallWithLoadingEligibility.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bebb1cbf446b50308f8e3ee65b2445799cefb304cfd98a02bcdb483631da5972
+size 455930

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS17-testTabletPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template1ViewTests/iOS17-testTabletPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91f2b6f13f3a3446018c793f6b4bc805c8620fd73a9d9b3ba8ee5c1052b3542d
+size 1014515

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS15-testCondensedFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS15-testCondensedFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f130340ba6876fa6d5068a35cb7586f9cffe3036d7fd0b601decb59fdae69bbc
+size 20099

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS15-testCustomFont.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS15-testCustomFont.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71a61869a3506e7116fe9ce0a38124c527c15da0e8922f573a87c90d07f94562
+size 876834

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS15-testDarkMode.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS15-testDarkMode.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4dd4646b4fe6b33a82a18c6361c8443d99d9cad12efdd339bff1dca78e7e2537
+size 890947

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS15-testFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS15-testFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c9346874a7885ac92ebb6f69b999682375e4599de70c69cd3143456920449bd
+size 34266

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS15-testPurchasingState.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS15-testPurchasingState.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bee072ffba37f67601b6423793b5f2a1d9c3f5aa775250bab37f6858470a495d
+size 994764

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS15-testSamplePaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS15-testSamplePaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83eaac2f4cb85dc70f984dce33c8267e3b66c5294309a1c5ad77ba22c6783a82
+size 890205

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS15-testTabletPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS15-testTabletPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a305d456937f621ae468afc88d216c648333b50c55506da9a4a76a45341ffbb3
+size 1644987

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS16-testCondensedFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS16-testCondensedFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:32db58995df404de52699ec5201078bb76c2ae72b33c91bacd687032cfca80e3
+size 20393

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS16-testCustomFont.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS16-testCustomFont.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03dcb9541c2278581cd5c08426eace2723a6283e99c42058a101aeb0f74775be
+size 888838

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS16-testDarkMode.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS16-testDarkMode.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f641f07276024d55167e37d3673b5021b14ce7c530cb021b4e86d8c15d7fc038
+size 899690

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS16-testFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS16-testFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c80d720a27b95bae0c52693395c5501d5c77bfba25c06c524554db148d75ff2b
+size 34715

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS16-testPurchasingState.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS16-testPurchasingState.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21a0b8f6d2c7ee0b41362c71f1bea9d97dc79338cdb0577d50dc77ddec254d00
+size 991191

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS16-testSamplePaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS16-testSamplePaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e0d39dfe65be29ecf093d45154f788e88a1334d467def6cbf86a75888c37779
+size 899642

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS16-testTabletPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS16-testTabletPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29a396d231d232f2a659666b4d104d417f3cf338bae23dc56d981296ea11c096
+size 1660586

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS17-testCondensedFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS17-testCondensedFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30a0fa5858d54d2c93e495357853a2ca0c5316ed3960f2160c0faa8db710bd7c
+size 20489

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS17-testCustomFont.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS17-testCustomFont.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee8ad045769ea689316ab2d9c3ec0643411d35aec5272dc562c26214485f458b
+size 889507

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS17-testDarkMode.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS17-testDarkMode.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4a029c31eb540cb2469ab8383628413303de6753ee2a766049d3dc92ceb5a65
+size 900502

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS17-testFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS17-testFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a793ab24e7b606379d739153744ba267995b4858caeec0599b8b5333dd98597
+size 34995

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS17-testPurchasingState.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS17-testPurchasingState.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d982753f93a2dbf6d4e4bb4ce070aea0a9904f0921711245def793b11f492e37
+size 991776

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS17-testSamplePaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS17-testSamplePaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55cc68a9440ce05fd3c69671a1e3fef65780c3815374011e12cdc8ee418e622c
+size 900356

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS17-testTabletPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template2ViewTests/iOS17-testTabletPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a4b22abf95e37f4dfc0e9a9cb5af53e8a87c5e9cad194cffe21ebf0835ff0b7
+size 1661332

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS15-testCondensedFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS15-testCondensedFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a29ba95e1fdc5196fbe1d74a620a39e7e205979a8d54ef9d92ed7b50b1f78f8
+size 19245

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS15-testCustomFont.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS15-testCustomFont.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f1791665807ff69ba0c4eac260ded658b6c36118680284d1ec063b6bb4c74b9
+size 77278

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS15-testDarkMode.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS15-testDarkMode.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:382a4dda0596c0f61956e40552fd7914a8c71a4f770ff983fa3b8acbb35eff3b
+size 74493

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS15-testFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS15-testFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a29ba95e1fdc5196fbe1d74a620a39e7e205979a8d54ef9d92ed7b50b1f78f8
+size 19245

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS15-testSamplePaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS15-testSamplePaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:377a4f5c7b49560749d437fd358cbea8348f7b5687e603697f94ae68b7a3af27
+size 76884

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS15-testTabletPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS15-testTabletPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2ea9a9ced7550ba786c72190d3783c60f85fa4300cfed65bf383205f89b3ec7
+size 88878

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS16-testCondensedFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS16-testCondensedFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c4d43613d6cfc63975e899796acc5843ba7b9da50efc6f6558d781d6413d27e
+size 19375

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS16-testCustomFont.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS16-testCustomFont.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:880e6fbc4906206d156afb0ab2d78c310b83d63f28845060e056547aee19bf8d
+size 77527

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS16-testDarkMode.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS16-testDarkMode.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffd95920c3dfeb2b820ada4230e3a36b6a817956fc296eda56d88e85b697bfdf
+size 74666

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS16-testFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS16-testFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c4d43613d6cfc63975e899796acc5843ba7b9da50efc6f6558d781d6413d27e
+size 19375

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS16-testSamplePaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS16-testSamplePaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f0a967122502f5387755235f91bcc4f9d1a302e6deff645cb76c4d563bb066a
+size 77106

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS16-testTabletPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS16-testTabletPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85abbac4fa7437ab5d2a32808562158794f4a792e0d10255ef219b99ad754955
+size 89178

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS17-testCondensedFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS17-testCondensedFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f17cd57e9f2411c604a1f99e7eab195691d798de66a4b067c14de277541b31cb
+size 19468

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS17-testCustomFont.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS17-testCustomFont.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00eb4bf6787cd75426b43e328246c87da36e053124c8d1861ea0154b0e3d10a1
+size 77712

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS17-testDarkMode.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS17-testDarkMode.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7bfc6fa360777b56f911f8df0ba1b0595859b9eb1ba87cd8db7c89b4f8df22c
+size 74899

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS17-testFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS17-testFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f17cd57e9f2411c604a1f99e7eab195691d798de66a4b067c14de277541b31cb
+size 19468

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS17-testSamplePaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS17-testSamplePaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b1cf8682c9369abdad4e7a1b9fd132e6d28e96f97cf89b2bf81e5ee85fdc5ad
+size 77361

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS17-testTabletPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template3ViewTests/iOS17-testTabletPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e86c2358df387a013dc9e47912da9fe862263828379c241bc2093dc0bc078c9a
+size 89472

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS15-testCondensedFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS15-testCondensedFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1be4988fd6c72cdd900a0486e6466a530a2245bc50ccbf8d3b2ab3e6b50883ef
+size 16782

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS15-testCustomFont.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS15-testCustomFont.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bccb13716df19f3944b513854cca170b5c46641688f55be70fa1c98b11862771
+size 642336

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS15-testFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS15-testFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef24e297f88a73e54f273acabc8157685ef5da3d6027b73cc1b3f462542f904c
+size 31628

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS15-testLargeDynamicType.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS15-testLargeDynamicType.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf5f31504455023c00a8950f6954cddc35af2101ea8d500f7079a5cd030d4e0a
+size 667292

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS15-testLargerDynamicType.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS15-testLargerDynamicType.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d87f53baafb929a67c8b344b1063b6adff4768e6d6c571fdfb99910f5bd1525
+size 520193

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS15-testSamplePaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS15-testSamplePaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:861b5f2a3056af1537ec0432f158c1bd553a818f67077ebe9de3b8a9ae4c1a3f
+size 710288

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS15-testTabletPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS15-testTabletPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a3db095f15ec0668da26341b98f31843a83e3b0b622eae04e6f4cc8f211900d
+size 1403569

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS16-testCondensedFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS16-testCondensedFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61ce90697192bf421e4ea23830313af4ea7e60eab3991359a717c38e74f8c202
+size 16956

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS16-testCustomFont.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS16-testCustomFont.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42408a2faf3fb05542a3fecced4aabe08fc89d8c620a56ff1bc4faedd2b11f94
+size 642908

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS16-testFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS16-testFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27e0131a9c13e9aad2255db23ce8ee848ffe17be7280aa087ab279dd519931a0
+size 31757

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS16-testLargeDynamicType.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS16-testLargeDynamicType.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f165018dca8fc47332cfbbd6fbdc391998ba1643993f67209c6b5a173f1953b5
+size 668243

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS16-testLargerDynamicType.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS16-testLargerDynamicType.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ed2c5bf128cc7155e38168270ddadfeea9c6121896f85c37bda7ac322c9fe9a
+size 556190

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS16-testSamplePaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS16-testSamplePaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51ba357ee250006eec43d63929f245f7f640f4299218fb742246b9c7961e3901
+size 710724

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS16-testTabletPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS16-testTabletPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb45d7ea84a691c8fd3c8302228d1f7a3f835428c4d4cd927457bb1bcf1a5fd3
+size 1403992

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS17-testCondensedFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS17-testCondensedFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c60c6a5f5828c97701b7e6a6d0f6f4fea9a61e4256c341390d3f6194673a104
+size 17033

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS17-testCustomFont.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS17-testCustomFont.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0624ea4ea1727566868efd91c626ecc4b2fa4baca18a224960247bc7aaae0ca
+size 642984

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS17-testFooterPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS17-testFooterPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab12a37369f114967d6f610caa32e0f18e8689aa231c910e2b031964cdd5882a
+size 31846

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS17-testLargeDynamicType.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS17-testLargeDynamicType.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e38a02101b07bbc878007757073a92df124c0411199054f8a4ef273a7facd72
+size 668432

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS17-testLargerDynamicType.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS17-testLargerDynamicType.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:024d236dd665f10b0e719d8e1bd5fcf8e07c21530bdd361230043d30f3e490f0
+size 556366

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS17-testSamplePaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS17-testSamplePaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab26d6eecdda176bea90cc04a109911da102ec2df72dd42e6cd50cc9f63afa42
+size 710825

--- a/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS17-testTabletPaywall.1.png
+++ b/Tests/RevenueCatUITests/Templates/__Snapshots__/Template4ViewTests/iOS17-testTabletPaywall.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f357967067a25237722eadb00f7da6c33993f4e3a2242010cb02760bb42d0ed2
+size 1404099


### PR DESCRIPTION
See:
- https://docs.github.com/en/repositories/working-with-files/managing-large-files/configuring-git-large-file-storage
- https://www.develer.com/en/blog/avoiding-git-lfs-bandwidth-waste-with-github-and-circleci/

Changes:
```bash
cd Tests/RevenueCatUITests/Templates/__Snapshots__
git lfs track *.png
```

This should be a big performance improvement reducing the size of the repo.