### PR TITLE
`Trusted Entitlements`: add support for signing request headers

### DIFF
--- a/RevenueCat.xcodeproj/project.pbxproj
+++ b/RevenueCat.xcodeproj/project.pbxproj
@@ -331,6 +331,7 @@
 		4FE6FEEB2AA940E300780B45 /* PaywallEventSerializerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE6FEE82AA940E300780B45 /* PaywallEventSerializerTests.swift */; };
 		4FF017C32AB378A7004976EB /* BaseStoreKitIntegrationTests+Verification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF017C22AB378A7004976EB /* BaseStoreKitIntegrationTests+Verification.swift */; };
 		4FF017C42AB378A7004976EB /* BaseStoreKitIntegrationTests+Verification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF017C22AB378A7004976EB /* BaseStoreKitIntegrationTests+Verification.swift */; };
+		4FF6E4B92B069B8C000141ED /* HTTPRequest+Signing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF6E4B82B069B8C000141ED /* HTTPRequest+Signing.swift */; };
 		4FF8464D2A32554300617F00 /* DiagnosticsStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF8464C2A32554300617F00 /* DiagnosticsStrings.swift */; };
 		4FFCED822AA941B200118EF4 /* PaywallEventsRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFCED802AA941B200118EF4 /* PaywallEventsRequestTests.swift */; };
 		4FFCED832AA941B200118EF4 /* PaywallEventsBackendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFCED812AA941B200118EF4 /* PaywallEventsBackendTests.swift */; };
@@ -1083,6 +1084,7 @@
 		4FE6FEE82AA940E300780B45 /* PaywallEventSerializerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallEventSerializerTests.swift; sourceTree = "<group>"; };
 		4FED3AD62AAA7DD4001D4D5E /* purchases-ios */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "purchases-ios"; path = ..; sourceTree = "<group>"; };
 		4FF017C22AB378A7004976EB /* BaseStoreKitIntegrationTests+Verification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BaseStoreKitIntegrationTests+Verification.swift"; sourceTree = "<group>"; };
+		4FF6E4B82B069B8C000141ED /* HTTPRequest+Signing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HTTPRequest+Signing.swift"; sourceTree = "<group>"; };
 		4FF8464C2A32554300617F00 /* DiagnosticsStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsStrings.swift; sourceTree = "<group>"; };
 		4FFCED802AA941B200118EF4 /* PaywallEventsRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallEventsRequestTests.swift; sourceTree = "<group>"; };
 		4FFCED812AA941B200118EF4 /* PaywallEventsBackendTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaywallEventsBackendTests.swift; sourceTree = "<group>"; };
@@ -2616,6 +2618,7 @@
 				5740FCD22996CE5E00E049F9 /* VerificationResult.swift */,
 				4F6EEBD82A38ED76007FD783 /* FakeSigning.swift */,
 				4F8452672A5756CC00084550 /* HTTPRequestBody+Signing.swift */,
+				4FF6E4B82B069B8C000141ED /* HTTPRequest+Signing.swift */,
 			);
 			path = Security;
 			sourceTree = "<group>";
@@ -3418,6 +3421,7 @@
 				5751379527F4C4D80064AB2C /* Optional+Extensions.swift in Sources */,
 				B3852FA026C1ED1F005384F8 /* IdentityManager.swift in Sources */,
 				9A65E03625918B0500DE00B0 /* ConfigureStrings.swift in Sources */,
+				4FF6E4B92B069B8C000141ED /* HTTPRequest+Signing.swift in Sources */,
 				57488C7729CB90F90000EE7E /* PurchasedProductsFetcher.swift in Sources */,
 				4F3C986A2A44FA60009AECA3 /* ErrorResponse.swift in Sources */,
 				578C5F2C28DB82DD00A56F02 /* PurchasesDiagnostics.swift in Sources */,

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -163,7 +163,7 @@ extension HTTPClient {
         case eTag = "X-RevenueCat-ETag"
         case eTagValidationTime = "X-RC-Last-Refresh-Time"
         case postParameters = "X-Post-Params-Hash"
-        case headerParametersForSignature = "X-Header-Params-Hash"
+        case headerParametersForSignature = "X-Headers-Hash"
         case sandbox = "X-Is-Sandbox"
 
     }

