### PR TITLE
`RevenueCatUI`: added support to other deployment targets

### DIFF
--- a/RevenueCatUI.podspec
+++ b/RevenueCatUI.podspec
@@ -16,7 +16,8 @@ Pod::Spec.new do |s|
   s.framework      = 'SwiftUI'
   s.swift_version  = '5.7'
 
-  # Technically PaywallView isn't available in all these platforms / versions but this can be detected at compile time.
+  # RevenueCatUI APIs are not available in all these platforms / versions, however retaining this support at the Pod level 
+  # allows us to depend on it in the same platforms as RevenueCat.
   # Opening support allows us to depend on it in the same platforms as RevenueCat.
   s.ios.deployment_target = '11.0'
   s.watchos.deployment_target = '6.2'

--- a/RevenueCatUI.podspec
+++ b/RevenueCatUI.podspec
@@ -16,9 +16,12 @@ Pod::Spec.new do |s|
   s.framework      = 'SwiftUI'
   s.swift_version  = '5.7'
 
-  # Technically PaywallView isn't available until iOS 15,
-  # but this can be detected at compile time.
+  # Technically PaywallView isn't available in all these platforms / versions but this can be detected at compile time.
+  # Opening support allows us to depend on it in the same platforms as RevenueCat.
   s.ios.deployment_target = '11.0'
+  s.watchos.deployment_target = '6.2'
+  s.tvos.deployment_target = '11.0'
+  s.osx.deployment_target = '10.13'
   
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 

