### PR TITLE
Enable explicit_init lint rule and fix issues

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -15,6 +15,7 @@ opt_in_rules:
   - multiline_parameters
   - vertical_parameter_alignment
   - vertical_parameter_alignment_on_call
+  - explicit_init
 
 disabled_rules:
   - orphaned_doc_comment

--- a/Sources/Error Handling/ErrorUtils.swift
+++ b/Sources/Error Handling/ErrorUtils.swift
@@ -731,9 +731,9 @@ extension Error {
 
     func addingUserInfo<Result: NSError>(_ userInfo: [String: Any]) -> Result {
         let nsError = self as NSError
-        return Result.init(domain: nsError.domain,
-                           code: nsError.code,
-                           userInfo: nsError.userInfo + userInfo)
+        return .init(domain: nsError.domain,
+                     code: nsError.code,
+                     userInfo: nsError.userInfo + userInfo)
     }
 
 }

--- a/Sources/Misc/Codable/IgnoreHashable.swift
+++ b/Sources/Misc/Codable/IgnoreHashable.swift
@@ -39,7 +39,7 @@ extension IgnoreHashable: Hashable {
 extension IgnoreHashable: Decodable where Value: Decodable {
 
     init(from decoder: Decoder) throws {
-        self.init(wrappedValue: try Value.init(from: decoder))
+        self.init(wrappedValue: try .init(from: decoder))
     }
 
 }

--- a/Sources/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK1StoreProductDiscount.swift
@@ -75,7 +75,7 @@ private extension StoreProductDiscount.PaymentMode {
         case .freeTrial:
             self = .freeTrial
         @unknown default:
-            Logger.appleWarning(Strings.storeKit.skunknown_payment_mode(String.init(describing: paymentMode)))
+            Logger.appleWarning(Strings.storeKit.skunknown_payment_mode(.init(describing: paymentMode)))
             return nil
         }
     }

--- a/Sources/Purchasing/StoreKitAbstractions/SK2StoreProductDiscount.swift
+++ b/Sources/Purchasing/StoreKitAbstractions/SK2StoreProductDiscount.swift
@@ -60,7 +60,7 @@ private extension StoreProductDiscount.PaymentMode {
         case .freeTrial:
             self = .freeTrial
         default:
-            Logger.appleWarning(Strings.storeKit.skunknown_payment_mode(String.init(describing: paymentMode)))
+            Logger.appleWarning(Strings.storeKit.skunknown_payment_mode(.init(describing: paymentMode)))
             return nil
         }
     }

