### PR TITLE
`PrivacyInfo.xcprivacy`: changed `NSPrivacyCollectedDataTypePurchaseHistory` to `false`

### DIFF
--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -19,7 +19,7 @@
 			<key>NSPrivacyCollectedDataType</key>
 			<string>NSPrivacyCollectedDataTypePurchaseHistory</string>
 			<key>NSPrivacyCollectedDataTypeLinked</key>
-			<true/>
+			<false/>
 			<key>NSPrivacyCollectedDataTypeTracking</key>
 			<false/>
 			<key>NSPrivacyCollectedDataTypePurposes</key>


### PR DESCRIPTION
Fixes https://community.revenuecat.com/sdks-51/xcode-15-s-privacyinfo-xcprivacy-privacy-manifest-what-if-developer-uses-anonymous-app-ids-only-3310?postid=10800#post10800

This new value matches [our documentation](https://community.revenuecat.com/sdks-51/xcode-15-s-privacyinfo-xcprivacy-privacy-manifest-what-if-developer-uses-anonymous-app-ids-only-3310?postid=10800#post10800:~:text=https%3A//www.revenuecat.com/docs/apple%2Dapp%2Dprivacy%232%2Dpurchase%2Dhistory%2Dlinked%2Dto%2Didentity).

> If you are using RevenueCat’s anonymous app user ID’s, and do not have a way to identify individual users, you can select ‘No’.

By default, the SDK uses anonymous user IDs, so this being `false` is a better default.
