### PR TITLE
`Paywalls`: fix template 2 top padding inside navigation view 

### DIFF
--- a/RevenueCatUI/Templates/Template2View.swift
+++ b/RevenueCatUI/Templates/Template2View.swift
@@ -78,6 +78,7 @@ struct Template2View: TemplateViewType {
             // Compensate for additional padding on condensed mode + iPad
             : self.defaultVerticalPaddingLength.map { $0 * -1 }
         )
+        .edgesIgnoringSafeArea(self.configuration.mode.shouldDisplayIcon ? .top : [])
     }
 
     private var scrollableContent: some View {


### PR DESCRIPTION
When presenting `PaywallView` inside of a `NavigationView` (which was automatic, and more common with #3359) the icon had too much padding at the top:
![Screenshot 2023-10-30 at 15 46 24](https://github.com/RevenueCat/purchases-ios/assets/685609/d625a58c-5487-4df8-8f62-fae740a18386)
e

With this fix (note there is no actual navigation title):
![Screenshot 2023-10-30 at 15 46 10](https://github.com/RevenueCat/purchases-ios/assets/685609/3881ec8e-56a1-4f8f-96dc-e734890ac19a)
