### PR TITLE
`RevenueCatUI`: lowered CocoaPods deployment target to 11.0

### DIFF
--- a/RevenueCatUI.podspec
+++ b/RevenueCatUI.podspec
@@ -16,7 +16,9 @@ Pod::Spec.new do |s|
   s.framework      = 'SwiftUI'
   s.swift_version  = '5.7'
 
-  s.ios.deployment_target = '15.0'
+  # Technically PaywallView isn't available until iOS 15,
+  # but this can be detected at compile time.
+  s.ios.deployment_target = '11.0'
   
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 


### PR DESCRIPTION
This allows us to use it with the same deployment target as `RevenueCat`.
