### PR TITLE
`Paywalls`: enable all iOS 17 tests

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -274,8 +274,8 @@ struct LoadedOfferingPaywallView: View {
                         locale: self.locale)
             .environmentObject(self.introEligibility)
             .environmentObject(self.purchaseHandler)
-            .preference(key: PurchasedCustomerInfoPreferenceKey.self,
-                        value: self.purchaseHandler.purchasedCustomerInfo)
+            .preference(key: PurchasedResultPreferenceKey.self,
+                        value: .init(data: self.purchaseHandler.purchaseResult))
             .preference(key: RestoredCustomerInfoPreferenceKey.self,
                         value: self.purchaseHandler.restoredCustomerInfo)
             .disabled(self.purchaseHandler.actionInProgress)

--- a/RevenueCatUI/Purchasing/PurchaseHandler+TestData.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler+TestData.swift
@@ -23,6 +23,7 @@ extension PurchaseHandler {
         return self.init(
             purchases: MockPurchases { _ in
                 return (
+                    // No current way to create a mock transaction with RevenueCat's public methods.
                     transaction: nil,
                     customerInfo: customerInfo,
                     userCancelled: false

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -33,7 +33,7 @@ final class PurchaseHandler: ObservableObject {
 
     /// When `purchased` becomes `true`, this will include the `CustomerInfo` associated to it.
     @Published
-    fileprivate(set) var purchasedCustomerInfo: CustomerInfo?
+    fileprivate(set) var purchaseResult: PurchaseResultData?
 
     /// Whether a restore was successfully completed.
     @Published
@@ -84,7 +84,7 @@ extension PurchaseHandler {
         } else {
             withAnimation(Constants.defaultAnimation) {
                 self.purchased = true
-                self.purchasedCustomerInfo = result.customerInfo
+                self.purchaseResult = result
             }
         }
 
@@ -189,11 +189,26 @@ private final class NotConfiguredPurchases: PaywallPurchasesType {
 // MARK: - Preference Keys
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
-struct PurchasedCustomerInfoPreferenceKey: PreferenceKey {
+struct PurchasedResultPreferenceKey: PreferenceKey {
 
-    static var defaultValue: CustomerInfo?
+    struct PurchaseResult: Equatable {
+        var transaction: StoreTransaction?
+        var customerInfo: CustomerInfo
 
-    static func reduce(value: inout CustomerInfo?, nextValue: () -> CustomerInfo?) {
+        init(data: PurchaseResultData) {
+            self.transaction = data.transaction
+            self.customerInfo = data.customerInfo
+        }
+
+        init?(data: PurchaseResultData?) {
+            guard let data else { return nil }
+            self.init(data: data)
+        }
+    }
+
+    static var defaultValue: PurchaseResult?
+
+    static func reduce(value: inout PurchaseResult?, nextValue: () -> PurchaseResult?) {
         value = nextValue()
     }
 

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -45,9 +45,12 @@ public final class PaywallViewController: UIViewController {
         let paywallView = self.offering.map { PaywallView(offering: $0) } ?? PaywallView()
 
         let view = paywallView
-            .onPurchaseCompleted { [weak self] customerInfo in
+            .onPurchaseCompleted { [weak self] transaction, customerInfo in
                 guard let self = self else { return }
                 self.delegate?.paywallViewController?(self, didFinishPurchasingWith: customerInfo)
+                self.delegate?.paywallViewController?(self,
+                                                      didFinishPurchasingWith: customerInfo,
+                                                      transaction: transaction)
             }
             .onRestoreCompleted { [weak self] customerInfo in
                 guard let self = self else { return }
@@ -82,6 +85,12 @@ public protocol PaywallViewControllerDelegate: AnyObject {
     @objc(paywallViewController:didFinishPurchasingWithCustomerInfo:)
     optional func paywallViewController(_ controller: PaywallViewController,
                                         didFinishPurchasingWith customerInfo: CustomerInfo)
+
+    /// Notifies that a purchase has completed in a ``PaywallViewController``.
+    @objc(paywallViewController:didFinishPurchasingWithCustomerInfo:transaction:)
+    optional func paywallViewController(_ controller: PaywallViewController,
+                                        didFinishPurchasingWith customerInfo: CustomerInfo,
+                                        transaction: StoreTransaction?)
 
     /// Notifies that the restore operation has completed in a ``PaywallViewController``.
     ///

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
@@ -15,6 +15,7 @@ struct App: View {
     private var offering: Offering
     private var fonts: PaywallFontProvider
     private var completed: PurchaseOrRestoreCompletedHandler = { (_: CustomerInfo) in }
+    private var purchaseCompleted: PurchaseCompletedHandler = { (_: CustomerInfo, _: StoreTransaction?) in }
 
     var body: some View {
         self.content
@@ -35,24 +36,29 @@ struct App: View {
         Text("")
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "")
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", fonts: self.fonts)
-            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", purchaseCompleted: completed)
-            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", restoreCompleted: completed)
-            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", fonts: self.fonts, purchaseCompleted: completed)
-            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", fonts: self.fonts, restoreCompleted: completed)
-            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", fonts: self.fonts, purchaseCompleted: completed,
-                                    restoreCompleted: completed)
+            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "",
+                                    purchaseCompleted: self.purchaseOrRestoreCompleted)
+            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "",
+                                    restoreCompleted: self.purchaseOrRestoreCompleted)
+            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", fonts: self.fonts,
+                                    purchaseCompleted: self.purchaseOrRestoreCompleted)
+            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", fonts: self.fonts,
+                                    restoreCompleted: self.purchaseOrRestoreCompleted)
+            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", fonts: self.fonts,
+                                    purchaseCompleted: self.purchaseOrRestoreCompleted,
+                                    restoreCompleted: self.purchaseOrRestoreCompleted)
             .presentPaywallIfNeeded(fonts: self.fonts) { (_: CustomerInfo) in false }
             .presentPaywallIfNeeded(fonts: self.fonts) { (_: CustomerInfo) in
                 false
             } purchaseCompleted: {
-                completed($0)
+                self.purchaseOrRestoreCompleted($0)
             }
             .presentPaywallIfNeeded(fonts: self.fonts) { (_: CustomerInfo) in
                 false
             } purchaseCompleted: {
-                completed($0)
+                self.purchaseOrRestoreCompleted($0)
             } restoreCompleted: {
-                completed($0)
+                self.purchaseOrRestoreCompleted($0)
             }
     }
 
@@ -61,37 +67,41 @@ struct App: View {
         Text("")
             .paywallFooter()
             .paywallFooter(fonts: self.fonts)
-            .paywallFooter(purchaseCompleted: completed)
-            .paywallFooter(fonts: self.fonts, purchaseCompleted: completed)
+            .paywallFooter(purchaseCompleted: self.purchaseOrRestoreCompleted)
+            .paywallFooter(fonts: self.fonts, purchaseCompleted: self.purchaseOrRestoreCompleted)
             .paywallFooter(condensed: true)
             .paywallFooter(condensed: true, fonts: self.fonts)
-            .paywallFooter(condensed: true, purchaseCompleted: completed)
-            .paywallFooter(condensed: true, fonts: self.fonts, purchaseCompleted: completed)
+            .paywallFooter(condensed: true, purchaseCompleted: self.purchaseOrRestoreCompleted)
+            .paywallFooter(condensed: true, fonts: self.fonts, purchaseCompleted: self.purchaseOrRestoreCompleted)
             .paywallFooter(condensed: true, fonts: self.fonts,
-                           purchaseCompleted: completed, restoreCompleted: completed)
+                           purchaseCompleted: self.purchaseOrRestoreCompleted,
+                           restoreCompleted: self.purchaseOrRestoreCompleted)
 
             .paywallFooter(offering: offering)
             .paywallFooter(offering: offering, condensed: true)
             .paywallFooter(offering: offering, condensed: true, fonts: self.fonts)
-            .paywallFooter(offering: offering, condensed: true, purchaseCompleted: completed)
-            .paywallFooter(offering: offering, condensed: true, restoreCompleted: completed)
-            .paywallFooter(offering: offering, condensed: true, fonts: self.fonts, purchaseCompleted: completed)
+            .paywallFooter(offering: offering, condensed: true, purchaseCompleted: self.purchaseOrRestoreCompleted)
+            .paywallFooter(offering: offering, condensed: true, restoreCompleted: self.purchaseOrRestoreCompleted)
             .paywallFooter(offering: offering, condensed: true, fonts: self.fonts,
-                           purchaseCompleted: completed, restoreCompleted: completed)
+                           purchaseCompleted: self.purchaseOrRestoreCompleted)
+            .paywallFooter(offering: offering, condensed: true, fonts: self.fonts,
+                           purchaseCompleted: self.purchaseOrRestoreCompleted,
+                           restoreCompleted: self.purchaseOrRestoreCompleted)
             .paywallFooter(offering: offering)
             .paywallFooter(offering: offering, fonts: self.fonts)
-            .paywallFooter(offering: offering, purchaseCompleted: completed)
-            .paywallFooter(offering: offering, restoreCompleted: completed)
-            .paywallFooter(offering: offering, fonts: self.fonts, purchaseCompleted: completed)
+            .paywallFooter(offering: offering, purchaseCompleted: self.purchaseOrRestoreCompleted)
+            .paywallFooter(offering: offering, restoreCompleted: self.purchaseOrRestoreCompleted)
+            .paywallFooter(offering: offering, fonts: self.fonts, purchaseCompleted: self.purchaseOrRestoreCompleted)
             .paywallFooter(offering: offering, fonts: self.fonts,
-                           purchaseCompleted: completed, restoreCompleted: completed)
+                           purchaseCompleted: completed, restoreCompleted: self.purchaseOrRestoreCompleted)
     }
 
     @ViewBuilder
     var checkOnPurchaseAndRestoreCompleted: some View {
         Text("")
-            .onPurchaseCompleted(self.completed)
-            .onRestoreCompleted(self.completed)
+            .onPurchaseCompleted(self.purchaseOrRestoreCompleted)
+            .onPurchaseCompleted(self.purchaseCompleted)
+            .onRestoreCompleted(self.purchaseOrRestoreCompleted)
     }
 
     private func fontProviders() {

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
@@ -14,8 +14,8 @@ struct App: View {
 
     private var offering: Offering
     private var fonts: PaywallFontProvider
-    private var completed: PurchaseOrRestoreCompletedHandler = { (_: CustomerInfo) in }
-    private var purchaseCompleted: PurchaseCompletedHandler = { (_: CustomerInfo, _: StoreTransaction?) in }
+    private var purchaseOrRestoreCompleted: PurchaseOrRestoreCompletedHandler = { (_: CustomerInfo) in }
+    private var purchaseCompleted: PurchaseCompletedHandler = { (_: StoreTransaction?, _: CustomerInfo) in }
 
     var body: some View {
         self.content
@@ -93,7 +93,8 @@ struct App: View {
             .paywallFooter(offering: offering, restoreCompleted: self.purchaseOrRestoreCompleted)
             .paywallFooter(offering: offering, fonts: self.fonts, purchaseCompleted: self.purchaseOrRestoreCompleted)
             .paywallFooter(offering: offering, fonts: self.fonts,
-                           purchaseCompleted: completed, restoreCompleted: self.purchaseOrRestoreCompleted)
+                           purchaseCompleted: self.purchaseOrRestoreCompleted,
+                           restoreCompleted: self.purchaseOrRestoreCompleted)
     }
 
     @ViewBuilder

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewControllerAPI.swift
@@ -24,6 +24,10 @@ final class Delegate: PaywallViewControllerDelegate {
                                didFinishPurchasingWith customerInfo: CustomerInfo) {}
 
     func paywallViewController(_ controller: PaywallViewController,
+                               didFinishPurchasingWith customerInfo: CustomerInfo,
+                               transaction: StoreTransaction?) {}
+
+    func paywallViewController(_ controller: PaywallViewController,
                                didFinishRestoringWith customerInfo: CustomerInfo) {}
 
 }

--- a/Tests/RevenueCatUITests/BaseSnapshotTest.swift
+++ b/Tests/RevenueCatUITests/BaseSnapshotTest.swift
@@ -87,7 +87,9 @@ extension BaseSnapshotTest {
 extension View {
 
     /// Adds the receiver to a view hierarchy to be able to test lifetime logic.
-    func addToHierarchy() throws {
+    /// - Returns: dispose block that removes the view from the hierarchy.
+    @discardableResult
+    func addToHierarchy() throws -> () -> Void {
         UIView.setAnimationsEnabled(false)
 
         let controller = UIHostingController(
@@ -100,16 +102,25 @@ extension View {
         window.isHidden = false
         window.rootViewController = controller
         window.frame.size = BaseSnapshotTest.fullScreenSize
-        window.makeKeyAndVisible()
 
         window.addSubview(controller.view)
-        controller.didMove(toParent: controller)
 
         window.setNeedsLayout()
         window.layoutIfNeeded()
 
         controller.beginAppearanceTransition(true, animated: false)
         controller.endAppearanceTransition()
+
+        window.makeKeyAndVisible()
+
+        return {
+            controller.beginAppearanceTransition(false, animated: false)
+            controller.view.removeFromSuperview()
+            controller.removeFromParent()
+            controller.endAppearanceTransition()
+            window.rootViewController = nil
+            window.resignKey()
+        }
     }
 
 }

--- a/Tests/RevenueCatUITests/BaseSnapshotTest.swift
+++ b/Tests/RevenueCatUITests/BaseSnapshotTest.swift
@@ -88,10 +88,6 @@ extension View {
 
     /// Adds the receiver to a view hierarchy to be able to test lifetime logic.
     func addToHierarchy() throws {
-        if #available(iOS 17.0, *) {
-            try XCTSkipIf(true, "This is currently not working on iOS 17")
-        }
-
         UIView.setAnimationsEnabled(false)
 
         let controller = UIHostingController(

--- a/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
+++ b/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
@@ -49,16 +49,11 @@ class PaywallViewEventsTests: TestCase {
         self.cancelEventExpectation = .init(description: "Cancel event")
     }
 
-    func testPaywallImpressionEvent() async throws {
-        let expectation = XCTestExpectation()
-
+    func testPaywallImpressionEvent() throws {
         try self.createView()
-        .onAppear { expectation.fulfill() }
-        .addToHierarchy()
+            .addToHierarchy()
 
-        await self.fulfillment(of: [expectation], timeout: 1)
-
-        expect(self.events).to(containElementSatisfying { $0.eventType == .impression })
+        expect(self.events).toEventually(containElementSatisfying { $0.eventType == .impression })
 
         let event = try XCTUnwrap(self.events.first { $0.eventType == .impression })
         self.verifyEventData(event.data)
@@ -123,7 +118,7 @@ class PaywallViewEventsTests: TestCase {
         await self.fulfillment(of: [self.impressionEventExpectation, self.closeEventExpectation], timeout: 1)
 
         expect(self.events).to(haveCount(4))
-        expect(self.events.map(\.eventType)) == [.impression, .close, .impression, .close]
+        expect(Set(self.events.map(\.eventType))) == [.impression, .close, .impression, .close]
         expect(Set(self.events.map(\.data.sessionIdentifier))).to(haveCount(2))
     }
 

--- a/Tests/RevenueCatUITests/PresentIfNeededTests.swift
+++ b/Tests/RevenueCatUITests/PresentIfNeededTests.swift
@@ -27,6 +27,10 @@ class PresentIfNeededTests: TestCase {
         try super.setUpWithError()
 
         try AvailabilityChecks.iOS16APIAvailableOrSkipTest()
+
+        if #available(iOS 17.0, *) {
+            try XCTSkipIf(true, "This test is currently not working on iOS 17")
+        }
     }
 
     func testPresentWithPurchaseHandler() throws {

--- a/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
@@ -70,6 +70,29 @@ class PurchaseCompletedHandlerTests: TestCase {
         expect(customerInfo).toEventually(be(TestData.customerInfo))
     }
 
+    func testOnPurchaseCompletedWithTransaction() throws {
+        var result: (transaction: StoreTransaction?, customerInfo: CustomerInfo)?
+
+        try PaywallView(
+            offering: Self.offering.withLocalImages,
+            customerInfo: TestData.customerInfo,
+            introEligibility: .producing(eligibility: .eligible),
+            purchaseHandler: Self.purchaseHandler
+        )
+            .onPurchaseCompleted { transaction, customerInfo in
+                result = (transaction, customerInfo)
+            }
+            .addToHierarchy()
+
+        Task {
+            _ = try await Self.purchaseHandler.purchase(package: Self.package)
+        }
+
+        expect(result).toEventuallyNot(beNil())
+        expect(result?.customerInfo) === TestData.customerInfo
+        expect(result?.transaction).to(beNil())
+    }
+
     func testOnRestoreCompleted() throws {
         var customerInfo: CustomerInfo?
 

--- a/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
+++ b/Tests/RevenueCatUITests/Purchasing/PurchaseHandlerTests.swift
@@ -25,7 +25,7 @@ class PurchaseHandlerTests: TestCase {
     func testInitialState() async throws {
         let handler: PurchaseHandler = .mock()
 
-        expect(handler.purchasedCustomerInfo).to(beNil())
+        expect(handler.purchaseResult).to(beNil())
         expect(handler.restoredCustomerInfo).to(beNil())
         expect(handler.purchased) == false
         expect(handler.restored) == false
@@ -37,7 +37,7 @@ class PurchaseHandlerTests: TestCase {
 
         _ = try await handler.purchase(package: TestData.packageWithIntroOffer)
 
-        expect(handler.purchasedCustomerInfo) === TestData.customerInfo
+        expect(handler.purchaseResult?.customerInfo) === TestData.customerInfo
         expect(handler.restoredCustomerInfo).to(beNil())
         expect(handler.purchased) == true
         expect(handler.actionInProgress) == false
@@ -47,7 +47,7 @@ class PurchaseHandlerTests: TestCase {
         let handler: PurchaseHandler = .cancelling()
 
         _ = try await handler.purchase(package: TestData.packageWithIntroOffer)
-        expect(handler.purchasedCustomerInfo).to(beNil())
+        expect(handler.purchaseResult).to(beNil())
         expect(handler.purchased) == false
         expect(handler.actionInProgress) == false
     }
@@ -61,7 +61,7 @@ class PurchaseHandlerTests: TestCase {
         expect(result.success) == false
         expect(handler.restored) == true
         expect(handler.restoredCustomerInfo) === TestData.customerInfo
-        expect(handler.purchasedCustomerInfo).to(beNil())
+        expect(handler.purchaseResult).to(beNil())
         expect(handler.actionInProgress) == false
     }
 


### PR DESCRIPTION
These were failing in some of the earlier Xcode 15 betas, but they all seem to be passing now. `PresentIfNeededTests` are still not working though. But I just manually verified that these modifiers do work correctly on iOS 17 on an app.