### PR TITLE
`ProductFetcherSK1`: enable `TimingUtil` log

### DIFF
--- a/Sources/Purchasing/ProductsManager.swift
+++ b/Sources/Purchasing/ProductsManager.swift
@@ -84,7 +84,7 @@ class ProductsManager: NSObject, ProductsManagerType {
             }
         } else {
             self.sk1Products(withIdentifiers: identifiers) { result in
-                completion(result.map { Set($0.map(StoreProduct.init(sk1Product:))) })
+                completion(result.map { Set($0.map(StoreProduct.from(product:))) })
             }
         }
     }
@@ -122,8 +122,8 @@ class ProductsManager: NSObject, ProductsManagerType {
 private extension ProductsManager {
 
     func sk1Products(withIdentifiers identifiers: Set<String>,
-                     completion: @escaping (Result<Set<SK1Product>, PurchasesError>) -> Void) {
-        return self.productsFetcherSK1.sk1Products(withIdentifiers: identifiers, completion: completion)
+                     completion: @escaping (Result<Set<SK1StoreProduct>, PurchasesError>) -> Void) {
+        return self.productsFetcherSK1.products(withIdentifiers: identifiers, completion: completion)
     }
 
 }


### PR DESCRIPTION
`ProductFetcherSK1` had 2 public methods for fetching products: `products(withIdentifiers:completion:)` and `sk1Products(withIdentifiers:completion:)`.
Only one of them was using `TimingUtil` to log slow requests, and that one happened to not be used by `ProductsManager`, which means that we weren't getting these logs.

This is evident in https://github.com/RevenueCat/react-native-purchases/issues/755. With this change, we'll now be able to see how long the product request took.
