### PR TITLE
`Purchases`: new `cachedCustomerInfo` and `cachedOfferings`

### DIFF
--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -42,7 +42,7 @@ class OfferingsManager {
         fetchPolicy: FetchPolicy = .default,
         completion: (@MainActor @Sendable (Result<Offerings, Error>) -> Void)?
     ) {
-        guard let memoryCachedOfferings = self.deviceCache.cachedOfferings else {
+        guard let memoryCachedOfferings = self.cachedOfferings else {
             Logger.debug(Strings.offering.no_cached_offerings_fetching_from_network)
 
             self.systemInfo.isApplicationBackgrounded { isAppBackgrounded in
@@ -65,6 +65,10 @@ class OfferingsManager {
                                           completion: nil)
             }
         }
+    }
+
+    var cachedOfferings: Offerings? {
+        return self.deviceCache.cachedOfferings
     }
 
     func updateOfferingsCache(

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -697,6 +697,10 @@ public extension Purchases {
         return try await self.offerings(fetchPolicy: .default)
     }
 
+    var cachedOfferings: Offerings? {
+        return self.offeringsManager.cachedOfferings
+    }
+
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     internal func offerings(fetchPolicy: OfferingsManager.FetchPolicy) async throws -> Offerings {
         return try await self.offeringsAsync(fetchPolicy: fetchPolicy)
@@ -842,6 +846,10 @@ public extension Purchases {
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func customerInfo(fetchPolicy: CacheFetchPolicy) async throws -> CustomerInfo {
         return try await self.customerInfoAsync(fetchPolicy: fetchPolicy)
+    }
+
+    var cachedCustomerInfo: CustomerInfo? {
+        return self.customerInfoManager.cachedCustomerInfo(appUserID: self.appUserID)
     }
 
     #endif

--- a/Sources/Purchasing/Purchases/PurchasesType.swift
+++ b/Sources/Purchasing/Purchases/PurchasesType.swift
@@ -168,6 +168,15 @@ public protocol PurchasesType: AnyObject {
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func customerInfo(fetchPolicy: CacheFetchPolicy) async throws -> CustomerInfo
 
+    /**
+     * The currently cached ``CustomerInfo`` if one is available.
+     * This is synchronous, and therefore useful for contexts where an app needs a `CustomerInfo`
+     * right away without waiting for a callback, like a SwiftUI view.
+     *
+     * This allows initializing state to ensure that UI can be loaded from the very first frame.
+     */
+    var cachedCustomerInfo: CustomerInfo? { get }
+
     #endif
 
     /**
@@ -201,6 +210,15 @@ public protocol PurchasesType: AnyObject {
      */
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     func offerings() async throws -> Offerings
+
+    /**
+     * The currently cached ``Offerings`` if available.
+     * This is synchronous, and therefore useful for contexts where an app needs an instance of `Offerings`
+     * right away without waiting for a callback, like a SwiftUI view.
+     *
+     * This allows initializing state to ensure that UI can be loaded from the very first frame.
+     */
+    var cachedOfferings: Offerings? { get }
 
     /**
      * Fetches the ``StoreProduct``s for your IAPs for given `productIdentifiers`.

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCPurchasesAPI.m
@@ -154,7 +154,11 @@ BOOL isAnonymous;
     [p getCustomerInfoWithFetchPolicy:RCCacheFetchPolicyFetchCurrent completion:^(RCCustomerInfo *customerInfo,
                                                                                   NSError *error) {}];
     [p getCustomerInfoWithCompletion:^(RCCustomerInfo *info, NSError *error) {}];
+    RCCustomerInfo * _Nullable __unused cachedCustomerInfo = p.cachedCustomerInfo;
+
     [p getOfferingsWithCompletion:^(RCOfferings *info, NSError *error) {}];
+    RCOfferings * _Nullable __unused offerings = p.cachedOfferings;
+
     [p getProductsWithIdentifiers:@[@""] completion:^(NSArray<RCStoreProduct *> *products) { }];
     [p purchaseProduct:storeProduct withCompletion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *error, BOOL userCancelled) { }];
     [p purchasePackage:pack withCompletion:^(RCStoreTransaction *t, RCCustomerInfo *i, NSError *e, BOOL userCancelled) { }];

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PurchasesAPI.swift
@@ -125,7 +125,11 @@ private func checkTypealiases(
 private func checkPurchasesPurchasingAPI(purchases: Purchases) {
     purchases.getCustomerInfo { (_: CustomerInfo?, _: Error?) in }
     purchases.getCustomerInfo(fetchPolicy: .default) { (_: CustomerInfo?, _: Error?) in }
+    let _: CustomerInfo? = purchases.cachedCustomerInfo
+
     purchases.getOfferings { (_: Offerings?, _: Error?) in }
+    let _: Offerings? = purchases.cachedOfferings
+
     purchases.getProducts([String]()) { (_: [StoreProduct]) in }
 
     let storeProduct: StoreProduct! = nil

--- a/Tests/UnitTests/Mocks/MockOfferingsManager.swift
+++ b/Tests/UnitTests/Mocks/MockOfferingsManager.swift
@@ -47,6 +47,10 @@ typealias OfferingsCompletion = @MainActor @Sendable (Result<Offerings, Error>) 
         }
     }
 
+    override var cachedOfferings: Offerings? {
+        return self.stubbedOfferingsCompletionResult.value
+    }
+
     struct InvokedUpdateOfferingsCacheParameters {
         let appUserID: String
         let isAppBackgrounded: Bool

--- a/Tests/UnitTests/Mocks/MockPurchases.swift
+++ b/Tests/UnitTests/Mocks/MockPurchases.swift
@@ -91,6 +91,10 @@ extension MockPurchases: PurchasesType {
         return try self.mockedCustomerInfoResponse.get()
     }
 
+    var cachedCustomerInfo: CustomerInfo? {
+        return self.mockedCustomerInfoResponse.value
+    }
+
     func getOfferings(completion: @escaping ((Offerings?, PublicError?) -> Void)) {
         self.invokedGetOfferings = true
         completion(self.mockedOfferingsResponse.value, self.mockedOfferingsResponse.error)
@@ -106,6 +110,10 @@ extension MockPurchases: PurchasesType {
         self.invokedGetOfferings = true
         self.invokedGetOfferingsParameters = fetchPolicy
         return try self.mockedOfferingsResponse.get()
+    }
+
+    var cachedOfferings: Offerings? {
+        return try? self.mockedOfferingsResponse.get()
     }
 
     // MARK: - Unimplemented

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetCustomerInfoTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetCustomerInfoTests.swift
@@ -219,16 +219,33 @@ class PurchasesGetCustomerInfoTests: BasePurchasesTests {
     }
 
     func testInvalidateCustomerInfoCacheRemovesCachedCustomerInfo() {
-        setupPurchases()
-        guard let nonOptionalPurchases = purchases else { fatalError("failed when setting up purchases for testing") }
-        let appUserID = identityManager.currentAppUserID
+        self.setupPurchases()
+
+        let appUserID = self.identityManager.currentAppUserID
         self.deviceCache.cache(customerInfo: Data(), appUserID: appUserID)
         expect(self.deviceCache.cachedCustomerInfoData(appUserID: appUserID)).toNot(beNil())
         expect(self.deviceCache.invokedClearCustomerInfoCacheCount) == 0
 
-        nonOptionalPurchases.invalidateCustomerInfoCache()
+        self.purchases.invalidateCustomerInfoCache()
         expect(self.deviceCache.cachedCustomerInfoData(appUserID: appUserID)).to(beNil())
         expect(self.deviceCache.invokedClearCustomerInfoCacheCount) == 1
+        expect(self.purchases.cachedCustomerInfo).to(beNil())
+    }
+
+    // MARK: - cachedCustomerInfo
+
+    func testCachedCustomerInfoWithNoCache() {
+        self.setupPurchases()
+
+        expect(self.purchases.cachedCustomerInfo).to(beNil())
+    }
+
+    func testCachedCustomerInfoWithCache() throws {
+        self.deviceCache.cache(customerInfo: try CustomerInfo.emptyInfo.jsonEncodedData, appUserID: Self.appUserID)
+
+        self.setupPurchases()
+
+        expect(self.purchases.cachedCustomerInfo) == .emptyInfo
     }
 
 }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesGetOfferingsTests.swift
@@ -90,6 +90,21 @@ class PurchasesGetOfferingsTests: BasePurchasesTests {
         expect(self.storeKit1Wrapper.finishCalled).toEventually(beTrue())
     }
 
+    func testCachedOfferingsEmptyByDefault() {
+        self.setupPurchases()
+
+        expect(self.purchases.cachedOfferings).to(beNil())
+    }
+
+    func testCachedOfferings() throws {
+        self.setupPurchases()
+
+        let offerings = try XCTUnwrap(self.offeringsFactory.createOfferings(from: [:], data: .mockResponse))
+        self.mockOfferingsManager.stubbedOfferingsCompletionResult = .success(offerings)
+
+        expect(self.purchases.cachedOfferings) === offerings
+    }
+
     func testInvalidateCustomerInfoCacheDoesntClearOfferingsCache() {
         self.setupPurchases()
 


### PR DESCRIPTION
This allows fixing #3283.
Fixes #2391.