--- a/Sources/Networking/HTTPClient/HTTPClient.swift
+++ b/Sources/Networking/HTTPClient/HTTPClient.swift
@@ -148,8 +148,14 @@ extension HTTPClient {
         }
     }
 
-    static func headerParametersForSignatureHeader(with headers: RequestHeaders) -> RequestHeaders {
-        if let header = HTTPRequest.headerParametersForSignatureHeader(headers: headers) {
+    static func headerParametersForSignatureHeader(
+        with headers: RequestHeaders,
+        path: HTTPRequestPath
+    ) -> RequestHeaders {
+        if let header = HTTPRequest.headerParametersForSignatureHeader(
+            headers: headers,
+            path: path
+        ) {
             return [RequestHeader.headerParametersForSignature.rawValue: header]
         } else {
             return [:]
@@ -543,7 +549,10 @@ extension HTTPRequest {
         if #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *),
            verificationMode.isEnabled,
            self.path.supportsSignatureVerification {
-            result += HTTPClient.headerParametersForSignatureHeader(with: defaultHeaders)
+            result += HTTPClient.headerParametersForSignatureHeader(
+                with: defaultHeaders,
+                path: self.path
+            )
 
             if let body = self.requestBody {
                 result += HTTPClient.postParametersHeaderForSigning(with: body)

--- a/Sources/Security/HTTPRequest+Signing.swift
+++ b/Sources/Security/HTTPRequest+Signing.swift
@@ -1,0 +1,91 @@
+//
+//  Copyright RevenueCat Inc. All Rights Reserved.
+//
+//  Licensed under the MIT License (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      https://opensource.org/licenses/MIT
+//
+//  HTTPRequest+Signing.swift
+//
+//  Created by Nacho Soto on 11/16/23.
+
+import CryptoKit
+import Foundation
+
+extension HTTPRequest {
+
+    static func headerParametersForSignatureHeader(headers: Headers) -> String? {
+        guard #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) else {
+            // Signature verification is not available.
+            return nil
+        }
+
+        let headersToSign = Self.headersToSign.map(\.rawValue)
+
+        if !headersToSign.isEmpty, let hash = Self.postParameterHash(headers) {
+            return Self.signatureHashHeader(keys: headersToSign, hash: hash)
+        } else {
+            return nil
+        }
+    }
+
+    /// - Returns: `nil` if none of the requested headers are found
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    private static func postParameterHash(_ headers: Headers) -> String? {
+        let headersToSign = Self.headersToSign.map(\.rawValue)
+        let values = headers
+            .filter { headersToSign.contains($0.key) }
+            .map(\.value)
+
+        guard !values.isEmpty else { return nil }
+
+        return Self.signingParameterHash(values)
+    }
+
+}
+
+extension HTTPRequest {
+
+    static func signatureHashHeader(
+        keys: [String],
+        hash: String
+    ) -> String {
+        return [
+            keys.joined(separator: ","),
+            postParameterHashingAlgorithmName,
+            hash
+        ].joined(separator: ":")
+    }
+
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
+    static func signingParameterHash(_ values: [String]) -> String {
+        var sha256 = SHA256()
+
+        for (index, value) in values.enumerated() {
+            if index > 0 {
+                sha256.update(data: fieldSeparator)
+            }
+
+            sha256.update(data: value.asData)
+        }
+
+        return sha256.toString()
+    }
+
+}
+
+// MARK: - Private
+
+private extension HTTPRequest {
+
+    /// Ordered list of header keys that will be included in the signature.
+    static let headersToSign: [HTTPClient.RequestHeader] = [
+        .sandbox
+    ]
+
+}
+
+private let postParameterHashingAlgorithmName = "sha256"
+private let fieldSeparator = Data(bytes: [0x00], count: 1)

--- a/Sources/Security/HTTPRequest+Signing.swift
+++ b/Sources/Security/HTTPRequest+Signing.swift
@@ -34,10 +34,7 @@ extension HTTPRequest {
     /// - Returns: `nil` if none of the requested headers are found
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
     private static func postParameterHash(_ headers: Headers) -> String? {
-        let headersToSign = Self.headersToSign.map(\.rawValue)
-        let values = headers
-            .filter { headersToSign.contains($0.key) }
-            .map(\.value)
+        let values = Self.headersToSign.compactMap { headers[$0.rawValue] }
 
         guard !values.isEmpty else { return nil }
 

--- a/Sources/Security/HTTPRequest+Signing.swift
+++ b/Sources/Security/HTTPRequest+Signing.swift
@@ -22,10 +22,9 @@ extension HTTPRequest {
             return nil
         }
 
-        let headersToSign = Self.headersToSign.map(\.rawValue)
-
-        if !headersToSign.isEmpty, let hash = Self.postParameterHash(headers) {
-            return Self.signatureHashHeader(keys: headersToSign, hash: hash)
+        if let hash = Self.postParameterHash(headers) {
+            return Self.signatureHashHeader(keys: Self.headersToSign.map(\.rawValue),
+                                            hash: hash)
         } else {
             return nil
         }

--- a/Sources/Security/HTTPRequest+Signing.swift
+++ b/Sources/Security/HTTPRequest+Signing.swift
@@ -16,9 +16,17 @@ import Foundation
 
 extension HTTPRequest {
 
-    static func headerParametersForSignatureHeader(headers: Headers) -> String? {
+    static func headerParametersForSignatureHeader(
+        headers: Headers,
+        path: HTTPRequestPath
+    ) -> String? {
         guard #available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *) else {
             // Signature verification is not available.
+            return nil
+        }
+
+        guard path.needsNonceForSigning else {
+            // Static signatures cannot sign header parameters
             return nil
         }
 

--- a/Sources/Security/HTTPRequestBody+Signing.swift
+++ b/Sources/Security/HTTPRequestBody+Signing.swift
@@ -11,7 +11,6 @@
 //
 //  Created by Nacho Soto on 7/6/23.
 
-import CryptoKit
 import Foundation
 
 extension HTTPRequestBody {
@@ -27,30 +26,12 @@ extension HTTPRequestBody {
             return nil
         }
 
-        let pieces = [
-            keys.joined(separator: ","),
-            postParameterHashingAlgorithmName,
-            self.postParameterHash
-        ]
-
-        return pieces.joined(separator: ":")
+        return HTTPRequest.signatureHashHeader(keys: keys, hash: self.postParameterHash)
     }
 
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.2, *)
-    var postParameterHash: String {
-        var sha256 = SHA256()
-
-        let values = self.contentForSignature.map(\.value)
-
-        for (index, value) in values.enumerated() {
-            if index > 0 {
-                sha256.update(data: fieldSeparator)
-            }
-
-            sha256.update(data: value.asData)
-        }
-
-        return sha256.toString()
+    private var postParameterHash: String {
+        return HTTPRequest.signingParameterHash(self.contentForSignature.map(\.value))
     }
 
 }
@@ -63,6 +44,3 @@ private extension HTTPRequestBody {
     }
 
 }
-
-private let postParameterHashingAlgorithmName = "sha256"
-private let fieldSeparator = Data(bytes: [0x00], count: 1)

--- a/Sources/Security/Signing.swift
+++ b/Sources/Security/Signing.swift
@@ -11,6 +11,8 @@
 //
 //  Created by Nacho Soto on 1/13/23.
 
+// swiftlint:disable file_length
+
 import CryptoKit
 import Foundation
 
@@ -37,6 +39,7 @@ final class Signing: SigningType {
 
         var path: HTTPRequestPath
         var message: Data?
+        var requestHeaders: HTTPRequest.Headers
         var requestBody: HTTPRequestBody?
         var nonce: Data?
         var etag: String?
@@ -246,6 +249,7 @@ extension Signing.SignatureParameters {
     init(
         path: HTTPRequest.Path,
         message: Data? = nil,
+        requestHeaders: HTTPRequest.Headers = [:],
         requestBody: HTTPRequestBody? = nil,
         nonce: Data? = nil,
         etag: String? = nil,
@@ -253,6 +257,7 @@ extension Signing.SignatureParameters {
     ) {
         self.path = path
         self.message = message
+        self.requestHeaders = requestHeaders
         self.requestBody = requestBody
         self.nonce = nonce
         self.etag = etag
@@ -267,6 +272,8 @@ extension Signing.SignatureParameters {
     var asData: Data {
         let nonce: Data = self.nonce ?? .init()
         let path: Data = self.path.relativePath.asData
+        let headerParametersHash: Data = HTTPRequest.headerParametersForSignatureHeader(headers: self.requestHeaders)?
+        .asData ?? .init()
         let postParameterHash: Data = self.requestBody?.postParameterHeader?.asData ?? .init()
         let requestDate: Data = String(self.requestDate).asData
         let etag: Data = (self.etag ?? "").asData
@@ -275,6 +282,7 @@ extension Signing.SignatureParameters {
         return (
             nonce +
             path +
+            headerParametersHash +
             postParameterHash +
             requestDate +
             etag +
@@ -291,6 +299,10 @@ extension Signing.SignatureParameters: CustomDebugStringConvertible {
         SignatureParameters(" +
             path: '\(self.path.relativePath)'
             message: '\(self.messageString.trimmingWhitespacesAndNewLines)'
+            headerParametersHash: '\(HTTPRequest.headerParametersForSignatureHeader(
+                headers: self.requestHeaders
+            ) ?? "")'
+            headers: '\(self.requestHeaders)'
             postParameterHeader: '\(self.requestBody?.postParameterHeader ?? "")'
             nonce: '\(self.nonce?.base64EncodedString() ?? "")'
             etag: '\(self.etag ?? "")'

--- a/Sources/Security/Signing.swift
+++ b/Sources/Security/Signing.swift
@@ -272,9 +272,9 @@ extension Signing.SignatureParameters {
     var asData: Data {
         let nonce: Data = self.nonce ?? .init()
         let path: Data = self.path.relativePath.asData
+        let postParameterHash: Data = self.requestBody?.postParameterHeader?.asData ?? .init()
         let headerParametersHash: Data = HTTPRequest.headerParametersForSignatureHeader(headers: self.requestHeaders)?
         .asData ?? .init()
-        let postParameterHash: Data = self.requestBody?.postParameterHeader?.asData ?? .init()
         let requestDate: Data = String(self.requestDate).asData
         let etag: Data = (self.etag ?? "").asData
         let message: Data = self.message ?? .init()
@@ -282,8 +282,8 @@ extension Signing.SignatureParameters {
         return (
             nonce +
             path +
-            headerParametersHash +
             postParameterHash +
+            headerParametersHash +
             requestDate +
             etag +
             message

--- a/Sources/Security/Signing.swift
+++ b/Sources/Security/Signing.swift
@@ -273,7 +273,10 @@ extension Signing.SignatureParameters {
         let nonce: Data = self.nonce ?? .init()
         let path: Data = self.path.relativePath.asData
         let postParameterHash: Data = self.requestBody?.postParameterHeader?.asData ?? .init()
-        let headerParametersHash: Data = HTTPRequest.headerParametersForSignatureHeader(headers: self.requestHeaders)?
+        let headerParametersHash: Data = HTTPRequest.headerParametersForSignatureHeader(
+            headers: self.requestHeaders,
+            path: self.path
+        )?
         .asData ?? .init()
         let requestDate: Data = String(self.requestDate).asData
         let etag: Data = (self.etag ?? "").asData
@@ -300,7 +303,8 @@ extension Signing.SignatureParameters: CustomDebugStringConvertible {
             path: '\(self.path.relativePath)'
             message: '\(self.messageString.trimmingWhitespacesAndNewLines)'
             headerParametersHash: '\(HTTPRequest.headerParametersForSignatureHeader(
-                headers: self.requestHeaders
+                headers: self.requestHeaders,
+                path: self.path
             ) ?? "")'
             headers: '\(self.requestHeaders)'
             postParameterHeader: '\(self.requestBody?.postParameterHeader ?? "")'

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -83,6 +83,8 @@ class MockHTTPClient: HTTPClient {
             .requestAddingNonceIfRequired(with: verificationMode)
             .withHardcodedNonce
 
+isRecording = true
+
         let call = Call(request: request,
                         headers: request.headers(with: self.authHeaders,
                                                  defaultHeaders: self.defaultHeaders,

--- a/Tests/UnitTests/Mocks/MockHTTPClient.swift
+++ b/Tests/UnitTests/Mocks/MockHTTPClient.swift
@@ -83,8 +83,6 @@ class MockHTTPClient: HTTPClient {
             .requestAddingNonceIfRequired(with: verificationMode)
             .withHardcodedNonce
 
-isRecording = true
-
         let call = Call(request: request,
                         headers: request.headers(with: self.authHeaders,
                                                  defaultHeaders: self.defaultHeaders,

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS13-testSendsNonceWhenEnabled.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS14-testSendsNonceWhenEnabled.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS15-testSendsNonceWhenEnabled.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS16-testSendsNonceWhenEnabled.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testSendsNonceWhenEnabled.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendGetCustomerInfoTests/iOS17-testSendsNonceWhenEnabled.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithFailedVerification.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS13-testLoginWithVerifiedResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithFailedVerification.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS14-testLoginWithVerifiedResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithFailedVerification.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS15-testLoginWithVerifiedResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithFailedVerification.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS16-testLoginWithVerifiedResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithFailedVerification.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendLoginTests/iOS17-testLoginWithVerifiedResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithFailedVerification.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS13-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithFailedVerification.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS14-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithFailedVerification.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS15-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithFailedVerification.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS16-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithFailedVerification.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithFailedVerification.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithVerifiedResponse.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendPostReceiptDataTests/iOS17-testGetsEntitlementsWithVerifiedResponse.1.json
@@ -6,6 +6,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestContainsSignatureHeader.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS13-testRequestFailsIfSignatureVerificationFails.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS14-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS14-testRequestContainsSignatureHeader.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS14-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS14-testRequestFailsIfSignatureVerificationFails.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestContainsSignatureHeader.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS15-testRequestFailsIfSignatureVerificationFails.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS16-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS16-testRequestContainsSignatureHeader.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS16-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS16-testRequestFailsIfSignatureVerificationFails.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestContainsSignatureHeader.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestContainsSignatureHeader.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestFailsIfSignatureVerificationFails.1.json
+++ b/Tests/UnitTests/Networking/Backend/__Snapshots__/BackendSignatureVerificationTests/iOS17-testRequestFailsIfSignatureVerificationFails.1.json
@@ -5,6 +5,7 @@
     "X-Client-Build-Version" : "12345",
     "X-Client-Bundle-ID" : "com.apple.dt.xctest.tool",
     "X-Client-Version" : "17.0.0",
+    "X-Headers-Hash" : "X-Is-Sandbox:sha256:b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b",
     "X-Is-Sandbox" : "true",
     "X-Nonce" : "MTIzNDU2Nzg5MGFi",
     "X-Observer-Mode-Enabled" : "false",

--- a/Tests/UnitTests/Networking/HTTPResponseTests.swift
+++ b/Tests/UnitTests/Networking/HTTPResponseTests.swift
@@ -28,7 +28,12 @@ class HTTPResponseTests: TestCase {
             responseHeaders: [:],
             body: Data()
         )
-        let verifiedResponse = response.verify(signing: Self.signing, request: request, publicKey: nil)
+        let verifiedResponse = response.verify(
+            signing: Self.signing,
+            request: request,
+            requestHeaders: [:],
+            publicKey: nil
+        )
 
         expect(verifiedResponse.verificationResult) == .notRequested
     }
@@ -45,7 +50,12 @@ class HTTPResponseTests: TestCase {
             responseHeaders: [:],
             body: Data()
         )
-        let verifiedResponse = response.verify(signing: Self.signing, request: request, publicKey: key)
+        let verifiedResponse = response.verify(
+            signing: Self.signing,
+            request: request,
+            requestHeaders: [:],
+            publicKey: key
+        )
 
         expect(verifiedResponse.verificationResult) == .notRequested
     }
@@ -62,7 +72,12 @@ class HTTPResponseTests: TestCase {
             responseHeaders: [:],
             body: Data()
         )
-        let verifiedResponse = response.verify(signing: Self.signing, request: request, publicKey: key)
+        let verifiedResponse = response.verify(
+            signing: Self.signing,
+            request: request,
+            requestHeaders: [:],
+            publicKey: key
+        )
 
         expect(verifiedResponse.verificationResult) == .failed
     }

--- a/Tests/UnitTests/Security/SigningTests.swift
+++ b/Tests/UnitTests/Security/SigningTests.swift
@@ -33,6 +33,9 @@ class SigningTests: TestCase {
 
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
+        // TODO: remove
+        Logger.logLevel = .verbose
+
         self.signing = .init(apiKey: Self.apiKey, clock: TestClock(now: Self.mockDate))
     }
 
@@ -505,7 +508,12 @@ class SigningTests: TestCase {
     func testResponseVerificationWithNoProvidedKey() throws {
         let request = HTTPRequest.createWithResponseVerification(method: .get, path: .health)
         let response = HTTPResponse<Data?>(httpStatusCode: .success, responseHeaders: [:], body: Data())
-        let verifiedResponse = response.verify(signing: self.signing, request: request, publicKey: nil)
+        let verifiedResponse = response.verify(
+            signing: self.signing,
+            request: request,
+            requestHeaders: [:],
+            publicKey: nil
+        )
 
         expect(verifiedResponse.verificationResult) == .notRequested
     }
@@ -514,7 +522,12 @@ class SigningTests: TestCase {
         let request = HTTPRequest.createWithResponseVerification(method: .get, path: .health)
 
         let response = HTTPResponse<Data?>(httpStatusCode: .success, responseHeaders: [:], body: Data())
-        let verifiedResponse = response.verify(signing: self.signing, request: request, publicKey: self.publicKey)
+        let verifiedResponse = response.verify(
+            signing: self.signing,
+            request: request,
+            requestHeaders: [:],
+            publicKey: self.publicKey
+        )
 
         expect(verifiedResponse.verificationResult) == .failed
 
@@ -531,7 +544,12 @@ class SigningTests: TestCase {
             ],
             body: Data()
         )
-        let verifiedResponse = response.verify(signing: self.signing, request: request, publicKey: self.publicKey)
+        let verifiedResponse = response.verify(
+            signing: self.signing,
+            request: request,
+            requestHeaders: [:],
+            publicKey: self.publicKey
+        )
 
         expect(verifiedResponse.verificationResult) == .failed
     }
@@ -543,9 +561,13 @@ class SigningTests: TestCase {
         let intermediateKey = try self.createIntermediatePublicKeyData(expiration: Self.intermediateKeyFutureExpiration)
         let salt = Self.createSalt()
         let request = HTTPRequest(method: .get, path: .health, nonce: nonce.asData)
+        let requestHeaders: HTTPRequest.Headers = [
+            HTTPClient.RequestHeader.sandbox.rawValue: "\(Bool.random())"
+        ]
 
         let signature = try self.sign(parameters: .init(path: request.path,
                                                         message: message.asData,
+                                                        requestHeaders: requestHeaders,
                                                         nonce: nonce.asData,
                                                         etag: nil,
                                                         requestDate: requestDate),
@@ -564,7 +586,12 @@ class SigningTests: TestCase {
             ],
             body: message.asData
         )
-        let verifiedResponse = response.verify(signing: self.signing, request: request, publicKey: self.publicKey)
+        let verifiedResponse = response.verify(
+            signing: self.signing,
+            request: request,
+            requestHeaders: requestHeaders,
+            publicKey: self.publicKey
+        )
 
         expect(verifiedResponse.verificationResult) == .verified
     }
@@ -576,9 +603,11 @@ class SigningTests: TestCase {
         let intermediateKey = try self.createIntermediatePublicKeyData(expiration: Self.intermediateKeyFutureExpiration)
         let salt = Self.createSalt()
         let request = HTTPRequest(method: .get, path: .health, nonce: nonce.asData)
+        let requestHeaders: HTTPRequest.Headers = [:]
 
         let signature = try self.sign(parameters: .init(path: request.path,
                                                         message: nil,
+                                                        requestHeaders: requestHeaders,
                                                         nonce: nonce.asData,
                                                         etag: etag,
                                                         requestDate: requestDate),
@@ -598,7 +627,12 @@ class SigningTests: TestCase {
             ],
             body: nil
         )
-        let verifiedResponse = response.verify(signing: self.signing, request: request, publicKey: self.publicKey)
+        let verifiedResponse = response.verify(
+            signing: self.signing,
+            request: request,
+            requestHeaders: requestHeaders,
+            publicKey: self.publicKey
+        )
 
         expect(verifiedResponse.verificationResult) == .verified
     }
@@ -609,9 +643,13 @@ class SigningTests: TestCase {
         let intermediateKey = try self.createIntermediatePublicKeyData(expiration: Self.intermediateKeyFutureExpiration)
         let salt = Self.createSalt()
         let request = HTTPRequest(method: .get, path: .health, nonce: nil)
+        let requestHeaders: HTTPRequest.Headers = [
+            HTTPClient.RequestHeader.sandbox.rawValue: "\(Bool.random())"
+        ]
 
         let signature = try self.sign(parameters: .init(path: request.path,
                                                         message: message.asData,
+                                                        requestHeaders: requestHeaders,
                                                         nonce: nil,
                                                         etag: nil,
                                                         requestDate: requestDate),
@@ -630,7 +668,12 @@ class SigningTests: TestCase {
             ],
             body: message.asData
         )
-        let verifiedResponse = response.verify(signing: self.signing, request: request, publicKey: self.publicKey)
+        let verifiedResponse = response.verify(
+            signing: self.signing,
+            request: request,
+            requestHeaders: requestHeaders,
+            publicKey: self.publicKey
+        )
 
         expect(verifiedResponse.verificationResult) == .verified
     }
@@ -647,7 +690,12 @@ class SigningTests: TestCase {
             ],
             body: message.asData
         )
-        let verifiedResponse = response.verify(signing: self.signing, request: request, publicKey: self.publicKey)
+        let verifiedResponse = response.verify(
+            signing: self.signing,
+            request: request,
+            requestHeaders: [:],
+            publicKey: self.publicKey
+        )
 
         expect(verifiedResponse.verificationResult) == .notRequested
 

--- a/Tests/UnitTests/Security/SigningTests.swift
+++ b/Tests/UnitTests/Security/SigningTests.swift
@@ -33,9 +33,6 @@ class SigningTests: TestCase {
 
         try AvailabilityChecks.iOS13APIAvailableOrSkipTest()
 
-        // TODO: remove
-        Logger.logLevel = .verbose
-
         self.signing = .init(apiKey: Self.apiKey, clock: TestClock(now: Self.mockDate))
     }
 


### PR DESCRIPTION
This adds support for including arbitrary headers in the signature verification, therefore preventing tampering of them.