### PR TITLE
`Paywalls`: created `ConsistentPackageContentView` to improve package change transitions

### DIFF
--- a/RevenueCatUI/Data/IntroEligibility/IntroEligibilityViewModel.swift
+++ b/RevenueCatUI/Data/IntroEligibility/IntroEligibilityViewModel.swift
@@ -42,6 +42,7 @@ extension IntroEligibilityViewModel {
         switch packages {
         case let .single(package):
             self.singleEligibility = await self.introEligibilityChecker.eligibility(for: package.content)
+            self.allEligibility[package.content] = self.singleEligibility
 
         case let .multiple(_, _, packages):
             self.allEligibility = await self.introEligibilityChecker.eligibility(for: packages.map(\.content))

--- a/RevenueCatUI/Modifiers/ConsistentPackageContentView.swift
+++ b/RevenueCatUI/Modifiers/ConsistentPackageContentView.swift
@@ -1,0 +1,48 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  ConsistentPackageContentView.swift
+//
+//  Created by Nacho Soto on 9/22/23.
+//
+
+import SwiftUI
+
+/// A wrapper view that can display content based on a selected package
+/// and maintain a consistent layout when that selected package changes.
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+struct ConsistentPackageContentView<Content: View>: View {
+
+    typealias Creator = @Sendable @MainActor (TemplateViewConfiguration.Package) -> Content
+
+    private let packages: [TemplateViewConfiguration.Package]
+    private let selected: TemplateViewConfiguration.Package
+    private let creator: Creator
+
+    init(
+        packages: [TemplateViewConfiguration.Package],
+        selected: TemplateViewConfiguration.Package,
+        creator: @escaping Creator
+    ) {
+        self.packages = packages
+        self.selected = selected
+        self.creator = creator
+    }
+
+    var body: some View {
+        // We need to layout all possible packages to accomodate for the longest text
+        return ZStack {
+            ForEach(self.packages, id: \.self.content) { package in
+                self.creator(package)
+                    .opacity(package.content == self.selected.content ? 1 : 0)
+            }
+        }
+    }
+
+}

--- a/RevenueCatUI/Templates/Template1View.swift
+++ b/RevenueCatUI/Templates/Template1View.swift
@@ -110,10 +110,9 @@ struct Template1View: TemplateViewType {
     @ViewBuilder
     private var button: some View {
         PurchaseButton(
-            package: self.configuration.packages.single,
-            configuration: self.configuration,
-            introEligibility: self.introEligibility,
-            purchaseHandler: self.purchaseHandler
+            packages: self.configuration.packages,
+            selectedPackage: self.configuration.packages.default,
+            configuration: self.configuration
         )
     }
 

--- a/RevenueCatUI/Templates/Template2View.swift
+++ b/RevenueCatUI/Templates/Template2View.swift
@@ -216,10 +216,9 @@ struct Template2View: TemplateViewType {
 
     private var subscribeButton: some View {
         PurchaseButton(
-            package: self.selectedPackage,
-            configuration: self.configuration,
-            introEligibility: self.introEligibility[self.selectedPackage.content],
-            purchaseHandler: self.purchaseHandler
+            packages: self.configuration.packages,
+            selectedPackage: self.selectedPackage,
+            configuration: self.configuration
         )
     }
 

--- a/RevenueCatUI/Templates/Template3View.swift
+++ b/RevenueCatUI/Templates/Template3View.swift
@@ -71,10 +71,9 @@ struct Template3View: TemplateViewType {
             .padding(.bottom)
 
             PurchaseButton(
-                package: self.configuration.packages.single,
-                configuration: self.configuration,
-                introEligibility: self.introEligibility,
-                purchaseHandler: self.purchaseHandler
+                packages: self.configuration.packages,
+                selectedPackage: self.configuration.packages.default,
+                configuration: self.configuration
             )
 
             FooterView(configuration: self.configuration,

--- a/RevenueCatUI/Templates/Template4View.swift
+++ b/RevenueCatUI/Templates/Template4View.swift
@@ -147,22 +147,26 @@ struct Template4View: TemplateViewType {
     }
 
     private var offerDetails: some View {
-        IntroEligibilityStateView(
-            textWithNoIntroOffer: self.selectedPackage.localization.offerDetails,
-            textWithIntroOffer: self.selectedPackage.localization.offerDetailsWithIntroOffer,
-            introEligibility: self.introEligibility[self.selectedPackage.content],
-            foregroundColor: self.configuration.colors.text1Color
-        )
+        ConsistentPackageContentView(
+            packages: self.configuration.packages.all,
+            selected: self.selectedPackage
+        ) { package in
+            IntroEligibilityStateView(
+                textWithNoIntroOffer: package.localization.offerDetails,
+                textWithIntroOffer: package.localization.offerDetailsWithIntroOffer,
+                introEligibility: self.introEligibility[package.content],
+                foregroundColor: self.configuration.colors.text1Color
+            )
+        }
         .font(self.font(for: .body).weight(.light))
         .dynamicTypeSize(...Constants.maximumDynamicTypeSize)
     }
 
     private var subscribeButton: some View {
         PurchaseButton(
-            package: self.selectedPackage,
-            configuration: self.configuration,
-            introEligibility: self.introEligibility[self.selectedPackage.content],
-            purchaseHandler: self.purchaseHandler
+            packages: self.configuration.packages,
+            selectedPackage: self.selectedPackage,
+            configuration: self.configuration
         )
     }
 

--- a/RevenueCatUI/Templates/Template5View.swift
+++ b/RevenueCatUI/Templates/Template5View.swift
@@ -240,10 +240,9 @@ struct Template5View: TemplateViewType {
 
     private var subscribeButton: some View {
         PurchaseButton(
-            package: self.selectedPackage,
-            configuration: self.configuration,
-            introEligibility: self.introEligibility[self.selectedPackage.content],
-            purchaseHandler: self.purchaseHandler
+            packages: self.configuration.packages,
+            selectedPackage: self.selectedPackage,
+            configuration: self.configuration
         )
     }
 


### PR DESCRIPTION
This abstracts away the logic to ensure layouts are consistent when selecting different packages in multi-package templates, in a way that the content doesn't move around.