### PR TITLE
`Paywalls`: don't apply dark appearance with no dark mode colors

### DIFF
--- a/RevenueCatUI/Helpers/ColorInformation+MultiScheme.swift
+++ b/RevenueCatUI/Helpers/ColorInformation+MultiScheme.swift
@@ -32,16 +32,6 @@ extension PaywallData.Configuration.ColorInformation {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
-extension TemplateViewConfiguration {
-
-    /// Whether  dark mode colors have been configured in this paywall.
-    var hasDarkMode: Bool {
-        return self.configuration.colors.dark != nil
-    }
-
-}
-
 extension PaywallData.Configuration.Colors {
 
     @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
@@ -86,6 +76,16 @@ extension PaywallData.Configuration.ColorInformation {
 }
 
 #endif
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+extension TemplateViewConfiguration {
+
+    /// Whether dark mode colors have been configured in this paywall.
+    var hasDarkMode: Bool {
+        return self.configuration.colors.dark != nil
+    }
+
+}
 
 #if canImport(SwiftUI)
 

--- a/RevenueCatUI/Helpers/ColorInformation+MultiScheme.swift
+++ b/RevenueCatUI/Helpers/ColorInformation+MultiScheme.swift
@@ -32,6 +32,16 @@ extension PaywallData.Configuration.ColorInformation {
 
 }
 
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+extension TemplateViewConfiguration {
+
+    /// Whether  dark mode colors have been configured in this paywall.
+    var hasDarkMode: Bool {
+        return self.configuration.colors.dark != nil
+    }
+
+}
+
 extension PaywallData.Configuration.Colors {
 
     @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -90,11 +90,19 @@ extension PaywallData {
                                   fonts: fonts,
                                   locale: locale) {
         case let .success(configuration):
-            Self.createView(template: template, configuration: configuration)
+            let view = Self.createView(template: template, configuration: configuration)
                 .task(id: offering) {
                     await introEligibility.computeEligibility(for: configuration.packages)
                 }
                 .background(configuration.backgroundView)
+
+            if configuration.hasDarkMode {
+                view
+            } else {
+                // If paywall has no dark mode configured, prevent materials
+                // and other SwiftUI elements from automatically taking a dark appearance.
+                view.environment(\.colorScheme, .light)
+            }
 
         case let .failure(error):
             DebugErrorView(error, releaseBehavior: .emptyView)


### PR DESCRIPTION
Reported by @joshdholtz. If the developer doesn't configure dark colors, we don't want things like materials from inheriting the automatic dark mode configuration.