### PR TITLE
`CI`: add workaround for `Carthage` timing out

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -188,12 +188,14 @@ platform :ios do
   desc "build tvOS, watchOS, macOS"
   lane :build_tv_watch_mac do |options|
     check_pods
+    load_spm_dependencies
     carthage(command: "build", no_skip_current: true, platform: "watchOS,tvOS,Mac", use_xcframeworks: true)
   end
 
   desc "macOS build"
   lane :build_mac do |options|
     check_pods
+    load_spm_dependencies
     carthage(command: "build", no_skip_current: true, platform: "Mac", use_xcframeworks: true)
   end
 
@@ -806,6 +808,8 @@ def check_no_github_release_exists(version_number)
 end
 
 def carthage_archive
+  load_spm_dependencies
+
   Dir.chdir("..") do
     # As of Carthage 0.38.0, we still can't archive xcframeworks directly.
     # there are also some issues which prevent us from archiving frameworks directly, since
@@ -825,6 +829,17 @@ lane :check_pods do
     platforms:"ios,osx,tvos",
     fail_fast: true
   )
+end
+
+lane :load_spm_dependencies do
+  # Carthage has a hardcoded timeout of 60 seconds when listing schemes.
+  # Because of CircleCI's network issues, that can sometimes fail.
+  # This preemptively runs this command to make sure the SPM dependencies are fetched
+  # without a timeout.
+
+  Dir.chdir("..") do
+    sh("xcodebuild", "-list")
+  end
 end
 
 def current_version_number


### PR DESCRIPTION
`xcodebuild -list` loads all SPM dependencies, which includes our own repo (necessary to test `RevenueCat_CustomEntitlementComputation`):
```
Resolve Package Graph

Resolve Package Graph

Resolved source packages:
  CwlPreconditionTesting: https://github.com/mattgallagher/CwlPreconditionTesting.git @ 2.1.2
  swift-snapshot-testing: https://github.com/pointfreeco/swift-snapshot-testing @ 1.11.1
  CwlCatchException: https://github.com/mattgallagher/CwlCatchException.git @ 2.1.2
  Nimble: https://github.com/quick/nimble @ 10.0.0
  OHHTTPStubs: https://github.com/AliSoftware/OHHTTPStubs.git @ 9.1.0
  RevenueCat: https://github.com/RevenueCat/purchases-ios @ main
```

`Carthage` has as [hardcoded timeout of 60 seconds](https://github.com/Carthage/Carthage/blob/0.39.0/Source/CarthageKit/XCDBLDExtensions.swift#L79). This has been failing ti due to our repo size growing combined with CircleCI's network issues.

To prevent that, this updates all lanes that use `Carthage` to pre-load SPM dependencies by calling `xcodebuild -list` first.
