### PR TITLE
Remove ObjC showStoreMessages API

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1E473B662AC42D34008B07F9 /* StoreMessagesHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E473B652AC42D34008B07F9 /* StoreMessagesHelper.swift */; };
 		1E473B682AC43254008B07F9 /* StoreMessageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E473B672AC43254008B07F9 /* StoreMessageType.swift */; };
 		1E473B6A2AC46908008B07F9 /* MockStoreMessagesHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E473B692AC46908008B07F9 /* MockStoreMessagesHelper.swift */; };
+		1E568B512ACC6A8300D3C12F /* StoreMessageTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E568B502ACC6A8300D3C12F /* StoreMessageTypeTests.swift */; };
 		1E99F81F2AC5917F0023E26E /* StoreMessagesHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E99F81D2AC5917F0023E26E /* StoreMessagesHelperTests.swift */; };
 		2C0B98CD2797070B00C5874F /* PromotionalOffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C0B98CC2797070B00C5874F /* PromotionalOffer.swift */; };
 		2CB8CF9327BF538F00C34DE3 /* PlatformInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CB8CF9227BF538F00C34DE3 /* PlatformInfo.swift */; };
@@ -812,6 +813,7 @@
 		1E473B652AC42D34008B07F9 /* StoreMessagesHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreMessagesHelper.swift; sourceTree = "<group>"; };
 		1E473B672AC43254008B07F9 /* StoreMessageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreMessageType.swift; sourceTree = "<group>"; };
 		1E473B692AC46908008B07F9 /* MockStoreMessagesHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreMessagesHelper.swift; sourceTree = "<group>"; };
+		1E568B502ACC6A8300D3C12F /* StoreMessageTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreMessageTypeTests.swift; sourceTree = "<group>"; };
 		1E99F81D2AC5917F0023E26E /* StoreMessagesHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreMessagesHelperTests.swift; sourceTree = "<group>"; };
 		2C0B98CC2797070B00C5874F /* PromotionalOffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromotionalOffer.swift; sourceTree = "<group>"; };
 		2C646C282A0EBD0300E5936E /* CI-Snapshots.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = "CI-Snapshots.xctestplan"; path = "Tests/TestPlans/CI-Snapshots.xctestplan"; sourceTree = "<group>"; };
@@ -1671,6 +1673,7 @@
 				F5355162286B70E0009CA47A /* OfferingsManagerStoreKitTests.swift */,
 				57CD86E5291C344000768DE1 /* UserDefaultsDefaultTests.swift */,
 				1E99F81D2AC5917F0023E26E /* StoreMessagesHelperTests.swift */,
+				1E568B502ACC6A8300D3C12F /* StoreMessageTypeTests.swift */,
 			);
 			path = StoreKitUnitTests;
 			sourceTree = "<group>";
@@ -3275,6 +3278,7 @@
 				2D90F8C126FD20F2009B9142 /* MockHTTPClient.swift in Sources */,
 				4F9BB6402A7AFB72001C120D /* MockPayment.swift in Sources */,
 				57DDA7B429CBEFB30098B89D /* MockPurchasedProductsFetcher.swift in Sources */,
+				1E568B512ACC6A8300D3C12F /* StoreMessageTypeTests.swift in Sources */,
 				57E6195028D291DC0093170C /* StoreKit2CachingProductsManagerTests.swift in Sources */,
 				F5847431278D00C1001B1CE6 /* MockDNSChecker.swift in Sources */,
 				5799708B2936CE5700FF3573 /* LoggerTests.swift in Sources */,

