### PR TITLE
`Paywalls`: events unit and integration tests

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -986,6 +986,7 @@
 		4F34AEEB2A5DCCBA00F4BCB0 /* VerificationResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationResultTests.swift; sourceTree = "<group>"; };
 		4F3C98692A44FA60009AECA3 /* ErrorResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorResponse.swift; sourceTree = "<group>"; };
 		4F3D56622A1E66A10070105A /* CustomerInfoManagerPostReceiptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerInfoManagerPostReceiptTests.swift; sourceTree = "<group>"; };
+		4F4EECE32AAFA8DA0047DE7A /* __Snapshots__ */ = {isa = PBXFileReference; lastKnownFileType = folder; path = __Snapshots__; sourceTree = "<group>"; };
 		4F4FF3E02A3B731A0028018C /* ETagStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ETagStrings.swift; sourceTree = "<group>"; };
 		4F54DF3E2A1D8C7500FD72BF /* MockStoreKit2TransactionFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreKit2TransactionFetcher.swift; sourceTree = "<group>"; };
 		4F54DF412A1D8D0700FD72BF /* MockTransactionPoster.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTransactionPoster.swift; sourceTree = "<group>"; };
@@ -2351,6 +2352,7 @@
 		4FE6FEE62AA940E300780B45 /* Events */ = {
 			isa = PBXGroup;
 			children = (
+				4F4EECE32AAFA8DA0047DE7A /* __Snapshots__ */,
 				4FFCED812AA941B200118EF4 /* PaywallEventsBackendTests.swift */,
 				4FFFE6C72AA9467800B2955C /* PaywallEventsManagerTests.swift */,
 				4FFCED802AA941B200118EF4 /* PaywallEventsRequestTests.swift */,
@@ -4183,7 +4185,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Tests/BackendIntegrationTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -4211,7 +4213,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Tests/BackendIntegrationTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -4477,7 +4479,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Tests/BackendIntegrationTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -4505,7 +4507,7 @@
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Tests/BackendIntegrationTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Sources/Diagnostics/FileHandler.swift
+++ b/Sources/Diagnostics/FileHandler.swift
@@ -56,6 +56,8 @@ actor FileHandler: FileHandlerType {
     /// - Note: this loads the entire file in memory
     /// For newer versions, consider using `readLines` instead.
     func readFile() throws -> Data {
+        RCTestAssertNotMainThread()
+
         try self.moveToBeginningOfFile()
 
         return self.fileHandle.availableData
@@ -64,6 +66,8 @@ actor FileHandler: FileHandlerType {
     /// Returns an async sequence for every line in the file
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
     func readLines() throws -> AsyncLineSequence<FileHandle.AsyncBytes> {
+        RCTestAssertNotMainThread()
+
         try self.moveToBeginningOfFile()
 
         return self.fileHandle.bytes.lines
@@ -71,6 +75,8 @@ actor FileHandler: FileHandlerType {
 
     /// Adds a line at the end of the file
     func append(line: String) {
+        RCTestAssertNotMainThread()
+
         self.fileHandle.seekToEndOfFile()
         self.fileHandle.write(line.asData)
         self.fileHandle.write(Self.lineBreakData)

--- a/Sources/Logging/Strings/PaywallsStrings.swift
+++ b/Sources/Logging/Strings/PaywallsStrings.swift
@@ -33,7 +33,7 @@ enum PaywallsStrings {
     case event_flush_already_in_progress
     case event_flush_with_empty_store
     case event_flush_starting(count: Int)
-    case event_flush_failed(BackendError)
+    case event_flush_failed(Error)
 
 }
 
@@ -78,7 +78,7 @@ extension PaywallsStrings: LogMessage {
             return "Paywall event flush: posting \(count) events."
 
         case let .event_flush_failed(error):
-            return "Paywall event flushing failed, will retry. Error: \(error.localizedDescription)"
+            return "Paywall event flushing failed, will retry. Error: \((error as NSError).localizedDescription)"
         }
     }
 

--- a/Sources/Networking/InternalAPI.swift
+++ b/Sources/Networking/InternalAPI.swift
@@ -56,11 +56,14 @@ class InternalAPI {
 
 extension InternalAPI {
 
+    /// - Throws: `BackendError`
     @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-    func postPaywallEvents(events: [PaywallStoredEvent]) async -> BackendError? {
-        return await Async.call { completion in
+    func postPaywallEvents(events: [PaywallStoredEvent]) async throws {
+        let error = await Async.call { completion in
             self.postPaywallEvents(events: events, completion: completion)
         }
+
+        if let error { throw error }
     }
 
 }

--- a/Sources/Paywalls/Events/Networking/PaywallEventsRequest.swift
+++ b/Sources/Paywalls/Events/Networking/PaywallEventsRequest.swift
@@ -33,9 +33,9 @@ extension PaywallEventsRequest {
 
     enum EventType: String {
 
-        case view
-        case cancel
-        case close
+        case impression = "paywall_impression"
+        case cancel = "paywall_cancel"
+        case close = "paywall_close"
 
     }
 
@@ -85,7 +85,7 @@ private extension PaywallEvent {
 
     var eventType: PaywallEventsRequest.EventType {
         switch self {
-        case .view: return .view
+        case .view: return .impression
         case .cancel: return .cancel
         case .close: return .close
         }
@@ -111,7 +111,7 @@ extension PaywallEventsRequest.Event: Encodable {
         case timestamp
         case displayMode
         case darkMode
-        case localeIdentifier
+        case localeIdentifier = "locale"
 
     }
 

--- a/Sources/Paywalls/Events/Networking/PaywallEventsRequest.swift
+++ b/Sources/Paywalls/Events/Networking/PaywallEventsRequest.swift
@@ -47,7 +47,7 @@ extension PaywallEventsRequest {
         var sessionID: String
         var offeringID: String
         var paywallRevision: Int
-        var timestamp: Date
+        var timestamp: UInt64
         var displayMode: PaywallViewMode
         var darkMode: Bool
         var localeIdentifier: String
@@ -69,7 +69,7 @@ extension PaywallEventsRequest.Event {
             sessionID: data.sessionIdentifier.uuidString,
             offeringID: data.offeringIdentifier,
             paywallRevision: data.paywallRevision,
-            timestamp: data.date,
+            timestamp: data.date.millisecondsSince1970,
             displayMode: data.displayMode,
             darkMode: data.darkMode,
             localeIdentifier: data.localeIdentifier

--- a/Sources/Paywalls/Events/PaywallEventStore.swift
+++ b/Sources/Paywalls/Events/PaywallEventStore.swift
@@ -85,10 +85,13 @@ internal actor PaywallEventStore: PaywallEventStoreType {
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
 extension PaywallEventStore {
 
-    static func createDefault() throws -> PaywallEventStore {
-        let url = try Self.documentsDirectory
+    static func createDefault(documentsDirectory: URL?) throws -> PaywallEventStore {
+        let documentsDirectory = try documentsDirectory ?? Self.documentsDirectory
+        let url = documentsDirectory
             .appendingPathComponent("revenuecat")
             .appendingPathComponent("paywall_event_store")
+
+        Logger.verbose(PaywallEventStoreStrings.initializing(url))
 
         return try .init(handler: FileHandler(url))
     }
@@ -116,6 +119,8 @@ extension PaywallEventStore {
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private enum PaywallEventStoreStrings {
 
+    case initializing(URL)
+
     case storing_event(PaywallEvent)
 
     case error_storing_event(Error)
@@ -131,6 +136,9 @@ extension PaywallEventStoreStrings: LogMessage {
 
     var description: String {
         switch self {
+        case let .initializing(directory):
+            return "Initializing PaywallEventStore: \(directory.absoluteString)"
+
         case let .storing_event(event):
             return "Storing event: \(event.debugDescription)"
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -260,6 +260,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     convenience init(apiKey: String,
                      appUserID: String?,
                      userDefaults: UserDefaults? = nil,
+                     documentsDirectory: URL? = nil,
                      observerMode: Bool = false,
                      platformInfo: PlatformInfo? = Purchases.platformInfo,
                      responseVerificationMode: Signing.ResponseVerificationMode,
@@ -359,7 +360,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                 paywallEventsManager = PaywallEventsManager(
                     internalAPI: backend.internalAPI,
                     userProvider: identityManager,
-                    store: try PaywallEventStore.createDefault()
+                    store: try PaywallEventStore.createDefault(documentsDirectory: documentsDirectory)
                 )
                 Logger.verbose(Strings.paywalls.event_manager_initialized)
             } else {
@@ -1266,6 +1267,7 @@ public extension Purchases {
         appUserID: String?,
         observerMode: Bool,
         userDefaults: UserDefaults?,
+        documentsDirectory: URL? = nil,
         platformInfo: PlatformInfo?,
         responseVerificationMode: Signing.ResponseVerificationMode,
         storeKit2Setting: StoreKit2Setting,
@@ -1277,6 +1279,7 @@ public extension Purchases {
             .init(apiKey: apiKey,
                   appUserID: appUserID,
                   userDefaults: userDefaults,
+                  documentsDirectory: documentsDirectory,
                   observerMode: observerMode,
                   platformInfo: platformInfo,
                   responseVerificationMode: responseVerificationMode,
@@ -1529,6 +1532,13 @@ internal extension Purchases {
 
     func invalidateOfferingsCache() {
         self.offeringsManager.invalidateCachedOfferings(appUserID: self.appUserID)
+    }
+
+    /// - Throws: if posting events fails
+    /// - Returns: the number of events posted
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
+    func flushPaywallEvents(count: Int) async throws -> Int {
+        return try await self.paywallEventsManager?.flushEvents(count: count) ?? 0
     }
 
 }

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -61,10 +61,14 @@ class BaseBackendIntegrationTests: TestCase {
     var proxyURL: String? { return Constants.proxyURL }
 
     func configurePurchases() {
+        Purchases.proxyURL = self.proxyURL.flatMap(URL.init(string:))
+        Purchases.logLevel = .verbose
+
         Purchases.configure(withAPIKey: self.apiKey,
                             appUserID: nil,
                             observerMode: Self.observerMode,
                             userDefaults: self.userDefaults,
+                            documentsDirectory: self.documentsDirectory,
                             platformInfo: nil,
                             responseVerificationMode: Self.responseVerificationMode,
                             storeKit2Setting: Self.storeKit2Setting,
@@ -173,8 +177,6 @@ private extension BaseBackendIntegrationTests {
         self.simulateForegroundingApp()
 
         Purchases.shared.delegate = self.purchasesDelegate
-        Purchases.proxyURL = self.proxyURL.flatMap(URL.init(string:))
-        Purchases.logLevel = .verbose
 
         await self.waitForAnonymousUser()
     }
@@ -216,6 +218,12 @@ private extension BaseBackendIntegrationTests {
     private var dangerousSettings: DangerousSettings {
         return .init(autoSyncPurchases: true,
                      internalSettings: self)
+    }
+
+    var documentsDirectory: URL {
+        return URL
+            .cachesDirectory
+            .appendingPathComponent(UUID().uuidString, conformingTo: .directory)
     }
 
 }

--- a/Tests/UnitTests/Mocks/MockPaywallEventsManager.swift
+++ b/Tests/UnitTests/Mocks/MockPaywallEventsManager.swift
@@ -26,9 +26,11 @@ actor MockPaywallEventsManager: PaywallEventsManagerType {
     var invokedFlushEvents = false
     var invokedFlushEventsCount = 0
 
-    func flushEvents(count: Int) async {
+    func flushEvents(count: Int) async -> Int {
         self.invokedFlushEvents = true
         self.invokedFlushEventsCount += 1
+
+        return 0
     }
 
 }

--- a/Tests/UnitTests/Paywalls/Events/PaywallEventStoreTests.swift
+++ b/Tests/UnitTests/Paywalls/Events/PaywallEventStoreTests.swift
@@ -33,7 +33,7 @@ class PaywallEventStoreTests: TestCase {
     // - MARK: -
 
     func testCreateDefaultDoesNotThrow() throws {
-        _ = try PaywallEventStore.createDefault()
+        _ = try PaywallEventStore.createDefault(documentsDirectory: nil)
     }
 
     // - MARK: store and fetch

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithMultipleEvents.1.json
@@ -13,7 +13,7 @@
           "offering_id" : "offering_1",
           "paywall_revision" : 5,
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
-          "timestamp" : 715722128,
+          "timestamp" : 1694029328000,
           "type" : "paywall_impression",
           "version" : 1
         },
@@ -25,7 +25,7 @@
           "offering_id" : "offering_2",
           "paywall_revision" : 3,
           "session_id" : "10CC0F1D-7665-4093-9624-1D7308FFF4DB",
-          "timestamp" : 715715121,
+          "timestamp" : 1694022321000,
           "type" : "paywall_close",
           "version" : 1
         }

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithMultipleEvents.1.json
@@ -9,24 +9,24 @@
           "app_user_id" : "user",
           "dark_mode" : true,
           "display_mode" : "condensed_footer",
-          "locale_identifier" : "es_ES",
+          "locale" : "es_ES",
           "offering_id" : "offering_1",
           "paywall_revision" : 5,
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 715722128,
-          "type" : "view",
+          "type" : "paywall_impression",
           "version" : 1
         },
         {
           "app_user_id" : "user",
           "dark_mode" : false,
           "display_mode" : "full_screen",
-          "locale_identifier" : "en_US",
+          "locale" : "en_US",
           "offering_id" : "offering_2",
           "paywall_revision" : 3,
           "session_id" : "10CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 715715121,
-          "type" : "close",
+          "type" : "paywall_close",
           "version" : 1
         }
       ]

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithOneEvent.1.json
@@ -9,12 +9,12 @@
           "app_user_id" : "user",
           "dark_mode" : true,
           "display_mode" : "condensed_footer",
-          "locale_identifier" : "es_ES",
+          "locale" : "es_ES",
           "offering_id" : "offering_1",
           "paywall_revision" : 5,
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 715722128,
-          "type" : "view",
+          "type" : "paywall_impression",
           "version" : 1
         }
       ]

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS15-testPostPaywallEventsWithOneEvent.1.json
@@ -13,7 +13,7 @@
           "offering_id" : "offering_1",
           "paywall_revision" : 5,
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
-          "timestamp" : 715722128,
+          "timestamp" : 1694029328000,
           "type" : "paywall_impression",
           "version" : 1
         }

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithMultipleEvents.1.json
@@ -13,7 +13,7 @@
           "offering_id" : "offering_1",
           "paywall_revision" : 5,
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
-          "timestamp" : 715722128,
+          "timestamp" : 1694029328000,
           "type" : "paywall_impression",
           "version" : 1
         },
@@ -25,7 +25,7 @@
           "offering_id" : "offering_2",
           "paywall_revision" : 3,
           "session_id" : "10CC0F1D-7665-4093-9624-1D7308FFF4DB",
-          "timestamp" : 715715121,
+          "timestamp" : 1694022321000,
           "type" : "paywall_close",
           "version" : 1
         }

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithMultipleEvents.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithMultipleEvents.1.json
@@ -9,24 +9,24 @@
           "app_user_id" : "user",
           "dark_mode" : true,
           "display_mode" : "condensed_footer",
-          "locale_identifier" : "es_ES",
+          "locale" : "es_ES",
           "offering_id" : "offering_1",
           "paywall_revision" : 5,
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 715722128,
-          "type" : "view",
+          "type" : "paywall_impression",
           "version" : 1
         },
         {
           "app_user_id" : "user",
           "dark_mode" : false,
           "display_mode" : "full_screen",
-          "locale_identifier" : "en_US",
+          "locale" : "en_US",
           "offering_id" : "offering_2",
           "paywall_revision" : 3,
           "session_id" : "10CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 715715121,
-          "type" : "close",
+          "type" : "paywall_close",
           "version" : 1
         }
       ]

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithOneEvent.1.json
@@ -9,12 +9,12 @@
           "app_user_id" : "user",
           "dark_mode" : true,
           "display_mode" : "condensed_footer",
-          "locale_identifier" : "es_ES",
+          "locale" : "es_ES",
           "offering_id" : "offering_1",
           "paywall_revision" : 5,
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
           "timestamp" : 715722128,
-          "type" : "view",
+          "type" : "paywall_impression",
           "version" : 1
         }
       ]

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithOneEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsBackendTests/iOS16-testPostPaywallEventsWithOneEvent.1.json
@@ -13,7 +13,7 @@
           "offering_id" : "offering_1",
           "paywall_revision" : 5,
           "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
-          "timestamp" : 715722128,
+          "timestamp" : 1694029328000,
           "type" : "paywall_impression",
           "version" : 1
         }

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsRequestTests/testCancelEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsRequestTests/testCancelEvent.1.json
@@ -2,11 +2,11 @@
   "app_user_id" : "Jack Shepard",
   "dark_mode" : true,
   "display_mode" : "condensed_footer",
-  "locale_identifier" : "es_ES",
+  "locale" : "es_ES",
   "offering_id" : "offering",
   "paywall_revision" : 5,
   "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
   "timestamp" : 715722128,
-  "type" : "cancel",
+  "type" : "paywall_cancel",
   "version" : 1
 }

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsRequestTests/testCancelEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsRequestTests/testCancelEvent.1.json
@@ -6,7 +6,7 @@
   "offering_id" : "offering",
   "paywall_revision" : 5,
   "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
-  "timestamp" : 715722128,
+  "timestamp" : 1694029328000,
   "type" : "paywall_cancel",
   "version" : 1
 }

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsRequestTests/testCloseEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsRequestTests/testCloseEvent.1.json
@@ -6,7 +6,7 @@
   "offering_id" : "offering",
   "paywall_revision" : 5,
   "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
-  "timestamp" : 715722128,
+  "timestamp" : 1694029328000,
   "type" : "paywall_close",
   "version" : 1
 }

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsRequestTests/testCloseEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsRequestTests/testCloseEvent.1.json
@@ -2,11 +2,11 @@
   "app_user_id" : "Jack Shepard",
   "dark_mode" : true,
   "display_mode" : "condensed_footer",
-  "locale_identifier" : "es_ES",
+  "locale" : "es_ES",
   "offering_id" : "offering",
   "paywall_revision" : 5,
   "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
   "timestamp" : 715722128,
-  "type" : "close",
+  "type" : "paywall_close",
   "version" : 1
 }

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsRequestTests/testViewEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsRequestTests/testViewEvent.1.json
@@ -6,7 +6,7 @@
   "offering_id" : "offering",
   "paywall_revision" : 5,
   "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
-  "timestamp" : 715722128,
+  "timestamp" : 1694029328000,
   "type" : "paywall_impression",
   "version" : 1
 }

--- a/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsRequestTests/testViewEvent.1.json
+++ b/Tests/UnitTests/Paywalls/Events/__Snapshots__/PaywallEventsRequestTests/testViewEvent.1.json
@@ -2,11 +2,11 @@
   "app_user_id" : "Jack Shepard",
   "dark_mode" : true,
   "display_mode" : "condensed_footer",
-  "locale_identifier" : "es_ES",
+  "locale" : "es_ES",
   "offering_id" : "offering",
   "paywall_revision" : 5,
   "session_id" : "98CC0F1D-7665-4093-9624-1D7308FFF4DB",
   "timestamp" : 715722128,
-  "type" : "view",
+  "type" : "paywall_impression",
   "version" : 1
 }


### PR DESCRIPTION
### Changes:
- Added `PurchasesOrchestrator` tests for paywall data sent through post receipt
- Fixed and tested state issue with cached paywall data and failed purchases
- Added `Integration Tests` for tracking and flushing events
- Configured `Integration Tests` with a custom documents directory to ensure it's empty on every test invocation
- Changed deployment target on `Integration Tests` to iOS 16 to simplify code
- Setting `Purchases.logLevel` before configuring purchases on `Integration Tests`
- Added assertion to ensure `FileHandler` never runs on the main thread