### PR TITLE
Fix runtime crash in SK2TransactionListener in iOS < 15

### DIFF
--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
@@ -62,11 +62,10 @@ actor StoreKit2TransactionListener: StoreKit2TransactionListenerType {
     // We can't directly store instances of `AsyncStream`, since that causes runtime crashes when
     // loading this type in iOS <= 15, even with @available checks correctly in place.
     // See https://openradar.appspot.com/radar?id=4970535809187840 / https://github.com/apple/swift/issues/58099
-    private let _updates: Any
+    private let _updates: Box<AsyncStream<TransactionResult>>
 
     var updates: AsyncStream<TransactionResult> {
-        // swiftlint:disable:next force_cast
-        return self._updates as! AsyncStream<TransactionResult>
+        return self._updates.value
     }
 
     init(delegate: StoreKit2TransactionListenerDelegate? = nil) {
@@ -80,7 +79,7 @@ actor StoreKit2TransactionListener: StoreKit2TransactionListenerType {
         updates: S
     ) where S.Element == TransactionResult {
         self.delegate = delegate
-        self._updates = updates.toAsyncStream()
+        self._updates = .init(updates.toAsyncStream())
     }
 
     func set(delegate: StoreKit2TransactionListenerDelegate) {

--- a/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
+++ b/Sources/Purchasing/StoreKit2/StoreKit2TransactionListener.swift
@@ -58,7 +58,16 @@ actor StoreKit2TransactionListener: StoreKit2TransactionListenerType {
     private(set) var taskHandle: Task<Void, Never>?
 
     private weak var delegate: StoreKit2TransactionListenerDelegate?
-    private let updates: AsyncStream<TransactionResult>
+
+    // We can't directly store instances of `AsyncStream`, since that causes runtime crashes when
+    // loading this type in iOS <= 15, even with @available checks correctly in place.
+    // See https://openradar.appspot.com/radar?id=4970535809187840 / https://github.com/apple/swift/issues/58099
+    private let _updates: Any
+
+    var updates: AsyncStream<TransactionResult> {
+        // swiftlint:disable:next force_cast
+        return self._updates as! AsyncStream<TransactionResult>
+    }
 
     init(delegate: StoreKit2TransactionListenerDelegate? = nil) {
         self.init(delegate: delegate, updates: StoreKit.Transaction.updates)
@@ -71,7 +80,7 @@ actor StoreKit2TransactionListener: StoreKit2TransactionListenerType {
         updates: S
     ) where S.Element == TransactionResult {
         self.delegate = delegate
-        self.updates = updates.toAsyncStream()
+        self._updates = updates.toAsyncStream()
     }
 
     func set(delegate: StoreKit2TransactionListenerDelegate) {


### PR DESCRIPTION
### Description
We found that there was another runtime crash in Capacitor in iOS < 15 similar to https://github.com/RevenueCat/purchases-ios/pull/3139. This applies the same fix to this new crash.