--- a/Sources/Misc/Concurrency/Purchases+nonasync.swift
+++ b/Sources/Misc/Concurrency/Purchases+nonasync.swift
@@ -68,38 +68,12 @@ public extension Purchases {
     @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
-    func showStoreMessages(completion: @escaping () -> Void
-    ) {
-        _ = Task<Void, Never> {
-            await self.showStoreMessages()
-            completion()
-        }
-    }
-
-    @available(iOS 16.0, *)
-    @available(macOS, unavailable)
-    @available(watchOS, unavailable)
-    @available(tvOS, unavailable)
     func showStoreMessages(
-        for types: Set<StoreMessageType>,
+        for types: Set<StoreMessageType> = Set(StoreMessageType.allCases),
         completion: @escaping () -> Void
     ) {
         _ = Task<Void, Never> {
             await self.showStoreMessages(for: types)
-            completion()
-        }
-    }
-
-    @available(iOS 16.0, *)
-    @available(macOS, unavailable)
-    @available(watchOS, unavailable)
-    @available(tvOS, unavailable)
-    func showStoreMessages(
-        for rawValues: Set<NSNumber>,
-        completion: @escaping () -> Void
-    ) {
-        _ = Task<Void, Never> {
-            await self.showStoreMessages(for: rawValues)
             completion()
         }
     }

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -186,7 +186,7 @@ import Foundation
         /// automatically.
         /// Then use the ``Purchases/showStoreMessages(for:)`` method to display the messages.
         /// More information:  https://rev.cat/storekit-message
-        /// - Important: Set this property only if you're using swift. If you're using ObjC, you won't be able to call
+        /// - Important: Set this property only if you're using Swift. If you're using ObjC, you won't be able to call
         /// the related methods
         @objc public func with(showStoreMessagesAutomatically: Bool) -> Builder {
             self.showStoreMessagesAutomatically = showStoreMessagesAutomatically

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -186,6 +186,8 @@ import Foundation
         /// automatically.
         /// Then use the ``Purchases/showStoreMessages(for:)`` method to display the messages.
         /// More information:  https://rev.cat/storekit-message
+        /// - Important: Set this property only if you're using swift. If you're using ObjC, you won't be able to call
+        /// the related methods
         @objc public func with(showStoreMessagesAutomatically: Bool) -> Builder {
             self.showStoreMessagesAutomatically = showStoreMessagesAutomatically
             return self

--- a/Sources/Purchasing/Configuration.swift
+++ b/Sources/Purchasing/Configuration.swift
@@ -184,7 +184,7 @@ import Foundation
         /// If you want to disable this behavior so that you can customize when these messages are shown, make sure
         /// you configure the SDK as early as possible in the app's lifetime, otherwise messages will be displayed
         /// automatically.
-        /// Then use the ``Purchases/showStoreMessages(for:)-8kw87`` method to display the messages.
+        /// Then use the ``Purchases/showStoreMessages(for:)`` method to display the messages.
         /// More information:  https://rev.cat/storekit-message
         @objc public func with(showStoreMessagesAutomatically: Bool) -> Builder {
             self.showStoreMessagesAutomatically = showStoreMessagesAutomatically

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -1078,26 +1078,7 @@ public extension Purchases {
     @available(macOS, unavailable)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
-    func showStoreMessages() async {
-        await self.storeMessagesHelper?.showStoreMessages(types: Set(StoreMessageType.allCases))
-    }
-
-    @available(iOS 16.0, *)
-    @available(macOS, unavailable)
-    @available(watchOS, unavailable)
-    @available(tvOS, unavailable)
-    func showStoreMessages(for rawValues: Set<NSNumber>) async {
-        let storeMessageTypes = rawValues.compactMap { number in
-            StoreMessageType(rawValue: number.intValue)
-        }
-        await self.storeMessagesHelper?.showStoreMessages(types: Set(storeMessageTypes))
-    }
-
-    @available(iOS 16.0, *)
-    @available(macOS, unavailable)
-    @available(watchOS, unavailable)
-    @available(tvOS, unavailable)
-    func showStoreMessages(for types: Set<StoreMessageType>) async {
+    func showStoreMessages(for types: Set<StoreMessageType> = Set(StoreMessageType.allCases)) async {
         await self.storeMessagesHelper?.showStoreMessages(types: types)
     }
 

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -736,41 +736,6 @@ public protocol PurchasesType: AnyObject {
 
     #endif
 
-    #if os(iOS) || targetEnvironment(macCatalyst) || VISION_OS
-
-    /**
-     * Displays all store in-app message types to the user if there are any available to be shown.
-     * - Important: This should only be used if you disabled these messages from showing automatically
-     * during SDK configuration using ``Configuration/Builder/with(showStoreMessagesAutomatically:)``
-     *
-     * ### Related Symbols
-     * - ``Purchases/showStoreMessages(for:)-8kw87``
-     * - ``Purchases/showStoreMessages(for:)-79d0o``
-     */
-    @available(iOS 16.0, *)
-    @available(macOS, unavailable)
-    @available(watchOS, unavailable)
-    @available(tvOS, unavailable)
-    func showStoreMessages() async
-
-    /**
-     * Displays the specified store in-app message types as raw values to the user if there are any
-     * available to be shown. Obj-C compatible version of this method.
-     * - Important: This should only be used if you disabled these messages from showing automatically
-     * during SDK configuration using ``Configuration/Builder/with(showStoreMessagesAutomatically:)``
-     *
-     * ### Related Symbols
-     * - ``Purchases/showStoreMessages()``
-     * - ``Purchases/showStoreMessages(for:)-8kw87``
-     */
-    @available(iOS 16.0, *)
-    @available(macOS, unavailable)
-    @available(watchOS, unavailable)
-    @available(tvOS, unavailable)
-    func showStoreMessages(for rawValues: Set<NSNumber>) async
-
-    #endif
-
     /**
      * Displays a sheet that enables users to redeem subscription offer codes that you generated in App Store Connect.
      *
@@ -1015,8 +980,7 @@ public protocol PurchasesSwiftType: AnyObject {
      * - Important: This should only be used if you disabled these messages from showing automatically
      * during SDK configuration using ``Configuration/Builder/with(showStoreMessagesAutomatically:)``
      * ### Related Symbols
-     * - ``Purchases/showStoreMessages()``
-     * - ``Purchases/showStoreMessages(for:)-79d0o``
+     * - ``Configuration/Builder/with(showStoreMessagesAutomatically:)``
      */
     @available(iOS 16.0, *)
     @available(macOS, unavailable)

--- a/Sources/Support/StoreMessageType.swift
+++ b/Sources/Support/StoreMessageType.swift
@@ -16,7 +16,7 @@ import StoreKit
 /// Type of messages available in StoreKit
 ///
 /// #### Related Symbols
-/// - ``Purchases/showStoreMessages(for:)-8kw87``
+/// - ``Purchases/showStoreMessages(for:)``
 @objc(RCStoreMessageType) public enum StoreMessageType: Int, CaseIterable, Sendable {
 
     /// Message shown when there are billing issues in a subscription

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -28,7 +28,6 @@ BOOL finishTransactions;
 id<RCPurchasesDelegate> delegate;
 NSString *appUserID;
 BOOL isAnonymous;
-NSSet<NSNumber *> *mesageTypeRawValues;
 
 + (void)checkAPI {
     RCPurchases *p = [RCPurchases configureWithAPIKey:@""];
@@ -199,11 +198,6 @@ NSSet<NSNumber *> *mesageTypeRawValues;
 #endif
 
 #if TARGET_OS_IPHONE && !TARGET_OS_TV && !TARGET_OS_WATCH
-    if (@available(iOS 16.0, *)) {
-        [p showStoreMessagesWithCompletionHandler:^{ }];
-        [p showStoreMessagesFor:mesageTypeRawValues completionHandler:^{ }];
-    }
-
     if (@available(iOS 14.0, *)) {
         [p presentCodeRedemptionSheet];
     }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -191,7 +191,6 @@ private func checkPurchasesSupportAPI(purchases: Purchases) {
     if #available(iOS 16.0, *) {
         Task {
             await purchases.showStoreMessages()
-            await purchases.showStoreMessages(for: [NSNumber(value: StoreMessageType.billingIssue.rawValue)])
             await purchases.showStoreMessages(for: [StoreMessageType.billingIssue])
         }
     }
@@ -286,10 +285,8 @@ func checkNonAsyncMethods(_ purchases: Purchases) {
     #endif
     #if os(iOS) || targetEnvironment(macCatalyst) || VISION_OS
     if #available(iOS 16.0, *) {
-        let rawValues: Set<NSNumber> = [NSNumber(value: StoreMessageType.generic.rawValue)]
         purchases.showStoreMessages { }
         purchases.showStoreMessages(for: [StoreMessageType.generic]) { }
-        purchases.showStoreMessages(for: rawValues) { }
     }
     #endif
 }

--- a/Tests/StoreKitUnitTests/StoreMessageTypeTests.swift
+++ b/Tests/StoreKitUnitTests/StoreMessageTypeTests.swift
@@ -1,0 +1,42 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  StoreMessageTypeTests.swift
+//
+//  Created by Antonio Rico Diez on 3/10/23.
+
+import Foundation
+import Nimble
+import StoreKit
+
+@testable import RevenueCat
+
+#if os(iOS) || targetEnvironment(macCatalyst) || VISION_OS
+
+@available(iOS 16.0, *)
+class StoreMessagesTypeTests: TestCase {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
+    }
+
+    func testMessageReasonIsMappedToCorrectStoreMessageType() async throws {
+        #if swift(>=5.8)
+        if #available(iOS 16.4, *) {
+            expect(Message.Reason.billingIssue.messageType) == .billingIssue
+        }
+        #endif
+        expect(Message.Reason.priceIncreaseConsent.messageType) == .priceIncreaseConsent
+        expect(Message.Reason.generic.messageType) == .generic
+    }
+}
+
+#endif

--- a/Tests/StoreKitUnitTests/StoreMessageTypeTests.swift
+++ b/Tests/StoreKitUnitTests/StoreMessageTypeTests.swift
@@ -37,7 +37,7 @@ class StoreMessagesTypeTests: TestCase {
         expect(Message.Reason.priceIncreaseConsent.messageType) == .priceIncreaseConsent
         expect(Message.Reason.generic.messageType) == .generic
     }
-    
+
 }
 
 #endif

--- a/Tests/StoreKitUnitTests/StoreMessageTypeTests.swift
+++ b/Tests/StoreKitUnitTests/StoreMessageTypeTests.swift
@@ -37,6 +37,7 @@ class StoreMessagesTypeTests: TestCase {
         expect(Message.Reason.priceIncreaseConsent.messageType) == .priceIncreaseConsent
         expect(Message.Reason.generic.messageType) == .generic
     }
+    
 }
 
 #endif

--- a/Tests/StoreKitUnitTests/StoreMessagesHelperTests.swift
+++ b/Tests/StoreKitUnitTests/StoreMessagesHelperTests.swift
@@ -11,7 +11,6 @@
 //
 //  Created by Antonio Rico Diez on 28/9/23.
 
-import Combine
 import Foundation
 import Nimble
 import StoreKit

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -452,17 +452,7 @@ extension MockPurchases: PurchasesSwiftType {
     #if os(iOS) || targetEnvironment(macCatalyst) || VISION_OS
 
     @available(iOS 16.0, *)
-    func showStoreMessages() async {
-        self.unimplemented()
-    }
-
-    @available(iOS 16.0, *)
-    func showStoreMessages(for rawValues: Set<NSNumber>) async {
-        self.unimplemented()
-    }
-
-    @available(iOS 16.0, *)
-    func showStoreMessages(for types: Set<StoreMessageType>) async {
+    func showStoreMessages(for types: Set<StoreMessageType> = Set(StoreMessageType.allCases)) async {
         self.unimplemented()
     }
 


### PR DESCRIPTION
### Description
This removes the extra APIs that were added to support showing store messages in ObjC. We will add these in PHC. If there is a demand for it we can always add it later.