### PR TITLE
`Integration Tests`: fixed more flaky failures

### DIFF
--- a/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OfflineStoreKitIntegrationTests.swift
@@ -105,6 +105,8 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testPurchaseWhileServerIsDownSucceedsButDoesNotFinishTransaction() async throws {
+        self.logger.clearMessages()
+
         self.serverDown()
         try await self.purchaseMonthlyProduct()
 
@@ -114,6 +116,8 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testPurchaseWhileServerIsDownPostsReceiptAfterServerComesBack() async throws {
+        self.logger.clearMessages()
+
         // 1. Purchase while server is down
         self.serverDown()
         try await self.purchaseMonthlyProduct()
@@ -292,6 +296,8 @@ class OfflineStoreKit1IntegrationTests: BaseOfflineStoreKitIntegrationTests {
 
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     func testPurchaseWhileServerIsDownPostsReceiptWhenForegroundingApp() async throws {
+        self.logger.clearMessages()
+
         // 1. Purchase while server is down
         self.serverDown()
         try await self.purchaseMonthlyProduct()


### PR DESCRIPTION
Same as #3167. These can fail when verifying that no transactions are finished because there might be leftover transactions before the test even begins. In order to ignore those, we clear `TestLogHandler` at the beginning. We don't do that for every test because in some test we want to look at what was logged during SDK initialization.