### PR TITLE
`PaywallEventStore`: changed container to use `URL.applicationSupportDirectory`

### DIFF
--- a/Sources/Paywalls/Events/PaywallEventStore.swift
+++ b/Sources/Paywalls/Events/PaywallEventStore.swift
@@ -93,7 +93,7 @@ extension PaywallEventStore {
         Logger.verbose(PaywallEventStoreStrings.initializing(url))
 
         let documentsDirectory = try documentsDirectory ?? Self.documentsDirectory
-        Self.removeStoreIfExists(Self.url(in: documentsDirectory))
+        Self.removeLegacyDirectoryIfExists(documentsDirectory)
 
         return try .init(handler: FileHandler(url))
     }
@@ -104,7 +104,8 @@ extension PaywallEventStore {
             .appendingPathComponent("paywall_event_store")
     }
 
-    private static func removeStoreIfExists(_ url: URL) {
+    private static func removeLegacyDirectoryIfExists(_ documentsDirectory: URL) {
+        let url = Self.url(in: documentsDirectory)
         guard Self.fileManager.fileExists(atPath: url.relativePath) else { return }
 
         Logger.debug(PaywallEventStoreStrings.removing_old_documents_store(url))

--- a/Sources/Paywalls/Events/PaywallEventStore.swift
+++ b/Sources/Paywalls/Events/PaywallEventStore.swift
@@ -85,9 +85,9 @@ internal actor PaywallEventStore: PaywallEventStoreType {
 @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, *)
 extension PaywallEventStore {
 
-    static func createDefault(documentsDirectory: URL?) throws -> PaywallEventStore {
-        let documentsDirectory = try documentsDirectory ?? Self.documentsDirectory
-        let url = documentsDirectory
+    static func createDefault(applicationSupportDirectory: URL?) throws -> PaywallEventStore {
+        let applicationSupportDirectory = try applicationSupportDirectory ?? Self.applicationSupportDirectory
+        let url = applicationSupportDirectory
             .appendingPathComponent("revenuecat")
             .appendingPathComponent("paywall_event_store")
 
@@ -96,13 +96,13 @@ extension PaywallEventStore {
         return try .init(handler: FileHandler(url))
     }
 
-    private static var documentsDirectory: URL {
+    private static var applicationSupportDirectory: URL {
         get throws {
             if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
-                return URL.documentsDirectory
+                return URL.applicationSupportDirectory
             } else {
                 return try FileManager.default.url(
-                    for: .documentDirectory,
+                    for: .applicationSupportDirectory,
                     in: .userDomainMask,
                     appropriateFor: nil,
                     create: true

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -261,7 +261,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     convenience init(apiKey: String,
                      appUserID: String?,
                      userDefaults: UserDefaults? = nil,
-                     documentsDirectory: URL? = nil,
+                     applicationSupportDirectory: URL? = nil,
                      observerMode: Bool = false,
                      platformInfo: PlatformInfo? = Purchases.platformInfo,
                      responseVerificationMode: Signing.ResponseVerificationMode,
@@ -362,7 +362,7 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
                 paywallEventsManager = PaywallEventsManager(
                     internalAPI: backend.internalAPI,
                     userProvider: identityManager,
-                    store: try PaywallEventStore.createDefault(documentsDirectory: documentsDirectory)
+                    store: try PaywallEventStore.createDefault(applicationSupportDirectory: applicationSupportDirectory)
                 )
                 Logger.verbose(Strings.paywalls.event_manager_initialized)
             } else {
@@ -1305,7 +1305,7 @@ public extension Purchases {
         appUserID: String?,
         observerMode: Bool,
         userDefaults: UserDefaults?,
-        documentsDirectory: URL? = nil,
+        applicationSupportDirectory: URL? = nil,
         platformInfo: PlatformInfo?,
         responseVerificationMode: Signing.ResponseVerificationMode,
         storeKit2Setting: StoreKit2Setting,
@@ -1318,7 +1318,7 @@ public extension Purchases {
             .init(apiKey: apiKey,
                   appUserID: appUserID,
                   userDefaults: userDefaults,
-                  documentsDirectory: documentsDirectory,
+                  applicationSupportDirectory: applicationSupportDirectory,
                   observerMode: observerMode,
                   platformInfo: platformInfo,
                   responseVerificationMode: responseVerificationMode,

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -39,7 +39,7 @@ final class TestPurchaseDelegate: NSObject, PurchasesDelegate, Sendable {
 class BaseBackendIntegrationTests: TestCase {
 
     private var userDefaults: UserDefaults!
-    private var documentsDirectory: URL!
+    private var applicationSupportDirectory: URL!
     private var testUUID: UUID!
 
     // swiftlint:disable:next weak_delegate
@@ -69,7 +69,7 @@ class BaseBackendIntegrationTests: TestCase {
                             appUserID: nil,
                             observerMode: Self.observerMode,
                             userDefaults: self.userDefaults,
-                            documentsDirectory: self.documentsDirectory,
+                            applicationSupportDirectory: self.applicationSupportDirectory,
                             platformInfo: nil,
                             responseVerificationMode: Self.responseVerificationMode,
                             storeKit2Setting: Self.storeKit2Setting,
@@ -99,7 +99,7 @@ class BaseBackendIntegrationTests: TestCase {
 
         self.createUserDefaults()
 
-        self.documentsDirectory = URL
+        self.applicationSupportDirectory = URL
             .cachesDirectory
             .appendingPathComponent(UUID().uuidString, conformingTo: .directory)
 

--- a/Tests/UnitTests/Paywalls/Events/PaywallEventStoreTests.swift
+++ b/Tests/UnitTests/Paywalls/Events/PaywallEventStoreTests.swift
@@ -33,7 +33,7 @@ class PaywallEventStoreTests: TestCase {
     // - MARK: -
 
     func testCreateDefaultDoesNotThrow() throws {
-        _ = try PaywallEventStore.createDefault(documentsDirectory: nil)
+        _ = try PaywallEventStore.createDefault(applicationSupportDirectory: nil)
     }
 
     // - MARK: store and fetch


### PR DESCRIPTION
See https://nemecek.be/blog/57/making-files-from-your-app-available-in-the-ios-files-app#writing-files-into-the-application-support-directory

Unfortunately the choice of `URL.documentsDirectory` meant that any app wanting to make its documents accessible via the Files app,
would have exposed these events.