### PR TITLE
`Integration Tests`: prevent false positives when purchasing returns 5xx

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -315,6 +315,8 @@
 		4FE6FEE52AA940B800780B45 /* PaywallStoredEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE6FEE42AA940B700780B45 /* PaywallStoredEvent.swift */; };
 		4FE6FEEA2AA940E300780B45 /* PaywallEventStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE6FEE72AA940E300780B45 /* PaywallEventStoreTests.swift */; };
 		4FE6FEEB2AA940E300780B45 /* PaywallEventSerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE6FEE82AA940E300780B45 /* PaywallEventSerializerTests.swift */; };
+		4FF017C32AB378A7004976EB /* BaseStoreKitIntegrationTests+Verification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF017C22AB378A7004976EB /* BaseStoreKitIntegrationTests+Verification.swift */; };
+		4FF017C42AB378A7004976EB /* BaseStoreKitIntegrationTests+Verification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF017C22AB378A7004976EB /* BaseStoreKitIntegrationTests+Verification.swift */; };
 		4FF8464D2A32554300617F00 /* DiagnosticsStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF8464C2A32554300617F00 /* DiagnosticsStrings.swift */; };
 		4FFCED822AA941B200118EF4 /* PaywallEventsRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFCED802AA941B200118EF4 /* PaywallEventsRequestTests.swift */; };
 		4FFCED832AA941B200118EF4 /* PaywallEventsBackendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFCED812AA941B200118EF4 /* PaywallEventsBackendTests.swift */; };
@@ -1053,6 +1055,7 @@
 		4FE6FEE72AA940E300780B45 /* PaywallEventStoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallEventStoreTests.swift; sourceTree = "<group>"; };
 		4FE6FEE82AA940E300780B45 /* PaywallEventSerializerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallEventSerializerTests.swift; sourceTree = "<group>"; };
 		4FED3AD62AAA7DD4001D4D5E /* purchases-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "purchases-ios"; path = ..; sourceTree = "<group>"; };
+		4FF017C22AB378A7004976EB /* BaseStoreKitIntegrationTests+Verification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BaseStoreKitIntegrationTests+Verification.swift"; sourceTree = "<group>"; };
 		4FF8464C2A32554300617F00 /* DiagnosticsStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsStrings.swift; sourceTree = "<group>"; };
 		4FFCED802AA941B200118EF4 /* PaywallEventsRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallEventsRequestTests.swift; sourceTree = "<group>"; };
 		4FFCED812AA941B200118EF4 /* PaywallEventsBackendTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallEventsBackendTests.swift; sourceTree = "<group>"; };
@@ -2303,6 +2306,7 @@
 				4FDF10EC2A726291004F3680 /* SK1ProductFetcher.swift */,
 				4FDF10EF2A7262D8004F3680 /* SK2ProductFetcher.swift */,
 				4F90AFCA2A3915340047E63F /* TestMessage.swift */,
+				4FF017C22AB378A7004976EB /* BaseStoreKitIntegrationTests+Verification.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -3834,6 +3838,7 @@
 				4F83F6B62A5DB773003F90A5 /* TestCase.swift in Sources */,
 				4FCBA84F2A15391B004134BD /* SnapshotTesting+Extensions.swift in Sources */,
 				4FFFE6E72AA948A600B2955C /* PaywallEventsIntegrationTests.swift in Sources */,
+				4FF017C32AB378A7004976EB /* BaseStoreKitIntegrationTests+Verification.swift in Sources */,
 				4FA696BD2A0020A000D228B1 /* MainThreadMonitor.swift in Sources */,
 				2D3BFAD126DEA45C00370B11 /* MockSK1Product.swift in Sources */,
 				57DD426E2926B9A50026DF09 /* StoreKitTestHelpers.swift in Sources */,
@@ -3892,6 +3897,7 @@
 				4F7C37E42A27EFE1001E17D3 /* BaseBackendIntegrationTests.swift in Sources */,
 				4FDF10EE2A726291004F3680 /* SK1ProductFetcher.swift in Sources */,
 				4F6BEE882A27E16B00CD9322 /* TestLogHandler.swift in Sources */,
