### PR TITLE
`PurchasedProductsFetcher`: remove cache

### DIFF
--- a/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
+++ b/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
@@ -35,8 +35,6 @@ enum OfflineEntitlementsStrings {
 
     case purchased_products_fetching
     case purchased_products_fetching_too_slow
-    case purchased_products_returning_cache(count: Int)
-    case purchased_products_invalidating_cache
 
 }
 
@@ -103,12 +101,6 @@ extension OfflineEntitlementsStrings: LogMessage {
 
         case .purchased_products_fetching_too_slow:
             return "PurchasedProductsFetcher: fetching products took too long"
-
-        case let .purchased_products_returning_cache(count):
-            return "PurchasedProductsFetcher: returning \(count) cached products"
-
-        case .purchased_products_invalidating_cache:
-            return "PurchasedProductsFetcher: invalidating cache"
         }
     }
 

--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -248,7 +248,6 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     private let customerInfoManager: CustomerInfoManager
     private let paywallEventsManager: PaywallEventsManagerType?
     private let trialOrIntroPriceEligibilityChecker: CachingTrialOrIntroPriceEligibilityChecker
-    private let purchasedProductsFetcher: PurchasedProductsFetcherType?
     private let purchasesOrchestrator: PurchasesOrchestrator
     private let receiptFetcher: ReceiptFetcher
     private let requestFetcher: StoreKitRequestFetcher
@@ -581,7 +580,6 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
         self.offeringsManager = offeringsManager
         self.offlineEntitlementsManager = offlineEntitlementsManager
         self.purchasesOrchestrator = purchasesOrchestrator
-        self.purchasedProductsFetcher = purchasedProductsFetcher
         self.trialOrIntroPriceEligibilityChecker = trialOrIntroPriceEligibilityChecker
         self.storeMessagesHelper = storeMessagesHelper
 
@@ -1607,7 +1605,6 @@ private extension Purchases {
     func handleCustomerInfoChanged(from old: CustomerInfo?, to new: CustomerInfo) {
         if old != nil {
             self.trialOrIntroPriceEligibilityChecker.clearCache()
-            self.purchasedProductsFetcher?.clearCache()
         }
 
         self.delegate?.purchases?(self, receivedUpdated: new)

--- a/Tests/StoreKitUnitTests/OfflineEntitlements/PurchasedProductsFetcherTests.swift
+++ b/Tests/StoreKitUnitTests/OfflineEntitlements/PurchasedProductsFetcherTests.swift
@@ -83,24 +83,4 @@ class PurchasedProductsFetcherTests: BasePurchasedProductsFetcherTests {
         ]))
     }
 
-    func testCacheIsInvalidated() async throws {
-        let product1 = try await self.fetchSk2Product(Self.productID)
-        _ = try await self.createTransactionWithPurchase(product: product1)
-
-        let products1 = try await self.fetcher.fetchPurchasedProducts()
-        expect(products1).to(haveCount(1))
-
-        let product2 = try await self.fetchSk2Product("com.revenuecat.annual_39.99_no_trial")
-        _ = try await self.createTransactionWithPurchase(product: product2)
-
-        self.fetcher.clearCache()
-
-        let products2 = try await self.fetcher.fetchPurchasedProducts()
-        expect(products2).to(haveCount(2))
-        expect(products2.map(\.productIdentifier)).to(contain([
-            product1.id,
-            product2.id
-        ]))
-    }
-
 }

--- a/Tests/UnitTests/Mocks/MockPurchasedProductsFetcher.swift
+++ b/Tests/UnitTests/Mocks/MockPurchasedProductsFetcher.swift
@@ -29,12 +29,4 @@ final class MockPurchasedProductsFetcher: PurchasedProductsFetcherType {
         return try self.stubbedResult.get()
     }
 
-    var invokedClearCache = false
-    var invokedClearCacheCount = 0
-
-    func clearCache() {
-        self.invokedClearCache = true
-        self.invokedClearCacheCount += 1
-    }
-
 }

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesConfiguringTests.swift
@@ -231,13 +231,6 @@ class PurchasesConfiguringTests: BasePurchasesTests {
         expect(self.cachingTrialOrIntroPriceEligibilityChecker.invokedClearCache) == false
     }
 
-    func testFirstInitializationDoesNotClearPurchasedProductsCache() {
-        self.setupPurchases()
-        expect(self.purchasesDelegate.customerInfoReceivedCount).toEventually(equal(1))
-
-        expect(self.mockPurchasedProductsFetcher.invokedClearCache) == false
-    }
-
     func testFirstInitializationFromForegroundDelegateForAnonIfNothingCached() {
         self.systemInfo.stubbedIsApplicationBackgrounded = false
         self.setupPurchases()

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesLogInTests.swift
@@ -263,19 +263,6 @@ class ExistingUserPurchasesLogInTests: BasePurchasesLogInTests {
         expect(self.cachingTrialOrIntroPriceEligibilityChecker.invokedClearCacheCount) == 1
     }
 
-    func testLogInClearsPurchasedProductsFetcherCache() {
-        expect(self.mockPurchasedProductsFetcher.invokedClearCache) == false
-
-        self.identityManager.mockLogInResult = .success((Self.mockLoggedInInfo, true))
-
-        waitUntil { completed in
-            self.purchases.logIn(Self.appUserID) { _, _, _ in completed() }
-        }
-
-        expect(self.mockPurchasedProductsFetcher.invokedClearCache).toEventually(beTrue())
-        expect(self.mockPurchasedProductsFetcher.invokedClearCacheCount) == 1
-    }
-
 }
 
 // MARK: -


### PR DESCRIPTION
I have a theory that this is what's making offline entitlements integration tests flaky.
