### PR TITLE
`Integration Tests`: new logs for troubleshooting flaky tests

### DIFF
--- a/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
+++ b/Sources/Logging/Strings/OfflineEntitlementsStrings.swift
@@ -34,6 +34,7 @@ enum OfflineEntitlementsStrings {
     case computed_offline_customer_info_details([PurchasedSK2Product], EntitlementInfos)
 
     case purchased_products_fetching
+    case purchased_products_fetched(count: Int)
     case purchased_products_fetching_too_slow
     case purchased_products_returning_cache(count: Int)
     case purchased_products_invalidating_cache
@@ -100,6 +101,9 @@ extension OfflineEntitlementsStrings: LogMessage {
 
         case .purchased_products_fetching:
             return "PurchasedProductsFetcher: fetching products from StoreKit"
+
+        case let .purchased_products_fetched(count):
+            return "PurchasedProductsFetcher: fetched \(count) products from StoreKit"
 
         case .purchased_products_fetching_too_slow:
             return "PurchasedProductsFetcher: fetching products took too long"

--- a/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
+++ b/Sources/OfflineEntitlements/PurchasedProductsFetcher.swift
@@ -95,8 +95,10 @@ final class PurchasedProductsFetcher: PurchasedProductsFetcherType {
         }
 
         Logger.debug(Strings.offlineEntitlements.purchased_products_fetching)
+        let result = await StoreKit.Transaction.currentEntitlements.extractValues()
+        Logger.debug(Strings.offlineEntitlements.purchased_products_fetched(count: result.count))
 
-        return await StoreKit.Transaction.currentEntitlements.extractValues()
+        return result
     }
 
 }

--- a/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseStoreKitIntegrationTests.swift
@@ -256,6 +256,11 @@ extension BaseStoreKitIntegrationTests {
             return
         }
 
+        await self.printReceipt()
+        await self.printStoreKit2Transactions()
+    }
+
+    private func printReceipt() async {
         do {
             let receipt = try await self.purchases.fetchReceipt(.always)
             let description = receipt.map { $0.debugDescription } ?? "<null>"
@@ -271,6 +276,18 @@ extension BaseStoreKitIntegrationTests {
             }
         } catch {
             Logger.error(TestMessage.error_parsing_receipt(error))
+        }
+    }
+
+    private func printStoreKit2Transactions() async {
+        do {
+            let transactions = await StoreKit.Transaction.currentEntitlements.extractValues()
+            Logger.appleWarning(TestMessage.current_entitlements(transactions))
+        }
+
+        do {
+            let transactions = await StoreKit.Transaction.unfinished.extractValues()
+            Logger.appleWarning(TestMessage.unfinished_transactions(transactions))
         }
     }
 

--- a/Tests/BackendIntegrationTests/Helpers/TestMessage.swift
+++ b/Tests/BackendIntegrationTests/Helpers/TestMessage.swift
@@ -19,6 +19,8 @@ import Foundation
 @testable import RevenueCat
 #endif
 
+import StoreKit
+
 // swiftlint:disable identifier_name
 
 enum TestMessage: LogMessage {
@@ -32,6 +34,8 @@ enum TestMessage: LogMessage {
     case removing_receipt(URL)
     case error_removing_url(URL, Error)
     case receipt_content(String)
+    case current_entitlements([StoreKit.VerificationResult<StoreKit.Transaction>])
+    case unfinished_transactions([StoreKit.VerificationResult<StoreKit.Transaction>])
     case unable_parse_receipt_without_sdk
     case error_parsing_receipt(Error)
 
@@ -68,6 +72,12 @@ extension TestMessage {
 
         case let .receipt_content(receipt):
             return "Receipt content:\n\(receipt)"
+
+        case let .current_entitlements(transactions):
+            return "Current entitlements:\n\(transactions)"
+
+        case let .unfinished_transactions(transactions):
+            return "Unfinished transactions:\n\(transactions)"
 
         case .unable_parse_receipt_without_sdk:
             return "Can't print receipt when purchases isn't configured"


### PR DESCRIPTION
This modifies `BaseStoreKitIntegrationTests.printReceipt` to also log `StoreKit 2` transactions which can be used to debug failures of `OfflineStoreKitIntegrationTests`.
`PurchasedProductsFetcher` also logs how many `currentEntitlements` it found since failures are coming from there.
