### PR TITLE
`PaywallData`: added `@NonEmptyString` to `subtitle` and `offerName`

### DIFF
--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -14,7 +14,7 @@
 import Foundation
 import RevenueCat
 
-// swiftlint:disable variable_name
+// swiftlint:disable identifier_name
 
 enum Strings {
 

--- a/Sources/Paywalls/PaywallData.swift
+++ b/Sources/Paywalls/PaywallData.swift
@@ -71,18 +71,25 @@ extension PaywallData {
         // swiftlint:disable missing_docs
 
         public var title: String
-        public var subtitle: String?
         public var callToAction: String
-        public var offerName: String?
+
+        @NonEmptyStringDecodable
+        var _subtitle: String?
         @NonEmptyStringDecodable
         var _callToActionWithIntroOffer: String?
         @NonEmptyStringDecodable
         var _offerDetails: String?
         @NonEmptyStringDecodable
         var _offerDetailsWithIntroOffer: String?
+        @NonEmptyStringDecodable
+        var _offerName: String?
         @DefaultDecodable.EmptyArray
         var _features: [Feature]
 
+        public var subtitle: String? {
+            get { return self._subtitle }
+            set { self._subtitle = newValue }
+        }
         public var callToActionWithIntroOffer: String? {
             get { return self._callToActionWithIntroOffer }
             set { self._callToActionWithIntroOffer = newValue }
@@ -94,6 +101,10 @@ extension PaywallData {
         public var offerDetailsWithIntroOffer: String? {
             get { return self._offerDetailsWithIntroOffer }
             set { self._offerDetailsWithIntroOffer = newValue }
+        }
+        public var offerName: String? {
+            get { return self._offerName }
+            set { self._offerName = newValue }
         }
         public var features: [Feature] {
             get { return self._features }
@@ -111,12 +122,12 @@ extension PaywallData {
             features: [Feature] = []
         ) {
             self.title = title
-            self.subtitle = subtitle
+            self._subtitle = subtitle
             self.callToAction = callToAction
             self._callToActionWithIntroOffer = callToActionWithIntroOffer
             self._offerDetails = offerDetails
             self._offerDetailsWithIntroOffer = offerDetailsWithIntroOffer
-            self.offerName = offerName
+            self._offerName = offerName
             self.features = features
         }
 
@@ -379,12 +390,12 @@ extension PaywallData.LocalizedConfiguration: Codable {
 
     private enum CodingKeys: String, CodingKey {
         case title
-        case subtitle
+        case _subtitle = "subtitle"
         case callToAction
         case _callToActionWithIntroOffer = "callToActionWithIntroOffer"
         case _offerDetails = "offerDetails"
         case _offerDetailsWithIntroOffer = "offerDetailsWithIntroOffer"
-        case offerName
+        case _offerName = "offerName"
         case _features = "features"
     }
 

--- a/Tests/BackendIntegrationTests/__Snapshots__/LoadShedderIntegrationTests/testCanGetOfferings.1.json
+++ b/Tests/BackendIntegrationTests/__Snapshots__/LoadShedderIntegrationTests/testCanGetOfferings.1.json
@@ -51,6 +51,7 @@
             ],
             "offer_details" : "{{ total_price_and_per_month }}",
             "offer_details_with_intro_offer" : "Try {{ sub_offer_duration }} for free, then {{ total_price_and_per_month }}",
+            "offer_name" : null,
             "subtitle" : "Get access to all content",
             "title" : "Ignite your child's curiosity"
           }

--- a/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedIconsGeneratesDefaultPaywall.1.json
+++ b/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedIconsGeneratesDefaultPaywall.1.json
@@ -33,6 +33,8 @@
       ],
       "offer_details" : "{{ total_price_and_per_month }}",
       "offer_details_with_intro_offer" : "Start your {{ sub_offer_duration }} trial, then {{ total_price_and_per_month }}.",
+      "offer_name" : null,
+      "subtitle" : null,
       "title" : "{{ app_name }}"
     }
   },

--- a/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedTemplateNameGeneratesDefaultPaywall.1.json
+++ b/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedTemplateNameGeneratesDefaultPaywall.1.json
@@ -33,6 +33,8 @@
       ],
       "offer_details" : "{{ total_price_and_per_month }}",
       "offer_details_with_intro_offer" : "Start your {{ sub_offer_duration }} trial, then {{ total_price_and_per_month }}.",
+      "offer_name" : null,
+      "subtitle" : null,
       "title" : "{{ app_name }}"
     }
   },

--- a/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedVariableGeneratesDefaultPaywall.1.json
+++ b/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedVariableGeneratesDefaultPaywall.1.json
@@ -33,6 +33,8 @@
       ],
       "offer_details" : "{{ total_price_and_per_month }}",
       "offer_details_with_intro_offer" : "Start your {{ sub_offer_duration }} trial, then {{ total_price_and_per_month }}.",
+      "offer_name" : null,
+      "subtitle" : null,
       "title" : "{{ app_name }}"
     }
   },

--- a/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedVariableInFeaturesGeneratesDefaultPaywall.1.json
+++ b/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedVariableInFeaturesGeneratesDefaultPaywall.1.json
@@ -33,6 +33,8 @@
       ],
       "offer_details" : "{{ total_price_and_per_month }}",
       "offer_details_with_intro_offer" : "Start your {{ sub_offer_duration }} trial, then {{ total_price_and_per_month }}.",
+      "offer_name" : null,
+      "subtitle" : null,
       "title" : "{{ app_name }}"
     }
   },

--- a/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testValidateMissingPaywall.1.json
+++ b/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testValidateMissingPaywall.1.json
@@ -33,6 +33,8 @@
       ],
       "offer_details" : "{{ total_price_and_per_month }}",
       "offer_details_with_intro_offer" : "Start your {{ sub_offer_duration }} trial, then {{ total_price_and_per_month }}.",
+      "offer_name" : null,
+      "subtitle" : null,
       "title" : "{{ app_name }}"
     }
   },


### PR DESCRIPTION
Thanks to @vegaro for pointing this out. It's not required, but it helps to ensure that these properties don't end up with empty strings.