### PR TITLE
`AAAttribution.attributionToken`: avoid using on main thread

### DIFF
--- a/Sources/Attribution/AttributionFetcher.swift
+++ b/Sources/Attribution/AttributionFetcher.swift
@@ -80,7 +80,7 @@ class AttributionFetcher {
     }
 
     // should match OS availability in https://developer.apple.com/documentation/ad_services
-    @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
+    @available(iOS 14.3, tvOS 14.3, macOS 11.1, watchOS 6.2, macCatalyst 14.3, *)
     var adServicesToken: String? {
         get async {
             #if canImport(AdServices)

--- a/Sources/Attribution/AttributionPoster.swift
+++ b/Sources/Attribution/AttributionPoster.swift
@@ -127,26 +127,34 @@ final class AttributionPoster {
     @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
-    func postAdServicesTokenOncePerInstallIfNeeded() {
-        guard let attributionToken = self.adServicesTokenToPostIfNeeded else { return }
+    func postAdServicesTokenOncePerInstallIfNeeded(completion: ((Error?) -> Void)? = nil) {
+        Task.detached(priority: .background) {
+            guard let attributionToken = await self.adServicesTokenToPostIfNeeded else {
+                completion?(nil)
+                return
+            }
 
-        self.post(adServicesToken: attributionToken)
+            self.post(adServicesToken: attributionToken, completion: completion)
+        }
     }
 
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     var adServicesTokenToPostIfNeeded: String? {
-        #if os(tvOS) || os(watchOS)
-        return nil
-        #else
-        guard #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) else {
+        get async {
+            #if os(tvOS) || os(watchOS)
             return nil
-        }
+            #else
+            guard #available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *) else {
+                return nil
+            }
 
-        guard self.latestNetworkIdAndAdvertisingIdentifierSent(network: .adServices) == nil else {
-            return nil
-        }
+            guard self.latestNetworkIdAndAdvertisingIdentifierSent(network: .adServices) == nil else {
+                return nil
+            }
 
-        return self.attributionFetcher.adServicesToken
-        #endif
+            return await self.attributionFetcher.adServicesToken
+            #endif
+        }
     }
 
     @discardableResult
@@ -185,7 +193,7 @@ final class AttributionPoster {
         postponedAttributionData = postponedData
     }
 
-    private func post(adServicesToken: String) {
+    private func post(adServicesToken: String, completion: ((Error?) -> Void)? = nil) {
         let currentAppUserID = self.currentUserProvider.currentAppUserID
 
         // set the cache in advance to avoid multiple post calls
@@ -194,6 +202,7 @@ final class AttributionPoster {
         self.backend.post(adServicesToken: adServicesToken, appUserID: currentAppUserID) { error in
              guard let error = error else {
                  Logger.debug(Strings.attribution.adservices_token_post_succeeded)
+                 completion?(nil)
                  return
              }
              Logger.warn(Strings.attribution.adservices_token_post_failed(error: error))
@@ -201,6 +210,8 @@ final class AttributionPoster {
             // if there's an error, reset the cache
             newDictToCache[AttributionNetwork.adServices] = nil
             self.deviceCache.set(latestAdvertisingIdsByNetworkSent: newDictToCache, appUserID: currentAppUserID)
+
+            completion?(error)
         }
     }
 

--- a/Sources/Attribution/AttributionPoster.swift
+++ b/Sources/Attribution/AttributionPoster.swift
@@ -124,7 +124,7 @@ final class AttributionPoster {
     }
 
     // should match OS availability in https://developer.apple.com/documentation/ad_services
-    @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
+    @available(iOS 14.3, tvOS 14.3, watchOS 6.2, macOS 11.1, macCatalyst 14.3, *)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
     func postAdServicesTokenOncePerInstallIfNeeded(completion: ((Error?) -> Void)? = nil) {

--- a/Sources/Purchasing/Purchases/Attribution.swift
+++ b/Sources/Purchasing/Purchases/Attribution.swift
@@ -415,12 +415,25 @@ extension Attribution {
         self.subscriberAttributesManager.unsyncedAttributesByKey(appUserID: appUserID)
     }
 
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     var unsyncedAdServicesToken: String? {
-        guard self.automaticAdServicesAttributionTokenCollection else {
-            return nil
+        get async {
+            return self.automaticAdServicesAttributionTokenCollection
+            ? await self.attributionPoster.adServicesTokenToPostIfNeeded
+            : nil
+        }
+    }
+
+    func unsyncedAdServicesToken(_ completion: @escaping (String?) -> Void) {
+        guard #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *),
+              self.automaticAdServicesAttributionTokenCollection else {
+            completion(nil)
+            return
         }
 
-        return self.attributionPoster.adServicesTokenToPostIfNeeded
+        Async.call(with: completion) {
+            await self.attributionPoster.adServicesTokenToPostIfNeeded
+        }
     }
 
     @discardableResult

--- a/Tests/UnitTests/Attribution/AttributionFetcherTests.swift
+++ b/Tests/UnitTests/Attribution/AttributionFetcherTests.swift
@@ -31,20 +31,21 @@ class AttributionFetcherTests: TestCase {
 
     #if canImport(AdServices)
     @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
-    func testAdServicesTokenIfAvailable() throws {
+    func testAdServicesTokenIfAvailable() async throws {
         try AvailabilityChecks.iOS14APIAvailableOrSkipTest()
 
         // Can't guarantee that this will produce a value in tests
         // but at least we ensure that it doesn't hang.
         // See https://github.com/RevenueCat/purchases-ios/issues/2121
-        _ = self.attributionFetcher.adServicesToken
+        _ = await self.attributionFetcher.adServicesToken
     }
     #else
     @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
-    func testAdServicesTokenNilIfNotAvailable() throws {
+    func testAdServicesTokenNilIfNotAvailable() async throws {
         try AvailabilityChecks.iOS14APIAvailableOrSkipTest()
 
-        expect(self.attributionFetcher.adServicesToken).to(beNil())
+        let token = await self.attributionFetcher.adServicesToken
+        expect(token).to(beNil())
     }
     #endif
 

--- a/Tests/UnitTests/Attribution/AttributionFetcherTests.swift
+++ b/Tests/UnitTests/Attribution/AttributionFetcherTests.swift
@@ -30,7 +30,7 @@ class AttributionFetcherTests: TestCase {
     }
 
     #if canImport(AdServices)
-    @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
+    @available(iOS 14.3, tvOS 14.3, macOS 11.1, watchOS 6.2, macCatalyst 14.3, *)
     func testAdServicesTokenIfAvailable() async throws {
         try AvailabilityChecks.iOS14APIAvailableOrSkipTest()
 
@@ -40,7 +40,7 @@ class AttributionFetcherTests: TestCase {
         _ = await self.attributionFetcher.adServicesToken
     }
     #else
-    @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
+    @available(iOS 14.3, tvOS 14.3, macOS 11.1, watchOS 6.2, macCatalyst 14.3, *)
     func testAdServicesTokenNilIfNotAvailable() async throws {
         try AvailabilityChecks.iOS14APIAvailableOrSkipTest()
 

--- a/Tests/UnitTests/Mocks/MockAttributionFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockAttributionFetcher.swift
@@ -18,7 +18,7 @@ class MockAttributionFetcher: AttributionFetcher {
     var adServicesTokenCollectionCalled = false
     var adServicesTokenToReturn: String? = "mockAdServicesToken"
 
-    @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
+    @available(iOS 14.3, tvOS 14.3, macOS 11.1, watchOS 6.2, macCatalyst 14.3, *)
     override var adServicesToken: String? {
         // Note: this needs to be `async` to avoid a crash
         // See https://github.com/apple/swift/issues/68998

--- a/Tests/UnitTests/Mocks/MockAttributionFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockAttributionFetcher.swift
@@ -17,6 +17,8 @@ class MockAttributionFetcher: AttributionFetcher {
 
     var adServicesTokenCollectionCalled = false
     var adServicesTokenToReturn: String? = "mockAdServicesToken"
+
+    @available(iOS 14.3, macOS 11.1, macCatalyst 14.3, *)
     override var adServicesToken: String? {
         // Note: this needs to be `async` to avoid a crash
         // See https://github.com/apple/swift/issues/68998

--- a/Tests/UnitTests/Mocks/MockAttributionFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockAttributionFetcher.swift
@@ -18,8 +18,12 @@ class MockAttributionFetcher: AttributionFetcher {
     var adServicesTokenCollectionCalled = false
     var adServicesTokenToReturn: String? = "mockAdServicesToken"
     override var adServicesToken: String? {
-        adServicesTokenCollectionCalled = true
-        return adServicesTokenToReturn
+        // Note: this needs to be `async` to avoid a crash
+        // See https://github.com/apple/swift/issues/68998
+        get async {
+            self.adServicesTokenCollectionCalled = true
+            return self.adServicesTokenToReturn
+        }
     }
 
 }


### PR DESCRIPTION
Fixes #3280.

Turns out that `AAAttribution.attributionToken()` is asynchronous, and Apple will happily allow you to make a blocking network request on the main thread. This avoids that.

I've refactored `AttributionFetcher.adServicesToken` to be `async` and added `RCTestAssertNotMainThread` to ensure this doesn't break again.

The rest of the changes were necessary to accommodate the new `async` API.