### PR TITLE
`Integration Tests`: fix potential crash on `tearDown`

### DIFF
--- a/Sources/Purchasing/Purchases/Purchases.swift
+++ b/Sources/Purchasing/Purchases/Purchases.swift
@@ -629,7 +629,10 @@ public typealias StartPurchaseBlock = (@escaping PurchaseCompletedBlock) -> Void
     }
 
     static func clearSingleton() {
-        Self.purchases.value = nil
+        self.purchases.modify { purchases in
+            purchases?.delegate = nil
+            purchases = nil
+        }
     }
 
     /// - Parameter purchases: this is an `@autoclosure` to be able to clear the previous instance

--- a/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
+++ b/Tests/BackendIntegrationTests/BaseBackendIntegrationTests.swift
@@ -194,7 +194,6 @@ private extension BaseBackendIntegrationTests {
         // - These run *before* `tearDown`.
         // - They run in LIFO order.
         self.addTeardownBlock {
-            Purchases.shared.delegate = nil
             Purchases.clearSingleton()
 
             // Note: this captures the boolean to avoid race conditions when Nimble tries


### PR DESCRIPTION
I ran into this locally. We re-initialize `Purchases` on some tests to simulate re-starting apps. If a test fails mid-test, `Purchases.shared` might not be defined.
