### PR TITLE
`SystemInfo`: fix flaky `Storefront` test

### DIFF
--- a/Tests/StoreKitUnitTests/StorefrontTests.swift
+++ b/Tests/StoreKitUnitTests/StorefrontTests.swift
@@ -47,4 +47,14 @@ class StorefrontTests: StoreKitConfigTestCase {
         }
     }
 
+    func testSystemInfoStorefront() async throws {
+        let expected = "ESP"
+        try await self.changeStorefront(expected)
+
+        let systemInfo = SystemInfo(platformInfo: nil, finishTransactions: false)
+        let storefront = try XCTUnwrap(systemInfo.storefront)
+
+        expect(storefront.countryCode) == expected
+    }
+
 }

--- a/Tests/UnitTests/Misc/SystemInfoTests.swift
+++ b/Tests/UnitTests/Misc/SystemInfoTests.swift
@@ -54,13 +54,12 @@ class SystemInfoTests: TestCase {
         expect(SystemInfo.withReceiptResult(.receiptWithData, sandboxDetector).isSandbox) == false
     }
 
-    func testStorefrontForUnsupportedPlatform() {
-        let storefront = SystemInfo(platformInfo: nil, finishTransactions: false).storefront
-
-        // See `StorefrontTests` for real tests
-        if #unavailable(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, macCatalyst 13.1) {
-            expect(storefront).to(beNil())
+    func testStorefrontForUnsupportedPlatforms() throws {
+        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, macCatalyst 13.1, *) {
+            throw XCTSkip("Test only for older platforms")
         }
+
+        expect(SystemInfo.default.storefront).to(beNil())
     }
 
     func testIsAppleSubscriptionURLWithAnotherURL() {

--- a/Tests/UnitTests/Misc/SystemInfoTests.swift
+++ b/Tests/UnitTests/Misc/SystemInfoTests.swift
@@ -54,12 +54,11 @@ class SystemInfoTests: TestCase {
         expect(SystemInfo.withReceiptResult(.receiptWithData, sandboxDetector).isSandbox) == false
     }
 
-    func testStorefront() {
+    func testStorefrontForUnsupportedPlatform() {
         let storefront = SystemInfo(platformInfo: nil, finishTransactions: false).storefront
 
-        if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, macCatalyst 13.1, *) {
-            expect(storefront?.countryCode) == "USA"
-        } else {
+        // See `StorefrontTests` for real tests
+        if #unavailable(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, macCatalyst 13.1) {
             expect(storefront).to(beNil())
         }
     }


### PR DESCRIPTION
Follow up to #3405.

`SystemInfo.storefront` relies on `SKPaymentQueue`, which requires an `SKTestSession`.
This is why this new test was being flaky. This new implementation explicitly sets the storefront to fix that.
