### PR TITLE
`carthage_installation_tests`: optimize SPM package loading

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -710,12 +710,8 @@ jobs:
       - run:
           name: Carthage Update
           working_directory: Tests/InstallationTests/CarthageInstallation/
-          # install without building, then remove the tests and build, so that carthage
-          # doesn't try to build the other installation tests
           command: |
-              carthage update --no-build
-              rm -rf Carthage/Checkouts/purchases-root/Tests/InstallationTests/
-              carthage build --use-xcframeworks --verbose
+              bundle exec fastlane installation_tests
 
       - install-dependencies-scan-and-archive:
           directory: Tests/InstallationTests/CarthageInstallation/

--- a/Tests/InstallationTests/CarthageInstallation/fastlane/Fastfile
+++ b/Tests/InstallationTests/CarthageInstallation/fastlane/Fastfile
@@ -7,3 +7,15 @@ desc "Update carthage commit"
   backup_extension = '.bck'
   sh("sed", '-i', backup_extension, sed_regex, '../Cartfile')
 end
+
+lane :installation_tests do
+  load_spm_dependencies
+  
+  Dir.chdir("..") do
+    # install without building, then remove the tests and build, so that carthage
+    # doesn't try to build the other installation tests
+    sh "carthage", "update", "--no-build"
+    sh "rm", "-rf", "Carthage/Checkouts/purchases-root/Tests/InstallationTests/"
+    sh "carthage", "build", "--use-xcframeworks", "--verbose"
+  end
+end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -837,7 +837,7 @@ lane :load_spm_dependencies do
   # This preemptively runs this command to make sure the SPM dependencies are fetched
   # without a timeout.
 
-  Dir.chdir("..") do
+  Dir.chdir("#{File.dirname(__FILE__)}/../") do
     sh("xcodebuild", "-list")
   end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -21,6 +21,14 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 
 
+### load_spm_dependencies
+
+```sh
+[bundle exec] fastlane load_spm_dependencies
+```
+
+
+
 ----
 
 


### PR DESCRIPTION
Follow up to #3119. This job also needed the workaround to make sure `Carthage` doesn't time out.

Also moved the implementation to Fastlane.