### PR TITLE
`Paywalls`: fixed broken layout on template 4

### DIFF
--- a/RevenueCatUI/Data/PaywallTemplate.swift
+++ b/RevenueCatUI/Data/PaywallTemplate.swift
@@ -19,9 +19,9 @@ internal enum PaywallTemplate: String {
     case template1 = "1"
     case template2 = "2"
     case template3 = "3"
+    case template4 = "4"
 
     // Temporarily disabled until it's supported in the dashboard
-    case template4 = "4_disabled"
     case template5 = "5_disabled"
 
 }

--- a/RevenueCatUI/Templates/Template4View.swift
+++ b/RevenueCatUI/Templates/Template4View.swift
@@ -25,7 +25,7 @@ struct Template4View: TemplateViewType {
     private var selectedPackage: TemplateViewConfiguration.Package
 
     @State
-    private var packageContentHeight: CGFloat = 10
+    private var packageContentHeight: CGFloat?
     @State
     private var containerWidth: CGFloat = 600
     @State
@@ -165,14 +165,14 @@ struct Template4View: TemplateViewType {
                               packageWidth: self.packageWidth,
                               desiredHeight: nil)
                 .onSizeChange(.vertical) {
-                    if $0 > self.packageContentHeight {
+                    if $0 > self.packageContentHeight ?? 0 {
                         self.packageContentHeight = $0
                     }
                 }
             }
         }
-        .onChange(of: self.dynamicTypeSize) { _ in self.packageContentHeight = 0 }
-        .onChange(of: self.packageWidth) { _ in self.packageContentHeight = 0 }
+        .onChange(of: self.dynamicTypeSize) { _ in self.packageContentHeight = nil }
+        .onChange(of: self.containerWidth) { _ in self.packageContentHeight = nil }
         .hidden()
     }
 

--- a/RevenueCatUI/Templates/Template4View.swift
+++ b/RevenueCatUI/Templates/Template4View.swift
@@ -102,6 +102,7 @@ struct Template4View: TemplateViewType {
 
             self.subscribeButton
                 .defaultHorizontalPadding()
+                .padding(.bottom, Self.verticalPadding / -2)
 
             FooterView(configuration: self.configuration,
                        bold: false,


### PR DESCRIPTION
I broke this on #3183.

![image](https://github.com/RevenueCat/purchases-ios/assets/685609/6911eac4-f251-4a32-8b93-d748e184466b)

We need to reset the height calculation when the inputs change, but setting it to 0 was making it layout with a 0 height instead of unlimited height to measure it.

This also now enables template 4 since it's ready!