### PR TITLE
PaywallsTester: allow easy testing of paywall modes for All Offerings tab

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2DBCEDFD2AC4BC060064C274 /* PaywallViewMode+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBCEDFC2AC4BC060064C274 /* PaywallViewMode+Extensions.swift */; };
 		4F102E272A840ECC0059EED6 /* CustomPaywall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F102E262A840ECC0059EED6 /* CustomPaywall.swift */; };
 		4F217A102A6DB6FB000B092D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4FC046BF2A572E3700A28BCF /* Assets.xcassets */; };
 		4F34FF632A60AD9A00AADF11 /* AppContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F34FF622A60AD9A00AADF11 /* AppContentView.swift */; };
@@ -37,6 +38,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2DBCEDFC2AC4BC060064C274 /* PaywallViewMode+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaywallViewMode+Extensions.swift"; sourceTree = "<group>"; };
 		4F0B5EA02A97CD9300DB0FC9 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4F0B5EA12A97CDAC00DB0FC9 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4F102E262A840ECC0059EED6 /* CustomPaywall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPaywall.swift; sourceTree = "<group>"; };
@@ -84,6 +86,7 @@
 				4FDF111F2A7270F3004F3680 /* SamplePaywallsList.swift */,
 				4F102E262A840ECC0059EED6 /* CustomPaywall.swift */,
 				4F71CDD12A992292001B9BEF /* CustomPaywallContent.swift */,
+				2DBCEDFC2AC4BC060064C274 /* PaywallViewMode+Extensions.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -232,6 +235,7 @@
 				4FDF11222A72714C004F3680 /* SamplePaywalls.swift in Sources */,
 				4F34FF652A60ADBD00AADF11 /* Configuration.swift in Sources */,
 				4FC6F8B22A7403D3002139B2 /* OfferingsList.swift in Sources */,
