### PR TITLE
PaywallsTester: allow resizing on macOS

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/OfferingsList.swift
@@ -61,47 +61,23 @@ struct OfferingsList: View {
         List {
             let offeringsWithPaywall = Self.offeringsWithPaywall(from: offerings)
 
-            #if targetEnvironment(macCatalyst)
             Section {
                 ForEach(offeringsWithPaywall, id: \.offering.id) { offering, paywall in
+                    #if targetEnvironment(macCatalyst)
                     NavigationLink(
                         destination: PaywallView(offering: offering),
                         tag: offering,
                         selection: self.$selectedOffering
                     ) {
-                        Button {
+                        OfferButton(offering: offering, paywall: paywall) {
                             self.selectedOffering = offering
-                        } label: {
-                            VStack(alignment: .leading) {
-                                Text(offering.serverDescription)
-                                Text(verbatim: "Template: \(paywall.templateName)")
-                            }
                         }
-                        .buttonStyle(.plain)
-                        .contentShape(Rectangle())
                     }
-                }
-            } header: {
-                Text(verbatim: "With paywall")
-            } footer: {
-                if offeringsWithPaywall.isEmpty {
-                    Text(verbatim: "No offerings with paywall")
-                }
-            }
-            #else
-            Section {
-                ForEach(offeringsWithPaywall, id: \.offering.id) { offering, paywall in
-
-                    Button {
+                    #else
+                    OfferButton(offering: offering, paywall: paywall) {
                         self.selectedOffering = offering
-                    } label: {
-                        VStack(alignment: .leading) {
-                            Text(offering.serverDescription)
-                            Text(verbatim: "Template: \(paywall.templateName)")
-                        }
                     }
-                    .buttonStyle(.plain)
-                    .contentShape(Rectangle())
+                    #endif
                 }
             } header: {
                 Text(verbatim: "With paywall")
@@ -110,13 +86,29 @@ struct OfferingsList: View {
                     Text(verbatim: "No offerings with paywall")
                 }
             }
-            #endif
 
             Section("Without paywall") {
                 ForEach(Self.offeringsWithNoPaywall(from: offerings), id: \.id) { offering in
                     Text(offering.serverDescription)
                 }
             }
+        }
+    }
+
+    private struct OfferButton: View {
+        let offering: Offering
+        let paywall: PaywallData
+        let action: () -> Void
+
+        var body: some View {
+            Button(action: action) {
+                VStack(alignment: .leading) {
+                    Text(offering.serverDescription)
+                    Text(verbatim: "Template: \(paywall.templateName)")
+                }
+            }
+            .buttonStyle(.plain)
+            .contentShape(Rectangle())
         }
     }
 


### PR DESCRIPTION
Refactored so that in mac catalyst, instead of presenting as a sheet, we present as part of navigation, so that resizing the view also resizes the paywall. 

This is useful for quick testing of different sizes on macOS.

iOS remains unchanged

https://github.com/RevenueCat/purchases-ios/assets/3922667/8de24c5d-80ef-4ed6-8813-eca72af00008

