### PR TITLE
`Integration Tests`: improve flaky tests

### DIFF
--- a/Sources/Logging/Strings/NetworkStrings.swift
+++ b/Sources/Logging/Strings/NetworkStrings.swift
@@ -113,7 +113,7 @@ extension NetworkStrings: LogMessage {
 
         #if DEBUG
         case let .api_request_forcing_server_error(request):
-            return "Returning fake HTTP 500 error for '\(request.description)'"
+            return "Returning fake HTTP 500 error for \(request.description)"
 
         case let .api_request_forcing_signature_failure(request):
             return "Returning fake signature verification failure for '\(request.description)'"

--- a/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
+++ b/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
@@ -30,7 +30,8 @@ enum OfflineEntitlementsStrings {
     case computing_offline_customer_info_for_consumable_product
     case computing_offline_customer_info
     case computing_offline_customer_info_failed(Error)
-    case computed_offline_customer_info(EntitlementInfos)
+    case computed_offline_customer_info([PurchasedSK2Product], EntitlementInfos)
+    case computed_offline_customer_info_details([PurchasedSK2Product], EntitlementInfos)
 
     case purchased_products_fetching
     case purchased_products_fetching_too_slow
@@ -79,8 +80,23 @@ extension OfflineEntitlementsStrings: LogMessage {
             return "Error computing offline CustomerInfo. Will return original error.\n" +
             "Creation error: \(error.localizedDescription)"
 
-        case let .computed_offline_customer_info(entitlements):
-            return "Computed offline CustomerInfo with \(entitlements.active.count) active entitlements."
+        case let .computed_offline_customer_info(products, entitlements):
+            return "Computed offline CustomerInfo from \(products.count) products " +
+            "with \(entitlements.active.count) active entitlements."
+
+        case let .computed_offline_customer_info_details(products, entitlements):
+            let productIDs = products
+                .lazy
+                .map(\.productIdentifier)
+                .joined(separator: ", ")
+            let entitlements = entitlements
+                .active
+                .values
+                .lazy
+                .map(\.identifier)
+                .joined(separator: ", ")
+
+            return "Purchased products: [\(productIDs)]. Active entitlements: [\(entitlements)]."
 
         case .purchased_products_fetching:
             return "PurchasedProductsFetcher: fetching products from StoreKit"

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -64,9 +64,12 @@ class HTTPClient {
         #if DEBUG
         guard !self.systemInfo.dangerousSettings.internalSettings.forceServerErrors else {
             Logger.warn(Strings.network.api_request_forcing_server_error(request))
-            completionHandler?(
-                .failure(.errorResponse(Self.serverErrorResponse, .internalServerError))
-            )
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(300)) {
+                completionHandler?(
+                    .failure(.errorResponse(Self.serverErrorResponse, .internalServerError))
+                )
+            }
+
             return
         }
         #endif

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -64,6 +64,10 @@ class HTTPClient {
         #if DEBUG
         guard !self.systemInfo.dangerousSettings.internalSettings.forceServerErrors else {
             Logger.warn(Strings.network.api_request_forcing_server_error(request))
+
+            // `FB13133387`: when computing offline CustomerInfo, `StoreKit.Transaction.unfinished`
+            // might be empty if called immediately after `Product.purchase()`.
+            // This introduces a delay to simulate a real API request, and avoid that race condition.
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(300)) {
                 completionHandler?(
                     .failure(.errorResponse(Self.serverErrorResponse, .internalServerError))

--- a/Sources/OfflineEntitlements/OfflineCustomerInfoCreator.swift
+++ b/Sources/OfflineEntitlements/OfflineCustomerInfoCreator.swift
@@ -80,7 +80,12 @@ class OfflineCustomerInfoCreator {
 
         let offlineCustomerInfo = creator(products, mapping, userID)
 
-        Logger.info(Strings.offlineEntitlements.computed_offline_customer_info(offlineCustomerInfo.entitlements))
+        Logger.info(Strings.offlineEntitlements.computed_offline_customer_info(
+            products, offlineCustomerInfo.entitlements
+        ))
+        Logger.debug(Strings.offlineEntitlements.computed_offline_customer_info_details(
+            products, offlineCustomerInfo.entitlements
+        ))
 
         return offlineCustomerInfo
     }

--- a/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
+++ b/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
@@ -204,7 +204,8 @@ class OfflineCustomerInfoResponseHandlerTests: BaseCustomerInfoResponseHandlerTe
 
         self.logger.verifyMessageWasLogged(Strings.offlineEntitlements.computing_offline_customer_info, level: .info)
         self.logger.verifyMessageWasLogged(
-            Strings.offlineEntitlements.computed_offline_customer_info(Self.offlineCustomerInfo.entitlements),
+            Strings.offlineEntitlements.computed_offline_customer_info([Self.purchasedProduct],
+                                                                       Self.offlineCustomerInfo.entitlements),
             level: .info
         )
     }


### PR DESCRIPTION
We get a lot of flaky failures on `OfflineStoreKitIntegrationTests` (example: https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/14843/workflows/a3cffa7c-da25-4811-931d-fc241befee0f/jobs/118214/tests).
I managed to reproduce locally running some of these 100+ times on a loop until they failed.

I traced the issue to this sequence:
- SK2 purchase
- `StoreKit.Transaction.unfinished` is empty

This is likely due to a race condition. In practice, when computing offline `CustomerInfo`, we never check it right away, since we need to wait for the server to return a 500.

I filed a Radar for this: `FB13133387`.

To make tests more realistic, I introduced a delay in `HTTPClient` returning fake 5xx errors. I haven't been able to reproduce this issue again, so this should make `OfflineStoreKitIntegrationTests` more reliable.

I've also added a new debug log that could help debug similar issues, because `Strings.offline.computed_offline_customer_info` was not very complete.