### PR TITLE
`Paywalls`: log warning when attempting to purchase already-subscribed product

### DIFF
--- a/RevenueCatUI/Data/Strings.swift
+++ b/RevenueCatUI/Data/Strings.swift
@@ -22,6 +22,8 @@ enum Strings {
     case found_multiple_packages_of_same_identifier(String)
     case unrecognized_variable_name(variableName: String)
 
+    case product_already_subscribed
+
     case determining_whether_to_display_paywall
     case displaying_paywall
     case not_displaying_paywall
@@ -45,6 +47,9 @@ extension Strings: CustomStringConvertible {
         case let .unrecognized_variable_name(variableName):
             return "Found an unrecognized variable '\(variableName)'. It will be replaced with an empty string.\n" +
             "See the docs for more information: https://www.revenuecat.com/docs/paywalls#variables"
+
+        case .product_already_subscribed:
+            return "User is already subscribed to this product. Ignoring."
 
         case .determining_whether_to_display_paywall:
             return "Determining whether to display paywall"

--- a/RevenueCatUI/Views/PurchaseButton.swift
+++ b/RevenueCatUI/Views/PurchaseButton.swift
@@ -66,7 +66,10 @@ struct PurchaseButton: View {
     private var button: some View {
         AsyncButton {
             guard !self.purchaseHandler.actionInProgress else { return }
-            guard !self.selectedPackage.currentlySubscribed else { return }
+            guard !self.selectedPackage.currentlySubscribed else {
+                Logger.warning(Strings.product_already_subscribed)
+                return
+            }
 
             _ = try await self.purchaseHandler.purchase(package: self.selectedPackage.content)
         } label: {


### PR DESCRIPTION
Until we improve the presentation of already-subscribed products this is just a no-op. This will at least help developers know why nothing is happening.
