### PR TITLE
`PaywallEventStore`: also remove legacy `revenuecat` documents directory

### DIFF
--- a/Sources/Paywalls/Events/PaywallEventStore.swift
+++ b/Sources/Paywalls/Events/PaywallEventStore.swift
@@ -98,14 +98,16 @@ extension PaywallEventStore {
         return try .init(handler: FileHandler(url))
     }
 
+    private static func revenueCatFolder(in container: URL) -> URL {
+        return container.appendingPathComponent("revenuecat")
+    }
+
     private static func url(in container: URL) -> URL {
-        return container
-            .appendingPathComponent("revenuecat")
-            .appendingPathComponent("paywall_event_store")
+        return self.revenueCatFolder(in: container).appendingPathComponent("paywall_event_store")
     }
 
     private static func removeLegacyDirectoryIfExists(_ documentsDirectory: URL) {
-        let url = Self.url(in: documentsDirectory)
+        let url = Self.revenueCatFolder(in: documentsDirectory)
         guard Self.fileManager.fileExists(atPath: url.relativePath) else { return }
 
         Logger.debug(PaywallEventStoreStrings.removing_old_documents_store(url))


### PR DESCRIPTION
Fixes #3316. Follow up to #3289.

That previous fix was only removing the store itself, but not the `revenuecat` folder.

Running an app with 4.27.2 produces this:
```bash
$ tree -L 3 ~/Library/Developer/CoreSimulator/Devices/.../data/Containers/Data/Application/.../
~/Library/Developer/CoreSimulator/Devices/.../data/Containers/Data/Application/.../
├── Documents
│   └── revenuecat
│       └── paywall_event_store
```

After this fix, the Documents directory is empty.
```bash
tree -L 4 ~/Library/Developer/CoreSimulator/Devices/.../data/Containers/Data/Application/.../
/Users/ignacio/Library/Developer/CoreSimulator/Devices/.../data/Containers/Data/Application/.../
├── Documents
├── Library
│   ├── Application Support
│   │   └── revenuecat
│   │       └── paywall_event_store
```

This is still covered by the same test introduced in #3289.