### PR TITLE
`CircleCI`: update simulators for Xcode 15.0.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,7 +398,7 @@ jobs:
           command: bundle exec fastlane test_revenuecatui
           no_output_timeout: 15m
           environment:
-            SCAN_DEVICE: iPhone 15 Pro,OS=17.0
+            SCAN_DEVICE: iPhone 15 Pro,OS=17.0.1
       - when:
           condition: << pipeline.parameters.generate_revenuecatui_snapshots >>
           steps:
@@ -427,7 +427,7 @@ jobs:
           command: bundle exec fastlane test_ios skip_sk_tests:true
           no_output_timeout: 15m
           environment:
-            SCAN_DEVICE: iPhone 15 (17.0)
+            SCAN_DEVICE: iPhone 15 (17.0.1)
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: RevenueCat


### PR DESCRIPTION
They haven't announced this yet, but iOS 17.0.0 isn't found anymore.
See https://app.circleci.com/pipelines/github/RevenueCat/purchases-ios/15764/workflows/45cfe00a-4721-4bc9-8b20-1e0acd4969d2/jobs/134809/parallel-runs/0/steps/0-112