### PR TITLE
`TestStoreProduct`: new `locale` parameter

### DIFF
--- a/Sources/Misc/PriceFormatterProvider.swift
+++ b/Sources/Misc/PriceFormatterProvider.swift
@@ -41,17 +41,20 @@ final class PriceFormatterProvider: Sendable {
 
     private let cachedPriceFormatterForSK2: Atomic<NumberFormatter?> = nil
 
-    func priceFormatterForSK2(withCurrencyCode currencyCode: String) -> NumberFormatter {
+    func priceFormatterForSK2(
+        withCurrencyCode currencyCode: String,
+        locale: Locale = .autoupdatingCurrent
+    ) -> NumberFormatter {
         func makePriceFormatterForSK2(with currencyCode: String) -> NumberFormatter {
             let formatter = NumberFormatter()
             formatter.numberStyle = .currency
-            formatter.locale = .autoupdatingCurrent
+            formatter.locale = locale
             formatter.currencyCode = currencyCode
             return formatter
         }
 
         return self.cachedPriceFormatterForSK2.modify { formatter in
-            guard let formatter = formatter, formatter.currencyCode == currencyCode else {
+            guard let formatter = formatter, formatter.currencyCode == currencyCode, formatter.locale == locale else {
                 let newFormatter = makePriceFormatterForSK2(with: currencyCode)
                 formatter = newFormatter
 

--- a/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
@@ -120,3 +120,8 @@ extension TestStoreProduct {
     }
 
 }
+
+#if swift(<5.7)
+// `Locale` isn't `Sendable` in Xcode 13
+extension TestStoreProduct: @unchecked Sendable {}
+#endif

--- a/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
@@ -59,6 +59,7 @@ public struct TestStoreProduct {
     public var isFamilyShareable: Bool
     public var introductoryDiscount: StoreProductDiscount?
     public var discounts: [StoreProductDiscount]
+    public var locale: Locale
 
     public init(
         localizedTitle: String,
@@ -71,7 +72,8 @@ public struct TestStoreProduct {
         subscriptionPeriod: SubscriptionPeriod? = nil,
         isFamilyShareable: Bool = false,
         introductoryDiscount: TestStoreProductDiscount? = nil,
-        discounts: [TestStoreProductDiscount] = []
+        discounts: [TestStoreProductDiscount] = [],
+        locale: Locale = .current
     ) {
         self.localizedTitle = localizedTitle
         self.price = price
@@ -84,6 +86,7 @@ public struct TestStoreProduct {
         self.isFamilyShareable = isFamilyShareable
         self.introductoryDiscount = introductoryDiscount?.toStoreProductDiscount()
         self.discounts = discounts.map { $0.toStoreProductDiscount() }
+        self.locale = locale
     }
 
     // swiftlint:enable missing_docs
@@ -98,13 +101,12 @@ extension TestStoreProduct: StoreProductType {
     internal var productCategory: StoreProduct.ProductCategory { return self.productType.productCategory }
 
     internal var currencyCode: String? {
-        // Test currency defaults to current locale
-        return Locale.current.rc_currencyCode
+        return self.locale.rc_currencyCode
     }
 
     internal var priceFormatter: NumberFormatter? {
         return self.currencyCode.map {
-            self.priceFormatterProvider.priceFormatterForSK2(withCurrencyCode: $0)
+            self.priceFormatterProvider.priceFormatterForSK2(withCurrencyCode: $0, locale: self.locale)
         }
     }
 

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/TestStoreProductAPI.swift
@@ -24,6 +24,7 @@ func checkTestStoreProductAPI() {
     let isFamilyShareable: Bool = testProduct.isFamilyShareable
     let introductoryDiscount: StoreProductDiscount? = testProduct.introductoryDiscount
     let discounts: [StoreProductDiscount] = testProduct.discounts
+    let locale: Locale = testProduct.locale
 
     // Setters
     testProduct.localizedTitle = localizedTitle
@@ -37,6 +38,7 @@ func checkTestStoreProductAPI() {
     testProduct.isFamilyShareable = isFamilyShareable
     testProduct.introductoryDiscount = introductoryDiscount
     testProduct.discounts = discounts
+    testProduct.locale = locale
 
     let _: StoreProduct = testProduct.toStoreProduct()
 }
@@ -62,6 +64,7 @@ private func checkStoreProductCreation(discount: TestStoreProductDiscount) {
         subscriptionPeriod: Optional<SubscriptionPeriod>.some(.init(value: 1, unit: .day)),
         isFamilyShareable: true,
         introductoryDiscount: Optional<TestStoreProductDiscount>.some(discount),
-        discounts: [discount]
+        discounts: [discount],
+        locale: Locale.current
     )
 }

--- a/Tests/StoreKitUnitTests/StoreProductTests.swift
+++ b/Tests/StoreKitUnitTests/StoreProductTests.swift
@@ -355,6 +355,7 @@ class StoreProductTests: StoreKitConfigTestCase {
         let subscriptionGroup = "group"
         let period: SubscriptionPeriod = .init(value: 1, unit: .month)
         let isFamilyShareable = Bool.random()
+        let expectedLocale: Locale = .current
 
         let product = TestStoreProduct(
             localizedTitle: title,
@@ -381,9 +382,28 @@ class StoreProductTests: StoreKitConfigTestCase {
         expect(storeProduct.localizedDescription) == description
         expect(storeProduct.subscriptionGroupIdentifier) == subscriptionGroup
         expect(storeProduct.subscriptionPeriod) == period
-        expect(storeProduct.currencyCode) == Locale.current.rc_currencyCode
-        expect(storeProduct.priceFormatter).toNot(beNil())
+        expect(storeProduct.currencyCode) == expectedLocale.rc_currencyCode
+        expect(storeProduct.priceFormatter?.locale) == expectedLocale
+        expect(storeProduct.priceFormatter?.currencyCode) == expectedLocale.rc_currencyCode
         expect(storeProduct.isFamilyShareable) == isFamilyShareable
+    }
+
+    func testTestProductWithCustomLocale() {
+        let locale: Locale = .init(identifier: "es_ES")
+        let product = TestStoreProduct(
+            localizedTitle: "product",
+            price: 3.99,
+            localizedPriceString: "$3.99",
+            productIdentifier: "identifier",
+            productType: .autoRenewableSubscription,
+            localizedDescription: "",
+            locale: locale
+        )
+        let storeProduct = product.toStoreProduct()
+
+        expect(storeProduct.currencyCode) == "EUR"
+        expect(storeProduct.priceFormatter?.locale) == locale
+        expect(storeProduct.priceFormatter?.currencyCode) == "EUR"
     }
 
     func testWarningLogWhenGettingSK1ProductType() {


### PR DESCRIPTION
This allows overriding the `Locale` to be used for this test product, which is used to configure the price formatter.
This will be used by #3133.
