### PR TITLE
`Integration Tests`: removed sleep to wait for expirations

### DIFF
--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -199,7 +199,7 @@ extension BaseStoreKitIntegrationTests {
         return try await self.purchases.purchase(package: package)
     }
 
-    func expireSubscription(_ entitlement: EntitlementInfo) async throws {
+    func expireSubscription(_ entitlement: EntitlementInfo) {
         Logger.info(TestMessage.expiring_subscription(productID: entitlement.productIdentifier))
 
         // Try expiring using `SKTestSession`

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -200,8 +200,6 @@ extension BaseStoreKitIntegrationTests {
     }
 
     func expireSubscription(_ entitlement: EntitlementInfo) async throws {
-        guard let expirationDate = entitlement.expirationDate else { return }
-
         Logger.info(TestMessage.expiring_subscription(productID: entitlement.productIdentifier))
 
         // Try expiring using `SKTestSession`
@@ -210,18 +208,6 @@ extension BaseStoreKitIntegrationTests {
         } catch {
             Logger.warn(TestMessage.expire_subscription_failed(error))
         }
-
-        let secondsUntilExpiration = expirationDate.timeIntervalSince(Date())
-        guard secondsUntilExpiration > 0 else {
-            Logger.info(TestMessage.finished_waiting_for_expiration)
-            return
-        }
-
-        let timeToSleep = Int(secondsUntilExpiration.rounded(.up) + 1)
-
-        // `SKTestSession.expireSubscription` doesn't seem to work, so force expiration by waiting
-        Logger.warn(TestMessage.sleeping_to_force_expiration(seconds: timeToSleep))
-        try await Task.sleep(nanoseconds: UInt64(timeToSleep * 1_000_000_000))
     }
 
     @available(iOS 15.2, tvOS 15.2, macOS 12.1, watchOS 8.3, *)

--- a/Tests/BackendIntegrationTests/Helpers/TestMessage.swift
+++ b/Tests/BackendIntegrationTests/Helpers/TestMessage.swift
@@ -25,8 +25,6 @@ enum TestMessage: LogMessage {
 
     case expiring_subscription(productID: String)
     case expire_subscription_failed(Error)
-    case finished_waiting_for_expiration
-    case sleeping_to_force_expiration(seconds: Int)
 
     case resetting_purchases_singleton
     case removing_receipt(URL)
@@ -50,12 +48,6 @@ extension TestMessage {
                 Test will now wait for expiration instead of triggering it.
                 Error: \(error.localizedDescription)
                 """
-
-        case .finished_waiting_for_expiration:
-            return "Done waiting for subscription expiration, continuing test."
-
-        case let .sleeping_to_force_expiration(seconds):
-            return "Sleeping for \(seconds) seconds to force expiration"
 
         case .resetting_purchases_singleton:
             return "Resetting Purchases.shared"

--- a/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/StoreKitIntegrationTests.swift
@@ -513,7 +513,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         let customerInfo = try await self.purchases.purchase(product: productWithNoTrial).customerInfo
         let entitlement = try XCTUnwrap(customerInfo.entitlements[Self.entitlementIdentifier])
 
-        try await self.expireSubscription(entitlement)
+        self.expireSubscription(entitlement)
 
         let eligibility = try await self.purchases.checkTrialOrIntroDiscountEligibility(product: productWithTrial)
         expect(eligibility) == .eligible
@@ -525,7 +525,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
         let customerInfo = try await self.purchases.purchase(product: monthlyWithTrial).customerInfo
         let entitlement = try XCTUnwrap(customerInfo.entitlements[Self.entitlementIdentifier])
-        try await self.expireSubscription(entitlement)
+        self.expireSubscription(entitlement)
 
         let eligibility = try await self.purchases.checkTrialOrIntroDiscountEligibility(product: annualWithTrial)
         expect(eligibility) == .ineligible
@@ -539,7 +539,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
         // 2. Expire subscription
         let entitlement = try XCTUnwrap(customerInfo.entitlements[Self.entitlementIdentifier])
-        try await self.expireSubscription(entitlement)
+        self.expireSubscription(entitlement)
 
         // 3. Check eligibility
         let eligibility = try await self.purchases.checkTrialOrIntroDiscountEligibility(product: product)
@@ -553,7 +553,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         let customerInfo = try await self.purchases.purchase(product: productWithNoIntro).customerInfo
         let entitlement = try await self.verifyEntitlementWentThrough(customerInfo)
 
-        try await self.expireSubscription(entitlement)
+        self.expireSubscription(entitlement)
         try await self.verifySubscriptionExpired()
 
         let eligibility = try await self.purchases.checkTrialOrIntroDiscountEligibility(product: productWithIntro)
@@ -569,7 +569,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         let customerInfo = try await self.purchaseMonthlyOffering().customerInfo
         let entitlement = try XCTUnwrap(customerInfo.entitlements.all[Self.entitlementIdentifier])
 
-        try await self.expireSubscription(entitlement)
+        self.expireSubscription(entitlement)
         try await self.verifySubscriptionExpired()
     }
 
@@ -587,7 +587,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         let entitlement = try XCTUnwrap(customerInfo.entitlements[Self.entitlementIdentifier])
 
         // 2. Expire subscription
-        try await self.expireSubscription(entitlement)
+        self.expireSubscription(entitlement)
 
         // 3. Resubscribe
         try await subscribe()
@@ -616,7 +616,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
         await waitForNewPurchaseDate()
 
         // 4. Expire subscription
-        try await self.expireSubscription(entitlement)
+        self.expireSubscription(entitlement)
 
         // 5. Re-open app
         await self.resetSingleton()
@@ -709,7 +709,7 @@ class StoreKit1IntegrationTests: BaseStoreKitIntegrationTests {
 
         // 2. Expire subscription
 
-        try await self.expireSubscription(entitlement)
+        self.expireSubscription(entitlement)
         try await self.verifySubscriptionExpired()
 
         // 3. Get eligible offer


### PR DESCRIPTION
I wonder if this is fixed in iOS 17.

We filed a Radar about this almost 1 year ago:
![Screenshot 2023-10-17 at 17 21 03](https://github.com/RevenueCat/purchases-ios/assets/685609/7eb51ca9-d701-4000-8b2a-93187e54d6e5)