+				2DBCEDFD2AC4BC060064C274 /* PaywallViewMode+Extensions.swift in Sources */,
 				4F102E272A840ECC0059EED6 /* CustomPaywall.swift in Sources */,
 				4FDF11202A7270F3004F3680 /* SamplePaywallsList.swift in Sources */,
 				4F34FF632A60AD9A00AADF11 /* AppContentView.swift in Sources */,

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/OfferingsList.swift
@@ -17,6 +17,9 @@ struct OfferingsList: View {
     @State
     private var selectedOffering: Offering?
 
+    @State
+    private var selectedMode: PaywallViewMode = .fullScreen
+
     var body: some View {
         NavigationView {
             self.content
@@ -48,7 +51,33 @@ struct OfferingsList: View {
             #if !targetEnvironment(macCatalyst)
                 .sheet(item: self.$selectedOffering) { offering in
                     NavigationView {
+                        switch self.$selectedMode.wrappedValue {
+                        case .fullScreen:
                         PaywallView(offering: offering)
+                            #if targetEnvironment(macCatalyst)
+                            .toolbar {
+                                ToolbarItem(placement: .destructiveAction) {
+                                    Button {
+                                        self.selectedOffering = nil
+                                    } label: {
+                                        Image(systemName: "xmark")
+                                    }
+                                }
+                            }
+                            #endif
+                        case .footer:
+                            VStack {
+                                Spacer()
+                                Text("This Paywall is being presented as a Footer")
+                                    .paywallFooter(offering: offering)
+                            }
+                        case .condensedFooter:
+                            VStack {
+                                Spacer()
+                                Text("This Paywall is being presented as a Condensed Footer")
+                                    .paywallFooter(offering: offering, condensed: true)
+                            }
+                        }
                     }
                 }
             #endif
@@ -85,29 +114,9 @@ struct OfferingsList: View {
                     .buttonStyle(.plain)
                     .contentShape(Rectangle())
                     .contextMenu {
-                        Button(action: {
-                            // Action for first option
-                            print("Option 1 selected")
-                        }) {
-                            Text("Full Screen")
-                            Image(systemName: PaywallViewMode.fullScreen.icon)
-                        }
-
-                        Button(action: {
-                            // Action for second option
-                            print("Option 2 selected")
-                        }) {
-                            Text("Footer")
-                            Image(systemName: PaywallViewMode.footer.icon)
-                        }
-
-                        Button(action: {
-                            // Action for third option
-                            print("Option 3 selected")
-                        }) {
-                            Text("Condensed Footer")
-                            Image(systemName: PaywallViewMode.condensedFooter.icon)
-                        }
+                        self.button(for: PaywallViewMode.fullScreen, offering: offering)
+                        self.button(for: PaywallViewMode.condensedFooter, offering: offering)
+                        self.button(for: PaywallViewMode.footer, offering: offering)
                     }
 
                 }
@@ -141,6 +150,25 @@ struct OfferingsList: View {
             }
             .buttonStyle(.plain)
             .contentShape(Rectangle())
+    }
+    
+    @ViewBuilder
+    private func button(for selectedMode: PaywallViewMode, offering: Offering) -> some View {
+        Button(action: {
+            self.selectedMode = selectedMode
+            self.selectedOffering = offering
+        }) {
+            switch selectedMode {
+            case .fullScreen:
+                Text("Full Screen")
+                Image(systemName: PaywallViewMode.fullScreen.icon)
+            case .condensedFooter:
+                Text("Condensed Footer")
+                Image(systemName: PaywallViewMode.condensedFooter.icon)
+            case .footer:
+                Text("footer")
+                Image(systemName: PaywallViewMode.footer.icon)
+            }
         }
     }
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/OfferingsList.swift
@@ -41,6 +41,9 @@ struct OfferingsList: View {
     private var content: some View {
         switch self.offerings {
         case let .success(offerings):
+            VStack {
+            Text("Press and hold to open in different modes.")
+                .font(.footnote)
             self.list(with: offerings)
             #if !targetEnvironment(macCatalyst)
                 .sheet(item: self.$selectedOffering) { offering in
@@ -79,6 +82,34 @@ struct OfferingsList: View {
                         self.selectedOffering = offering
                     }
                     #endif
+                    .buttonStyle(.plain)
+                    .contentShape(Rectangle())
+                    .contextMenu {
+                        Button(action: {
+                            // Action for first option
+                            print("Option 1 selected")
+                        }) {
+                            Text("Full Screen")
+                            Image(systemName: PaywallViewMode.fullScreen.icon)
+                        }
+
+                        Button(action: {
+                            // Action for second option
+                            print("Option 2 selected")
+                        }) {
+                            Text("Footer")
+                            Image(systemName: PaywallViewMode.footer.icon)
+                        }
+
+                        Button(action: {
+                            // Action for third option
+                            print("Option 3 selected")
+                        }) {
+                            Text("Condensed Footer")
+                            Image(systemName: PaywallViewMode.condensedFooter.icon)
+                        }
+                    }
+
                 }
             } header: {
                 Text(verbatim: "With paywall")
@@ -141,7 +172,7 @@ private extension OfferingsList {
 struct OfferingsList_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            SamplePaywallsList()
+            OfferingsList()
         }
     }
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/OfferingsList.swift
@@ -45,7 +45,12 @@ struct OfferingsList: View {
         switch self.offerings {
         case let .success(offerings):
             VStack {
-                Text("Press and hold to open in different modes.")
+                #if targetEnvironment(macCatalyst)
+                let modesInstructions = "Right click or ⌘ + click to open in different modes."
+                #else
+                let modesInstructions = "Press and hold to open in different modes."
+                #endif
+                Text(modesInstructions)
                     .font(.footnote)
                 self.list(with: offerings)
                     .sheet(item: self.$selectedOffering) { offering in
@@ -126,7 +131,8 @@ struct OfferingsList: View {
                         self.button(for: PaywallViewMode.condensedFooter, offering: offering)
                         self.button(for: PaywallViewMode.footer, offering: offering)
                     }
-
+                    .buttonStyle(.plain)
+                    .contentShape(Rectangle())
                 }
             } header: {
                 Text(verbatim: "With paywall")
@@ -174,7 +180,7 @@ struct OfferingsList: View {
                 Text("Condensed Footer")
                 Image(systemName: PaywallViewMode.condensedFooter.icon)
             case .footer:
-                Text("footer")
+                Text("Footer")
                 Image(systemName: PaywallViewMode.footer.icon)
             }
         }
@@ -188,33 +194,39 @@ struct PaywallPresenter: View {
 
     var body: some View {
         NavigationView {
-            switch selectedMode {
-            case .fullScreen:
-                PaywallView(offering: selectedOffering!)
-                #if targetEnvironment(macCatalyst)
-                    .toolbar {
-                        ToolbarItem(placement: .destructiveAction) {
-                            Button {
-                                self.selectedOffering = nil
-                            } label: {
-                                Image(systemName: "xmark")
-                            }
+            Group {
+                if let offering = selectedOffering {
+                    switch selectedMode {
+                    case .fullScreen:
+                        PaywallView(offering: offering)
+
+
+                    case .footer:
+                        VStack {
+                            Spacer()
+                            Text("This Paywall is being presented as a Footer")
+                                .paywallFooter(offering: selectedOffering!)
+                        }
+                    case .condensedFooter:
+                        VStack {
+                            Spacer()
+                            Text("This Paywall is being presented as a Condensed Footer")
+                                .paywallFooter(offering: selectedOffering!, condensed: true)
                         }
                     }
-            #endif
-            case .footer:
-                VStack {
-                    Spacer()
-                    Text("This Paywall is being presented as a Footer")
-                        .paywallFooter(offering: selectedOffering!)
-                }
-            case .condensedFooter:
-                VStack {
-                    Spacer()
-                    Text("This Paywall is being presented as a Condensed Footer")
-                        .paywallFooter(offering: selectedOffering!, condensed: true)
                 }
             }
+            #if targetEnvironment(macCatalyst)
+            .toolbar {
+                ToolbarItem(placement: .destructiveAction) {
+                    Button {
+                        self.selectedOffering = nil
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
+                }
+            }
+            #endif
         }
     }
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/PaywallViewMode+Extensions.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/PaywallViewMode+Extensions.swift
@@ -1,0 +1,33 @@
+//
+//  PaywallViewMode+Extensions.swift
+//  PaywallsTester
+//
+//  Created by Andrés Boedo on 9/27/23.
+//
+
+import Foundation
+import RevenueCat
+
+
+internal extension PaywallViewMode {
+
+    var icon: String {
+        switch self {
+        case .fullScreen: return "iphone"
+        case .footer: return "lanyardcard"
+        case .condensedFooter: return "ruler"
+        }
+    }
+
+    var name: String {
+        switch self {
+        case .fullScreen:
+            return "Fullscreen"
+        case .footer:
+            return "Footer"
+        case .condensedFooter:
+            return "Condensed Footer"
+        }
+    }
+
+}

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/SamplePaywallsList.swift
@@ -229,30 +229,6 @@ extension PaywallTemplate {
 
 }
 
-private extension PaywallViewMode {
-
-    var icon: String {
-        switch self {
-        case .fullScreen: return "iphone"
-        case .footer: return "lanyardcard"
-        case .condensedFooter: return "ruler"
-        }
-    }
-
-    var name: String {
-        switch self {
-        case .fullScreen:
-            return "Fullscreen"
-        case .footer:
-            return "Footer"
-        case .condensedFooter:
-            return "Condensed Footer"
-        }
-    }
-
-}
-
-#if DEBUG
 
 struct SamplePaywallsList_Previews: PreviewProvider {
     static var previews: some View {
@@ -261,7 +237,5 @@ struct SamplePaywallsList_Previews: PreviewProvider {
         }
     }
 }
-
-#endif
 
 #endif


### PR DESCRIPTION
Adds a Haptic Touch gesture to allow you to press and hold the name of a template in All Templates to select which specific mode to open it in. 

![IMG_41D724343EE3-1](https://github.com/RevenueCat/purchases-ios/assets/3922667/dec9800f-5684-42a5-94e1-a1723a891c08)


https://github.com/RevenueCat/purchases-ios/assets/3922667/4713daef-c6d4-427b-9551-dca31129785b

