### PR TITLE
`OperationDispatcher`: add support for "long" delays

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -260,6 +260,7 @@
 		4F8929192A65EF3000A91EA2 /* EnsureNonEmptyCollectionDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8929182A65EF3000A91EA2 /* EnsureNonEmptyCollectionDecodable.swift */; };
 		4F8A58172A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */; };
 		4F8A58182A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */; };
+		4F8DDB692AAA9189000188F2 /* OperationDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8DDB682AAA9189000188F2 /* OperationDispatcherTests.swift */; };
 		4F90AFCB2A3915340047E63F /* TestMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F90AFCA2A3915340047E63F /* TestMessage.swift */; };
 		4F90AFCC2A3915BC0047E63F /* TestMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F90AFCA2A3915340047E63F /* TestMessage.swift */; };
 		4F98E9D32A465A4400DB6EAB /* TestStoreProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F98E9D22A465A4400DB6EAB /* TestStoreProduct.swift */; };
@@ -989,6 +990,7 @@
 		4F8452672A5756CC00084550 /* HTTPRequestBody+Signing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HTTPRequestBody+Signing.swift"; sourceTree = "<group>"; };
 		4F8929182A65EF3000A91EA2 /* EnsureNonEmptyCollectionDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnsureNonEmptyCollectionDecodable.swift; sourceTree = "<group>"; };
 		4F8A58162A16EE3500EF97AD /* MockOfflineCustomerInfoCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOfflineCustomerInfoCreator.swift; sourceTree = "<group>"; };
+		4F8DDB682AAA9189000188F2 /* OperationDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationDispatcherTests.swift; sourceTree = "<group>"; };
 		4F90AFCA2A3915340047E63F /* TestMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestMessage.swift; sourceTree = "<group>"; };
 		4F98E9D22A465A4400DB6EAB /* TestStoreProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestStoreProduct.swift; sourceTree = "<group>"; };
 		4F9BB63E2A7AFB72001C120D /* MockPayment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPayment.swift; sourceTree = "<group>"; };
@@ -1952,6 +1954,7 @@
 				579189E828F47E8D00BF4963 /* PurchasesDiagnosticsTests.swift */,
 				57032ABE28C13CE4004FF47A /* StoreKit2SettingTests.swift */,
 				5712BE9129241F7900A83F15 /* TimingUtilTests.swift */,
+				4F8DDB682AAA9189000188F2 /* OperationDispatcherTests.swift */,
 			);
 			path = Misc;
 			sourceTree = "<group>";
@@ -3583,6 +3586,7 @@
 				57E6C27E29723F9E001AFE98 /* SigningTests.swift in Sources */,
 				574A2F3F282D75E300150D40 /* OfferingsDecodingTests.swift in Sources */,
 				35E840CE2710E2EB00899AE2 /* MockManageSubscriptionsHelper.swift in Sources */,
+				4F8DDB692AAA9189000188F2 /* OperationDispatcherTests.swift in Sources */,
 				57FFD2512922DBED00A9A878 /* MockStoreTransaction.swift in Sources */,
 				57CB2A7A29CCC61600C91439 /* CustomerInfoResponseHandlerTests.swift in Sources */,
 				F591492826B9956C00D32E58 /* MockTransaction.swift in Sources */,

--- a/Sources/Identity/CustomerInfoManager.swift
+++ b/Sources/Identity/CustomerInfoManager.swift
@@ -370,7 +370,7 @@ private extension CustomerInfoManager {
         )
 
         self.backend.getCustomerInfo(appUserID: appUserID,
-                                     withRandomDelay: isAppBackgrounded,
+                                     isAppBackgrounded: isAppBackgrounded,
                                      allowComputingOffline: allowComputingOffline,
                                      completion: completion)
     }

--- a/Sources/Misc/Concurrency/OperationDispatcher.swift
+++ b/Sources/Misc/Concurrency/OperationDispatcher.swift
@@ -94,6 +94,21 @@ extension OperationDispatcher {
 
 }
 
