### PR TITLE
`SPM`: update `Package.resolved`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,6 +363,7 @@ jobs:
     steps:
       - checkout
       - install-dependencies
+      - update-spm-installation-commit
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios
@@ -391,6 +392,7 @@ jobs:
     steps:
       - checkout
       - install-dependencies
+      - update-spm-installation-commit
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios
@@ -453,6 +455,7 @@ jobs:
     steps:
       - checkout
       - install-dependencies
+      - update-spm-installation-commit
       - run:
           name: Run tests
           command: bundle exec fastlane test_ios
@@ -479,6 +482,7 @@ jobs:
     steps:
       - checkout
       - install-dependencies
+      - update-spm-installation-commit
       - install-and-create-sim:
           install-name: iOS 13.7 Simulator
           sim-device-type: iPhone-8
@@ -510,6 +514,7 @@ jobs:
     steps:
       - checkout
       - install-dependencies
+      - update-spm-installation-commit
       - install-and-create-sim:
           install-name: iOS 12.4 Simulator
           sim-device-type: iPhone-6

--- a/Package@swift-5.6.swift
+++ b/Package@swift-5.6.swift
@@ -1,0 +1,56 @@
+// swift-tools-version:5.6
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+import class Foundation.ProcessInfo
+
+// Only add DocC Plugin when building docs, so that clients of this library won't
+// unnecessarily also get the DocC Plugin
+let environmentVariables = ProcessInfo.processInfo.environment
+let shouldIncludeDocCPlugin = environmentVariables["INCLUDE_DOCC_PLUGIN"] == "true"
+
+var dependencies: [Package.Dependency] = [
+    .package(url: "git@github.com:Quick/Nimble.git", from: "10.0.0")
+]
+if shouldIncludeDocCPlugin {
+    dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
+}
+
+let package = Package(
+    name: "RevenueCat",
+    platforms: [
+        .macOS(.v10_13),
+        .watchOS("6.2"),
+        .tvOS(.v11),
+        .iOS(.v11)
+    ],
+    products: [
+        .library(name: "RevenueCat",
+                 targets: ["RevenueCat"]),
+        .library(name: "RevenueCat_CustomEntitlementComputation",
+                 targets: ["RevenueCat_CustomEntitlementComputation"]),
+        .library(name: "ReceiptParser",
+                 targets: ["ReceiptParser"])
+    ],
+    dependencies: dependencies,
+    targets: [
+        .target(name: "RevenueCat",
+                path: "Sources",
+                exclude: ["Info.plist", "LocalReceiptParsing/ReceiptParser-only-files"],
+                resources: [
+                    .copy("../Sources/PrivacyInfo.xcprivacy")
+                ]),
+        .target(name: "RevenueCat_CustomEntitlementComputation",
+                path: "CustomEntitlementComputation",
+                exclude: ["Info.plist", "LocalReceiptParsing/ReceiptParser-only-files"],
+                resources: [
+                    .copy("PrivacyInfo.xcprivacy")
+                ],
+                swiftSettings: [.define("ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION")]),
+        .target(name: "ReceiptParser",
+                path: "LocalReceiptParsing"),
+        .testTarget(name: "ReceiptParserTests",
+                    dependencies: ["ReceiptParser", "Nimble"],
+                    exclude: ["ReceiptParserTests-Info.plist"])
+    ]
+)

--- a/RevenueCat.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/RevenueCat.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,7 +42,7 @@
       "location" : "https://github.com/RevenueCat/purchases-ios",
       "state" : {
         "branch" : "main",
-        "revision" : "e65912c9020cd27cbc14a80d2054b06a4f8b6331"
+        "revision" : "59034d03d51ba6a99b2e874b638a5cf77fd31d40"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "dc46eeb3928a75390651fac6c1ef7f93ad59a73b",
-        "version" : "1.11.1"
+        "revision" : "26ed3a2b4a2df47917ca9b790a57f91285b923fb",
+        "version" : "1.12.0"
       }
     }
   ],


### PR DESCRIPTION
This updates:
- `swift-snapshot-testing`
- `purchases-ios`

Updating our own commit fixes this issue that could happen if you didn't "update to latest package versions" locally:
![Screenshot 2023-08-31 at 12 57 43](https://github.com/RevenueCat/purchases-ios/assets/685609/5873c3d7-2efc-4efa-9ce2-3b3899c116c9)
