### PR TITLE
`PurchasesOrchestrator`: return early if receipt has no transactions when checking for promo offers

### DIFF
--- a/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
+++ b/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift
@@ -249,6 +249,13 @@ final class PurchasesOrchestrator {
                 return
             }
 
+            if !self.receiptParser.receiptHasTransactions(receiptData: receiptData) {
+              // Promotional offers require existing purchases.
+              // Fail early if receipt has no transactions.
+              completion(.failure(ErrorUtils.ineligibleError()))
+              return
+            }
+
             self.backend.offerings.post(offerIdForSigning: discountIdentifier,
                                         productIdentifier: product.productIdentifier,
                                         subscriptionGroup: subscriptionGroupIdentifier,

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -537,6 +537,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
     func testGetPromotionalOfferWithNoPurchasesReturnsIneligible() async throws {
         let product = try await self.monthlyPackage.storeProduct
         let discount = try XCTUnwrap(product.discounts.onlyElement)
+        self.logger.clearMessages()
 
         do {
             _ = try await self.purchases.promotionalOffer(forProductDiscount: discount, product: product)

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -543,6 +543,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         } catch {
             expect(error).to(matchError(ErrorCode.ineligibleError))
         }
+        self.logger.verifyMessageWasNotLogged("API request started")
     }
 
     func testUserHasNoEligibleOffersByDefault() async throws {

--- a/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
+++ b/Tests/StoreKitUnitTests/PurchasesOrchestratorTests.swift
@@ -376,6 +376,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
     func testGetSK1PromotionalOffer() async throws {
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
         offerings.stubbedPostOfferCompletionResult = .success(("signature", "identifier", UUID(), 12345))
+        self.receiptParser.stubbedReceiptHasTransactionsResult = true
 
         let product = try await fetchSk1Product()
 
@@ -425,6 +426,32 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
 
         expect(self.offerings.invokedPostOffer) == false
     }
+
+    func testGetPromotionalOfferFailsWithIneligibleIfReceiptHasNoTransactions() async throws {
+      self.receiptParser.stubbedReceiptHasTransactionsResult = false
+
+      let product = try await self.fetchSk1Product()
+      let storeProductDiscount = MockStoreProductDiscount(offerIdentifier: "offerid1",
+                                                          currencyCode: product.priceLocale.currencyCode,
+                                                          price: 11.1,
+                                                          localizedPriceString: "$11.10",
+                                                          paymentMode: .payAsYouGo,
+                                                          subscriptionPeriod: .init(value: 1, unit: .month),
+                                                          numberOfPeriods: 2,
+                                                          type: .promotional)
+
+      do {
+          _ = try await Async.call { completion in
+              self.orchestrator.promotionalOffer(forProductDiscount: storeProductDiscount,
+                                                 product: StoreProduct(sk1Product: product),
+                                                 completion: completion)
+          }
+      } catch {
+          expect(error).to(matchError(ErrorCode.ineligibleError))
+      }
+
+      expect(self.offerings.invokedPostOffer) == false
+  }
 
     func testGetSK1PromotionalOfferFailsWithIneligibleDiscount() async throws {
         self.customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
@@ -1023,6 +1050,7 @@ class PurchasesOrchestratorTests: StoreKitConfigTestCase {
         customerInfoManager.stubbedCachedCustomerInfoResult = mockCustomerInfo
         backend.stubbedPostReceiptResult = .success(mockCustomerInfo)
         offerings.stubbedPostOfferCompletionResult = .success(("signature", "identifier", UUID(), 12345))
+        self.receiptParser.stubbedReceiptHasTransactionsResult = true
 
         let storeProduct = try await self.fetchSk2StoreProduct()
 


### PR DESCRIPTION
Avoids an extra request to the /offers endpoint in the common case where receipt has no trasactions.