### PR TITLE
`Paywalls`: move size configuration to `TemplateViewType`

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -254,7 +254,7 @@ struct LoadedOfferingPaywallView: View {
     }
 
     var body: some View {
-        let view = self.paywall
+        self.paywall
             .createView(for: self.offering,
                         activelySubscribedProductIdentifiers: self.activelySubscribedProductIdentifiers,
                         template: self.template,
@@ -271,16 +271,6 @@ struct LoadedOfferingPaywallView: View {
             .disabled(self.purchaseHandler.actionInProgress)
             .onAppear { self.purchaseHandler.trackPaywallImpression(self.createEventData()) }
             .onDisappear { self.purchaseHandler.trackPaywallClose() }
-
-        switch self.mode {
-        case .fullScreen:
-            view
-
-        case .footer, .condensedFooter:
-            view
-                .fixedSize(horizontal: false, vertical: true)
-                .edgesIgnoringSafeArea(.bottom)
-        }
     }
 
     private func createEventData() -> PaywallEvent.Data {

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -154,6 +154,7 @@ extension View {
         self
             .background(configuration.backgroundView)
             .adjustColorScheme(with: configuration)
+            .adjustSize(with: configuration.mode)
     }
 
     @ViewBuilder
@@ -164,6 +165,19 @@ extension View {
             // If paywall has no dark mode configured, prevent materials
             // and other SwiftUI elements from automatically taking a dark appearance.
             self.environment(\.colorScheme, .light)
+        }
+    }
+
+    @ViewBuilder
+    private func adjustSize(with mode: PaywallViewMode) -> some View {
+        switch mode {
+        case .fullScreen:
+            self
+
+        case .footer, .condensedFooter:
+            self
+                .fixedSize(horizontal: false, vertical: true)
+                .edgesIgnoringSafeArea(.bottom)
         }
     }
 


### PR DESCRIPTION
This simplifies the implementation in `PaywallView` and reuses this code so `PreviewableTemplate` can use it too.
