### PR TITLE
`Paywalls`: `{{ price_per_period }}` now takes `SubscriptionPeriod.value` into account

### DIFF
--- a/RevenueCatUI/Data/Localization.swift
+++ b/RevenueCatUI/Data/Localization.swift
@@ -18,10 +18,10 @@ enum Localization {
 
     /// - Returns: an appropriately short abbreviation for the given `unit`.
     static func abbreviatedUnitLocalizedString(
-        for unit: SubscriptionPeriod.Unit,
+        for period: SubscriptionPeriod,
         locale: Locale = .current
     ) -> String {
-        let (full, brief, abbreviated) = self.unitLocalizedString(for: unit.calendarUnit, locale: locale)
+        let (full, brief, abbreviated) = self.unitLocalizedString(for: period, locale: locale)
 
         let options = [
             full,
@@ -123,15 +123,16 @@ enum Localization {
 private extension Localization {
 
     static func unitLocalizedString(
-        for unit: NSCalendar.Unit,
+        for period: SubscriptionPeriod,
         locale: Locale = .current
     ) -> (full: String, brief: String, abbreviated: String) {
         var calendar: Calendar = .current
         calendar.locale = locale
 
         let date = Date()
-        let value = 1
+        let unit = period.unit.calendarUnit
         let component = unit.component
+        let value = period.value
 
         guard let sinceUnits = calendar.date(byAdding: component,
                                              value: value,
@@ -145,9 +146,14 @@ private extension Localization {
             formatter.unitsStyle = style
             guard let string = formatter.string(from: date, to: sinceUnits) else { return "" }
 
-            return string
-                .replacingOccurrences(of: String(value), with: "")
-                .trimmingCharacters(in: .whitespaces)
+            if value == 1 {
+                return string
+                    .replacingOccurrences(of: String(value), with: "")
+                    .trimmingCharacters(in: .whitespaces)
+            } else {
+                return string
+                    .replacingOccurrences(of: " ", with: "")
+            }
         }
 
         return (full: result(for: .full),

--- a/RevenueCatUI/Data/TestData.swift
+++ b/RevenueCatUI/Data/TestData.swift
@@ -36,10 +36,21 @@ internal enum TestData {
         subscriptionPeriod: .init(value: 1, unit: .month),
         introductoryDiscount: Self.intro(7, .day)
     )
+    static let threeMonthProduct = TestStoreProduct(
+        localizedTitle: "3 months",
+        price: 4.99,
+        localizedPriceString: "$4.99",
+        productIdentifier: "com.revenuecat.product_5",
+        productType: .autoRenewableSubscription,
+        localizedDescription: "PRO monthly",
+        subscriptionGroupIdentifier: "group",
+        subscriptionPeriod: .init(value: 3, unit: .month),
+        introductoryDiscount: Self.intro(7, .day)
+    )
     static let sixMonthProduct = TestStoreProduct(
-        localizedTitle: "Monthly",
-        price: 34.99,
-        localizedPriceString: "$34.99",
+        localizedTitle: "6 months",
+        price: 7.99,
+        localizedPriceString: "$7.99",
         productIdentifier: "com.revenuecat.product_5",
         productType: .autoRenewableSubscription,
         localizedDescription: "PRO monthly",
@@ -110,6 +121,12 @@ internal enum TestData {
         identifier: PackageType.monthly.identifier,
         packageType: .monthly,
         storeProduct: Self.monthlyProduct.toStoreProduct(),
+        offeringIdentifier: Self.offeringIdentifier
+    )
+    static let threeMonthPackage = Package(
+        identifier: PackageType.threeMonth.identifier,
+        packageType: .threeMonth,
+        storeProduct: Self.threeMonthProduct.toStoreProduct(),
         offeringIdentifier: Self.offeringIdentifier
     )
     static let sixMonthPackage = Package(

--- a/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
+++ b/RevenueCatUI/Helpers/Package+VariableDataProvider.swift
@@ -53,7 +53,7 @@ extension Package: VariableDataProvider {
             return self.localizedPrice
         }
 
-        let unit = Localization.abbreviatedUnitLocalizedString(for: period.unit, locale: locale)
+        let unit = Localization.abbreviatedUnitLocalizedString(for: period, locale: locale)
         return "\(self.localizedPrice)/\(unit)"
     }
 
@@ -61,7 +61,8 @@ extension Package: VariableDataProvider {
         if !self.isSubscription || self.isMonthly {
             return self.localizedPricePerPeriod(locale)
         } else {
-            let unit = Localization.abbreviatedUnitLocalizedString(for: .month, locale: locale)
+            let unit = Localization.abbreviatedUnitLocalizedString(for: .init(value: 1, unit: .month),
+                                                                   locale: locale)
             return "\(self.localizedPrice) (\(self.localizedPricePerMonth)/\(unit))"
         }
     }

--- a/Sources/Misc/PriceFormatterProvider.swift
+++ b/Sources/Misc/PriceFormatterProvider.swift
@@ -41,17 +41,20 @@ final class PriceFormatterProvider: Sendable {
 
     private let cachedPriceFormatterForSK2: Atomic<NumberFormatter?> = nil
 
-    func priceFormatterForSK2(withCurrencyCode currencyCode: String) -> NumberFormatter {
+    func priceFormatterForSK2(
+        withCurrencyCode currencyCode: String,
+        locale: Locale = .autoupdatingCurrent
+    ) -> NumberFormatter {
         func makePriceFormatterForSK2(with currencyCode: String) -> NumberFormatter {
             let formatter = NumberFormatter()
             formatter.numberStyle = .currency
-            formatter.locale = .autoupdatingCurrent
+            formatter.locale = locale
             formatter.currencyCode = currencyCode
             return formatter
         }
 
         return self.cachedPriceFormatterForSK2.modify { formatter in
-            guard let formatter = formatter, formatter.currencyCode == currencyCode else {
+            guard let formatter = formatter, formatter.currencyCode == currencyCode, formatter.locale == locale else {
                 let newFormatter = makePriceFormatterForSK2(with: currencyCode)
                 formatter = newFormatter
 

--- a/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
@@ -120,3 +120,8 @@ extension TestStoreProduct {
     }
 
 }
+
+#if swift(<5.7)
+// `Locale` isn't `Sendable` in Xcode 13
+extension TestStoreProduct: @unchecked Sendable {}
+#endif

--- a/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
@@ -59,6 +59,7 @@ public struct TestStoreProduct {
     public var isFamilyShareable: Bool
     public var introductoryDiscount: StoreProductDiscount?
     public var discounts: [StoreProductDiscount]
+    public var locale: Locale
 
     public init(
         localizedTitle: String,
@@ -71,7 +72,8 @@ public struct TestStoreProduct {
         subscriptionPeriod: SubscriptionPeriod? = nil,
         isFamilyShareable: Bool = false,
         introductoryDiscount: TestStoreProductDiscount? = nil,
-        discounts: [TestStoreProductDiscount] = []
+        discounts: [TestStoreProductDiscount] = [],
+        locale: Locale = .current
     ) {
         self.localizedTitle = localizedTitle
         self.price = price
@@ -84,6 +86,7 @@ public struct TestStoreProduct {
         self.isFamilyShareable = isFamilyShareable
         self.introductoryDiscount = introductoryDiscount?.toStoreProductDiscount()
         self.discounts = discounts.map { $0.toStoreProductDiscount() }
+        self.locale = locale
     }
 
     // swiftlint:enable missing_docs
@@ -98,13 +101,12 @@ extension TestStoreProduct: StoreProductType {
     internal var productCategory: StoreProduct.ProductCategory { return self.productType.productCategory }
 
     internal var currencyCode: String? {
-        // Test currency defaults to current locale
-        return Locale.current.rc_currencyCode
+        return self.locale.rc_currencyCode
     }
 
     internal var priceFormatter: NumberFormatter? {
         return self.currencyCode.map {
-            self.priceFormatterProvider.priceFormatterForSK2(withCurrencyCode: $0)
+            self.priceFormatterProvider.priceFormatterForSK2(withCurrencyCode: $0, locale: self.locale)
         }
     }
 

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductAPI.swift
@@ -24,6 +24,7 @@ func checkTestStoreProductAPI() {
     let isFamilyShareable: Bool = testProduct.isFamilyShareable
     let introductoryDiscount: StoreProductDiscount? = testProduct.introductoryDiscount
     let discounts: [StoreProductDiscount] = testProduct.discounts
+    let locale: Locale = testProduct.locale
 
     // Setters
     testProduct.localizedTitle = localizedTitle
@@ -37,6 +38,7 @@ func checkTestStoreProductAPI() {
     testProduct.isFamilyShareable = isFamilyShareable
     testProduct.introductoryDiscount = introductoryDiscount
     testProduct.discounts = discounts
+    testProduct.locale = locale
 
     let _: StoreProduct = testProduct.toStoreProduct()
 }
@@ -62,6 +64,7 @@ private func checkStoreProductCreation(discount: TestStoreProductDiscount) {
         subscriptionPeriod: Optional<SubscriptionPeriod>.some(.init(value: 1, unit: .day)),
         isFamilyShareable: true,
         introductoryDiscount: Optional<TestStoreProductDiscount>.some(discount),
-        discounts: [discount]
+        discounts: [discount],
+        locale: Locale.current
     )
 }

--- a/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
+++ b/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
@@ -40,6 +40,8 @@ class PackageVariablesTests: TestCase {
     func testEnglishLocalizedPricePerPeriod() {
         expect(TestData.weeklyPackage.localizedPricePerPeriod(Self.english)) == "$1.99/wk"
         expect(TestData.monthlyPackage.localizedPricePerPeriod(Self.english)) == "$6.99/mo"
+        expect(TestData.threeMonthPackage.localizedPricePerPeriod(Self.english)) == "$4.99/3mo"
+        expect(TestData.sixMonthPackage.localizedPricePerPeriod(Self.english)) == "$7.99/6mo"
         expect(TestData.annualPackage.localizedPricePerPeriod(Self.english)) == "$53.99/yr"
         expect(TestData.lifetimePackage.localizedPricePerPeriod(Self.english)) == "$119.49"
     }
@@ -47,6 +49,8 @@ class PackageVariablesTests: TestCase {
     func testSpanishLocalizedPricePerPeriod() {
         expect(TestData.weeklyPackage.localizedPricePerPeriod(Self.spanish)) == "$1.99/sem"
         expect(TestData.monthlyPackage.localizedPricePerPeriod(Self.spanish)) == "$6.99/m."
+        expect(TestData.threeMonthPackage.localizedPricePerPeriod(Self.spanish)) == "$4.99/3m"
+        expect(TestData.sixMonthPackage.localizedPricePerPeriod(Self.spanish)) == "$7.99/6m"
         expect(TestData.annualPackage.localizedPricePerPeriod(Self.spanish)) == "$53.99/año"
         expect(TestData.lifetimePackage.localizedPricePerPeriod(Self.spanish)) == "$119.49"
     }

--- a/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
+++ b/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
@@ -57,6 +57,23 @@ class PackageVariablesTests: TestCase {
         expect(TestData.lifetimePackage.localizedPricePerPeriod(Self.spanish)) == "$119.49"
     }
 
+    func testArabicLocalizedPricePerPeriod() {
+        let arabicPrice = "٣.٩٩ درهم"
+
+        expect(TestData.weeklyPackage.with(arabicPrice, Self.arabic).localizedPricePerPeriod(Self.arabic))
+        == "٣.٩٩ درهم/أسبوع"
+        expect(TestData.monthlyPackage.with(arabicPrice, Self.arabic).localizedPricePerPeriod(Self.arabic))
+        == "٣.٩٩ درهم/شهر"
+        expect(TestData.threeMonthPackage.with(arabicPrice, Self.arabic).localizedPricePerPeriod(Self.arabic))
+        == "٣.٩٩ درهم/3شهر"
+        expect(TestData.sixMonthPackage.with(arabicPrice, Self.arabic).localizedPricePerPeriod(Self.arabic))
+        == "٣.٩٩ درهم/6شهر"
+        expect(TestData.annualPackage.with(arabicPrice, Self.arabic).localizedPricePerPeriod(Self.arabic))
+        == "٣.٩٩ درهم/سنة"
+        expect(TestData.lifetimePackage.with(arabicPrice, Self.arabic).localizedPricePerPeriod(Self.arabic))
+        == "٣.٩٩ درهم"
+    }
+
     func testEnglishLocalizedPriceAndPerMonth() {
         expect(TestData.weeklyPackage.localizedPriceAndPerMonth(Self.english)) == "$1.99 ($7.96/mo)"
         expect(TestData.monthlyPackage.localizedPriceAndPerMonth(Self.english)) == "$6.99/mo"
@@ -73,6 +90,23 @@ class PackageVariablesTests: TestCase {
         expect(TestData.sixMonthPackage.localizedPriceAndPerMonth(Self.spanish)) == "$7.99 ($1.33/m.)"
         expect(TestData.annualPackage.localizedPriceAndPerMonth(Self.spanish)) == "$53.99 ($4.49/m.)"
         expect(TestData.lifetimePackage.localizedPriceAndPerMonth(Self.spanish)) == "$119.49"
+    }
+
+    func testArabicLocalizedPriceAndPerMonth() {
+        let arabicPrice = "٣.٩٩ درهم"
+
+        expect(TestData.weeklyPackage.with(arabicPrice, Self.arabic).localizedPriceAndPerMonth(Self.arabic))
+        == "٣.٩٩ درهم (‏7.96 ‏د.إ.‏/شهر)"
+        expect(TestData.monthlyPackage.with(arabicPrice, Self.arabic).localizedPriceAndPerMonth(Self.arabic))
+        == "٣.٩٩ درهم/شهر"
+        expect(TestData.threeMonthPackage.with(arabicPrice, Self.arabic).localizedPriceAndPerMonth(Self.arabic))
+        == "٣.٩٩ درهم (‏1.66 ‏د.إ.‏/شهر)"
+        expect(TestData.sixMonthPackage.with(arabicPrice, Self.arabic).localizedPriceAndPerMonth(Self.arabic))
+        == "٣.٩٩ درهم (‏1.33 ‏د.إ.‏/شهر)"
+        expect(TestData.annualPackage.with(arabicPrice, Self.arabic).localizedPriceAndPerMonth(Self.arabic))
+        == "٣.٩٩ درهم (‏4.49 ‏د.إ.‏/شهر)"
+        expect(TestData.lifetimePackage.with(arabicPrice, Self.arabic).localizedPriceAndPerMonth(Self.arabic))
+        == arabicPrice
     }
 
     func testProductName() {
@@ -130,5 +164,57 @@ private extension PackageVariablesTests {
 
     static let english: Locale = .init(identifier: "en_US")
     static let spanish: Locale = .init(identifier: "es_ES")
+    static let arabic: Locale = .init(identifier: "ar_AE")
+
+}
+
+// MARK: -
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension Package {
+
+    func with(_ newLocalizedPrice: String, _ locale: Locale) -> Package {
+        return .init(
+            identifier: self.identifier,
+            packageType: self.packageType,
+            storeProduct: self.storeProduct
+                .toTestProduct()
+                .with(newLocalizedPrice, locale)
+                .toStoreProduct(),
+            offeringIdentifier: self.offeringIdentifier
+        )
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension TestStoreProduct {
+
+    func with(_ newLocalizedPrice: String, _ locale: Locale) -> Self {
+        var copy = self
+        copy.localizedPriceString = newLocalizedPrice
+        copy.locale = locale
+
+        return copy
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension StoreProduct {
+
+    func toTestProduct() -> TestStoreProduct {
+        return .init(
+            localizedTitle: self.localizedTitle,
+            price: self.price,
+            localizedPriceString: self.localizedPriceString,
+            productIdentifier: self.productIdentifier,
+            productType: self.productType,
+            localizedDescription: self.localizedDescription,
+            subscriptionGroupIdentifier: self.subscriptionGroupIdentifier,
+            subscriptionPeriod: self.subscriptionPeriod,
+            isFamilyShareable: self.isFamilyShareable
+        )
+    }
 
 }

--- a/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
+++ b/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
@@ -218,19 +218,3 @@ private extension StoreProduct {
     }
 
 }
-
-/// iOS 16 and 17 differ slightly in how Arabic strings are encoded, iOS 16 having an additional RTL marker (U+200F)
-/// This allows comparing strings ignoring those markers.
-private func equalIgnoringRTL(_ expectedValue: String?) -> Nimble.Predicate<String> {
-    return Predicate.define("equal to <\(stringify(expectedValue))> ignoring RTL marks") { actualExpression, msg in
-        if let actual = try actualExpression.evaluate(), let expected = expectedValue {
-            let options: String.CompareOptions = [.diacriticInsensitive, .widthInsensitive]
-            let areEqual = actual.compare(expected, options: options) == .orderedSame
-            return PredicateResult(
-                bool: areEqual,
-                message: msg.appended(message: " (ignoring RTL marks)")
-            )
-        }
-        return PredicateResult(status: .fail, message: msg)
-    }
-}

--- a/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
+++ b/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
@@ -58,6 +58,8 @@ class PackageVariablesTests: TestCase {
     func testEnglishLocalizedPriceAndPerMonth() {
         expect(TestData.weeklyPackage.localizedPriceAndPerMonth(Self.english)) == "$1.99 ($7.96/mo)"
         expect(TestData.monthlyPackage.localizedPriceAndPerMonth(Self.english)) == "$6.99/mo"
+        expect(TestData.threeMonthPackage.localizedPriceAndPerMonth(Self.english)) == "$4.99 ($1.66/mo)"
+        expect(TestData.sixMonthPackage.localizedPriceAndPerMonth(Self.english)) == "$7.99 ($1.33/mo)"
         expect(TestData.annualPackage.localizedPriceAndPerMonth(Self.english)) == "$53.99 ($4.49/mo)"
         expect(TestData.lifetimePackage.localizedPriceAndPerMonth(Self.english)) == "$119.49"
     }
@@ -65,6 +67,8 @@ class PackageVariablesTests: TestCase {
     func testSpanishLocalizedPriceAndPerMonth() {
         expect(TestData.weeklyPackage.localizedPriceAndPerMonth(Self.spanish)) == "$1.99 ($7.96/m.)"
         expect(TestData.monthlyPackage.localizedPriceAndPerMonth(Self.spanish)) == "$6.99/m."
+        expect(TestData.threeMonthPackage.localizedPriceAndPerMonth(Self.spanish)) == "$4.99 ($1.66/m.)"
+        expect(TestData.sixMonthPackage.localizedPriceAndPerMonth(Self.spanish)) == "$7.99 ($1.33/m.)"
         expect(TestData.annualPackage.localizedPriceAndPerMonth(Self.spanish)) == "$53.99 ($4.49/m.)"
         expect(TestData.lifetimePackage.localizedPriceAndPerMonth(Self.spanish)) == "$119.49"
     }

--- a/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
+++ b/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
@@ -33,6 +33,8 @@ class PackageVariablesTests: TestCase {
     func testLocalizedPricePerMonth() {
         expect(TestData.weeklyPackage.localizedPricePerMonth) == "$7.96"
         expect(TestData.monthlyPackage.localizedPricePerMonth) == "$6.99"
+        expect(TestData.threeMonthPackage.localizedPricePerMonth) == "$6.99"
+        expect(TestData.sixMonthPackage.localizedPricePerMonth) == "$6.99"
         expect(TestData.annualPackage.localizedPricePerMonth) == "$4.49"
         expect(TestData.lifetimePackage.localizedPricePerMonth) == "$119.49"
     }
@@ -76,6 +78,8 @@ class PackageVariablesTests: TestCase {
     func testProductName() {
         expect(TestData.weeklyPackage.productName) == "Weekly"
         expect(TestData.monthlyPackage.productName) == "Monthly"
+        expect(TestData.threeMonthPackage.productName) == "3 months"
+        expect(TestData.sixMonthPackage.productName) == "6 months"
         expect(TestData.annualPackage.productName) == "Annual"
         expect(TestData.lifetimePackage.productName) == "Lifetime"
     }
@@ -83,6 +87,8 @@ class PackageVariablesTests: TestCase {
     func testEnglishPeriodName() {
         expect(TestData.weeklyPackage.periodName(Self.english)) == "Weekly"
         expect(TestData.monthlyPackage.periodName(Self.english)) == "Monthly"
+        expect(TestData.threeMonthPackage.periodName(Self.english)) == "3 Month"
+        expect(TestData.sixMonthPackage.periodName(Self.english)) == "6 Month"
         expect(TestData.annualPackage.periodName(Self.english)) == "Annual"
         expect(TestData.lifetimePackage.periodName(Self.english)) == "Lifetime"
     }
@@ -90,6 +96,8 @@ class PackageVariablesTests: TestCase {
     func testSpanishPeriodName() {
         expect(TestData.weeklyPackage.periodName(Self.spanish)) == "Semanalmente"
         expect(TestData.monthlyPackage.periodName(Self.spanish)) == "Mensual"
+        expect(TestData.threeMonthPackage.periodName(Self.spanish)) == "3 meses"
+        expect(TestData.sixMonthPackage.periodName(Self.spanish)) == "6 meses"
         expect(TestData.annualPackage.periodName(Self.spanish)) == "Anual"
         expect(TestData.lifetimePackage.periodName(Self.spanish)) == "Toda la vida"
     }

--- a/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
+++ b/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
@@ -33,8 +33,8 @@ class PackageVariablesTests: TestCase {
     func testLocalizedPricePerMonth() {
         expect(TestData.weeklyPackage.localizedPricePerMonth) == "$7.96"
         expect(TestData.monthlyPackage.localizedPricePerMonth) == "$6.99"
-        expect(TestData.threeMonthPackage.localizedPricePerMonth) == "$6.99"
-        expect(TestData.sixMonthPackage.localizedPricePerMonth) == "$6.99"
+        expect(TestData.threeMonthPackage.localizedPricePerMonth) == "$1.66"
+        expect(TestData.sixMonthPackage.localizedPricePerMonth) == "$1.33"
         expect(TestData.annualPackage.localizedPricePerMonth) == "$4.49"
         expect(TestData.lifetimePackage.localizedPricePerMonth) == "$119.49"
     }

--- a/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
+++ b/Tests/RevenueCatUITests/Data/PackageVariablesTests.swift
@@ -96,15 +96,15 @@ class PackageVariablesTests: TestCase {
         let arabicPrice = "٣.٩٩ درهم"
 
         expect(TestData.weeklyPackage.with(arabicPrice, Self.arabic).localizedPriceAndPerMonth(Self.arabic))
-        == "٣.٩٩ درهم (‏7.96 ‏د.إ.‏/شهر)"
+            .to(equalIgnoringRTL("٣.٩٩ درهم (‏7.96 ‏د.إ.‏/شهر)"))
         expect(TestData.monthlyPackage.with(arabicPrice, Self.arabic).localizedPriceAndPerMonth(Self.arabic))
-        == "٣.٩٩ درهم/شهر"
+            .to(equalIgnoringRTL("٣.٩٩ درهم/شهر"))
         expect(TestData.threeMonthPackage.with(arabicPrice, Self.arabic).localizedPriceAndPerMonth(Self.arabic))
-        == "٣.٩٩ درهم (‏1.66 ‏د.إ.‏/شهر)"
+            .to(equalIgnoringRTL("٣.٩٩ درهم (‏1.66 ‏د.إ.‏/شهر)"))
         expect(TestData.sixMonthPackage.with(arabicPrice, Self.arabic).localizedPriceAndPerMonth(Self.arabic))
-        == "٣.٩٩ درهم (‏1.33 ‏د.إ.‏/شهر)"
+            .to(equalIgnoringRTL("٣.٩٩ درهم (‏1.33 ‏د.إ.‏/شهر)"))
         expect(TestData.annualPackage.with(arabicPrice, Self.arabic).localizedPriceAndPerMonth(Self.arabic))
-        == "٣.٩٩ درهم (‏4.49 ‏د.إ.‏/شهر)"
+            .to(equalIgnoringRTL("٣.٩٩ درهم (‏4.49 ‏د.إ.‏/شهر)"))
         expect(TestData.lifetimePackage.with(arabicPrice, Self.arabic).localizedPriceAndPerMonth(Self.arabic))
         == arabicPrice
     }
@@ -217,4 +217,20 @@ private extension StoreProduct {
         )
     }
 
+}
+
+/// iOS 16 and 17 differ slightly in how Arabic strings are encoded, iOS 16 having an additional RTL marker (U+200F)
+/// This allows comparing strings ignoring those markers.
+private func equalIgnoringRTL(_ expectedValue: String?) -> Nimble.Predicate<String> {
+    return Predicate.define("equal to <\(stringify(expectedValue))> ignoring RTL marks") { actualExpression, msg in
+        if let actual = try actualExpression.evaluate(), let expected = expectedValue {
+            let options: String.CompareOptions = [.diacriticInsensitive, .widthInsensitive]
+            let areEqual = actual.compare(expected, options: options) == .orderedSame
+            return PredicateResult(
+                bool: areEqual,
+                message: msg.appended(message: " (ignoring RTL marks)")
+            )
+        }
+        return PredicateResult(status: .fail, message: msg)
+    }
 }

--- a/Tests/RevenueCatUITests/LocalizationTests.swift
+++ b/Tests/RevenueCatUITests/LocalizationTests.swift
@@ -43,6 +43,10 @@ class AbbreviatedUnitEnglishLocalizationTests: BaseLocalizationTests {
         verify(.month, "mo")
     }
 
+    func testTwoMonths() {
+        verify(.init(2, .month), "2mo")
+    }
+
     func testThreeMonths() {
         verify(.init(3, .month), "3mo")
     }
@@ -72,6 +76,10 @@ class AbbreviatedUnitSpanishLocalizationTests: BaseLocalizationTests {
 
     func testMonth() {
         verify(.month, "m.")
+    }
+
+    func testTwoMonths() {
+        verify(.init(2, .month), "2m")
     }
 
     func testThreeMonths() {

--- a/Tests/RevenueCatUITests/LocalizationTests.swift
+++ b/Tests/RevenueCatUITests/LocalizationTests.swift
@@ -43,6 +43,14 @@ class AbbreviatedUnitEnglishLocalizationTests: BaseLocalizationTests {
         verify(.month, "mo")
     }
 
+    func testThreeMonths() {
+        verify(.init(3, .month), "3mo")
+    }
+
+    func testSixMonths() {
+        verify(.init(6, .month), "6mo")
+    }
+
     func testYear() {
         verify(.year, "yr")
     }
@@ -64,6 +72,14 @@ class AbbreviatedUnitSpanishLocalizationTests: BaseLocalizationTests {
 
     func testMonth() {
         verify(.month, "m.")
+    }
+
+    func testThreeMonths() {
+        verify(.init(3, .month), "3m")
+    }
+
+    func testSixMonths() {
+        verify(.init(6, .month), "6m")
     }
 
     func testYear() {
@@ -92,6 +108,7 @@ class SubscriptionPeriodEnglishLocalizationTests: BaseLocalizationTests {
     func testMonthPeriod() {
         verify(1, .month, "1 month")
         verify(3, .month, "3 months")
+        verify(6, .month, "6 months")
     }
 
     func testYearPeriod() {
@@ -265,6 +282,14 @@ class DiscountOtherLanguageLocalizationTests: BaseLocalizationTests {
 
 // MARK: - Private
 
+private extension SubscriptionPeriod {
+
+    convenience init(_ value: Int, _ unit: Unit) {
+        self.init(value: value, unit: unit)
+    }
+
+}
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private extension BaseLocalizationTests {
 
@@ -286,7 +311,16 @@ private extension BaseLocalizationTests {
         file: StaticString = #file,
         line: UInt = #line
     ) {
-        let result = Localization.abbreviatedUnitLocalizedString(for: unit,
+        self.verify(.init(1, unit), expected, file: file, line: line)
+    }
+
+    func verify(
+        _ period: SubscriptionPeriod,
+        _ expected: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let result = Localization.abbreviatedUnitLocalizedString(for: period,
                                                                  locale: self.locale)
         expect(file: file, line: line, result) == expected
     }

--- a/Tests/StoreKitUnitTests/StoreProductTests.swift
+++ b/Tests/StoreKitUnitTests/StoreProductTests.swift
@@ -355,6 +355,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         let subscriptionGroup = "group"
         let period: SubscriptionPeriod = .init(value: 1, unit: .month)
         let isFamilyShareable = Bool.random()
+        let expectedLocale: Locale = .current
 
         let product = TestStoreProduct(
             localizedTitle: title,
@@ -381,9 +382,28 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(storeProduct.localizedDescription) == description
         expect(storeProduct.subscriptionGroupIdentifier) == subscriptionGroup
         expect(storeProduct.subscriptionPeriod) == period
-        expect(storeProduct.currencyCode) == Locale.current.rc_currencyCode
-        expect(storeProduct.priceFormatter).toNot(beNil())
+        expect(storeProduct.currencyCode) == expectedLocale.rc_currencyCode
+        expect(storeProduct.priceFormatter?.locale) == expectedLocale
+        expect(storeProduct.priceFormatter?.currencyCode) == expectedLocale.rc_currencyCode
         expect(storeProduct.isFamilyShareable) == isFamilyShareable
+    }
+
+    func testTestProductWithCustomLocale() {
+        let locale: Locale = .init(identifier: "es_ES")
+        let product = TestStoreProduct(
+            localizedTitle: "product",
+            price: 3.99,
+            localizedPriceString: "$3.99",
+            productIdentifier: "identifier",
+            productType: .autoRenewableSubscription,
+            localizedDescription: "",
+            locale: locale
+        )
+        let storeProduct = product.toStoreProduct()
+
+        expect(storeProduct.currencyCode) == "EUR"
+        expect(storeProduct.priceFormatter?.locale) == locale
+        expect(storeProduct.priceFormatter?.currencyCode) == "EUR"
     }
 
     func testWarningLogWhenGettingSK1ProductType() {


### PR DESCRIPTION
This was incorrect for `PackageType.threeMonth` and `PackageType.sixMonth`.

![image](https://github.com/RevenueCat/purchases-ios/assets/685609/87b1ec00-04a0-4baa-ba73-edc4ce138388)
