### PR TITLE
`Paywalls`: `.presentPaywallIfNeeded` allows overriding `Offering`

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -77,6 +77,7 @@ public struct PaywallView: View {
     ///
     /// - Note: if `offering` does not have a current paywall, or it fails to load due to invalid data,
     /// a default paywall will be displayed.
+    /// - Note: Specifying this parameter means that it will ignore the offering configured in an active experiment.
     /// - Warning: `Purchases` must have been configured prior to displaying it.
     public init(
         offering: Offering,

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -31,17 +31,25 @@ extension View {
     /// ```
     /// - Note: If loading the `CustomerInfo` fails (for example, if Internet is offline),
     /// the paywall won't be displayed.
-    /// 
+    ///
+    /// - Parameter offering: The `Offering` containing the desired `PaywallData` to display.
+    /// If `nil` (the default), `Offerings.current` will be used. Note that specifying this parameter means
+    /// that it will ignore the offering configured in an active experiment.
+    /// - Parameter fonts: An optional `PaywallFontProvider`.
+    ///
     /// ### Related Articles
     /// [Documentation](https://rev.cat/paywalls)
     public func presentPaywallIfNeeded(
         requiredEntitlementIdentifier: String,
+        offering: Offering? = nil,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
         onDismiss: (() -> Void)? = nil
     ) -> some View {
         return self.presentPaywallIfNeeded(
+            offering: offering,
+            fonts: fonts,
             shouldDisplay: { info in
                 !info.entitlements
                     .activeInCurrentEnvironment
@@ -73,7 +81,13 @@ extension View {
     /// ```
     /// - Note: If loading the `CustomerInfo` fails (for example, if Internet is offline),
     /// the paywall won't be displayed.
+    ///
+    /// - Parameter offering: The `Offering` containing the desired `PaywallData` to display.
+    /// If `nil` (the default), `Offerings.current` will be used. Note that specifying this parameter means
+    /// that it will ignore the offering configured in an active experiment.
+    /// - Parameter fonts: An optional `PaywallFontProvider`.
     public func presentPaywallIfNeeded(
+        offering: Offering? = nil,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         shouldDisplay: @escaping @Sendable (CustomerInfo) -> Bool,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
@@ -81,6 +95,8 @@ extension View {
         onDismiss: (() -> Void)? = nil
     ) -> some View {
         return self.presentPaywallIfNeeded(
+            offering: offering,
+            fonts: fonts,
             shouldDisplay: shouldDisplay,
             purchaseCompleted: purchaseCompleted,
             restoreCompleted: restoreCompleted,

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
@@ -41,7 +41,10 @@ struct App: View {
         Text("")
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "")
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", onDismiss: self.paywallDismissed)
+            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", offering: nil)
+            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", offering: self.offering)
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", fonts: self.fonts)
+            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", offering: self.offering, fonts: self.fonts)
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "",
                                     purchaseCompleted: self.purchaseOrRestoreCompleted)
             .presentPaywallIfNeeded(requiredEntitlementIdentifier: "",
@@ -57,7 +60,14 @@ struct App: View {
                                     purchaseCompleted: self.purchaseOrRestoreCompleted,
                                     restoreCompleted: self.purchaseOrRestoreCompleted,
                                     onDismiss: self.paywallDismissed)
+            .presentPaywallIfNeeded(requiredEntitlementIdentifier: "", offering: self.offering, fonts: self.fonts,
+                                    purchaseCompleted: self.purchaseOrRestoreCompleted,
+                                    restoreCompleted: self.purchaseOrRestoreCompleted,
+                                    onDismiss: self.paywallDismissed)
+            .presentPaywallIfNeeded(offering: nil) { (_: CustomerInfo) in false }
+            .presentPaywallIfNeeded(offering: self.offering) { (_: CustomerInfo) in false }
             .presentPaywallIfNeeded(fonts: self.fonts) { (_: CustomerInfo) in false }
+            .presentPaywallIfNeeded(offering: self.offering, fonts: self.fonts) { (_: CustomerInfo) in false }
             .presentPaywallIfNeeded(fonts: self.fonts) { (_: CustomerInfo) in
                 false
             } purchaseCompleted: {
@@ -71,6 +81,15 @@ struct App: View {
                 self.purchaseOrRestoreCompleted($0)
             }
             .presentPaywallIfNeeded(fonts: self.fonts) { (_: CustomerInfo) in
+                false
+            } purchaseCompleted: {
+                self.purchaseOrRestoreCompleted($0)
+            } restoreCompleted: {
+                self.purchaseOrRestoreCompleted($0)
+            } onDismiss: {
+                self.paywallDismissed()
+            }
+            .presentPaywallIfNeeded(offering: self.offering, fonts: self.fonts) { (_: CustomerInfo) in
                 false
             } purchaseCompleted: {
                 self.purchaseOrRestoreCompleted($0)


### PR DESCRIPTION
This brings parity with `PaywallView()`.

I've also added notes mentioning that this would disable automatic offering selection for experiments.