### PR TITLE
Add `Attribution.setOnesignalUserID`

### DIFF
--- a/Sources/Purchasing/Purchases/Attribution.swift
+++ b/Sources/Purchasing/Purchases/Attribution.swift
@@ -228,7 +228,7 @@ public extension Attribution {
 
     /**
      * Subscriber attribute associated with the OneSignal Player ID for the user.
-     * Required for the RevenueCat OneSignal integration.
+     * Required for the RevenueCat OneSignal integration. Deprecated for OneSignal versions above v9.0.
      *
      * #### Related Articles
      * - [OneSignal RevenueCat Integration](https://docs.revenuecat.com/docs/onesignal)
@@ -237,6 +237,19 @@ public extension Attribution {
      */
     @objc func setOnesignalID(_ onesignalID: String?) {
         self.subscriberAttributesManager.setOnesignalID(onesignalID, appUserID: appUserID)
+    }
+
+    /**
+     * Subscriber attribute associated with the OneSignal User ID for the user.
+     * Required for the RevenueCat OneSignal integration with versions v11.0 and above.
+     *
+     * #### Related Articles
+     * - [OneSignal RevenueCat Integration](https://docs.revenuecat.com/docs/onesignal)
+     *
+     *- Parameter onesignalUserID: Empty String or `nil` will delete the subscriber attribute.
+     */
+    @objc func setOnesignalUserID(_ onesignalUserID: String?) {
+        self.subscriberAttributesManager.setOnesignalUserID(onesignalUserID, appUserID: appUserID)
     }
 
     /**

--- a/Sources/SubscriberAttributes/ReservedSubscriberAttributes.swift
+++ b/Sources/SubscriberAttributes/ReservedSubscriberAttributes.swift
@@ -36,6 +36,7 @@ enum ReservedSubscriberAttribute: String {
     case fBAnonID = "$fbAnonId"
     case mpParticleID = "$mparticleId"
     case oneSignalID = "$onesignalId"
+    case oneSignalUserID = "$onesignalUserId"
     case airshipChannelID = "$airshipChannelId"
     case cleverTapID = "$clevertapId"
     case mixpanelDistinctID = "$mixpanelDistinctId"

--- a/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -84,6 +84,10 @@ class SubscriberAttributesManager {
         setReservedAttribute(.oneSignalID, value: onesignalID, appUserID: appUserID)
     }
 
+    func setOnesignalID(_ onesignalUserID: String?, appUserID: String) {
+        setReservedAttribute(.oneSignalUserID, value: onesignalUserID, appUserID: appUserID)
+    }
+
     func setAirshipChannelID(_ airshipChannelID: String?, appUserID: String) {
         setReservedAttribute(.airshipChannelID, value: airshipChannelID, appUserID: appUserID)
     }

--- a/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -84,7 +84,7 @@ class SubscriberAttributesManager {
         setReservedAttribute(.oneSignalID, value: onesignalID, appUserID: appUserID)
     }
 
-    func setOnesignalID(_ onesignalUserID: String?, appUserID: String) {
+    func setOnesignalUserID(_ onesignalUserID: String?, appUserID: String) {
         setReservedAttribute(.oneSignalUserID, value: onesignalUserID, appUserID: appUserID)
     }
 

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCAttributionAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCAttributionAPI.m
@@ -34,6 +34,8 @@
     [a setMparticleID: @""];
     [a setOnesignalID: nil];
     [a setOnesignalID: @""];
+    [a setOnesignalUserID: nil];
+    [a setOnesignalUserID: @""];
     [a setCleverTapID: nil];
     [a setCleverTapID: @""];
     [a setMixpanelDistinctID: nil];

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/AttributionAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/AttributionAPI.swift
@@ -43,6 +43,9 @@ func checkAttributionAPI() {
     attribution.setOnesignalID("")
     attribution.setOnesignalID(nil)
 
+    attribution.setOnesignalUserID("")
+    attribution.setOnesignalUserID(nil)
+
     attribution.setCleverTapID("")
     attribution.setCleverTapID(nil)
 

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -380,6 +380,10 @@ extension MockPurchases: PurchasesType {
         self.unimplemented()
     }
 
+    func setOnesignalUserID(_ onesignalUserID: String?) {
+        self.unimplemented()
+    }
+
     func setMediaSource(_ mediaSource: String?) {
         self.unimplemented()
     }

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -380,10 +380,6 @@ extension MockPurchases: PurchasesType {
         self.unimplemented()
     }
 
-    func setOnesignalUserID(_ onesignalUserID: String?) {
-        self.unimplemented()
-    }
-
     func setMediaSource(_ mediaSource: String?) {
         self.unimplemented()
     }

--- a/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
+++ b/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
@@ -149,8 +149,8 @@ class MockSubscriberAttributesManager: SubscriberAttributesManager {
     override func setOnesignalUserID(_ onesignalUserID: String?, appUserID: String) {
         invokedSetOnesignalUserID = true
         invokedSetOnesignalUserIDCount += 1
-        invokedSetOnesignalUserIDParameters = (onesignalID, appUserID)
-        invokedSetOnesignalUserIDParametersList.append((onesignalID, appUserID))
+        invokedSetOnesignalUserIDParameters = (onesignalUserID, appUserID)
+        invokedSetOnesignalUserIDParametersList.append((onesignalUserID, appUserID))
     }
 
     var invokedSetAirshipChannelID = false

--- a/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
+++ b/Tests/UnitTests/Mocks/MockSubscriberAttributesManager.swift
@@ -141,6 +141,18 @@ class MockSubscriberAttributesManager: SubscriberAttributesManager {
         invokedSetOnesignalIDParametersList.append((onesignalID, appUserID))
     }
 
+    var invokedSetOnesignalUserID = false
+    var invokedSetOnesignalUserIDCount = 0
+    var invokedSetOnesignalUserIDParameters: (onesignalUserID: String?, appUserID: String?)?
+    var invokedSetOnesignalUserIDParametersList = [(onesignalUserID: String?, appUserID: String?)]()
+
+    override func setOnesignalUserID(_ onesignalUserID: String?, appUserID: String) {
+        invokedSetOnesignalUserID = true
+        invokedSetOnesignalUserIDCount += 1
+        invokedSetOnesignalUserIDParameters = (onesignalID, appUserID)
+        invokedSetOnesignalUserIDParametersList.append((onesignalID, appUserID))
+    }
+
     var invokedSetAirshipChannelID = false
     var invokedSetAirshipChannelIDCount = 0
     var invokedSetAirshipChannelIDParameters: (airshipChannelID: String?, appUserID: String?)?

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -609,8 +609,8 @@ class PurchasesSubscriberAttributesTests: TestCase {
         Purchases.shared.attribution.setOnesignalUserID("123abc")
         expect(self.mockSubscriberAttributesManager.invokedSetOnesignalUserIDCount) == 1
         expect(self.mockSubscriberAttributesManager.invokedSetOnesignalUserIDParameters?.onesignalUserID) == "123abc"
-        expect(self.mockSubscriberAttributesManager.invokedSetOnesignalUserIDParameters?.appUserID) == mockIdentityManager
-            .currentAppUserID
+        expect(self.mockSubscriberAttributesManager.invokedSetOnesignalUserIDParameters?.appUserID) ==
+            mockIdentityManager.currentAppUserID
     }
 
     func testSetAirshipChannelIDMakesRightCalls() {

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -402,7 +402,7 @@ class PurchasesSubscriberAttributesTests: TestCase {
             .to(equal((nil, purchases.appUserID)))
     }
 
-    func testSetAndClearOnesignalID() {
+    func testSetAndClearOnesignalUserID() {
         setupPurchases()
         purchases.attribution.setOnesignalUserID("oneSig")
         purchases.attribution.setOnesignalUserID(nil)
@@ -600,6 +600,16 @@ class PurchasesSubscriberAttributesTests: TestCase {
         expect(self.mockSubscriberAttributesManager.invokedSetOnesignalIDCount) == 1
         expect(self.mockSubscriberAttributesManager.invokedSetOnesignalIDParameters?.onesignalID) == "123abc"
         expect(self.mockSubscriberAttributesManager.invokedSetOnesignalIDParameters?.appUserID) == mockIdentityManager
+            .currentAppUserID
+    }
+
+    func testSetOnesignalUserIDMakesRightCalls() {
+        setupPurchases()
+
+        Purchases.shared.attribution.setOnesignalUserID("123abc")
+        expect(self.mockSubscriberAttributesManager.invokedSetOnesignalUserIDCount) == 1
+        expect(self.mockSubscriberAttributesManager.invokedSetOnesignalUserIDParameters?.onesignalUserID) == "123abc"
+        expect(self.mockSubscriberAttributesManager.invokedSetOnesignalUserIDParameters?.appUserID) == mockIdentityManager
             .currentAppUserID
     }
 

--- a/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/PurchasesSubscriberAttributesTests.swift
@@ -402,6 +402,16 @@ class PurchasesSubscriberAttributesTests: TestCase {
             .to(equal((nil, purchases.appUserID)))
     }
 
+    func testSetAndClearOnesignalID() {
+        setupPurchases()
+        purchases.attribution.setOnesignalUserID("oneSig")
+        purchases.attribution.setOnesignalUserID(nil)
+        expect(self.mockSubscriberAttributesManager.invokedSetOnesignalUserIDParametersList[0])
+            .to(equal(("oneSig", purchases.appUserID)))
+        expect(self.mockSubscriberAttributesManager.invokedSetOnesignalUserIDParametersList[1])
+            .to(equal((nil, purchases.appUserID)))
+    }
+
     func testSetAndClearAirshipChannelID() {
         setupPurchases()
         purchases.attribution.setAirshipChannelID("airship")

--- a/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
+++ b/Tests/UnitTests/SubscriberAttributes/SubscriberAttributesManagerTests.swift
@@ -915,6 +915,79 @@ class SubscriberAttributesManagerTests: TestCase {
         checkDeviceIdentifiersAreNotSet()
     }
     // endregion
+    // region OnesignalUserID
+    func testSetOnesignalUserID() {
+        let onesignalUserID = "onesignalUserID"
+        self.subscriberAttributesManager.setOnesignalUserID(onesignalUserID, appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+        guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
+            fatalError("no attributes received")
+        }
+        let receivedAttribute = invokedParams.attribute
+        expect(receivedAttribute.key) == "$onesignalUserId"
+        expect(receivedAttribute.value) == onesignalUserID
+        expect(receivedAttribute.isSynced) == false
+    }
+
+    func testSetOnesignalUserIDSetsEmptyIfNil() {
+        let onesignalUserID = "onesignalUserID"
+        self.subscriberAttributesManager.setOnesignalUserID(onesignalUserID, appUserID: "kratos")
+
+        self.subscriberAttributesManager.setOnesignalUserID(nil, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 2
+        guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
+            fatalError("no attributes received")
+        }
+        let receivedAttribute = invokedParams.attribute
+        expect(receivedAttribute.key) == "$onesignalUserId"
+        expect(receivedAttribute.value) == ""
+        expect(receivedAttribute.isSynced) == false
+    }
+
+    func testSetOnesignalUserIDSkipsIfSameValue() {
+        let onesignalUserID = "onesignalUserID"
+
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$onesignalUserId",
+                                                                                    value: onesignalUserID)
+
+        self.subscriberAttributesManager.setOnesignalUserID(onesignalUserID, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 0
+    }
+
+    func testSetOnesignalUserIDOverwritesIfNewValue() {
+        let oldSyncTime = Date()
+        let onesignalUserID = "onesignalUserID"
+
+        self.mockDeviceCache.stubbedSubscriberAttributeResult = SubscriberAttribute(withKey: "$onesignalUserId",
+                                                                                    value: "old_id",
+                                                                                    isSynced: true,
+                                                                                    setTime: oldSyncTime)
+
+        self.subscriberAttributesManager.setOnesignalUserID(onesignalUserID, appUserID: "kratos")
+
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+        guard let invokedParams = self.mockDeviceCache.invokedStoreParameters else {
+            fatalError("no attributes received")
+        }
+        let receivedAttribute = invokedParams.attribute
+        expect(receivedAttribute.key) == "$onesignalUserId"
+        expect(receivedAttribute.value) == onesignalUserID
+        expect(receivedAttribute.isSynced) == false
+        expect(receivedAttribute.setTime) > oldSyncTime
+    }
+
+    func testSetOnesignalUserIDDoesNotSetDeviceIdentifiers() {
+        let onesignalUserID = "onesignalUserID"
+        self.subscriberAttributesManager.setOnesignalUserID(onesignalUserID, appUserID: "kratos")
+        expect(self.mockDeviceCache.invokedStoreCount) == 1
+
+        expect(self.mockDeviceCache.invokedStoreParametersList.count) == 1
+
+        checkDeviceIdentifiersAreNotSet()
+    }
+    // endregion
     // region AirshipChannelID
     func testSetAirshipChannelID() throws {
         let airshipChannelID = "airshipChannelID"


### PR DESCRIPTION
### Motivation
OneSignal is migrating to a new User Centric API (v11.0). Adding a new reserved attribute to provide the new OneSignal User Id.

### Description
* Added $onesignalUserId reserved attribute with setter methods 