+// MARK: -
+
+/// Visible for testing
+extension Delay {
+
+    var hasDelay: Bool {
+        return self.maximum > 0
+    }
+
+    var range: Range<TimeInterval> {
+        return self.minimum..<self.maximum
+    }
+
+}
+
 private extension Delay {
 
     var minimum: TimeInterval {
@@ -112,12 +127,8 @@ private extension Delay {
         }
     }
 
-    var hasDelay: Bool {
-        return self.maximum > 0
-    }
-
     func random() -> TimeInterval {
-        Double.random(in: self.minimum..<self.maximum)
+        Double.random(in: self.range)
     }
 
     private static let maxJitter: TimeInterval = 5

--- a/Sources/Misc/Concurrency/OperationDispatcher.swift
+++ b/Sources/Misc/Concurrency/OperationDispatcher.swift
@@ -14,6 +14,22 @@
 
 import Foundation
 
+/// Represents a delay for asynchonous operations.
+///
+/// These delays prevent DDOS if a notification leads to many users opening an app at the same time,
+/// by spreading asynchronous operations over time.
+enum Delay {
+
+    case none
+    case `default`
+    case long
+
+    static func `default`(forBackgroundedApp inBackground: Bool) -> Self {
+        return inBackground ? .default : .none
+    }
+
+}
+
 class OperationDispatcher {
 
     private let mainQueue: DispatchQueue = .main
@@ -41,12 +57,22 @@ class OperationDispatcher {
         Self.dispatchOnMainActor(block)
     }
 
-    func dispatchOnWorkerThread(withRandomDelay: Bool = false, block: @escaping @Sendable () -> Void) {
-        if withRandomDelay {
-            let delay = Double.random(in: 0..<self.maxJitterInSeconds)
-            self.workerQueue.asyncAfter(deadline: .now() + delay, execute: block)
+    func dispatchOnWorkerThread(delay: Delay = .none, block: @escaping @Sendable () -> Void) {
+        if delay.hasDelay {
+            self.workerQueue.asyncAfter(deadline: .now() + delay.random(), execute: block)
         } else {
             self.workerQueue.async(execute: block)
+        }
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    func dispatchOnWorkerThread(delay: Delay = .none, block: @escaping @Sendable () async -> Void) {
+        Task.detached(priority: .background) {
+            if delay.hasDelay {
+                try? await Task.sleep(nanoseconds: DispatchTimeInterval(delay.random()).nanoseconds)
+            }
+
+            await block()
         }
     }
 
@@ -67,6 +93,38 @@ extension OperationDispatcher {
     }
 
 }
+
+private extension Delay {
+
+    var minimum: TimeInterval {
+        switch self {
+        case .none: return 0
+        case .`default`: return 0
+        case .long: return Self.maxJitter
+        }
+    }
+
+    var maximum: TimeInterval {
+        switch self {
+        case .none: return 0
+        case .`default`: return Self.maxJitter
+        case .long: return Self.maxJitter * 2
+        }
+    }
+
+    var hasDelay: Bool {
+        return self.maximum > 0
+    }
+
+    func random() -> TimeInterval {
+        Double.random(in: self.minimum..<self.maximum)
+    }
+
+    private static let maxJitter: TimeInterval = 5
+
+}
+
+// MARK: -
 
 // `DispatchQueue` is not `Sendable` as of Swift 5.8, but this class performs no mutations.
 extension OperationDispatcher: @unchecked Sendable {}

--- a/Sources/Networking/Backend.swift
+++ b/Sources/Networking/Backend.swift
@@ -100,11 +100,11 @@ class Backend {
     }
 
     func getCustomerInfo(appUserID: String,
-                         withRandomDelay randomDelay: Bool,
+                         isAppBackgrounded: Bool,
                          allowComputingOffline: Bool = true,
                          completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
         self.customer.getCustomerInfo(appUserID: appUserID,
-                                      withRandomDelay: randomDelay,
+                                      isAppBackgrounded: isAppBackgrounded,
                                       allowComputingOffline: allowComputingOffline,
                                       completion: completion)
     }

--- a/Sources/Networking/BackendConfiguration.swift
+++ b/Sources/Networking/BackendConfiguration.swift
@@ -50,10 +50,10 @@ extension BackendConfiguration {
     /// Adds the `operation` to the `OperationQueue` (based on `CallbackCacheStatus`) potentially adding a random delay.
     func addCacheableOperation<T: CacheableNetworkOperation>(
         with factory: CacheableNetworkOperationFactory<T>,
-        withRandomDelay randomDelay: Bool,
+        delay: Delay,
         cacheStatus: CallbackCacheStatus
     ) {
-        self.operationDispatcher.dispatchOnWorkerThread(withRandomDelay: randomDelay) {
+        self.operationDispatcher.dispatchOnWorkerThread(delay: delay) {
             self.operationQueue.addCacheableOperation(with: factory, cacheStatus: cacheStatus)
         }
     }

--- a/Sources/Networking/CustomerAPI.swift
+++ b/Sources/Networking/CustomerAPI.swift
@@ -29,7 +29,7 @@ final class CustomerAPI {
     }
 
     func getCustomerInfo(appUserID: String,
-                         withRandomDelay randomDelay: Bool,
+                         isAppBackgrounded: Bool,
                          allowComputingOffline: Bool,
                          completion: @escaping CustomerInfoResponseHandler) {
         let config = NetworkOperation.UserSpecificConfiguration(httpClient: self.backendConfig.httpClient,
@@ -48,7 +48,7 @@ final class CustomerAPI {
                                             completion: completion)
         let cacheStatus = self.customerInfoCallbackCache.addOrAppendToPostReceiptDataOperation(callback: callback)
         self.backendConfig.addCacheableOperation(with: factory,
-                                                 withRandomDelay: randomDelay,
+                                                 delay: .default(forBackgroundedApp: isAppBackgrounded),
                                                  cacheStatus: cacheStatus)
     }
 

--- a/Sources/Networking/InternalAPI.swift
+++ b/Sources/Networking/InternalAPI.swift
@@ -34,7 +34,7 @@ final class InternalAPI {
         let cacheStatus = self.callbackCache.add(callback)
 
         self.backendConfig.addCacheableOperation(with: factory,
-                                                 withRandomDelay: false,
+                                                 delay: .none,
                                                  cacheStatus: cacheStatus)
     }
 

--- a/Sources/Networking/OfferingsAPI.swift
+++ b/Sources/Networking/OfferingsAPI.swift
@@ -48,7 +48,7 @@ class OfferingsAPI {
 
         self.backendConfig.addCacheableOperation(
             with: factory,
-            withRandomDelay: isAppBackgrounded,
+            delay: .default(forBackgroundedApp: isAppBackgrounded),
             cacheStatus: cacheStatus
         )
     }

--- a/Sources/Networking/OfflineEntitlementsAPI.swift
+++ b/Sources/Networking/OfflineEntitlementsAPI.swift
@@ -25,7 +25,7 @@ class OfflineEntitlementsAPI {
         self.productEntitlementMappingCallbacksCache = .init()
     }
 
-    func getProductEntitlementMapping(withRandomDelay randomDelay: Bool,
+    func getProductEntitlementMapping(isAppBackgrounded: Bool,
                                       completion: @escaping ProductEntitlementMappingResponseHandler) {
         let factory = GetProductEntitlementMappingOperation.createFactory(
             configuration: self.backendConfig,
@@ -37,7 +37,7 @@ class OfflineEntitlementsAPI {
 
         self.backendConfig.addCacheableOperation(
             with: factory,
-            withRandomDelay: randomDelay,
+            delay: .default(forBackgroundedApp: isAppBackgrounded),
             cacheStatus: cacheStatus
         )
     }

--- a/Sources/OfflineEntitlements/OfflineEntitlementsManager.swift
+++ b/Sources/OfflineEntitlements/OfflineEntitlementsManager.swift
@@ -50,7 +50,7 @@ class OfflineEntitlementsManager {
 
         Logger.debug(Strings.offlineEntitlements.product_entitlement_mapping_stale_updating)
 
-        self.api.getProductEntitlementMapping(withRandomDelay: isAppBackgrounded) { result in
+        self.api.getProductEntitlementMapping(isAppBackgrounded: isAppBackgrounded) { result in
             switch result {
             case let .success(response):
                 self.handleProductEntitlementMappingBackendResult(with: response)

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1366,7 +1366,7 @@ extension Purchases: InternalPurchasesType {
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func productEntitlementMapping() async throws -> ProductEntitlementMapping {
         let response = try await Async.call { completion in
-            self.backend.offlineEntitlements.getProductEntitlementMapping(withRandomDelay: false) { result in
+            self.backend.offlineEntitlements.getProductEntitlementMapping(isAppBackgrounded: false) { result in
                 completion(result.mapError(\.asPublicError))
             }
         }

--- a/Tests/UnitTests/Identity/CustomerInfoManagerPostReceiptTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerPostReceiptTests.swift
@@ -35,7 +35,7 @@ class CustomerInfoManagerPostReceiptTests: BaseCustomerInfoManagerTests {
         expect(result) === self.mockCustomerInfo
 
         expect(self.mockBackend.invokedGetSubscriberDataCount) == 1
-        expect(self.mockBackend.invokedGetSubscriberDataParameters?.randomDelay) == false
+        expect(self.mockBackend.invokedGetSubscriberDataParameters?.isAppBackgrounded) == false
         expect(self.mockTransactionPoster.invokedHandlePurchasedTransaction.value) == false
     }
 

--- a/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
+++ b/Tests/UnitTests/Identity/CustomerInfoManagerTests.swift
@@ -119,14 +119,14 @@ class CustomerInfoManagerTests: BaseCustomerInfoManagerTests {
         try self.fetchAndCacheCustomerInfo(isAppBackground: true)
 
         expect(self.mockBackend.invokedGetSubscriberDataCount) == 1
-        expect(self.mockBackend.invokedGetSubscriberDataParameters?.randomDelay) == true
+        expect(self.mockBackend.invokedGetSubscriberDataParameters?.isAppBackgrounded) == true
     }
 
     func testFetchAndCacheCustomerInfoCallsBackendWithoutRandomDelayIfAppForegrounded() throws {
         try self.fetchAndCacheCustomerInfo(isAppBackground: false)
 
         expect(self.mockBackend.invokedGetSubscriberDataCount) == 1
-        expect(self.mockBackend.invokedGetSubscriberDataParameters?.randomDelay) == false
+        expect(self.mockBackend.invokedGetSubscriberDataParameters?.isAppBackgrounded) == false
     }
 
     func testFetchAndCacheCustomerInfoPassesBackendErrors() throws {

--- a/Tests/UnitTests/Misc/OperationDispatcherTests.swift
+++ b/Tests/UnitTests/Misc/OperationDispatcherTests.swift
@@ -26,4 +26,19 @@ class OperationDispatcherTests: TestCase {
         expect(Delay.default(forBackgroundedApp: false)) == Delay.none
     }
 
+    func testNoDelay() {
+        expect(Delay.none.hasDelay) == false
+        expect(Delay.none.range) == 0..<0
+    }
+
+    func testDefaultDelay() {
+        expect(Delay.default.hasDelay) == true
+        expect(Delay.default.range) == 0..<5
+    }
+
+    func testLongDelay() {
+        expect(Delay.long.hasDelay) == true
+        expect(Delay.long.range) == 5..<10
+    }
+
 }

--- a/Tests/UnitTests/Misc/OperationDispatcherTests.swift
+++ b/Tests/UnitTests/Misc/OperationDispatcherTests.swift
@@ -1,0 +1,29 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  OperationDispatcherTests.swift
+//
+//  Created by Nacho Soto on 9/7/23.
+
+import Foundation
+import Nimble
+@testable import RevenueCat
+import XCTest
+
+class OperationDispatcherTests: TestCase {
+
+    func testDelayForBackgroundedApp() {
+        expect(Delay.default(forBackgroundedApp: true)) == .default
+    }
+
+    func testDelayForForegroundedApp() {
+        expect(Delay.default(forBackgroundedApp: false)) == Delay.none
+    }
+
+}

--- a/Tests/UnitTests/Mocks/MockBackend.swift
+++ b/Tests/UnitTests/Mocks/MockBackend.swift
@@ -67,24 +67,24 @@ class MockBackend: Backend {
     var invokedGetSubscriberData = false
     var invokedGetSubscriberDataCount = 0
     var invokedGetSubscriberDataParameters: (appUserID: String?,
-                                             randomDelay: Bool,
+                                             isAppBackgrounded: Bool,
                                              allowComputingOffline: Bool,
                                              completion: CustomerAPI.CustomerInfoResponseHandler?)?
     var invokedGetSubscriberDataParametersList = [(appUserID: String?,
-                                                   randomDelay: Bool,
+                                                   isAppBackgrounded: Bool,
                                                    allowComputingOffline: Bool,
                                                    completion: CustomerAPI.CustomerInfoResponseHandler?)]()
 
     var stubbedGetCustomerInfoResult: Result<CustomerInfo, BackendError> = .failure(.missingAppUserID())
 
     override func getCustomerInfo(appUserID: String,
-                                  withRandomDelay randomDelay: Bool,
+                                  isAppBackgrounded: Bool,
                                   allowComputingOffline: Bool,
                                   completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
         invokedGetSubscriberData = true
         invokedGetSubscriberDataCount += 1
-        invokedGetSubscriberDataParameters = (appUserID, randomDelay, allowComputingOffline, completion)
-        invokedGetSubscriberDataParametersList.append((appUserID, randomDelay, allowComputingOffline, completion))
+        invokedGetSubscriberDataParameters = (appUserID, isAppBackgrounded, allowComputingOffline, completion)
+        invokedGetSubscriberDataParametersList.append((appUserID, isAppBackgrounded, allowComputingOffline, completion))
 
         completion(self.stubbedGetCustomerInfoResult)
     }

--- a/Tests/UnitTests/Mocks/MockOfflineEntitlementsAPI.swift
+++ b/Tests/UnitTests/Mocks/MockOfflineEntitlementsAPI.swift
@@ -27,12 +27,12 @@ class MockOfflineEntitlementsAPI: OfflineEntitlementsAPI {
     var stubbedGetProductEntitlementMappingResult: Result<ProductEntitlementMappingResponse, BackendError>?
 
     override func getProductEntitlementMapping(
-        withRandomDelay randomDelay: Bool,
+        isAppBackgrounded: Bool,
         completion: @escaping ProductEntitlementMappingResponseHandler
     ) {
         self.invokedGetProductEntitlementMapping = true
         self.invokedGetProductEntitlementMappingCount += 1
-        self.invokedGetProductEntitlementMappingParameter = randomDelay
+        self.invokedGetProductEntitlementMappingParameter = isAppBackgrounded
 
         completion(self.stubbedGetProductEntitlementMappingResult ?? .failure(.missingAppUserID()))
     }

--- a/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
+++ b/Tests/UnitTests/Mocks/MockOperationDispatcher.swift
@@ -57,18 +57,19 @@ class MockOperationDispatcher: OperationDispatcher {
     var invokedDispatchOnWorkerThreadCount = 0
     var shouldInvokeDispatchOnWorkerThreadBlock = true
     var forwardToOriginalDispatchOnWorkerThread = false
-    var invokedDispatchOnWorkerThreadRandomDelayParam: Bool?
+    var invokedDispatchOnWorkerThreadDelayParam: Delay?
 
-    public override func dispatchOnWorkerThread(withRandomDelay: Bool = false, block: @escaping @Sendable () -> Void) {
-        invokedDispatchOnWorkerThreadRandomDelayParam = withRandomDelay
-        invokedDispatchOnWorkerThread = true
-        invokedDispatchOnWorkerThreadCount += 1
-        if forwardToOriginalDispatchOnWorkerThread {
-            super.dispatchOnWorkerThread(withRandomDelay: withRandomDelay, block: block)
+    override func dispatchOnWorkerThread(delay: Delay = .none, block: @escaping @Sendable () -> Void) {
+        self.invokedDispatchOnWorkerThreadDelayParam = delay
+        self.invokedDispatchOnWorkerThread = true
+        self.invokedDispatchOnWorkerThreadCount += 1
+        if self.forwardToOriginalDispatchOnWorkerThread {
+            super.dispatchOnWorkerThread(delay: delay, block: block)
             return
         }
-        if shouldInvokeDispatchOnWorkerThreadBlock {
+        if self.shouldInvokeDispatchOnWorkerThreadBlock {
             block()
         }
     }
+
 }

--- a/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetCustomerInfoTests.swift
@@ -29,8 +29,8 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
             response: .init(statusCode: .success, response: Self.validCustomerResponse)
         )
 
-        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) { _ in }
-        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) { _ in }
+        self.backend.getCustomerInfo(appUserID: Self.userID, isAppBackgrounded: false) { _ in }
+        self.backend.getCustomerInfo(appUserID: Self.userID, isAppBackgrounded: false) { _ in }
 
         expect(self.httpClient.calls).toEventually(haveCount(1))
     }
@@ -41,8 +41,8 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         httpClient.mock(requestPath: .getCustomerInfo(appUserID: Self.userID), response: response)
         httpClient.mock(requestPath: .getCustomerInfo(appUserID: userID2), response: response)
 
-        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) { _ in }
-        backend.getCustomerInfo(appUserID: userID2, withRandomDelay: false) { _ in }
+        self.backend.getCustomerInfo(appUserID: Self.userID, isAppBackgrounded: false) { _ in }
+        self.backend.getCustomerInfo(appUserID: userID2, isAppBackgrounded: false) { _ in }
 
         expect(self.httpClient.calls).toEventually(haveCount(2))
     }
@@ -53,7 +53,7 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
 
         self.httpClient.mock(requestPath: path, response: response)
 
-        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) { _ in }
+        backend.getCustomerInfo(appUserID: Self.userID, isAppBackgrounded: false) { _ in }
         expect(self.httpClient.calls).toEventually(haveCount(1))
     }
 
@@ -64,7 +64,7 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         )
 
         let customerInfo = waitUntilValue { completed in
-            self.backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false, completion: completed)
+            self.backend.getCustomerInfo(appUserID: Self.userID, isAppBackgrounded: false, completion: completed)
         }
 
         expect(customerInfo).to(beSuccess())
@@ -83,7 +83,7 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         )
 
         let result = waitUntilValue { completed in
-            self.backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false, completion: completed)
+            self.backend.getCustomerInfo(appUserID: Self.userID, isAppBackgrounded: false, completion: completed)
         }
 
         expect(result).to(beFailure())
@@ -97,7 +97,7 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         )
 
         let result = waitUntilValue { completed in
-            self.backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false, completion: completed)
+            self.backend.getCustomerInfo(appUserID: Self.userID, isAppBackgrounded: false, completion: completed)
         }
 
         guard case .failure(.networkError(.decoding)) = result else {
@@ -122,11 +122,11 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         let firstResult: Atomic<Result<CustomerInfo, BackendError>?> = nil
         let secondResult: Atomic<Result<CustomerInfo, BackendError>?> = nil
 
-        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) {
+        backend.getCustomerInfo(appUserID: Self.userID, isAppBackgrounded: false) {
             firstResult.value = $0
         }
 
-        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) {
+        backend.getCustomerInfo(appUserID: Self.userID, isAppBackgrounded: false) {
             secondResult.value = $0
         }
 
@@ -147,7 +147,7 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         )
 
         let customerInfo = waitUntilValue { completed in
-            self.backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false, completion: completed)
+            self.backend.getCustomerInfo(appUserID: Self.userID, isAppBackgrounded: false, completion: completed)
         }
 
         expect(customerInfo).to(beSuccess())
@@ -166,7 +166,7 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         )
 
         let customerInfo = waitUntilValue { completed in
-            self.backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false, completion: completed)
+            self.backend.getCustomerInfo(appUserID: Self.userID, isAppBackgrounded: false, completion: completed)
         }
 
         expect(customerInfo).to(beSuccess())
@@ -188,7 +188,7 @@ class BackendGetCustomerInfoTests: BaseBackendTests {
         )
 
         let response = waitUntilValue { completed in
-            self.backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false, completion: completed)
+            self.backend.getCustomerInfo(appUserID: Self.userID, isAppBackgrounded: false, completion: completed)
         }
 
         expect(response).to(beSuccess())
@@ -221,7 +221,7 @@ class BackendGetCustomerInfoSignatureTests: BaseBackendTests {
         )
 
         let result = waitUntilValue { completed in
-            self.backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false, completion: completed)
+            self.backend.getCustomerInfo(appUserID: Self.userID, isAppBackgrounded: false, completion: completed)
         }
         let request = self.httpClient.calls.onlyElement
 

--- a/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetOfferingsTests.swift
@@ -35,7 +35,7 @@ class BackendGetOfferingsTests: BaseBackendTests {
 
         expect(result).to(beSuccess())
         expect(self.httpClient.calls).to(haveCount(1))
-        expect(self.operationDispatcher.invokedDispatchOnWorkerThreadRandomDelayParam) == false
+        expect(self.operationDispatcher.invokedDispatchOnWorkerThreadDelayParam) == Delay.none
     }
 
     func testGetOfferingsCallsHTTPMethodWithRandomDelay() {
@@ -50,7 +50,7 @@ class BackendGetOfferingsTests: BaseBackendTests {
 
         expect(result).to(beSuccess())
         expect(self.httpClient.calls).to(haveCount(1))
-        expect(self.operationDispatcher.invokedDispatchOnWorkerThreadRandomDelayParam) == true
+        expect(self.operationDispatcher.invokedDispatchOnWorkerThreadDelayParam) == .default
     }
 
     func testGetOfferingsCachesForSameUserID() {

--- a/Tests/UnitTests/Networking/Backend/BackendOfflineEntitlementsTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendOfflineEntitlementsTests.swift
@@ -24,7 +24,7 @@ class BackendOfflineEntitlementsTests: BaseBackendTests {
     }
 
     func testGetProductEntitlementMapping() {
-        let randomDelay: Bool = .random()
+        let isAppBackgrounded: Bool = .random()
 
         self.httpClient.mock(
             requestPath: .getProductEntitlementMapping,
@@ -32,11 +32,14 @@ class BackendOfflineEntitlementsTests: BaseBackendTests {
         )
 
         let result = waitUntilValue { completed in
-            self.offlineEntitlements.getProductEntitlementMapping(withRandomDelay: randomDelay, completion: completed)
+            self.offlineEntitlements.getProductEntitlementMapping(isAppBackgrounded: isAppBackgrounded,
+                                                                  completion: completed)
         }
 
         expect(self.httpClient.calls).to(haveCount(1))
-        expect(self.operationDispatcher.invokedDispatchOnWorkerThreadRandomDelayParam) == randomDelay
+        expect(self.operationDispatcher.invokedDispatchOnWorkerThreadDelayParam) == .default(
+            forBackgroundedApp: isAppBackgrounded
+        )
 
         expect(result).to(beSuccess())
         expect(result?.value?.products).to(haveCount(2))
@@ -52,8 +55,8 @@ class BackendOfflineEntitlementsTests: BaseBackendTests {
 
         let responses: Atomic<Int> = .init(0)
 
-        self.offlineEntitlements.getProductEntitlementMapping(withRandomDelay: false) { _ in responses.value += 1 }
-        self.offlineEntitlements.getProductEntitlementMapping(withRandomDelay: false) { _ in responses.value += 1 }
+        self.offlineEntitlements.getProductEntitlementMapping(isAppBackgrounded: false) { _ in responses.value += 1 }
+        self.offlineEntitlements.getProductEntitlementMapping(isAppBackgrounded: false) { _ in responses.value += 1 }
 
         expect(responses.value).toEventually(equal(2))
         expect(self.httpClient.calls).to(haveCount(1))

--- a/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendPostReceiptDataTests.swift
@@ -483,7 +483,7 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
         let callOrder: Atomic<(initialGet: Bool,
                                postResponse: Bool,
                                updatedGet: Bool)> = .init((false, false, false))
-        self.backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) { result in
+        self.backend.getCustomerInfo(appUserID: Self.userID, isAppBackgrounded: false) { result in
             originalSubscriberInfo.value = result.value
             callOrder.value.initialGet = true
 
@@ -505,7 +505,7 @@ class BackendPostReceiptDataTests: BaseBackendPostReceiptDataTests {
             postSubscriberInfo.value = result.value
         }
 
-        backend.getCustomerInfo(appUserID: Self.userID, withRandomDelay: false) { result in
+        backend.getCustomerInfo(appUserID: Self.userID, isAppBackgrounded: false) { result in
             expect(callOrder.value) == (true, true, false)
             updatedSubscriberInfo.value = result.value
             callOrder.value.updatedGet = true

--- a/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/BasePurchasesTests.swift
@@ -390,7 +390,7 @@ extension BasePurchasesTests {
         )
 
         override func getCustomerInfo(appUserID: String,
-                                      withRandomDelay randomDelay: Bool,
+                                      isAppBackgrounded: Bool,
                                       allowComputingOffline: Bool,
                                       completion: @escaping CustomerAPI.CustomerInfoResponseHandler) {
             self.getCustomerInfoCallCount += 1


### PR DESCRIPTION
See also https://github.com/RevenueCat/purchases-android/pull/1017.
This will be used for dispatching paywall events.