### PR TITLE
`Paywalls`: fixed template 2 + `.condensedFooter` + iPad

### DIFF
--- a/RevenueCatUI/Templates/Template2View.swift
+++ b/RevenueCatUI/Templates/Template2View.swift
@@ -51,7 +51,7 @@ struct Template2View: TemplateViewType {
     @ViewBuilder
     var content: some View {
         VStack(spacing: self.defaultVerticalPaddingLength) {
-            // Avoid unnecessary spacing, except for iOS 15 because SwiftuI breaks the layout.
+            // Avoid unnecessary spacing, except for iOS 15 because SwiftUI breaks the layout.
             Spacer(minLength: VersionDetector.iOS15 ? nil : 0)
 
             self.scrollableContent
@@ -71,7 +71,13 @@ struct Template2View: TemplateViewType {
         .animation(Constants.fastAnimation, value: self.selectedPackage)
         .multilineTextAlignment(.center)
         .frame(maxHeight: .infinity)
-        .padding(.top, self.defaultVerticalPaddingLength)
+        .padding(
+            .top,
+            self.displayingAllPlans
+            ? self.defaultVerticalPaddingLength
+            // Compensate for additional padding on condensed mode + iPad
+            : self.defaultVerticalPaddingLength.map { $0 * -1 }
+        )
     }
 
     private var scrollableContent: some View {


### PR DESCRIPTION
Follow up to #3171.

### Before:
![image](https://github.com/RevenueCat/purchases-ios/assets/685609/aec73f92-9bbf-4edd-986a-e14951649028)

### After:
![image](https://github.com/RevenueCat/purchases-ios/assets/685609/693aa199-c9a0-4ee9-839a-e4227e0ba0b1)
