### PR TITLE
Adds `X-Storefront` request header for App Store Storefront

### DIFF
--- a/Sources/Misc/SystemInfo.swift
+++ b/Sources/Misc/SystemInfo.swift
@@ -53,6 +53,14 @@ class SystemInfo {
         return self.sandboxEnvironmentDetector.isSandbox
     }
 
+    var storefront: StorefrontType? {
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, macCatalyst 13.1, *) {
+            return Storefront.sk1CurrentStorefrontType
+        } else {
+            return nil
+        }
+    }
+
     static var frameworkVersion: String {
         return "4.31.0-SNAPSHOT"
     }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -222,9 +222,12 @@ private extension HTTPClient {
             "X-Client-Bundle-ID": SystemInfo.bundleIdentifier,
             "X-StoreKit2-Enabled": "\(self.systemInfo.storeKit2Setting.isEnabledAndAvailable)",
             "X-Observer-Mode-Enabled": "\(self.systemInfo.observerMode)",
-            "X-Is-Sandbox": "\(self.systemInfo.isSandbox)",
-            "X-Storefront": self.systemInfo.storefront?.countryCode ?? ""
+            "X-Is-Sandbox": "\(self.systemInfo.isSandbox)"
         ]
+
+        if let storefront = self.systemInfo.storefront {
+            headers["X-Storefront"] = storefront.countryCode
+        }
 
         if let platformFlavorVersion = self.systemInfo.platformFlavorVersion {
             headers["X-Platform-Flavor-Version"] = platformFlavorVersion

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -222,7 +222,8 @@ private extension HTTPClient {
             "X-Client-Bundle-ID": SystemInfo.bundleIdentifier,
             "X-StoreKit2-Enabled": "\(self.systemInfo.storeKit2Setting.isEnabledAndAvailable)",
             "X-Observer-Mode-Enabled": "\(self.systemInfo.observerMode)",
-            "X-Is-Sandbox": "\(self.systemInfo.isSandbox)"
+            "X-Is-Sandbox": "\(self.systemInfo.isSandbox)",
+            "X-Storefront": self.systemInfo.storefront?.countryCode ?? ""
         ]
 
         if let platformFlavorVersion = self.systemInfo.platformFlavorVersion {

--- a/Sources/Purchasing/StoreKitAbstractions/Storefront.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/Storefront.swift
@@ -86,7 +86,7 @@ public extension Storefront {
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, macCatalyst 13.1, *)
-    private static var sk1CurrentStorefrontType: StorefrontType? {
+    internal static var sk1CurrentStorefrontType: StorefrontType? {
         return SKPaymentQueue.default().storefront.map(SK1Storefront.init)
     }
 

--- a/Tests/UnitTests/Misc/SystemInfoTests.swift
+++ b/Tests/UnitTests/Misc/SystemInfoTests.swift
@@ -54,6 +54,16 @@ class SystemInfoTests: TestCase {
         expect(SystemInfo.withReceiptResult(.receiptWithData, sandboxDetector).isSandbox) == false
     }
 
+    func testStorefront() {
+        let storefront = SystemInfo(platformInfo: nil, finishTransactions: false).storefront
+
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, macCatalyst 13.1, *) {
+            expect(storefront?.countryCode) == "USA"
+        } else {
+            expect(storefront).to(beNil())
+        }
+    }
+
     func testIsAppleSubscriptionURLWithAnotherURL() {
         expect(SystemInfo.isAppleSubscription(managementURL: URL(string: "www.google.com")!)) == false
     }

--- a/Tests/UnitTests/Mocks/MockSystemInfo.swift
+++ b/Tests/UnitTests/Mocks/MockSystemInfo.swift
@@ -15,6 +15,7 @@ class MockSystemInfo: SystemInfo {
 
     var stubbedIsApplicationBackgrounded: Bool?
     var stubbedIsSandbox: Bool?
+    var stubbedStorefront: StorefrontType?
 
     convenience init(platformInfo: Purchases.PlatformInfo? = nil,
                      finishTransactions: Bool,
@@ -56,6 +57,9 @@ class MockSystemInfo: SystemInfo {
         return self.stubbedIsSandbox ?? super.isSandbox
     }
 
+    override var storefront: StorefrontType? {
+        return self.stubbedStorefront
+    }
 }
 
 extension OperatingSystemVersion: Comparable {

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -306,24 +306,23 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
     }
 
     func testRequestsWithoutStorefrontDoNotSendHeader() {
-        let headerName = "X-Storefrontt"
-        self.systemInfo.stubbedStorefront = nil
-
+        let headerName = "X-Storefront"
         let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
-        var headerPresent = true
+        self.systemInfo.stubbedStorefront = nil
+
+        let header: Atomic<(value: String?, set: Bool)> = .init((nil, false))
 
         stub(condition: isPath(request.path)) { request in
-            let headers =  request.allHTTPHeaderFields ?? [:]
-            headerPresent = headers[headerName] != nil
+            header.value = (value: request.value(forHTTPHeaderField: headerName), set: true)
             return .emptySuccessResponse()
         }
 
         waitUntil { completion in
-            self.client.perform(request) { (_: DataResponse) in completion() }
+            self.client.perform(request) { (_: EmptyResponse) in completion() }
         }
 
-        expect(headerPresent) == false
+        expect(header.value) == (value: nil, set: true)
     }
 
     func testCallsTheGivenPath() {

--- a/Tests/UnitTests/Networking/HTTPClientTests.swift
+++ b/Tests/UnitTests/Networking/HTTPClientTests.swift
@@ -285,7 +285,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
         expect(header.value) == "false"
     }
 
-    func testRequestWithStorefrontPassesHeader() {
+    func testRequestWithStorefrontSendsHeader() {
         let headerName = "X-Storefront"
         self.systemInfo.stubbedStorefront = MockStorefront(countryCode: "USA")
 
@@ -306,21 +306,21 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
     }
 
     func testRequestsWithoutStorefrontDoNotSendHeader() {
-        let headerName = "X-Storefront"
+        let headerName = "X-Storefrontt"
         self.systemInfo.stubbedStorefront = nil
 
-        var headerPresent = false
+        let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
-        stub(condition: hasHeaderNamed(headerName)) { request in
+        var headerPresent = true
+
+        stub(condition: isPath(request.path)) { request in
             let headers =  request.allHTTPHeaderFields ?? [:]
             headerPresent = headers[headerName] != nil
             return .emptySuccessResponse()
         }
 
-        let request = HTTPRequest(method: .post([:]), path: .mockPath)
-
         waitUntil { completion in
-            self.client.perform(request) { (_: EmptyResponse) in completion() }
+            self.client.perform(request) { (_: DataResponse) in completion() }
         }
 
         expect(headerPresent) == false
@@ -956,7 +956,7 @@ final class HTTPClientTests: BaseHTTPClientTests<MockETagManager> {
 
         let request = HTTPRequest(method: .post([:]), path: .mockPath)
 
-        var headerPresent = false
+        var headerPresent = true
 
         stub(condition: isPath(request.path)) { request in
             let headers =  request.allHTTPHeaderFields ?? [:]


### PR DESCRIPTION
### Motivation

Allow backend to determine Storefront of customer

### Description

- Adds `X-Storefront` as a default header
- Uses StoreKit 1 implementation since its not async
  - StoreKit 2 implementation is async and would require a some restructuring that we don't need right now
