### PR TITLE
`Paywalls`: simplified `LoadingPaywallView`

### DIFF
--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -40,7 +40,7 @@ struct LoadingPaywallView: View {
             introEligibility: Self.introEligibility,
             purchaseHandler: Self.purchaseHandler
         )
-        .disabled(true)
+        .allowsHitTesting(false)
         .redacted(reason: .placeholder)
     }
 

--- a/RevenueCatUI/Views/PurchaseButton.swift
+++ b/RevenueCatUI/Views/PurchaseButton.swift
@@ -117,9 +117,6 @@ private struct PurchaseButtonLabel: View {
     @Environment(\.isEnabled)
     private var isEnabled
 
-    @Environment(\.redactionReasons.isEmpty)
-    private var isNotRedacted
-
     var body: some View {
         IntroEligibilityStateView(
             textWithNoIntroOffer: self.package.localization.callToAction,
@@ -135,7 +132,7 @@ private struct PurchaseButtonLabel: View {
             .padding()
             .hidden(if: !self.isEnabled)
             .overlay {
-                if !self.isEnabled && self.isNotRedacted {
+                if !self.isEnabled {
                     ProgressView()
                         .progressViewStyle(.circular)
                         .tint(self.colors.callToActionForegroundColor)


### PR DESCRIPTION
This is a better fix than #3235. Instead of marking the view as disabled, which is also used by `PurchaseHandler` to signal that a purchase is in progress, we simply make that view not accept touches.

Which has the actual effect that we want (not being interactive), without messing with how it's displayed).

![Screenshot 2023-10-02 at 14 04 49](https://github.com/RevenueCat/purchases-ios/assets/685609/049a1931-8e71-4875-b297-c00562d318e6)
