### PR TITLE
`ErrorUtils.purchasesError(withSKError:)`: handle `URLError`s

### DIFF
--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -288,6 +288,15 @@ enum ErrorUtils {
             return skError.asPurchasesError
         case let purchasesError as PurchasesError:
             return purchasesError
+        case is URLError:
+            // Some StoreKit APIs can return `URLError`s.
+            // See https://github.com/RevenueCat/purchases-ios/issues/3343
+            return NetworkError.networkError(
+                error as NSError,
+                .init(file: fileName,
+                      function: functionName,
+                      line: line)
+            ).asPurchasesError
         default:
             return ErrorUtils.unknownError(
                 error: error,

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -527,14 +527,7 @@ private extension NetworkError {
             Logger.error(blockedError.description)
             self = blockedError
         } else {
-            let nsError = error as NSError
-
-            switch (nsError.domain, nsError.code) {
-            case (NSURLErrorDomain, NSURLErrorNotConnectedToInternet):
-                self = .offlineConnection()
-            default:
-                self = .networkError(error)
-            }
+            self = .networkError(error as NSError)
         }
     }
 

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -1282,6 +1282,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         let path: HTTPRequest.Path = .mockPath
 
         let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
+        let expectedError: NetworkError = .networkError(error)
 
         stub(condition: isPath(path)) { _ in
             let response = HTTPStubsResponse.emptySuccessResponse()
@@ -1295,8 +1296,9 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
             }
         }
 
-        expect(obtainedError).toNot(beNil())
-        expect(obtainedError) == .offlineConnection()
+        // Can't compare the errors directly because `obtainedError` has additional userInfo.
+        expect(obtainedError?.asPurchasesError)
+            .to(matchError(expectedError.asPurchasesError))
     }
 
     func testErrorIsLoggedAndReturnsDNSErrorWhenGETRequestFailedWithDNSError() {

--- a/Tests/UnitTests/Networking/NetworkErrorTests.swift
+++ b/Tests/UnitTests/Networking/NetworkErrorTests.swift
@@ -381,4 +381,15 @@ extension NetworkError {
         )
     }
 
+    static func offlineConnection(
+        file: String = #fileID, function: String = #function, line: UInt = #line
+    ) -> Self {
+        return .networkError(
+            NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet),
+            file: file,
+            function: function,
+            line: line
+        )
+    }
+
 }

--- a/Tests/UnitTests/Paywalls/Events/PaywallEventsManagerTests.swift
+++ b/Tests/UnitTests/Paywalls/Events/PaywallEventsManagerTests.swift
@@ -126,12 +126,13 @@ class PaywallEventsManagerTests: TestCase {
     func testFlushWithUnsuccessfulPostError() async throws {
         let event = await self.storeRandomEvent()
         let storedEvent: PaywallStoredEvent = .init(event: event, userID: Self.userID)
+        let expectedError: NetworkError = .offlineConnection()
 
-        self.api.stubbedPostPaywallEventsCompletionResult = .networkError(.offlineConnection())
+        self.api.stubbedPostPaywallEventsCompletionResult = .networkError(expectedError)
         do {
             _ = try await self.manager.flushEvents(count: 1)
             fail("Expected error")
-        } catch BackendError.networkError(.offlineConnection) {
+        } catch BackendError.networkError(expectedError) {
             // Expected
         } catch {
             throw error

--- a/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
+++ b/Tests/UnitTests/Purchasing/ErrorUtilsTests.swift
@@ -136,6 +136,14 @@ class ErrorUtilsTests: TestCase {
             .to(matchError(error))
     }
 
+    func testPurchasesErrorWithNetworkErrorAsSKError() {
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
+        let expectedError = ErrorUtils.offlineConnectionError()
+
+        expect(ErrorUtils.purchasesError(withSKError: error))
+            .to(matchError(expectedError))
+    }
+
     func testPurchaseErrorsAreLoggedAsApppleErrors() {
         let underlyingError = NSError(domain: SKErrorDomain, code: SKError.Code.paymentInvalid.rawValue)
         let error = ErrorUtils.purchaseNotAllowedError(error: underlyingError)


### PR DESCRIPTION
Fixes #3343.

`SKPaymentTransaction.error` docs say:
> The error property is undefined except when `transactionState` is set to `SKPaymentTransactionState.failed`. Your application can read the error property to determine why the transaction failed. For a list of error constants, see `SKErrorDomain` in StoreKit Constants.

Which is why [`PurchasesOrchestrator` only considered that domain](https://github.com/RevenueCat/purchases-ios/blob/4.28.1/Sources/Purchasing/Purchases/PurchasesOrchestrator.swift#L792).

This expands this handling to consider any other network error, therefore providing more precise errors.

Since offline connection error detection was only in `HTTPClient`, I also moved that out and removed `NetworkError.offlineConnection`, so that we detect this when converting `NetworkError.networkError` instead.
