### PR TITLE
`Paywalls`: new optional `displayCloseButton` parameter

### DIFF
--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -151,34 +151,24 @@ private struct PresentingPaywallModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .sheet(item: self.$data, onDismiss: self.onDismiss) { data in
-                NavigationView {
-                    PaywallView(
-                        offering: self.offering,
-                        customerInfo: data.customerInfo,
-                        fonts: self.fontProvider,
-                        introEligibility: self.introEligibility,
-                        purchaseHandler: self.purchaseHandler
-                    )
-                    .onPurchaseCompleted {
-                        self.purchaseCompleted?($0)
+                PaywallView(
+                    offering: self.offering,
+                    customerInfo: data.customerInfo,
+                    fonts: self.fontProvider,
+                    displayCloseButton: true,
+                    introEligibility: self.introEligibility,
+                    purchaseHandler: self.purchaseHandler
+                )
+                .onPurchaseCompleted {
+                    self.purchaseCompleted?($0)
 
+                    self.close()
+                }
+                .onRestoreCompleted { customerInfo in
+                    self.restoreCompleted?(customerInfo)
+
+                    if !self.shouldDisplay(customerInfo) {
                         self.close()
-                    }
-                    .onRestoreCompleted { customerInfo in
-                        self.restoreCompleted?(customerInfo)
-
-                        if !self.shouldDisplay(customerInfo) {
-                            self.close()
-                        }
-                    }
-                    .toolbar {
-                        ToolbarItem(placement: .destructiveAction) {
-                            Button {
-                                self.close()
-                            } label: {
-                                Image(systemName: "xmark")
-                            }
-                        }
                     }
                 }
             }

--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -22,6 +22,7 @@ import SwiftUI
 struct LoadingPaywallView: View {
 
     var mode: PaywallViewMode
+    var dismiss: (() -> Void)?
 
     var shimmer: Bool = true
 
@@ -39,6 +40,7 @@ struct LoadingPaywallView: View {
             template: Self.template,
             mode: self.mode,
             fonts: DefaultPaywallFontProvider(),
+            dismiss: dismiss,
             introEligibility: Self.introEligibility,
             purchaseHandler: Self.purchaseHandler
         )

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
@@ -27,9 +27,13 @@ struct App: View {
     @ViewBuilder
     var content: some View {
         PaywallView()
+        PaywallView(displayCloseButton: true)
         PaywallView(fonts: self.fonts)
+        PaywallView(fonts: self.fonts, displayCloseButton: true)
         PaywallView(offering: self.offering)
+        PaywallView(offering: self.offering, displayCloseButton: true)
         PaywallView(offering: self.offering, fonts: self.fonts)
+        PaywallView(offering: self.offering, fonts: self.fonts, displayCloseButton: true)
     }
 
     @ViewBuilder

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/AppContentView.swift
@@ -109,7 +109,7 @@ struct AppContentView: View {
             }
 
             ProminentButton(title: "Present default paywall") {
-                showingDefaultPaywall.toggle()
+                self.showingDefaultPaywall.toggle()
             }
         }
         .padding(.horizontal)
@@ -125,20 +125,7 @@ struct AppContentView: View {
         }
         #endif
         .sheet(isPresented: self.$showingDefaultPaywall) {
-            NavigationView {
-                PaywallView()
-                #if targetEnvironment(macCatalyst)
-                    .toolbar {
-                        ToolbarItem(placement: .destructiveAction) {
-                            Button {
-                                self.showingDefaultPaywall = false
-                            } label: {
-                                Image(systemName: "xmark")
-                            }
-                        }
-                    }
-                #endif
-            }
+            PaywallView(displayCloseButton: true)
         }
         .task(id: self.configuration.currentMode) {
             if Purchases.isConfigured {

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/OfferingsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/OfferingsList.swift
@@ -91,14 +91,13 @@ struct OfferingsList: View {
                         if let paywall = offering.paywall {
                             #if targetEnvironment(macCatalyst)
                             NavigationLink(
-                                destination: PaywallPresenter(offering: offering,
-                                                              mode: self.selectedMode),
-                                tag: offering,
-                                selection: self.$selectedOffering
+                                destination: PaywallPresenter(offering: offering, 
+                                                              mode: .default,
+                                                              displayCloseButton: false),
+                                tag: PresentedPaywall(offering: offering, mode: .default),
+                                selection: self.$presentedPaywall
                             ) {
-                                OfferButton(offering: offering, paywall: paywall) {
-                                    self.selectedOffering = offering
-                                }
+                                OfferButton(offering: offering, paywall: paywall) {}
                                 .contextMenu {
                                     self.contextMenu(for: offering)
                                 }
@@ -168,11 +167,12 @@ private struct PaywallPresenter: View {
 
     var offering: Offering
     var mode: PaywallViewMode
+    var displayCloseButton: Bool = true
 
     var body: some View {
         switch self.mode {
         case .fullScreen:
-            PaywallView(offering: self.offering)
+            PaywallView(offering: self.offering, displayCloseButton: self.displayCloseButton)
 
         case .footer:
             CustomPaywallContent()

--- a/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/SamplePaywallsList.swift
+++ b/Tests/TestingApps/PaywallsTester/PaywallsTester/Views/SamplePaywallsList.swift
@@ -22,23 +22,7 @@ struct SamplePaywallsList: View {
                 .navigationTitle("Test Paywalls")
         }
             .sheet(item: self.$display) { display in
-                NavigationView {
-                    self.view(for: display)
-                        #if targetEnvironment(macCatalyst) || (swift(>=5.9) && os(xrOS))
-                        .toolbar {
-                            ToolbarItem(placement: .destructiveAction) {
-                                Button {
-                                    self.display = nil
-                                } label: {
-                                    Image(systemName: "xmark")
-                                }
-                            }
-                        }
-                        #endif
-                }
-            }
-            .onPurchaseCompleted { _ in
-                self.display = nil
+                self.view(for: display)
             }
             .navigationTitle("Paywalls")
             .navigationViewStyle(StackNavigationViewStyle())
@@ -52,6 +36,7 @@ struct SamplePaywallsList: View {
             case .fullScreen:
                 PaywallView(offering: Self.loader.offering(for: template),
                             customerInfo: Self.loader.customerInfo,
+                            displayCloseButton: true,
                             introEligibility: Self.introEligibility,
                             purchaseHandler: .default())
 
@@ -67,6 +52,7 @@ struct SamplePaywallsList: View {
             PaywallView(offering: Self.loader.offering(for: template),
                         customerInfo: Self.loader.customerInfo,
                         fonts: Self.customFontProvider,
+                        displayCloseButton: true,
                         introEligibility: Self.introEligibility,
                         purchaseHandler: .default())
 


### PR DESCRIPTION
The [documentation](https://www.revenuecat.com/docs/displaying-paywalls#close-button) points out that this is only automatic when using `presentPaywallIfNeeded`, but it can also be useful to have `RevenueCatUI` do this automatically.
