### PR TITLE
PaywallsTester: allow for configuration for demos

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
@@ -29,7 +29,7 @@ class Configuration: ObservableObject {
     }
 
     private init() {
-        currentMode = apiKey.isEmpty ? .custom : .testing
+        currentMode = apiKey.isEmpty ? .testing : .custom
     }
 
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
@@ -33,7 +33,12 @@ final class Configuration: ObservableObject {
     private static let apiKeyFromCIForDemos = ""
 
     private init() {
-        self.currentMode = Self.apiKey.isEmpty ? .testing : .custom
+        if Self.apiKey.isEmpty {
+            self.currentMode = Self.apiKeyFromCIForTesting.isEmpty ? .listOnly : .testing
+        } else {
+            self.currentMode = .custom
+        }
+
         Purchases.logLevel = .verbose
         Purchases.proxyURL = Self.proxyURL.isEmpty
         ? nil

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
@@ -8,29 +8,35 @@
 import Foundation
 import RevenueCat
 
-enum Configuration {
+class Configuration: ObservableObject {
+    static let shared = Configuration()
+
+    // This is modified by CI:
+    private static let apiKeyFromCIForTesting = ""
+    private static let apiKeyFromCIForDemos = ""
+
+    @Published private(set) var currentMode: Mode
+
+    let entitlement = "pro"
 
     #warning("Configure API key if you want to test paywalls from your dashboard")
-
     // Note: you can leave this empty to use the production server, or point to your own instance.
-    static let proxyURL = ""
-    static let apiKey = ""
+    private let proxyURL = ""
+    private let apiKey = ""
 
-    static let entitlement = "pro"
-
-}
-
-extension Configuration {
     enum Mode {
         case custom, testing, demos
     }
 
-    static private(set) var currentMode: Mode = Self.apiKey.isEmpty ? .custom : .testing
+    private init() {
+        currentMode = apiKey.isEmpty ? .custom : .testing
+    }
 
-    static var currentAPIKey: String {
+
+    var currentAPIKey: String {
         switch currentMode {
         case .custom:
-            Self.apiKey
+            self.apiKey
         case .testing:
             Self.apiKeyFromCIForTesting
         case .demos:
@@ -38,8 +44,8 @@ extension Configuration {
         }
     }
 
-    static func reconfigure(for mode: Mode) {
-        Self.currentMode = mode
+    func reconfigure(for mode: Mode) {
+        self.currentMode = mode
         Purchases.configure(
             with: .init(withAPIKey: currentAPIKey)
                 .with(entitlementVerificationMode: .informational)
@@ -47,11 +53,11 @@ extension Configuration {
         )
     }
 
-    static func configure() {
+    func configure() {
         Purchases.logLevel = .verbose
-        Purchases.proxyURL = Configuration.proxyURL.isEmpty
+        Purchases.proxyURL = self.proxyURL.isEmpty
         ? nil
-        : URL(string: Configuration.proxyURL)!
+        : URL(string: self.proxyURL)!
 
         Purchases.configure(
             with: .init(withAPIKey: currentAPIKey)
@@ -59,9 +65,5 @@ extension Configuration {
                 .with(usesStoreKit2IfAvailable: true)
         )
     }
-
-    // This is modified by CI:
-    static let apiKeyFromCIForTesting = ""
-    static let apiKeyFromCIForDemos = ""
 
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
@@ -8,7 +8,7 @@
 import Foundation
 import RevenueCat
 
-class Configuration: ObservableObject {
+final class Configuration: ObservableObject {
     static let shared = Configuration()
 
     // This is modified by CI:
@@ -21,22 +21,22 @@ class Configuration: ObservableObject {
 
     #warning("Configure API key if you want to test paywalls from your dashboard")
     // Note: you can leave this empty to use the production server, or point to your own instance.
-    private let proxyURL = ""
-    private let apiKey = ""
+    private static let proxyURL = ""
+    private static let apiKey = ""
 
     enum Mode {
         case custom, testing, demos
     }
 
     private init() {
-        currentMode = apiKey.isEmpty ? .testing : .custom
+        self.currentMode = Self.apiKey.isEmpty ? .testing : .custom
     }
 
 
     var currentAPIKey: String {
         switch currentMode {
         case .custom:
-            self.apiKey
+            Self.apiKey
         case .testing:
             Self.apiKeyFromCIForTesting
         case .demos:
@@ -55,9 +55,9 @@ class Configuration: ObservableObject {
 
     func configure() {
         Purchases.logLevel = .verbose
-        Purchases.proxyURL = self.proxyURL.isEmpty
+        Purchases.proxyURL = Self.proxyURL.isEmpty
         ? nil
-        : URL(string: self.proxyURL)!
+        : URL(string: Self.proxyURL)!
 
         Purchases.configure(
             with: .init(withAPIKey: currentAPIKey)

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
@@ -22,7 +22,7 @@ enum Configuration {
 extension Configuration {
 
     static var effectiveApiKey: String = {
-        return Self.apiKey.nonEmpty ?? Self.apiKeyFromCI
+        return Self.apiKey.nonEmpty ?? Self.apiKeyFromCIForTesting
     }()
 
     // This is modified by CI:

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
@@ -26,7 +26,8 @@ extension Configuration {
     }()
 
     // This is modified by CI:
-    private static let apiKeyFromCI = ""
+    static let apiKeyFromCI = ""
+    static let apiKeyForDemos = ""
 
 }
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
@@ -11,11 +11,15 @@ import RevenueCat
 final class Configuration: ObservableObject {
     static let shared = Configuration()
 
-    @Published private(set) var currentMode: Mode
+    @Published var currentMode: Mode {
+        didSet {
+            configure()
+        }
+    }
 
     static let entitlement = "pro"
 
-    enum Mode {
+    enum Mode: Equatable {
         case custom, testing, demos, listOnly
     }
 
@@ -30,6 +34,12 @@ final class Configuration: ObservableObject {
 
     private init() {
         self.currentMode = Self.apiKey.isEmpty ? .testing : .custom
+        Purchases.logLevel = .verbose
+        Purchases.proxyURL = Self.proxyURL.isEmpty
+        ? nil
+        : URL(string: Self.proxyURL)!
+
+        self.configure()
     }
 
     var currentAPIKey: String? {
@@ -45,20 +55,7 @@ final class Configuration: ObservableObject {
         }
     }
 
-    func reconfigure(for mode: Mode) {
-        self.currentMode = mode
-        self.configureRCSDK()
-    }
-
-    func configure() {
-        Purchases.logLevel = .verbose
-        Purchases.proxyURL = Self.proxyURL.isEmpty
-        ? nil
-        : URL(string: Self.proxyURL)!
-        self.configureRCSDK()
-    }
-
-    private func configureRCSDK() {
+    private func configure() {
         guard let currentAPIKey = self.currentAPIKey,
               !currentAPIKey.isEmpty else {
             return

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
@@ -13,7 +13,7 @@ final class Configuration: ObservableObject {
 
     @Published private(set) var currentMode: Mode
 
-    let entitlement = "pro"
+    static let entitlement = "pro"
 
     enum Mode {
         case custom, testing, demos

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
@@ -26,8 +26,8 @@ extension Configuration {
     }()
 
     // This is modified by CI:
-    static let apiKeyFromCI = ""
-    static let apiKeyForDemos = ""
+    static let apiKeyFromCIForTesting = ""
+    static let apiKeyFromCIForDemos = ""
 
 }
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
@@ -11,27 +11,26 @@ import RevenueCat
 final class Configuration: ObservableObject {
     static let shared = Configuration()
 
-    // This is modified by CI:
-    private static let apiKeyFromCIForTesting = ""
-    private static let apiKeyFromCIForDemos = ""
-
     @Published private(set) var currentMode: Mode
 
     let entitlement = "pro"
+
+    enum Mode {
+        case custom, testing, demos
+    }
 
     #warning("Configure API key if you want to test paywalls from your dashboard")
     // Note: you can leave this empty to use the production server, or point to your own instance.
     private static let proxyURL = ""
     private static let apiKey = ""
 
-    enum Mode {
-        case custom, testing, demos
-    }
+    // This is modified by CI:
+    private static let apiKeyFromCIForTesting = ""
+    private static let apiKeyFromCIForDemos = ""
 
     private init() {
         self.currentMode = Self.apiKey.isEmpty ? .testing : .custom
     }
-
 
     var currentAPIKey: String {
         switch currentMode {
@@ -46,11 +45,7 @@ final class Configuration: ObservableObject {
 
     func reconfigure(for mode: Mode) {
         self.currentMode = mode
-        Purchases.configure(
-            with: .init(withAPIKey: currentAPIKey)
-                .with(entitlementVerificationMode: .informational)
-                .with(usesStoreKit2IfAvailable: true)
-        )
+        configureRCSDK()
     }
 
     func configure() {
@@ -58,7 +53,10 @@ final class Configuration: ObservableObject {
         Purchases.proxyURL = Self.proxyURL.isEmpty
         ? nil
         : URL(string: Self.proxyURL)!
+        configureRCSDK()
+    }
 
+    private func configureRCSDK() {
         Purchases.configure(
             with: .init(withAPIKey: currentAPIKey)
                 .with(entitlementVerificationMode: .informational)

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Configuration.swift
@@ -13,7 +13,7 @@ final class Configuration: ObservableObject {
 
     @Published var currentMode: Mode {
         didSet {
-            configure()
+            self.configure()
         }
     }
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/SimpleApp.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/SimpleApp.swift
@@ -27,11 +27,7 @@ struct SimpleApp: App {
 
     var body: some Scene {
         WindowGroup {
-            AppContentView(
-                customerInfoStream: Self.apiKeyIsConfigured
-                ? Purchases.shared.customerInfoStream
-                : nil
-            )
+            AppContentView()
         }
     }
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/SimpleApp.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/SimpleApp.swift
@@ -10,10 +10,6 @@ import SwiftUI
 @main
 struct SimpleApp: App {
 
-    init() {
-        Configuration.shared.configure()
-    }
-
     var body: some Scene {
         WindowGroup {
             AppContentView()

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/SimpleApp.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/SimpleApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct SimpleApp: App {
 
     init() {
-        Configuration.configure()
+        Configuration.shared.configure()
     }
 
     var body: some Scene {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/SimpleApp.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/SimpleApp.swift
@@ -5,24 +5,13 @@
 //  Created by Nacho Soto on 5/30/23.
 //
 
-import RevenueCat
-import RevenueCatUI
 import SwiftUI
 
 @main
 struct SimpleApp: App {
 
     init() {
-        Purchases.logLevel = .verbose
-        Purchases.proxyURL = Configuration.proxyURL.isEmpty
-            ? nil
-            : URL(string: Configuration.proxyURL)!
-
-        Purchases.configure(
-            with: .init(withAPIKey: Configuration.effectiveApiKey)
-                .with(entitlementVerificationMode: .informational)
-                .with(usesStoreKit2IfAvailable: true)
-        )
+        Configuration.configure()
     }
 
     var body: some Scene {
@@ -30,7 +19,5 @@ struct SimpleApp: App {
             AppContentView()
         }
     }
-
-    private static let apiKeyIsConfigured = !Configuration.effectiveApiKey.isEmpty
 
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
@@ -87,14 +87,12 @@ struct AppContentView: View {
             Spacer()
             
             Button("Configure for demos") {
-                Purchases.configure(withAPIKey: Configuration.apiKeyFromCIForDemos)
-                self.observeCustomerInfoStream()
+                self.reconfigure(with: Configuration.apiKeyFromCIForDemos)
             }
             .prominentButtonStyle()
 
             Button("Configure for testing") {
-                Purchases.configure(withAPIKey: Configuration.apiKeyFromCIForTesting)
-                self.observeCustomerInfoStream()
+                self.reconfigure(with: Configuration.apiKeyFromCIForTesting)
             }
             .prominentButtonStyle()
             
@@ -134,6 +132,11 @@ struct AppContentView: View {
                 #endif
             }
         }
+    }
+
+    private func reconfigure(with apiKey: String) {
+        Purchases.configure(withAPIKey: apiKey)
+        self.observeCustomerInfoStream()
     }
 
     private func observeCustomerInfoStream() {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
@@ -96,11 +96,11 @@ struct AppContentView: View {
                 .font(.footnote)
 
             ConfigurationButton(title: "Configure for demos", mode: .demos, configuration: configuration) {
-                self.reconfigure(for: .demos)
+                self.configuration.currentMode = .demos
             }
 
             ConfigurationButton(title: "Configure for testing", mode: .testing, configuration: configuration) {
-                self.reconfigure(for: .testing)
+                self.configuration.currentMode = .testing
             }
 
             ProminentButton(title: "Present default paywall") {
@@ -111,9 +111,6 @@ struct AppContentView: View {
         .padding(.bottom, 80)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .navigationTitle("Simple App")
-        .task {
-            self.observeCustomerInfoStream()
-        }
         #if DEBUG
         .overlay {
             if #available(iOS 16.0, macOS 13.0, *) {
@@ -138,16 +135,7 @@ struct AppContentView: View {
                 #endif
             }
         }
-    }
-
-    private func reconfigure(for mode: Configuration.Mode) {
-        self.configuration.reconfigure(for: mode)
-        self.observeCustomerInfoStream()
-    }
-
-    private func observeCustomerInfoStream() {
-        self.customerInfoTask?.cancel()
-        self.customerInfoTask = Task {
+        .task(id: self.configuration.currentMode) {
             if Purchases.isConfigured {
                 for await info in Purchases.shared.customerInfoStream {
                     self.customerInfo = info

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
@@ -177,8 +177,8 @@ private struct ProminentButton: View {
     var background: Color = .accentColor
 
     var body: some View {
-        Button(action: action) {
-            Text(title)
+        Button(action: self.action) {
+            Text(self.title)
                 .bold()
                 .padding()
                 .frame(maxWidth: .infinity)
@@ -190,6 +190,7 @@ private struct ProminentButton: View {
 }
 
 private struct ConfigurationButton: View {
+
     var title: String
     var mode: Configuration.Mode
     @ObservedObject var configuration: Configuration
@@ -203,6 +204,7 @@ private struct ConfigurationButton: View {
         )
         .disabled(self.configuration.currentMode == mode)
     }
+
 }
 
 extension CustomerInfo {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
@@ -86,14 +86,14 @@ struct AppContentView: View {
             }
             Spacer()
             
-            Button("Reconfigure for demos") {
-                Purchases.configure(withAPIKey: Configuration.apiKeyForDemos)
+            Button("Configure for demos") {
+                Purchases.configure(withAPIKey: Configuration.apiKeyFromCIForDemos)
                 self.observeCustomerInfoStream()
             }
             .prominentButtonStyle()
 
-            Button("Reconfigure for testing") {
-                Purchases.configure(withAPIKey: Configuration.apiKeyFromCI)
+            Button("Configure for testing") {
+                Purchases.configure(withAPIKey: Configuration.apiKeyFromCIForTesting)
                 self.observeCustomerInfoStream()
             }
             .prominentButtonStyle()

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
@@ -23,7 +23,6 @@ struct AppContentView: View {
     @State
     private var customerInfoTask: Task<(), Never>? = nil
 
-
     var body: some View {
         TabView {
             if Purchases.isConfigured {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
@@ -91,12 +91,12 @@ struct AppContentView: View {
             Spacer()
             
             Button("Configure for demos") {
-                self.reconfigure(with: Configuration.apiKeyFromCIForDemos)
+                self.reconfigure(for: .demos)
             }
             .prominentButtonStyle()
 
             Button("Configure for testing") {
-                self.reconfigure(with: Configuration.apiKeyFromCIForTesting)
+                self.reconfigure(for: .testing)
             }
             .prominentButtonStyle()
             
@@ -138,8 +138,8 @@ struct AppContentView: View {
         }
     }
 
-    private func reconfigure(with apiKey: String) {
-        Purchases.configure(withAPIKey: apiKey)
+    private func reconfigure(for mode: Configuration.Mode) {
+        Configuration.reconfigure(for: mode)
         self.observeCustomerInfoStream()
     }
 

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
@@ -142,7 +142,7 @@ struct AppContentView: View {
     }
 
     private func reconfigure(for mode: Configuration.Mode) {
-        configuration.reconfigure(for: mode)
+        self.configuration.reconfigure(for: mode)
         self.observeCustomerInfoStream()
     }
 
@@ -152,14 +152,13 @@ struct AppContentView: View {
             if Purchases.isConfigured {
                 for await info in Purchases.shared.customerInfoStream {
                     self.customerInfo = info
-                    self.showingDefaultPaywall = self.showingDefaultPaywall && info.activeSubscriptions.count == 0
+                    self.showingDefaultPaywall = self.showingDefaultPaywall && info.activeSubscriptions.isEmpty
                 }
             }
         }
     }
 
     private func descriptionForCurrentMode() -> String {
-
         switch self.configuration.currentMode {
         case .custom:
             return "the API set locally in Configuration.swift"
@@ -198,18 +197,18 @@ private struct ConfigurationButton: View {
 
     var body: some View {
         ProminentButton(
-            title: title,
-            action: action,
-            background: configuration.currentMode == mode ? Color.gray : Color.accentColor
+            title: self.title,
+            action: self.action,
+            background: self.configuration.currentMode == mode ? Color.gray : Color.accentColor
         )
-        .disabled(configuration.currentMode == mode)
+        .disabled(self.configuration.currentMode == mode)
     }
 }
 
 extension CustomerInfo {
 
     var hasPro: Bool {
-        return self.entitlements.active.contains { $1.identifier == Configuration.shared.entitlement }
+        return self.entitlements.active.contains { $1.identifier == Configuration.entitlement }
     }
 
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
@@ -165,8 +165,9 @@ struct AppContentView: View {
             return "the Paywalls Tester app in RevenueCat Dashboard"
         case .demos:
             return "Demos"
+        case .listOnly:
+            return "showcasing the different Paywall Templates and Modes available"
         }
-
     }
 
 }

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
@@ -180,6 +180,7 @@ private struct ProminentButton: View {
     var body: some View {
         Button(action: action) {
             Text(title)
+                .bold()
                 .padding()
                 .frame(maxWidth: .infinity)
                 .background(background)

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
@@ -17,6 +17,10 @@ struct AppContentView: View {
     @State
     private var showingDefaultPaywall: Bool = false
 
+    @State
+    private var customerInfoTask: Task<(), Never>? = nil
+
+
     var body: some View {
         TabView {
             if Purchases.isConfigured {
@@ -140,7 +144,8 @@ struct AppContentView: View {
     }
 
     private func observeCustomerInfoStream() {
-        Task {
+        self.customerInfoTask?.cancel()
+        self.customerInfoTask = Task {
             if Purchases.isConfigured {
                 for await info in Purchases.shared.customerInfoStream {
                     self.customerInfo = info

--- a/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
+++ b/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
@@ -6,8 +6,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 if [ -z "$PAYWALLS_TESTER_API_KEY_FOR_TESTING" ]; then
     echo "PaywallsTester API key for testing environment variable is not set."
-elif
-if [ -z "$PAYWALLS_TESTER_API_KEY_FOR_DEMOS" ]; then
+elif [ -z "$PAYWALLS_TESTER_API_KEY_FOR_DEMOS" ]; then
     echo "PaywallsTester API key for demos environment variable is not set."
 else
     echo "Replacing API keys on PaywallsTester"

--- a/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
+++ b/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
@@ -12,7 +12,7 @@ else
     echo "Replacing API keys on PaywallsTester"
 
     file="$SCRIPT_DIR/../PaywallsTester/Configuration.swift"
-    sed -i.bak 's/static let apiKeyFromCIForTesting = ""/static let apiKeyFromCIForTesting = "'$PAYWALLS_TESTER_API_KEY_FOR_TESTING'"/g' $file
-    sed -i.bak 's/static let apiKeyFromCIForDemos = ""/static let apiKeyFromCIForDemos = "'$PAYWALLS_TESTER_API_KEY_FOR_DEMOS'"/g' $file
+    sed -i.bak 's/private static let apiKeyFromCIForTesting = ""/private static let apiKeyFromCIForTesting = "'$PAYWALLS_TESTER_API_KEY_FOR_TESTING'"/g' $file
+    sed -i.bak 's/private static let apiKeyFromCIForDemos = ""/private static let apiKeyFromCIForDemos = "'$PAYWALLS_TESTER_API_KEY_FOR_DEMOS'"/g' $file
     rm $file.bak
 fi

--- a/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
+++ b/Tests/TestingApps/PaywallsTester/ci_scripts/ci_pre_xcodebuild.sh
@@ -1,14 +1,19 @@
 #!/bin/bash -e
 
-PAYWALLS_TESTER_API_KEY=$REVENUECAT_XCODE_CLOUD_SIMPLE_APP_API_KEY
+PAYWALLS_TESTER_API_KEY_FOR_TESTING=$REVENUECAT_XCODE_CLOUD_SIMPLE_APP_API_KEY_FOR_TESTING
+PAYWALLS_TESTER_API_KEY_FOR_DEMOS=$REVENUECAT_XCODE_CLOUD_SIMPLE_APP_API_KEY_FOR_DEMOS
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-if [ -z "$PAYWALLS_TESTER_API_KEY" ]; then
-    echo "PaywallsTester API key environment variable is not set."
+if [ -z "$PAYWALLS_TESTER_API_KEY_FOR_TESTING" ]; then
+    echo "PaywallsTester API key for testing environment variable is not set."
+elif
+if [ -z "$PAYWALLS_TESTER_API_KEY_FOR_DEMOS" ]; then
+    echo "PaywallsTester API key for demos environment variable is not set."
 else
-    echo "Replacing API key on PaywallsTester"
+    echo "Replacing API keys on PaywallsTester"
 
     file="$SCRIPT_DIR/../PaywallsTester/Configuration.swift"
-    sed -i.bak 's/private static let apiKeyFromCI = ""/private static let apiKeyFromCI = "'$PAYWALLS_TESTER_API_KEY'"/g' $file
+    sed -i.bak 's/static let apiKeyFromCIForTesting = ""/static let apiKeyFromCIForTesting = "'$PAYWALLS_TESTER_API_KEY_FOR_TESTING'"/g' $file
+    sed -i.bak 's/static let apiKeyFromCIForDemos = ""/static let apiKeyFromCIForDemos = "'$PAYWALLS_TESTER_API_KEY_FOR_DEMOS'"/g' $file
     rm $file.bak
 fi


### PR DESCRIPTION
This introduces buttons that allow you to reconfigure the app with a different API key. 

This will be useful when doing demos for customers, since the Testing app's Offerings are pretty cluttered at this point. 

<img width="447" alt="image" src="https://github.com/RevenueCat/purchases-ios/assets/3922667/c603f289-4e5e-45fd-b725-a76b552f4fde">
