### PR TITLE
`Integration Tests`: fix flaky test failure due to leftover transaction

### DIFF
--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -319,6 +319,8 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testPurchasingMultipleProductsWhileServerIsDownHandlesAllTransactionsWhenForegroundingApp() async throws {
+        self.logger.clearMessages()
+
         // 1. Purchase while server is down
         self.serverDown()
 


### PR DESCRIPTION
Fixes https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/14917/workflows/4f22199c-2229-45da-8758-9587559d02be/jobs/119481/tests

This test was failing with this error:
> failed - Message 'Finishing transaction' should not have been logged

I looked through the logs, and noticed that transaction had been finished prior to the test even starting (before `.serverDown()` was called), likely due to a leftover transaction from an earlier test (this can still happen with `SKTestSession` despite our best efforts. Supposedly fully fixed in iOS 17).

This removes that possibility by clearing the log history at the beginning of the test.
