### PR TITLE
`Paywalls`: fixed `macOS` compilation

### DIFF
--- a/RevenueCatUI/Modifiers/ViewExtensions.swift
+++ b/RevenueCatUI/Modifiers/ViewExtensions.swift
@@ -317,7 +317,7 @@ private extension Axis {
 
 // MARK: -
 
-#if swift(>=5.9)
+#if swift(>=5.9) && canImport(UIKit)
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 private extension UnevenRoundedRectangle {
 


### PR DESCRIPTION
Fixes https://community.revenuecat.com/sdks-51/issue-with-app-build-after-adding-sdk-package-in-xcode-15-0-3404

Note that `RevenueCatUI` isn't actually compatible with `macOS` yet (see #3128), but it should at least build.