### PR TITLE
`CircleCI`: change iOS 17 job to use M1 Large resource

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,7 +416,7 @@ jobs:
           
   run-test-ios-17:
     <<: *base-job
-    resource_class: macos.m1.medium.gen1
+    resource_class: macos.m1.large.gen1
     steps:
       - checkout
       - install-dependencies


### PR DESCRIPTION
See https://circleci.com/product/features/resource-classes/#macos
See https://discuss.circleci.com/t/severe-performance-problems-with-xcode-15/

Hopefully this makes the iOS 17 failures less common.
