### PR TITLE
`Paywalls`: support fuzzy-Locale search in `iOS 15`

### DIFF
--- a/RevenueCatUI/Helpers/PaywallData+Default.swift
+++ b/RevenueCatUI/Helpers/PaywallData+Default.swift
@@ -15,7 +15,7 @@ import Foundation
 import RevenueCat
 import SwiftUI
 
-#if canImport(SwiftUI) && swift(>=5.7)
+#if canImport(SwiftUI)
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 extension PaywallData {

--- a/Sources/Paywalls/PaywallColor.swift
+++ b/Sources/Paywalls/PaywallColor.swift
@@ -34,8 +34,7 @@ public struct PaywallColor {
     /// The original Hex representation for this color.
     public var stringRepresentation: String
 
-    // `Color` is not `Sendable` in Xcode 13.
-    #if canImport(SwiftUI) && swift(>=5.7)
+    #if canImport(SwiftUI)
     /// The underlying SwiftUI `Color`.
     @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
     public var underlyingColor: Color {
@@ -53,7 +52,7 @@ public struct PaywallColor {
 
 extension PaywallColor {
 
-    #if canImport(SwiftUI) && swift(>=5.7)
+    #if canImport(SwiftUI)
 
     /// Creates a color from a Hex string: `#RRGGBB` or `#RRGGBBAA`.
     public init(stringRepresentation: String) throws {
@@ -77,13 +76,6 @@ extension PaywallColor {
 
         #endif
 
-    #else
-
-    /// Creates a color from a Hex string: `#RRGGBB` or `#RRGGBBAA`.
-    public init(stringRepresentation: String) throws {
-        self.init(stringRepresentation: stringRepresentation, underlyingColor: nil)
-    }
-
     #endif
 
 }
@@ -94,12 +86,10 @@ private extension PaywallColor {
 
     #if canImport(SwiftUI)
 
-        #if swift(>=5.7)
-        @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
-        init(stringRepresentation: String, color: Color) {
-            self.init(stringRepresentation: stringRepresentation, underlyingColor: color)
-        }
-        #endif
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
+    init(stringRepresentation: String, color: Color) {
+        self.init(stringRepresentation: stringRepresentation, underlyingColor: color)
+    }
 
     @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
     static func parseColor(_ input: String) throws -> Color {
@@ -201,16 +191,12 @@ public extension Color {
         self.init(light: UIColor(light), dark: UIColor(dark))
     }
 
-    #if swift(>=5.7)
-
     /// Converts a `Color` into a `PaywallColor`.
     /// - Warning: This `PaywallColor` won't be able to be encoded,
     /// its ``PaywallColor/stringRepresentation`` will be undefined.
     var asPaywallColor: PaywallColor {
         return .init(stringRepresentation: "#FFFFFF", color: self)
     }
-
-    #endif
 
 }
 #endif

--- a/Sources/Paywalls/PaywallData.swift
+++ b/Sources/Paywalls/PaywallData.swift
@@ -451,28 +451,18 @@ extension PaywallData.Configuration.Colors: Sendable {}
 extension PaywallData.Configuration.Images: Sendable {}
 extension PaywallData.Configuration: Sendable {}
 
-#if swift(>=5.7)
 extension PaywallData: Sendable {}
-#else
-// `@unchecked` because:
-// - `URL` is not `Sendable` until Swift 5.7
-extension PaywallData: @unchecked Sendable {}
-#endif
 
 // MARK: - Extensions
 
 private extension Locale {
 
     func sharesLanguageCode(with other: Locale) -> Bool {
-        #if swift(>=5.7)
         if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             return self.language.languageCode == other.language.languageCode
         } else {
-            return false
+            return self.languageCode == other.languageCode
         }
-        #else
-        return false
-        #endif
     }
 
 }

--- a/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Test Data/TestStoreProduct.swift
@@ -120,8 +120,3 @@ extension TestStoreProduct {
     }
 
 }
-
-#if swift(<5.7)
-// `Locale` isn't `Sendable` in Xcode 13
-extension TestStoreProduct: @unchecked Sendable {}
-#endif

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PaywallAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PaywallAPI.swift
@@ -130,7 +130,7 @@ func checkPaywallColorInformation(_ config: PaywallData.Configuration.ColorInfor
 func checkPaywallColor(_ color: PaywallColor) throws {
     _ = try PaywallColor(stringRepresentation: "")
 
-    #if canImport(UIKit) && !os(watchOS) && swift(>=5.7)
+    #if canImport(UIKit) && !os(watchOS)
     if #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *) {
         _ = PaywallColor(light: color, dark: color)
     }
@@ -138,7 +138,7 @@ func checkPaywallColor(_ color: PaywallColor) throws {
 
     let _: String = color.debugDescription
     let _: String = color.stringRepresentation
-    #if canImport(SwiftUI) && swift(>=5.7)
+    #if canImport(SwiftUI)
     if #available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *) {
         let _: Color = color.underlyingColor
     }

--- a/Tests/UnitTests/Paywalls/PaywallColorTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallColorTests.swift
@@ -11,7 +11,7 @@
 //
 //  Created by Nacho Soto on 7/14/23.
 
-#if canImport(UIKit) && canImport(SwiftUI) && swift(>=5.7)
+#if canImport(UIKit) && canImport(SwiftUI)
 
 import Nimble
 @testable import RevenueCat

--- a/Tests/UnitTests/Paywalls/PaywallDataTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallDataTests.swift
@@ -83,10 +83,6 @@ class PaywallDataTests: BaseHTTPResponseTest {
     }
 
     func testFindsLocaleWithOnlyLanguage() throws {
-        // `Locale.language.languageCode` is iOS 16 only
-        // and so is RevenueCatUI anyway.
-        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
-
         let paywall: PaywallData = try self.decodeFixture("PaywallData-Sample1")
 
         let enConfig = try XCTUnwrap(paywall.config(for: Locale(identifier: "en")))


### PR DESCRIPTION
See #2847.

Thanks to @vegaro for pointing this out.

Also removed all checks for Xcode 13 (see #3161 and #3147).