### PR TITLE
PaywallsTester: add a new tab that calls presentPaywallIfNeeded

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2D708C7F2AC6050000336AC8 /* UpsellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D708C7E2AC6050000336AC8 /* UpsellView.swift */; };
 		2DBCEDFD2AC4BC060064C274 /* PaywallViewMode+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBCEDFC2AC4BC060064C274 /* PaywallViewMode+Extensions.swift */; };
 		4F102E272A840ECC0059EED6 /* CustomPaywall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F102E262A840ECC0059EED6 /* CustomPaywall.swift */; };
 		4F217A102A6DB6FB000B092D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4FC046BF2A572E3700A28BCF /* Assets.xcassets */; };
@@ -38,6 +39,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2D708C7E2AC6050000336AC8 /* UpsellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpsellView.swift; sourceTree = "<group>"; };
 		2DBCEDFC2AC4BC060064C274 /* PaywallViewMode+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaywallViewMode+Extensions.swift"; sourceTree = "<group>"; };
 		4F0B5EA02A97CD9300DB0FC9 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4F0B5EA12A97CDAC00DB0FC9 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -86,6 +88,7 @@
 				4FDF111F2A7270F3004F3680 /* SamplePaywallsList.swift */,
 				4F102E262A840ECC0059EED6 /* CustomPaywall.swift */,
 				4F71CDD12A992292001B9BEF /* CustomPaywallContent.swift */,
+				2D708C7E2AC6050000336AC8 /* UpsellView.swift */,
 				2DBCEDFC2AC4BC060064C274 /* PaywallViewMode+Extensions.swift */,
 			);
 			path = Views;
@@ -235,6 +238,7 @@
 				4FDF11222A72714C004F3680 /* SamplePaywalls.swift in Sources */,
 				4F34FF652A60ADBD00AADF11 /* Configuration.swift in Sources */,
 				4FC6F8B22A7403D3002139B2 /* OfferingsList.swift in Sources */,
+				2D708C7F2AC6050000336AC8 /* UpsellView.swift in Sources */,
 				2DBCEDFD2AC4BC060064C274 /* PaywallViewMode+Extensions.swift in Sources */,
 				4F102E272A840ECC0059EED6 /* CustomPaywall.swift in Sources */,
 				4FDF11202A7270F3004F3680 /* SamplePaywallsList.swift in Sources */,

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
@@ -57,6 +57,13 @@ struct AppContentView: View {
                     .tabItem {
                         Label("All paywalls", systemImage: "network")
                     }
+
+                UpsellView()
+                    .tabItem {
+                        Label("Upsell view", systemImage: "dollarsign")
+                    }
+                    .navigationTitle("Upsell view")
+
             }
         }
     }
@@ -108,7 +115,7 @@ struct AppContentView: View {
             if let stream = self.customerInfoStream {
                 for await info in stream {
                     self.customerInfo = info
-                    self.showingDefaultPaywall = info.activeSubscriptions.count == 0
+                    self.showingDefaultPaywall = self.showingDefaultPaywall && info.activeSubscriptions.count == 0
                 }
                 
             }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/UpsellView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/UpsellView.swift
@@ -1,0 +1,32 @@
+//
+//  LockedView.swift
+//  PaywallsTester
+//
+//  Created by Andrés Boedo on 9/28/23.
+//
+
+import SwiftUI
+
+struct UpsellView: View {
+    var body: some View {
+        VStack {
+            Text("""
+                This view automatically displays the default paywall if you're not subscribed.
+                
+                This is achieved by calling
+                `.presentPaywallIfNeeded(requiredEntitlementIdentifier: \(Configuration.entitlement))
+                """)
+
+        }
+        .padding()
+        .presentPaywallIfNeeded(requiredEntitlementIdentifier: Configuration.entitlement)
+    }
+}
+
+struct UpsellView_Previews: PreviewProvider {
+
+    static var previews: some View {
+        UpsellView()
+    }
+
+}

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/UpsellView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/UpsellView.swift
@@ -8,19 +8,21 @@
 import SwiftUI
 
 struct UpsellView: View {
+
     var body: some View {
         VStack {
             Text("""
                 This view automatically displays the default paywall if you're not subscribed.
                 
                 This is achieved by calling
-                `.presentPaywallIfNeeded(requiredEntitlementIdentifier: \(Configuration.entitlement))
+                `.presentPaywallIfNeeded(requiredEntitlementIdentifier: \(Configuration.entitlement))`
                 """)
 
         }
         .padding()
         .presentPaywallIfNeeded(requiredEntitlementIdentifier: Configuration.entitlement)
     }
+
 }
 
 struct UpsellView_Previews: PreviewProvider {


### PR DESCRIPTION
Adds a new tab that calls `presentPaywallIfNeeded`

![Screenshot 2023-09-28 at 4 25 28 PM](https://github.com/RevenueCat/purchases-ios/assets/3922667/f4fe8b08-77e6-4141-bc24-5a7081acd51a)
