### PR TITLE
`Paywalls`: avoid animating `PurchaseButton` labels when text does not change

### DIFF
--- a/RevenueCatUI/Templates/Template1View.swift
+++ b/RevenueCatUI/Templates/Template1View.swift
@@ -43,8 +43,8 @@ struct Template1View: TemplateViewType {
             Spacer()
 
             IntroEligibilityStateView(
-                textWithNoIntroOffer: self.localization.offerDetails,
-                textWithIntroOffer: self.localization.offerDetailsWithIntroOffer,
+                display: .offerDetails,
+                localization: self.localization,
                 introEligibility: self.introEligibility,
                 foregroundColor: self.configuration.colors.text1Color
             )

--- a/RevenueCatUI/Templates/Template2View.swift
+++ b/RevenueCatUI/Templates/Template2View.swift
@@ -198,8 +198,8 @@ struct Template2View: TemplateViewType {
 
     private func offerDetails(package: TemplateViewConfiguration.Package, selected: Bool) -> some View {
         IntroEligibilityStateView(
-            textWithNoIntroOffer: package.localization.offerDetails,
-            textWithIntroOffer: package.localization.offerDetailsWithIntroOffer,
+            display: .offerDetails,
+            localization: package.localization,
             introEligibility: self.introEligibility[package.content],
             foregroundColor: self.textColor(selected),
             alignment: Self.packageButtonAlignment

--- a/RevenueCatUI/Templates/Template3View.swift
+++ b/RevenueCatUI/Templates/Template3View.swift
@@ -61,8 +61,8 @@ struct Template3View: TemplateViewType {
             Spacer()
 
             IntroEligibilityStateView(
-                textWithNoIntroOffer: self.localization.offerDetails,
-                textWithIntroOffer: self.localization.offerDetailsWithIntroOffer,
+                display: .offerDetails,
+                localization: self.localization,
                 introEligibility: self.introEligibility,
                 foregroundColor: self.configuration.colors.text2Color
             )

--- a/RevenueCatUI/Templates/Template4View.swift
+++ b/RevenueCatUI/Templates/Template4View.swift
@@ -152,8 +152,8 @@ struct Template4View: TemplateViewType {
             selected: self.selectedPackage
         ) { package in
             IntroEligibilityStateView(
-                textWithNoIntroOffer: package.localization.offerDetails,
-                textWithIntroOffer: package.localization.offerDetailsWithIntroOffer,
+                display: .offerDetails,
+                localization: package.localization,
                 introEligibility: self.introEligibility[package.content],
                 foregroundColor: self.configuration.colors.text1Color
             )

--- a/RevenueCatUI/Templates/Template5View.swift
+++ b/RevenueCatUI/Templates/Template5View.swift
@@ -241,8 +241,8 @@ struct Template5View: TemplateViewType {
 
     private func offerDetails(package: TemplateViewConfiguration.Package, selected: Bool) -> some View {
         IntroEligibilityStateView(
-            textWithNoIntroOffer: package.localization.offerDetails,
-            textWithIntroOffer: package.localization.offerDetailsWithIntroOffer,
+            display: .offerDetails,
+            localization: package.localization,
             introEligibility: self.introEligibility[package.content],
             foregroundColor: self.configuration.colors.text1Color,
             alignment: Self.packageButtonAlignment

--- a/RevenueCatUI/Views/IntroEligibilityStateView.swift
+++ b/RevenueCatUI/Views/IntroEligibilityStateView.swift
@@ -18,13 +18,36 @@ import SwiftUI
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 struct IntroEligibilityStateView: View {
 
-    var textWithNoIntroOffer: String?
-    var textWithIntroOffer: String?
-    var introEligibility: IntroEligibilityStatus?
-    var foregroundColor: Color?
-    var alignment: Alignment
+    enum Display {
+
+        case callToAction
+        case offerDetails
+
+    }
+
+    private var textWithNoIntroOffer: String?
+    private var textWithIntroOffer: String?
+    private var introEligibility: IntroEligibilityStatus?
+    private var foregroundColor: Color?
+    private var alignment: Alignment
 
     init(
+        display: Display,
+        localization: ProcessedLocalizedConfiguration,
+        introEligibility: IntroEligibilityStatus?,
+        foregroundColor: Color? = nil,
+        alignment: Alignment = .center
+    ) {
+        self.init(
+            textWithNoIntroOffer: display.textWithNoIntroOffer(localization),
+            textWithIntroOffer: display.textWithIntroOffer(localization),
+            introEligibility: introEligibility,
+            foregroundColor: foregroundColor,
+            alignment: alignment
+        )
+    }
+
+    fileprivate init(
         textWithNoIntroOffer: String?,
         textWithIntroOffer: String?,
         introEligibility: IntroEligibilityStatus?,
@@ -56,6 +79,27 @@ struct IntroEligibilityStateView: View {
             // Display text with intro offer as a backup to ensure layout does not change
             // when switching states.
             return self.textWithNoIntroOffer ?? self.textWithIntroOffer ?? ""
+        }
+    }
+
+}
+
+// MARK: - Private
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+private extension IntroEligibilityStateView.Display {
+
+    func textWithNoIntroOffer(_ localization: ProcessedLocalizedConfiguration) -> String? {
+        switch self {
+        case .callToAction: return localization.callToAction
+        case .offerDetails: return localization.offerDetails
+        }
+    }
+
+    func textWithIntroOffer(_ localization: ProcessedLocalizedConfiguration) -> String? {
+        switch self {
+        case .callToAction: return localization.callToActionWithIntroOffer
+        case .offerDetails: return localization.offerDetailsWithIntroOffer
         }
     }
 

--- a/RevenueCatUI/Views/IntroEligibilityStateView.swift
+++ b/RevenueCatUI/Views/IntroEligibilityStateView.swift
@@ -73,12 +73,41 @@ struct IntroEligibilityStateView: View {
     }
 
     private var text: String {
-        if let textWithIntroOffer = self.textWithIntroOffer, self.isEligibleForIntro {
+        return Self.text(
+            textWithNoIntroOffer: self.textWithNoIntroOffer,
+            textWithIntroOffer: self.textWithIntroOffer,
+            introEligibility: self.introEligibility
+        )
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+extension IntroEligibilityStateView {
+
+    static func text(
+        for display: Display,
+        localization: ProcessedLocalizedConfiguration,
+        introEligibility: IntroEligibilityStatus?
+    ) -> String {
+        return Self.text(
+            textWithNoIntroOffer: display.textWithNoIntroOffer(localization),
+            textWithIntroOffer: display.textWithIntroOffer(localization),
+            introEligibility: introEligibility
+        )
+    }
+
+    private static func text(
+        textWithNoIntroOffer: String?,
+        textWithIntroOffer: String?,
+        introEligibility: IntroEligibilityStatus?
+    ) -> String {
+        if let textWithIntroOffer, introEligibility.isEligibleForIntro {
             return textWithIntroOffer
         } else {
             // Display text with intro offer as a backup to ensure layout does not change
             // when switching states.
-            return self.textWithNoIntroOffer ?? self.textWithIntroOffer ?? ""
+            return textWithNoIntroOffer ?? textWithIntroOffer ?? ""
         }
     }
 
@@ -111,15 +140,28 @@ private extension IntroEligibilityStateView.Display {
 private extension IntroEligibilityStateView {
 
     var isEligibleForIntro: Bool {
-        return self.introEligibility?.isEligible != false
+        return self.introEligibility.isEligibleForIntro
     }
 
     var isNotEligibleForIntro: Bool {
-        return self.introEligibility?.isEligible == false
+        return self.introEligibility.isNotEligibleForIntro
     }
 
     var needsToWaitForIntroEligibility: Bool {
         return self.introEligibility == nil && self.textWithIntroOffer != nil
+    }
+
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+private extension Optional<IntroEligibilityStatus> {
+
+    var isEligibleForIntro: Bool {
+        return self?.isEligible != false
+    }
+
+    var isNotEligibleForIntro: Bool {
+        return self?.isEligible == false
     }
 
 }

--- a/RevenueCatUI/Views/PurchaseButton.swift
+++ b/RevenueCatUI/Views/PurchaseButton.swift
@@ -85,6 +85,11 @@ struct PurchaseButton: View {
         .tint(.clear)
         .frame(maxWidth: .infinity)
         .dynamicTypeSize(...Constants.maximumDynamicTypeSize)
+        .transaction { transaction in
+            if !self.packagesProduceDifferentLabels {
+                transaction.animation = nil
+            }
+        }
     }
 
     @ViewBuilder
@@ -108,6 +113,29 @@ struct PurchaseButton: View {
     }
 
 }
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(tvOS, unavailable)
+private extension PurchaseButton {
+
+    var packagesProduceDifferentLabels: Bool {
+        return Set(
+            self.packages.all
+                .lazy
+                .map {
+                    IntroEligibilityStateView.text(
+                        for: .callToAction,
+                        localization: $0.localization,
+                        introEligibility: self.introEligibilityViewModel.allEligibility[$0.content]
+                    )
+                }
+        )
+        .count > 1
+    }
+
+}
+
+// MARK: -
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 private struct PurchaseButtonLabel: View {

--- a/RevenueCatUI/Views/PurchaseButton.swift
+++ b/RevenueCatUI/Views/PurchaseButton.swift
@@ -122,8 +122,8 @@ private struct PurchaseButtonLabel: View {
 
     var body: some View {
         IntroEligibilityStateView(
-            textWithNoIntroOffer: self.package.localization.callToAction,
-            textWithIntroOffer: self.package.localization.callToActionWithIntroOffer,
+            display: .callToAction,
+            localization: self.package.localization,
             introEligibility: self.introEligibility,
             foregroundColor: self.colors.callToActionForegroundColor
         )


### PR DESCRIPTION
Equivalent to https://github.com/RevenueCat/purchases-android/pull/1416