### PR TITLE
`Integration Tests`: another flaky failure

### DIFF
--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -258,7 +258,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
         try await self.verifyEntitlementWentThrough(customerInfo)
 
         self.logger.verifyMessageWasLogged(
-            "Found 2 unfinished transactions, will post receipt in lieu of fetching CustomerInfo",
+            "unfinished transactions, will post receipt in lieu of fetching CustomerInfo",
             level: .debug,
             expectedCount: 1
         )

--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -250,7 +250,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
             productIdentifier: await self.monthlyPackage.storeProduct.productIdentifier
         )
 
-        try await self.waitUntilUnfinishedTransactions(2)
+        try await self.waitUntilUnfinishedTransactions { $0 >= 2 }
 
         self.serverUp()
 

--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
@@ -47,21 +47,21 @@ extension XCTestCase {
     }
 
     func waitUntilUnfinishedTransactions(
-        _ expectedCount: Int,
+        condition: @Sendable @escaping (Int) -> Bool,
         file: FileString = #fileID,
         line: UInt = #line
     ) async throws {
         try await asyncWait(
-            description: "Expected at least \(expectedCount) unfinished transactions",
+            description: { "Transaction expectation never met: \($0 ?? [])" },
             file: file,
-            line: line
-        ) {
-            await Transaction.unfinished.extractValues().count >= expectedCount
-        }
+            line: line,
+            until: { await Transaction.unfinished.extractValues() },
+            condition: { condition($0.count) }
+        )
     }
 
     func waitUntilNoUnfinishedTransactions(file: FileString = #fileID, line: UInt = #line) async throws {
-        try await self.waitUntilUnfinishedTransactions(0)
+        try await self.waitUntilUnfinishedTransactions { $0 == 0 }
     }
 
     func deleteAllTransactions(session: SKTestSession) async {

--- a/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
+++ b/Tests/StoreKitUnitTests/TestHelpers/StoreKitTestHelpers.swift
@@ -52,11 +52,11 @@ extension XCTestCase {
         line: UInt = #line
     ) async throws {
         try await asyncWait(
-            description: "Expected \(expectedCount) unfinished transactions",
+            description: "Expected at least \(expectedCount) unfinished transactions",
             file: file,
             line: line
         ) {
-            await Transaction.unfinished.extractValues().count == expectedCount
+            await Transaction.unfinished.extractValues().count >= expectedCount
         }
     }
 


### PR DESCRIPTION
See https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/14903/workflows/a607f078-553a-44c0-8873-16abc12d3e3a/jobs/119243

This test (`testCallToGetCustomerInfoWithPendingTransactionsPostsReceiptOnlyOnce`) has a race condition. It currently does:
- `purchaseMonthlyProduct`
- `forceRenewalOfSubscription`

However, with a slow CPU, it's possible that StoreKit will renew automatically, leading to more unfinished transactions.

This modifies the test to be a bit more lenient, while still complying with the spirit of the test: `testCallToGetCustomerInfoWithPendingTransactionsPostsReceiptOnlyOnce`.
