### PR TITLE
Expose `productPlanIdentifier` in `EntitlementInfo`

### DIFF
--- a/Sources/Purchasing/EntitlementInfo.swift
+++ b/Sources/Purchasing/EntitlementInfo.swift
@@ -134,7 +134,7 @@ extension PeriodType: DefaultValueProvider {
     @objc public var productIdentifier: String { self.contents.productIdentifier }
 
     /**
-     The product plan identifier that unlocked this entitlement (usually for a Google Play purchase)
+     The product plan identifier that unlocked this entitlement (for a Google Play subscription purchase)
      */
     @objc public var productPlanIdentifier: String? { self.contents.productPlanIdentifier }
 

--- a/Sources/Purchasing/EntitlementInfo.swift
+++ b/Sources/Purchasing/EntitlementInfo.swift
@@ -136,7 +136,7 @@ extension PeriodType: DefaultValueProvider {
     /**
      The product plan identifier that unlocked this entitlement (usually for a Google Play purchase)
      */
-    @objc internal var productPlanIdentifier: String? { self.contents.productPlanIdentifier }
+    @objc public var productPlanIdentifier: String? { self.contents.productPlanIdentifier }
 
     /**
      False if this entitlement is unlocked via a production purchase
@@ -194,6 +194,7 @@ extension PeriodType: DefaultValueProvider {
             expirationDate=\(String(describing: self.expirationDate)),
             store=\(self.store),
             productIdentifier=\(self.productIdentifier),
+            productPlanIdentifier=\(self.productPlanIdentifier ?? "null"),
             isSandbox=\(self.isSandbox),
             unsubscribeDetectedAt=\(String(describing: self.unsubscribeDetectedAt)),
             billingIssueDetectedAt=\(String(describing: self.billingIssueDetectedAt)),

--- a/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCEntitlementInfoAPI.m
+++ b/Tests/APITesters/ObjCAPITester/ObjCAPITester/RCEntitlementInfoAPI.m
@@ -25,6 +25,7 @@
     NSDate *ed = [ri expirationDate];
     RCStore s = [ri store];
     NSString *pi = [ri productIdentifier];
+    NSString *ppi = [ri productPlanIdentifier];
     BOOL is = [ri isSandbox];
     NSDate *uda = [ri unsubscribeDetectedAt];
     NSDate *bida = [ri billingIssueDetectedAt];
@@ -35,7 +36,7 @@
         RCVerificationResult ver __unused = [ri verification];
     }
 
-    NSLog(i, ia, iaae, iace, ri, wr, pt, lpd, opd, ed, s, pi, is, uda, bida, ot, rawData);
+    NSLog(i, ia, iaae, iace, ri, wr, pt, lpd, opd, ed, s, pi, ppi, is, uda, bida, ot, rawData);
 }
 
 + (void)checkEnums {

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/EntitlementInfoAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/EntitlementInfoAPI.swift
@@ -27,6 +27,7 @@ func checkEntitlementInfoAPI() {
     let eDate: Date? = entitlementInfo.expirationDate
     let store: Store = entitlementInfo.store
     let pId: String = entitlementInfo.productIdentifier
+    let ppId: String? = entitlementInfo.productPlanIdentifier
     let iss: Bool = entitlementInfo.isSandbox
     let uda: Date? = entitlementInfo.unsubscribeDetectedAt
     let bida: Date? = entitlementInfo.billingIssueDetectedAt
@@ -39,7 +40,7 @@ func checkEntitlementInfoAPI() {
     let rawData: [String: Any] = entitlementInfo.rawData
 
     print(entitlementInfo!, ident, isActive, isActiveInAnyEnvironment, isActiveInCurrentEnvironment,
-          willRenew, pType, lpd!, opd!, eDate!, store, pId, iss, uda!, bida!, oType, rawData)
+          willRenew, pType, lpd!, opd!, eDate!, store, pId, ppId!, iss, uda!, bida!, oType, rawData)
 }
 
 var store: Store!


### PR DESCRIPTION
### Description
Exposes `productPlanIdentifier` in `EntitlementInfo`. This will be helpful in the hybrids so they have actual values for users purchasing Google play products and using iOS apps.
