### PR TITLE
PaywallsTester: improve navigation on macOS and iPadOS

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/OfferingsList.swift
@@ -34,6 +34,7 @@ struct OfferingsList: View {
                     self.offerings = .failure(error)
                 }
             }
+            .navigationViewStyle(StackNavigationViewStyle())
     }
 
     @ViewBuilder

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/SamplePaywallsList.swift
@@ -41,6 +41,7 @@ struct SamplePaywallsList: View {
                 self.display = nil
             }
             .navigationTitle("Paywalls")
+            .navigationViewStyle(StackNavigationViewStyle())
     }
 
     @ViewBuilder


### PR DESCRIPTION
The navigation is slightly awkward because we're rendering a list on the left side, but then we display a sheet, so the right side pane is never filled. This just updates it so that it always looks like a full screen list instead. The changes don't apply to iPhone, just iPad landscape and macOS


| Before | After |
| :-: | :-: |
| <img width="1031" alt="Screenshot 2023-09-27 at 5 53 31 PM" src="https://github.com/RevenueCat/purchases-ios/assets/3922667/c9d3da09-d716-40ca-9497-c00d99a0e672"> | <img width="730" alt="Screenshot 2023-09-27 at 6 06 55 PM" src="https://github.com/RevenueCat/purchases-ios/assets/3922667/cc5d2477-bab5-4c92-bccc-fdb592f27204"> |
