### PR TITLE
`Paywalls`: fixed data flow resulting in multiple `PurchaseHandler` instances

### DIFF
--- a/RevenueCatUI/Helpers/TrialOrIntroEligibilityChecker.swift
+++ b/RevenueCatUI/Helpers/TrialOrIntroEligibilityChecker.swift
@@ -19,6 +19,9 @@ final class TrialOrIntroEligibilityChecker: ObservableObject {
 
     typealias Checker = @Sendable ([Package]) async -> [Package: IntroEligibilityStatus]
 
+    /// `false` if this `TrialOrIntroEligibilityChecker` is not backend by a configured `Purchases`instance.
+    let isConfigured: Bool
+
     let checker: Checker
 
     convenience init(purchases: Purchases = .shared) {
@@ -29,12 +32,19 @@ final class TrialOrIntroEligibilityChecker: ObservableObject {
     }
 
     /// Creates an instance with a custom checker, useful for testing or previews.
-    init(checker: @escaping Checker) {
+    init(isConfigured: Bool = true, checker: @escaping Checker) {
+        self.isConfigured = isConfigured
         self.checker = checker
     }
 
-    static func `default`() -> Self? {
-        return Purchases.isConfigured ? .init() : nil
+    static func `default`() -> Self {
+        return Purchases.isConfigured ? .init() : .notConfigured()
+    }
+
+    private static func notConfigured() -> Self {
+        return .init(isConfigured: false) { _ in
+            return [:]
+        }
     }
 
 }

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -142,12 +142,12 @@ private struct PresentingPaywallModifier: ViewModifier {
                     .onPurchaseCompleted {
                         self.purchaseCompleted?($0)
 
-                        self.data = nil
+                        self.close()
                     }
                     .toolbar {
                         ToolbarItem(placement: .destructiveAction) {
                             Button {
-                                self.data = nil
+                                self.close()
                             } label: {
                                 Image(systemName: "xmark")
                             }
@@ -168,6 +168,10 @@ private struct PresentingPaywallModifier: ViewModifier {
                     Logger.debug(Strings.not_displaying_paywall)
                 }
             }
+    }
+
+    private func close() {
+        self.data = nil
     }
 
 }


### PR DESCRIPTION
This was breaking event notifications as well as `OnPurchaseCompletedModifier`, because there were multiple `PurchaseHandler` instances created.

The solution is to make `PaywallView` store these as `@StateObject`. In order to do that, the type can't be optional, so I instead encoded the "is configured" information inside.