+				4FF017C42AB378A7004976EB /* BaseStoreKitIntegrationTests+Verification.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/BackendIntegrationTests/Helpers/BaseStoreKitIntegrationTests+Verification.swift
+++ b/Tests/BackendIntegrationTests/Helpers/BaseStoreKitIntegrationTests+Verification.swift
@@ -1,0 +1,188 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  BaseStoreKitIntegrationTests+Verification.swift
+//
+//  Created by Nacho Soto on 9/14/23.
+
+import Foundation
+import Nimble
+import XCTest
+
+#if ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+@testable import RevenueCat_CustomEntitlementComputation
+#else
+@testable import RevenueCat
+#endif
+
+extension BaseStoreKitIntegrationTests {
+
+    @discardableResult
+    func verifyEntitlementWentThrough(
+        _ customerInfo: CustomerInfo,
+        file: FileString = #file,
+        line: UInt = #line
+    ) async throws -> EntitlementInfo {
+        // This is used to throw an error when the test fails.
+        // For some reason XCTest is continuing execution even after a test failure
+        // despite having `self.continueAfterFailure = false`
+        //
+        // By doing this, instead of only calling `fail`, we ensure that
+        // Swift stops executing code when an assertion has failed,
+        // and therefore avoid code running after the test has already failed.
+        // This prevents test crashes from code calling `Purchases.shared` after the test has ended.
+        func failTest(_ message: String) async throws {
+            struct ExpectationFailure: Swift.Error {}
+
+            await self.printReceiptContent()
+
+            fail(message, file: file, line: line)
+            throw ExpectationFailure()
+        }
+
+        let entitlements = customerInfo.entitlements.all
+        if entitlements.count != 1 {
+            try await failTest("Expected 1 Entitlement. Got: \(entitlements)")
+        }
+
+        let entitlement: EntitlementInfo
+
+        do {
+            entitlement = try XCTUnwrap(
+                entitlements[Self.entitlementIdentifier],
+                file: file, line: line
+            )
+        } catch {
+            await self.printReceiptContent()
+            throw error
+        }
+
+        if !entitlement.isActive {
+            try await failTest("Entitlement is not active: \(entitlement)")
+        }
+
+        return entitlement
+    }
+
+    func assertNoActiveSubscription(
+        _ customerInfo: CustomerInfo,
+        file: FileString = #file,
+        line: UInt = #line
+    ) {
+        expect(
+            file: file, line: line,
+            customerInfo.entitlements.active
+        ).to(
+            beEmpty(),
+            description: "Expected no active entitlements"
+        )
+    }
+
+    func assertNoPurchases(
+        _ customerInfo: CustomerInfo,
+        file: FileString = #file,
+        line: UInt = #line
+    ) {
+        expect(
+            file: file, line: line,
+            customerInfo.entitlements.all
+        )
+        .to(
+            beEmpty(),
+            description: "Expected no entitlements. Got: \(customerInfo.entitlements.all)"
+        )
+    }
+
+    func verifyTransactionWasFinished(
+        count: Int = 1,
+        file: FileString = #file,
+        line: UInt = #line
+    ) {
+        self.logger.verifyMessageWasLogged(Self.finishingTransactionLog,
+                                           level: .info,
+                                           expectedCount: count,
+                                           file: file,
+                                           line: line)
+    }
+
+    func verifyNoTransactionsWereFinished(
+        file: FileString = #file,
+        line: UInt = #line
+    ) {
+        self.logger.verifyMessageWasNotLogged(Self.finishingTransactionLog, file: file, line: line)
+    }
+
+    func verifyTransactionIsEventuallyFinished(
+        count: Int? = nil,
+        file: FileString = #file,
+        line: UInt = #line
+    ) async throws {
+        try await self.logger.verifyMessageIsEventuallyLogged(
+            Self.finishingTransactionLog,
+            level: .info,
+            expectedCount: count,
+            timeout: .seconds(5),
+            pollInterval: .milliseconds(100),
+            file: file,
+            line: line
+        )
+    }
+
+    func verifyCustomerInfoWasComputedOffline(
+        logger: TestLogHandler? = nil,
+        file: FileString = #file,
+        line: UInt = #line
+    ) {
+        let logger: TestLogHandler = logger ?? self.logger
+        logger.verifyMessageWasLogged(
+            Strings.offlineEntitlements.computing_offline_customer_info,
+            level: .info,
+            file: file,
+            line: line
+        )
+    }
+
+    func verifyCustomerInfoWasNotComputedOffline(
+        logger: TestLogHandler? = nil,
+        file: FileString = #file,
+        line: UInt = #line
+    ) {
+        let logger: TestLogHandler = logger ?? self.logger
+
+        logger.verifyMessageWasNotLogged(
+            Strings.offlineEntitlements.computing_offline_customer_info,
+            file: file,
+            line: line
+        )
+    }
+
+    func verifyReceiptIsEventuallyPosted(
+        file: FileString = #file,
+        line: UInt = #line
+    ) async throws {
+        try await self.logger.verifyMessageIsEventuallyLogged(
+            Strings.network.operation_state(PostReceiptDataOperation.self, state: "Finished").description,
+            timeout: .seconds(3),
+            pollInterval: .milliseconds(100),
+            file: file,
+            line: line
+        )
+    }
+
+    #if !ENABLE_CUSTOM_ENTITLEMENT_COMPUTATION
+    @discardableResult
+    func verifySubscriptionExpired() async throws -> CustomerInfo {
+        let info = try await self.purchases.syncPurchases()
+        self.assertNoActiveSubscription(info)
+
+        return info
+    }
+    #endif
+
+}

--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -108,9 +108,9 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
         self.logger.clearMessages()
 
         self.serverDown()
-        try await self.purchaseMonthlyProduct()
+        try await self.purchaseMonthlyProduct(allowOfflineEntitlements: true)
 
-        self.logger.verifyMessageWasLogged(Strings.offlineEntitlements.computing_offline_customer_info, level: .info)
+        self.verifyCustomerInfoWasComputedOffline()
         self.verifyNoTransactionsWereFinished()
     }
 
@@ -120,7 +120,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
 
         // 1. Purchase while server is down
         self.serverDown()
-        try await self.purchaseMonthlyProduct()
+        try await self.purchaseMonthlyProduct(allowOfflineEntitlements: true)
 
         self.verifyNoTransactionsWereFinished()
 
@@ -154,7 +154,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
     func testReopeningAppWithOfflineEntitlementsDoesNotReturnStaleCache() async throws {
         // 1. Purchase while server is down
         self.serverDown()
-        try await self.purchaseMonthlyProduct()
+        try await self.purchaseMonthlyProduct(allowOfflineEntitlements: true)
 
         // 2. "Re-open" the app
         await self.resetSingleton()
@@ -168,7 +168,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
     func testPurchaseAgainAfterServerRecovers() async throws {
         // 1. Purchase while server is down
         self.serverDown()
-        try await self.purchaseMonthlyProduct()
+        try await self.purchaseMonthlyProduct(allowOfflineEntitlements: true)
 
         // 2. Purchase again when the server is back up
         // (maybe the app failed the first time?)
@@ -222,7 +222,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
     func testSimultanousCallsToGetCustomerInfoWithPendingTransactionPostsReceiptOnlyOnce() async throws {
         self.serverDown()
 
-        _ = try await self.purchaseMonthlyProduct()
+        _ = try await self.purchaseMonthlyProduct(allowOfflineEntitlements: true)
 
         self.serverUp()
 
@@ -249,7 +249,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
 
         self.serverDown()
 
-        try await self.purchaseMonthlyProduct()
+        try await self.purchaseMonthlyProduct(allowOfflineEntitlements: true)
         try self.testSession.forceRenewalOfSubscription(
             productIdentifier: await self.monthlyPackage.storeProduct.productIdentifier
         )
@@ -300,7 +300,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
 
         // 1. Purchase while server is down
         self.serverDown()
-        try await self.purchaseMonthlyProduct()
+        try await self.purchaseMonthlyProduct(allowOfflineEntitlements: true)
 
         self.verifyNoTransactionsWereFinished()
 
@@ -330,7 +330,7 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
         // 1. Purchase while server is down
         self.serverDown()
 
-        try await self.purchaseMonthlyProduct()
+        try await self.purchaseMonthlyProduct(allowOfflineEntitlements: true)
         do {
             try await self.purchaseConsumablePackage()
             fail("Consumable purchases should fail while offline")

--- a/Tests/BackendIntegrationTests/SignatureVerificationIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/SignatureVerificationIntegrationTests.swift
@@ -152,7 +152,7 @@ class InformationalSignatureVerificationIntegrationTests: BaseSignatureVerificat
         try AvailabilityChecks.iOS15APIAvailableOrSkipTest()
 
         self.serverDown()
-        try await self.purchaseMonthlyOffering()
+        try await self.purchaseMonthlyOffering(allowOfflineEntitlements: true)
 
         self.serverUp()
         self.invalidSignature = true


### PR DESCRIPTION
Good news: offline entitlements are amazing, and our SDK is very resilient to the backend being down.
Bad news: this is kind of a false positive, this behavior is already verified by `OfflineStoreKitIntegrationTests`.

I refactored `BaseStoreKitIntegrationTests` because it had grown a lot. I put this verification in the `purchase` methods so all tests benefit from this.

So that `OfflineStoreKitIntegrationTests` don't fail, I added a parameter to ignore that verification in those tests.