### PR TITLE
`CI`: updated iOS 17 simulator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,7 +398,7 @@ jobs:
           command: bundle exec fastlane test_revenuecatui
           no_output_timeout: 15m
           environment:
-            SCAN_DEVICE: iPhone 14 Pro,OS=17.0
+            SCAN_DEVICE: iPhone 15 Pro,OS=17.0
       - when:
           condition: << pipeline.parameters.generate_revenuecatui_snapshots >>
           steps:
@@ -427,7 +427,7 @@ jobs:
           command: bundle exec fastlane test_ios skip_sk_tests:true
           no_output_timeout: 15m
           environment:
-            SCAN_DEVICE: iPhone 14 (17.0)
+            SCAN_DEVICE: iPhone 15 (17.0)
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: RevenueCat


### PR DESCRIPTION
Now that `CircleCI` updated the `xcode-15` image this wasn't found. Available simulators now:
```
[19:40:56]: ▸ { platform:iOS Simulator, id:6105C8BF-2099-4DEF-BAF2-732BFECFD90B, OS:16.4, name:iPad (10th generation) }
[19:40:56]: ▸ { platform:iOS Simulator, id:6684C364-D76B-461D-AB76-07BA7D5CBFB3, OS:17.0, name:iPad (10th generation) }
[19:40:56]: ▸ { platform:iOS Simulator, id:A0AADD88-4AC3-453F-AAC0-AC424BD543CF, OS:16.4, name:iPad Air (5th generation) }
[19:40:56]: ▸ { platform:iOS Simulator, id:72B511A8-E129-4D2B-9A73-B8BE5F07FE8F, OS:17.0, name:iPad Air (5th generation) }
[19:40:56]: ▸ { platform:iOS Simulator, id:A5D8B4DD-7D7C-4350-B237-2C10DA03D312, OS:16.4, name:iPad Pro (11-inch) (4th generation) }
[19:40:56]: ▸ { platform:iOS Simulator, id:D0FF23E7-18A4-4DAC-AFDF-AB6C2CC7A25E, OS:17.0, name:iPad Pro (11-inch) (4th generation) }
[19:40:56]: ▸ { platform:iOS Simulator, id:AB3D72C0-96D7-49AB-A926-346574AA820D, OS:16.4, name:iPad Pro (12.9-inch) (6th generation) }
[19:40:56]: ▸ { platform:iOS Simulator, id:DDF22951-123E-4CA2-9677-1C4D9280B14A, OS:17.0, name:iPad Pro (12.9-inch) (6th generation) }
[19:40:56]: ▸ { platform:iOS Simulator, id:F5190BA0-C568-4506-92D5-3946F51557EC, OS:16.4, name:iPad mini (6th generation) }
[19:40:56]: ▸ { platform:iOS Simulator, id:D2FF03EE-0957-43D7-BEEF-8E9A2CEA5F4D, OS:17.0, name:iPad mini (6th generation) }
[19:40:56]: ▸ { platform:iOS Simulator, id:2391B473-8B92-4211-ABDC-990FEC412C25, OS:16.4, name:iPhone 14 }
[19:40:56]: ▸ { platform:iOS Simulator, id:551677A8-3142-41CF-BD25-D3FC1DE85C93, OS:16.4, name:iPhone 14 Plus }
[19:40:56]: ▸ { platform:iOS Simulator, id:C2681058-8EBF-4FFF-9961-D967A2D56FA8, OS:16.4, name:iPhone 14 Pro }
[19:40:56]: ▸ { platform:iOS Simulator, id:CB582BE6-FB54-484F-8177-57951039F272, OS:16.4, name:iPhone 14 Pro Max }
[19:40:56]: ▸ { platform:iOS Simulator, id:353D3AC9-5A58-4413-B44B-4CE1E345BC08, OS:17.0, name:iPhone 15 }
[19:40:56]: ▸ { platform:iOS Simulator, id:552C951E-C772-4B80-AA46-3CD2043543C9, OS:17.0, name:iPhone 15 Plus }
[19:40:56]: ▸ { platform:iOS Simulator, id:3372AC76-1C1D-49FF-8289-AB2F2A0DC43C, OS:17.0, name:iPhone 15 Pro }
[19:40:56]: ▸ { platform:iOS Simulator, id:4BE68FCA-8846-4C73-834D-13BC57F65286, OS:17.0, name:iPhone 15 Pro Max }
[19:40:56]: ▸ { platform:iOS Simulator, id:75BD5314-6960-4941-B6CB-9D8081CC02F5, OS:16.4, name:iPhone SE (3rd generation) }
[19:40:56]: ▸ { platform:iOS Simulator, id:34BADD35-EF01-49B3-A76B-5A78C9065B67, OS:17.0, name:iPhone SE (3rd generation) }
```
