### PR TITLE
`Paywalls`: test plan for running non-snapshot tests

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/RevenueCatUI.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/RevenueCatUI.xcscheme
@@ -38,6 +38,9 @@
          <TestPlanReference
             reference = "container:Tests/RevenueCatUITests/TestPlans/CI-RevenueCatUI.xctestplan">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:Tests/RevenueCatUITests/TestPlans/RevenueCatUI-UnitTests.xctestplan">
+         </TestPlanReference>
       </TestPlans>
       <Testables>
          <TestableReference

--- a/Tests/RevenueCatUITests/BaseSnapshotTest.swift
+++ b/Tests/RevenueCatUITests/BaseSnapshotTest.swift
@@ -34,7 +34,14 @@ class BaseSnapshotTest: TestCase {
     override class func setUp() {
         super.setUp()
 
+        // Uncomment this line to manually record snapshots:
         // isRecording = true
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        try Self.skipTestIfNeeded()
     }
 
     static func createPaywall(
@@ -50,6 +57,13 @@ class BaseSnapshotTest: TestCase {
                            fonts: fonts,
                            introEligibility: eligibleChecker,
                            purchaseHandler: purchaseHandler)
+    }
+
+    private static func skipTestIfNeeded() throws {
+        try XCTSkipIf(
+            ProcessInfo.processInfo.environment["RC_SKIP_SNAPSHOT_TESTS"] == "1",
+            "Skipping snapshot test"
+        )
     }
 
 }

--- a/Tests/RevenueCatUITests/TestPlans/RevenueCatUI-UnitTests.xctestplan
+++ b/Tests/RevenueCatUITests/TestPlans/RevenueCatUI-UnitTests.xctestplan
@@ -1,0 +1,32 @@
+{
+  "configurations" : [
+    {
+      "id" : "9A1CEA19-F9E9-4C9C-9FC8-6F9A5B29F2AE",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "environmentVariableEntries" : [
+      {
+        "key" : "RC_SKIP_SNAPSHOT_TESTS",
+        "value" : "1"
+      }
+    ],
+    "maximumTestExecutionTimeAllowance" : 180,
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "RevenueCatUITests",
+        "name" : "RevenueCatUITests"
+      }
+    }
+  ],
+  "version" : 1
+}


### PR DESCRIPTION
Snapshot tests are inherently slow. Sometimes it's useful to be able to run the rest of unit tests alone, and this test plan makes that easier.