### PR TITLE
PaywallsTester: fix StoreKit Configuration scheme

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - SK config.xcscheme
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/xcshareddata/xcschemes/PaywallsTester - SK config.xcscheme
@@ -50,7 +50,7 @@
          </BuildableReference>
       </BuildableProductRunnable>
       <StoreKitConfigurationFileReference
-         identifier = "../SimpleApp/Products.storekit">
+         identifier = "../PaywallsTester/Products.storekit">
       </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction


### PR DESCRIPTION
The SK config file scheme was broken after the rename from SimpleApp to PaywallsTester, this fixes it. 