### PR TITLE
`Paywalls`: changed `PaywallsTester` to allow not configuring API key

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum Configuration {
 
-    #warning("This needs to be configured.")
+    #warning("Configure API key if you want to test paywalls from your dashboard")
 
     // Note: you can leave this empty to use the production server, or point to your own instance.
     static let proxyURL = ""

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/SimpleApp.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/SimpleApp.swift
@@ -27,8 +27,14 @@ struct SimpleApp: App {
 
     var body: some Scene {
         WindowGroup {
-            AppContentView()
+            AppContentView(
+                customerInfoStream: Self.apiKeyIsConfigured
+                ? Purchases.shared.customerInfoStream
+                : nil
+            )
         }
     }
+
+    private static let apiKeyIsConfigured = !Configuration.effectiveApiKey.isEmpty
 
 }

--- a/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
+++ b/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
@@ -9,6 +9,6 @@ else
     echo "Replacing API key on PaywallsTester"
 
     file="$SCRIPT_DIR/../PaywallsTester/Configuration.swift"
-    sed -i.bak 's/private static let apiKeyFromCI = ""/private static let apiKeyFromCI = "'$SIMPLE_APP_API_KEY'"/g' $file
+    sed -i.bak 's/private static let apiKeyFromCI = ""/private static let apiKeyFromCI = "'$PAYWALLS_TESTER_API_KEY'"/g' $file
     rm $file.bak
 fi

--- a/Tests/TestingApps/SimpleApp/SimpleApp.xcworkspace/contents.xcworkspacedata
+++ b/Tests/TestingApps/SimpleApp/SimpleApp.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "group:SimpleApp.xcodeproj">
-   </FileRef>
-</Workspace>


### PR DESCRIPTION
When launching the app now _without_ a configured API key, it goes into a simpler mode where it only shows the "offline" test paywalls.

![simulator_screenshot_1B287355-2D40-497C-A924-18FADD711514](https://github.com/RevenueCat/purchases-ios/assets/685609/e0f73104-bb9f-48a8-afa2-2fdf08445f33)