--- a/Tests/APITesters/SwiftAPITester/SwiftAPITester/PaywallAPI.swift
+++ b/Tests/APITesters/SwiftAPITester/SwiftAPITester/PaywallAPI.swift
@@ -216,7 +216,7 @@ func checkPaywallEventCreationData(_ creationData: PaywallEvent.CreationData) {
         id: PaywallEvent.ID,
         date: Date
     ) {
-        _ = PaywallEvent.CreationData.init(
+        _ = PaywallEvent.CreationData(
             id: id,
             date: date
         )
@@ -240,7 +240,7 @@ func checkPaywallEventData(_ data: PaywallEvent.Data) {
         locale: Locale,
         darkMode: Bool
     ) {
-        _ = PaywallEvent.Data.init(
+        _ = PaywallEvent.Data(
             offering: offering,
             paywall: paywall,
             sessionID: sessionID,

--- a/Tests/UnitTests/Networking/Backend/BackendGetIntroEligibilityTests.swift
+++ b/Tests/UnitTests/Networking/Backend/BackendGetIntroEligibilityTests.swift
@@ -74,7 +74,7 @@ class BackendGetIntroEligibilityTests: BaseBackendTests {
         let eligibility: [String: IntroEligibility]? = waitUntilValue { completed in
             let products: Set<String> = ["producta", "productb", "productc"]
             self.offerings.getIntroEligibility(appUserID: Self.userID,
-                                               receiptData: Data.init(1...2),
+                                               receiptData: .init(1...2),
                                                productIdentifiers: products,
                                                completion: {(productEligibility, error) in
                 expect(error).to(beNil())
@@ -97,7 +97,7 @@ class BackendGetIntroEligibilityTests: BaseBackendTests {
         let products: Set<String> = ["producta"]
         var eventualError: BackendError?
         self.backend.offerings.getIntroEligibility(appUserID: "",
-                                                   receiptData: Data.init(1...2),
+                                                   receiptData: .init(1...2),
                                                    productIdentifiers: products,
                                                    completion: {(productEligibility, error) in
             eventualError = error
@@ -112,7 +112,7 @@ class BackendGetIntroEligibilityTests: BaseBackendTests {
         eventualError = nil
 
         self.offerings.getIntroEligibility(appUserID: "   ",
-                                           receiptData: Data.init(1...2),
+                                           receiptData: .init(1...2),
                                            productIdentifiers: products,
                                            completion: {(productEligibility, error) in
             eventualError = error
@@ -136,7 +136,7 @@ class BackendGetIntroEligibilityTests: BaseBackendTests {
         let eligibility: [String: IntroEligibility]? = waitUntilValue { completed in
 
             self.offerings.getIntroEligibility(appUserID: Self.userID,
-                                               receiptData: Data.init(1...2),
+                                               receiptData: .init(1...2),
                                                productIdentifiers: products,
                                                completion: { productEligbility, error in
                 expect(error).to(beNil())

--- a/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
+++ b/Tests/UnitTests/Purchasing/Purchases/PurchasesPurchasingTests.swift
@@ -740,7 +740,7 @@ class PurchasesPurchasingTests: BasePurchasesTests {
         }
 
         let transaction = MockTransaction()
-        transaction.mockPayment = SKPayment.init(product: otherProduct)
+        transaction.mockPayment = .init(product: otherProduct)
 
         self.backend.postReceiptResult = .success(try CustomerInfo(data: Self.emptyCustomerInfoData))
 

--- a/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
+++ b/Tests/UnitTests/Purchasing/StoreKit1WrapperTests.swift
@@ -78,7 +78,7 @@ class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
     }
 
     func testAddsPaymentsToTheQueue() {
-        let payment = SKPayment.init(product: SK1Product())
+        let payment = SKPayment(product: SK1Product())
 
         wrapper?.add(payment)
 
@@ -86,7 +86,7 @@ class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
     }
 
     func testCallsDelegateWhenTransactionsAreUpdated() {
-        let payment = SKPayment.init(product: SK1Product())
+        let payment = SKPayment(product: SK1Product())
         wrapper?.add(payment)
 
         let transaction = MockTransaction()
@@ -134,10 +134,10 @@ class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
     #endif
 
     func testCallsDelegateOncePerTransaction() {
-        let payment1 = SKPayment.init(product: SK1Product())
+        let payment1 = SKPayment(product: SK1Product())
         wrapper?.add(payment1)
 
-        let payment2 = SKPayment.init(product: SK1Product())
+        let payment2 = SKPayment(product: SK1Product())
         wrapper?.add(payment2)
 
         let transaction1 = MockTransaction()
@@ -203,9 +203,9 @@ class StoreKit1WrapperTests: TestCase, StoreKit1WrapperDelegate {
 
     func testCallsRemovedTransactionDelegateMethod() {
         let transaction1 = MockTransaction()
-        transaction1.mockPayment = SKPayment.init(product: SK1Product())
+        transaction1.mockPayment = SKPayment(product: SK1Product())
         let transaction2 = MockTransaction()
-        transaction2.mockPayment = SKPayment.init(product: SK1Product())
+        transaction2.mockPayment = SKPayment(product: SK1Product())
 
         wrapper?.paymentQueue(paymentQueue, removedTransactions: [transaction1, transaction2])
 


### PR DESCRIPTION
This rule will warn when calling `init` with the explicit type where it can be inferred, or where the `.init` part can be omitted.