### PR TITLE
`Paywalls`: only pre-warm images/intro-eligibility for `Offerings.current`

### DIFF
--- a/Sources/Paywalls/PaywallCacheWarming.swift
+++ b/Sources/Paywalls/PaywallCacheWarming.swift
@@ -97,11 +97,16 @@ final class DefaultPaywallImageFetcher: PaywallImageFetcherType {
 
 private extension Offerings {
 
+    var offeringsToPreWarm: [Offering] {
+        // At the moment we only want to pre-warm the current offering to prevent
+        // apps with many paywalls from downloading a large amount of images
+        return self.current.map { [$0] } ?? []
+    }
+
     var allProductIdentifiersInPaywalls: Set<String> {
         return .init(
             self
-                .all
-                .values
+                .offeringsToPreWarm
                 .lazy
                 .flatMap(\.productIdentifiersInPaywall)
         )
@@ -110,8 +115,7 @@ private extension Offerings {
     var allImagesInPaywalls: Set<URL> {
         return .init(
             self
-                .all
-                .values
+                .offeringsToPreWarm
                 .lazy
                 .compactMap(\.paywall)
                 .flatMap(\.allImageURLs)

--- a/Tests/UnitTests/Networking/Responses/Fixtures/PaywallData-missing_current_locale.json
+++ b/Tests/UnitTests/Networking/Responses/Fixtures/PaywallData-missing_current_locale.json
@@ -12,7 +12,9 @@
     },
     "config": {
         "packages": ["$rc_monthly", "$rc_annual"],
-        "images": {},
+        "images": {
+            "header": "another_header.jpg"
+        },
         "colors": {
             "light": {
                 "background": "#FFFFFF",


### PR DESCRIPTION
If a developer ends up with a lot of different paywalls (like our test app), potentially _a lot_ of images will get downloaded on app launch. Example:
```
[https://assets.pawwalls.com/954459_1691526599.png, https://assets.pawwalls.com/954459_1693514956.png, https://assets.pawwalls.com/954459_1691434999.jpg, https://assets.pawwalls.com/954459_1692617804.jpeg, https://assets.pawwalls.com/954459_1694552000.jpg, https://assets.pawwalls.com/954459_1690923068.png, https://assets.pawwalls.com/954459_1691438608.jpg, https://assets.pawwalls.com/954459_1692992845.png, https://assets.pawwalls.com/954459_1691445169.jpg, https://assets.pawwalls.com/954459_1692723197.png, https://assets.pawwalls.com/954459_1692821276.png, https://assets.pawwalls.com/954459_1692984654.jpg, https://assets.pawwalls.com/954459_1694470630.jpg, https://assets.pawwalls.com/954459_1691454058.png, https://assets.pawwalls.com/954459_1691440278.jpg, https://assets.pawwalls.com/954459_1693514902.JPG, https://assets.pawwalls.com/954459_1690923331.png, https://assets.pawwalls.com/954459_1694635166.jpg, https://assets.pawwalls.com/954459_1691445170.jpg]
```

That is _a lot_ of images to download on app launch, even if done lazily, in the background, and after a delay.

The downside is that users who manually select an `Offering` to display a paywall won't benefit from this pre-warming, but I think that's an acceptable compromise.