### PR TITLE
`visionOS`: fix support for `Xcode 15.1 beta 3`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ if shouldIncludeDocCPlugin {
 }
 
 // See https://github.com/RevenueCat/purchases-ios/pull/2989
-// #if os(xrOS) can't really be used in Xcode 13, so we use this instead.
+// #if os(visionOS) can't really be used in Xcode 13, so we use this instead.
 let visionOSSetting: SwiftSetting = .define("VISION_OS", .when(platforms: [.visionOS]))
 
 let package = Package(

--- a/RevenueCatUI/PaywallFontProvider.swift
+++ b/RevenueCatUI/PaywallFontProvider.swift
@@ -49,7 +49,7 @@ open class DefaultPaywallFontProvider: PaywallFontProvider {
         case .caption: return .caption
         case .caption2: return .caption2
 
-        #if swift(>=5.9) && os(xrOS)
+        #if swift(>=5.9) && os(visionOS)
         case .extraLargeTitle: return .extraLargeTitle
         case .extraLargeTitle2: return .extraLargeTitle2
         #endif
@@ -109,7 +109,7 @@ private extension Font.TextStyle {
         case .caption: return .caption1
         case .caption2: return .caption2
 
-        #if swift(>=5.9) && os(xrOS)
+        #if swift(>=5.9) && os(visionOS)
         case .extraLargeTitle: return .extraLargeTitle
         case .extraLargeTitle2: return .extraLargeTitle2
         #endif

--- a/RevenueCatUI/Templates/Template4View.swift
+++ b/RevenueCatUI/Templates/Template4View.swift
@@ -186,7 +186,7 @@ struct Template4View: TemplateViewType {
                 }
             }
         }
-        #if swift(>=5.9) && os(xrOS)
+        #if swift(>=5.9) && os(visionOS)
         .onChange(of: self.dynamicTypeSize) { _, _ in self.packageContentHeight = nil }
         .onChange(of: self.containerWidth) { _, _ in self.packageContentHeight = nil }
         #else

--- a/RevenueCatUI/Views/FooterView.swift
+++ b/RevenueCatUI/Views/FooterView.swift
@@ -103,7 +103,7 @@ struct FooterView: View {
         .frame(maxWidth: .infinity)
         .padding(.horizontal)
         .dynamicTypeSize(...Constants.maximumDynamicTypeSize)
-        #if targetEnvironment(macCatalyst) || (swift(>=5.9) && os(xrOS))
+        #if targetEnvironment(macCatalyst) || (swift(>=5.9) && os(visionOS))
         .buttonStyle(.plain)
         #endif
     }

--- a/Sources/FoundationExtensions/Locale+Extensions.swift
+++ b/Sources/FoundationExtensions/Locale+Extensions.swift
@@ -19,7 +19,7 @@ extension Locale {
     var rc_currencyCode: String? {
         #if swift(>=5.9)
         // `Locale.currencyCode` is deprecated
-        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, xrOS 1.0, *) {
+        if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, visionOS 1.0, *) {
             return self.currency?.identifier
         } else {
             return self.currencyCode

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/AdaptiveStack.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/AdaptiveStack.swift
@@ -27,7 +27,7 @@ struct AdaptiveStack<Content: View>: View {
     }
 
     var body: some View {
-        #if os(xrOS)
+        #if os(visionOS)
         VStack(alignment: self.horizontalAlignment, spacing: self.spacing, content: self.content)
         #else
         HStack(alignment: self.verticalAlignment, spacing: spacing, content: self.content)

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/ObserverModeManager.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/ObserverModeManager.swift
@@ -34,7 +34,7 @@ final class ObserverModeManager: ObservableObject {
         _ = await self.purchasesOrchestrator.purchase(sk1Product: sk1Product)
     }
 
-    #if !os(xrOS)
+    #if !os(visionOS)
     func purchaseAsSK2Product(_ product: StoreProduct) async throws {
         guard let sk2Product = try await self.productFetcherSK2.products(with: [product.productIdentifier]).first else {
             print("Failed to find product")

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/PurchasesOrchestrator.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Helpers/PurchasesOrchestrator.swift
@@ -42,7 +42,7 @@ final class PurchasesOrchestrator: NSObject {
     }
 
     // Fix-me: inject @Environment(\.product) to fix this
-    #if !os(xrOS)
+    #if !os(visionOS)
     func purchase(sk2Product product: SK2Product) async throws {
         let result = try await product.purchase()
 

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/HomeView.swift
@@ -171,7 +171,7 @@ struct HomeView: View {
     }
 
     var body: some View {
-        #if DEBUG && !os(xrOS) && !os(watchOS)
+        #if DEBUG && !os(visionOS) && !os(watchOS)
         if #available(iOS 16.0, macOS 13.0, *) {
             self.content
                 .debugRevenueCatOverlay(isPresented: self.$debugOverlayVisible)
@@ -320,7 +320,7 @@ private struct CustomerInfoHeaderView: View {
     }
     
     private var horizontalAlignment: HorizontalAlignment {
-        #if os(xrOS)
+        #if os(visionOS)
         return .center
         #else
         return .leading

--- a/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Offerings/OfferingDetailView.swift
+++ b/Tests/TestingApps/PurchaseTesterSwiftUI/Shared/Views/Offerings/OfferingDetailView.swift
@@ -94,7 +94,7 @@ struct OfferingDetailView: View {
                         try await self.purchaseAsSK1Product()
                     }
 
-                    #if !os(xrOS)
+                    #if !os(visionOS)
                     self.button("Buy directly from SK2 (w/o RevenueCat)") {
                         try await self.purchaseAsSK2Product()
                     }
@@ -152,7 +152,7 @@ struct OfferingDetailView: View {
             try await self.observerModeManager.purchaseAsSK1Product(self.package.storeProduct)
         }
 
-        #if !os(xrOS)
+        #if !os(visionOS)
         private func purchaseAsSK2Product() async throws {
             self.isPurchasing = true
             defer { self.isPurchasing = false }


### PR DESCRIPTION
Apple changed `xrOS` to `visionOS` on the latest beta. Looks like this was already supported in prior `Xcode 15.1` betas, so this doesn't break compatibility with them.