### PR TITLE
`HTTPClient`: verbose logs for request IDs

### DIFF
--- a/Sources/FoundationExtensions/OperationQueue+Extensions.swift
+++ b/Sources/FoundationExtensions/OperationQueue+Extensions.swift
@@ -30,7 +30,7 @@ extension OperationQueue {
             Logger.debug(
                 Strings.network.reusing_existing_request_for_operation(
                     T.self,
-                    Logger.logLevel == .verbose
+                    Logger.verboseLogsEnabled
                     ? factory.cacheKey
                     : factory.cacheKey.prefix(15) + "…"
                 )

--- a/Sources/Logging/Logger.swift
+++ b/Sources/Logging/Logger.swift
@@ -69,6 +69,12 @@ struct Logger {
 
 }
 
+extension Logger {
+
+    static var verboseLogsEnabled: Bool { self.logLevel == .verbose }
+
+}
+
 // MARK: - LoggerType implementation
 
 /// `Logger` can be used both with static or instance methods.

--- a/Sources/Networking/HTTPClient/ETagManager.swift
+++ b/Sources/Networking/HTTPClient/ETagManager.swift
@@ -81,7 +81,7 @@ class ETagManager {
     func httpResultFromCacheOrBackend(with response: VerifiedHTTPResponse<Data?>,
                                       request: URLRequest,
                                       retried: Bool) -> VerifiedHTTPResponse<Data>? {
-        let statusCode: HTTPStatusCode = response.statusCode
+        let statusCode: HTTPStatusCode = response.httpStatusCode
         let resultFromBackend = response.asOptionalResponse
 
         guard let eTagInResponse = response.value(forHeaderField: Self.eTagResponseHeader) else {
@@ -172,7 +172,7 @@ private extension ETagManager {
                 self.storeIfPossible(
                     Response(
                         eTag: eTag,
-                        statusCode: response.statusCode,
+                        statusCode: response.httpStatusCode,
                         data: data,
                         verificationResult: response.verificationResult
                     ),
@@ -257,7 +257,7 @@ extension ETagManager.Response {
         responseVerificationResult: VerificationResult
     ) -> VerifiedHTTPResponse<Data> {
         return HTTPResponse(
-            statusCode: self.statusCode,
+            httpStatusCode: self.statusCode,
             responseHeaders: headers,
             body: self.data,
             requestDate: requestDate
@@ -280,10 +280,10 @@ private extension VerifiedHTTPResponse {
 
     var shouldStore: Bool {
         return (
-            self.statusCode != .notModified &&
+            self.httpStatusCode != .notModified &&
             // Note that we do want to store 400 responses to help the server
             // If the request was wrong, it will also be wrong the next time.
-            !self.statusCode.isServerError &&
+            !self.httpStatusCode.isServerError &&
             self.verificationResult.shouldStore
         )
     }

--- a/Sources/Networking/HTTPClient/HTTPStatusCode.swift
+++ b/Sources/Networking/HTTPClient/HTTPStatusCode.swift
@@ -101,13 +101,3 @@ extension HTTPStatusCode {
     }
 
 }
-
-extension URLResponse {
-
-    var httpStatusCode: HTTPStatusCode? {
-        guard let response = self as? HTTPURLResponse else { return nil }
-
-        return .init(rawValue: response.statusCode)
-    }
-
-}

--- a/Sources/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
+++ b/Sources/Networking/Operations/Handling/CustomerInfoResponseHandler.swift
@@ -32,7 +32,7 @@ class CustomerInfoResponseHandler {
                 if !response.body.errorResponse.attributeErrors.isEmpty {
                     // If there are any, log attribute errors.
                     // Creating the error implicitly logs it.
-                    _ = response.body.errorResponse.asBackendError(with: response.statusCode)
+                    _ = response.body.errorResponse.asBackendError(with: response.httpStatusCode)
                 }
 
                 return response.body.customerInfo.copy(with: response.verificationResult)

--- a/Sources/Networking/Operations/LogInOperation.swift
+++ b/Sources/Networking/Operations/LogInOperation.swift
@@ -84,7 +84,7 @@ private extension LogInOperation {
             .map { response in
                 (
                     response.body.copy(with: response.verificationResult),
-                    created: response.statusCode == .createdSuccess
+                    created: response.httpStatusCode == .createdSuccess
                 )
             }
             .mapError(BackendError.networkError)

--- a/Sources/Networking/Operations/PostOfferForSigningOperation.swift
+++ b/Sources/Networking/Operations/PostOfferForSigningOperation.swift
@@ -61,7 +61,7 @@ class PostOfferForSigningOperation: NetworkOperation {
                     }
                 }
                 .flatMap { response in
-                    let (statusCode, response) = (response.statusCode, response.body)
+                    let (statusCode, response) = (response.httpStatusCode, response.body)
 
                     let offers = response.offers
 

--- a/Sources/Security/Signing+ResponseVerification.swift
+++ b/Sources/Security/Signing+ResponseVerification.swift
@@ -22,7 +22,7 @@ extension HTTPResponse where Body == Data? {
     ) -> VerifiedHTTPResponse<Body> {
         let verificationResult = Self.verificationResult(
             body: self.body,
-            statusCode: self.statusCode,
+            statusCode: self.httpStatusCode,
             headers: self.responseHeaders,
             requestDate: self.requestDate,
             request: request,
@@ -36,7 +36,7 @@ extension HTTPResponse where Body == Data? {
                 request,
                 self.body,
                 self.responseHeaders,
-                statusCode
+                self.httpStatusCode
             ))
         }
         #endif

--- a/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/OtherIntegrationTests.swift
@@ -59,7 +59,8 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
             Strings.network.api_request_completed(
                 .init(method: .get,
                       path: .getCustomerInfo(appUserID: try self.purchases.appUserID)),
-                httpCode: .notModified
+                httpCode: .notModified,
+                metadata: nil
             ),
             level: .debug,
             expectedCount: 1
@@ -103,7 +104,8 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
             Strings.network.api_request_completed(
                 .init(method: .get,
                       path: .getOfferings(appUserID: try self.purchases.appUserID)),
-                httpCode: .notModified
+                httpCode: .notModified,
+                metadata: nil
             ),
             level: .debug,
             expectedCount: 1
@@ -156,7 +158,7 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
 
         // 3. Verify response was 304
         self.logger.verifyMessageWasLogged(
-            Strings.network.api_request_completed(expectedRequest, httpCode: .notModified)
+            Strings.network.api_request_completed(expectedRequest, httpCode: .notModified, metadata: nil)
         )
     }
 
@@ -175,7 +177,7 @@ class OtherIntegrationTests: BaseBackendIntegrationTests {
 
         // 4. Verify response was 304
         self.logger.verifyMessageWasLogged(
-            Strings.network.api_request_completed(expectedRequest, httpCode: .notModified)
+            Strings.network.api_request_completed(expectedRequest, httpCode: .notModified, metadata: nil)
         )
     }
 

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -35,7 +35,7 @@ class MockHTTPClient: HTTPClient {
 
             let response = VerifiedHTTPResponse(
                 response: .init(
-                    statusCode: statusCode,
+                    httpStatusCode: statusCode,
                     responseHeaders: responseHeaders,
                     body: data
                 ),

--- a/Tests/UnitTests/Networking/ETagManagerTests.swift
+++ b/Tests/UnitTests/Networking/ETagManagerTests.swift
@@ -66,7 +66,7 @@ class ETagManagerTests: TestCase {
             )
         )
 
-        expect(response.statusCode) == .success
+        expect(response.httpStatusCode) == .success
         expect(response.body) == cachedResponse
         expect(response.responseHeaders).toNot(beEmpty())
         expect(Set(response.responseHeaders.keys.compactMap { $0 as? String }))
@@ -92,7 +92,7 @@ class ETagManagerTests: TestCase {
             retried: false
         )
         expect(response).toNot(beNil())
-        expect(response?.statusCode) == .success
+        expect(response?.httpStatusCode) == .success
         expect(response?.body) == cachedResponse
 
         let newCachedResponse = try self.getCachedResponse(for: request)
@@ -118,7 +118,7 @@ class ETagManagerTests: TestCase {
         )
 
         expect(response).toNot(beNil())
-        expect(response?.statusCode) == .success
+        expect(response?.httpStatusCode) == .success
         expect(response?.body) == responseObject
         expect(response?.requestDate) == requestDate
     }
@@ -153,7 +153,7 @@ class ETagManagerTests: TestCase {
         )
 
         expect(response).toNot(beNil())
-        expect(response?.statusCode) == .notModified
+        expect(response?.httpStatusCode) == .notModified
         expect(response?.body) == responseObject
     }
 
@@ -253,7 +253,7 @@ class ETagManagerTests: TestCase {
         )
 
         expect(response).toNot(beNil())
-        expect(response?.statusCode) == .internalServerError
+        expect(response?.httpStatusCode) == .internalServerError
         expect(response?.body) == responseObject
 
         expect(self.mockUserDefaults.setObjectForKeyCallCount) == 0
@@ -352,7 +352,7 @@ class ETagManagerTests: TestCase {
             retried: true
         )
         expect(response).toNot(beNil())
-        expect(response?.statusCode) == .notModified
+        expect(response?.httpStatusCode) == .notModified
         expect(response?.body) == actualResponse
     }
 
@@ -662,7 +662,7 @@ class ETagManagerTests: TestCase {
             retried: true
         )
         expect(response).toNot(beNil())
-        expect(response?.statusCode) == .success
+        expect(response?.httpStatusCode) == .success
         expect(response?.body) == actualResponse
         expect(response?.verificationResult) == .notRequested
     }
@@ -691,7 +691,7 @@ class ETagManagerTests: TestCase {
             retried: true
         )
         expect(response).toNot(beNil())
-        expect(response?.statusCode) == .success
+        expect(response?.httpStatusCode) == .success
         expect(response?.body) == actualResponse
         expect(response?.verificationResult) == .verified
     }
@@ -720,7 +720,7 @@ class ETagManagerTests: TestCase {
             retried: true
         )
         expect(response).toNot(beNil())
-        expect(response?.statusCode) == .success
+        expect(response?.httpStatusCode) == .success
         expect(response?.body) == actualResponse
         expect(response?.verificationResult) == .failed
     }
@@ -747,7 +747,7 @@ class ETagManagerTests: TestCase {
             retried: true
         )
         expect(response).toNot(beNil())
-        expect(response?.statusCode) == .success
+        expect(response?.httpStatusCode) == .success
         expect(response?.body) == actualResponse
         expect(response?.verificationResult) == .notRequested
     }
@@ -804,7 +804,7 @@ private extension ETagManagerTests {
         requestDate: Date? = nil,
         verificationResult: RevenueCat.VerificationResult = .defaultValue
     ) -> VerifiedHTTPResponse<Data?> {
-        return .init(statusCode: statusCode,
+        return .init(httpStatusCode: statusCode,
                      responseHeaders: self.getHeaders(eTag: eTag),
                      body: body,
                      requestDate: requestDate,

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -643,7 +643,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         expect(result).toNot(beNil())
         expect(result).to(beSuccess())
         expect(result?.value?.body) == response
-        expect(result?.value?.statusCode) == .success
+        expect(result?.value?.httpStatusCode) == .success
     }
 
     func testCachedRequestsIncludeETagHeader() {
@@ -1153,7 +1153,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         self.eTagManager.stubResponseEtag(eTag)
         self.eTagManager.shouldReturnResultFromBackend = false
         self.eTagManager.stubbedHTTPResultFromCacheOrBackendResult = .init(
-            statusCode: .success,
+            httpStatusCode: .success,
             responseHeaders: headers,
             body: mockedCachedResponse,
             verificationResult: .verified
@@ -1174,7 +1174,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         }
 
         expect(response).toNot(beNil())
-        expect(response?.value?.statusCode) == .success
+        expect(response?.value?.httpStatusCode) == .success
         expect(response?.value?.body) == mockedCachedResponse
         expect(response?.value?.requestDate).to(beCloseToDate(requestDate))
         expect(response?.value?.verificationResult) == .notRequested
@@ -1392,7 +1392,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         self.eTagManager.stubResponseEtag(eTag)
         self.eTagManager.shouldReturnResultFromBackend = false
         self.eTagManager.stubbedHTTPResultFromCacheOrBackendResult = .init(
-            statusCode: .success,
+            httpStatusCode: .success,
             responseHeaders: [:],
             body: encodedResponse,
             requestDate: requestDate,

--- a/Tests/UnitTests/Networking/HTTPResponseTests.swift
+++ b/Tests/UnitTests/Networking/HTTPResponseTests.swift
@@ -24,7 +24,7 @@ class HTTPResponseTests: TestCase {
     func testResponseVerificationNotRequestedWithNoPublicKey() {
         let request = HTTPRequest(method: .get, path: .health)
         let response = HTTPResponse<Data?>(
-            statusCode: .success,
+            httpStatusCode: .success,
             responseHeaders: [:],
             body: Data()
         )
@@ -41,7 +41,7 @@ class HTTPResponseTests: TestCase {
 
         let request = HTTPRequest(method: .get, path: .postOfferForSigning)
         let response = HTTPResponse<Data?>(
-            statusCode: .success,
+            httpStatusCode: .success,
             responseHeaders: [:],
             body: Data()
         )
@@ -58,7 +58,7 @@ class HTTPResponseTests: TestCase {
 
         let request = HTTPRequest(method: .get, path: .getProductEntitlementMapping)
         let response = HTTPResponse<Data?>(
-            statusCode: .success,
+            httpStatusCode: .success,
             responseHeaders: [:],
             body: Data()
         )
@@ -123,7 +123,7 @@ class HTTPResponseTests: TestCase {
 private extension HTTPResponse where Body == HTTPEmptyResponseBody {
 
     static func create(_ headers: HTTPResponse.Headers) -> Self {
-        return .init(statusCode: .success,
+        return .init(httpStatusCode: .success,
                      responseHeaders: headers,
                      body: .init())
     }
@@ -133,7 +133,7 @@ private extension HTTPResponse where Body == HTTPEmptyResponseBody {
 private extension HTTPResponse where Body == Data {
 
     static func create(body: Data, headers: HTTPResponse.Headers) -> Self {
-        return .init(statusCode: .success,
+        return .init(httpStatusCode: .success,
                      responseHeaders: headers,
                      body: body,
                      requestDate: Date())

--- a/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/SignatureVerificationHTTPClientTests.swift
@@ -373,7 +373,7 @@ final class InformationalSignatureVerificationHTTPClientTests: BaseSignatureVeri
         }
 
         expect(response).toNot(beNil())
-        expect(response?.value?.statusCode) == .success
+        expect(response?.value?.httpStatusCode) == .success
         expect(response?.value?.verificationResult) == .verified
     }
 

--- a/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
+++ b/Tests/UnitTests/OfflineEntitlements/CustomerInfoResponseHandlerTests.swift
@@ -43,7 +43,7 @@ class NormalCustomerInfoResponseHandlerTests: BaseCustomerInfoResponseHandlerTes
     func testHandleNormalResponse() async {
         let result = await self.handle(
             .success(
-                .init(statusCode: .success,
+                .init(httpStatusCode: .success,
                       responseHeaders: [:],
                       body: .init(customerInfo: Self.sampleCustomerInfo,
                                   errorResponse: .default),
@@ -60,7 +60,7 @@ class NormalCustomerInfoResponseHandlerTests: BaseCustomerInfoResponseHandlerTes
     func testHandleWithFailedVerification() async {
         let result = await self.handle(
             .success(
-                .init(statusCode: .success,
+                .init(httpStatusCode: .success,
                       responseHeaders: [:],
                       body: .init(customerInfo: Self.sampleCustomerInfo,
                                   errorResponse: .default),
@@ -98,7 +98,7 @@ class NormalCustomerInfoResponseHandlerTests: BaseCustomerInfoResponseHandlerTes
 
         let result = await self.handle(
             .success(
-                .init(statusCode: .success,
+                .init(httpStatusCode: .success,
                       responseHeaders: [:],
                       body: .init(customerInfo: Self.sampleCustomerInfo,
                                   errorResponse: errorResponse),

--- a/Tests/UnitTests/Security/SigningTests.swift
+++ b/Tests/UnitTests/Security/SigningTests.swift
@@ -504,7 +504,7 @@ class SigningTests: TestCase {
 
     func testResponseVerificationWithNoProvidedKey() throws {
         let request = HTTPRequest.createWithResponseVerification(method: .get, path: .health)
-        let response = HTTPResponse<Data?>(statusCode: .success, responseHeaders: [:], body: Data())
+        let response = HTTPResponse<Data?>(httpStatusCode: .success, responseHeaders: [:], body: Data())
         let verifiedResponse = response.verify(signing: self.signing, request: request, publicKey: nil)
 
         expect(verifiedResponse.verificationResult) == .notRequested
@@ -513,7 +513,7 @@ class SigningTests: TestCase {
     func testResponseVerificationWithNoSignatureInResponse() throws {
         let request = HTTPRequest.createWithResponseVerification(method: .get, path: .health)
 
-        let response = HTTPResponse<Data?>(statusCode: .success, responseHeaders: [:], body: Data())
+        let response = HTTPResponse<Data?>(httpStatusCode: .success, responseHeaders: [:], body: Data())
         let verifiedResponse = response.verify(signing: self.signing, request: request, publicKey: self.publicKey)
 
         expect(verifiedResponse.verificationResult) == .failed
@@ -525,7 +525,7 @@ class SigningTests: TestCase {
     func testResponseVerificationWithInvalidSignature() throws {
         let request = HTTPRequest.createWithResponseVerification(method: .get, path: .health)
         let response = HTTPResponse<Data?>(
-            statusCode: .success,
+            httpStatusCode: .success,
             responseHeaders: [
                 HTTPClient.ResponseHeader.signature.rawValue: "invalid_signature"
             ],
@@ -557,7 +557,7 @@ class SigningTests: TestCase {
         )
 
         let response = HTTPResponse<Data?>(
-            statusCode: .success,
+            httpStatusCode: .success,
             responseHeaders: [
                 HTTPClient.ResponseHeader.signature.rawValue: fullSignature.base64EncodedString(),
                 HTTPClient.ResponseHeader.requestDate.rawValue: String(requestDate)
@@ -590,7 +590,7 @@ class SigningTests: TestCase {
         )
 
         let response = HTTPResponse<Data?>(
-            statusCode: .success,
+            httpStatusCode: .success,
             responseHeaders: [
                 HTTPClient.ResponseHeader.signature.rawValue: fullSignature.base64EncodedString(),
                 HTTPClient.ResponseHeader.requestDate.rawValue: String(requestDate),
@@ -623,7 +623,7 @@ class SigningTests: TestCase {
         )
 
         let response = HTTPResponse<Data?>(
-            statusCode: .success,
+            httpStatusCode: .success,
             responseHeaders: [
                 HTTPClient.ResponseHeader.signature.rawValue: fullSignature.base64EncodedString(),
                 HTTPClient.ResponseHeader.requestDate.rawValue: String(requestDate)
@@ -641,7 +641,7 @@ class SigningTests: TestCase {
 
         let request = HTTPRequest(method: .get, path: .postOfferForSigning, nonce: nil)
         let response = HTTPResponse<Data?>(
-            statusCode: .success,
+            httpStatusCode: .success,
             responseHeaders: [
                 HTTPClient.ResponseHeader.requestDate.rawValue: String(requestDate)
             ],


### PR DESCRIPTION
See https://github.com/RevenueCat/khepri/pull/6798.
This can help debug issues as it helps us cross-reference requests on our end.

### Changes:
- Logging `X-Request-ID` and `X-Amzn-Trace-ID` headers if present (only in verbose mode)
- Logging these even for failed requests
- Also logging `request_handled_by_load_shedder` for failed requests
- To accomplish that. `HTTPURLResponse` now conforms to our `HTTPResponseType`, this allows us to extract headers in an uniform way

### Example:
```
[network] DEBUG: ℹ️ API request completed: GET '/v1/subscribers/$RCAnonymousID%3Ad9dc4f3b33054cf28c0f2ec9da0f48d5' (304)
Request-ID: 'be534c50-5231-403b-be2f-7c077861751d'; Amzn-Trace-ID: 'Root=1-6532c6ca-7ef80f961ec9c4145484df13'
```