--- a/RevenueCatUI/Data/Constants.swift
+++ b/RevenueCatUI/Data/Constants.swift
@@ -64,7 +64,6 @@ extension Constants {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-@available(watchOS, unavailable)
 extension TemplateViewType {
 
     var defaultHorizontalPaddingLength: CGFloat? {

--- a/RevenueCatUI/Data/Constants.swift
+++ b/RevenueCatUI/Data/Constants.swift
@@ -13,7 +13,7 @@
 
 import SwiftUI
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 enum Constants {
 
     static let defaultAnimation: Animation = .easeInOut(duration: 0.2)
@@ -54,7 +54,7 @@ enum Constants {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension Constants {
 
     static var checkmarkImage: some View {
@@ -63,7 +63,8 @@ extension Constants {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
 @available(tvOS, unavailable)
 extension TemplateViewType {
 

--- a/RevenueCatUI/Data/Constants.swift
+++ b/RevenueCatUI/Data/Constants.swift
@@ -65,7 +65,6 @@ extension Constants {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
-@available(tvOS, unavailable)
 extension TemplateViewType {
 
     var defaultHorizontalPaddingLength: CGFloat? {

--- a/RevenueCatUI/Data/Constants.swift
+++ b/RevenueCatUI/Data/Constants.swift
@@ -64,6 +64,7 @@ extension Constants {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(tvOS, unavailable)
 extension TemplateViewType {
 
     var defaultHorizontalPaddingLength: CGFloat? {

--- a/RevenueCatUI/Data/IntroEligibility/IntroEligibilityViewModel.swift
+++ b/RevenueCatUI/Data/IntroEligibility/IntroEligibilityViewModel.swift
@@ -16,7 +16,7 @@ import SwiftUI
 
 /// Holds the state for dynamically computed `IntroEligibilityStatus`
 /// for single or multi-package templates, depending on `PackageConfiguration`.
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @MainActor
 final class IntroEligibilityViewModel: ObservableObject {
 
@@ -35,7 +35,7 @@ final class IntroEligibilityViewModel: ObservableObject {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension IntroEligibilityViewModel {
 
     func computeEligibility(for packages: PackageConfiguration) async {

--- a/RevenueCatUI/Data/ProcessedLocalizedConfiguration.swift
+++ b/RevenueCatUI/Data/ProcessedLocalizedConfiguration.swift
@@ -13,7 +13,7 @@ import Foundation
 import RevenueCat
 
 /// A `PaywallData.LocalizedConfiguration` with processed variables
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct ProcessedLocalizedConfiguration: PaywallLocalizedConfiguration {
 
     typealias Feature = PaywallData.LocalizedConfiguration.Feature
@@ -75,5 +75,5 @@ struct ProcessedLocalizedConfiguration: PaywallLocalizedConfiguration {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension ProcessedLocalizedConfiguration: Equatable {}

--- a/RevenueCatUI/Data/TemplateViewConfiguration+Images.swift
+++ b/RevenueCatUI/Data/TemplateViewConfiguration+Images.swift
@@ -14,7 +14,7 @@
 import Foundation
 import RevenueCat
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension TemplateViewConfiguration {
 
     var headerImageURL: URL? { self.url(for: \.header) }
@@ -23,7 +23,7 @@ extension TemplateViewConfiguration {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension TemplateViewConfiguration {
 
     var backgroundImageURLToDisplay: URL? {
@@ -34,7 +34,7 @@ extension TemplateViewConfiguration {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private extension TemplateViewConfiguration {
 
     func url(for image: KeyPath<PaywallData.Configuration.Images, String?>) -> URL? {
@@ -49,7 +49,7 @@ private extension TemplateViewConfiguration {
 
 // MARK: -
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension PaywallData {
 
     var headerImageURL: URL? { self.url(for: \.header) }
@@ -66,7 +66,7 @@ extension PaywallData {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private extension PaywallData {
 
     static func url(

--- a/RevenueCatUI/Data/TemplateViewConfiguration.swift
+++ b/RevenueCatUI/Data/TemplateViewConfiguration.swift
@@ -15,7 +15,7 @@ import Foundation
 import RevenueCat
 
 /// The processed data necessary to render a `TemplateViewType`.
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct TemplateViewConfiguration {
 
     let mode: PaywallViewMode
@@ -29,7 +29,7 @@ struct TemplateViewConfiguration {
 
 // MARK: - Packages
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension TemplateViewConfiguration {
 
     /// A `Package` with its processed localized strings.
@@ -63,7 +63,7 @@ extension TemplateViewConfiguration {
 
 // MARK: - Properties
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension TemplateViewConfiguration.PackageConfiguration {
 
     /// Returns a single package, useful for templates that expect a single package.
@@ -100,7 +100,7 @@ extension TemplateViewConfiguration.PackageConfiguration {
 
 // MARK: - Creation
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension TemplateViewConfiguration.PackageConfiguration {
 
     /// Creates a `PackageConfiguration` based on `setting`.
@@ -187,7 +187,7 @@ extension TemplateViewConfiguration.PackageConfiguration {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension TemplateViewConfiguration {
 
     /// Filters `packages`, extracting only the values corresponding to `identifiers`.

--- a/RevenueCatUI/Data/TestData.swift
+++ b/RevenueCatUI/Data/TestData.swift
@@ -13,7 +13,7 @@ import SwiftUI
 
 #if DEBUG
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 internal enum TestData {
 
     static let weeklyProduct = TestStoreProduct(
@@ -442,7 +442,9 @@ internal enum TestData {
         accent2: "#FF00FF"
     )
 
-    #if canImport(SwiftUI) && canImport(UIKit)
+    #if os(watchOS)
+    static let colors: PaywallData.Configuration.Colors = Self.darkColors
+    #elseif canImport(SwiftUI) && canImport(UIKit)
     static let colors: PaywallData.Configuration.Colors = .combine(light: Self.lightColors, dark: Self.darkColors)
     #endif
 

--- a/RevenueCatUI/Data/UserInterfaceIdiom.swift
+++ b/RevenueCatUI/Data/UserInterfaceIdiom.swift
@@ -20,7 +20,7 @@ enum UserInterfaceIdiom {
 
 extension UserInterfaceIdiom {
 
-    #if canImport(UIKit)
+    #if canImport(UIKit) && !os(watchOS)
     static let `default`: Self = UIDevice.interfaceIdiom
     #elseif os(macOS)
     static let `default`: Self = .mac
@@ -49,7 +49,7 @@ extension EnvironmentValues {
 
 // MARK: - UIKit
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
 
 private extension UIDevice {
 

--- a/RevenueCatUI/Data/Variables.swift
+++ b/RevenueCatUI/Data/Variables.swift
@@ -13,7 +13,7 @@ import Foundation
 import RegexBuilder
 import RevenueCat
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension PaywallData.LocalizedConfiguration {
 
     func processVariables(
@@ -49,7 +49,7 @@ protocol VariableDataProvider {
 }
 
 /// Processes strings, replacing `{{ variable }}` with their associated content.
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 enum VariableHandler {
 
     /// Information necessary for computing variables
@@ -65,7 +65,7 @@ enum VariableHandler {
         context: Context,
         locale: Locale = .current
     ) -> String {
-        if #available(iOS 16.0, macOS 13.0, tvOS 16.0, *) {
+        if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             return VariableHandlerIOS16.processVariables(in: string,
                                                          with: provider,
                                                          context: context,
@@ -118,7 +118,7 @@ enum VariableHandler {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension String {
 
     func processed(
@@ -130,7 +130,7 @@ extension String {
     }
 
     func unrecognizedVariables() -> Set<String> {
-        if #available(iOS 16.0, macOS 13.0, tvOS 16.0, *) {
+        if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             return VariableHandlerIOS16.unrecognizedVariables(in: self)
         } else {
             return VariableHandlerIOS15.unrecognizedVariables(in: self)
@@ -139,7 +139,7 @@ extension String {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private extension VariableDataProvider {
 
     func value(
@@ -154,7 +154,7 @@ private extension VariableDataProvider {
 
 // MARK: - Regex iOS 16
 
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *)
 private enum VariableHandlerIOS16 {
 
     static func processVariables(
@@ -210,7 +210,7 @@ private enum VariableHandlerIOS16 {
 
 // MARK: - Regex iOS 15
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private enum VariableHandlerIOS15 {
 
     static func processVariables(

--- a/RevenueCatUI/Helpers/ColorInformation+MultiScheme.swift
+++ b/RevenueCatUI/Helpers/ColorInformation+MultiScheme.swift
@@ -14,7 +14,7 @@
 import Foundation
 import RevenueCat
 
-#if canImport(SwiftUI) && canImport(UIKit)
+#if canImport(SwiftUI) && canImport(UIKit) && !os(watchOS)
 
 extension PaywallData.Configuration.ColorInformation {
 
@@ -79,7 +79,7 @@ extension PaywallData.Configuration.ColorInformation {
 
 #endif
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension TemplateViewConfiguration {
 
     /// Whether dark mode colors have been configured in this paywall.

--- a/RevenueCatUI/Helpers/PaywallData+Default.swift
+++ b/RevenueCatUI/Helpers/PaywallData+Default.swift
@@ -64,7 +64,7 @@ private extension PaywallData {
             return Self.fallbackColors
         }
 
-        #if os(macOS)
+        #if os(macOS) || os(watchOS)
         return Self.fallbackColors
         #else
         let background: PaywallColor = .init(light: Color.white.asPaywallColor, dark: Color.black.asPaywallColor)
@@ -122,7 +122,7 @@ private extension PaywallData {
 
 #if DEBUG
 
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)

--- a/RevenueCatUI/Helpers/PreviewHelpers.swift
+++ b/RevenueCatUI/Helpers/PreviewHelpers.swift
@@ -16,7 +16,7 @@ import SwiftUI
 
 #if DEBUG
 
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
 @available(macOS, unavailable)
 @MainActor
@@ -40,7 +40,8 @@ enum PreviewHelpers {
 ///   PaywallTemplate($0)
 /// }
 /// ```
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
 struct PreviewableTemplate<T: TemplateViewType>: View {

--- a/RevenueCatUI/Modifiers/ConsistentPackageContentView.swift
+++ b/RevenueCatUI/Modifiers/ConsistentPackageContentView.swift
@@ -16,7 +16,7 @@ import SwiftUI
 
 /// A wrapper view that can display content based on a selected package
 /// and maintain a consistent layout when that selected package changes.
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct ConsistentPackageContentView<Content: View>: View {
 
     typealias Creator = @Sendable @MainActor (TemplateViewConfiguration.Package) -> Content

--- a/RevenueCatUI/Modifiers/FooterHidingModifier.swift
+++ b/RevenueCatUI/Modifiers/FooterHidingModifier.swift
@@ -14,7 +14,7 @@
 import RevenueCat
 import SwiftUI
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
 
     func hideFooterContent(
@@ -27,7 +27,7 @@ extension View {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private struct FooterHidingModifier: ViewModifier {
 
     @State

--- a/RevenueCatUI/Modifiers/ViewExtensions.swift
+++ b/RevenueCatUI/Modifiers/ViewExtensions.swift
@@ -79,7 +79,7 @@ extension View {
 
 // MARK: - Padding
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
 
     func defaultHorizontalPadding() -> some View {
@@ -98,7 +98,7 @@ extension View {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private struct DefaultHorizontalPaddingModifier: ViewModifier {
 
     @Environment(\.userInterfaceIdiom)
@@ -111,7 +111,7 @@ private struct DefaultHorizontalPaddingModifier: ViewModifier {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private struct DefaultVerticalPaddingModifier: ViewModifier {
 
     @Environment(\.userInterfaceIdiom)

--- a/RevenueCatUI/PaywallFontProvider.swift
+++ b/RevenueCatUI/PaywallFontProvider.swift
@@ -93,7 +93,11 @@ private extension Font.TextStyle {
 
     var style: UIFont.TextStyle {
         switch self {
+        #if os(tvOS)
+        case .largeTitle: return .title1
+        #else
         case .largeTitle: return .largeTitle
+        #endif
         case .title: return .title1
         case .title2: return .title2
         case .title3: return .title3

--- a/RevenueCatUI/PaywallFontProvider.swift
+++ b/RevenueCatUI/PaywallFontProvider.swift
@@ -21,7 +21,7 @@ import SwiftUI
 public protocol PaywallFontProvider {
 
     /// - Returns: Desired `Font` for the given `Font.TextStyle`.
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
     func font(for textStyle: Font.TextStyle) -> Font
 
 }
@@ -33,7 +33,7 @@ open class DefaultPaywallFontProvider: PaywallFontProvider {
     // swiftlint:disable:next missing_docs
     public init() {}
 
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
     // swiftlint:disable:next cyclomatic_complexity missing_docs
     open func font(for textStyle: Font.TextStyle) -> Font {
         switch textStyle {
@@ -72,7 +72,7 @@ open class CustomPaywallFontProvider: PaywallFontProvider {
         self.fontName = fontName
     }
 
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
     // swiftlint:disable:next missing_docs
     open func font(for textStyle: Font.TextStyle) -> Font {
         return Font.custom(self.fontName,

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -339,6 +339,7 @@ struct LoadedOfferingPaywallView: View {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(tvOS, unavailable)
 private extension LoadedOfferingPaywallView {
 
     struct DisplayedPaywall: Equatable {

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -14,6 +14,8 @@
 import RevenueCat
 import SwiftUI
 
+#if !os(macOS)
+
 /// A SwiftUI view for displaying a `PaywallData` for an `Offering`.
 ///
 /// ### Related Articles
@@ -418,5 +420,7 @@ private extension PaywallViewMode {
     }
 
 }
+
+#endif
 
 #endif

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -18,7 +18,7 @@ import SwiftUI
 ///
 /// ### Related Articles
 /// [Documentation](https://rev.cat/paywalls)
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable, message: "RevenueCatUI does not support watchOS yet")
 @available(macOS, unavailable, message: "RevenueCatUI does not support macOS yet")
 @available(tvOS, unavailable, message: "RevenueCatUI does not support tvOS yet")
@@ -233,7 +233,8 @@ private extension PaywallView {
 
 // MARK: -
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
 @available(tvOS, unavailable)
 struct LoadedOfferingPaywallView: View {
 
@@ -338,7 +339,8 @@ struct LoadedOfferingPaywallView: View {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
 @available(tvOS, unavailable)
 private extension LoadedOfferingPaywallView {
 
@@ -362,7 +364,7 @@ private extension LoadedOfferingPaywallView {
 
 #if DEBUG
 
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -235,6 +235,7 @@ private extension PaywallView {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
+@available(macOS, unavailable)
 @available(tvOS, unavailable)
 struct LoadedOfferingPaywallView: View {
 
@@ -341,6 +342,7 @@ struct LoadedOfferingPaywallView: View {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
+@available(macOS, unavailable)
 @available(tvOS, unavailable)
 private extension LoadedOfferingPaywallView {
 

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -14,7 +14,7 @@
 import RevenueCat
 import SwiftUI
 
-#if !os(macOS) && !os(tvOS)
+#if !os(macOS) && !os(tvOS) && !os(watchOS)
 
 /// A SwiftUI view for displaying a `PaywallData` for an `Offering`.
 ///

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -14,7 +14,7 @@
 import RevenueCat
 import SwiftUI
 
-#if !os(macOS)
+#if !os(macOS) && !os(tvOS)
 
 /// A SwiftUI view for displaying a `PaywallData` for an `Offering`.
 ///

--- a/RevenueCatUI/Purchasing/MockPurchases.swift
+++ b/RevenueCatUI/Purchasing/MockPurchases.swift
@@ -16,7 +16,7 @@ import RevenueCat
 #if DEBUG
 
 /// An implementation of `PaywallPurchasesType` that allows creating custom blocks.
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class MockPurchases: PaywallPurchasesType {
 
     typealias PurchaseBlock = @Sendable (Package) async throws -> PurchaseResultData
@@ -51,7 +51,7 @@ final class MockPurchases: PaywallPurchasesType {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension PaywallPurchasesType {
 
     /// Creates a copy of this `PaywallPurchasesType` wrapping `purchase` and `restore`.

--- a/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
+++ b/RevenueCatUI/Purchasing/PaywallPurchasesType.swift
@@ -14,7 +14,7 @@
 import RevenueCat
 
 /// A simplified protocol for the subset of `PurchasesType` needed for `RevenueCatUI`.
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 protocol PaywallPurchasesType: Sendable {
 
     @Sendable

--- a/RevenueCatUI/Purchasing/PurchaseHandler+TestData.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler+TestData.swift
@@ -16,7 +16,7 @@ import RevenueCat
 
 #if DEBUG
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension PurchaseHandler {
 
     static func mock(_ customerInfo: CustomerInfo = TestData.customerInfo) -> Self {

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -15,7 +15,7 @@ import RevenueCat
 import StoreKit
 import SwiftUI
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 final class PurchaseHandler: ObservableObject {
 
     private let purchases: PaywallPurchasesType
@@ -67,7 +67,7 @@ final class PurchaseHandler: ObservableObject {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension PurchaseHandler {
 
     @MainActor
@@ -143,7 +143,7 @@ extension PurchaseHandler {
 
 #if DEBUG
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension PurchaseHandler {
 
     /// Creates a copy of this `PurchaseHandler` wrapping the purchase and restore blocks.
@@ -172,7 +172,7 @@ extension PurchaseHandler {
 
 // MARK: - Private
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private extension PurchaseHandler {
 
     func track(_ event: PaywallEvent) {
@@ -183,7 +183,7 @@ private extension PurchaseHandler {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private final class NotConfiguredPurchases: PaywallPurchasesType {
 
     func purchase(package: Package) async throws -> PurchaseResultData {
@@ -200,7 +200,7 @@ private final class NotConfiguredPurchases: PaywallPurchasesType {
 
 // MARK: - Preference Keys
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct PurchasedResultPreferenceKey: PreferenceKey {
 
     struct PurchaseResult: Equatable {
@@ -226,7 +226,7 @@ struct PurchasedResultPreferenceKey: PreferenceKey {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct RestoredCustomerInfoPreferenceKey: PreferenceKey {
 
     static var defaultValue: CustomerInfo?

--- a/RevenueCatUI/Templates/Template1View.swift
+++ b/RevenueCatUI/Templates/Template1View.swift
@@ -14,7 +14,8 @@
 import RevenueCat
 import SwiftUI
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
 @available(tvOS, unavailable)
 struct Template1View: TemplateViewType {
 
@@ -175,7 +176,7 @@ private struct CircleMaskModifier: ViewModifier {
 
 #if DEBUG
 
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)

--- a/RevenueCatUI/Templates/Template2View.swift
+++ b/RevenueCatUI/Templates/Template2View.swift
@@ -14,8 +14,7 @@
 import RevenueCat
 import SwiftUI
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 10.0, *)
-@available(watchOS, unavailable)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct Template2View: TemplateViewType {
 
     let configuration: TemplateViewConfiguration
@@ -160,6 +159,7 @@ struct Template2View: TemplateViewType {
                 self.roundedRectangle
                     .foregroundColor(self.selectedBackgroundColor)
             } else {
+                #if !os(watchOS)
                 if self.configuration.backgroundImageURLToDisplay != nil {
                     // Blur background if there is a background image.
                     self.roundedRectangle
@@ -168,6 +168,7 @@ struct Template2View: TemplateViewType {
                     // Otherwise the text should have enough contrast with the selected background color.
                     EmptyView()
                 }
+                #endif
             }
         }
     }
@@ -280,7 +281,6 @@ struct Template2View: TemplateViewType {
 // MARK: - Extensions
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-@available(watchOS, unavailable)
 private extension Template2View {
 
     var selectedLocalization: ProcessedLocalizedConfiguration {

--- a/RevenueCatUI/Templates/Template2View.swift
+++ b/RevenueCatUI/Templates/Template2View.swift
@@ -16,7 +16,6 @@ import SwiftUI
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 10.0, *)
 @available(watchOS, unavailable)
-@available(tvOS, unavailable)
 struct Template2View: TemplateViewType {
 
     let configuration: TemplateViewConfiguration
@@ -282,7 +281,6 @@ struct Template2View: TemplateViewType {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
-@available(tvOS, unavailable)
 private extension Template2View {
 
     var selectedLocalization: ProcessedLocalizedConfiguration {

--- a/RevenueCatUI/Templates/Template2View.swift
+++ b/RevenueCatUI/Templates/Template2View.swift
@@ -16,6 +16,7 @@ import SwiftUI
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 10.0, *)
 @available(watchOS, unavailable)
+@available(macOS, unavailable)
 @available(tvOS, unavailable)
 struct Template2View: TemplateViewType {
 

--- a/RevenueCatUI/Templates/Template2View.swift
+++ b/RevenueCatUI/Templates/Template2View.swift
@@ -14,7 +14,8 @@
 import RevenueCat
 import SwiftUI
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 10.0, *)
+@available(watchOS, unavailable)
 @available(tvOS, unavailable)
 struct Template2View: TemplateViewType {
 
@@ -279,7 +280,9 @@ struct Template2View: TemplateViewType {
 
 // MARK: - Extensions
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
+@available(macOS, unavailable)
 @available(tvOS, unavailable)
 private extension Template2View {
 
@@ -321,7 +324,7 @@ private extension Bundle {
 
 #if DEBUG
 
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)

--- a/RevenueCatUI/Templates/Template2View.swift
+++ b/RevenueCatUI/Templates/Template2View.swift
@@ -16,7 +16,6 @@ import SwiftUI
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 10.0, *)
 @available(watchOS, unavailable)
-@available(macOS, unavailable)
 @available(tvOS, unavailable)
 struct Template2View: TemplateViewType {
 
@@ -283,7 +282,6 @@ struct Template2View: TemplateViewType {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
-@available(macOS, unavailable)
 @available(tvOS, unavailable)
 private extension Template2View {
 

--- a/RevenueCatUI/Templates/Template3View.swift
+++ b/RevenueCatUI/Templates/Template3View.swift
@@ -14,7 +14,8 @@
 import RevenueCat
 import SwiftUI
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
 @available(tvOS, unavailable)
 struct Template3View: TemplateViewType {
 
@@ -104,7 +105,7 @@ struct Template3View: TemplateViewType {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private struct FeatureView: View {
 
     let feature: PaywallData.LocalizedConfiguration.Feature
@@ -182,7 +183,7 @@ private struct FeatureView: View {
 
 #if DEBUG
 
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)

--- a/RevenueCatUI/Templates/Template4View.swift
+++ b/RevenueCatUI/Templates/Template4View.swift
@@ -17,6 +17,7 @@ import SwiftUI
 // swiftlint:disable file_length
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(tvOS, unavailable)
 struct Template4View: TemplateViewType {
 
     let configuration: TemplateViewConfiguration
@@ -242,6 +243,7 @@ struct Template4View: TemplateViewType {
 // MARK: - Views
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(tvOS, unavailable)
 private struct PackageButton: View {
 
     var configuration: TemplateViewConfiguration
@@ -420,6 +422,7 @@ private extension PaywallViewMode {
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 @available(watchOS, unavailable)
 @available(macOS, unavailable)
+@available(tvOS, unavailable)
 struct Template4View_Previews: PreviewProvider {
 
     static var previews: some View {

--- a/RevenueCatUI/Templates/Template4View.swift
+++ b/RevenueCatUI/Templates/Template4View.swift
@@ -18,7 +18,6 @@ import SwiftUI
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
-@available(tvOS, unavailable)
 struct Template4View: TemplateViewType {
 
     let configuration: TemplateViewConfiguration
@@ -245,7 +244,6 @@ struct Template4View: TemplateViewType {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
-@available(tvOS, unavailable)
 private struct PackageButton: View {
 
     var configuration: TemplateViewConfiguration

--- a/RevenueCatUI/Templates/Template4View.swift
+++ b/RevenueCatUI/Templates/Template4View.swift
@@ -16,7 +16,8 @@ import SwiftUI
 
 // swiftlint:disable file_length
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
 @available(tvOS, unavailable)
 struct Template4View: TemplateViewType {
 
@@ -242,7 +243,8 @@ struct Template4View: TemplateViewType {
 
 // MARK: - Views
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
 @available(tvOS, unavailable)
 private struct PackageButton: View {
 
@@ -419,7 +421,7 @@ private extension PaywallViewMode {
 
 #if DEBUG
 
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)

--- a/RevenueCatUI/Templates/Template4View.swift
+++ b/RevenueCatUI/Templates/Template4View.swift
@@ -17,7 +17,6 @@ import SwiftUI
 // swiftlint:disable file_length
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-@available(watchOS, unavailable)
 struct Template4View: TemplateViewType {
 
     let configuration: TemplateViewConfiguration
@@ -243,7 +242,6 @@ struct Template4View: TemplateViewType {
 // MARK: - Views
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-@available(watchOS, unavailable)
 private struct PackageButton: View {
 
     var configuration: TemplateViewConfiguration

--- a/RevenueCatUI/Templates/Template5View.swift
+++ b/RevenueCatUI/Templates/Template5View.swift
@@ -15,7 +15,6 @@ import RevenueCat
 import SwiftUI
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-@available(watchOS, unavailable)
 struct Template5View: TemplateViewType {
 
     let configuration: TemplateViewConfiguration
@@ -294,7 +293,6 @@ private extension PaywallData.Configuration.Colors {
 // MARK: - Extensions
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-@available(watchOS, unavailable)
 private extension Template5View {
 
     var selectedLocalization: ProcessedLocalizedConfiguration {

--- a/RevenueCatUI/Templates/Template5View.swift
+++ b/RevenueCatUI/Templates/Template5View.swift
@@ -14,7 +14,8 @@
 import RevenueCat
 import SwiftUI
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
 @available(tvOS, unavailable)
 struct Template5View: TemplateViewType {
 
@@ -293,7 +294,8 @@ private extension PaywallData.Configuration.Colors {
 
 // MARK: - Extensions
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
 @available(tvOS, unavailable)
 private extension Template5View {
 
@@ -319,7 +321,7 @@ private extension PaywallViewMode {
 
 #if DEBUG
 
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)

--- a/RevenueCatUI/Templates/Template5View.swift
+++ b/RevenueCatUI/Templates/Template5View.swift
@@ -16,7 +16,6 @@ import SwiftUI
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
-@available(tvOS, unavailable)
 struct Template5View: TemplateViewType {
 
     let configuration: TemplateViewConfiguration
@@ -296,7 +295,6 @@ private extension PaywallData.Configuration.Colors {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
-@available(tvOS, unavailable)
 private extension Template5View {
 
     var selectedLocalization: ProcessedLocalizedConfiguration {

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -37,7 +37,6 @@ import SwiftUI
 /// A `SwiftUI` view that can display a paywall with `TemplateViewConfiguration`.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
-@available(tvOS, unavailable)
 protocol TemplateViewType: SwiftUI.View {
 
     var configuration: TemplateViewConfiguration { get }
@@ -49,7 +48,6 @@ protocol TemplateViewType: SwiftUI.View {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
-@available(tvOS, unavailable)
 extension TemplateViewType {
 
     func font(for textStyle: Font.TextStyle) -> Font {

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -47,6 +47,7 @@ protocol TemplateViewType: SwiftUI.View {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(tvOS, unavailable)
 extension TemplateViewType {
 
     func font(for textStyle: Font.TextStyle) -> Font {

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -35,7 +35,8 @@ import SwiftUI
 */
 
 /// A `SwiftUI` view that can display a paywall with `TemplateViewConfiguration`.
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
 @available(tvOS, unavailable)
 protocol TemplateViewType: SwiftUI.View {
 
@@ -46,7 +47,8 @@ protocol TemplateViewType: SwiftUI.View {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
 @available(tvOS, unavailable)
 extension TemplateViewType {
 
@@ -56,7 +58,7 @@ extension TemplateViewType {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private extension PaywallTemplate {
 
     var packageSetting: TemplateViewConfiguration.PackageSetting {
@@ -71,7 +73,8 @@ private extension PaywallTemplate {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
 @available(tvOS, unavailable)
 extension PaywallData {
 
@@ -148,7 +151,8 @@ extension PaywallData {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
 extension View {
 
     func adaptTemplateView(with configuration: TemplateViewConfiguration) -> some View {
@@ -186,7 +190,8 @@ extension View {
 
 // MARK: - Private
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 10.0, *)
+@available(watchOS, unavailable)
 private extension TemplateViewConfiguration {
 
     @ViewBuilder

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -36,7 +36,6 @@ import SwiftUI
 
 /// A `SwiftUI` view that can display a paywall with `TemplateViewConfiguration`.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-@available(watchOS, unavailable)
 protocol TemplateViewType: SwiftUI.View {
 
     var configuration: TemplateViewConfiguration { get }
@@ -47,7 +46,6 @@ protocol TemplateViewType: SwiftUI.View {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-@available(watchOS, unavailable)
 extension TemplateViewType {
 
     func font(for textStyle: Font.TextStyle) -> Font {

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -75,6 +75,7 @@ private extension PaywallTemplate {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
+@available(macOS, unavailable)
 @available(tvOS, unavailable)
 extension PaywallData {
 

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -11,7 +11,7 @@
 //  
 //  Created by Nacho Soto on 8/1/23.
 
-#if canImport(UIKit) && !os(tvOS)
+#if canImport(UIKit) && !os(tvOS) && !os(watchOS)
 
 import RevenueCat
 import SwiftUI

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -11,7 +11,7 @@
 //  
 //  Created by Nacho Soto on 8/1/23.
 
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(tvOS)
 
 import RevenueCat
 import SwiftUI

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -14,7 +14,8 @@
 import RevenueCat
 import SwiftUI
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable, message: "RevenueCatUI does not support watchOS yet")
 @available(macOS, unavailable, message: "RevenueCatUI does not support macOS yet")
 @available(tvOS, unavailable, message: "RevenueCatUI does not support tvOS yet")
 extension View {
@@ -139,7 +140,8 @@ extension View {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
 private struct PresentingPaywallModifier: ViewModifier {

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -14,7 +14,7 @@
 import RevenueCat
 import SwiftUI
 
-#if !os(macOS)
+#if !os(macOS) && !os(tvOS)
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable, message: "RevenueCatUI does not support watchOS yet")

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -14,6 +14,8 @@
 import RevenueCat
 import SwiftUI
 
+#if !os(macOS)
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable, message: "RevenueCatUI does not support watchOS yet")
 @available(macOS, unavailable, message: "RevenueCatUI does not support macOS yet")
@@ -212,3 +214,5 @@ private struct PresentingPaywallModifier: ViewModifier {
     }
 
 }
+
+#endif

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -14,7 +14,7 @@
 import RevenueCat
 import SwiftUI
 
-#if !os(macOS) && !os(tvOS)
+#if !os(macOS) && !os(tvOS) && !os(watchOS)
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable, message: "RevenueCatUI does not support watchOS yet")

--- a/RevenueCatUI/View+PresentPaywallFooter.swift
+++ b/RevenueCatUI/View+PresentPaywallFooter.swift
@@ -14,9 +14,9 @@
 import RevenueCat
 import SwiftUI
 
+#if !os(watchOS) && !os(tvOS)
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
-@available(macOS, unavailable, message: "RevenueCatUI does not support macOS yet")
-@available(tvOS, unavailable, message: "RevenueCatUI does not support tvOS yet")
 extension View {
 
     /// Presents a ``PaywallFooterView`` at the bottom of a view that loads the `Offerings.current`.
@@ -99,8 +99,6 @@ extension View {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
-@available(macOS, unavailable)
-@available(tvOS, unavailable)
 private struct PresentingPaywallFooterModifier: ViewModifier {
 
     let offering: Offering?
@@ -133,3 +131,5 @@ private struct PresentingPaywallFooterModifier: ViewModifier {
         }
     }
 }
+
+#endif

--- a/RevenueCatUI/View+PresentPaywallFooter.swift
+++ b/RevenueCatUI/View+PresentPaywallFooter.swift
@@ -14,7 +14,7 @@
 import RevenueCat
 import SwiftUI
 
-#if !os(watchOS) && !os(tvOS)
+#if !os(watchOS) && !os(tvOS) && !os(macOS)
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
 extension View {

--- a/RevenueCatUI/View+PurchaseRestoreCompleted.swift
+++ b/RevenueCatUI/View+PurchaseRestoreCompleted.swift
@@ -21,7 +21,8 @@ public typealias PurchaseOrRestoreCompletedHandler = @MainActor @Sendable (Custo
 public typealias PurchaseCompletedHandler = @MainActor @Sendable (_ transaction: StoreTransaction?,
                                                                   _ customerInfo: CustomerInfo) -> Void
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable, message: "RevenueCatUI does not support watchOS yet")
 @available(macOS, unavailable, message: "RevenueCatUI does not support macOS yet")
 extension View {
 
@@ -113,7 +114,7 @@ extension View {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private struct OnPurchaseCompletedModifier: ViewModifier {
 
     let handler: PurchaseCompletedHandler
@@ -137,7 +138,7 @@ private struct OnPurchaseCompletedModifier: ViewModifier {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private struct OnRestoreCompletedModifier: ViewModifier {
 
     let handler: PurchaseOrRestoreCompletedHandler

--- a/RevenueCatUI/Views/AsyncButton.swift
+++ b/RevenueCatUI/Views/AsyncButton.swift
@@ -15,7 +15,7 @@
 import RevenueCat
 import SwiftUI
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct AsyncButton<Label>: View where Label: View {
 
     typealias Action = @Sendable @MainActor () async throws -> Void

--- a/RevenueCatUI/Views/DebugErrorView.swift
+++ b/RevenueCatUI/Views/DebugErrorView.swift
@@ -15,7 +15,7 @@ import Foundation
 import SwiftUI
 
 /// A view that displays an error in debug builds
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct DebugErrorView<Content: View>: View {
 
     private let description: String
@@ -92,7 +92,7 @@ struct DebugErrorView<Content: View>: View {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension DebugErrorView where Content == AnyView {
 
     init(_ error: Error, releaseBehavior: ReleaseBehavior) {

--- a/RevenueCatUI/Views/ErrorDisplay.swift
+++ b/RevenueCatUI/Views/ErrorDisplay.swift
@@ -14,7 +14,7 @@
 import SwiftUI
 
 /// A modifier that allows easily displaying an `NSError` as an `alert`.
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct ErrorDisplay: ViewModifier {
 
     @Binding
@@ -53,7 +53,7 @@ struct ErrorDisplay: ViewModifier {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension View {
 
     func displayError(_ error: Binding<NSError?>, dismissOnClose: Bool = false) -> some View {

--- a/RevenueCatUI/Views/FooterView.swift
+++ b/RevenueCatUI/Views/FooterView.swift
@@ -251,6 +251,7 @@ private struct LinkButton: View {
 @available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
 @available(watchOS, unavailable)
 @available(macOS, unavailable)
+@available(tvOS, unavailable)
 struct Footer_Previews: PreviewProvider {
 
     static var previews: some View {

--- a/RevenueCatUI/Views/FooterView.swift
+++ b/RevenueCatUI/Views/FooterView.swift
@@ -14,7 +14,7 @@
 import RevenueCat
 import SwiftUI
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct FooterView: View {
 
     @Environment(\.userInterfaceIdiom)
@@ -139,7 +139,7 @@ struct FooterView: View {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private struct SeparatorView: View {
 
     var bold: Bool
@@ -157,7 +157,7 @@ private struct SeparatorView: View {
     private var boldSeparatorSize: CGFloat = 5
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private struct RestorePurchasesButton: View {
 
     let purchaseHandler: PurchaseHandler
@@ -172,7 +172,7 @@ private struct RestorePurchasesButton: View {
                 self.displayRestoredAlert = true
             }
         } label: {
-            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, *) {
+            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
                 let largestText = Text("Restore purchases", bundle: .module)
 
                 ViewThatFits {
@@ -193,7 +193,7 @@ private struct RestorePurchasesButton: View {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private struct LinkButton: View {
 
     @Environment(\.locale)
@@ -210,7 +210,7 @@ private struct LinkButton: View {
     var body: some View {
         let bundle = Localization.localizedBundle(self.locale)
 
-        if #available(iOS 16.0, macOS 13.0, tvOS 16.0, *) {
+        if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             ViewThatFits {
                 ForEach(self.titles, id: \.self) { title in
                     self.link(for: title, bundle: bundle)
@@ -248,7 +248,7 @@ private struct LinkButton: View {
 
 #if DEBUG && canImport(SwiftUI) && canImport(UIKit)
 
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)

--- a/RevenueCatUI/Views/IconView.swift
+++ b/RevenueCatUI/Views/IconView.swift
@@ -15,7 +15,7 @@ import RevenueCat
 import SwiftUI
 
 /// A view that renders an icon by name, tinted with a color.
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct IconView<S: ShapeStyle>: View {
 
     let icon: PaywallIcon
@@ -94,7 +94,7 @@ extension PaywallData.LocalizedConfiguration.Feature {
 
 #if DEBUG
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct IconView_Previews: PreviewProvider {
 
     static var previews: some View {

--- a/RevenueCatUI/Views/IntroEligibilityStateView.swift
+++ b/RevenueCatUI/Views/IntroEligibilityStateView.swift
@@ -15,7 +15,7 @@ import RevenueCat
 import SwiftUI
 
 /// A view that can process intro eligibility and display different data based on the result.
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct IntroEligibilityStateView: View {
 
     enum Display {
@@ -82,7 +82,7 @@ struct IntroEligibilityStateView: View {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 extension IntroEligibilityStateView {
 
     static func text(
@@ -115,7 +115,7 @@ extension IntroEligibilityStateView {
 
 // MARK: - Private
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private extension IntroEligibilityStateView.Display {
 
     func textWithNoIntroOffer(_ localization: ProcessedLocalizedConfiguration) -> String? {
@@ -136,7 +136,7 @@ private extension IntroEligibilityStateView.Display {
 
 // MARK: - Extensions
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private extension IntroEligibilityStateView {
 
     var isEligibleForIntro: Bool {
@@ -166,7 +166,7 @@ private extension Optional<IntroEligibilityStatus> {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private extension View {
 
     func withPendingData(_ pending: Bool, alignment: Alignment) -> some View {
@@ -186,9 +186,10 @@ private extension View {
 
 #if DEBUG
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
 @available(macOS, unavailable)
+@available(tvOS, unavailable)
 struct IntroEligibilityStateView_Previews: PreviewProvider {
 
     static var previews: some View {

--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -15,7 +15,8 @@ import RevenueCat
 import SwiftUI
 
 /// A `PaywallView` suitable to be displayed as a loading placeholder.
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
 @MainActor
@@ -75,7 +76,8 @@ struct LoadingPaywallView: View {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
 private extension LoadingPaywallView {

--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -14,7 +14,7 @@
 import RevenueCat
 import SwiftUI
 
-#if !os(macOS) && !os(tvOS)
+#if !os(macOS) && !os(tvOS) && !os(watchOS)
 
 /// A `PaywallView` suitable to be displayed as a loading placeholder.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -14,7 +14,7 @@
 import RevenueCat
 import SwiftUI
 
-#if !os(macOS)
+#if !os(macOS) && !os(tvOS)
 
 /// A `PaywallView` suitable to be displayed as a loading placeholder.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)

--- a/RevenueCatUI/Views/LoadingPaywallView.swift
+++ b/RevenueCatUI/Views/LoadingPaywallView.swift
@@ -14,6 +14,8 @@
 import RevenueCat
 import SwiftUI
 
+#if !os(macOS)
+
 /// A `PaywallView` suitable to be displayed as a loading placeholder.
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
@@ -239,5 +241,7 @@ struct LoadingPaywallView_Previews: PreviewProvider {
     }
 
 }
+
+#endif
 
 #endif

--- a/RevenueCatUI/Views/PackageButtonStyle.swift
+++ b/RevenueCatUI/Views/PackageButtonStyle.swift
@@ -17,7 +17,7 @@ import SwiftUI
 /// Features:
 /// - Automatic handling of disabled state
 /// - Replaces itself with a loading indicator if it's the selected package.
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct PackageButtonStyle: ButtonStyle {
 
     var fadeDuringPurchases: Bool = true

--- a/RevenueCatUI/Views/PurchaseButton.swift
+++ b/RevenueCatUI/Views/PurchaseButton.swift
@@ -14,7 +14,8 @@
 import RevenueCat
 import SwiftUI
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
 @available(tvOS, unavailable)
 struct PurchaseButton: View {
 
@@ -128,7 +129,8 @@ struct PurchaseButton: View {
 
 }
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
 @available(tvOS, unavailable)
 private extension PurchaseButton {
 
@@ -151,7 +153,9 @@ private extension PurchaseButton {
 
 // MARK: -
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
 private struct PurchaseButtonLabel: View {
 
     let package: TemplateViewConfiguration.Package
@@ -173,8 +177,9 @@ private struct PurchaseButtonLabel: View {
 
 #if DEBUG && canImport(SwiftUI) && canImport(UIKit)
 
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
-@available(tvOS, unavailable, message: "RevenueCatUI does not support tvOS yet")
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
 struct PurchaseButton_Previews: PreviewProvider {
 
     @MainActor

--- a/RevenueCatUI/Views/PurchaseButton.swift
+++ b/RevenueCatUI/Views/PurchaseButton.swift
@@ -16,7 +16,6 @@ import SwiftUI
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
-@available(tvOS, unavailable)
 struct PurchaseButton: View {
 
     let packages: TemplateViewConfiguration.PackageConfiguration
@@ -131,7 +130,6 @@ struct PurchaseButton: View {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
-@available(tvOS, unavailable)
 private extension PurchaseButton {
 
     var packagesProduceDifferentLabels: Bool {
@@ -155,7 +153,6 @@ private extension PurchaseButton {
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
-@available(tvOS, unavailable)
 private struct PurchaseButtonLabel: View {
 
     let package: TemplateViewConfiguration.Package

--- a/RevenueCatUI/Views/PurchaseButton.swift
+++ b/RevenueCatUI/Views/PurchaseButton.swift
@@ -15,7 +15,6 @@ import RevenueCat
 import SwiftUI
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-@available(watchOS, unavailable)
 struct PurchaseButton: View {
 
     let packages: TemplateViewConfiguration.PackageConfiguration
@@ -129,7 +128,6 @@ struct PurchaseButton: View {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-@available(watchOS, unavailable)
 private extension PurchaseButton {
 
     var packagesProduceDifferentLabels: Bool {
@@ -152,7 +150,6 @@ private extension PurchaseButton {
 // MARK: -
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-@available(watchOS, unavailable)
 private struct PurchaseButtonLabel: View {
 
     let package: TemplateViewConfiguration.Package

--- a/RevenueCatUI/Views/RemoteImage.swift
+++ b/RevenueCatUI/Views/RemoteImage.swift
@@ -13,7 +13,7 @@
 
 import SwiftUI
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct RemoteImage: View {
 
     let url: URL

--- a/RevenueCatUI/Views/TemplateBackgroundImageView.swift
+++ b/RevenueCatUI/Views/TemplateBackgroundImageView.swift
@@ -14,7 +14,7 @@
 import RevenueCat
 import SwiftUI
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct TemplateBackgroundImageView: View {
 
     private let url: URL?
@@ -65,7 +65,7 @@ struct TemplateBackgroundImageView: View {
 
 #if DEBUG
 
-@available(iOS 16.0, macOS 13.0, tvOS 16.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(watchOS, unavailable)
 @available(macOS, unavailable)
 @available(tvOS, unavailable)

--- a/Sources/Paywalls/PaywallColor.swift
+++ b/Sources/Paywalls/PaywallColor.swift
@@ -172,23 +172,7 @@ private extension UIColor {
 }
 #endif
 
-#if canImport(SwiftUI) && canImport(UIKit)
-
-#if !os(watchOS)
-@available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
-private extension Color {
-
-    init(light: UIColor, dark: UIColor) {
-        self.init(UIColor(light: light, dark: dark))
-    }
-
-    @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
-    init(light: Color, dark: Color) {
-        self.init(light: UIColor(light), dark: UIColor(dark))
-    }
-
-}
-#endif
+#if canImport(SwiftUI)
 
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public extension Color {
@@ -201,6 +185,24 @@ public extension Color {
 
 }
 
+#if canImport(UIKit)
+
+    #if !os(watchOS)
+    @available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.2, *)
+    private extension Color {
+
+        init(light: UIColor, dark: UIColor) {
+            self.init(UIColor(light: light, dark: dark))
+        }
+
+        @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+        init(light: Color, dark: Color) {
+            self.init(light: UIColor(light), dark: UIColor(dark))
+        }
+
+    }
+    #endif
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 public extension UIColor {
 
@@ -210,6 +212,20 @@ public extension UIColor {
     }
 
 }
+
+#elseif os(macOS)
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+public extension NSColor {
+
+    /// Converts an `NSColor` into a `PaywallColor`.
+    var asPaywallColor: PaywallColor {
+        return Color(nsColor: self).asPaywallColor
+    }
+
+}
+
+#endif
 
 #endif
 
@@ -281,6 +297,29 @@ internal extension Color {
     }
 
 }
+
+#elseif os(macOS)
+
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+internal extension Color {
+
+    var rgba: (red: Int, green: Int, blue: Int, alpha: Int) {
+        let color = NSColor(self)
+
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        color.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+        return (red.rounded, green.rounded, blue.rounded, alpha.rounded)
+    }
+
+}
+
+#endif
+
+#if canImport(SwiftUI)
 
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 private extension Color {

--- a/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
+++ b/Tests/APITesters/RevenueCatUIAPITester/SwiftAPITester/PaywallViewAPI.swift
@@ -9,7 +9,7 @@ import RevenueCat
 import RevenueCatUI
 import SwiftUI
 
-@available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct App: View {
 
     private var offering: Offering
@@ -152,7 +152,7 @@ struct App: View {
 
 private struct CustomFontProvider: PaywallFontProvider {
 
-    @available(iOS 15.0, macOS 12.0, tvOS 15.0, *)
+    @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
     func font(for textStyle: Font.TextStyle) -> Font {
         return Font.body
     }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PaywallAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PaywallAPI.swift
@@ -162,6 +162,17 @@ func checkConversions(color: Color, uiColor: UIColor) {
     }
 }
 
+#elseif os(macOS)
+
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
+func checkConversions(color: Color, nsColor: NSColor) {
+    let _: PaywallColor = color.asPaywallColor
+
+    if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+        let _: PaywallColor = nsColor.asPaywallColor
+    }
+}
+
 #endif
 
 func checkPaywallViewMode(_ mode: PaywallViewMode) {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -960,7 +960,7 @@ lane :check_pods do
     verbose: true,
     podspec: 'RevenueCatUI.podspec',
     include_podspecs: 'RevenueCat.podspec',
-    platforms: 'ios',
+    platforms: 'ios,osx,tvos,watchos',
     fail_fast: true
   )
 end


### PR DESCRIPTION
Follow up to #3378.

This allows us to link both `RevenueCat` and `RevenueCatUI` from `PurchasesHybridCommon` supporting the same platforms.
The actual types might not be available in some platforms / versions, but we can detect that at compile time.

See https://app.circleci.com/pipelines/github/RevenueCat/purchases-hybrid-common/2564/workflows/ea6a4e24-e1eb-4c7a-a930-173945732999/jobs/10352
