### PR TITLE
`PaywallColor`: change visibility of `Color.init(light:dark:)` to `private`

### DIFF
--- a/Sources/Paywalls/PaywallColor.swift
+++ b/Sources/Paywalls/PaywallColor.swift
@@ -180,16 +180,15 @@ private extension Color {
         self.init(UIColor(light: light, dark: dark))
     }
 
-}
-
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
-public extension Color {
-
-    /// Creates a `Color` given a light and a dark `Color`.
     @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
     init(light: Color, dark: Color) {
         self.init(light: UIColor(light), dark: UIColor(dark))
     }
+
+}
+
+@available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
+public extension Color {
 
     /// Converts a `Color` into a `PaywallColor`.
     /// - Warning: This `PaywallColor` won't be able to be encoded,


### PR DESCRIPTION
Fixes #3344.

This wasn't meant to be `public` as it's only used within the `RevenueCat` framework and can lead to conflicts.