### PR TITLE
`CircleCI`: fix `visionOS` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -632,6 +632,7 @@ jobs:
 
   build-visionos:
     <<: *base-job
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - install-dependencies


### PR DESCRIPTION
`visionOS` requires M1 since Xcode 15.1 beta 2.