### PR TITLE
`Catalyst`: fixed a couple of Catalyst build warnings

### DIFF
--- a/Sources/FoundationExtensions/UIApplication+RCExtensions.swift
+++ b/Sources/FoundationExtensions/UIApplication+RCExtensions.swift
@@ -16,7 +16,7 @@ import UIKit
 
 extension UIApplication {
 
-    @available(iOS 13.0, macCatalystApplicationExtension 13.1, *)
+    @available(iOS 13.0, macCatalyst 13.1, *)
     @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(watchOSApplicationExtension, unavailable)

--- a/Sources/Paywalls/PaywallColor.swift
+++ b/Sources/Paywalls/PaywallColor.swift
@@ -165,7 +165,7 @@ private extension PaywallColor {
 #if canImport(UIKit) && !os(watchOS)
 private extension UIColor {
 
-    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
+    @available(iOS 13.0, tvOS 13.0, macCatalyst 13.1, macOS 10.15, watchOS 6.2, *)
     convenience init(light: UIColor, dark: UIColor) {
         self.init { trait in
             switch trait.userInterfaceStyle {


### PR DESCRIPTION
Fixes this warning:
```
PaywallColor.swift:168:6: Initializer cannot be more available than enclosing scope
PaywallColor.swift:168:6: Enclosing scope requires availability of Mac Catalyst 13.1 or newer
```