### PR TITLE
`Codable`: improved decoding errors

### DIFF
--- a/Sources/FoundationExtensions/Decoder+Extensions.swift
+++ b/Sources/FoundationExtensions/Decoder+Extensions.swift
@@ -125,7 +125,7 @@ extension ErrorUtils {
 
     static func logDecodingError(_ error: Error, type: Any.Type, data: Data? = nil) {
         if let data = data {
-            Logger.debug(Strings.codable.invalid_data_when_decoding(data))
+            Logger.debug(Strings.codable.invalid_data_when_decoding(data, type))
         }
 
         guard let decodingError = error as? DecodingError else {

--- a/Sources/Logging/Strings/CodableStrings.swift
+++ b/Sources/Logging/Strings/CodableStrings.swift
@@ -16,7 +16,7 @@ import Foundation
 // swiftlint:disable identifier_name
 enum CodableStrings {
 
-    case invalid_data_when_decoding(Data)
+    case invalid_data_when_decoding(Data, _ type: Any.Type)
     case unexpectedValueError(type: Any.Type, value: Any)
     case valueNotFoundError(value: Any.Type, context: DecodingError.Context)
     case keyNotFoundError(type: Any.Type, key: CodingKey, context: DecodingError.Context)
@@ -32,9 +32,9 @@ extension CodableStrings: LogMessage {
 
     var description: String {
         switch self {
-        case let .invalid_data_when_decoding(data):
+        case let .invalid_data_when_decoding(data, type):
             let content = String(data: data, encoding: .utf8) ?? ""
-            return "Encountered error when decoding JSON: \(content)"
+            return "Encountered error when decoding JSON for '\(type)': \(content)"
         case let .unexpectedValueError(type, value):
             return "Found unexpected value '\(value)' for type '\(type)'"
         case let .valueNotFoundError(value, context):


### PR DESCRIPTION
This adds the type to the errors.

### Before:
```
2023-09-06 15:58:05.394583-0700 xctest[55784:3435527] [codable] DEBUG: ℹ️ Encountered error when decoding JSON: not an event
```

### After:
```
2023-09-06 16:03:29.606223-0700 xctest[57222:3447821] [codable] DEBUG: ℹ️ Encountered error when decoding JSON for 'PaywallStoredEvent': this is not an event
```
