### PR TITLE
`Paywalls`: extracted common `TemplateViewType` method for previews

### DIFF
--- a/RevenueCatUI/Helpers/PreviewHelpers.swift
+++ b/RevenueCatUI/Helpers/PreviewHelpers.swift
@@ -99,7 +99,7 @@ struct PreviewableTemplate<T: TemplateViewType>: View {
             self.creator(configuration)
                 .environmentObject(self.introEligibilityViewModel)
                 .environmentObject(PreviewHelpers.purchaseHandler)
-                .background(configuration.backgroundView)
+                .adaptTemplateView(with: configuration)
                 .disabled(PreviewHelpers.purchaseHandler.actionInProgress)
                 .task {
                     await self.introEligibilityViewModel.computeEligibility(

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -90,19 +90,11 @@ extension PaywallData {
                                   fonts: fonts,
                                   locale: locale) {
         case let .success(configuration):
-            let view = Self.createView(template: template, configuration: configuration)
+            Self.createView(template: template, configuration: configuration)
+                .adaptTemplateView(with: configuration)
                 .task(id: offering) {
                     await introEligibility.computeEligibility(for: configuration.packages)
                 }
-                .background(configuration.backgroundView)
-
-            if configuration.hasDarkMode {
-                view
-            } else {
-                // If paywall has no dark mode configured, prevent materials
-                // and other SwiftUI elements from automatically taking a dark appearance.
-                view.environment(\.colorScheme, .light)
-            }
 
         case let .failure(error):
             DebugErrorView(error, releaseBehavior: .emptyView)
@@ -156,7 +148,31 @@ extension PaywallData {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
-extension TemplateViewConfiguration {
+extension View {
+
+    func adaptTemplateView(with configuration: TemplateViewConfiguration) -> some View {
+        self
+            .background(configuration.backgroundView)
+            .adjustColorScheme(with: configuration)
+    }
+
+    @ViewBuilder
+    private func adjustColorScheme(with configuration: TemplateViewConfiguration) -> some View {
+        if configuration.hasDarkMode {
+            self
+        } else {
+            // If paywall has no dark mode configured, prevent materials
+            // and other SwiftUI elements from automatically taking a dark appearance.
+            self.environment(\.colorScheme, .light)
+        }
+    }
+
+}
+
+// MARK: - Private
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+private extension TemplateViewConfiguration {
 
     @ViewBuilder
     var backgroundView: some View {
@@ -176,7 +192,7 @@ extension TemplateViewConfiguration {
     }
 
     @ViewBuilder
-    private var backgroundContent: some View {
+    var backgroundContent: some View {
         let view = Rectangle()
             .edgesIgnoringSafeArea(.all)
 


### PR DESCRIPTION
`PreviewHelpers` was duplicating the call to `background()` and was missing the color scheme override.
In an upcoming PR I needed to add a third change to the view that would have been missing on previews, so this refactor helps.
