### PR TITLE
`Paywalls Tester`: improve `.paywallFooter` presentation

### DIFF
--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/CustomPaywall.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/CustomPaywall.swift
@@ -25,8 +25,6 @@ struct CustomPaywall: View {
 
     private var content: some View {
         CustomPaywallContent()
-            .scrollableIfNecessary(.vertical)
-            .background(CustomPaywallContent.backgroundColor)
             .paywallFooter(offering: self.offering,
                            customerInfo: self.customerInfo,
                            condensed: self.condensed,

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/CustomPaywallContent.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/CustomPaywallContent.swift
@@ -5,6 +5,11 @@
 //  Created by Nacho Soto on 8/25/23.
 //
 
+#if DEBUG
+@testable import RevenueCatUI
+#else
+import RevenueCatUI
+#endif
 
 import SwiftUI
 
@@ -14,6 +19,15 @@ struct CustomPaywallContent: View {
     @State private var starOpacity: Double = 1
 
     var body: some View {
+        self.content
+        #if DEBUG
+            .scrollableIfNecessary(.vertical)
+        #endif
+            .background(CustomPaywallContent.backgroundColor)
+    }
+
+    @ViewBuilder
+    private var content: some View {
         VStack(alignment: .leading, spacing: 8) {
             Image("cat-picture")
                 .resizable()


### PR DESCRIPTION
This uses `CustomPaywallContent` instead of the `Text` simple paywall:

### Before:
![Simulator Screenshot - iPhone 14 Pro Max - 2023-10-25 at 10 51 45](https://github.com/RevenueCat/purchases-ios/assets/685609/97b6366e-3f9b-465f-803b-9b5f1ffd8c40)

### After:
![simulator_screenshot_F8012E6F-ECAF-4EBE-A71F-70C610C6466C](https://github.com/RevenueCat/purchases-ios/assets/685609/dc3000de-4ae7-45b1-8425-946f02b6daee)

I also fixed a bug where the context menu no longer worked since #3339, by unifying the state into a single property.
