### PR TITLE
`Paywalls`: convert empty images into `nil`

### DIFF
--- a/Sources/Paywalls/PaywallData.swift
+++ b/Sources/Paywalls/PaywallData.swift
@@ -262,13 +262,29 @@ extension PaywallData.Configuration {
     public struct Images {
 
         /// Image displayed as a header in a template.
-        public var header: String?
+        public var header: String? {
+            get { self._header }
+            set { self._header = newValue }
+        }
 
         /// Image displayed as a background in a template.
-        public var background: String?
+        public var background: String? {
+            get { self._background }
+            set { self._background = newValue }
+        }
 
         /// Image displayed as an app icon in a template.
-        public var icon: String?
+        public var icon: String? {
+            get { self._icon }
+            set { self._icon = newValue }
+        }
+
+        @NonEmptyStringDecodable
+        var _header: String?
+        @NonEmptyStringDecodable
+        var _background: String?
+        @NonEmptyStringDecodable
+        var _icon: String?
 
         // swiftlint:disable:next missing_docs
         public init(header: String? = nil, background: String? = nil, icon: String? = nil) {
@@ -418,7 +434,16 @@ extension PaywallData.LocalizedConfiguration: Codable {
 
 extension PaywallData.Configuration.ColorInformation: Codable {}
 extension PaywallData.Configuration.Colors: Codable {}
-extension PaywallData.Configuration.Images: Codable {}
+
+extension PaywallData.Configuration.Images: Codable {
+
+    private enum CodingKeys: String, CodingKey {
+        case _header = "header"
+        case _background = "background"
+        case _icon = "icon"
+    }
+
+}
 
 extension PaywallData.Configuration: Codable {
 

--- a/Tests/BackendIntegrationTests/__Snapshots__/LoadShedderIntegrationTests/testCanGetOfferings.1.json
+++ b/Tests/BackendIntegrationTests/__Snapshots__/LoadShedderIntegrationTests/testCanGetOfferings.1.json
@@ -34,7 +34,9 @@
           },
           "display_restore_purchases" : true,
           "images" : {
-            "header" : "903907_1693958145.jpg"
+            "background" : null,
+            "header" : "903907_1693958145.jpg",
+            "icon" : null
           },
           "packages" : [
             "$rc_monthly"

--- a/Tests/BackendIntegrationTests/__Snapshots__/StoreKitIntegrationTests/testCanGetOfferings.1.json
+++ b/Tests/BackendIntegrationTests/__Snapshots__/StoreKitIntegrationTests/testCanGetOfferings.1.json
@@ -47,6 +47,7 @@
           "display_restore_purchases" : true,
           "images" : {
             "background" : "300883_1691437592.jpg",
+            "header" : null,
             "icon" : "300883_1691437591.jpg"
           },
           "packages" : [

--- a/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedIconsGeneratesDefaultPaywall.1.json
+++ b/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedIconsGeneratesDefaultPaywall.1.json
@@ -15,6 +15,7 @@
     "display_restore_purchases" : true,
     "images" : {
       "background" : "background.jpg",
+      "header" : null,
       "icon" : "revenuecatui_default_paywall_app_icon"
     },
     "packages" : [

--- a/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedTemplateNameGeneratesDefaultPaywall.1.json
+++ b/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedTemplateNameGeneratesDefaultPaywall.1.json
@@ -15,6 +15,7 @@
     "display_restore_purchases" : true,
     "images" : {
       "background" : "background.jpg",
+      "header" : null,
       "icon" : "revenuecatui_default_paywall_app_icon"
     },
     "packages" : [

--- a/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedVariableGeneratesDefaultPaywall.1.json
+++ b/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedVariableGeneratesDefaultPaywall.1.json
@@ -15,6 +15,7 @@
     "display_restore_purchases" : true,
     "images" : {
       "background" : "background.jpg",
+      "header" : null,
       "icon" : "revenuecatui_default_paywall_app_icon"
     },
     "packages" : [

--- a/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedVariableInFeaturesGeneratesDefaultPaywall.1.json
+++ b/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testUnrecognizedVariableInFeaturesGeneratesDefaultPaywall.1.json
@@ -15,6 +15,7 @@
     "display_restore_purchases" : true,
     "images" : {
       "background" : "background.jpg",
+      "header" : null,
       "icon" : "revenuecatui_default_paywall_app_icon"
     },
     "packages" : [

--- a/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testValidateMissingPaywall.1.json
+++ b/Tests/RevenueCatUITests/Data/__Snapshots__/PaywallDataValidationTests/testValidateMissingPaywall.1.json
@@ -15,6 +15,7 @@
     "display_restore_purchases" : true,
     "images" : {
       "background" : "background.jpg",
+      "header" : null,
       "icon" : "revenuecatui_default_paywall_app_icon"
     },
     "packages" : [

--- a/Tests/UnitTests/Networking/Responses/Fixtures/PaywallData-empty_images.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/PaywallData-empty_images.json
@@ -1,0 +1,32 @@
+{
+    "template_name": "1",
+    "localized_strings": {
+        "en_US": {
+            "title": "Paywall",
+            "subtitle": "Description",
+            "call_to_action": "Purchase now",
+            "call_to_action_with_intro_offer": "Purchase now",
+            "offer_details": "{{ sub_price_per_month }} per month",
+            "offer_details_with_intro_offer": "Start your {{ sub_offer_duration }} trial, then {{ sub_price_per_month }} per month"
+        }
+    },
+    "config": {
+        "packages": ["$rc_monthly", "$rc_annual"],
+        "images": {
+            "header": "",
+            "background": "",
+            "icon": ""
+        },
+        "colors": {
+            "light": {
+                "background": "#FFFFFF",
+                "text_1": "#FFFFFF",
+                "call_to_action_background": "#FFFFFF",
+                "call_to_action_foreground": "#FFFFFF",
+                "accent_1": "#FFFFFF"
+            },
+            "dark": null
+        }
+    },
+    "asset_base_url": "https://rc-paywalls.s3.amazonaws.com"
+}

--- a/Tests/UnitTests/Paywalls/PaywallDataTests.swift
+++ b/Tests/UnitTests/Paywalls/PaywallDataTests.swift
@@ -109,6 +109,15 @@ class PaywallDataTests: BaseHTTPResponseTest {
         expect(localization.title) == "Tienda"
     }
 
+    func testEmptyImageNamesAreParsedAsNil() throws {
+        let paywall: PaywallData = try self.decodeFixture("PaywallData-empty_images")
+
+        let images = paywall.config.images
+        expect(images.header).to(beNil())
+        expect(images.background).to(beNil())
+        expect(images.icon).to(beNil())
+    }
+
     func testEncodePaywallViewMode() throws {
         // iOS 12 does not allow decoding fragments (top-level objects)
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()


### PR DESCRIPTION
Ideally the backend would never send `""` for images, but better to be defensive.