### PR TITLE
`CircleCI`: upgrade to Xcode 15.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -442,7 +442,7 @@ jobs:
           
   run-test-ios-17:
     <<: *base-job
-    resource_class: macos.m1.large.gen1
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - install-dependencies
@@ -451,7 +451,7 @@ jobs:
           command: bundle exec fastlane test_ios
           no_output_timeout: 15m
           environment:
-            SCAN_DEVICE: iPhone 15 (17.0.1)
+            SCAN_DEVICE: iPhone 15 (17.2.0)
       - compress_result_bundle:
           directory: fastlane/test_output/xctest/ios
           bundle_name: RevenueCat
@@ -995,7 +995,7 @@ workflows:
     when: << pipeline.parameters.generate_snapshots >>
     jobs:
       - run-test-ios-17:
-          xcode_version: '15.0.1'
+          xcode_version: '15.1'
       - run-test-ios-16:
           xcode_version: '14.3.0'
       - run-test-ios-15:
@@ -1046,7 +1046,7 @@ workflows:
       - spm-revenuecat-ui-watchos:
           xcode_version: '14.3.0'
       - run-test-ios-17:
-          xcode_version: '15.0.1'
+          xcode_version: '15.1'
       - run-test-ios-16:
           xcode_version: '14.3.0'
       - run-test-ios-15:


### PR DESCRIPTION
Supposedly [the new image](https://discuss.circleci.com/t/xcode-15-beta-2-re-released-and-bumped-to-macos-14-1/49816) has a fix for the [performance issues](https://discuss.circleci.com/t/severe-performance-problems-with-xcode-15/49205/110).

Blocked by `FB13358220`. Waiting on CircleCi to update to Xcode 15.1 beta 3.